### PR TITLE
1.3

### DIFF
--- a/cake/libs/model/model_behavior.php
+++ b/cake/libs/model/model_behavior.php
@@ -491,6 +491,11 @@ class BehaviorCollection extends Object {
 			if (in_array($name, $this->_disabled)) {
 				continue;
 			}
+
+			if (!method_exists($this->{$name}, $callback)) {
+				continue;
+			}
+
 			$result = $this->{$name}->dispatchMethod($model, $callback, $params);
 
 			if ($options['break'] && ($result === $options['breakOn'] || (is_array($options['breakOn']) && in_array($result, $options['breakOn'], true)))) {

--- a/cake/tests/lib/reporter/cake_cli_reporter.php
+++ b/cake/tests/lib/reporter/cake_cli_reporter.php
@@ -98,7 +98,7 @@ class CakeCliReporter extends CakeBaseReporter {
  */
 	function paintException($exception) {
 		parent::paintException($exception);
-		$message .= sprintf('Unexpected exception of type [%s] with message [%s] in [%s] line [%s]',
+		$message = sprintf('Unexpected exception of type [%s] with message [%s] in [%s] line [%s]',
 			get_class($exception),
 			$exception->getMessage(),
 			$exception->getFile(),


### PR DESCRIPTION
We added customized callbacks to our models and behaviors, but they won't work on e.g. core behaviors which do not have these custom callbacks.

Therefore we added these lines to just leave out those behaviors not supporting the callbacks.
