### PR TITLE
multiple caching of i18n translations (#1085)

### DIFF
--- a/cake/libs/i18n.php
+++ b/cake/libs/i18n.php
@@ -81,14 +81,6 @@ class I18n extends Object {
 	var $__noLocale = false;
 
 /**
- * Determine what should be cached
- *
- * @var boolean
- * @access private
- */
-	var $__cache = array();
-
-/**
  * Set to true when I18N::__bindTextDomain() is called for the first time.
  * If a translation file is found it is set to false again
  *
@@ -153,15 +145,16 @@ class I18n extends Object {
 		if (is_null($domain)) {
 			$domain = 'default';
 		}
-		$_this->domain = $domain . '_' . $_this->l10n->locale;
 
-		if (!isset($_this->__domains[$domain][$_this->__lang])) {
+		$_this->domain = $domain . '_' . $_this->l10n->lang;
+
+		if (empty($_this->__domains[$domain][$_this->__lang])) {
 			$_this->__domains[$domain][$_this->__lang] = Cache::read($_this->domain, '_cake_core_');
 		}
 
 		if (empty($_this->__domains[$domain][$_this->__lang][$_this->category])) {
 			$_this->__bindTextDomain($domain);
-			$_this->__cache[] = array('key' => $_this->domain, 'lang' => $_this->__lang, 'domain' => $domain);
+			Cache::write($_this->domain, $_this->__domains[$domain][$_this->__lang], '_cake_core_');
 		}
 
 		if ($_this->category == 'LC_TIME') {
@@ -559,20 +552,5 @@ class I18n extends Object {
 			}
 		}
 		return $format;
-	}
-
-/**
- * Object destructor
- *
- * Write cache file if changes have been made to the $__map or $__paths
- * @access private
- */
-	function __destruct() {
-		if (!empty($this->__cache)) {
-			foreach($this->__cache as $entry) {
-				if (empty($this->__domains[$entry['domain']][$entry['lang']])) continue;
-				Cache::write($entry['key'],	array_filter($this->__domains[$entry['domain']][$entry['lang']]), '_cake_core_');
-			}
-		}
 	}
 }

--- a/cake/libs/i18n.php
+++ b/cake/libs/i18n.php
@@ -155,19 +155,13 @@ class I18n extends Object {
 		}
 		$_this->domain = $domain . '_' . $_this->l10n->locale;
 
-		if (!isset($_this->__domains[$_this->category][$_this->__lang][$domain])) {
-			$_this->__domains[$_this->category][$_this->__lang][$domain] = Cache::read($_this->domain, '_cake_core_');
+		if (!isset($_this->__domains[$domain][$_this->__lang])) {
+			$_this->__domains[$domain][$_this->__lang] = Cache::read($_this->domain, '_cake_core_');
 		}
 
-		if (empty($_this->__domains[$_this->category][$_this->__lang][$domain])) {
+		if (empty($_this->__domains[$domain][$_this->__lang][$_this->category])) {
 			$_this->__bindTextDomain($domain);
-			$_this->__cache[] = array(
-				'key' => $_this->domain,
-				'category' => $_this->category,
-				'lang' => $_this->__lang,
-				'domain' => $domain,
-				'locale' => $_this->l10n->locale
-			);
+			$_this->__cache[] = array('key' => $_this->domain, 'lang' => $_this->__lang, 'domain' => $domain);
 		}
 
 		if ($_this->category == 'LC_TIME') {
@@ -176,8 +170,8 @@ class I18n extends Object {
 
 		if (!isset($count)) {
 			$plurals = 0;
-		} elseif (!empty($_this->__domains[$_this->category][$_this->__lang][$domain]["%plural-c"]) && $_this->__noLocale === false) {
-			$header = $_this->__domains[$_this->category][$_this->__lang][$domain]["%plural-c"];
+		} elseif (!empty($_this->__domains[$domain][$_this->__lang][$_this->category]["%plural-c"]) && $_this->__noLocale === false) {
+			$header = $_this->__domains[$domain][$_this->__lang][$_this->category]["%plural-c"];
 			$plurals = $_this->__pluralGuess($header, $count);
 		} else {
 			if ($count != 1) {
@@ -187,8 +181,8 @@ class I18n extends Object {
 			}
 		}
 
-		if (!empty($_this->__domains[$_this->category][$_this->__lang][$domain][$singular])) {
-			if (($trans = $_this->__domains[$_this->category][$_this->__lang][$domain][$singular]) || ($plurals) && ($trans = $_this->__domains[$_this->category][$_this->__lang][$domain][$plural])) {
+		if (!empty($_this->__domains[$domain][$_this->__lang][$_this->category][$singular])) {
+			if (($trans = $_this->__domains[$domain][$_this->__lang][$_this->category][$singular]) || ($plurals) && ($trans = $_this->__domains[$domain][$_this->__lang][$_this->category][$plural])) {
 				if (is_array($trans)) {
 					if (isset($trans[$plurals])) {
 						$trans = $trans[$plurals];
@@ -294,12 +288,12 @@ class I18n extends Object {
 					if (file_exists($fn = "$app.mo")) {
 						$this->__loadMo($fn, $domain);
 						$this->__noLocale = false;
-						$merge[$this->category][$this->__lang][$domain] = $this->__domains[$this->category][$this->__lang][$domain];
+						$merge[$domain][$this->__lang][$this->category] = $this->__domains[$domain][$this->__lang][$this->category];
 						$core = null;
 					} elseif (file_exists($fn = "$app.po") && ($f = fopen($fn, "r"))) {
 						$this->__loadPo($f, $domain);
 						$this->__noLocale = false;
-						$merge[$this->category][$this->__lang][$domain] = $this->__domains[$this->category][$this->__lang][$domain];
+						$merge[$domain][$this->__lang][$this->category] = $this->__domains[$domain][$this->__lang][$this->category];
 						$core = null;
 					}
 				}
@@ -320,27 +314,27 @@ class I18n extends Object {
 			}
 		}
 
-		if (empty($this->__domains[$this->category][$this->__lang][$domain])) {
-			$this->__domains[$this->category][$this->__lang][$domain] = array();
+		if (empty($this->__domains[$domain][$this->__lang][$this->category])) {
+			$this->__domains[$domain][$this->__lang][$this->category] = array();
 			return $domain;
 		}
 
-		if ($head = $this->__domains[$this->category][$this->__lang][$domain][""]) {
+		if ($head = $this->__domains[$domain][$this->__lang][$this->category][""]) {
 			foreach (explode("\n", $head) as $line) {
 				$header = strtok($line,":");
 				$line = trim(strtok("\n"));
-				$this->__domains[$this->category][$this->__lang][$domain]["%po-header"][strtolower($header)] = $line;
+				$this->__domains[$domain][$this->__lang][$this->category]["%po-header"][strtolower($header)] = $line;
 			}
 
-			if (isset($this->__domains[$this->category][$this->__lang][$domain]["%po-header"]["plural-forms"])) {
-				$switch = preg_replace("/(?:[() {}\\[\\]^\\s*\\]]+)/", "", $this->__domains[$this->category][$this->__lang][$domain]["%po-header"]["plural-forms"]);
-				$this->__domains[$this->category][$this->__lang][$domain]["%plural-c"] = $switch;
-				unset($this->__domains[$this->category][$this->__lang][$domain]["%po-header"]);
+			if (isset($this->__domains[$domain][$this->__lang][$this->category]["%po-header"]["plural-forms"])) {
+				$switch = preg_replace("/(?:[() {}\\[\\]^\\s*\\]]+)/", "", $this->__domains[$domain][$this->__lang][$this->category]["%po-header"]["plural-forms"]);
+				$this->__domains[$domain][$this->__lang][$this->category]["%plural-c"] = $switch;
+				unset($this->__domains[$domain][$this->__lang][$this->category]["%po-header"]);
 			}
 			$this->__domains = Set::pushDiff($this->__domains, $merge);
 
-			if (isset($this->__domains[$this->category][$this->__lang][$domain][null])) {
-				unset($this->__domains[$this->category][$this->__lang][$domain][null]);
+			if (isset($this->__domains[$domain][$this->__lang][$this->category][null])) {
+				unset($this->__domains[$domain][$this->__lang][$this->category][null]);
 			}
 		}
 		return $domain;
@@ -376,10 +370,10 @@ class I18n extends Object {
 					if (strpos($msgstr, "\000")) {
 						$msgstr = explode("\000", $msgstr);
 					}
-					$this->__domains[$this->category][$this->__lang][$domain][$msgid] = $msgstr;
+					$this->__domains[$domain][$this->__lang][$this->category][$msgid] = $msgstr;
 
 					if (isset($msgid_plural)) {
-						$this->__domains[$this->category][$this->__lang][$domain][$msgid_plural] =& $this->__domains[$this->category][$this->__lang][$domain][$msgid];
+						$this->__domains[$domain][$this->__lang][$this->category][$msgid_plural] =& $this->__domains[$domain][$this->__lang][$this->category][$msgid];
 					}
 				}
 			}
@@ -454,7 +448,7 @@ class I18n extends Object {
 		} while (!feof($file));
 		fclose($file);
 		$merge[""] = $header;
-		return $this->__domains[$this->category][$this->__lang][$domain] = array_merge($merge ,$translations);
+		return $this->__domains[$domain][$this->__lang][$this->category] = array_merge($merge ,$translations);
 	}
 
 /**
@@ -512,9 +506,9 @@ class I18n extends Object {
 				$value[$i] = $val;
 			}
 			if (count($value) == 1) {
-				$this->__domains[$this->category][$this->__lang][$domain][$currentToken] = array_pop($value);
+				$this->__domains[$domain][$this->__lang][$this->category][$currentToken] = array_pop($value);
 			} else {
-				$this->__domains[$this->category][$this->__lang][$domain][$currentToken] = $value;
+				$this->__domains[$domain][$this->__lang][$this->category][$currentToken] = $value;
 			}
 		}
 	}
@@ -559,8 +553,8 @@ class I18n extends Object {
  * @access private
  */
 	function __translateTime($format, $domain) {
-		if (!empty($this->__domains['LC_TIME'][$this->__lang][$domain][$format])) {
-			if (($trans = $this->__domains[$this->category][$this->__lang][$domain][$format])) {
+		if (!empty($this->__domains[$domain][$this->__lang]['LC_TIME'][$format])) {
+			if (($trans = $this->__domains[$domain][$this->__lang][$this->category][$format])) {
 				return $trans;
 			}
 		}
@@ -576,17 +570,9 @@ class I18n extends Object {
 	function __destruct() {
 		if (!empty($this->__cache)) {
 			foreach($this->__cache as $entry) {
-				if (empty($this->__domains[$entry['category']][$entry['lang']][$entry['domain']])) {
-					continue;
-				}
-				Cache::write(
-					$entry['key'],
-					array_filter($this->__domains[$entry['category']][$entry['lang']][$entry['domain']]),
-					'_cake_core_'
-				);
+				if (empty($this->__domains[$entry['domain']][$entry['lang']])) continue;
+				Cache::write($entry['key'],	array_filter($this->__domains[$entry['domain']][$entry['lang']]), '_cake_core_');
 			}
 		}
-		$this->__cache = array();
-		$this->__domains = array();
 	}
 }

--- a/cake/tests/cases/libs/i18n.test.php
+++ b/cake/tests/cases/libs/i18n.test.php
@@ -58,26 +58,21 @@ class I18nTest extends CakeTestCase {
 	function testTranslationCaching() {
 		Configure::write('Config.language', 'cache_test_po');
 		$i18n =& i18n::getInstance();	
-		// reset cache & i18n
-		$i18n->__destruct();
+
 		// reset internally stored entries
 		$i18n->__cache = array();
 		$i18n->__domains = array();
 		
 		Cache::clear(false, '_cake_core_');
-		$lang = $i18n->l10n->locale;
+		$lang = Configure::read('Config.language');#$i18n->l10n->locale;
 
 		Cache::config('_cake_core_', Cache::config('default'));
 
 		// make some calls to translate using different domains
 		$this->assertEqual(i18n::translate('dom1.foo', false, 'dom1'), 'Dom 1 Foo');
 		$this->assertEqual(i18n::translate('dom1.bar', false, 'dom1'), 'Dom 1 Bar');
-		$this->assertEqual($i18n->__cache[0]['key'], 'dom1_' . $lang);
-		$this->assertEqual($i18n->__cache[0]['domain'], 'dom1');
 		$this->assertEqual($i18n->__domains['dom1']['cache_test_po']['LC_MESSAGES']['dom1.foo'], 'Dom 1 Foo');
 
-		// destruct -> writes to cache
-		$i18n->__destruct();
 		// reset internally stored entries
 		$i18n->__domains = array();
 		$i18n->__cache = array();
@@ -92,22 +87,16 @@ class I18nTest extends CakeTestCase {
 		// translate a item of dom2 (adds dom2 to cache)
 		$this->assertEqual(i18n::translate('dom2.foo', false, 'dom2'), 'Dom 2 Foo');
 
-		// modify cache entry manually to verify that dom1 entry is now read from cache 
-		$cachedDom1['LC_MESSAGES']['dom1.foo'] = 'FOO';
-		Cache::write('dom1_' . $lang, $cachedDom1, '_cake_core_');
-		$this->assertEqual(i18n::translate('dom1.foo', false, 'dom1'), 'FOO');
-		
-		// verify that only dom2 will be cached now
-		$this->assertEqual($i18n->__cache[0]['key'], 'dom2_' . $lang);
-		$this->assertEqual(count($i18n->__cache), 1);
-
-		// write to cache
-		$i18n->__destruct();
-
-		// verify caching through manual read from cache
+		// verify dom2 was cached through manual read from cache
 		$cachedDom2 = Cache::read('dom2_' . $lang, '_cake_core_');
 		$this->assertEqual($cachedDom2['LC_MESSAGES']['dom2.foo'], 'Dom 2 Foo');
 		$this->assertEqual($cachedDom2['LC_MESSAGES']['dom2.bar'], 'Dom 2 Bar');
+
+		// modify cache entry manually to verify that dom1 entries now will be read from cache 
+		$cachedDom1['LC_MESSAGES']['dom1.foo'] = 'FOO';
+		Cache::write('dom1_' . $lang, $cachedDom1, '_cake_core_');
+		$this->assertEqual(i18n::translate('dom1.foo', false, 'dom1'), 'FOO');
+	
 	}
 
 

--- a/cake/tests/cases/libs/i18n.test.php
+++ b/cake/tests/cases/libs/i18n.test.php
@@ -57,10 +57,13 @@ class I18nTest extends CakeTestCase {
 
 	function testTranslationCaching() {
 		Configure::write('Config.language', 'cache_test_po');
-		$i18n =& i18n::getInstance();
-		
+		$i18n =& i18n::getInstance();	
 		// reset cache & i18n
 		$i18n->__destruct();
+		// reset internally stored entries
+		$i18n->__cache = array();
+		$i18n->__domains = array();
+		
 		Cache::clear(false, '_cake_core_');
 		$lang = $i18n->l10n->locale;
 
@@ -69,29 +72,31 @@ class I18nTest extends CakeTestCase {
 		// make some calls to translate using different domains
 		$this->assertEqual(i18n::translate('dom1.foo', false, 'dom1'), 'Dom 1 Foo');
 		$this->assertEqual(i18n::translate('dom1.bar', false, 'dom1'), 'Dom 1 Bar');
-
 		$this->assertEqual($i18n->__cache[0]['key'], 'dom1_' . $lang);
 		$this->assertEqual($i18n->__cache[0]['domain'], 'dom1');
-		$this->assertEqual($i18n->__domains['LC_MESSAGES']['cache_test_po']['dom1']['dom1.foo'], 'Dom 1 Foo');
+		$this->assertEqual($i18n->__domains['dom1']['cache_test_po']['LC_MESSAGES']['dom1.foo'], 'Dom 1 Foo');
 
 		// destruct -> writes to cache
 		$i18n->__destruct();
+		// reset internally stored entries
+		$i18n->__domains = array();
+		$i18n->__cache = array();
 
 		// now only dom1 should be in cache
 		$cachedDom1 = Cache::read('dom1_' . $lang, '_cake_core_');
-		$this->assertEqual($cachedDom1['dom1.foo'], 'Dom 1 Foo');
-		$this->assertEqual($cachedDom1['dom1.bar'], 'Dom 1 Bar');
+		$this->assertEqual($cachedDom1['LC_MESSAGES']['dom1.foo'], 'Dom 1 Foo');
+		$this->assertEqual($cachedDom1['LC_MESSAGES']['dom1.bar'], 'Dom 1 Bar');
 		// dom2 not in cache
 		$this->assertFalse(Cache::read('dom2_' . $lang, '_cake_core_'));
 
 		// translate a item of dom2 (adds dom2 to cache)
 		$this->assertEqual(i18n::translate('dom2.foo', false, 'dom2'), 'Dom 2 Foo');
 
-		// modify cache entry to verify that dom1 entry is now read from cache 
-		$cachedDom1['dom1.foo'] = 'FOO';
+		// modify cache entry manually to verify that dom1 entry is now read from cache 
+		$cachedDom1['LC_MESSAGES']['dom1.foo'] = 'FOO';
 		Cache::write('dom1_' . $lang, $cachedDom1, '_cake_core_');
 		$this->assertEqual(i18n::translate('dom1.foo', false, 'dom1'), 'FOO');
-
+		
 		// verify that only dom2 will be cached now
 		$this->assertEqual($i18n->__cache[0]['key'], 'dom2_' . $lang);
 		$this->assertEqual(count($i18n->__cache), 1);
@@ -101,8 +106,8 @@ class I18nTest extends CakeTestCase {
 
 		// verify caching through manual read from cache
 		$cachedDom2 = Cache::read('dom2_' . $lang, '_cake_core_');
-		$this->assertEqual($cachedDom2['dom2.foo'], 'Dom 2 Foo');
-		$this->assertEqual($cachedDom2['dom2.bar'], 'Dom 2 Bar');
+		$this->assertEqual($cachedDom2['LC_MESSAGES']['dom2.foo'], 'Dom 2 Foo');
+		$this->assertEqual($cachedDom2['LC_MESSAGES']['dom2.bar'], 'Dom 2 Bar');
 	}
 
 


### PR DESCRIPTION
Indexing order of the internal domains variable was reversed to allow separate caching entries per language and domain. This is an alternative solution to having separate caching entries for each language, domain and category (see ticket).
