### PR TITLE
Fixing address formatting in the Email component

### DIFF
--- a/cake/libs/controller/components/email.php
+++ b/cake/libs/controller/components/email.php
@@ -745,6 +745,9 @@ class EmailComponent extends Object{
 	function _formatAddress($string, $smtp = false) {
 		$hasAlias = preg_match('/(.+)\s<(.+)>/', $string, $matches);
 		if ($hasAlias) {
+            if ($smtp == true) {
+                return $this->_strip('<' . $matches[2] . '>');
+            }
 			return $this->_strip($matches[1] . ' <' . $matches[2] . '>');
 		}
 		return $this->_strip($string);


### PR DESCRIPTION
I'm not sure if this is the preferred way of sending patches for CakePHP, so if it's not, let me know what you prefer ;-)

```
This fixes a problem with formatting e-mail addresses for use in the SMTP
session.

GMail, amongst other, lower profile services, requires that no e-mail alias be
added to the MAIL or RCPT commands during the SMTP session.  While many SMTP
servers do allow this behavior, it is contrary to the specifications in the
RFC, which state that only a valid e-mail address, enclosed inside angle
brackets.

This simple fix restores the ability to use the Email component with GMail as
an SMTP service.
```
