### PR TITLE
Untitled

### DIFF
--- a/cake/libs/view/errors/missing_action.ctp
+++ b/cake/libs/view/errors/missing_action.ctp
@@ -42,5 +42,5 @@ class <?php echo $controller;?> extends AppController {
 </pre>
 <p class="notice">
 	<strong><?php __('Notice'); ?>: </strong>
-	<?php printf(__('If you want to customize this error message, create %s.', true), APP_DIR . DS . 'views' . DS . 'errors' . DS . 'missing_action.ctp'); ?>
+	<?php printf(__('If you want to customize this error message, create %s', true), APP_DIR . DS . 'views' . DS . 'errors' . DS . 'missing_action.ctp'); ?>
 </p>


### PR DESCRIPTION
Removing a dot at the end of a message in mission_action.ctp because there is no dot in the same message in all other error views, this can help for translations.
