### PR TITLE
1.3

### DIFF
--- a/app/config/core.php
+++ b/app/config/core.php
@@ -167,7 +167,7 @@
 	Configure::write('Session.cookie', 'CAKEPHP');
 
 /**
- * Session time out time (in minutes).
+ * Session time out time (in seconds).
  * Actual value depends on 'Security.level' setting.
  */
 	Configure::write('Session.timeout', '120');

--- a/cake/console/templates/skel/config/core.php
+++ b/cake/console/templates/skel/config/core.php
@@ -167,7 +167,7 @@
 	Configure::write('Session.cookie', 'CAKEPHP');
 
 /**
- * Session time out time (in minutes).
+ * Session time out time (in seconds).
  * Actual value depends on 'Security.level' setting.
  */
 	Configure::write('Session.timeout', '120');

--- a/cake/dispatcher.php
+++ b/cake/dispatcher.php
@@ -339,7 +339,7 @@ class Dispatcher extends Object {
 			if ($webroot === 'webroot' && $webroot === basename($base)) {
 				$base = dirname($base);
 			}
-			if ($dir === APP_DIR && $dir === basename($base)) {
+			if ($dir === 'app' && $dir === basename($base)) {
 				$base = dirname($base);
 			}
 

--- a/cake/libs/controller/components/auth.php
+++ b/cake/libs/controller/components/auth.php
@@ -527,7 +527,6 @@ class AuthComponent extends Object {
 				$valid = $this->Acl->check($user, $this->action());
 			break;
 			case 'crud':
-				$this->mapActions();
 				if (!isset($this->actionMap[$this->params['action']])) {
 					trigger_error(
 						sprintf(__('Auth::startup() - Attempted access of un-mapped action "%1$s" in controller "%2$s"', true), $this->params['action'], $this->params['controller']),
@@ -542,7 +541,6 @@ class AuthComponent extends Object {
 				}
 			break;
 			case 'model':
-				$this->mapActions();
 				$action = $this->params['action'];
 				if (isset($this->actionMap[$action])) {
 					$action = $this->actionMap[$action];

--- a/cake/libs/controller/components/security.php
+++ b/cake/libs/controller/components/security.php
@@ -618,10 +618,15 @@ class SecurityComponent extends Object {
 		}
 		unset($check['_Token']);
 
+		$locked = str_rot13($locked);
+		if (preg_match('/(\A|;|{|})O\:[0-9]+/', $locked)) {
+			return false;
+		}
+
 		$lockedFields = array();
 		$fields = Set::flatten($check);
 		$fieldList = array_keys($fields);
-		$locked = unserialize(str_rot13($locked));
+		$locked = unserialize($locked);
 		$multi = array();
 
 		foreach ($fieldList as $i => $key) {

--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -1831,7 +1831,7 @@ class Model extends Overloadable {
 				));
 			}
 
-			if ($db->delete($this)) {
+			if ($db->delete($this, array($this->alias . '.' . $this->primaryKey => $id))) {
 				if (!empty($this->belongsTo)) {
 					$this->updateCounterCache($keys[$this->alias]);
 				}

--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -559,9 +559,9 @@ class Model extends Overloadable {
  *
  * Example: Turn off the associated Model Support request,
  * to temporarily lighten the User model:
- * 
+ *
  * `$this->User->unbindModel( array('hasMany' => array('Supportrequest')) );`
- * 
+ *
  * unbound models that are not made permanent will reset with the next call to Model::find()
  *
  * @param array $params Set of bindings to unbind (indexed by binding type)
@@ -1589,7 +1589,7 @@ class Model extends Overloadable {
 		}
 
 		if ($options['atomic'] && $options['validate'] !== 'only') {
-			$db->begin($this);
+			$transactionBegun = $db->begin($this);
 		}
 
 		if (Set::numeric(array_keys($data))) {
@@ -1629,8 +1629,12 @@ class Model extends Overloadable {
 					break;
 					default:
 						if ($options['atomic']) {
-							if ($validates && ($db->commit($this) !== false)) {
-								return true;
+							if ($validates) {
+								if ($transactionBegun) {
+									return $db->commit($this) !== false;
+								} else {
+									return true;
+								}
 							}
 							$db->rollback($this);
 							return false;
@@ -1740,7 +1744,11 @@ class Model extends Overloadable {
 				default:
 					if ($options['atomic']) {
 						if ($validates) {
-							return ($db->commit($this) !== false);
+							if ($transactionBegun) {
+								return $db->commit($this) !== false;
+							} else {
+								return true;
+							}
 						} else {
 							$db->rollback($this);
 						}

--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -221,7 +221,8 @@ class FormHelper extends AppHelper {
 			$data = $this->fieldset[$modelEntity];
 			$recordExists = (
 				isset($this->data[$model]) &&
-				!empty($this->data[$model][$data['key']])
+				!empty($this->data[$model][$data['key']]) &&
+				!is_array($this->data[$model][$data['key']])
 			);
 
 			if ($recordExists) {

--- a/cake/libs/view/helpers/number.php
+++ b/cake/libs/view/helpers/number.php
@@ -48,7 +48,7 @@ class NumberHelper extends AppHelper {
 			'decimals' => '.', 'negative' => '()','escape' => false
 		),
 		'EUR' => array(
-			'before'=>'&#8364;', 'after' => 'c', 'zero' => 0, 'places' => 2, 'thousands' => '.',
+			'before'=>'&#8364;', 'after' => false, 'zero' => 0, 'places' => 2, 'thousands' => '.',
 			'decimals' => ',', 'negative' => '()', 'escape' => false
 		)
 	);

--- a/cake/tests/cases/libs/cake_test_case.test.php
+++ b/cake/tests/cases/libs/cake_test_case.test.php
@@ -184,7 +184,7 @@ class CakeTestCaseTest extends CakeTestCase {
 			'/a'
 		);
 		$this->assertTrue($this->Case->assertTags($input, $pattern), 'Single quoted attributes %s');
-		
+
 		$input = "<a href='/test.html' class='active'>My link</a>";
 		$pattern = array(
 			'a' => array('href' => 'preg:/.*\.html/', 'class' => 'active'),
@@ -348,10 +348,10 @@ class CakeTestCaseTest extends CakeTestCase {
 		), true);
 
 		$result = $this->Case->testAction('/tests_apps/index', array('return' => 'view'));
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
+		$this->assertPattern('/^\s*This is the TestsAppsController index view\s*$/i', $result);
 
 		$result = $this->Case->testAction('/tests_apps/index', array('return' => 'contents'));
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
+		$this->assertPattern('/\bThis is the TestsAppsController index view\b/i', $result);
 		$this->assertPattern('/<html/', $result);
 		$this->assertPattern('/<\/html>/', $result);
 

--- a/cake/tests/cases/libs/controller/components/security.test.php
+++ b/cake/tests/cases/libs/controller/components/security.test.php
@@ -608,6 +608,30 @@ DIGEST;
 		$result = $this->Controller->Security->validatePost($this->Controller);
 		$this->assertFalse($result, 'validatePost passed when key was missing. %s');
 	}
+
+/**
+ * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI 
+ * attacks. Thanks to Felix Wilhelm
+ *
+ * @return void
+ */
+	function testValidatePostObjectDeserialize() {
+		$this->Controller->Security->startup($this->Controller);
+		$key = $this->Controller->params['_Token']['key'];
+		$fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877';
+
+		// a corrupted serialized object, so we can see if it ever gets to deserialize
+		$attack = 'O:3:"App":1:{s:5:"__map";a:1:{s:3:"foo";s:7:"Hacked!";s:1:"fail"}}';
+		$fields .= urlencode(':' . str_rot13($attack));
+
+		$this->Controller->data = array(
+			'Model' => array('username' => 'mark', 'password' => 'foo', 'valid' => '0'),
+			'_Token' => compact('key', 'fields')
+		);
+		$result = $this->Controller->Security->validatePost($this->Controller);
+		$this->assertFalse($result, 'validatePost passed when key was missing. %s');
+	}
+
 /**
  * Tests validation of checkbox arrays
  *

--- a/cake/tests/cases/libs/model/model_write.test.php
+++ b/cake/tests/cases/libs/model/model_write.test.php
@@ -3122,6 +3122,22 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * test saveAll with nested saveAll call.
+ *
+ * @return void
+ */
+	function testSaveAllNestedSaveAll() {
+		$this->loadFixtures('Sample');
+		$TransactionTestModel =& new TransactionTestModel();
+
+		$data = array(
+			array('apple_id' => 1, 'name' => 'sample5'),
+		);
+
+		$this->assertTrue($TransactionTestModel->saveAll($data, array('atomic' => true)));
+	}
+
+/**
  * testSaveAllTransaction method
  *
  * @access public

--- a/cake/tests/cases/libs/model/models.php
+++ b/cake/tests/cases/libs/model/models.php
@@ -290,7 +290,7 @@ class Article extends CakeTestModel {
  */
 class BeforeDeleteComment extends CakeTestModel {
 	var $name = 'BeforeDeleteComment';
-	
+
 	var $useTable = 'comments';
 
 	function beforeDelete($cascade = true) {
@@ -3557,6 +3557,7 @@ class FruitNoWith extends CakeTestModel {
 		)
 	);
 }
+
 class UuidTagNoWith extends CakeTestModel {
 	var $name = 'UuidTag';
 	var $useTable = 'uuid_tags';
@@ -3573,11 +3574,21 @@ class UuidTagNoWith extends CakeTestModel {
 class ProductUpdateAll extends CakeTestModel {
 	var $name = 'ProductUpdateAll';
 	var $useTable = 'product_update_all';
-
 }
 
 class GroupUpdateAll extends CakeTestModel {
 	var $name = 'GroupUpdateAll';
 	var $useTable = 'group_update_all';
+}
 
+class TransactionTestModel extends CakeTestModel {
+	var $name = 'TransactionTestModel';
+	var $useTable = 'samples';
+
+	function afterSave($created) {
+		$data = array(
+			array('apple_id' => 1, 'name' => 'sample6'),
+		);
+		$this->saveAll($data, array('atomic' => true, 'callbacks' => false));
+	}
 }

--- a/cake/tests/cases/libs/router.test.php
+++ b/cake/tests/cases/libs/router.test.php
@@ -74,6 +74,8 @@ class RouterTest extends CakeTestCase {
 	function testFullBaseURL() {
 		$this->assertPattern('/^http(s)?:\/\//', Router::url('/', true));
 		$this->assertPattern('/^http(s)?:\/\//', Router::url(null, true));
+		$this->assertPattern('/^http(s)?:\/\//', Router::url(array('full_base' => true)));
+		$this->assertIdentical(FULL_BASE_URL . '/', Router::url(array('full_base' => true)));
 	}
 
 /**
@@ -1702,8 +1704,8 @@ class RouterTest extends CakeTestCase {
 	function testParsingWithPatternOnAction() {
 		Router::reload();
 		Router::connect(
-			'/blog/:action/*', 
-			array('controller' => 'blog_posts'), 
+			'/blog/:action/*',
+			array('controller' => 'blog_posts'),
 			array('action' => 'other|actions')
 		);
 		$result = Router::parse('/blog/other');
@@ -1725,7 +1727,7 @@ class RouterTest extends CakeTestCase {
 			'named' => array()
 		);
 		$this->assertEqual($expected, $result);
-		
+
 		$result = Router::url(array('controller' => 'blog_posts', 'action' => 'foo'));
 		$this->assertEqual('/blog_posts/foo', $result);
 
@@ -2535,20 +2537,20 @@ class CakeRouteTestCase extends CakeTestCase {
  */
 	function testPatternOnAction() {
 		$route =& new CakeRoute(
-			'/blog/:action/*', 
-			array('controller' => 'blog_posts'), 
+			'/blog/:action/*',
+			array('controller' => 'blog_posts'),
 			array('action' => 'other|actions')
 		);
 		$result = $route->match(array('controller' => 'blog_posts', 'action' => 'foo'));
 		$this->assertFalse($result);
-		
+
 		$result = $route->match(array('controller' => 'blog_posts', 'action' => 'actions'));
 		$this->assertTrue($result);
-		
+
 		$result = $route->parse('/blog/other');
 		$expected = array('controller' => 'blog_posts', 'action' => 'other', 'pass' => array(), 'named' => array());
 		$this->assertEqual($expected, $result);
-		
+
 		$result = $route->parse('/blog/foobar');
 		$this->assertFalse($result);
 	}

--- a/cake/tests/cases/libs/view/helpers/form.test.php
+++ b/cake/tests/cases/libs/view/helpers/form.test.php
@@ -5627,6 +5627,31 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * test that create() doesn't cause errors by multiple id's being in the primary key
+ * as could happen with multiple select or checkboxes.
+ *
+ * @return void
+ */
+	function testCreateWithMultipleIdInData() {
+		$encoding = strtolower(Configure::read('App.encoding'));
+
+		$this->Form->data['Contact']['id'] = array(1, 2);
+		$result = $this->Form->create('Contact');
+		$expected = array(
+			'form' => array(
+				'id' => 'ContactAddForm',
+				'method' => 'post',
+				'action' => '/contacts/add',
+				'accept-charset' => $encoding
+			),
+			'div' => array('style' => 'display:none;'),
+			'input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST'),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * test that create() doesn't add in extra passed params.
  *
  * @return void

--- a/cake/tests/cases/libs/view/helpers/number.test.php
+++ b/cake/tests/cases/libs/view/helpers/number.test.php
@@ -236,7 +236,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '99c';
+		$expected = '&#8364;0,99';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -258,7 +258,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '(99c)';
+		$expected = '(&#8364;0,99)';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -270,7 +270,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR', array('negative'=>'-'));
-		$expected = '-99c';
+		$expected = '-&#8364;0,99';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('negative'=>'-'));
@@ -335,6 +335,10 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency('0.35', 'GBP');
 		$expected = '35p';
+		$this->assertEqual($expected, $result);
+		
+		$result = $this->Number->currency('0.35', 'EUR');
+		$expected = '&#8364;0,35';
 		$this->assertEqual($expected, $result);
 	}
 

--- a/cake/tests/cases/libs/view/helpers/paginator.test.php
+++ b/cake/tests/cases/libs/view/helpers/paginator.test.php
@@ -21,6 +21,10 @@ App::import('Helper', array('Html', 'Paginator', 'Form', 'Ajax', 'Javascript', '
 
 Mock::generate('JsHelper', 'PaginatorMockJsHelper');
 
+if (!defined('FULL_BASE_URL')) {
+	define('FULL_BASE_URL', 'http://cakephp.org');
+}
+
 /**
  * PaginatorHelperTest class
  *
@@ -1715,6 +1719,16 @@ class PaginatorHelperTest extends CakeTestCase {
 			' | ',
 			'<span',
 			array('a' => array('href' => '/index/page:15/sort:Client.name/direction:DESC')), '15', '/a',
+			'/span',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->options(array('url' => array('full_base' => true)));
+		$result = $this->Paginator->first();
+
+		$expected = array(
+			'<span',
+			array('a' => array('href' => FULL_BASE_URL . '/index/page:1/sort:Client.name/direction:DESC')), '&lt;&lt; first', '/a',
 			'/span',
 		);
 		$this->assertTags($result, $expected);

--- a/cake/tests/lib/cake_test_case.php
+++ b/cake/tests/lib/cake_test_case.php
@@ -64,6 +64,10 @@ class CakeTestDispatcher extends Dispatcher {
 	function _invoke(&$controller, $params, $missingAction = false) {
 		$this->controller =& $controller;
 
+		if (array_key_exists('layout', $params)) {
+			$this->controller->layout = $params['layout'];
+		}
+
 		if (isset($this->testCase) && method_exists($this->testCase, 'startController')) {
 			$this->testCase->startController($this->controller, $params);
 		}


### PR DESCRIPTION
This fixes an issue where CakeTestCase::testAction() would always include the layout, regardless if the setting return was set to either 'view' or 'contents'. Previous unit test was always succeeding because it did not correctly checked that the layout was not included when return was set to 'view'.
