### PR TITLE
NumberHelper EUR format

### DIFF
--- a/cake/libs/view/helpers/number.php
+++ b/cake/libs/view/helpers/number.php
@@ -48,9 +48,9 @@ class NumberHelper extends AppHelper {
 			'decimals' => '.', 'negative' => '()','escape' => false
 		),
 		'EUR' => array(
-			'before'=>'&#8364;', 'after' => 'c', 'zero' => 0, 'places' => 2, 'thousands' => '.',
+			'before'=>'', 'after' => '&#160;&#8364;', 'zero' => 0, 'places' => 2, 'thousands' => '.',
 			'decimals' => ',', 'negative' => '()', 'escape' => false
-		)
+		) 
 	);
 
 /**

--- a/cake/tests/cases/libs/view/helpers/number.test.php
+++ b/cake/tests/cases/libs/view/helpers/number.test.php
@@ -322,7 +322,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('escape' => true));
-		$expected = '&amp;#163;1,234,567.89';
+		$expected = '&#163;1,234,567.89';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency('0.35', 'USD', array('after' => false));

--- a/cake/tests/cases/libs/view/helpers/number.test.php
+++ b/cake/tests/cases/libs/view/helpers/number.test.php
@@ -107,7 +107,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '&#8364;100.100.100,00';
+		$expected = '100.100.100,00&#160;&#8364;';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -179,7 +179,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '&#8364;100.100.100,00';
+		$expected = '100.100.100,00&#160;&#8364;';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -213,7 +213,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR', array('negative'=>'-'));
-		$expected = '-&#8364;100.100.100,00';
+		$expected = '-100.100.100,00&#160;&#8364;';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('negative'=>'-'));
@@ -236,7 +236,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '99c';
+		$expected = '0,99&#160;&#8364;';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -258,7 +258,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '(99c)';
+		$expected = '(-0,99&#160;&#8364;)';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
@@ -292,7 +292,7 @@ class NumberHelperTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
-		$expected = '&#8364;0,00';
+		$expected = '0,00&#160;&#8364;';
 		$this->assertEqual($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');


### PR DESCRIPTION
Fixed EUR output to match the common usage in the EU. See http://publications.europa.eu/code/de/de-370303.htm#position.
