### PR TITLE
1.3

### DIFF
--- a/cake/tests/cases/libs/cake_test_case.test.php
+++ b/cake/tests/cases/libs/cake_test_case.test.php
@@ -184,7 +184,7 @@ class CakeTestCaseTest extends CakeTestCase {
 			'/a'
 		);
 		$this->assertTrue($this->Case->assertTags($input, $pattern), 'Single quoted attributes %s');
-		
+
 		$input = "<a href='/test.html' class='active'>My link</a>";
 		$pattern = array(
 			'a' => array('href' => 'preg:/.*\.html/', 'class' => 'active'),
@@ -348,10 +348,10 @@ class CakeTestCaseTest extends CakeTestCase {
 		), true);
 
 		$result = $this->Case->testAction('/tests_apps/index', array('return' => 'view'));
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
+		$this->assertPattern('/^\s*This is the TestsAppsController index view\s*$/i', $result);
 
 		$result = $this->Case->testAction('/tests_apps/index', array('return' => 'contents'));
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
+		$this->assertPattern('/\bThis is the TestsAppsController index view\b/i', $result);
 		$this->assertPattern('/<html/', $result);
 		$this->assertPattern('/<\/html>/', $result);
 

--- a/cake/tests/lib/cake_test_case.php
+++ b/cake/tests/lib/cake_test_case.php
@@ -64,6 +64,10 @@ class CakeTestDispatcher extends Dispatcher {
 	function _invoke(&$controller, $params, $missingAction = false) {
 		$this->controller =& $controller;
 
+		if (array_key_exists('layout', $params)) {
+			$this->controller->layout = $params['layout'];
+		}
+
 		if (isset($this->testCase) && method_exists($this->testCase, 'startController')) {
 			$this->testCase->startController($this->controller, $params);
 		}


### PR DESCRIPTION
This fixes an issue where CakeTestCase::testAction() would always include the layout, regardless if the setting return was set to either 'view' or 'contents'. Previous unit test was always succeeding because it did not correctly checked that the layout was not included when return was set to 'view'.

NOTE: This was originally pull request #12, but Mark correctly pointed out that the solution included a feature that was removed in 1.3, so I refactored the code to still fix the failing test case, but only do the appropriate fix in CakeTestCase
