### PR TITLE
Patch for SecurityComponent unserialize() Vulnerability

### DIFF
--- a/cake/libs/controller/components/security.php
+++ b/cake/libs/controller/components/security.php
@@ -612,13 +612,9 @@ class SecurityComponent extends Object {
 		$locked = null;
 		$check = $controller->data;
 		$token = urldecode($check['_Token']['fields']);
-
-		if (strpos($token, ':')) {
-			list($token, $locked) = explode(':', $token, 2);
-		}
 		unset($check['_Token']);
 
-		$locked = str_rot13($locked);
+		$locked = $this->Session->read('_locked', $locked);
 		if (preg_match('/(\A|;|{|})O\:[0-9]+/', $locked)) {
 			return false;
 		}

--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -406,10 +406,15 @@ class FormHelper extends AppHelper {
 		$fields += $locked;
 
 		$fields = Security::hash(serialize($fields) . Configure::read('Security.salt'));
-		$locked = str_rot13(serialize(array_keys($locked)));
+		$locked = serialize(array_keys($locked));
+
+		$Session = ClassRegistry::getObject('Session');
+		if (is_object($Session)) {
+			$Session->write('_locked', $locked);
+		}
 
 		$out = $this->hidden('_Token.fields', array(
-			'value' => urlencode($fields . ':' . $locked),
+			'value' => urlencode($fields),
 			'id' => 'TokenFields' . mt_rand()
 		));
 		$out = sprintf($this->Html->tags['block'], ' style="display:none;"', $out);
@@ -1423,7 +1428,7 @@ class FormHelper extends AppHelper {
 		$style = null;
 		$tag = null;
 		$attributes += array(
-			'class' => null, 
+			'class' => null,
 			'escape' => true,
 			'secure' => null,
 			'empty' => '',

--- a/cake/tests/cases/libs/controller/components/security.test.php
+++ b/cake/tests/cases/libs/controller/components/security.test.php
@@ -573,8 +573,9 @@ DIGEST;
 	function testValidatePost() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3An%3A1%3A%7Bv%3A0%3B';
-		$fields .= 'f%3A11%3A%22Zbqry.inyvq%22%3B%7D';
+		$fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877';
+
+		$this->Controller->Session->write('_locked', 'a:1:{i:0;s:11:"Model.valid";}');
 
 		$this->Controller->data = array(
 			'Model' => array('username' => 'nate', 'password' => 'foo', 'valid' => '0'),
@@ -610,7 +611,7 @@ DIGEST;
 	}
 
 /**
- * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI 
+ * Test that objects can't be passed into the serialized string. This was a vector for RFI and LFI
  * attacks. Thanks to Felix Wilhelm
  *
  * @return void
@@ -641,7 +642,8 @@ DIGEST;
 	function testValidatePostArray() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'f7d573650a295b94e0938d32b323fde775e5f32b%3An%3A0%3A%7B%7D';
+		$fields = 'f7d573650a295b94e0938d32b323fde775e5f32b';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'Model' => array('multi_field' => array('1', '3')),
@@ -659,7 +661,8 @@ DIGEST;
 	function testValidatePostNoModel() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '540ac9c60d323c22bafe997b72c0790f39a8bdef%3An%3A0%3A%7B%7D';
+		$fields = '540ac9c60d323c22bafe997b72c0790f39a8bdef';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'anything' => 'some_data',
@@ -679,7 +682,8 @@ DIGEST;
 	function testValidatePostSimple() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '69f493434187b867ea14b901fdf58b55d27c935d%3An%3A0%3A%7B%7D';
+		$fields = '69f493434187b867ea14b901fdf58b55d27c935d';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = $data = array(
 			'Model' => array('username' => '', 'password' => ''),
@@ -699,8 +703,8 @@ DIGEST;
 	function testValidatePostComplex() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'c9118120e680a7201b543f562e5301006ccfcbe2%3An%3A2%3A%7Bv%3A0%3Bf%3A14%3A%';
-		$fields .= '22Nqqerffrf.0.vq%22%3Bv%3A1%3Bf%3A14%3A%22Nqqerffrf.1.vq%22%3B%7D';
+		$fields = 'c9118120e680a7201b543f562e5301006ccfcbe2';
+		$this->Controller->Session->write('_locked', 'a:2:{i:0;s:14:"Addresses.0.id";i:1;s:14:"Addresses.1.id";}');
 
 		$this->Controller->data = array(
 			'Addresses' => array(
@@ -727,7 +731,8 @@ DIGEST;
 	function testValidatePostMultipleSelect() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '422cde416475abc171568be690a98cad20e66079%3An%3A0%3A%7B%7D';
+		$fields = '422cde416475abc171568be690a98cad20e66079';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'Tag' => array('Tag' => array(1, 2)),
@@ -750,7 +755,8 @@ DIGEST;
 		$result = $this->Controller->Security->validatePost($this->Controller);
 		$this->assertTrue($result);
 
-		$fields = '19464422eafe977ee729c59222af07f983010c5f%3An%3A0%3A%7B%7D';
+		$fields = '19464422eafe977ee729c59222af07f983010c5f';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 		$this->Controller->data = array(
 			'User.password' => 'bar', 'User.name' => 'foo', 'User.is_valid' => '1',
 			'Tag' => array('Tag' => array(1)), '_Token' => compact('key', 'fields'),
@@ -771,8 +777,8 @@ DIGEST;
 	function testValidatePostCheckbox() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877%3An%3A1%3A%7Bv%3A0%';
-		$fields .= '3Bf%3A11%3A%22Zbqry.inyvq%22%3B%7D';
+		$fields = 'a5475372b40f6e3ccbf9f8af191f20e1642fd877';
+		$this->Controller->Session->write('_locked', 'a:1:{i:0;s:11:"Model.valid";}');
 
 		$this->Controller->data = array(
 			'Model' => array('username' => '', 'password' => '', 'valid' => '0'),
@@ -782,7 +788,8 @@ DIGEST;
 		$result = $this->Controller->Security->validatePost($this->Controller);
 		$this->assertTrue($result);
 
-		$fields = '874439ca69f89b4c4a5f50fb9c36ff56a28f5d42%3An%3A0%3A%7B%7D';
+		$fields = '874439ca69f89b4c4a5f50fb9c36ff56a28f5d42';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'Model' => array('username' => '', 'password' => '', 'valid' => '0'),
@@ -815,8 +822,8 @@ DIGEST;
 	function testValidatePostHidden() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '51ccd8cb0997c7b3d4523ecde5a109318405ef8c%3An%3A2%3A%7Bv%3A0%3Bf%3A12%3A';
-		$fields .= '%22Zbqry.uvqqra%22%3Bv%3A1%3Bf%3A18%3A%22Zbqry.bgure_uvqqra%22%3B%7D';
+		$fields = '51ccd8cb0997c7b3d4523ecde5a109318405ef8c';
+		$this->Controller->Session->write('_locked', 'a:2:{i:0;s:12:"Model.hidden";i:1;s:18:"Model.other_hidden";}');
 
 		$this->Controller->data = array(
 			'Model' => array(
@@ -839,8 +846,8 @@ DIGEST;
 		$this->Controller->Security->disabledFields = array('Model.username', 'Model.password');
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'ef1082968c449397bcd849f963636864383278b1%3An%3A1%3A%7Bv%';
-		$fields .= '3A0%3Bf%3A12%3A%22Zbqry.uvqqra%22%3B%7D';
+		$fields = 'ef1082968c449397bcd849f963636864383278b1';
+		$this->Controller->Session->write('_locked', 'a:1:{i:0;s:12:"Model.hidden";}');
 
 		$this->Controller->data = array(
 			'Model' => array(
@@ -862,9 +869,8 @@ DIGEST;
 	function testValidateHiddenMultipleModel() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = 'a2d01072dc4660eea9d15007025f35a7a5b58e18%3An%3A3%3A%7Bv%3A0%3Bf%3A11';
-		$fields .= '%3A%22Zbqry.inyvq%22%3Bv%3A1%3Bf%3A12%3A%22Zbqry2.inyvq%22%3Bv%3A2%';
-		$fields .= '3Bf%3A12%3A%22Zbqry3.inyvq%22%3B%7D';
+		$fields = 'a2d01072dc4660eea9d15007025f35a7a5b58e18';
+		$this->Controller->Session->write('_locked', 'a:3:{i:0;s:11:"Model.valid";i:1;s:12:"Model2.valid";i:2;s:12:"Model3.valid";}');
 
 		$this->Controller->data = array(
 			'Model' => array('username' => '', 'password' => '', 'valid' => '0'),
@@ -895,9 +901,8 @@ DIGEST;
 	function testValidateHasManyModel() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '51e3b55a6edd82020b3f29c9ae200e14bbeb7ee5%3An%3A4%3A%7Bv%3A0%3Bf%3A14%3A%2';
-		$fields .= '2Zbqry.0.uvqqra%22%3Bv%3A1%3Bf%3A13%3A%22Zbqry.0.inyvq%22%3Bv%3A2%3Bf%3';
-		$fields .= 'A14%3A%22Zbqry.1.uvqqra%22%3Bv%3A3%3Bf%3A13%3A%22Zbqry.1.inyvq%22%3B%7D';
+		$fields = '51e3b55a6edd82020b3f29c9ae200e14bbeb7ee5';
+		$this->Controller->Session->write('_locked', 'a:4:{i:0;s:14:"Model.0.hidden";i:1;s:13:"Model.0.valid";i:2;s:14:"Model.1.hidden";i:3;s:13:"Model.1.valid";}');
 
 		$this->Controller->data = array(
 			'Model' => array(
@@ -926,9 +931,8 @@ DIGEST;
 	function testValidateHasManyRecordsPass() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '7a203edb3d345bbf38fe0dccae960da8842e11d7%3An%3A4%3A%7Bv%3A0%3Bf%3A12%3A%2';
-		$fields .= '2Nqqerff.0.vq%22%3Bv%3A1%3Bf%3A17%3A%22Nqqerff.0.cevznel%22%3Bv%3A2%3Bf%';
-		$fields .= '3A12%3A%22Nqqerff.1.vq%22%3Bv%3A3%3Bf%3A17%3A%22Nqqerff.1.cevznel%22%3B%7D';
+		$fields = '7a203edb3d345bbf38fe0dccae960da8842e11d7';
+		$this->Controller->Session->write('_locked', 'a:4:{i:0;s:12:"Address.0.id";i:1;s:17:"Address.0.primary";i:2;s:12:"Address.1.id";i:3;s:17:"Address.1.primary";}');
 
 		$this->Controller->data = array(
 			'Address' => array(
@@ -1181,7 +1185,8 @@ DIGEST;
 	function testFormDisabledFields() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '11842060341b9d0fc3808b90ba29fdea7054d6ad%3An%3A0%3A%7B%7D';
+		$fields = '11842060341b9d0fc3808b90ba29fdea7054d6ad';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'MyModel' => array('name' => 'some data'),
@@ -1212,7 +1217,8 @@ DIGEST;
 	function testRadio() {
 		$this->Controller->Security->startup($this->Controller);
 		$key = $this->Controller->params['_Token']['key'];
-		$fields = '575ef54ca4fc8cab468d6d898e9acd3a9671c17e%3An%3A0%3A%7B%7D';
+		$fields = '575ef54ca4fc8cab468d6d898e9acd3a9671c17e';
+		$this->Controller->Session->write('_locked', 'a:0:{}');
 
 		$this->Controller->data = array(
 			'_Token' => compact('key', 'fields')

--- a/cake/tests/cases/libs/view/helpers/form.test.php
+++ b/cake/tests/cases/libs/view/helpers/form.test.php
@@ -829,10 +829,10 @@ class FormHelperTest extends CakeTestCase {
 		$key = 'testKey';
 		$fields = array('Model.password', 'Model.username', 'Model.valid' => '0');
 		$this->Form->params['_Token']['key'] = $key;
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($fields);
 
 		$expected = Security::hash(serialize($fields) . Configure::read('Security.salt'));
-		$expected .= ':' . str_rot13(serialize(array('Model.valid')));
 
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
@@ -843,6 +843,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$Session = ClassRegistry::getObject('Session');
+		$locked = 'a:1:{i:0;s:11:"Model.valid";}';
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -892,11 +896,10 @@ class FormHelperTest extends CakeTestCase {
 			'Model.1.hidden' => 'value', 'Model.1.valid' => '0'
 		);
 		$this->Form->params['_Token']['key'] = $key;
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($fields);
 
-		$hash  = '51e3b55a6edd82020b3f29c9ae200e14bbeb7ee5%3An%3A4%3A%7Bv%3A0%3Bf%3A14%3A%22Zbqry.';
-		$hash .= '0.uvqqra%22%3Bv%3A1%3Bf%3A13%3A%22Zbqry.0.inyvq%22%3Bv%3A2%3Bf%3A14%3A%22Zbqry.1';
-		$hash .= '.uvqqra%22%3Bv%3A3%3Bf%3A13%3A%22Zbqry.1.inyvq%22%3B%7D';
+		$hash  = '51e3b55a6edd82020b3f29c9ae200e14bbeb7ee5';
 
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
@@ -907,6 +910,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$Session = ClassRegistry::getObject('Session');
+		$locked = 'a:4:{i:0;s:14:"Model.0.hidden";i:1;s:13:"Model.0.valid";i:2;s:14:"Model.1.hidden";i:3;s:13:"Model.1.valid";}';
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -983,10 +990,10 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->input('Addresses.1.phone');
 		$this->Form->input('Addresses.1.primary', array('type' => 'checkbox'));
 
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($this->Form->fields);
 
-		$hash = 'c9118120e680a7201b543f562e5301006ccfcbe2%3An%3A2%3A%7Bv%3A0%3Bf%3A14%';
-		$hash .= '3A%22Nqqerffrf.0.vq%22%3Bv%3A1%3Bf%3A14%3A%22Nqqerffrf.1.vq%22%3B%7D';
+		$hash = 'c9118120e680a7201b543f562e5301006ccfcbe2';
 
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
@@ -997,6 +1004,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$locked = 'a:2:{i:0;s:14:"Addresses.0.id";i:1;s:14:"Addresses.1.id";}';
+		$Session = ClassRegistry::getObject('Session');
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -1028,9 +1039,9 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->input('Addresses.1.city');
 		$this->Form->input('Addresses.1.phone');
 
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($this->Form->fields);
-		$hash = '774df31936dc850b7d8a5277dc0b890123788b09%3An%3A2%3A%7Bv%3A0%3Bf%3A14%3A%22Nqqerf';
-		$hash .= 'frf.0.vq%22%3Bv%3A1%3Bf%3A14%3A%22Nqqerffrf.1.vq%22%3B%7D';
+		$hash = '774df31936dc850b7d8a5277dc0b890123788b09';
 
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
@@ -1041,6 +1052,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$locked = 'a:2:{i:0;s:14:"Addresses.0.id";i:1;s:14:"Addresses.1.id";}';
+		$Session = ClassRegistry::getObject('Session');
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -1072,10 +1087,10 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertEqual($result, $expected);
 
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($expected);
 
-		$hash = '449b7e889128e8e52c5e81d19df68f5346571492%3An%3A1%3A%';
-		$hash .= '7Bv%3A0%3Bf%3A12%3A%22Nqqerffrf.vq%22%3B%7D';
+		$hash = '449b7e889128e8e52c5e81d19df68f5346571492';
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
 			'input' => array(
@@ -1085,6 +1100,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$locked = 'a:1:{i:0;s:12:"Addresses.id";}';
+		$Session = ClassRegistry::getObject('Session');
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -1179,9 +1198,9 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertEqual($result, $expected);
 
-		$hash = 'bd7c4a654e5361f9a433a43f488ff9a1065d0aaf%3An%3A2%3A%7Bv%3A0%3Bf%3A15%3';
-		$hash .= 'A%22HfreSbez.uvqqra%22%3Bv%3A1%3Bf%3A14%3A%22HfreSbez.fghss%22%3B%7D';
+		$hash = 'bd7c4a654e5361f9a433a43f488ff9a1065d0aaf';
 
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($this->Form->fields);
 		$expected = array(
 			'div' => array('style' => 'display:none;'),
@@ -1192,6 +1211,10 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+
+		$locked = 'a:2:{i:0;s:15:"UserForm.hidden";i:1;s:14:"UserForm.stuff";}';
+		$Session = ClassRegistry::getObject('Session');
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -3137,7 +3160,7 @@ class FormHelperTest extends CakeTestCase {
 			'/select'
 		);
 		$this->assertTags($result, $expected);
-		
+
 		$options = array(
 			'>< Key' => array(
 				1 => 'One',
@@ -3515,7 +3538,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	function testSelectMultipleCheckboxDiv() {
 		$result = $this->Form->select(
-			'Model.tags', 
+			'Model.tags',
 			array('first', 'second'),
 			null,
 			array('multiple' => 'checkbox', 'class' => 'my-class')
@@ -3544,7 +3567,7 @@ class FormHelperTest extends CakeTestCase {
 
 		$result = $this->Form->input('Model.tags', array(
 			'options' => array('first', 'second'),
-			'multiple' => 'checkbox', 
+			'multiple' => 'checkbox',
 			'class' => 'my-class',
 			'div' => false,
 			'label' => false
@@ -3568,9 +3591,14 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertEqual($this->Form->fields, array('Model.multi_field'));
 
+		ClassRegistry::addObject('Session', new FormHelperTestSessionMock());
 		$result = $this->Form->secure($this->Form->fields);
-		$key = 'f7d573650a295b94e0938d32b323fde775e5f32b%3An%3A0%3A%7B%7D';
+		$key = 'f7d573650a295b94e0938d32b323fde775e5f32b';
 		$this->assertPattern('/"' . $key . '"/', $result);
+
+		$Session = ClassRegistry::getObject('Session');
+		$locked = 'a:0:{}';
+		$this->assertEqual($locked, $Session->read('_locked'));
 	}
 
 /**
@@ -6615,4 +6643,19 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+}
+
+class FormHelperTestSessionMock {
+  var $values = array();
+
+  function write($key, $value) {
+		$this->values[$key] = $value;
+  }
+
+  function read($key) {
+		if (!empty($this->values[$key])) {
+		  return $this->values[$key];
+		}
+		return null;
+  }
 }


### PR DESCRIPTION
- $locked(SecurityComponent#_validatePost()) is no need to receive from outside.
- This patch changed that it store $locked in a session instead of a hidden field.
- So that unserialize($locked) is safety beacuse $locked can't change from outside.
