### PR TITLE
Model::field() with TranslateBehavior

### DIFF
--- a/cake/libs/model/behaviors/translate.php
+++ b/cake/libs/model/behaviors/translate.php
@@ -115,6 +115,8 @@ class TranslateBehavior extends ModelBehavior {
 				)
 			);
 			return $query;
+		} elseif (is_string($query['fields'])) {
+			$query['fields'] = array($query['fields']);
 		}
 		$autoFields = false;
 

--- a/cake/tests/cases/libs/model/behaviors/translate.test.php
+++ b/cake/tests/cases/libs/model/behaviors/translate.test.php
@@ -493,6 +493,23 @@ class TranslateBehaviorTest extends CakeTestCase {
 	}
 
 /**
+ * testReadTranslatedField method
+ *
+ * @access public
+ * @return void
+ */
+	function testReadTranslatedField() {
+		$this->loadFixtures('Translate', 'TranslatedItem');
+
+		$TestModel =& new TranslatedItem();
+		$TestModel->locale = 'eng';
+		$TestModel->id = 1;
+		$result = $TestModel->field('title');
+		$expected = 'Title #1';
+		$this->assertEqual($result, $expected);
+	}
+
+/**
  * testSaveCreate method
  *
  * @access public


### PR DESCRIPTION
This fixes the Model::field() call on a field that is handled with translation using the TranslateBehavior.
