### PR TITLE
Fix for bad encoded strftime() values when LC_TIME has code points higher than 128

### DIFF
--- a/cake/libs/multibyte.php
+++ b/cake/libs/multibyte.php
@@ -1066,6 +1066,34 @@ class Multibyte extends Object {
 	}
 
 /**
+ * Format a local time/date according to locale settings, using the app's encoding
+ *
+ * @return string
+ * @access public
+ * @static
+ */
+	function strftime() {
+		$args = func_get_args();
+		$format = call_user_func_array('strftime', $args);
+		if (function_exists('mb_internal_encoding')) {
+			$encoding = mb_internal_encoding();
+		} else {
+			$encoding = Configure::read('App.encoding');
+		}
+		if (!empty($encoding) && $encoding === 'UTF-8') {
+			if (function_exists('mb_check_encoding')) {
+				$valid = mb_check_encoding($format, $encoding);
+			} else {
+				$multibyte = Multibyte::checkMultibyte($format);
+			}
+			if (empty($valid) || !empty($multibyte)) {
+				$format = utf8_encode($format);
+			}
+		}
+		return $format;
+	}
+
+/**
  * Return the Code points range for Unicode characters
  *
  * @param interger $decimal

--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -19,6 +19,9 @@
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+if (!class_exists('Multibyte')) {
+	App::import('Core', 'Multibyte');
+}
 
 /**
  * Form helper library.
@@ -1811,7 +1814,7 @@ class FormHelper extends AppHelper {
 				extract($selected);
 			} else {
 				if (is_numeric($selected)) {
-					$selected = strftime('%Y-%m-%d %H:%M:%S', $selected);
+					$selected = Multibyte::strftime('%Y-%m-%d %H:%M:%S', $selected);
 				}
 				$meridian = 'am';
 				$pos = strpos($selected, '-');
@@ -2135,7 +2138,7 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
+						$data[sprintf("%02s", $m)] = Multibyte::strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
 					}
 				}
 			break;

--- a/cake/libs/view/helpers/time.php
+++ b/cake/libs/view/helpers/time.php
@@ -17,6 +17,9 @@
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+if (!class_exists('Multibyte')) {
+	App::import('Core', 'Multibyte');
+}
 
 /**
  * Time Helper class for easy use of time data.
@@ -204,7 +207,7 @@ class TimeHelper extends AppHelper {
 			$date = time();
 		}
 		$format = $this->convertSpecifiers('%a, %b %eS %Y, %H:%M', $date);
-		return strftime($format, $date);
+		return Multibyte::strftime($format, $date);
 	}
 
 /**
@@ -227,12 +230,12 @@ class TimeHelper extends AppHelper {
 		$y = $this->isThisYear($date) ? '' : ' %Y';
 
 		if ($this->isToday($date)) {
-			$ret = sprintf(__('Today, %s',true), strftime("%H:%M", $date));
+			$ret = sprintf(__('Today, %s',true), Multibyte::strftime("%H:%M", $date));
 		} elseif ($this->wasYesterday($date)) {
-			$ret = sprintf(__('Yesterday, %s',true), strftime("%H:%M", $date));
+			$ret = sprintf(__('Yesterday, %s',true), Multibyte::strftime("%H:%M", $date));
 		} else {
 			$format = $this->convertSpecifiers("%b %eS{$y}, %H:%M", $date);
-			$ret = strftime($format, $date);
+			$ret = Multibyte::strftime($format, $date);
 		}
 
 		return $ret;
@@ -730,6 +733,6 @@ class TimeHelper extends AppHelper {
 			$format = '%x';
 		}
 		$format = $this->convertSpecifiers($format, $date);
-		return strftime($format, $date);
+		return Multibyte::strftime($format, $date);
 	}
 }

--- a/cake/tests/cases/libs/view/helpers/time.test.php
+++ b/cake/tests/cases/libs/view/helpers/time.test.php
@@ -751,18 +751,18 @@ class TimeHelperTest extends CakeTestCase {
 			'locales' => array(TEST_CAKE_CORE_INCLUDE_PATH . 'tests' . DS . 'test_app' . DS . 'locale' . DS)
 		), true);
 		Configure::write('Config.language', 'time_test');
-		$time = strtotime('Thu Jan 14 13:59:28 2010');
+		$time = strtotime('Wed Jan 13 13:59:28 2010');
 
 		$result = $this->Time->i18nFormat($time);
-		$expected = '14/01/10';
+		$expected = '13/01/10';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Time->i18nFormat($time, '%c');
-		$expected = 'jue 14 ene 2010 13:59:28 ' . strftime('%Z', $time);
+		$expected = 'mié 13 ene 2010 13:59:28 ' . strftime('%Z', $time);
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
-		$expected = 'Time is 01:59:28 PM, and date is 14/01/10';
+		$expected = 'Time is 01:59:28 PM, and date is 13/01/10';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Time->i18nFormat('invalid date', '%x', 'Date invalid');


### PR DESCRIPTION
Fixes 912 (http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/912) and maybe more. Harden tests.
