### PR TITLE
Oracle driver problem

### DIFF
--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -270,6 +270,7 @@ class DboOracle extends DboSource {
 		$find = array('SELECT');
 		$replace = array('');
 		$fieldList = trim(str_replace($find, $replace, $preFrom));
+        $fieldList = preg_replace('/\([^)]*\)/', '', $fieldList); // this line fixes problems with functions like SUBSTR(string, start, width)
 		$fields = preg_split('/,\s+/', $fieldList);//explode(', ', $fieldList);
 		$lastTableName	= '';
 


### PR DESCRIPTION
When you use sql functions like SUBSTR, which requires more than one parameter, the final mapping is incorrect.

Example:
select substr(field_1, 1, 6) as renamed_field, field_2 from table;

Expected mapping:
array('renamed_field' => 'value1', 'field_2' => 'value2');

Current mapping:
array('substr(field_1' => 'value1', '1' => 'value2');
