### PR TITLE
Fixed a small potential bug.

### DIFF
--- a/cake/libs/view/helper.php
+++ b/cake/libs/view/helper.php
@@ -708,7 +708,7 @@ class Helper extends Overloadable {
 		}
 
 		$habtmKey = $this->field();
-		if (empty($result) && isset($this->data[$habtmKey][$habtmKey])) {
+		if (empty($result) && isset($this->data[$habtmKey][$habtmKey]) && is_array($this->data[$habtmKey])) {
 			$result = $this->data[$habtmKey][$habtmKey];
 		} elseif (empty($result) && isset($this->data[$habtmKey]) && is_array($this->data[$habtmKey])) {
 			if (ClassRegistry::isKeySet($habtmKey)) {


### PR DESCRIPTION
When creating a form like this:

```
        <?= $form->create(false, array('action' => 'search')) ?>
```

A textfield created like this:

```
        <?= $form->input('Ad.location_name')) ?>
```

Would trigger a bug where the value would be set to the first character of the string $data['location_name'].

I realize this is not a big issue, but It was very unexpected, and took me a while to trace down. Workaround/Solution: Don't use model names in "false" forms.
