### PR TITLE
Allow to disable the garbage collector autolauch

### DIFF
--- a/cake/libs/cache.php
+++ b/cake/libs/cache.php
@@ -149,7 +149,7 @@ class Cache {
 		$cacheClass = $class . 'Engine';
 		$this->_engines[$name] =& new $cacheClass();
 		if ($this->_engines[$name]->init($config)) {
-			if (!is_null($this->_engines[$name]->settings['probability']) && time() % $this->_engines[$name]->settings['probability'] === 0) {
+			if ($this->_engines[$name]->settings['probability'] && time() % $this->_engines[$name]->settings['probability'] === 0) {
 				$this->_engines[$name]->gc();
 			}
 			return true;

--- a/cake/libs/cache.php
+++ b/cake/libs/cache.php
@@ -149,7 +149,7 @@ class Cache {
 		$cacheClass = $class . 'Engine';
 		$this->_engines[$name] =& new $cacheClass();
 		if ($this->_engines[$name]->init($config)) {
-			if (time() % $this->_engines[$name]->settings['probability'] === 0) {
+			if (!is_null($this->_engines[$name]->settings['probability']) && time() % $this->_engines[$name]->settings['probability'] === 0) {
 				$this->_engines[$name]->gc();
 			}
 			return true;


### PR DESCRIPTION
On large cache datasets, the garbage collecting may be a weighted process.
If it happens while responding to an http request, it may leads to an overtime for the client.

This commit allows to disable the auto lauch by setting a "null" probability in the cache config.
Then, an extra process should be implemented, such as a shell process which calls the garbage collector outside any web request.

Not sure about which branch to request the pull.
