### PR TITLE
Fixing undefined var and docblock error in CakeCliReporter->paintException().

### DIFF
--- a/cake/tests/lib/reporter/cake_cli_reporter.php
+++ b/cake/tests/lib/reporter/cake_cli_reporter.php
@@ -92,13 +92,13 @@ class CakeCliReporter extends CakeBaseReporter {
 /**
  * Paint exception faildetail to STDERR.
  *
- * @param string $message Message of the Error
+ * @param object $exception Exception instance
  * @return void
  * @access public
  */
 	function paintException($exception) {
 		parent::paintException($exception);
-		$message .= sprintf('Unexpected exception of type [%s] with message [%s] in [%s] line [%s]',
+		$message = sprintf('Unexpected exception of type [%s] with message [%s] in [%s] line [%s]',
 			get_class($exception),
 			$exception->getMessage(),
 			$exception->getFile(),


### PR DESCRIPTION
If you run the testsuite on the command line and it catches an unexpected exception, there's a warning thrown due to a small syntax error in the reporter:

```
E_NOTICE: Undefined variable: message in ..../cake/tests/lib/reporter/cake_cli_reporter.php on line 106
```

Also the docblock is incorrect as it refers to a $message string when the param is actually an $exception object.

Both these problems were introduced in the same commit d3e0ddbb0e008782bd401dfa07e492ceffac2883 which was just supposed to fix copyright years.
