### PR TITLE
Added parse error attribute to xml class.

### DIFF
--- a/cake/libs/xml.php
+++ b/cake/libs/xml.php
@@ -838,6 +838,16 @@ class Xml extends XmlNode {
  * @access private
  */
 	var $encoding = 'UTF-8';
+	
+/**
+ * XML parse error
+ *
+ * @var array
+ * @access public
+ */
+	var $error = array();
+
+
 
 /**
  * Constructor.  Sets up the XML parser with options, gives it this object as
@@ -937,6 +947,10 @@ class Xml extends XmlNode {
 		));
 
 		xml_parse_into_struct($this->__parser, $this->__rawData, $vals);
+		$this->error['code'] = xml_get_error_code($this->__parser);
+		$this->error['message'] = xml_error_string(xml_get_error_code($this->__parser));  
+		$this->error['line_number'] = xml_get_current_line_number($this->__parser);
+		
 		$xml =& $this;
 		$count = count($vals);
 


### PR DESCRIPTION
Added parse error attribute to xml class. 

Now after you do something like:

<pre><code>
$xml = new Xml($xmlString); 
$xml->error['code']; 
$xml->error['message']; 
$xml->error['line_number'];
</code></pre>


are all available to help you figure out what is going on.
