### PR TITLE
Generate full url from Router::reverse()

### DIFF
--- a/cake/libs/router.php
+++ b/cake/libs/router.php
@@ -1060,7 +1060,7 @@ class Router {
  * @access public
  * @static
  */
-	function reverse($params) {
+	function reverse($params, $full = false) {
 		$pass = $params['pass'];
 		$named = $params['named'];
 		$url = $params['url'];
@@ -1072,7 +1072,7 @@ class Router {
 		if (!empty($url)) {
 			$params['?'] = $url;
 		}
-		return Router::url($params);
+		return Router::url($params, $full);
 	}
 
 /**

--- a/cake/tests/cases/libs/router.test.php
+++ b/cake/tests/cases/libs/router.test.php
@@ -2147,6 +2147,17 @@ class RouterTest extends CakeTestCase {
 		);
 		$result = Router::reverse($params);
 		$this->assertEqual($result, '/eng/posts/view/1?foo=bar&baz=quu');
+		
+		$params = array(
+			'lang' => 'eng',
+			'controller' => 'posts',
+			'action' => 'view',
+			'pass' => array(1),
+			'named' => array(),
+			'url' => array('url' => 'eng/posts/view/1')
+		);
+		$result = Router::reverse($params, true);
+		$this->assertPattern('/^http(s)?:\/\//', $result);
 	}
 }
 


### PR DESCRIPTION
Added a  flag to Router::reverse that is passed on to the Router::url call to generate a full url. Defaults to false in Router::reverse().
