### PR TITLE
Fix issue #1559

### DIFF
--- a/cake/tests/lib/cake_test_fixture.php
+++ b/cake/tests/lib/cake_test_fixture.php
@@ -69,7 +69,7 @@ class CakeTestFixture extends Object {
 	function init() {
 		if (isset($this->import) && (is_string($this->import) || is_array($this->import))) {
 			$import = array_merge(
-				array('connection' => 'default', 'records' => false), 
+				array('connection' => 'default', 'records' => false),
 				is_array($this->import) ? $this->import : array('model' => $this->import)
 			);
 
@@ -175,15 +175,25 @@ class CakeTestFixture extends Object {
 			$values = array();
 
 			if (isset($this->records) && !empty($this->records)) {
+				$fields = array();
+				foreach($this->records as $record) {
+					$fields = array_merge($fields, array_keys(array_intersect_key($record, $this->fields)));
+				}
+				$fields = array_unique($fields);
+				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-					$fields = array_keys($record);
-					$values[] = '(' . implode(', ', array_map(array(&$db, 'value'), array_values($record))) . ')';
+					$recordValues = array();
+					foreach(array_merge($default, array_map(array(&$db, 'value'), $record)) as $value) {
+						$recordValues[] = is_null($value) ? 'NULL' : $value;
+					}
+					$values[] = '(' . implode(', ', $recordValues) . ')';
 				}
 				return $db->insertMulti($this->table, $fields, $values);
 			}
 			return true;
 		}
 	}
+
 
 /**
  * Truncates the current fixture. Can be overwritten by classes extending CakeFixture to trigger other events before / after


### PR DESCRIPTION
Fixes issue with fixture records defining fields in wrong order, or adding fields in some records that are not defined in others. This issue is documented in:

http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/1559-fixtures-records-with-different-fields-are-not-inserted-properly#ticket-1559-5
