### PR TITLE
Support for setting variables in PostgresSQL and MySQL DboSource. 

### DIFF
--- a/cake/libs/model/datasources/dbo/dbo_mysql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysql.php
@@ -562,7 +562,14 @@ class DboMysql extends DboMysqlBase {
 		if (!empty($config['encoding'])) {
 			$this->setEncoding($config['encoding']);
 		}
-
+	
+		// Support any SET ... = ... (http://dev.mysql.com/doc/refman/5.1/en/set-option.html)	
+		if (!empty($config['settings'])) {
+			foreach ($config['settings'] as $name => $value) {
+				$this->_execute("SET " . $name . " = " . $value);
+			}
+		}
+		
 		$this->_useAlias = (bool)version_compare(mysql_get_server_info($this->connection), "4.1", ">=");
 
 		return $this->connected;

--- a/cake/libs/model/datasources/dbo/dbo_postgres.php
+++ b/cake/libs/model/datasources/dbo/dbo_postgres.php
@@ -129,6 +129,12 @@ class DboPostgres extends DboSource {
 		if (!empty($config['encoding'])) {
 			$this->setEncoding($config['encoding']);
 		}
+		// Support any SET ... TO ... (http://www.postgresql.org/docs/9.0/static/sql-set.html)	
+		if (!empty($config['settings'])) {
+			foreach ($config['settings'] as $name => $value) {
+				$this->_execute("SET " . $name . " TO " . $value);
+			}
+		}
 		return $this->connected;
 	}
 


### PR DESCRIPTION
I've made some modification in the DboPostgres and DboMysqlBase in order to allow to set variables in the begining of the connection.

The sintax is described in:
http://www.postgresql.org/docs/9.0/static/sql-set.html
http://dev.mysql.com/doc/refman/5.1/en/set-option.html

The idea is very simple: In the database configuration, it could be set the key settings with an array of variables to set in the beginning of the connection.

One concrete example of use is to set a different datestyle.

PS: That's my first pull request, I hope everything is ok, if no, please tell me.
PS2: I know that there is a similar pull request of remidewitte (https://github.com/cakephp/cakephp/pull/41). I've done this one because this request is smaller and atomic.
