### PR TITLE
fixing bug #1646 - split element parameters into varaibles and params

### DIFF
--- a/cake/tests/cases/libs/view/view.test.php
+++ b/cake/tests/cases/libs/view/view.test.php
@@ -422,7 +422,7 @@ class ViewTest extends CakeTestCase {
 		$result = $this->View->element('test_element');
 		$this->assertEqual($result, 'this is the test element');
 		
-		$result = $this->View->element('plugin_element', array('plugin' => 'test_plugin'));
+		$result = $this->View->element('plugin_element', array(), array('plugin' => 'test_plugin'));
 		$this->assertEqual($result, 'this is the plugin element using params[plugin]');
 		
 		$this->View->plugin = 'test_plugin';

--- a/cake/tests/cases/libs/view/view.test.php
+++ b/cake/tests/cases/libs/view/view.test.php
@@ -500,32 +500,34 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 		$View->elementCache = 'test_view';
 
-		$result = $View->element('test_element', array('cache' => true));
+		$result = $View->element('test_element', array(), array('cache' => true));
 		$expected = 'this is the test element';
 		$this->assertEquals($expected, $result);
 
 		$result = Cache::read('element__test_element_cache', 'test_view');
 		$this->assertEquals($expected, $result);
-		
-		$result = $View->element('test_element', array('cache' => true, 'param' => 'one', 'foo' => 'two'));
+
+		$result = $View->element('test_element', array('param' => 'one', 'foo' => 'two'), array('cache' => true));
 		$this->assertEquals($expected, $result);
 
 		$result = Cache::read('element__test_element_cache_param_foo', 'test_view');
 		$this->assertEquals($expected, $result);
-		
+
 		$result = $View->element('test_element', array(
-			'cache' => array('key' => 'custom_key'),
 			'param' => 'one',
 			'foo' => 'two'
+		), array(
+			'cache' => array('key' => 'custom_key')
 		));
 		$result = Cache::read('element_custom_key', 'test_view');
 		$this->assertEquals($expected, $result);
-		
+
 		$View->elementCache = 'default';
 		$result = $View->element('test_element', array(
-			'cache' => array('config' => 'test_view'),
 			'param' => 'one',
 			'foo' => 'two'
+		), array(
+			'cache' => array('config' => 'test_view')
 		));
 		$result = Cache::read('element__test_element_cache_param_foo', 'test_view');
 		$this->assertEquals($expected, $result);


### PR DESCRIPTION
related to:
http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/1646-viewelement-should-separate-passed-variables-and-parameters
