### PR TITLE
Fixed a bug in the dateTime function of the form helper.

### DIFF
--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -1826,9 +1826,8 @@ class FormHelper extends AppHelper {
 
 				if (!empty($timeFormat)) {
 					$time = explode(':', $days[1]);
-					$check = str_replace(':', '', $days[1]);
 
-					if (($check > 115959) && $timeFormat == '12') {
+					if (($time[0] > 12) && $timeFormat == '12') {
 						$time[0] = $time[0] - 12;
 						$meridian = 'pm';
 					} elseif ($time[0] == '00' && $timeFormat == '12') {


### PR DESCRIPTION
I fixed a bug in the dateTime function that prevented the proper hour from being selected because the check for past noon required seconds to be set and they weren't. The view needed hour, minute, and meridian boxes and the time to be shown was 18:15. Debugging the value of $check showed that it was 1815 which is not greater than 115959 which prevented the 12 hours from being subtracted which then prevented the value of 6 from being selected by default in the HTML select box. This fix instead checks to see if the hours is greater than 12 and if so subtracts 12 and sets the meridian to PM.
