### PR TITLE
Fix Ticket #825

### DIFF
--- a/cake/libs/cache.php
+++ b/cake/libs/cache.php
@@ -548,6 +548,12 @@ class Cache {
 		}
 		return array();
 	}
+
+	function __destruct() {
+		if (Configure::read('Session.save') == 'cache' && function_exists('session_write_close')) {
+		        session_write_close();
+		    }
+	}
 }
 
 /**


### PR DESCRIPTION
http://cakephp.lighthouseapp.com/projects/42648/tickets/825-debuggerphp-error-when-session-set-to-cache

As proposed by 0x20h
