### PR TITLE
2.0 testsuite

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -21,7 +21,7 @@ define('CORE_TEST_CASES', LIBS . 'tests' . DS . 'Case');
 define('APP_TEST_CASES', TESTS . 'Case');
 
 App::uses('CakeTestSuiteCommand', 'TestSuite');
-
+App::uses('Router', 'Routing');
 /**
  * CakeTestSuiteDispatcher handles web requests to the test suite and runs the correct action.
  *
@@ -92,6 +92,8 @@ class CakeTestSuiteDispatcher {
 	function dispatch() {
 		$this->_checkPHPUnit();
 		$this->_parseParams();
+
+		Router::setRequestInfo($this->params);
 
 		if ($this->params['case']) {
 			$value = $this->_runTestCase();


### PR DESCRIPTION
Added call to Router::setRequestInfo() in CakeTestSuiteDispatcher::dispatch().
Fixes creation of Controller object with missing CakeRequest in Exception Renderer.
Fixes #1678
