### PR TITLE
2.0 memcache

### DIFF
--- a/app/config/core.php
+++ b/app/config/core.php
@@ -279,7 +279,7 @@
  * 		'servers' => array(
  * 			'127.0.0.1:11211' // localhost, default port 11211
  * 		), //[optional]
- * 		'persistent' => true // [optional] set this to false for non-persistent connections (i.e. when using fcgi)
+ * 		'persistent' => true, // [optional] set this to false for non-persistent connections
  * 		'compress' => false, // [optional] compress data in Memcache (slower, but uses less memory)
  *	));
  *

--- a/app/config/core.php
+++ b/app/config/core.php
@@ -279,6 +279,7 @@
  * 		'servers' => array(
  * 			'127.0.0.1:11211' // localhost, default port 11211
  * 		), //[optional]
+ * 		'persistent' => true // [optional] set this to false for non-persistent connections (i.e. when using fcgi)
  * 		'compress' => false, // [optional] compress data in Memcache (slower, but uses less memory)
  *	));
  *

--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -64,6 +64,7 @@ class MemcacheEngine extends CacheEngine {
 			'engine'=> 'Memcache',
 			'prefix' => Inflector::slug(APP_DIR) . '_',
 			'servers' => array('127.0.0.1'),
+			'persistent' => true,
 			'compress'=> false
 			), $settings)
 		);
@@ -79,7 +80,7 @@ class MemcacheEngine extends CacheEngine {
 			$this->_Memcache = new Memcache();
 			foreach ($this->settings['servers'] as $server) {
 				list($host, $port) = $this->_parseServerString($server);
-				if ($this->_Memcache->addServer($host, $port)) {
+				if ($this->_Memcache->addServer($host, $port, $this->settings['persistent'])) {
 					$return = true;
 				}
 			}

--- a/lib/Cake/Console/templates/skel/config/core.php
+++ b/lib/Cake/Console/templates/skel/config/core.php
@@ -279,6 +279,7 @@
  * 		'servers' => array(
  * 			'127.0.0.1:11211' // localhost, default port 11211
  * 		), //[optional]
+ * 		'persistent' => true, // [optional] set this to false for non-persistent connections
  * 		'compress' => false, // [optional] compress data in Memcache (slower, but uses less memory)
  *	));
  *

--- a/lib/Cake/tests/Case/Cache/Engine/MemcacheTest.php
+++ b/lib/Cake/tests/Case/Cache/Engine/MemcacheTest.php
@@ -50,7 +50,7 @@ class MemcacheEngineTest extends CakeTestCase {
  * @return void
  */
 	function setUp() {
-		$this->skipIf(!class_exists('Memcache'), '%s Apc is not installed or configured properly');
+		$this->skipIf(!class_exists('Memcache'), '%s Memcache is not installed or configured properly');
 		$this->_cacheDisable = Configure::read('Cache.disable');
 		Configure::write('Cache.disable', false);
 		Cache::config('memcache', array(
@@ -86,6 +86,7 @@ class MemcacheEngineTest extends CakeTestCase {
 			'duration'=> 3600,
 			'probability' => 100,
 			'servers' => array('127.0.0.1'),
+			'persistent' => true,
 			'compress' => false,
 			'engine' => 'Memcache'
 		);


### PR DESCRIPTION
Added 'persistent' setting to MemcacheEngine.
Updated corresponding test case. 
Fixes #1705 when connections are not closed when using i.e. FCGI.
