### PR TITLE
Bake interactive console for 'Model' does not show validation rule 'uuid'

### DIFF
--- a/cake/console/libs/tasks/model.php
+++ b/cake/console/libs/tasks/model.php
@@ -353,6 +353,7 @@ class ModelTask extends BakeTask {
 				$default++;
 			}
 		}
+		$choices[$default] = 'none'; // Needed since index starts at 1
 		$this->_validations = $choices;
 		return $choices;
 	}
@@ -391,6 +392,8 @@ class ModelTask extends BakeTask {
 			if ($metaData['null'] != 1 && !in_array($fieldName, array($primaryKey, 'created', 'modified', 'updated'))) {
 				if ($fieldName == 'email') {
 					$guess = $methods['email'];
+				} elseif ($metaData['type'] == 'string' && $metaData['length'] == 36) {
+					$guess = $methods['uuid'];
 				} elseif ($metaData['type'] == 'string') {
 					$guess = $methods['notempty'];
 				} elseif ($metaData['type'] == 'integer') {

--- a/cake/tests/cases/console/libs/tasks/model.test.php
+++ b/cake/tests/cases/console/libs/tasks/model.test.php
@@ -197,31 +197,31 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('notempty' => 'notempty');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'date', 'length' => 10, 'null' => false));
 		$expected = array('date' => 'date');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'time', 'length' => 10, 'null' => false));
 		$expected = array('time' => 'time');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('email', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('email' => 'email');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('test', array('type' => 'integer', 'length' => 10, 'null' => false));
 		$expected = array('numeric' => 'numeric');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('test', array('type' => 'boolean', 'length' => 10, 'null' => false));
 		$expected = array('boolean' => 'boolean');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 
 		$result = $this->Task->fieldValidation('test', array('type' => 'string', 'length' => 36, 'null' => false));
 		$expected = array('uuid' => 'uuid');
-		$this->assertEqual($result, $expected);
+		$this->assertEqual($expected, $result);
 	}
 
 /**

--- a/cake/tests/cases/console/libs/tasks/model.test.php
+++ b/cake/tests/cases/console/libs/tasks/model.test.php
@@ -197,21 +197,31 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('notempty' => 'notempty');
+		$this->assertEqual($result, $expected);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'date', 'length' => 10, 'null' => false));
 		$expected = array('date' => 'date');
+		$this->assertEqual($result, $expected);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'time', 'length' => 10, 'null' => false));
 		$expected = array('time' => 'time');
+		$this->assertEqual($result, $expected);
 
 		$result = $this->Task->fieldValidation('email', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('email' => 'email');
+		$this->assertEqual($result, $expected);
 
 		$result = $this->Task->fieldValidation('test', array('type' => 'integer', 'length' => 10, 'null' => false));
 		$expected = array('numeric' => 'numeric');
+		$this->assertEqual($result, $expected);
 
 		$result = $this->Task->fieldValidation('test', array('type' => 'boolean', 'length' => 10, 'null' => false));
-		$expected = array('numeric' => 'numeric');
+		$expected = array('boolean' => 'boolean');
+		$this->assertEqual($result, $expected);
+
+		$result = $this->Task->fieldValidation('test', array('type' => 'string', 'length' => 36, 'null' => false));
+		$expected = array('uuid' => 'uuid');
+		$this->assertEqual($result, $expected);
 	}
 
 /**


### PR DESCRIPTION
When I used the interactive bake console to bake a model, I realized that the uuid validation message is missing. So I investigated this and realized that when the validation method index is starting at 1, you need to add one more index for the 'Do no validation rule', hence leaving the last validation rule (here: 'uuid') out.

Commit message:
Fixed wrong validation init in Model bake task when having index starting at 1.
Added guess 'uuid' for type 'string' and length 36.
Updated missing calls to assertEqual() testFieldValidationGuessing().
Added test for uuid guessing.
Fixes #1710.
