### PR TITLE
Fixed small typo in CakeTestLoader.php

### DIFF
--- a/lib/Cake/TestSuite/CakeTestLoader.php
+++ b/lib/Cake/TestSuite/CakeTestLoader.php
@@ -55,7 +55,7 @@ class CakeTestLoader extends PHPUnit_Runner_StandardTestSuiteLoader {
 		} elseif (!empty($params['app'])) {
 			$result = APP_TEST_CASES;
 		} else if (!empty($params['plugin']) && CakePlugin::loaded($params['plugin'])) {
-			$pluginPath = CakePLugin::path($params['plugin']);
+			$pluginPath = CakePlugin::path($params['plugin']);
 			$result = $pluginPath . 'Test' . DS . 'Case';
 		}
 		return $result;


### PR DESCRIPTION
Little typo in the CakeTestLoader.

BTW, plugin tests are not displayed since the plugins need to be loaded somewhere during test dispatching since `...} else if (!empty($params['plugin']) && CakePlugin::loaded($params['plugin'])) {...` will always be false at the moment.

Just as a hint :)

Greetz
Thomas
