### PR TITLE
Making plugin test cases being loaded by CakeTestLoader

### DIFF
--- a/lib/Cake/TestSuite/CakeTestLoader.php
+++ b/lib/Cake/TestSuite/CakeTestLoader.php
@@ -54,7 +54,10 @@ class CakeTestLoader extends PHPUnit_Runner_StandardTestSuiteLoader {
 			$result = CORE_TEST_CASES;
 		} elseif (!empty($params['app'])) {
 			$result = APP_TEST_CASES;
-		} else if (!empty($params['plugin']) && CakePlugin::loaded($params['plugin'])) {
+		} else if (!empty($params['plugin'])) {
+			if (!CakePlugin::loaded($params['plugin'])) {
+				CakePlugin::load($params['plugin']);
+			}
 			$pluginPath = CakePlugin::path($params['plugin']);
 			$result = $pluginPath . 'Test' . DS . 'Case';
 		}


### PR DESCRIPTION
Moved check for CakePlugin::loaded() out of if statement in CakeTestLoader::_basePath(). Plugin will only be loaded when the plugin tests are requested.
