### PR TITLE
2.0 appshell

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -210,6 +210,7 @@ class ShellDispatcher {
 		$class = Inflector::camelize($shell) . 'Shell';
 
 		App::uses('Shell', 'Console');
+		App::uses('AppShell', 'Console');
 		App::uses($class, $plugin . 'Console/Command');
 
 		if (!class_exists($class)) {


### PR DESCRIPTION
Load AppShell class.

This was discussed here and marked as resolved http://cakephp.lighthouseapp.com/projects/42648/tickets/1114-rfc-add-support-for-an-appshell-class but somehow the actual loading of the class got lost/left out.
