### PR TITLE
2.0 cakeplugin tests

### DIFF
--- a/lib/Cake/Test/Case/Core/CakePluginTest.php
+++ b/lib/Cake/Test/Case/Core/CakePluginTest.php
@@ -38,6 +38,7 @@ class CakePluginTest extends CakeTestCase {
  * @return void
  */
 	public function testLoadSingle() {
+		CakePlugin::unload();
 		CakePlugin::load('TestPlugin');
 		$expected = array('TestPlugin');
 		$this->assertEquals($expected, CakePlugin::loaded());

--- a/lib/Cake/Test/Case/Core/CakePluginTest.php
+++ b/lib/Cake/Test/Case/Core/CakePluginTest.php
@@ -28,6 +28,7 @@ class CakePluginTest extends CakeTestCase {
  */
 	public function tearDown() {
 		App::build();
+		App::objects('plugins', null, false);
 		CakePlugin::unload();
 		Configure::delete('CakePluginTest');
 	}

--- a/lib/Cake/Test/Case/Core/CakePluginTest.php
+++ b/lib/Cake/Test/Case/Core/CakePluginTest.php
@@ -18,6 +18,7 @@ class CakePluginTest extends CakeTestCase {
 		App::build(array(
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
 		), true);
+		App::objects('plugins', null, false);
 	}
 
 /**


### PR DESCRIPTION
Prevent application plugins from polluting core tests. I found that the App::objects() cache needs to be cleared again on teardown or the console will crash until the cache gets updated (3-5 seconds).
