### PR TITLE
2.0 app plugin pollution

### DIFF
--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -47,6 +47,7 @@ class CommandListTest extends CakeTestCase {
 				CAKE . 'Test' . DS . 'test_app' . DS . 'Console' . DS . 'Command' . DS
 			)
 		), true);
+		App::objects('plugins', null, false);
 		CakePlugin::loadAll();
 
 		$out = new TestStringOutput();
@@ -67,6 +68,8 @@ class CommandListTest extends CakeTestCase {
 	function tearDown() {
 		parent::tearDown();
 		unset($this->Shell);
+		App::build();
+		App::objects('plugins', null, false);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -123,6 +123,7 @@ class ShellDispatcherTest extends CakeTestCase {
 				CAKE . 'Test' . DS . 'test_app' . DS . 'Console' . DS . 'Command' . DS
 			)
 		), true);
+		App::objects('plugins', null, false);
 		CakePlugin::loadAll();
 	}
 

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -671,6 +671,7 @@ class AppImportTest extends CakeTestCase {
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS),
 			'vendors' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Vendor'. DS),
 		), App::RESET);
+		App::objects('plugins', null, false);
 		CakePlugin::loadAll();
 
 		ob_start();


### PR DESCRIPTION
Prevent application plugins from polluting core tests. This should take care of all occurrences for now. 
