### PR TITLE
Ticket 105 saving habtm between different db-schemas - reworked and hopefully final version

### DIFF
--- a/cake/libs/model/cake_schema.php
+++ b/cake/libs/model/cake_schema.php
@@ -253,7 +253,7 @@ class CakeSchema extends Object {
 				}
 
 				if (is_object($Object) && $Object->useTable !== false) {
-					$fulltable = $table = $db->fullTableName($Object, false);
+					$fulltable = $table = $db->fullTableName($Object, false, false);
 					if ($prefix && strpos($table, $prefix) !== 0) {
 						continue;
 					}
@@ -273,7 +273,7 @@ class CakeSchema extends Object {
 									$class = $assocData['with'];
 								}
 								if (is_object($Object->$class)) {
-									$withTable = $db->fullTableName($Object->$class, false);
+									$withTable = $db->fullTableName($Object->$class, false, false);
 									if ($prefix && strpos($withTable, $prefix) !== 0) {
 										continue;
 									}

--- a/cake/libs/model/datasources/datasource.php
+++ b/cake/libs/model/datasources/datasource.php
@@ -584,6 +584,16 @@ class DataSource extends Object {
 	}
 
 /**
+ * To-be-overridden in subclasses.
+ *
+ * @return string schema name
+ * @access public
+ */
+	function getSchemaName() {
+		return false;
+	}
+
+/**
  * Closes the current datasource.
  *
  * @return void

--- a/cake/libs/model/datasources/dbo/dbo_mssql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mssql.php
@@ -235,7 +235,7 @@ class DboMssql extends DboSource {
 			return $cache;
 		}
 
-		$table = $this->fullTableName($model, false);
+		$table = $this->fullTableName($model, false, false);
 		$cols = $this->fetchAll("SELECT COLUMN_NAME as Field, DATA_TYPE as Type, COL_LENGTH('" . $table . "', COLUMN_NAME) as Length, IS_NULLABLE As [Null], COLUMN_DEFAULT as [Default], COLUMNPROPERTY(OBJECT_ID('" . $table . "'), COLUMN_NAME, 'IsIdentity') as [Key], NUMERIC_SCALE as Size FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '" . $table . "'", false);
 
 		$fields = false;
@@ -263,7 +263,7 @@ class DboMssql extends DboSource {
 				$fields[$field]['length'] = null;
 			}
 		}
-		$this->__cacheDescription($this->fullTableName($model, false), $fields);
+		$this->__cacheDescription($this->fullTableName($model, false, false), $fields);
 		return $fields;
 	}
 

--- a/cake/libs/model/datasources/dbo/dbo_mysql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysql.php
@@ -805,4 +805,14 @@ class DboMysql extends DboMysqlBase {
 		}
 		return false;
 	}
+
+/**
+ * Gets the schema name
+ *
+ * @return string The schema name
+ */
+	function getSchemaName() {
+		return !empty($this->config['database']) ? $this->config['database'] : false;
+	}
+
 }

--- a/cake/libs/model/datasources/dbo/dbo_mysql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysql.php
@@ -257,7 +257,7 @@ class DboMysqlBase extends DboSource {
  */
 	function index($model) {
 		$index = array();
-		$table = $this->fullTableName($model);
+		$table = $this->fullTableName($model, true, false);
 		if ($table) {
 			$indexes = $this->query('SHOW INDEX FROM ' . $table);
 			if (isset($indexes[0]['STATISTICS'])) {

--- a/cake/libs/model/datasources/dbo/dbo_mysqli.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysqli.php
@@ -329,4 +329,14 @@ class DboMysqli extends DboMysqlBase {
 	function hasResult() {
 		return is_object($this->_result);
 	}
+
+/**
+ * Gets the schema name
+ *
+ * @return string The schema name
+ */
+	function getSchemaName() {
+		return !empty($this->config['database']) ? $this->config['database'] : false;
+	}
+
 }

--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -1156,4 +1156,13 @@ class DboOracle extends DboSource {
 			}
 			return $out;
 		}
+
+/**
+ * Gets the schema name
+ *
+ * @return string The schema name
+ */
+		function getSchemaName() {
+			return !empty($this->config['login']) ? $this->config['login'] : false;
+		}
 }

--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -655,7 +655,7 @@ class DboOracle extends DboSource {
  */
 	function index($model) {
 		$index = array();
-		$table = $this->fullTableName($model, false);
+		$table = $this->fullTableName($model, false, false);
 		if ($table) {
 			$indexes = $this->query('SELECT
 			  cc.table_name,

--- a/cake/libs/model/datasources/dbo/dbo_postgres.php
+++ b/cake/libs/model/datasources/dbo/dbo_postgres.php
@@ -977,4 +977,13 @@ class DboPostgres extends DboSource {
 			break;
 		}
 	}
+
+/**
+ * Gets the schema name
+ *
+ * @return string The schema name
+ */
+	function getSchemaName() {
+		return !empty($this->config['schema']) ? $this->config['schema'] : false;
+	}
 }

--- a/cake/libs/model/datasources/dbo/dbo_postgres.php
+++ b/cake/libs/model/datasources/dbo/dbo_postgres.php
@@ -205,7 +205,7 @@ class DboPostgres extends DboSource {
  */
 	function &describe(&$model) {
 		$fields = parent::describe($model);
-		$table = $this->fullTableName($model, false);
+		$table = $this->fullTableName($model, false, false);
 		$this->_sequenceMap[$table] = array();
 
 		if ($fields === null) {
@@ -522,7 +522,7 @@ class DboPostgres extends DboSource {
  */
 	function index($model) {
 		$index = array();
-		$table = $this->fullTableName($model, false);
+		$table = $this->fullTableName($model, false, false);
 		if ($table) {
 			$indexes = $this->query("SELECT c2.relname, i.indisprimary, i.indisunique, i.indisclustered, i.indisvalid, pg_catalog.pg_get_indexdef(i.indexrelid, 0, true) as statement, c2.reltablespace
 			FROM pg_catalog.pg_class c, pg_catalog.pg_class c2, pg_catalog.pg_index i

--- a/cake/libs/model/datasources/dbo/dbo_sqlite.php
+++ b/cake/libs/model/datasources/dbo/dbo_sqlite.php
@@ -568,7 +568,7 @@ class DboSqlite extends DboSource {
  */
 	function index(&$model) {
 		$index = array();
-		$table = $this->fullTableName($model);
+		$table = $this->fullTableName($model, true, false);
 		if ($table) {
 			$indexes = $this->query('PRAGMA index_list(' . $table . ')');
 			$tableInfo = $this->query('PRAGMA table_info(' . $table . ')');

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -694,21 +694,33 @@ class DboSource extends DataSource {
  *
  * @param mixed $model Either a Model object or a string table name.
  * @param boolean $quote Whether you want the table name quoted.
+ * @param boolean $schema Whether you want the schema name included.
  * @return string Full quoted table name
  * @access public
  */
-	function fullTableName($model, $quote = true) {
+	function fullTableName($model, $quote = true, $schema = true) {
+		$schemaName = $this->getSchemaName();
 		if (is_object($model)) {
+			$schemaName = $model->getDataSource()->getSchemaName();
 			$table = $model->tablePrefix . $model->table;
 		} elseif (isset($this->config['prefix'])) {
 			$table = $this->config['prefix'] . strval($model);
 		} else {
 			$table = strval($model);
 		}
+
 		if ($quote) {
-			return $this->name($table);
+			if ($schema && $schemaName) {
+				return $this->name($schemaName) . '.' . $this->name($table);
+			} else {
+				return $this->name($table);
+			}
 		}
-		return $table;
+		if ($schema && $schemaName) {
+			return $schemaName . '.' . $table;
+		} else {
+			return $table;
+		}
 	}
 
 /**

--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -1387,6 +1387,13 @@ class Model extends Overloadable {
 			if (isset($this->hasAndBelongsToMany[$assoc])) {
 				list($join) = $this->joinModel($this->hasAndBelongsToMany[$assoc]['with']);
 
+				if ($with = $this->hasAndBelongsToMany[$assoc]['with']) {
+					$withModel = is_array($with) ? key($with) : $with;
+					$dbMulti = $this->{$withModel}->getDataSource();
+				} else {
+					$dbMulti = $db;
+				}
+
 				$isUUID = !empty($this->{$join}->primaryKey) && (
 						$this->{$join}->_schema[$this->{$join}->primaryKey]['length'] == 36 && (
 						$this->{$join}->_schema[$this->{$join}->primaryKey]['type'] === 'string' ||
@@ -1398,8 +1405,8 @@ class Model extends Overloadable {
 				$primaryAdded = false;
 
 				$fields =  array(
-					$db->name($this->hasAndBelongsToMany[$assoc]['foreignKey']),
-					$db->name($this->hasAndBelongsToMany[$assoc]['associationForeignKey'])
+					$dbMulti->name($this->hasAndBelongsToMany[$assoc]['foreignKey']),
+					$dbMulti->name($this->hasAndBelongsToMany[$assoc]['associationForeignKey'])
 				);
 
 				$idField = $db->name($this->{$join}->primaryKey);
@@ -1411,8 +1418,8 @@ class Model extends Overloadable {
 				foreach ((array)$data as $row) {
 					if ((is_string($row) && (strlen($row) == 36 || strlen($row) == 16)) || is_numeric($row)) {
 						$values = array(
-							$db->value($id, $this->getColumnType($this->primaryKey)),
-							$db->value($row)
+							$dbMulti->value($id, $this->getColumnType($this->primaryKey)),
+							$dbMulti->value($row)
 						);
 						if ($isUUID && $primaryAdded) {
 							$values[] = $db->value(String::uuid());
@@ -1444,7 +1451,7 @@ class Model extends Overloadable {
 					$oldLinks = Set::extract($links, "{n}.{$associationForeignKey}");
 					if (!empty($oldLinks)) {
  						$conditions[$associationForeignKey] = $oldLinks;
-						$db->delete($this->{$join}, $conditions);
+						$dbMulti->delete($this->{$join}, $conditions);
 					}
 				}
 
@@ -1458,7 +1465,7 @@ class Model extends Overloadable {
 
 				if (!empty($newValues)) {
 					$fields = implode(',', $fields);
-					$db->insertMulti($this->{$join}, $fields, $newValues);
+					$dbMulti->insertMulti($this->{$join}, $fields, $newValues);
 				}
 			}
 		}

--- a/cake/tests/cases/libs/model/datasources/dbo/dbo_mysql.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo/dbo_mysql.test.php
@@ -392,7 +392,7 @@ class DboMysqlTest extends CakeTestCase {
  * @return void
  */
 	function testIndexOnMySQL4Output() {
-		$name = $this->db->fullTableName('simple');
+		$name = $this->db->fullTableName('simple', true, false);
 
 		$mockDbo =& new QueryMockDboMysql($this);
 		$columnData = array(
@@ -837,7 +837,7 @@ class DboMysqlTest extends CakeTestCase {
 	function testDeleteWithJoins() {
 		$model =& new Post();
 		$mockDbo =& new QueryMockDboMysql($this);
-		$mockDbo->expectAt(0, 'execute', array(new PatternExpectation('/LEFT JOIN `authors`/')));
+		$mockDbo->expectAt(0, 'execute', array(new PatternExpectation('/LEFT JOIN ' . $mockDbo->fullTableName($model->Author) . '/')));
 		$mockDbo->setReturnValue('execute', true);
 
 		$mockDbo->delete($model, array('Author.id' => 1));
@@ -851,8 +851,8 @@ class DboMysqlTest extends CakeTestCase {
 	function testDeleteWithJoinsAndMultipleConditions() {
 		$model =& new Post();
 		$mockDbo =& new QueryMockDboMysql($this);
-		$mockDbo->expectAt(0, 'execute', array(new PatternExpectation('/LEFT JOIN `authors`/')));
-		$mockDbo->expectAt(1, 'execute', array(new PatternExpectation('/LEFT JOIN `authors`/')));
+		$mockDbo->expectAt(0, 'execute', array(new PatternExpectation('/LEFT JOIN ' . $mockDbo->fullTableName($model->Author) . '/')));
+		$mockDbo->expectAt(1, 'execute', array(new PatternExpectation('/LEFT JOIN ' . $mockDbo->fullTableName($model->Author) . '/')));
 		$mockDbo->setReturnValue('execute', true);
 
 		$mockDbo->delete($model, array('Author.id' => 1, 'Post.id' => 2));

--- a/cake/tests/cases/libs/model/datasources/dbo/dbo_mysqli.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo/dbo_mysqli.test.php
@@ -180,14 +180,14 @@ class DboMysqliTest extends CakeTestCase {
 	function testIndexDetection() {
 		$this->db->cacheSources = false;
 
-		$name = $this->db->fullTableName('simple');
+		$name = $this->db->fullTableName('simple', true, false);
 		$this->db->query('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id));');
 		$expected = array('PRIMARY' => array('column' => 'id', 'unique' => 1));
 		$result = $this->db->index($name, false);
 		$this->assertEqual($expected, $result);
 		$this->db->query('DROP TABLE ' . $name);
 
-		$name = $this->db->fullTableName('with_a_key');
+		$name = $this->db->fullTableName('with_a_key', true, false);
 		$this->db->query('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ));');
 		$expected = array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
@@ -197,7 +197,7 @@ class DboMysqliTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 		$this->db->query('DROP TABLE ' . $name);
 
-		$name = $this->db->fullTableName('with_two_keys');
+		$name = $this->db->fullTableName('with_two_keys', true, false);
 		$this->db->query('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ));');
 		$expected = array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
@@ -208,7 +208,7 @@ class DboMysqliTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 		$this->db->query('DROP TABLE ' . $name);
 
-		$name = $this->db->fullTableName('with_compound_keys');
+		$name = $this->db->fullTableName('with_compound_keys', true, false);
 		$this->db->query('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ), KEY `one_way` ( `bool`, `small_int` ));');
 		$expected = array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
@@ -220,7 +220,7 @@ class DboMysqliTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 		$this->db->query('DROP TABLE ' . $name);
 
-		$name = $this->db->fullTableName('with_multiple_compound_keys');
+		$name = $this->db->fullTableName('with_multiple_compound_keys', true, false);
 		$this->db->query('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ), KEY `one_way` ( `bool`, `small_int` ), KEY `other_way` ( `small_int`, `bool` ));');
 		$expected = array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),

--- a/cake/tests/cases/libs/model/datasources/dbo/dbo_postgres.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo/dbo_postgres.test.php
@@ -458,7 +458,7 @@ class DboPostgresTest extends CakeTestCase {
 	function testLastInsertIdMultipleInsert() {
 		$db1 = ConnectionManager::getDataSource('test_suite');
 
-		$table = $db1->fullTableName('users', false);
+		$table = $db1->fullTableName('users', false, false);
 		$password = '5f4dcc3b5aa765d61d8327deb882cf99';
 		$db1->execute(
 			"INSERT INTO {$table} (\"user\", password) VALUES ('mariano', '{$password}')"
@@ -626,7 +626,7 @@ class DboPostgresTest extends CakeTestCase {
  * @return void
  */
 	function testIndexGeneration() {
-		$name = $this->db->fullTableName('index_test', false);
+		$name = $this->db->fullTableName('index_test', false, false);
 		$this->db->query('CREATE TABLE ' . $name . ' ("id" serial NOT NULL PRIMARY KEY, "bool" integer, "small_char" varchar(50), "description" varchar(40) )');
 		$this->db->query('CREATE INDEX pointless_bool ON ' . $name . '("bool")');
 		$this->db->query('CREATE UNIQUE INDEX char_index ON ' . $name . '("small_char")');
@@ -640,7 +640,7 @@ class DboPostgresTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$this->db->query('DROP TABLE ' . $name);
-		$name = $this->db->fullTableName('index_test_2', false);
+		$name = $this->db->fullTableName('index_test_2', false, false);
 		$this->db->query('CREATE TABLE ' . $name . ' ("id" serial NOT NULL PRIMARY KEY, "bool" integer, "small_char" varchar(50), "description" varchar(40) )');
 		$this->db->query('CREATE UNIQUE INDEX multi_col ON ' . $name . '("small_char", "bool")');
 		$expected = array(

--- a/cake/tests/cases/libs/model/datasources/dbo_source.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo_source.test.php
@@ -1366,7 +1366,7 @@ class DboSourceTest extends CakeTestCase {
 			'conditions' => null,
 			'recursive' => -1
 		));
-		$this->assertEqual(trim($test->simulated[0]), 'SELECT `Article`.`id` FROM `' . $this->testDb->fullTableName('article', false) . '` AS `Article`   WHERE 1 = 1');
+		$this->assertEqual(trim($test->simulated[0]), 'SELECT `Article`.`id` FROM ' . $this->testDb->fullTableName('article') . ' AS `Article`   WHERE 1 = 1');
 
 		$test->startQuote = '[';
 		$test->endQuote = ']';
@@ -1380,7 +1380,7 @@ class DboSourceTest extends CakeTestCase {
 			'conditions' => null,
 			'recursive' => -1
 		));
-		$this->assertEqual(trim($test->simulated[1]), 'SELECT [Article].[id] FROM [' . $this->testDb->fullTableName('article', false) . '] AS [Article]   WHERE 1 = 1');
+		$this->assertEqual(trim($test->simulated[1]), 'SELECT [Article].[id] FROM [' . $this->Model->schemaName . '].[' . $this->testDb->fullTableName('article', false, false) . '] AS [Article]   WHERE 1 = 1');
 
 		ClassRegistry::removeObject('Article');
 	}
@@ -1465,7 +1465,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
+		$this->assertPattern('/FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4Parent`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+1 = 1\s+$/', $result);
 
@@ -1491,12 +1491,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$this->testDb->read($this->Model, array('recursive' => 1));
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/`TestModel9` LEFT JOIN `' . $this->testDb->fullTableName('test_model8', false) . '`/', $result);
+		$this->assertPattern('/`TestModel9` LEFT JOIN ' . $this->testDb->fullTableName($this->Model->TestModel8) . '/', $result);
 
 		$this->Model->belongsTo['TestModel8']['type'] = 'INNER';
 		$this->testDb->read($this->Model, array('recursive' => 1));
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/`TestModel9` INNER JOIN `' . $this->testDb->fullTableName('test_model8', false) . '`/', $result);
+		$this->assertPattern('/`TestModel9` INNER JOIN ' . $this->testDb->fullTableName($this->Model->TestModel8) . '/', $result);
 
 	}
 
@@ -1523,7 +1523,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`, `TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model8` AS `TestModel8`\s+LEFT JOIN\s+`test_model9` AS `TestModel9`/', $result);
+		$this->assertPattern('/FROM\s+'. $this->testDb->fullTableName($this->Model) . ' AS `TestModel8`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel9). ' AS `TestModel9`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel9`\.`name` != \'mariano\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 	}
@@ -1550,7 +1550,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`, `TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model9` AS `TestModel9`\s+LEFT JOIN\s+`test_model8` AS `TestModel8`/', $result);
+		$this->assertPattern('/FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel9`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel8) . ' AS `TestModel8`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel8`\.`name` != \'larry\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 	}
@@ -1578,7 +1578,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
+		$this->assertPattern('/FROM\s+' . $this->testDb->fullTableName($this->Model) .' AS `TestModel4`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model) .' AS `TestModel4Parent`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?`TestModel4Parent`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 
@@ -1610,7 +1610,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertPattern(
 			'/^SELECT\s+`Featured2`\.`id`, `Featured2`\.`article_id`, `Featured2`\.`category_id`, `Featured2`\.`name`,\s+'.
 			'`ArticleFeatured2`\.`id`, `ArticleFeatured2`\.`title`, `ArticleFeatured2`\.`user_id`, `ArticleFeatured2`\.`published`\s+' .
-			'FROM\s+`featured2` AS `Featured2`\s+LEFT JOIN\s+`article_featured` AS `ArticleFeatured2`' .
+			'FROM\s+' . $this->testDb->fullTableName($this->Featured2) .' AS `Featured2`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Featured2->ArticleFeatured2) .' AS `ArticleFeatured2`' .
 			'\s+ON\s+\(`ArticleFeatured2`.`published` = \'Y\'\s+AND\s+`Featured2`\.`article_featured2_id` = `ArticleFeatured2`\.`id`\)' .
 			'\s+WHERE\s+1\s+=\s+1\s*$/',
 			$result
@@ -1640,12 +1640,12 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->testDb->buildJoinStatement($queryData['joins'][0]);
-		$expected = ' LEFT JOIN `test_model5` AS `TestModel5` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
+		$expected = ' LEFT JOIN ' . $this->testDb->fullTableName($this->Model->TestModel5) . ' AS `TestModel5` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
 		$this->assertEqual(trim($result), trim($expected));
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+LEFT JOIN\s+/', $result);
 		$this->assertPattern('/`test_model5` AS `TestModel5`\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
@@ -1675,7 +1675,7 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model5` AS `TestModel5`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel5) . ' AS `TestModel5`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id`\s+=\s+`TestModel4`.`id`\)\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*`TestModel5`.`name`\s+!=\s+\'mariano\'\s*(?:\))?\s*$/', $result);
 	}
@@ -1702,12 +1702,12 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->testDb->buildJoinStatement($queryData['joins'][0]);
-		$expected = ' LEFT JOIN `test_model4` AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
+		$expected = ' LEFT JOIN ' . $this->testDb->fullTableName($this->Model->TestModel4) . ' AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
 		$this->assertEqual(trim($result), trim($expected));
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel4) . ' AS `TestModel4`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
@@ -1734,12 +1734,12 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->testDb->buildJoinStatement($queryData['joins'][0]);
-		$expected = ' LEFT JOIN `test_model4` AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
+		$expected = ' LEFT JOIN ' . $this->testDb->fullTableName($this->Model->TestModel4) . ' AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
 		$this->assertEqual(trim($result), trim($expected));
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel4) . ' AS `TestModel4`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+`TestModel5`.`name` != \'mariano\'\s*$/', $result);
 	}
@@ -1765,12 +1765,12 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+`TestModel6`.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
 
@@ -1798,7 +1798,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertPattern(
 			'/^SELECT\s+' .
 			'`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+'.
-			'FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+' .
+			'FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+' .
 			'`TestModel6`.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)\s*'.
 			'LIMIT \d*'.
 			'\s*$/', $result
@@ -1808,7 +1808,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertPattern(
 			'/^SELECT\s+'.
 			'`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+'.
-			'FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+'.
+			'FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+'.
 			'(?:\()?\s*1 = 1\s*(?:\))?'.
 			'\s*$/', $result
 		);
@@ -1834,12 +1834,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?`TestModel5`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 	}
 
@@ -1869,13 +1869,13 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 		$this->assertPattern('/\s+LIMIT 2,\s*5\s*$/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6'] = $__backup;
@@ -1906,13 +1906,13 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 		$this->assertPattern('/\s+LIMIT 5,\s*5\s*$/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6'] = $__backup;
@@ -1938,12 +1938,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$binding = array('type' => 'hasMany', 'model' => 'TestModel6');
@@ -1955,12 +1955,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$binding = array('type' => 'hasMany', 'model' => 'TestModel6');
@@ -1972,12 +1972,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6']['fields'] = array('name');
@@ -1991,12 +1991,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
@@ -2012,12 +2012,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
@@ -2033,12 +2033,12 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel6`\.`test_model5_id`, `TestModel6`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel6) . ' AS `TestModel6`\s+WHERE\s+/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel5`\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
@@ -2086,14 +2086,14 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7` AS `TestModel7`\s+JOIN\s+`' . $this->testDb->fullTableName('test_model4_test_model7', false) . '`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel7) . ' AS `TestModel7`\s+JOIN\s+' . $this->Model->TestModel7->schemaName . '.' . $this->testDb->fullTableName('test_model4_test_model7', false, false) . '/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+AND/', $result);
 		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)/', $result);
 		$this->assertPattern('/WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model). ' AS `TestModel4`\s+WHERE/', $result);
 		$this->assertPattern('/\s+WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
 	}
 
@@ -2117,13 +2117,13 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel7) . '\s+AS\s+`TestModel7`\s+JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel4TestModel7) . '\s+AS\s+`TestModel4TestModel7`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
 		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?`TestModel4`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+WHERE\s+(?:\()?`TestModel4`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -2151,14 +2151,14 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel7) . '\s+AS\s+`TestModel7`\s+JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel4TestModel7) . '\s+AS\s+`TestModel4TestModel7`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+/', $result);
 		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 2,\s*5\s*$/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasAndBelongsToMany['TestModel7'] = $__backup;
 	}
@@ -2188,14 +2188,14 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model->TestModel7) . '\s+AS\s+`TestModel7`\s+JOIN\s+' . $this->testDb->fullTableName($this->Model->TestModel4TestModel7) . '\s+AS\s+`TestModel4TestModel7`/', $result);
 		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
 		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
 		$this->assertPattern('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 5,\s*5\s*$/', $result);
 
 		$result = $this->testDb->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertPattern('/\s+FROM\s+' . $this->testDb->fullTableName($this->Model) . ' AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasAndBelongsToMany['TestModel7'] = $__backup;
 	}
@@ -3314,27 +3314,27 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->update($Article, array('field1'), array('value1'));
 		$this->assertFalse($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . '\s+SET\s+`field1`\s*=\s*\'value1\'\s+WHERE\s+1 = 1\s*$/', $result);
+		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName($Article) . '\s+SET\s+`field1`\s*=\s*\'value1\'\s+WHERE\s+1 = 1\s*$/', $result);
 
 		$result = $this->testDb->update($Article, array('field1'), array('2'), '2=2');
 		$this->assertFalse($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . ' AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+SET\s+`Article`\.`field1`\s*=\s*2\s+WHERE\s+2\s*=\s*2\s*$/', $result);
+		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName($Article) . ' AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($Article->User) . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+SET\s+`Article`\.`field1`\s*=\s*2\s+WHERE\s+2\s*=\s*2\s*$/', $result);
 
 		$result = $this->testDb->delete($Article);
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+WHERE\s+1 = 1\s*$/', $result);
+		$this->assertPattern('/^\s*DELETE\s+FROM\s+' . $this->testDb->fullTableName($Article) . '\s+WHERE\s+1 = 1\s*$/', $result);
 
 		$result = $this->testDb->delete($Article, true);
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+1\s*=\s*1\s*$/', $result);
+		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName($Article) . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($Article->User) . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+1\s*=\s*1\s*$/', $result);
 
 		$result = $this->testDb->delete($Article, '2=2');
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+2\s*=\s*2\s*$/', $result);
+		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName($Article) . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName($Article->User) . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+2\s*=\s*2\s*$/', $result);
 
 		$result = $this->testDb->hasAny($Article, '1=2');
 		$this->assertFalse($result);
@@ -3342,7 +3342,7 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->insertMulti('articles', array('field'), array('(1)', '(2)'));
 		$this->assertFalse($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*INSERT INTO\s+' . $this->testDb->fullTableName('articles') . '\s+\(`field`\)\s+VALUES\s+\(1\),\s*\(2\)\s*$/', $result);
+		$this->assertPattern('/^\s*INSERT INTO\s+' . $this->testDb->fullTableName($Article) . '\s+\(`field`\)\s+VALUES\s+\(1\),\s*\(2\)\s*$/', $result);
 	}
 
 /**
@@ -3977,7 +3977,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertTrue(!empty($result));
 
 		$result = $this->db->fetchRow($result);
-		$expected = array($this->db->fullTableName('apples', false) => array(
+		$expected = array($this->db->fullTableName('apples', false, false) => array(
 			'color' => 'Red 1',
 			'name' => 'Red Apple 1'
 		));
@@ -3985,17 +3985,17 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $this->db->fetchAll('SELECT name FROM ' . $this->testDb->fullTableName('apples') . ' ORDER BY id');
 		$expected = array(
-			array($this->db->fullTableName('apples', false) => array('name' => 'Red Apple 1')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'Bright Red Apple')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'green blue')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'Test Name')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'Blue Green')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'My new apple')),
-			array($this->db->fullTableName('apples', false) => array('name' => 'Some odd color'))
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'Red Apple 1')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'Bright Red Apple')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'green blue')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'Test Name')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'Blue Green')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'My new apple')),
+			array($this->db->fullTableName('apples', false, false) => array('name' => 'Some odd color'))
 		);
 		$this->assertEqual($result, $expected);
 
-		$result = $this->db->field($this->testDb->fullTableName('apples', false), 'SELECT color, name FROM ' . $this->testDb->fullTableName('apples') . ' ORDER BY id');
+		$result = $this->db->field($this->testDb->fullTableName('apples', false, false), 'SELECT color, name FROM ' . $this->testDb->fullTableName('apples') . ' ORDER BY id');
 		$expected = array(
 			'color' => 'Red 1',
 			'name' => 'Red Apple 1'
@@ -4277,8 +4277,8 @@ class DboSourceTest extends CakeTestCase {
 		$Article->virtualFields = array(
 			'this_moment' => 'NOW()',
 			'two' => '1 + 1',
-			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments') .
-				' WHERE Article.id = ' . $this->db->fullTableName('comments') . '.article_id'
+			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments', true, false) .
+				' WHERE Article.id = ' . $this->db->fullTableName('comments', true, false) . '.article_id'
 		);
 		$result = $this->db->fields($Article);
 		$expected = array(
@@ -4345,8 +4345,8 @@ class DboSourceTest extends CakeTestCase {
 		$Article->virtualFields = array(
 			'this_moment' => 'NOW()',
 			'two' => '1 + 1',
-			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments') .
-				' WHERE Article.id = ' . $this->db->fullTableName('comments') . '.article_id'
+			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments', true, false) .
+				' WHERE Article.id = ' . $this->db->fullTableName('comments', true, false) . '.article_id'
 		);
 		$conditions = array('two' => 2);
 		$result = $this->db->conditions($conditions, true, false, $Article);
@@ -4424,8 +4424,8 @@ class DboSourceTest extends CakeTestCase {
 		$Article->virtualFields = array(
 			'this_moment' => 'NOW()',
 			'two' => '1 + 1',
-			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments') .
-				' WHERE Article.id = ' . $this->db->fullTableName('comments'). '.article_id'
+			'comment_count' => 'SELECT COUNT(*) FROM ' . $this->db->fullTableName('comments', true, false) .
+				' WHERE Article.id = ' . $this->db->fullTableName('comments', true, false). '.article_id'
 		);
 
 		$result = $this->db->calculate($Article, 'count', array('this_moment'));
@@ -4572,16 +4572,16 @@ class DboSourceTest extends CakeTestCase {
  */
 	function testFullTablePermutations() {
 		$Article =& ClassRegistry::init('Article');
-		$result = $this->testDb->fullTableName($Article, false);
+		$result = $this->testDb->fullTableName($Article, false, false);
 		$this->assertEqual($result, 'articles');
 
 		$Article->tablePrefix = 'tbl_';
-		$result = $this->testDb->fullTableName($Article, false);
+		$result = $this->testDb->fullTableName($Article, false, false);
 		$this->assertEqual($result, 'tbl_articles');
 		
 		$Article->useTable = $Article->table = 'with spaces';
 		$Article->tablePrefix = '';
-		$result = $this->testDb->fullTableName($Article);
+		$result = $this->testDb->fullTableName($Article, true, false);
 		$this->assertEqual($result, '`with spaces`');
 	}
 

--- a/cake/tests/cases/libs/model/model_cross_schema_habtm.test.php
+++ b/cake/tests/cases/libs/model/model_cross_schema_habtm.test.php
@@ -1,0 +1,194 @@
+<?php
+
+require_once dirname(__FILE__) . DS . 'model.test.php';
+App::import('Core', 'DboSource');
+
+/**
+ * Tests cross database HABTM.  Requires $test and $test2 to both be set in DATABASE_CONFIG
+ * NOTE: When testing on MySQL, you must set 'persistent' => false on *both* database connections,
+ * or one connection will step on the other.
+ *
+ * @package       cake
+ * @subpackage    cake.tests.cases.libs.model.operations
+ */
+class ModelCrossSchemaHabtmTest extends BaseModelTest {
+
+	var $fixtures = array('core.something', 'core.something_else', 'core.join_thing');
+
+	var $autoFixtures = false;
+
+	var $dropTables = false;
+
+	var $skip = false;
+
+	function start() {
+		parent::start();
+		$this->_checkConfigs();
+		$this->_setupFixtures();
+	}
+
+	function end() {
+		$this->_cleanupFixtures();
+		parent::end();
+	}
+
+	function _checkConfigs() {
+		$config = new DATABASE_CONFIG();
+
+		$this->skip = $this->skipIf(
+			!isset($config->test) || !isset($config->test2),
+			 '%s Primary and secondary test databases not configured, skipping cross-database '
+			.'join tests.'
+			.' To run these tests, you must define $test and $test2 in your database configuration.'
+		);
+	}
+
+	function _setupFixtures() {
+		if ($this->skip) { return; }
+		$db  =& ConnectionManager::getDataSource('test');
+		$db2 =& ConnectionManager::getDataSource('test2');
+		$this->_fixtures[$this->_fixtureClassMap['Something']]->drop($db);
+		$this->_fixtures[$this->_fixtureClassMap['Something']]->create($db);
+		$this->_fixtures[$this->_fixtureClassMap['Something']]->insert($db);
+		$this->_fixtures[$this->_fixtureClassMap['SomethingElse']]->drop($db);
+		$this->_fixtures[$this->_fixtureClassMap['SomethingElse']]->create($db);
+		$this->_fixtures[$this->_fixtureClassMap['SomethingElse']]->insert($db);
+		$this->_fixtures[$this->_fixtureClassMap['JoinThing']]->db = $db2;
+		$this->_fixtures[$this->_fixtureClassMap['JoinThing']]->drop($db2);
+		$this->_fixtures[$this->_fixtureClassMap['JoinThing']]->create($db2);
+		$this->_fixtures[$this->_fixtureClassMap['JoinThing']]->insert($db2);
+	}
+
+	function _cleanupFixtures() {
+		if ($this->skip) { return; }
+		$db  =& ConnectionManager::getDataSource('test');
+		$db2 =& ConnectionManager::getDataSource('test2');
+		$this->_fixtures[$this->_fixtureClassMap['Something']]->drop($db);
+		$this->_fixtures[$this->_fixtureClassMap['SomethingElse']]->drop($db);
+		$this->_fixtures[$this->_fixtureClassMap['JoinThing']]->drop($db2);
+	}
+
+	function testHabtmFind() {
+		if ($this->skip) { return; }
+
+		$this->_setupFixtures();
+
+		$Something =& ClassRegistry::init(array('class' => 'JoinThing', 'ds' => 'test2'));
+		$Something =& ClassRegistry::init('Something');
+		$Something->Behaviors->attach('Containable');
+		$Something->SomethingElse->Behaviors->attach('Containable');
+		$Something->SomethingElse->JoinThing->Behaviors->attach('Containable');
+
+		$count = $Something->JoinThing->find('count');
+		$this->assertEqual(3, $count);
+
+		$expected = array(
+			array(
+				'Something' => array(
+					'id' => 1,
+					'title' => 'First Post',
+					),
+				'SomethingElse' => array(
+					array(
+						'id' => 2,
+						'title' => 'Second Post',
+						'JoinThing' => array(
+							'doomed' => 1,
+							'something_id' => 1,
+							'something_else_id' => 2,
+							),
+						),
+					),
+				),
+			);
+		$options = array(
+			'conditions' => array('Something.id' => 1),
+			'fields' => array('id', 'title'),
+			'contain' => array(
+				'SomethingElse' => array(
+					'fields' => array('id', 'title'),
+					'JoinThing' =>  array(
+						'fields' => array('something_id', 'something_else_id'),
+						),
+					),
+				),
+			);
+		$results = $Something->find('all', $options);
+		$this->assertEqual($results, $expected);
+	}
+
+
+	function testHabtmSave() {
+		if ($this->skip) { return; }
+
+		$this->_setupFixtures();
+
+		$Something =& ClassRegistry::init(array('class' => 'JoinThing', 'ds' => 'test2'));
+		$Something =& ClassRegistry::init('Something');
+		$count = $Something->JoinThing->find('count');
+		$this->assertEqual(3, $count);
+
+		$data = $Something->create(array(
+			'Something' => array(
+				'id' => 1,
+				),
+			'SomethingElse' => array(
+				'SomethingElse' => array(2,3)
+				)
+			));
+
+		$results = $Something->saveAll($data, array('validate' => 'first'));
+
+		$this->assertNotEqual($results, false);
+
+		$count = $Something->JoinThing->find('count');
+		$this->assertEqual(4, $count);
+
+		$Something->Behaviors->attach('Containable');
+		$Something->SomethingElse->Behaviors->attach('Containable');
+		$Something->SomethingElse->JoinThing->Behaviors->attach('Containable');
+		$expected = array(
+			array(
+				'Something' => array(
+					'id' => 1,
+					'title' => 'First Post',
+					),
+				'SomethingElse' => array(
+					array(
+						'id' => 2,
+						'title' => 'Second Post',
+						'JoinThing' => array(
+							'doomed' => 0,
+							'something_id' => 1,
+							'something_else_id' => 2,
+							),
+						),
+					array(
+						'id' => 3,
+						'title' => 'Third Post',
+						'JoinThing' => array(
+							'doomed' => 0,
+							'something_id' => 1,
+							'something_else_id' => 3,
+							),
+						),
+					),
+				),
+			);
+		$options = array(
+			'conditions' => array('Something.id' => 1),
+			'fields' => array('id', 'title'),
+			'contain' => array(
+				'SomethingElse' => array(
+					'fields' => array('id', 'title'),
+					'JoinThing' =>  array(
+						'fields' => array('something_id', 'something_else_id'),
+						),
+					),
+				),
+			);
+		$results = $Something->find('all', $options);
+		$this->assertEqual($results, $expected);
+	}
+
+}

--- a/cake/tests/cases/libs/model/model_integration.test.php
+++ b/cake/tests/cases/libs/model/model_integration.test.php
@@ -833,39 +833,39 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$TestModel = new Apple();
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEqual($this->db->fullTableName($TestModel, false, false), 'aaa_apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'aaa_apples');
+		$this->assertEqual($db2->fullTableName($TestModel, false, false), 'aaa_apples');
 
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'bbb_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'bbb_apples');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'bbb_apples');
+		$this->assertEqual($this->db->fullTableName($TestModel, false, false), 'bbb_apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'bbb_apples');
+		$this->assertEqual($db2->fullTableName($TestModel, false, false), 'bbb_apples');
 
 		$TestModel = new Apple();
 		$TestModel->tablePrefix = 'custom_';
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'custom_apples');
+		$this->assertEqual($this->db->fullTableName($TestModel, false, false), 'custom_apples');
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'custom_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'custom_apples');
+		$this->assertEqual($this->db->fullTableName($TestModel, false, false), 'custom_apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'custom_apples');
 
 		$TestModel = new Apple();
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEqual($this->db->fullTableName($TestModel, false, false), 'aaa_apples');
 		$TestModel->tablePrefix = '';
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'apples');
+		$this->assertEqual($db2->fullTableName($TestModel, false, false), 'apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'apples');
 
 		$TestModel->tablePrefix = null;
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEqual($db2->fullTableName($TestModel, false, false), 'aaa_apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'aaa_apples');
 
 		$TestModel->tablePrefix = false;
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'apples');
+		$this->assertEqual($db2->fullTableName($TestModel, false, false), 'apples');
+		$this->assertEqual($db1->fullTableName($TestModel, false, false), 'apples');
 	}
 
 /**

--- a/cake/tests/cases/libs/model/model_read.test.php
+++ b/cake/tests/cases/libs/model/model_read.test.php
@@ -294,7 +294,7 @@ class ModelReadTest extends BaseModelTest {
 		$result = $Article->query($query, $params);
 		$expected = array(
 			'0' => array(
-				$this->db->fullTableName('articles', false) => array(
+				$this->db->fullTableName('articles', false, false) => array(
 					'title' => 'First Article', 'published' => 'Y')
 		));
 
@@ -319,7 +319,7 @@ class ModelReadTest extends BaseModelTest {
 		$result = $Article->query($query, $params, false);
 		$this->assertTrue(is_array($result));
 		$this->assertTrue(
-			   isset($result[0][$this->db->fullTableName('articles', false)])
+			   isset($result[0][$this->db->fullTableName('articles', false, false)])
 			|| isset($result[0][0])
 		);
 		$this->assertFalse(isset($this->db->_queryCache[$finalQuery]));
@@ -332,7 +332,7 @@ class ModelReadTest extends BaseModelTest {
 		$result = $Article->query($query, $params);
 		$this->assertTrue(is_array($result));
 		$this->assertTrue(
-			   isset($result[0][$this->db->fullTableName('articles', false)]['title'])
+			   isset($result[0][$this->db->fullTableName('articles', false, false)]['title'])
 			|| isset($result[0][0]['title'])
 		);
 

--- a/cake/tests/lib/cake_test_case.php
+++ b/cake/tests/lib/cake_test_case.php
@@ -288,7 +288,8 @@ class CakeTestCase extends UnitTestCase {
 	function endController(&$controller, $params = array()) {
 		if (isset($this->db) && isset($this->_actionFixtures) && !empty($this->_actionFixtures) && $this->dropTables) {
 			foreach ($this->_actionFixtures as $fixture) {
-				$fixture->drop($this->db);
+				$db = $fixture->db === null ? $this->db : $fixture->db;
+				$fixture->drop($db);
 			}
 		}
 	}
@@ -417,7 +418,8 @@ class CakeTestCase extends UnitTestCase {
 		// Create records
 		if (isset($this->_fixtures) && isset($this->db) && !in_array(strtolower($method), array('start', 'end')) && $this->__truncated && $this->autoFixtures == true) {
 			foreach ($this->_fixtures as $fixture) {
-				$inserts = $fixture->insert($this->db);
+				$db = $fixture->db === null ? $this->db : $fixture->db;
+				$inserts = $fixture->insert($db);
 			}
 		}
 
@@ -444,12 +446,13 @@ class CakeTestCase extends UnitTestCase {
 				return;
 			}
 			foreach ($this->_fixtures as $fixture) {
-				$table = $this->db->config['prefix'] . $fixture->table;
+				$db = $fixture->db === null ? $this->db : $fixture->db;
+				$table = $db->config['prefix'] . $fixture->table;
 				if (in_array($table, $sources)) {
-					$fixture->drop($this->db);
-					$fixture->create($this->db);
+					$fixture->drop($db);
+					$fixture->create($db);
 				} elseif (!in_array($table, $sources)) {
-					$fixture->create($this->db);
+					$fixture->create($db);
 				}
 			}
 		}
@@ -465,7 +468,8 @@ class CakeTestCase extends UnitTestCase {
 		if (isset($this->_fixtures) && isset($this->db)) {
 			if ($this->dropTables) {
 				foreach (array_reverse($this->_fixtures) as $fixture) {
-					$fixture->drop($this->db);
+					$db = $fixture->db === null ? $this->db : $fixture->db;
+					$fixture->drop($db);
 				}
 			}
 			$this->db->sources(true);
@@ -489,7 +493,8 @@ class CakeTestCase extends UnitTestCase {
 
 		if (isset($this->_fixtures) && isset($this->db) && $isTestMethod) {
 			foreach ($this->_fixtures as $fixture) {
-				$fixture->truncate($this->db);
+				$db = $fixture->db === null ? $this->db : $fixture->db;
+				$fixture->truncate($db);
 			}
 			$this->__truncated = true;
 		} else {
@@ -534,8 +539,9 @@ class CakeTestCase extends UnitTestCase {
 			if (isset($this->_fixtureClassMap[$class])) {
 				$fixture = $this->_fixtures[$this->_fixtureClassMap[$class]];
 
-				$fixture->truncate($this->db);
-				$fixture->insert($this->db);
+				$db = $fixture->db === null ? $this->db : $fixture->db;
+				$fixture->truncate($db);
+				$fixture->insert($db);
 			} else {
 				trigger_error(sprintf(__('Referenced fixture class %s not found', true), $class), E_USER_WARNING);
 			}


### PR DESCRIPTION
Hi,

This is a reworked of: https://github.com/cakephp/cakephp/pull/69.

I have also included @lorenzo's suggestion from  https://github.com/rchavik/cakephp/commit/4f12dde53d5a2c8095c42984188081d663a2231d#commitcomment-393555

Notable changes on this changeset:
- change of DboSource->fullTableName() by adding a new parameter $schema defaulting to true
- addition of property $schemaName in Model.  Although not exactly required to fix #105, i think having the schema name is handy.
- CakeTestCase inspect $fixture->db and use it when it has been set. This is needed for testing for cross schema operations.

The following commits are not directly related to #105, detected when running tests
- rchavik@935d17d8 is a fix for mysqli driver (virtualField tests was failing)
- rchavik@80c64d8d is a fix for postsql driver (adding IF EXISTS in DROP statements)

I have updated the Dboes as best as I can.  I have tested model_cross_schema_habtm.test.php with mysql, mysqli, and postgres with all test passes.  For mysql, mysqli, all model, behavior, and database group tests passes (with the exception on mysqli in testArrayConditionsParsing (dbo_source.test.php:2552 and 2556).

On my env, running postgres tests is very slow, so I only run minimal tests on this driver.

Thanks.
