### PR TITLE
Ticket 275 - Old HABTM links should not be deleted when new HABTM links contain these

### DIFF
--- a/cake/tests/cases/libs/model/model.test.php
+++ b/cake/tests/cases/libs/model/model.test.php
@@ -65,7 +65,8 @@ class BaseModelTest extends CakeTestCase {
 		'core.counter_cache_user_nonstandard_primary_key',
 		'core.counter_cache_post_nonstandard_primary_key', 'core.uuidportfolio',
 		'core.uuiditems_uuidportfolio', 'core.uuiditems_uuidportfolio_numericid', 'core.fruit',
-		'core.fruits_uuid_tag', 'core.uuid_tag', 'core.product_update_all', 'core.group_update_all'
+		'core.fruits_uuid_tag', 'core.uuid_tag', 'core.product_update_all', 'core.group_update_all',
+		'core.site', 'core.domain', 'core.domains_site',
 	);
 
 /**

--- a/cake/tests/cases/libs/model/model_integration.test.php
+++ b/cake/tests/cases/libs/model/model_integration.test.php
@@ -1927,4 +1927,94 @@ class ModelIntegrationTest extends BaseModelTest {
 		$expected = $db->name('Domain.DomainHandle');
 		$this->assertEqual($result, $expected);
 	}
+
+/**
+ * test HABM operations without clobbering existing records #275
+ *
+ * @return void
+ */
+	function testHABTMKeep() {
+		$this->loadFixtures('Site', 'Domain', 'DomainsSite');
+
+		$Site =& new Site();
+		$results = $Site->find('count');
+		$expected = 3;
+		$this->assertEqual($results, $expected);
+
+		$data = $Site->findById(1);
+
+		// include api.cakephp.org
+		$data['Domain'] = array('Domain' => array(10, 11, 12));
+		$Site->save($data);
+
+		$Site->id = 1;
+		$results = $Site->read();
+		$expected = 3; // 3 domains belonging to site 1: cakephp
+		$this->assertEqual(count($results['Domain']), $expected);
+
+
+		$Site->id = 2;
+		$results = $Site->read();
+		$expected = 2; // 2 domains belonging to markstory
+		$this->assertEqual(count($results['Domain']), $expected);
+
+		$Site->id = 3;
+		$results = $Site->read();
+		$expected = 2;
+		$this->assertEqual(count($results['Domain']), $expected);
+		$results['Domain'] = array('Domain' => array(31));
+		$Site->save($results); // remove association from domain 30
+		$results = $Site->read();
+		$expected = 1; // only 1 domain left belonging to rchavik
+		$this->assertEqual(count($results['Domain']), $expected);
+
+		// add deleted domain back
+		$results['Domain'] = array('Domain' => array(30, 31));
+		$Site->save($results);
+		$results = $Site->read();
+		$expected = 2; // 2 domains belonging to rchavik
+		$this->assertEqual(count($results['Domain']), $expected);
+
+		$Site->DomainsSite->id = $results['Domain'][0]['DomainsSite']['id'];
+		$Site->DomainsSite->saveField('active', true);
+
+		$results = $Site->Domain->DomainsSite->find('count', array(
+			'conditions' => array(
+				'DomainsSite.active' => true,
+				),
+			));
+		$expected = 5;
+		$this->assertEqual($results, $expected);
+
+		// activate api.cakephp.org
+		$activated = $Site->DomainsSite->findByDomainId(12);
+		$activated['DomainsSite']['active'] = true;
+		$Site->DomainsSite->save($activated);
+
+		$results = $Site->DomainsSite->find('count', array(
+			'conditions' => array(
+				'DomainsSite.active' => true,
+				),
+			));
+		$expected = 6;
+		$this->assertEqual($results, $expected);
+
+		// remove 2 previously active domains, and leave $activated alone
+		$data = array(
+			'Site' => array('id' => 1, 'name' => 'cakephp (modified)'),
+			'Domain' => array(
+				'Domain' => array(12),
+				)
+			);
+		$Site->create($data);
+		$Site->save($data);
+
+		// tests that record is still identical prior to removal
+		$Site->id = 1;
+		$results = $Site->read();
+		unset($results['Domain'][0]['DomainsSite']['updated']);
+		unset($activated['DomainsSite']['updated']);
+		$this->assertEqual($results['Domain'][0]['DomainsSite'], $activated['DomainsSite']);
+	}
+
 }

--- a/cake/tests/cases/libs/model/models.php
+++ b/cake/tests/cases/libs/model/models.php
@@ -3592,3 +3592,21 @@ class TransactionTestModel extends CakeTestModel {
 		$this->saveAll($data, array('atomic' => true, 'callbacks' => false));
 	}
 }
+
+class Site extends CakeTestModel {
+	var $name = 'Site';
+	var $useTable = 'sites';
+
+	var $hasAndBelongsToMany = array(
+		'Domain' => array('unique' => true),
+		);
+}
+
+class Domain extends CakeTestModel {
+	var $name = 'Domain';
+	var $useTable = 'domains';
+
+	var $hasAndBelongsToMany = array(
+		'Site' => array('unique' => true),
+		);
+}

--- a/cake/tests/fixtures/domain_fixture.php
+++ b/cake/tests/fixtures/domain_fixture.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP versions 4 and 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ *  Licensed under The Open Group Test Suite License
+ *  Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ * @since         CakePHP(tm) v 1.2.0.4667
+ * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ */
+class DomainFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Domain'
+ * @access public
+ */
+	var $name = 'Domain';
+
+/**
+ * fields property
+ *
+ * @var array
+ * @access public
+ */
+	var $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'domain' => array('type' => 'string', 'null' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime'
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ * @access public
+ */
+	var $records = array(
+		array('id' => 10, 'domain' => 'cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('id' => 11, 'domain' => 'book.cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('id' => 12, 'domain' => 'api.cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('id' => 20, 'domain' => 'mark-story.com', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
+		array('id' => 21, 'domain' => 'tinadurocher.com', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
+		array('id' => 30, 'domain' => 'chavik.com', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+		array('id' => 31, 'domain' => 'xintesa.com', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+	);
+}

--- a/cake/tests/fixtures/domains_site_fixture.php
+++ b/cake/tests/fixtures/domains_site_fixture.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP versions 4 and 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ *  Licensed under The Open Group Test Suite License
+ *  Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ * @since         CakePHP(tm) v 1.2.0.4667
+ * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ */
+class DomainsSiteFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Domain'
+ * @access public
+ */
+	var $name = 'DomainsSite';
+
+/**
+ * fields property
+ *
+ * @var array
+ * @access public
+ */
+	var $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'domain_id' => array('type' => 'integer', 'null' => false),
+		'site_id' => array('type' => 'integer', 'null' => false),
+		'active' => array('type' => 'boolean', 'null' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime',
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ * @access public
+ */
+	var $records = array(
+		array('site_id' => 1, 'domain_id' => 10, 'active' => true, 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('site_id' => 1, 'domain_id' => 11, 'active' => true, 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('site_id' => 2, 'domain_id' => 20, 'active' => true, 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
+		array('site_id' => 2, 'domain_id' => 21, 'active' => true, 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
+		array('site_id' => 3, 'domain_id' => 30, 'active' => true, 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+		array('site_id' => 3, 'domain_id' => 31, 'active' => false, 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+	);
+}

--- a/cake/tests/fixtures/site_fixture.php
+++ b/cake/tests/fixtures/site_fixture.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP versions 4 and 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ *  Licensed under The Open Group Test Suite License
+ *  Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2010, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ * @since         CakePHP(tm) v 1.2.0.4667
+ * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       cake
+ * @subpackage    cake.tests.fixtures
+ */
+class SiteFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Site'
+ * @access public
+ */
+	var $name = 'Site';
+
+/**
+ * fields property
+ *
+ * @var array
+ * @access public
+ */
+	var $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'null' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime'
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ * @access public
+ */
+	var $records = array(
+		array('id' => 1, 'name' => 'cakephp', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+		array('id' => 2, 'name' => 'Mark Story\'s sites', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
+		array('id' => 3, 'name' => 'rchavik sites', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+	);
+}


### PR DESCRIPTION
Hi,

This patch closes http://cakephp.lighthouseapp.com/projects/42648/tickets/275.
- Requires `unique = true`.
- No additional database call is required.
- All existing Model, Database, Behaviors tests pass.

I will port it to 2.0 as well.
