### PR TITLE
Fix for 2.0 BehaviorCollection::load() invalid callback afterError in list.

### DIFF
--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -148,7 +148,7 @@ class BehaviorCollection extends ObjectCollection {
 		$parentMethods = array_flip(get_class_methods('ModelBehavior'));
 		$callbacks = array(
 			'setup', 'cleanup', 'beforeFind', 'afterFind', 'beforeSave', 'afterSave',
-			'beforeDelete', 'afterDelete', 'afterError'
+			'beforeDelete', 'afterDelete', 'onError'
 		);
 
 		foreach ($methods as $m) {


### PR DESCRIPTION
Fix for wrong callback in $callbacks array: renamed afterError to onError. ModelBehavior::afterError() does not exists at all.
