### PR TITLE
2.0 Shell - Wrong underscore naming of Shells and Tasks

### DIFF
--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -467,7 +467,7 @@ class TestTask extends BakeTask {
 	public function getPath() {
 		$path = $this->path;
 		if (isset($this->plugin)) {
-			$path = $this->_pluginPath($this->plugin) . 'tests' . DS;
+			$path = $this->_pluginPath($this->plugin) . 'Test' . DS;
 		}
 		return $path;
 	}

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -149,7 +149,7 @@ class Shell extends Object {
  */
 	function __construct($stdout = null, $stderr = null, $stdin = null) {
 		if ($this->name == null) {
-			$this->name = Inflector::underscore(str_replace(array('Shell', 'Task'), '', get_class($this)));
+			$this->name = Inflector::camelize(str_replace(array('Shell', 'Task'), '', get_class($this)));
 		}
 		$this->Tasks = new TaskCollection($this);
 

--- a/lib/Cake/Test/Case/Console/Command/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/ShellTest.php
@@ -172,6 +172,7 @@ class ShellTest extends CakeTestCase {
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS),
 			'models' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS)
 		), true);
+		CakePlugin::load('TestPlugin');
 
 		$this->Shell->uses = array('TestPlugin.TestPluginPost');
 		$this->Shell->initialize();
@@ -798,5 +799,18 @@ TEXT;
   This is the song that never ends.
 TEXT;
 		$this->assertEquals($expected, $result, 'Text not wrapped.');
+	}
+
+/**
+ * Testing camel cased naming of tasks
+ * 
+ * @access public
+ * @return void
+ */
+	public function testShellNaming() {
+		$this->Shell->tasks = array('TestApple');
+		$this->Shell->loadTasks();
+		$expected = 'TestApple';
+		$this->assertEqual($expected, $this->Shell->TestApple->name);
 	}
 }


### PR DESCRIPTION
Fixed Shell naming from using Inflector::underscore() to Inflector::camelize(). Added small test case for Shell naming. Fixed missing CakePlugin::load() call in ShellTest.
