### PR TITLE
Removing call to non-existent method

### DIFF
--- a/lib/Cake/View/Layouts/rss/default.ctp
+++ b/lib/Cake/View/Layouts/rss/default.ctp
@@ -1,6 +1,4 @@
 <?php
-echo $this->Rss->header();
-
 if (!isset($channel)) {
 	$channel = array();
 }


### PR DESCRIPTION
I've removed a call to RssHelper::header() from the default rss layout
