### PR TITLE
Fix for bad encoded strftime() values when LC_TIME has code points higher than 128

### DIFF
--- a/cake/libs/multibyte.php
+++ b/cake/libs/multibyte.php
@@ -1066,6 +1066,34 @@ class Multibyte extends Object {
 	}
 
 /**
+ * Format a local time/date according to locale settings, using the app's encoding
+ *
+ * @return string
+ * @access public
+ * @static
+ */
+	function strftime() {
+		$args = func_get_args();
+		$format = call_user_func_array('strftime', $args);
+		if (function_exists('mb_internal_encoding')) {
+			$encoding = mb_internal_encoding();
+		} else {
+			$encoding = Configure::read('App.encoding');
+		}
+		if (!empty($encoding) && $encoding === 'UTF-8') {
+			if (function_exists('mb_check_encoding')) {
+				$valid = mb_check_encoding($format, $encoding);
+			} else {
+				$valid = !Multibyte::checkMultibyte($format);
+			}
+			if (!$valid) {
+				$format = utf8_encode($format);
+			}
+		}
+		return $format;
+	}
+
+/**
  * Return the Code points range for Unicode characters
  *
  * @param interger $decimal

--- a/cake/libs/view/helpers/time.php
+++ b/cake/libs/view/helpers/time.php
@@ -17,6 +17,9 @@
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+if (!class_exists('Multibyte')) {
+	App::import('Core', 'Multibyte');
+}
 
 /**
  * Time Helper class for easy use of time data.
@@ -213,7 +216,7 @@ class TimeHelper extends AppHelper {
 			$date = time();
 		}
 		$format = $this->convertSpecifiers('%a, %b %eS %Y, %H:%M', $date);
-		return strftime($format, $date);
+		return Multibyte::strftime($format, $date);
 	}
 
 /**
@@ -236,12 +239,12 @@ class TimeHelper extends AppHelper {
 		$y = $this->isThisYear($date) ? '' : ' %Y';
 
 		if ($this->isToday($dateString, $userOffset)) {
-			$ret = sprintf(__('Today, %s',true), strftime("%H:%M", $date));
+			$ret = sprintf(__('Today, %s',true), Multibyte::strftime("%H:%M", $date));
 		} elseif ($this->wasYesterday($dateString, $userOffset)) {
-			$ret = sprintf(__('Yesterday, %s',true), strftime("%H:%M", $date));
+			$ret = sprintf(__('Yesterday, %s',true), Multibyte::strftime("%H:%M", $date));
 		} else {
 			$format = $this->convertSpecifiers("%b %eS{$y}, %H:%M", $date);
-			$ret = strftime($format, $date);
+			$ret = Multibyte::strftime($format, $date);
 		}
 
 		return $ret;
@@ -739,6 +742,6 @@ class TimeHelper extends AppHelper {
 			$format = '%x';
 		}
 		$format = $this->convertSpecifiers($format, $date);
-		return strftime($format, $date);
+		return Multibyte::strftime($format, $date);
 	}
 }

--- a/cake/tests/cases/libs/view/helpers/time.test.php
+++ b/cake/tests/cases/libs/view/helpers/time.test.php
@@ -770,6 +770,7 @@ class TimeHelperTest extends CakeTestCase {
 			'locales' => array(TEST_CAKE_CORE_INCLUDE_PATH . 'tests' . DS . 'test_app' . DS . 'locale' . DS)
 		), true);
 		Configure::write('Config.language', 'time_test');
+
 		$time = strtotime('Thu Jan 14 13:59:28 2010');
 
 		$result = $this->Time->i18nFormat($time);
@@ -782,6 +783,20 @@ class TimeHelperTest extends CakeTestCase {
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
 		$expected = 'Time is 01:59:28 PM, and date is 14/01/10';
+		$this->assertEqual($result, $expected);
+
+		$time = strtotime('Wed Jan 13 13:59:28 2010');
+
+		$result = $this->Time->i18nFormat($time);
+		$expected = '13/01/10';
+		$this->assertEqual($result, $expected);
+
+		$result = $this->Time->i18nFormat($time, '%c');
+		$expected = 'mié 13 ene 2010 13:59:28 ' . strftime('%Z', $time);
+		$this->assertEqual($result, $expected);
+
+		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
+		$expected = 'Time is 01:59:28 PM, and date is 13/01/10';
 		$this->assertEqual($result, $expected);
 
 		$result = $this->Time->i18nFormat('invalid date', '%x', 'Date invalid');


### PR DESCRIPTION
Removed FormHelper changes and updated to 1.3.10
Original request here: https://github.com/cakephp/cakephp/pull/27
