### PR TITLE
printing the legend of the forms in the templates

### DIFF
--- a/lib/Cake/Console/Templates/default/views/form.ctp
+++ b/lib/Cake/Console/Templates/default/views/form.ctp
@@ -19,7 +19,7 @@
 <div class="<?php echo $pluralVar;?> form">
 <?php echo "<?php echo \$this->Form->create('{$modelClass}');?>\n";?>
 	<fieldset>
-		<legend><?php printf("<?php __('%s %s'); ?>", Inflector::humanize($action), $singularHumanName); ?></legend>
+		<legend><?php printf("<?php echo __('%s %s'); ?>", Inflector::humanize($action), $singularHumanName); ?></legend>
 <?php
 		echo "\t<?php\n";
 		foreach ($fields as $field) {


### PR DESCRIPTION
the legend of the baked forms are not being printed according to the changes in the functions of internationalization and localization[1].

[1] http://cakephp.lighthouseapp.com/projects/42648/2-0-migration-guide
