### PR TITLE
Oracle DBO Updates addressing persistModel and sequencing issues

### DIFF
--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -187,6 +187,9 @@ class DboOracle extends DboSource {
 			if (!empty($config['nls_comp'])) {
 				$this->execute('ALTER SESSION SET NLS_COMP='.$config['nls_comp']);
 			}
+			if (!empty($config['schema'])) {
+			  $this->execute('ALTER SESSION SET CURRENT_SCHEMA='.$config['schema']);
+			}
 			$this->execute("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD HH24:MI:SS'");
 		} else {
 			$this->connected = false;
@@ -463,11 +466,17 @@ class DboOracle extends DboSource {
  * @access public
  */
 	function listSources() {
+		$config = $this->config;
 		$cache = parent::listSources();
 		if ($cache != null) {
 			return $cache;
 		}
-		$sql = 'SELECT view_name AS name FROM all_views UNION SELECT table_name AS name FROM all_tables';
+		
+		if (!empty($config['schema'])) {
+		  $sql = 'SELECT view_name AS name FROM all_views WHERE owner = \'' . $config['schema'] . '\' UNION SELECT table_name AS name FROM all_tables  WHERE owner = \'' . $config['schema'] . '\'';
+		} else {
+		  $sql = 'SELECT view_name AS name FROM all_views UNION SELECT table_name AS name FROM all_tables';
+		}
 
 		if (!$this->execute($sql)) {
 			return false;

--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -503,7 +503,7 @@ class DboOracle extends DboSource {
 		if (!empty($model->sequence)) {
 			$this->_sequenceMap[$table] = $model->sequence;
 		} elseif (!empty($model->table)) {
-			$this->_sequenceMap[$table] = $model->table . '_seq';
+			$this->_sequenceMap[$table] = $model->tablePrefix . $model->table . '_seq';
 		}
 
 		$cache = parent::describe($model);


### PR DESCRIPTION
These updates should address the ticket I made before [#1666](http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/1666).

The _persist() method of Object is used to resolve the issue of sequence names not being available when persistModel is true in the controller. This was particularly a problem in the method lastInsertId(), which would only be passed a string of the table name, and would therefore have no other way of knowing the sequence name, which can be modified using a table prefix or through a model property. While caching is enabled, this update will resolve that issue, and when caching is disabled, so is persistModel, so this is no longer an issue.

Sequences now correctly take table prefixes.

A 'schema' key can be defined in the database configuration to allow faster enumeration of database tables by reducing the set to the relevant tables owner.

I've also changed the Oracle unit tests to be more inline with other DBOs, while including tests for these updates and some of the existing functionality.

Let me know if you think anything could be done better here.

Thanks

Ben
