### PR TITLE
Added App::import('Model', 'ConnectionManager') to cake/libs/sanitize.php

### DIFF
--- a/cake/libs/sanitize.php
+++ b/cake/libs/sanitize.php
@@ -1,4 +1,5 @@
 <?php
+App::import('Model', 'ConnectionManager');
 /**
  * Washes strings from unwanted noise.
  *


### PR DESCRIPTION
When using Sanitize::escape(), CakePHP will raise "Fatal error: Class 'ConnectionManager' not found in /home/tploch/Aptana Studio 3 Workspace/cakephp/cake/libs/sanitize.php on line 73"

Adding the App::import call will fix this.
