### PR TITLE
2.0 set CakePlugin::loadAll() in bootstrap

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -52,3 +52,7 @@ Cache::config('default', array('engine' => 'File'));
  * Inflector::rules('plural', array('rules' => array(), 'irregular' => array(), 'uninflected' => array()));
  *
  */
+
+
+// Load all the plugins located in the configured plugins folders
+CakePlugin::loadAll();


### PR DESCRIPTION
Before we use plugins in CakePHP2.0, we have to call CakePlugin::load().
I suggest using CakePlugin::loadAll() in app/Config/bootstrap.php by default.
It's easy to use plugins in CakePHP2.0
