### PR TITLE
Refactored DatabaseSession to use only 'Session.handler.model' config

### DIFF
--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -31,23 +31,18 @@ class DatabaseSession implements CakeSessionHandlerInterface {
  */
 	public function __construct() {
 		$modelName = Configure::read('Session.handler.model');
-		$database = Configure::read('Session.handler.database');
-		$table = Configure::read('Session.handler.table');
-
-		if (empty($database)) {
-			$database = 'default';
-		}
-		$settings = array(
-			'class' => 'Session',
-			'alias' => 'Session',
-			'table' => 'cake_sessions',
-			'ds' => $database
-		);
-		if (!empty($modelName)) {
-			$settings['class'] = $modelName;
-		}
-		if (!empty($table)) {
-			$settings['table'] = $table;
+		
+		if (empty($modelName)) {
+			$settings = array(
+				'class' =>'Session',
+				'alias' => 'Session',
+				'table' => 'cake_sessions',
+			);
+		} else {
+			$settings = array(
+				'class' =>$modelName,
+				'alias' => 'Session',
+			);
 		}
 		ClassRegistry::init($settings);
 	}
@@ -71,7 +66,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 	public function close() {
 		$probability = mt_rand(1, 150);
 		if ($probability <= 3) {
-			DatabaseSession::gc();
+			$this->gc();
 		}
 		return true;
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -23,8 +23,8 @@ App::uses('DatabaseSession', 'Model/Datasource/Session');
 class_exists('CakeSession');
 
 class SessionTestModel extends Model {
-	var $name = 'SessionTestModel';
-	var $useTable = 'sessions';
+	public $name = 'SessionTestModel';
+	public $useTable = 'sessions';
 }
 
 /**
@@ -52,8 +52,6 @@ class DatabaseSessionTest extends CakeTestCase {
 		self::$_sessionBackup = Configure::read('Session');
 		Configure::write('Session.handler', array(
 			'model' => 'SessionTestModel',
-			'database' => 'test',
-			'table' => 'sessions'
 		));
 		Configure::write('Session.timeout', 100);
 	}
@@ -99,6 +97,7 @@ class DatabaseSessionTest extends CakeTestCase {
 		$this->assertInstanceOf('SessionTestModel', $session);
 		$this->assertEquals('Session', $session->alias);
 		$this->assertEquals('test', $session->useDbConfig);
+		$this->assertEquals('sessions', $session->useTable);
 	}
 
 /**

--- a/lib/Cake/Test/Fixture/SessionFixture.php
+++ b/lib/Cake/Test/Fixture/SessionFixture.php
@@ -46,7 +46,7 @@ class SessionFixture extends CakeTestFixture {
  * @access public
  */
 	public $fields = array(
-		'id' => array('type' => 'string', 'length' => 255, 'key' => 'primary'),
+		'id' => array('type' => 'string', 'length' => 128, 'key' => 'primary'),
 		'data' => array('type' => 'text','null' => true),
 		'expires' => array('type' => 'integer', 'length' => 11, 'null' => true)
 	);


### PR DESCRIPTION
To configure custom session model only 'Session.handler.model' config is required as stated in docs: http://cakephp.lighthouseapp.com/projects/42648/20-session. 
I think this closes ticket #1766 http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/1766

Fix for SessionFixture `id` column primary key length VARCHAR (255):
´Warning: SQL Error: 1071: Specified key was too long; max key length is 767 bytes`
On MySQL 5.5.8 InnoDB and utf8_unicode_ci collation

Updated testsuite a bit.
