### PR TITLE
Feature/2.0 return query

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2102,7 +2102,7 @@ class Model extends Object {
  *  - Otherwise, first and second fields are used for key and value.
  *
  * @param string $type Type of find operation (all / first / count / neighbors / list / threaded)
- * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
+ * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks / returnQuery)
  * @return array Array of records
  * @link http://book.cakephp.org/view/1018/find
  */
@@ -2113,7 +2113,8 @@ class Model extends Object {
 		$query = array_merge(
 			array(
 				'conditions' => null, 'fields' => null, 'joins' => array(), 'limit' => null,
-				'offset' => null, 'order' => null, 'page' => 1, 'group' => null, 'callbacks' => true
+				'offset' => null, 'order' => null, 'page' => 1, 'group' => null, 'callbacks' => true,
+				'returnQuery' => false
 			),
 			(array)$query
 		);
@@ -2154,6 +2155,10 @@ class Model extends Object {
 			if ($return === false) {
 				return null;
 			}
+		}
+
+		if ($query['returnQuery'] == true) {
+			return $query;
 		}
 
 		$results = $this->getDataSource()->read($this, $query);

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -6011,12 +6011,12 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
- * test find() with the returnQuery opton in the 2nd argument to get the query array back
+ * test buildQuery()
  *
  * @access public
  * @return void
  */
-	public function testFindReturnQuery() {
+	public function testBuildQuery() {
 		$this->loadFixtures('User');
 		$TestModel = new User();
 		$TestModel->cacheQueries = false;
@@ -6034,7 +6034,7 @@ class ModelReadTest extends BaseModelTest {
 			'group' => NULL,
 			'callbacks' => true,
 			'returnQuery' => true);
-		$result = $TestModel->find('all', array('returnQuery' => true, 'conditions' => array('user' => 'larry')));
+		$result = $TestModel->buildQuery('all', array('returnQuery' => true, 'conditions' => array('user' => 'larry')));
 		$this->assertEqual($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -6011,6 +6011,34 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * test find() with the returnQuery opton in the 2nd argument to get the query array back
+ *
+ * @access public
+ * @return void
+ */
+	public function testFindReturnQuery() {
+		$this->loadFixtures('User');
+		$TestModel = new User();
+		$TestModel->cacheQueries = false;
+
+		$expected = array(
+			'conditions' => array(
+				'user' => 'larry'),
+			'fields' => NULL,
+			'joins' => array (),
+			'limit' => NULL,
+			'offset' => NULL,
+			'order' => array(
+				0 => NULL),
+			'page' => 1,
+			'group' => NULL,
+			'callbacks' => true,
+			'returnQuery' => true);
+		$result = $TestModel->find('all', array('returnQuery' => true, 'conditions' => array('user' => 'larry')));
+		$this->assertEqual($expected, $result);
+	}
+
+/**
  * test find('all') method
  *
  * @access public


### PR DESCRIPTION
Adding the "returnQuery" key to the 2nd argument of the find() method to be able to get the query array back from the before state of findMethod() calls. This was required in the past for some more complex queries and is in 2.0 no longer possible because the find methods became protected.
