### PR TITLE
1.3 - Minor FormHelper fix

### DIFF
--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -1833,7 +1833,7 @@ class FormHelper extends AppHelper {
 				if (!empty($timeFormat)) {
 					$time = explode(':', $days[1]);
 
-					if (($time[0] > 12) && $timeFormat == '12') {
+					if (($time[0] >= 12) && $timeFormat == '12') {
 						$time[0] = $time[0] - 12;
 						$meridian = 'pm';
 					} elseif ($time[0] == '00' && $timeFormat == '12') {


### PR DESCRIPTION
fixed the FormHelper time() meridian selector, when the selected input hour is 12 and the hourformat is 12... it should be 'pm' -- changed comparison from '>' to '>='

(replaces: https://github.com/cakephp/cakephp/pull/148#issuecomment-1554866)
