### PR TITLE
2.0

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -224,11 +224,16 @@ class CakeSchema extends Object {
 				$models = App::objects('Model');
 			}
 		}
-
+		
 		if (is_array($models)) {
 			foreach ($models as $model) {
 				$importModel = $model;
 				$plugin = null;
+				
+				if ($model == 'AppModel') {
+					continue;
+				}
+				
 				if (isset($this->plugin)) {
 					if ($model == $this->plugin . 'AppModel') {
 						continue;
@@ -236,7 +241,7 @@ class CakeSchema extends Object {
 					$importModel = $model;
 					$plugin = $this->plugin . '.';
 				}
-
+				
 				App::uses($importModel, $plugin . 'Model');
 				if (!class_exists($importModel)) {
 					continue;
@@ -290,7 +295,7 @@ class CakeSchema extends Object {
 				}
 			}
 		}
-
+		
 		if (!empty($currentTables)) {
 			foreach ($currentTables as $table) {
 				if ($prefix) {
@@ -324,6 +329,7 @@ class CakeSchema extends Object {
 
 		ksort($tables);
 		return compact('name', 'tables');
+		
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -602,6 +602,41 @@ class CakeSchemaTest extends CakeTestCase {
 		));
 		$this->assertFalse(isset($read['tables']['missing']['posts_tags']), 'Join table marked as missing');
 	}
+	
+/**
+* testSchemaReadWithAppModel method
+*
+* @access public
+* @return void
+*/
+	public function testSchemaReadWithAppModel() {
+		$connections = ConnectionManager::enumConnectionObjects();
+		if (!empty($connections['default'])) { 
+			$backup = $connections['default']; 
+			ConnectionManager::drop('default'); 
+		}
+		ConnectionManager::create('default', $connections['test']);
+		try {
+			$read = $this->Schema->read(array(
+					'connection' => 'default',
+					'name' => 'TestApp',
+					'models' => array('AppModel')
+			));
+			unset($read['tables']['missing']);
+			$this->assertTrue(empty($read['tables']));
+			if (!empty($backup)) {
+				ConnectionManager::drop('default');
+				ConnectionManager::create('default', $backup);
+			}
+		} catch(MissingTableException $mte) {
+			if (!empty($backup)) {
+				ConnectionManager::drop('default');
+				ConnectionManager::create('default', $backup);
+			}
+			$this->fail($mte->getMessage());
+		}
+		
+	}
 
 /**
  * testSchemaReadWithOddTablePrefix method


### PR DESCRIPTION
Included validation to skip AppModel on CakeSchema->readSchema because it tries to find 'app_models' table. Added testSchemaReadWithAppModel test
