### PR TITLE
Add HTML5 Form Inputs to FormHelper

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1048,9 +1048,6 @@ class FormHelper extends AppHelper {
 			case 'radio':
 				$input = $this->radio($fieldName, $radioOptions, $options);
 			break;
-			case 'file':
-				$input = $this->file($fieldName, $options);
-			break;
 			case 'select':
 				$options += array('options' => array(), 'value' => $selected);
 				$list = $options['options'];
@@ -1072,8 +1069,12 @@ class FormHelper extends AppHelper {
 			case 'textarea':
 				$input = $this->textarea($fieldName, $options + array('cols' => '30', 'rows' => '6'));
 			break;
-			default:
+			case 'file':
 				$input = $this->{$type}($fieldName, $options);
+			break;
+			default:
+				$options['type'] = $type;
+				$input = $this->text($fieldName, $options);
 		}
 
 		if ($type != 'hidden' && $error !== false) {


### PR DESCRIPTION
I would have added `case 'password':` above `case 'file':` without a `break;` however I can't seem to find the password method anymore. I figured it was removed due to changes I'm unaware of so I left it out.

This approach also degrades a bit more gracefully in that if the form method isn't found, the `<input type="whatever">` approach is used which is a bit more semantically correct for HTML5.

If however you feel this breaks the 'automagic' of letting devs add their own methods, perhaps a check could be added to see if the method exists first, and then if not use this approach?
