### PR TITLE
Fix for lowercased schema folder when baking plugin skel.

### DIFF
--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -98,7 +98,7 @@ class PluginTask extends Shell {
 		if (strtolower($looksGood) == 'y') {
 			$Folder = new Folder($this->path . $plugin);
 			$directories = array(
-				'Config' . DS . 'schema',
+				'Config' . DS . 'Schema',
 				'Model' . DS . 'Behavior',
 				'Model' . DS . 'Datasource',
 				'Console' . DS . 'Command' . DS . 'Task',

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -86,7 +86,7 @@ class PluginTaskTest extends CakeTestCase {
 		$this->assertTrue(is_dir($path), 'No plugin dir %s');
 		
 		$directories = array(
-			'Config' . DS . 'schema',
+			'Config' . DS . 'Schema',
 			'Model' . DS . 'Behavior',
 			'Model' . DS . 'Datasource',
 			'Console' . DS . 'Command' . DS . 'Task',


### PR DESCRIPTION
`PluginTask` creates lower cased 'schema' folder.

There's `app/Config/Schema` and testsuite uses
`test_app/Plugin/TestPlugin/Config/Schema`.
