### PR TITLE
Add App::uses to the Oracle DBO

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Oracle.php
+++ b/lib/Cake/Model/Datasource/Database/Oracle.php
@@ -17,6 +17,8 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+App::uses('DboSource', 'Model/Datasource');
+
 /**
  * Oracle layer for DBO.
  *


### PR DESCRIPTION
This allows it to extend DboSource successfully. Now it's much happier.

Ben
