### PR TITLE
Making requireAuth work on Security Component

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -373,7 +373,7 @@ class SecurityComponent extends Component {
  * @return bool true if authentication required
  */
 	protected function _authRequired($controller) {
-		if (is_array($this->requireAuth) && !empty($this->requireAuth) && !empty($this->request->data)) {
+		if (is_array($this->requireAuth) && !empty($this->requireAuth)) {
 			$requireAuth = $this->requireAuth;
 
 			if (in_array($this->request->params['action'], $requireAuth) || $this->requireAuth == array('*')) {


### PR DESCRIPTION
I don't get it why this statement was there in the first place. I might be wrong but as soon I removed the statement with $this->request->data the requireAuth starts working just fine.

And I believe the delete action is always blackholed when you add the Security component to your controller. 
