### PR TITLE
generating schema file based on default connection's database name

### DIFF
--- a/cake/libs/model/cake_schema.php
+++ b/cake/libs/model/cake_schema.php
@@ -90,7 +90,9 @@ class CakeSchema extends Object {
 		}
 
 		if (strtolower($this->name) === 'cake') {
-			$this->name = Inflector::camelize(Inflector::slug(Configure::read('App.dir')));
+			$cm = new ConnectionManager;
+			$dbname = $cm->config->default['database'];
+			$this->name = Inflector::camelize(Inflector::slug($dbname));
 		}
 
 		if (empty($options['path'])) {


### PR DESCRIPTION
Addressing ticket #1891 (http://cakephp.lighthouseapp.com/projects/42648/tickets/1891-cake-schema)

Small (maybe experimental) change:

When executing `cake generate schema` a schema.php file is generated: the class declaration inside the schema.php file now reads:
    class MyDatabaseSchema

instead of how it currently reads:
    class MyAppFolderNameSchema

This is helpful when creating a schema somewhere and updating somewhere else (and you have different APP folder names).
