### PR TITLE
In baked views, under related models, the "new" link should use the singular form of the model name.

### DIFF
--- a/cake/console/templates/default/views/view.ctp
+++ b/cake/console/templates/default/views/view.ctp
@@ -139,7 +139,7 @@ echo "\t<?php endforeach; ?>\n";
 <?php echo "<?php endif; ?>\n\n";?>
 	<div class="actions">
 		<ul>
-			<li><?php echo "<?php echo \$this->Html->link(__('New " . Inflector::humanize(Inflector::underscore($alias)) . "', true), array('controller' => '{$details['controller']}', 'action' => 'add'));?>";?> </li>
+			<li><?php echo "<?php echo \$this->Html->link(__('New " . Inflector::humanize(Inflector::underscore(Inflector::singularize($alias))) . "', true), array('controller' => '{$details['controller']}', 'action' => 'add'));?>";?> </li>
 		</ul>
 	</div>
 </div>

--- a/cake/libs/view/scaffolds/view.ctp
+++ b/cake/libs/view/scaffolds/view.ctp
@@ -152,7 +152,7 @@ $otherSingularVar = Inflector::variable($_alias);
 <?php endif; ?>
 	<div class="actions">
 		<ul>
-			<li><?php echo $this->Html->link(sprintf(__("New %s", true), Inflector::humanize(Inflector::underscore($_alias))), array('controller' => $_details['controller'], 'action' => 'add'));?> </li>
+			<li><?php echo $this->Html->link(sprintf(__("New %s", true), Inflector::humanize(Inflector::underscore(Inflector::singularize($_alias)))), array('controller' => $_details['controller'], 'action' => 'add'));?> </li>
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
Fixed (I think?) pull request based on ADmad's comment on the corresponding ticket

http://cakephp.lighthouseapp.com/projects/42648/tickets/1902-use-singular-form-for-new-links-in-baked-views
