### PR TITLE
1.3 added "encoding" => "utf8" to default db config

### DIFF
--- a/app/config/database.php.default
+++ b/app/config/database.php.default
@@ -81,6 +81,7 @@ class DATABASE_CONFIG {
 		'password' => 'password',
 		'database' => 'database_name',
 		'prefix' => '',
+		//'encoding' => 'utf8',
 	);
 
 	var $test = array(
@@ -91,5 +92,6 @@ class DATABASE_CONFIG {
 		'password' => 'password',
 		'database' => 'test_database_name',
 		'prefix' => '',
+		//'encoding' => 'utf8',
 	);
 }

--- a/cake/console/templates/skel/config/database.php.default
+++ b/cake/console/templates/skel/config/database.php.default
@@ -81,6 +81,7 @@ class DATABASE_CONFIG {
 		'password' => 'password',
 		'database' => 'database_name',
 		'prefix' => '',
+		//'encoding' => 'utf8',
 	);
 
 	var $test = array(
@@ -91,5 +92,6 @@ class DATABASE_CONFIG {
 		'password' => 'password',
 		'database' => 'test_database_name',
 		'prefix' => '',
+		//'encoding' => 'utf8',
 	);
 }


### PR DESCRIPTION
Assuming that a lot of people want to run their database with utf8 I added the option to the `database.php.default`. It is just a comment, so you can activate if you need it.
