### PR TITLE
Form::dateTime() shows incorrect 12 hour time for 24-hour input $selected values

### DIFF
--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -1833,12 +1833,12 @@ class FormHelper extends AppHelper {
 				if (!empty($timeFormat)) {
 					$time = explode(':', $days[1]);
 
-					if (($time[0] > 12) && $timeFormat == '12') {
+					if (($time[0] >= 12) && $timeFormat == '12') {
 						$time[0] = $time[0] - 12;
 						$meridian = 'pm';
 					} elseif ($time[0] == '00' && $timeFormat == '12') {
 						$time[0] = 12;
-					} elseif ($time[0] > 12) {
+					} elseif ($time[0] >= 12) {
 						$meridian = 'pm';
 					}
 					if ($time[0] == 0 && $timeFormat == '12') {


### PR DESCRIPTION
A time of 12:xx should be displayed with "pm" meridian, not "am". For example, the current behavior will show "12:35 am" for an input of 12:35:00, even though it should be "12:35 pm".
