### PR TITLE
backporting fix for #1660 to branch 1.2

### DIFF
--- a/cake/libs/cache/file.php
+++ b/cake/libs/cache/file.php
@@ -139,13 +139,24 @@ class FileEngine extends CacheEngine {
 			}
 		}
 
-		if ($this->settings['lock']) {
-			$this->__File->lock = true;
-		}
 		$expires = time() + $duration;
 		$contents = $expires . $lineBreak . $data . $lineBreak;
-		$success = $this->__File->write($contents);
-		$this->__File->close();
+
+		if (!$handle = fopen($this->__File->path, 'c')) {
+			return false;
+		}
+
+		if ($this->settings['lock']) {
+			flock($handle, LOCK_EX);
+		}
+		
+		$success = ftruncate($handle, 0) && fwrite($handle, $contents) && fflush($handle);
+
+		if ($this->settings['lock']) {
+			flock($handle, LOCK_UN);
+		}
+
+		fclose($handle);
 		return $success;
 	}
 /**


### PR DESCRIPTION
backporting fix for #1660 to branch 1.2, fixed broken locking when writing cache files.

see http://cakephp.lighthouseapp.com/projects/42648/tickets/1660 for discussion.
