### PR TITLE
Patch for ticket #1965 - Scientific notation in queries

### DIFF
--- a/cake/libs/model/datasources/dbo/dbo_mysql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysql.php
@@ -672,7 +672,7 @@ class DboMysql extends DboMysqlBase {
 					return 'NULL';
 				}
 				if (is_float($data)) {
-					return sprintf('%F', $data);
+					return str_replace(',', '.', sprintf('%G', $data));
 				}
 				if ((is_int($data) || $data === '0') || (
 					is_numeric($data) && strpos($data, ',') === false &&

--- a/cake/tests/cases/libs/model/datasources/dbo/dbo_mysql.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo/dbo_mysql.test.php
@@ -239,12 +239,31 @@ class DboMysqlTest extends CakeTestCase {
 		setlocale(LC_ALL, 'de_DE');
 
 		$result = $this->db->value(3.141593, 'float');
-		$this->assertEqual((string)$result, '3.141593');
-		
+		$this->assertTrue(strpos((string)$result, ',') === false);
+
 		$result = $this->db->value(3.141593);
-		$this->assertEqual((string)$result, '3.141593');
+		$this->assertTrue(strpos((string)$result, ',') === false);
+
+		$result = $this->db->value(2.2E-54, 'float');
+		$this->assertEqual('2.2E-54', (string)$result);
+
+		$result = $this->db->value(2.2E-54);
+		$this->assertEqual('2.2E-54', (string)$result);
 
 		setlocale(LC_ALL, $restore);
+	}
+
+/**
+ * test that scientific notations are working correctly
+ *
+ * @return void
+ */
+	function testScientificNotation() {
+		$result = $this->db->value(2.2E-54, 'float');
+		$this->assertEqual('2.2E-54', (string)$result);
+
+		$result = $this->db->value(2.2E-54);
+		$this->assertEqual('2.2E-54', (string)$result);
 	}
 
 /**


### PR DESCRIPTION
sprintf('%F', $value) was transforming scientific notations into their normal string variants, for example, 2.2E-5 was transformed to 0.000022, if the last part of the scientific notation was high enough it would truncate the resulting data.

I fixed this by replacing %F by %G which automatically switches between %F and %E based on the input given. The str_replace is used to make sure localised floats dont break queries.

As a result this patch fully implements the support of scientific notations for mysql.
