### PR TITLE
i18n: parse (multiline) strings concatenated with "."

### DIFF
--- a/cake/tests/cases/console/libs/tasks/extract.test.php
+++ b/cake/tests/cases/console/libs/tasks/extract.test.php
@@ -139,6 +139,18 @@ class ExtractTaskTest extends CakeTestCase {
 		$pattern .= 'msgid "Editing this Page"\nmsgstr ""/';
 		$this->assertPattern($pattern, $result);
 
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:17\nmsgid "';
+		$pattern .= 'Hot features!';
+		$pattern .= '\\\n - No Configuration: Set-up the database and let the magic begin';
+		$pattern .= '\\\n - Extremely Simple: Just look at the name...It\'s Cake';
+		$pattern .= '\\\n - Active, Friendly Community: Join us #cakephp on IRC. We\'d love to help you get started';
+		$pattern .= '"\nmsgstr ""/';
+		$this->assertPattern($pattern, $result);
+
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:26\n';
+		$pattern .= 'msgid "Found "/';
+		$this->assertNoPattern($pattern, $result);
+
 		// extract.ctp - reading the domain.pot
 		$result = file_get_contents($path . DS . 'domain.pot');
 
@@ -156,7 +168,7 @@ class ExtractTaskTest extends CakeTestCase {
 		$Folder->delete();
 	}
 	function getTests() {
-		return array('start', 'startCase', 'testExtractMultiplePaths', 'endCase', 'end');
+		return array('start', 'startCase', 'testExecute', 'testExtractMultiplePaths', 'endCase', 'end');
 	}
 
 /**

--- a/cake/tests/test_app/views/pages/extract.ctp
+++ b/cake/tests/test_app/views/pages/extract.ctp
@@ -12,3 +12,15 @@ __dn('domain', 'You deleted %d message (domain).', 'You deleted %d messages (dom
 
 // Duplicated Message
 __('Editing this Page');
+
+// Multiline with comments
+__('Hot features!'
+  . "\n - No Configuration:"				// Comments will be stripped
+		. ' Set-up the database and let the magic begin'
+	. "\n - Extremely Simple:"				// Comments will be stripped
+		. ' Just look at the name...It\'s Cake'
+	. "\n - Active, Friendly Community:"	// Comments will be stripped
+		. ' Join us #cakephp on IRC. We\'d love to help you get started');
+
+// This throws an error and is not parsed
+__('Found ' . $count . ' new messages');


### PR DESCRIPTION
Ticket #1969

The patch is based on code of 2.0, but with this fix, comments are allowed, and an exception is thrown if invalid output is found. Examples:

```
__('Split' . ' string')     => ok
__('Split' . // Comment
    ' string')                => ok
__('Split' . $var)         => error
```
