### PR TITLE
2.0 version of the patch for ticket #1938

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -598,8 +598,6 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testUserOffset() {
-		$this->skipIf(!class_exists('DateTimeZone'), 'DateTimeZone class not available.');
-
 		$timezoneServer = new DateTimeZone(date_default_timezone_get());
 		$timeServer = new DateTime('now', $timezoneServer);
 		$yourTimezone = $timezoneServer->getOffset($timeServer) / HOUR;

--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -396,6 +396,14 @@ class TimeHelperTest extends CakeTestCase {
  */
 	public function testToRss() {
 		$this->assertEqual(date('r'), $this->Time->toRss(time()));
+
+		$timezones = array('Europe/London', 'Europe/Brussels', 'UTC', 'America/Denver', 'America/Caracas', 'Asia/Kathmandu');
+		foreach ($timezones as $timezone) {
+			$yourTimezone = new DateTimeZone($timezone);
+			$yourTime = new DateTime('now', $yourTimezone);
+			$userOffset = $yourTimezone->getOffset($yourTime) / HOUR;
+			$this->assertEqual($yourTime->format('r'), $this->Time->toRss(time(), $userOffset));	
+		}
 	}
 
 /**

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -454,6 +454,17 @@ class TimeHelper extends AppHelper {
  */
 	public function toRSS($dateString, $userOffset = null) {
 		$date = $this->fromString($dateString, $userOffset);
+
+		if (!is_null($userOffset)) {
+			if ($userOffset == 0) {
+				$timezone = '+0000';
+			} else {
+				$hours = (int) floor(abs($userOffset));
+				$minutes = (int) (fmod(abs($userOffset), $hours) * 60);
+				$timezone = ($userOffset < 0 ? '-' : '+') . str_pad($hours, 2, '0', STR_PAD_LEFT) . str_pad($minutes, 2, '0', STR_PAD_LEFT);
+			}
+			return date('D, d M Y H:i:s', $date) . ' ' . $timezone;
+		}
 		return date("r", $date);
 	}
 


### PR DESCRIPTION
The 2.0 branch still has the toRSS() RFC bug referenced in ticket #1938.

date('r'); generates a RFC 2822 string like "Thu, 21 Dec 2000 16:01:07 +0200" with the timezone added on the end.

When the server is in UTC and you call this method with a userOffset of 1. It will return the correct date time combination but the timezone part on the end will still be +0000 and not +0100 like it should be.

This happens because date('r') takes its timezone info from the timezone set in php or from the system.

Original pull request for the 1.3.11 branch: https://github.com/cakephp/cakephp/pull/182
