### PR TITLE
1.3 TranslateBehaviour: Cleaner code and optimized query

### DIFF
--- a/cake/libs/model/behaviors/translate.php
+++ b/cake/libs/model/behaviors/translate.php
@@ -182,26 +182,18 @@ class TranslateBehavior extends ModelBehavior {
 				} else {
 					$query['fields'][] = 'I18n__'.$field.'.content';
 					$query['joins'][] = array(
-						'type' => 'LEFT',
+						'type' => 'INNER',
 						'alias' => 'I18n__'.$field,
 						'table' => $db->name($tablePrefix . $RuntimeModel->useTable),
 						'conditions' => array(
 							$model->alias . '.' . $model->primaryKey => $db->identifier("I18n__{$field}.foreign_key"),
 							'I18n__'.$field.'.model' => $model->name,
-							'I18n__'.$field.'.'.$RuntimeModel->displayField => $field
+							'I18n__'.$field.'.'.$RuntimeModel->displayField => $field,
+							'I18n__'.$field.'.locale' => $locale
 						)
 					);
-
-					if (is_string($query['conditions'])) {
-						$query['conditions'] = $db->conditions($query['conditions'], true, false, $model) . ' AND '.$db->name('I18n__'.$field.'.locale').' = \''.$locale.'\'';
-					} else {
-						$query['conditions'][$db->name("I18n__{$field}.locale")] = $locale;
-					}
 				}
 			}
-		}
-		if (is_array($query['fields'])) {
-			$query['fields'] = array_merge($query['fields']);
 		}
 		$this->runtime[$model->alias]['beforeFind'] = $addFields;
 		return $query;


### PR DESCRIPTION
Added "locale = $locale" to the ON part and changed the join type to an INNER join.
Because adding it to the WHERE part caused the translation to be mandatory anyway.
This cleans up the code and "INNER" joins are generally faster than LEFT joins.
