### PR TITLE
Refactored a bunch of expectError()'s to PHPUnit annotations

### DIFF
--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -111,10 +111,10 @@ class CacheTest extends CakeTestCase {
  *
  * Test that the cache class doesn't cause fatal errors with a partial path
  *
+ * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
-	public function testInvaidConfig() {
-		$this->expectError();
+	public function testInvalidConfig() {
 		Cache::config('invalid', array(
 			'engine' => 'File',
 			'duration' => '+1 year',
@@ -124,7 +124,6 @@ class CacheTest extends CakeTestCase {
 			'random' => 'wii'
 		));
 		$read = Cache::read('Test', 'invalid');
-		$this->assertEqual($read, null);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -317,12 +317,12 @@ class FileEngineTest extends CakeTestCase {
 /**
  * check that FileEngine generates an error when a configured Path does not exist.
  *
+ * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testErrorWhenPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'file_failure'), 'Cannot run test directory exists.');
 
-		$this->expectError();
 		Cache::config('failure', array(
 			'engine' => 'File',
 			'path' => TMP . 'tests' . DS . 'file_failure'

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -147,12 +147,19 @@ class ContainableBehaviorTest extends CakeTestCase {
 /**
  * testInvalidContainments method
  *
+ * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testInvalidContainments() {
-		$this->expectError();
 		$r = $this->__containments($this->Article, array('Comment', 'InvalidBinding'));
+	}
 
+/**
+ * testInvalidContainments method with suppressing error notices
+ *
+ * @return void
+ */
+	public function testInvalidContainmentsNoNotices() {
 		$this->Article->Behaviors->attach('Containable', array('notices' => false));
 		$r = $this->__containments($this->Article, array('Comment', 'InvalidBinding'));
 	}
@@ -226,8 +233,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$r = $this->Article->find('all', array('contain' => array()));
 		$this->assertFalse(Set::matches('/User', $r));
 		$this->assertFalse(Set::matches('/Comment', $r));
+	}
 
-		$this->expectError();
+/**
+ * testBeforeFindWithNonExistingBinding method
+ * 
+ * @expectedException PHPUnit_Framework_Error_Warning
+ * @return void
+ */
+	public function testBeforeFindWithNonExistingBinding() {
 		$r = $this->Article->find('all', array('contain' => array('Comment' => 'NonExistingBinding')));
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -2479,16 +2479,22 @@ class MysqlTest extends CakeTestCase {
 		$Schema = new CakeSchema();
 		$Schema->tables = array('table' => array(), 'anotherTable' => array());
 
-		$this->expectError();
-		$result = $this->Dbo->dropSchema(null);
-		$this->assertTrue($result === null);
-
 		$result = $this->Dbo->dropSchema($Schema, 'non_existing');
 		$this->assertTrue(empty($result));
 
 		$result = $this->Dbo->dropSchema($Schema, 'table');
 		$this->assertPattern('/^\s*DROP TABLE IF EXISTS\s+' . $this->Dbo->fullTableName('table') . ';\s*$/s', $result);
 	}
+
+/**
+ * testDropSchemaNoSchema method
+ *
+ * @expectedException PHPUnit_Framework_Error
+ * @return void
+ */
+	public function testDropSchemaNoSchema() {
+		$result = $this->Dbo->dropSchema(null);
+	}	
 
 /**
  * testOrderParsing method
@@ -2693,16 +2699,6 @@ class MysqlTest extends CakeTestCase {
  * @return void
  */
 	public function testBuildColumn2() {
-		$this->expectError();
-		$data = array(
-			'name' => 'testName',
-			'type' => 'varchar(255)',
-			'default',
-			'null' => true,
-			'key'
-		);
-		$this->Dbo->buildColumn($data);
-
 		$data = array(
 			'name' => 'testName',
 			'type' => 'string',
@@ -2798,6 +2794,23 @@ class MysqlTest extends CakeTestCase {
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`modified` timestamp NULL';
 		$this->assertEqual($expected, $result);
+	}
+
+/**
+ * testBuildColumnBadType method
+ *
+ * @expectedException PHPUnit_Framework_Error
+ * @return void
+ */
+	public function testBuildColumnBadType() {
+		$data = array(
+			'name' => 'testName',
+			'type' => 'varchar(255)',
+			'default',
+			'null' => true,
+			'key'
+		);
+		$this->Dbo->buildColumn($data);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -417,11 +417,18 @@ class ModelDeleteTest extends BaseModelTest {
 
 		$result = $TestModel->deleteAll(array('Article.user_id' => 999));
 		$this->assertTrue($result, 'deleteAll returned false when all no records matched conditions. %s');
+	}
 
-		$this->expectError();
-		ob_start();
+/**
+ * testDeleteAllUnknownColumn method
+ *
+ * @expectedException PDOException
+ * @return void
+ */
+	public function testDeleteAllUnknownColumn() {
+		$this->loadFixtures('Article');
+		$TestModel = new Article();
 		$result = $TestModel->deleteAll(array('Article.non_existent_field' => 999));
-		ob_get_clean();
 		$this->assertFalse($result, 'deleteAll returned true when find query generated sql error. %s');
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -4943,8 +4943,17 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('Post');
 		$TestModel = new Post();
 		$this->assertEqual(3, count($TestModel->find('all')));
+	}
 
-		$this->expectError();
+/**
+ * testCallbackSourceChangeUnknownDatasource method
+ *
+ * @expectedException MissingDatasourceConfigException
+ * @return void
+ */
+	public function testCallbackSourceChangeUnknownDatasource() {
+		$this->loadFixtures('Post');
+		$TestModel = new Post();
 		$this->assertFalse($TestModel->find('all', array('connection' => 'foo')));
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -643,6 +643,7 @@ class ModelValidationTest extends BaseModelTest {
  * Test that missing validation methods trigger errors in development mode.
  * Helps to make developement easier.
  *
+ * @expectedException PHPUnit_Framework_Error
  * @return void
  */
 	public function testMissingValidationErrorTriggering() {
@@ -656,7 +657,6 @@ class ModelValidationTest extends BaseModelTest {
 				'required' => true
 			)
 		);
-		$this->expectError();
 		$TestModel->invalidFields(array('fieldList' => array('title')));
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2145,12 +2145,18 @@ class ModelWriteTest extends BaseModelTest {
 
 		$TestModel = new TheVoid();
 		$this->assertFalse($TestModel->exists());
+	}
 
+/**
+ * testRecordExistsMissingTable method
+ *
+ * @expectedException PDOException
+ * @return void
+ */
+	public function testRecordExistsMissingTable() {
+		$TestModel = new TheVoid();
 		$TestModel->id = 5;
-		$this->expectError();
-		ob_start();
-		$this->assertFalse($TestModel->exists());
-		$output = ob_get_clean();
+		$TestModel->exists();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -378,11 +378,17 @@ class HttpResponseTest extends CakeTestCase {
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
 		$this->assertEquals($r['body'], $decoded);
 		$this->assertEquals($r['header'], array('foo-header' => 'bar', 'cake' => 'PHP'));
+	}
 
+/**
+ * testDecodeChunkedBodyError method
+ *
+ * @expectedException SocketException
+ * @return void
+ */
+	public function testDecodeChunkedBodyError() {
 		$encoded = "19\r\nThis is a chunked message\r\nE\r\n\nThat is cool\n\r\n";
-		$this->expectError();
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
-		$this->assertEquals($r, false);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -546,12 +546,18 @@ class HttpSocketTest extends CakeTestCase {
 		$request = array('method' => 'POST', 'uri' => 'http://www.cakephp.org/posts/add', 'body' => array('name' => 'HttpSocket-is-released', 'date' => 'today'));
 		$response = $this->Socket->request($request);
 		$this->assertEquals($this->Socket->request['body'], "name=HttpSocket-is-released&date=today");
+	}
 
+/**
+ * The "*" asterisk character is only allowed for the following methods: OPTIONS.
+ *
+ * @expectedException SocketException
+ * @return void
+ */
+	public function testRequestNotAllowedUri() {
+		$this->Socket->reset();
 		$request = array('uri' => '*', 'method' => 'GET');
-		$this->expectError();
 		$response = $this->Socket->request($request);
-		$this->assertFalse($response);
-		$this->assertFalse($this->Socket->response);
 	}
 
 /**
@@ -1036,20 +1042,20 @@ class HttpSocketTest extends CakeTestCase {
 /**
  * testBadBuildRequestLine method
  *
+ * @expectedException SocketException
  * @return void
  */
 	public function testBadBuildRequestLine() {
-		$this->expectError();
 		$r = $this->Socket->buildRequestLine('Foo');
 	}
 
 /**
  * testBadBuildRequestLine2 method
  *
+ * @expectedException SocketException
  * @return void
  */
 	public function testBadBuildRequestLine2() {
-		$this->expectError();
 		$r = $this->Socket->buildRequestLine("GET * HTTP/1.1\r\n");
 	}
 

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -144,10 +144,17 @@ class SecurityTest extends CakeTestCase {
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
 		$this->assertEqual(Security::cipher($result, $key), $txt);
+	}
 
+/**
+ * testCipherEmptyKey method
+ *
+ * @expectedException PHPUnit_Framework_Error
+ * @return void
+ */
+	public function testCipherEmptyKey() {
 		$txt = 'some_text';
 		$key = '';
-		$this->expectError();
 		$result = Security::cipher($txt, $key);
 	}
 }


### PR DESCRIPTION
The simpletest lib has some of these too, but i havent touched those beause i dont know if those should be refactored or not.

The ACLComponent still has expectError calls but i cant test them due to the bug explained in ticket [#1985](http://cakephp.lighthouseapp.com/projects/42648/tickets/1985-testsuite-fails-running-multiple-testcase-classes-in-one-file)
