### PR TITLE
Bug fixed. saveAll() with validation option "only" or "first" works well with associated data.

### DIFF
--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -1687,7 +1687,10 @@ class Model extends Overloadable {
 					$type = $associations[$association];
 					switch ($type) {
 						case 'hasOne':
-							$values[$this->{$type}[$association]['foreignKey']] = $this->id;
+							if (!$validating) {
+								$values[$this->{$type}[$association]['foreignKey']] = $this->id;
+							}
+
 							if (!$this->{$association}->__save($values, $options)) {
 								$validationErrors[$association] = $this->{$association}->validationErrors;
 								$validates = false;
@@ -1697,9 +1700,12 @@ class Model extends Overloadable {
 							}
 						break;
 						case 'hasMany':
-							foreach ($values as $i => $value) {
-								$values[$i][$this->{$type}[$association]['foreignKey']] =  $this->id;
+							if (!$validating) {
+								foreach ($values as $i => $value) {
+									$values[$i][$this->{$type}[$association]['foreignKey']] =  $this->id;
+								}
 							}
+
 							$_options = array_merge($options, array('atomic' => false));
 
 							if ($_options['validate'] === 'first') {


### PR DESCRIPTION
saveAll() did set null foreign key when it just validates. 

For example, I've assigned numeric validation on the hasMany side model and validation did fail with this behavior. 

``` PHP
$data = array(
    'Post' => array(
        'title' => 'Hello world',
    ), 
    'Keyword' => array(
        array(
            'word' => 'foo',
        ),
        array(
            'word' => 'bar',
        ),
        ...
    ),
);
```

I've changed this not to set foreign key when it just validation.
