### PR TITLE
2.0 Added unittest for saveAll() validation with the data no id assigned.

### DIFF
--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -640,6 +640,48 @@ class ModelValidationTest extends BaseModelTest {
 	}
 
 /**
+ * test that saveAll and with models at initial insert (no id has set yet)
+ * with validation interact well
+ *
+ * @return void
+ */
+	public function testValidatesWithModelsAndSaveAllWithoutId() {
+		$this->loadFixtures('Post', 'Author');
+
+		$data = array(
+			'Author' => array(
+				'name' => 'Foo Bar',
+			),
+			'Post' => array(
+				array('title' => 'Hello'),
+				array('title' => 'World'),
+			)
+		);
+		$Author = new Author();
+		$Post = $Author->Post;
+
+		$Post->validate = array('author_id' => array('rule' => 'numeric'));
+
+		$Author->create();
+		$result = $Author->saveAll($data, array('validate' => 'only'));
+		$this->assertTrue($result);
+
+		$Author->create();
+		$result = $Author->saveAll($data, array('validate' => 'first'));
+		$this->assertTrue($result);
+		$this->assertFalse(is_null($Author->id));
+
+		$id = $Author->id;
+		$count = $Author->find('count', array('conditions' => array('Author.id' => $id)));
+		$this->assertIdentical($count, 1);
+
+		$count = $Post->find('count', array(
+			'conditions' => array('Post.author_id' => $id)
+		));
+		$this->assertEqual($count, count($data['Post']));
+	}
+
+/**
  * Test that missing validation methods trigger errors in development mode.
  * Helps to make developement easier.
  *


### PR DESCRIPTION
Cake2 separates the save and validation phase, so the error was not happened as 1.3 did.
