### PR TITLE
1.3 Router urlencode fix

### DIFF
--- a/cake/libs/router.php
+++ b/cake/libs/router.php
@@ -948,7 +948,7 @@ class Router {
 
 		if (!empty($named)) {
 			foreach ($named as $name => $value) {
-				$output .= '/' . $name . $this->named['separator'] . $value;
+				$output .= '/' . $name . $this->named['separator'] . rawurlencode($value);
 			}
 		}
 		return $output;
@@ -1218,6 +1218,7 @@ class Router {
 			$separatorIsPresent = strpos($param, $self->named['separator']) !== false;
 			if ((!isset($options['named']) || !empty($options['named'])) && $separatorIsPresent) {
 				list($key, $val) = explode($self->named['separator'], $param, 2);
+				$val = urldecode($val);
 				$hasRule = isset($rules[$key]);
 				$passIt = (!$hasRule && !$greedy) || ($hasRule && !$self->matchNamed($key, $val, $rules[$key], $context));
 				if ($passIt) {

--- a/cake/tests/cases/libs/router.test.php
+++ b/cake/tests/cases/libs/router.test.php
@@ -1343,6 +1343,12 @@ class RouterTest extends CakeTestCase {
 		$result = Router::url(array('type'=> 'new'));
 		$expected = "/admin/controller/index/type:new";
 		$this->assertEqual($result, $expected);
+		
+		// named argument's values should be urlencode.
+		Router::reload();
+		$result = Router::url(array('controller' => 'posts', 'action' => 'index', 'param1' => 'hello world', 'param2' => '#cakephp'));
+		$expected = '/posts/index/param1:hello%20world/param2:%23cakephp';
+		$this->assertEqual($result, $expected);
 	}
 
 /**
@@ -1409,6 +1415,12 @@ class RouterTest extends CakeTestCase {
 		Router::connectNamed(array(), array('greedy' => false));
 		$result = Router::parse('/foo/param1:value1:1/param2:value2:3/param3:value');
 		$expected = array('pass' => array('param2:value2:3', 'param3:value'), 'named' => array('param1' => 'value1:1'), 'controller' => 'bar', 'action' => 'fubar', 'plugin' => null);
+		$this->assertEqual($result, $expected);
+		
+		// named argument's values should be urlencode.
+		Router::reload();
+		$result = Router::parse('/controller/action/param1:hello+world/param2:%23cakephp');
+		$expected = array('pass' => array(), 'named' => array('param1' => 'hello world', 'param2' => '#cakephp'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
 		$this->assertEqual($result, $expected);
 	}
 


### PR DESCRIPTION
Router's named arguments doesn't encode and decode url values, but it should be. fixed.

For example, CakeDC's search plugin will force redirected to the url
with the POST values encoded as named args. It is safe to encode them.
