### PR TITLE
Minor updates to Helper.

### DIFF
--- a/cake/libs/view/helper.php
+++ b/cake/libs/view/helper.php
@@ -586,7 +586,7 @@ class Helper extends Overloadable {
 		$errors = $this->validationErrors;
 		$entity = $view->entity();
 		if (!empty($entity)) {
-			return Set::extract($errors, join('.', $entity));
+			return Set::extract(join('.', $entity), $errors);
 		}
 	}
 
@@ -704,7 +704,7 @@ class Helper extends Overloadable {
 
 		$entity = $view->entity();
 		if (!empty($this->data) && !empty($entity)) {
-			$result = Set::extract($this->data, join('.', $entity));
+			$result = Set::extract(join('.', $entity), $this->data);
 		}
 
 		$habtmKey = $this->field();

--- a/cake/libs/view/helper.php
+++ b/cake/libs/view/helper.php
@@ -573,13 +573,13 @@ class Helper extends Overloadable {
 	}
 
 /**
- * Returns false if given FORM field has no errors. Otherwise it returns the constant set in
+ * Returns null if given FORM field has no errors. Otherwise it returns the constant set in
  * the array Model->validationErrors.
  *
  * @param string $model Model name as a string
  * @param string $field Fieldname as a string
  * @param integer $modelID Unique index identifying this record within the form
- * @return boolean True on errors.
+ * @return mixed Null if no errors, string with error otherwhise.
  */
 	function tagIsInvalid($model = null, $field = null, $modelID = null) {
 		$view =& ClassRegistry::getObject('view');


### PR DESCRIPTION
Set::extract() calls inside Helper are issued like in the old days :P
Update Helper->tagIsInvalid() documentation.
