### PR TITLE
Fixing failing test.

### DIFF
--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2329,6 +2329,7 @@ class RouterTest extends CakeTestCase {
 			'named' => array(),
 			'ext' => 'json',
 		));
+		$request->query = array();
 		$result = Router::reverse($request);
 		$expected = '/posts/view/1.json';
 		$this->assertEquals($expected, $result);

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -264,7 +264,7 @@ class DebuggerTest extends CakeTestCase {
 		ob_start();
 		$foo .= '';
 		$result = ob_get_clean();
-		$this->assertEquals('Notice: I eated an error CORE/Cake/Test/Case/Utility/DebuggerTest.php', $result);
+		$this->assertEquals('Notice: I eated an error ' . 'CORE' . DS . ltrim(__FILE__, CAKE_CORE_INCLUDE_PATH), $result);
 	}
 
 /**


### PR DESCRIPTION
Fixing failing test for Router because of testsuite query string.
`test.php?case=Utility\Debugger`

Debugger test fails on windows due to different directory separator.
