### PR TITLE
Form input elements can now be rendered with 'error' class appended and empty error messages.

### DIFF
--- a/cake/libs/view/helper.php
+++ b/cake/libs/view/helper.php
@@ -756,7 +756,7 @@ class Helper extends Overloadable {
 		$options = $this->_name($options);
 		$options = $this->value($options);
 		$options = $this->domId($options);
-		if ($this->tagIsInvalid()) {
+		if ($this->tagIsInvalid() !== null) {
 			$options = $this->addClass($options, 'form-error');
 		}
 		return $options;

--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -512,7 +512,7 @@ class FormHelper extends AppHelper {
 				unset($options[$error]);
 			}
 
-			if ($text != null) {
+			if ($text !== null) {
 				$error = $text;
 			} elseif (is_numeric($error)) {
 				$error = sprintf(__('Error in field %s', true), Inflector::humanize($this->field()));

--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -490,7 +490,8 @@ class FormHelper extends AppHelper {
 		$options = array_merge($defaults, $options);
 		$this->setEntity($field);
 
-		if ($error = $this->tagIsInvalid()) {
+		$error = $this->tagIsInvalid();
+		if ($error !== null) {
 			if (is_array($error)) {
 				list(,,$field) = explode('.', $field);
 				if (isset($error[$field])) {

--- a/cake/tests/cases/libs/view/helpers/form.test.php
+++ b/cake/tests/cases/libs/view/helpers/form.test.php
@@ -1326,6 +1326,34 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testEmptyErrorValidation method
+ *
+ * test validation error div
+ *
+ * @access public
+ * @return void
+ */
+	function testEmptyErrorValidation() {
+		$this->Form->validationErrors['Contact']['password'] = 'Please provide a password';
+		$result = $this->Form->input('Contact.password', array('error' => ''));
+		$expected = array(
+			'div' => array('class' => 'input password error'),
+			'label' => array('for' => 'ContactPassword'),
+			'Password',
+			'/label',
+			'input' => array(
+				'type' => 'password', 'name' => 'data[Contact][password]',
+				'id' => 'ContactPassword', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'error-message')),
+			array(),
+			'/div',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * testFormValidationAssociated method
  *
  * test display of form errors in conjunction with model::validates.
@@ -5804,7 +5832,7 @@ class FormHelperTest extends CakeTestCase {
 
 		$expected = array(
 			'form' => array(
-				'id' => 'ContactAddForm', 'method' => 'post', 
+				'id' => 'ContactAddForm', 'method' => 'post',
 				'onsubmit' => 'someFunction();event.returnValue = false; return false;',
 				'action' => '/contacts/index/param',
 				'accept-charset' => 'utf-8'

--- a/cake/tests/cases/libs/view/helpers/form.test.php
+++ b/cake/tests/cases/libs/view/helpers/form.test.php
@@ -1297,6 +1297,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertEqual($result, $expected);
 	}
+
 /**
  * testPasswordValidation method
  *
@@ -1328,12 +1329,40 @@ class FormHelperTest extends CakeTestCase {
 /**
  * testEmptyErrorValidation method
  *
- * test validation error div
+ * test validation error div when validation message is an empty string
  *
  * @access public
  * @return void
  */
 	function testEmptyErrorValidation() {
+		$this->Form->validationErrors['Contact']['password'] = '';
+		$result = $this->Form->input('Contact.password');
+		$expected = array(
+			'div' => array('class' => 'input password error'),
+			'label' => array('for' => 'ContactPassword'),
+			'Password',
+			'/label',
+			'input' => array(
+				'type' => 'password', 'name' => 'data[Contact][password]',
+				'id' => 'ContactPassword', 'class' => 'form-error'
+			),
+			array('div' => array('class' => 'error-message')),
+			array(),
+			'/div',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * testEmptyInputErrorValidation method
+ *
+ * test validation error div when validation message is overriden by an empty string when calling input()
+ *
+ * @access public
+ * @return void
+ */
+	function testEmptyInputErrorValidation() {
 		$this->Form->validationErrors['Contact']['password'] = 'Please provide a password';
 		$result = $this->Form->input('Contact.password', array('error' => ''));
 		$expected = array(


### PR DESCRIPTION
Allow setting empty error messages inside Model->validate and allows overriding error messages by empty strings from Form->input().
