### PR TITLE
Custom reporter

### DIFF
--- a/cake/tests/lib/cake_test_suite_dispatcher.php
+++ b/cake/tests/lib/cake_test_suite_dispatcher.php
@@ -184,10 +184,10 @@ class CakeTestSuiteDispatcher {
 
 			$appClass = $this->params['output'] . 'Reporter';
 			$appFile = APPLIBS . 'test_suite' . DS . 'reporter' . DS . $type . '_reporter.php';
-			if (include_once $coreFile) {
-				$Reporter =& new $coreClass(null, $this->params);
-			} elseif (include_once $appFile) {
+			if (file_exists($appFile) && include_once $appFile) {
 				$Reporter =& new $appClass(null, $this->params);
+			} elseif (include_once $coreFile) {
+				$Reporter =& new $coreClass(null, $this->params);
 			}
 		}
 		return $Reporter;


### PR DESCRIPTION
When having a custom reporter, errors were thrown because the reporter isn't in the core. I changed the order of the includes so it would check the application first (making overrides possible) and also added a file_exists() call to prevent the errors it threw.
