### PR TITLE
1.3

### DIFF
--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -682,6 +682,14 @@ class DboSource extends DataSource {
 			$out = null;
 			if ($error) {
 				trigger_error('<span style="color:Red;text-align:left"><b>' . __('SQL Error:', true) . "</b> {$this->error}</span>", E_USER_WARNING);
+				$caseSensitivityTestFile = new File(TMP.DS.'caseSensitivityTestFile.tmp');
+				if ($caseSensitivityTestFile->create()) {
+					if (file_exists(TMP.DS.'caseSensitivityTestFile.tmp') && !file_exists(TMP.DS.'casesensitivitytestfile.tmp')) {
+						trigger_error('<span style="color:orange; class="dev-heads-up">Underlying file system is case-sensitive, check query arguments are also case-sensitive.</span>', E_USER_NOTICE);
+					}
+					$caseSensitivityTestFile->delete();
+				}
+
 			} else {
 				$out = ('<small>[' . sprintf(__('Aff:%s Num:%s Took:%sms', true), $this->affected, $this->numRows, $this->took) . ']</small>');
 			}


### PR DESCRIPTION
Notify dev if filesystem is case sensitive when query fails. Useful in rare situation where poorly written query works under Windows but fails under Linux.
