### PR TITLE
Refactoring app build

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -359,8 +359,13 @@ class App {
 			}
 		}
 
+		if (empty($paths)) {
+			self::$_packages = $defaults;
+			return;
+		}
+
 		foreach ($defaults as $type => $default) {
-			if (empty(self::$_packages[$type]) || empty($paths)) {
+			if (empty(self::$_packages[$type])) {
 				self::$_packages[$type] = $default;
 			}
 

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -365,21 +365,23 @@ class App {
 		}
 
 		foreach ($defaults as $type => $default) {
-			if (empty(self::$_packages[$type])) {
-				self::$_packages[$type] = $default;
-			}
-
-			if (!empty($paths[$type])) {
-				if ($mode === App::PREPEND) {
-					$path = array_merge((array)$paths[$type], self::$_packages[$type]);
-				} else {
-					$path = array_merge(self::$_packages[$type], (array)$paths[$type]);
-				}
-			} else {
+			if (!empty(self::$_packages[$type])) {
 				$path = self::$_packages[$type];
 			}
 
-			self::$_packages[$type] = array_values(array_unique($path));
+			if (!empty($paths[$type])) {
+				$newPath = (array)$paths[$type];
+
+				if ($mode === App::PREPEND) {
+					$path = array_merge($newPath, $path);
+				} else {
+					$path = array_merge($path, $newPath);
+				}
+
+				$path = array_values(array_unique($path));
+			}
+
+			self::$_packages[$type] = $path;
 		}
 	}
 


### PR DESCRIPTION
- cleaner code.
- reduce call of array_values and array_unique.
- clear intent of code.

Bypass unnecessary foreach loop to improve speed when $paths is empty.
