### PR TITLE
2.0: Added resolution of symbolic links in cake CLI bash script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /app/Config
 /app/tmp
-/lib/Cake/Console/Templates/skel/tmp/
 /plugins
 /vendors
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/Migration"]
+	path = plugins/Migration
+	url = git@github.com:tPl0ch/migrations.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "plugins/Migration"]
-	path = plugins/Migration
-	url = git@github.com:tPl0ch/migrations.git

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -125,7 +125,7 @@ class ShellDispatcher {
 		define('APP', $this->params['working'] . DS);
 		define('WWW_ROOT', APP . $this->params['webroot'] . DS);
 		if (!is_dir(ROOT . DS . APP_DIR . DS . 'tmp')) {
-			define('TMP', CAKE_CORE_INCLUDE_PATH . DS . 'Cake' . DS . 'Console' . DS . 'Templates' . DS . 'skel' . DS . 'tmp' . DS);
+			define('TMP', sys_get_temp_dir());
 		}
 		$boot = file_exists(ROOT . DS . APP_DIR . DS . 'Config' . DS . 'bootstrap.php');
 		require CORE_PATH . 'Cake' . DS . 'bootstrap.php';

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -125,7 +125,11 @@ class ShellDispatcher {
 		define('APP', $this->params['working'] . DS);
 		define('WWW_ROOT', APP . $this->params['webroot'] . DS);
 		if (!is_dir(ROOT . DS . APP_DIR . DS . 'tmp')) {
-			define('TMP', sys_get_temp_dir());
+			if (!$temp = getenv('TMPDIR')) {
+				$temp = realpath(sys_get_temp_dir());
+			}
+			define('TMP', $temp)
+			unset($temp);
 		}
 		$boot = file_exists(ROOT . DS . APP_DIR . DS . 'Config' . DS . 'bootstrap.php');
 		require CORE_PATH . 'Cake' . DS . 'bootstrap.php';

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP versions 4 and 5
+# PHP versions 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -17,7 +17,16 @@
 # @license			MIT License (http://www.opensource.org/licenses/mit-license.php)
 #
 ################################################################################
-LIB=${0/%cake/}
+LIB=${0}
+SYM=$(readlink ${0})
+
+if [ "$SYM" != "" ]
+	then
+		LIB=${SYM%/*}"/"
+	else
+		LIB=${LIB%/*}"/"
+fi
+
 APP=`pwd`
 
 exec php -q ${LIB}cake.php -working "${APP}" "$@"

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP 5
+# PHP versions 4 and 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.
@@ -10,21 +10,26 @@
 # Licensed under The MIT License
 # Redistributions of files must retain the above copyright notice.
 #
-# @copyright		Copyright 2005-2011, Cake Software Foundation, Inc.
-# @link				http://cakephp.org CakePHP(tm) Project
-# @package   		app.Console
-# @since			CakePHP(tm) v 2.0
-# @license			MIT License (http://www.opensource.org/licenses/mit-license.php)
+# @copyright            Copyright 2005-2011, Cake Software Foundation, Inc.
+# @link                 http://cakephp.org CakePHP(tm) Project
+# @package              cake
+# @subpackage           cake.cake.console
+# @since                CakePHP(tm) v 1.2.0.5012
+# @license              MIT License (http://www.opensource.org/licenses/mit-license.php)
 #
 ################################################################################
 LIB=${0}
+
+# Unfortunately readlink() does not resolve paths with whitespaces correctly.
+# Path will be cut after the first whitespace occurance.
+# TODO: Implement workaround in pure bash using 'sed' and 'pwd -P'.
 SYM=$(readlink ${0})
 
-if [ "$SYM" != "" ]
-	then
-		LIB=${SYM%/*}"/"
-	else
-		LIB=${LIB%/*}"/"
+if [ ! -n "$SYM" ]
+        then
+                LIB=${LIB%/*}"/"
+        else
+                LIB=${SYM%/*}"/"
 fi
 
 APP=`pwd`

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP versions 5
+# PHP 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -12,8 +12,8 @@
 #
 # @copyright            Copyright 2005-2011, Cake Software Foundation, Inc.
 # @link                 http://cakephp.org CakePHP(tm) Project
-# @package              cake
-# @subpackage           cake.cake.console
+# @package              Cake
+# @subpackage           Cake.Console
 # @since                CakePHP(tm) v 1.2.0.5012
 # @license              MIT License (http://www.opensource.org/licenses/mit-license.php)
 #

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP versions 4 and 5
+# PHP versions 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -17,12 +17,14 @@
 # @license			MIT License (http://www.opensource.org/licenses/mit-license.php)
 #
 ################################################################################
-LIB=${0/%cake/}
-SYM=$(readlink $LIB)
+LIB=${0}
+SYM=$(readlink ${0})
 
 if [ "$SYM" != "" ]
 	then
 		LIB=${SYM%/*}"/"
+	else
+		LIB=${LIB%/*}"/"
 fi
 
 APP=`pwd`

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP 5
+# PHP versions 4 and 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.
@@ -10,21 +10,26 @@
 # Licensed under The MIT License
 # Redistributions of files must retain the above copyright notice.
 #
-# @copyright		Copyright 2005-2011, Cake Software Foundation, Inc.
-# @link				http://cakephp.org CakePHP(tm) Project
-# @package   		cake.console
-# @since			CakePHP(tm) v 1.2.0.5012
-# @license			MIT License (http://www.opensource.org/licenses/mit-license.php)
+# @copyright            Copyright 2005-2011, Cake Software Foundation, Inc.
+# @link                 http://cakephp.org CakePHP(tm) Project
+# @package              cake
+# @subpackage           cake.cake.console
+# @since                CakePHP(tm) v 1.2.0.5012
+# @license              MIT License (http://www.opensource.org/licenses/mit-license.php)
 #
 ################################################################################
 LIB=${0}
+
+# Unfortunately readlink() does not resolve paths with whitespaces correctly.
+# Path will be cut after the first whitespace occurance.
+# TODO: Implement workaround in pure bash using 'sed' and 'pwd -P'.
 SYM=$(readlink ${0})
 
-if [ "$SYM" != "" ]
-	then
-		LIB=${SYM%/*}"/"
-	else
-		LIB=${LIB%/*}"/"
+if [ ! -n "$SYM" ]
+        then
+                LIB=${LIB%/*}"/"
+        else
+                LIB=${SYM%/*}"/"
 fi
 
 APP=`pwd`

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP versions 5
+# PHP 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright 2005-2011, Cake Software Foundation, Inc.

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -12,8 +12,8 @@
 #
 # @copyright            Copyright 2005-2011, Cake Software Foundation, Inc.
 # @link                 http://cakephp.org CakePHP(tm) Project
-# @package              cake
-# @subpackage           cake.cake.console
+# @package              Cake
+# @subpackage           Cake.Console
 # @since                CakePHP(tm) v 1.2.0.5012
 # @license              MIT License (http://www.opensource.org/licenses/mit-license.php)
 #

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -18,6 +18,13 @@
 #
 ################################################################################
 LIB=${0/%cake/}
+SYM=$(readlink $LIB)
+
+if [ "$SYM" != "" ]
+	then
+		LIB=${SYM%/*}"/"
+fi
+
 APP=`pwd`
 
 exec php -q ${LIB}cake.php -working "${APP}" "$@"


### PR DESCRIPTION
Added resolution of symbolic links in cake CLI bash script. Now works when either being linked to '/usr/bin/cake2' or called from PATH, which makes having executables for 1.2, 1.3 and 2.0 linked into PATH a charm.
