### PR TITLE
2.0: Fixing bug in setEncoding/getEncoding for PostgreSQL. 

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -769,10 +769,7 @@ class Postgres extends DboSource {
  * @return boolean True on success, false on failure
  */
 	public function setEncoding($enc) {
-		if ($this->_execute("SET NAMES '?'", array($enc))) {
-			return true;
-		}
-		return false;
+		return $this->_execute("SET NAMES '{$enc}'") !== false;
 	}
 
 /**
@@ -781,7 +778,12 @@ class Postgres extends DboSource {
  * @return string The database encoding
  */
 	public function getEncoding() {
-		$cosa = $this->_execute('SHOW client_encoding')->fetch();
+		$result = $this->_execute('SHOW client_encoding')->fetch();
+		if ( $result === false ) {
+			return false;
+		}
+		
+		return (isset($result['client_encoding']))?$result['client_encoding']:false;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -832,4 +832,23 @@ class PostgresTest extends CakeTestCase {
 		$this->assertEqual(2, substr_count($result, 'field_two'), 'Too many fields');
 		$this->assertFalse(strpos(';ALTER', $result), 'Too many semi colons');
 	}
+	
+/**
+ * test encoding setting.
+ *
+ * @return void
+ */
+	public function testEncoding() {
+		$result = $this->Dbo->setEncoding('utf8');
+		$this->assertTrue($result) ;
+		
+		$result = $this->Dbo->getEncoding();
+		$this->assertEqual('utf8', $result) ;
+		
+		$result = $this->Dbo->setEncoding('EUC-JP');
+		$this->assertTrue($result) ;
+		
+		$result = $this->Dbo->getEncoding();
+		$this->assertEqual('EUC-JP', $result) ;
+	}
 }


### PR DESCRIPTION
- When execute 'SET NAMES' with placeholder, then PDOStatement::execute return false. 
- getEncoding was not return encoding type string.
