### PR TITLE
2.0: Refactoring app build

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -260,17 +260,6 @@ class App {
  * @return void
  */
 	public static function build($paths = array(), $mode = App::PREPEND) {
-		if ($mode === App::RESET) {
-			foreach ($paths as $type => $new) {
-				if (!empty(self::$legacy[$type])) {
-					$type = self::$legacy[$type];
-				}
-				self::$_packages[$type] = (array)$new;
-				self::objects($type, null, false);
-			}
-			return $paths;
-		}
-
 		//Provides Backwards compatibility for old-style package names
 		$legacyPaths = array();
 		foreach ($paths as $type => $path) {
@@ -280,6 +269,14 @@ class App {
 			$legacyPaths[$type] = $path;
 		}
 		$paths = $legacyPaths;
+
+		if ($mode === App::RESET) {
+			foreach ($paths as $type => $new) {
+				self::$_packages[$type] = (array)$new;
+				self::objects($type, null, false);
+			}
+			return $paths;
+		}
 
 		if (empty(self::$_packageFormat)) {
 			self::$_packageFormat = array(

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -275,7 +275,7 @@ class App {
 				self::$_packages[$type] = (array)$new;
 				self::objects($type, null, false);
 			}
-			return $paths;
+			return;
 		}
 
 		if (empty(self::$_packageFormat)) {

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -214,8 +214,9 @@ class App {
 		if (!empty($plugin)) {
 			$path = array();
 			$pluginPath = self::pluginPath($plugin);
-			if (!empty(self::$_packageFormat[$type])) {
-				foreach (self::$_packageFormat[$type] as $f) {
+			$packageFormat= self::_packageFormat();
+			if (!empty($packageFormat[$type])) {
+				foreach ($packageFormat[$type] as $f) {
 					$path[] = sprintf($f, $pluginPath);
 				}
 			}
@@ -278,81 +279,10 @@ class App {
 			return;
 		}
 
-		if (empty(self::$_packageFormat)) {
-			self::$_packageFormat = array(
-				'Model' => array(
-					'%s' . 'Model' . DS,
-					'%s' . 'models' . DS
-				),
-				'Model/Behavior' => array(
-					'%s' . 'Model' . DS . 'Behavior' . DS,
-					'%s' . 'models' . DS . 'behaviors' . DS
-				),
-				'Model/Datasource' => array(
-					'%s' . 'Model' . DS . 'Datasource' . DS,
-					'%s' . 'models' . DS . 'datasources' . DS
-				),
-				'Model/Datasource/Database' => array(
-					'%s' . 'Model' . DS . 'Datasource' . DS . 'Database' . DS,
-					'%s' . 'models' . DS . 'datasources' . DS . 'database' . DS
-				),
-				'Model/Datasource/Session' => array(
-					'%s' . 'Model' . DS . 'Datasource' . DS . 'Session' . DS,
-					'%s' . 'models' . DS . 'datasources' . DS . 'session' . DS
-				),
-				'Controller' => array(
-					'%s' . 'Controller' . DS,
-					'%s' . 'controllers' . DS
-				),
-				'Controller/Component' => array(
-					'%s' . 'Controller' . DS . 'Component' . DS,
-					'%s' . 'controllers' . DS . 'components' . DS
-				),
-				'Controller/Component/Auth' => array(
-					'%s' . 'Controller' . DS . 'Component' . DS . 'Auth' . DS,
-					'%s' . 'controllers' . DS . 'components' . DS . 'auth' . DS
-				),
-				'View' => array(
-					'%s' . 'View' . DS,
-					'%s' . 'views' . DS
-				),
-				'View/Helper' => array(
-					'%s' . 'View' . DS . 'Helper' . DS,
-					'%s' . 'views' . DS . 'helpers' . DS
-				),
-				'Console' => array(
-					'%s' . 'Console' . DS,
-					'%s' . 'console' . DS
-				),
-				'Console/Command' => array(
-					'%s' . 'Console' . DS . 'Command' . DS,
-					'%s' . 'console' . DS . 'shells' . DS,
-				),
-				'Console/Command/Task' => array(
-					'%s' . 'Console' . DS . 'Command' . DS . 'Task' . DS,
-					'%s' . 'console' . DS . 'shells' . DS . 'tasks' . DS
-				),
-				'Lib' => array(
-					'%s' . 'Lib' . DS,
-					'%s' . 'libs' . DS
-				),
-				'locales' => array(
-					'%s' . 'Locale' . DS,
-					'%s' . 'locale' . DS
-				),
-				'Vendor' => array(
-					'%s' . 'Vendor' . DS, VENDORS
-				),
-				'Plugin' => array(
-					APP . 'Plugin' . DS,
-					APP . 'plugins' . DS,
-					dirname(dirname(CAKE)) . DS . 'plugins' . DS
-				)
-			);
-		}
+		$packageFormat = self::_packageFormat();
 
 		$defaults = array();
-		foreach (self::$_packageFormat as $package => $format) {
+		foreach ($packageFormat as $package => $format) {
 			foreach ($format as $f) {
 				$defaults[$package][] = sprintf($f, APP);
 			}
@@ -850,6 +780,83 @@ class App {
 			return self::$_map[$name];
 		}
 		return false;
+	}
+
+	protected static function _packageFormat() {
+		if (empty(self::$_packageFormat)) {
+			self::$_packageFormat = array(
+				'Model' => array(
+					'%s' . 'Model' . DS,
+					'%s' . 'models' . DS
+				),
+				'Model/Behavior' => array(
+					'%s' . 'Model' . DS . 'Behavior' . DS,
+					'%s' . 'models' . DS . 'behaviors' . DS
+				),
+				'Model/Datasource' => array(
+					'%s' . 'Model' . DS . 'Datasource' . DS,
+					'%s' . 'models' . DS . 'datasources' . DS
+				),
+				'Model/Datasource/Database' => array(
+					'%s' . 'Model' . DS . 'Datasource' . DS . 'Database' . DS,
+					'%s' . 'models' . DS . 'datasources' . DS . 'database' . DS
+				),
+				'Model/Datasource/Session' => array(
+					'%s' . 'Model' . DS . 'Datasource' . DS . 'Session' . DS,
+					'%s' . 'models' . DS . 'datasources' . DS . 'session' . DS
+				),
+				'Controller' => array(
+					'%s' . 'Controller' . DS,
+					'%s' . 'controllers' . DS
+				),
+				'Controller/Component' => array(
+					'%s' . 'Controller' . DS . 'Component' . DS,
+					'%s' . 'controllers' . DS . 'components' . DS
+				),
+				'Controller/Component/Auth' => array(
+					'%s' . 'Controller' . DS . 'Component' . DS . 'Auth' . DS,
+					'%s' . 'controllers' . DS . 'components' . DS . 'auth' . DS
+				),
+				'View' => array(
+					'%s' . 'View' . DS,
+					'%s' . 'views' . DS
+				),
+				'View/Helper' => array(
+					'%s' . 'View' . DS . 'Helper' . DS,
+					'%s' . 'views' . DS . 'helpers' . DS
+				),
+				'Console' => array(
+					'%s' . 'Console' . DS,
+					'%s' . 'console' . DS
+				),
+				'Console/Command' => array(
+					'%s' . 'Console' . DS . 'Command' . DS,
+					'%s' . 'console' . DS . 'shells' . DS,
+				),
+				'Console/Command/Task' => array(
+					'%s' . 'Console' . DS . 'Command' . DS . 'Task' . DS,
+					'%s' . 'console' . DS . 'shells' . DS . 'tasks' . DS
+				),
+				'Lib' => array(
+					'%s' . 'Lib' . DS,
+					'%s' . 'libs' . DS
+				),
+				'locales' => array(
+					'%s' . 'Locale' . DS,
+					'%s' . 'locale' . DS
+				),
+				'Vendor' => array(
+					'%s' . 'Vendor' . DS, VENDORS
+				),
+				'Plugin' => array(
+					APP . 'Plugin' . DS,
+					APP . 'plugins' . DS,
+					dirname(dirname(CAKE)) . DS . 'plugins' . DS
+				)
+			);
+		}
+
+		return self::$_packageFormat;
 	}
 
 /**

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -260,6 +260,27 @@ class App {
  * @return void
  */
 	public static function build($paths = array(), $mode = App::PREPEND) {
+		if ($mode === App::RESET) {
+			foreach ($paths as $type => $new) {
+				if (!empty(self::$legacy[$type])) {
+					$type = self::$legacy[$type];
+				}
+				self::$_packages[$type] = (array)$new;
+				self::objects($type, null, false);
+			}
+			return $paths;
+		}
+
+		//Provides Backwards compatibility for old-style package names
+		$legacyPaths = array();
+		foreach ($paths as $type => $path) {
+			if (!empty(self::$legacy[$type])) {
+				$type = self::$legacy[$type];
+			}
+			$legacyPaths[$type] = $path;
+		}
+		$paths = $legacyPaths;
+
 		if (empty(self::$_packageFormat)) {
 			self::$_packageFormat = array(
 				'Model' => array(
@@ -333,27 +354,6 @@ class App {
 			);
 		}
 
-		if ($mode === App::RESET) {
-			foreach ($paths as $type => $new) {
-				if (!empty(self::$legacy[$type])) {
-					$type = self::$legacy[$type];
-				}
-				self::$_packages[$type] = (array)$new;
-				self::objects($type, null, false);
-			}
-			return $paths;
-		}
-
-		//Provides Backwards compatibility for old-style package names
-		$legacyPaths = array();
-		foreach ($paths as $type => $path) {
-			if (!empty(self::$legacy[$type])) {
-				$type = self::$legacy[$type];
-			}
-			$legacyPaths[$type] = $path;
-		}
-
-		$paths = $legacyPaths;
 		$defaults = array();
 		foreach (self::$_packageFormat as $package => $format) {
 			foreach ($format as $f) {

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -322,11 +322,13 @@ class App {
 					'%s' . 'Locale' . DS,
 					'%s' . 'locale' . DS
 				),
-				'Vendor' => array('%s' . 'Vendor' . DS, VENDORS),
+				'Vendor' => array(
+					'%s' . 'Vendor' . DS, VENDORS
+				),
 				'Plugin' => array(
 					APP . 'Plugin' . DS,
 					APP . 'plugins' . DS,
-					dirname(dirname(CAKE)) . DS . 'plugins' . DS,
+					dirname(dirname(CAKE)) . DS . 'plugins' . DS
 				)
 			);
 		}

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -328,7 +328,7 @@ class AppTest extends CakeTestCase {
 		$path = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS;
 		App::build(array(
 			'plugins' => array($path)
-		), true);
+		), App::RESET);
 		mkdir($path . '.svn');
 		$result = App::objects('plugin', null, false);
 		rmdir($path . '.svn');
@@ -345,7 +345,7 @@ class AppTest extends CakeTestCase {
 		App::build(array(
 			'Model' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS),
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
-		), true);
+		), App::RESET);
 		CakePlugin::loadAll();
 
 		$result = App::objects('TestPlugin.model');


### PR DESCRIPTION
App::build looks a little bit complex. Clean it up to make the intent clearer.
- App::build with RESET can do its work without others, so separate it in the beginning.
- App::$_packageFormats was initialized in the method, but this method is also used in other place. Also initializing the huge array in the regular method looks like not polite way.
- Legacy type conversion was held in two places, but this conversion is vital, so I move that in the beginning, do it only once.
- I'm not sure there are historical reason, but App::build was declared as void return. In case with App::RESET, it returns $paths. I think it's a bug, so I've removed that. I can not find any usage of this pattern in the codebase.
