### PR TITLE
Removed unnessecary call to array_merge() in Model::_deleteLinks().

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2278,7 +2278,7 @@ class Model extends Object {
 		foreach ($this->hasAndBelongsToMany as $assoc => $data) {
 			list($plugin, $joinModel) = pluginSplit($data['with']);
 			$records = $this->{$joinModel}->find('all', array(
-				'conditions' => array_merge(array($this->{$joinModel}->escapeField($data['foreignKey']) => $id)),
+				'conditions' => array($this->{$joinModel}->escapeField($data['foreignKey']) => $id),
 				'fields' => $this->{$joinModel}->primaryKey,
 				'recursive' => -1,
 				'callbacks' => false


### PR DESCRIPTION
Removed unnessecary call to array_merge() in Model::_deleteLinks(). Fixes #2075 .

http://cakephp.lighthouseapp.com/projects/42648/tickets/2075-function-_deletelinks-of-model-optimization
