### PR TITLE
1.3: Added support for NULL values in Set::format(). Added test case.

### DIFF
--- a/cake/libs/set.php
+++ b/cake/libs/set.php
@@ -327,7 +327,7 @@ class Set {
 			for ($j = 0; $j < $count; $j++) {
 				$args = array();
 				for ($i = 0; $i < $count2; $i++) {
-					if (isset($data[$i][$j]) || $data[$i][$j] === null) {
+					if (array_key_exists($j, $data[$i])) {
 						$args[] = $data[$i][$j];
 					}
 				}

--- a/cake/libs/set.php
+++ b/cake/libs/set.php
@@ -327,7 +327,7 @@ class Set {
 			for ($j = 0; $j < $count; $j++) {
 				$args = array();
 				for ($i = 0; $i < $count2; $i++) {
-					if (isset($data[$i][$j])) {
+					if (isset($data[$i][$j]) || $data[$i][$j] === null) {
 						$args[] = $data[$i][$j];
 					}
 				}

--- a/cake/tests/cases/libs/set.test.php
+++ b/cake/tests/cases/libs/set.test.php
@@ -2256,6 +2256,26 @@ class SetTest extends CakeTestCase {
 	}
 
 /**
+ * testFormattingNullValues method
+ *
+ * @return void
+ */
+	public function testFormattingNullValues() {
+		$data = array(
+			array('Person' => array('first_name' => 'Nate', 'last_name' => 'Abele', 'city' => 'Boston', 'state' => 'MA', 'something' => '42')),
+			array('Person' => array('first_name' => 'Larry', 'last_name' => 'Masters', 'city' => 'Boondock', 'state' => 'TN', 'something' => null)),
+			array('Person' => array('first_name' => 'Garrett', 'last_name' => 'Woodworth', 'city' => 'Venice Beach', 'state' => 'CA', 'something' => null)));
+
+		$result = Set::format($data, '%s', array('{n}.Person.something'));
+		$expected = array('42', '', '');
+		$this->assertEqual($expected, $result);
+
+		$result = Set::format($data, '{0}, {1}', array('{n}.Person.city', '{n}.Person.something'));
+		$expected = array('Boston, 42', 'Boondock, ', 'Venice Beach, ');
+		$this->assertEqual($expected, $result);
+	}
+
+/**
  * testCountDim method
  *
  * @access public


### PR DESCRIPTION
Added support for NULL values in Set::format(). Added test case. Fixes #2076 .

http://cakephp.lighthouseapp.com/projects/42648/tickets/2076-setcombine-cant-handle-null-values
