### PR TITLE
fix setting of permissions when using file cache

### DIFF
--- a/cake/libs/cache/file.php
+++ b/cake/libs/cache/file.php
@@ -138,10 +138,10 @@ class FileEngine extends CacheEngine {
 
 		$expires = time() + $duration;
 		$contents = $expires . $lineBreak . $data . $lineBreak;
-
-		if (!$handle = fopen($this->_File->path, 'a')) {
-		    return false;
-		}
+		$old = umask(0);
+		$handle = fopen($this->_File->path, 'a');
+		umask($old);
+		if (!$handle) return false;
 
 		if ($this->settings['lock']) {
 		    flock($handle, LOCK_EX);


### PR DESCRIPTION
see http://cakephp.lighthouseapp.com/projects/42648/tickets/2080-core-cache-files-can-not-be-written-by-cron-and-web-user
