### PR TITLE
Removed unnessecary file handler in FileEngine caching. Added 'mask' attribute to FileEngine::$settings

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -67,7 +67,7 @@ class FileEngine extends CacheEngine {
 		parent::init(array_merge(
 			array(
 				'engine' => 'File', 'path' => CACHE, 'prefix'=> 'cake_', 'lock'=> true,
-				'serialize'=> true, 'isWindows' => false, 'mask' => 666
+				'serialize'=> true, 'isWindows' => false, 'mask' => 0666
 			),
 			$settings
 		));
@@ -284,7 +284,7 @@ class FileEngine extends CacheEngine {
 			return false;
 		}
 
-		$old = umask(decoct(666 - $this->settings['mask']));
+		$old = umask(0666 & ~$this->settings['mask']);
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
 			$this->_File = $path->openFile('a+');
 		}

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -284,8 +284,10 @@ class FileEngine extends CacheEngine {
 			return false;
 		}
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
+			$exists = file_exists($path->getPathname());
 			$this->_File = $path->openFile('c+');
-			if (!chmod($this->_File->getPathname(), $this->settings['mask'])) {
+			unset($path);
+			if (!$exists && !chmod($this->_File->getPathname(), $this->settings['mask'])) {
 				trigger_error(__d(
 					'cake_dev',
 					'Could not apply permission mask "%s" on cache file "%s"',

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -289,18 +289,14 @@ class FileEngine extends CacheEngine {
 			try {
 				$this->_File = $path->openFile('c+');
 			} catch (Exception $e) {
-				trigger_error(__d(
-					'cake_dev',
-					'Could not open cache file "%s" for writing',
-					array($path->getPathname())), E_USER_WARNING);
+				trigger_error(__d('cake_dev', $e->getMessage()), E_USER_WARNING);
 				return false;
 			}
 			unset($path);
 
 			if (!$exists && !chmod($this->_File->getPathname(), (int) $this->settings['mask'])) {
 				trigger_error(__d(
-					'cake_dev',
-					'Could not apply permission mask "%s" on cache file "%s"',
+					'cake_dev', 'Could not apply permission mask "%s" on cache file "%s"',
 					array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
 			}
 		}

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -285,16 +285,25 @@ class FileEngine extends CacheEngine {
 		}
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
 			$exists = file_exists($path->getPathname());
-			$this->_File = $path->openFile('c+');
+			try {
+				$this->_File = $path->openFile('c+');
+			} catch (Exception $e) {
+				trigger_error(__d(
+					'cake_dev',
+					'Could not open cache file "%s" for writing',
+					array($path->getPathname())), E_USER_WARNING);
+				return false;
+			}
 			unset($path);
-			if (!$exists && !chmod($this->_File->getPathname(), $this->settings['mask'])) {
+
+			if (!$exists && !chmod($this->_File->getPathname(), (int) $this->settings['mask'])) {
 				trigger_error(__d(
 					'cake_dev',
 					'Could not apply permission mask "%s" on cache file "%s"',
 					array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
 			}
 		}
-		return $this->_File->isFile();
+		return true;
 	}
 
 /**

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -133,6 +133,9 @@ class FileEngine extends CacheEngine {
 		if ($this->settings['lock']) {
 		    $this->_File->flock(LOCK_UN);
 		}
+		if (!chmod($this->_File->getPathname(), $this->settings['mask'])) {
+			trigger_error(__d('cake_dev', 'Could not apply permission mask "%s" on cache file "%s"', array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
+		}
 
 		return $success;
 	}
@@ -283,14 +286,10 @@ class FileEngine extends CacheEngine {
 		if (!$createKey && !$path->isFile()) {
 			return false;
 		}
-
-		$old = umask(0666 & ~$this->settings['mask']);
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
 			$this->_File = $path->openFile('c+');
 		}
-		umask($old);
-
-		return true;
+		return $this->_File->isFile();
 	}
 
 /**

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -286,7 +286,7 @@ class FileEngine extends CacheEngine {
 
 		$old = umask(0666 & ~$this->settings['mask']);
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
-			$this->_File = $path->openFile('a+');
+			$this->_File = $path->openFile('c+');
 		}
 		umask($old);
 

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -286,7 +286,10 @@ class FileEngine extends CacheEngine {
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
 			$this->_File = $path->openFile('c+');
 			if (!chmod($this->_File->getPathname(), $this->settings['mask'])) {
-				trigger_error(__d('cake_dev', 'Could not apply permission mask "%s" on cache file "%s"', array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
+				trigger_error(__d(
+					'cake_dev',
+					'Could not apply permission mask "%s" on cache file "%s"',
+					array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
 			}
 		}
 		return $this->_File->isFile();

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -271,7 +271,8 @@ class FileEngine extends CacheEngine {
 	}
 
 /**
- * Sets the current cache key this class is managing
+ * Sets the current cache key this class is managing, and creates a writable SplFileObject
+ * for the cache file the key is refering to.
  *
  * @param string $key The key
  * @param boolean $createKey Whether the key should be created if it doesn't exists, or not

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -67,7 +67,7 @@ class FileEngine extends CacheEngine {
 		parent::init(array_merge(
 			array(
 				'engine' => 'File', 'path' => CACHE, 'prefix'=> 'cake_', 'lock'=> true,
-				'serialize'=> true, 'isWindows' => false, 'mask' => 0666
+				'serialize'=> true, 'isWindows' => false, 'mask' => 0664
 			),
 			$settings
 		));
@@ -132,9 +132,6 @@ class FileEngine extends CacheEngine {
 
 		if ($this->settings['lock']) {
 		    $this->_File->flock(LOCK_UN);
-		}
-		if (!chmod($this->_File->getPathname(), $this->settings['mask'])) {
-			trigger_error(__d('cake_dev', 'Could not apply permission mask "%s" on cache file "%s"', array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
 		}
 
 		return $success;
@@ -288,6 +285,9 @@ class FileEngine extends CacheEngine {
 		}
 		if (empty($this->_File) || $this->_File->getBaseName() !== $key) {
 			$this->_File = $path->openFile('c+');
+			if (!chmod($this->_File->getPathname(), $this->settings['mask'])) {
+				trigger_error(__d('cake_dev', 'Could not apply permission mask "%s" on cache file "%s"', array($this->_File->getPathname(), $this->settings['mask'])), E_USER_WARNING);
+			}
 		}
 		return $this->_File->isFile();
 	}

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -202,7 +202,8 @@ class CacheTest extends CakeTestCase {
 			'duration' => 3600,
 			'probability' => 100,
 			'engine' => 'File',
-			'isWindows' => DIRECTORY_SEPARATOR == '\\'
+			'isWindows' => DIRECTORY_SEPARATOR == '\\',
+			'mask' => 666
 		);
 		$this->assertEqual($expected, Cache::settings('sessions'));
 

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -203,7 +203,7 @@ class CacheTest extends CakeTestCase {
 			'probability' => 100,
 			'engine' => 'File',
 			'isWindows' => DIRECTORY_SEPARATOR == '\\',
-			'mask' => 666
+			'mask' => 0666
 		);
 		$this->assertEqual($expected, Cache::settings('sessions'));
 

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -203,7 +203,7 @@ class CacheTest extends CakeTestCase {
 			'probability' => 100,
 			'engine' => 'File',
 			'isWindows' => DIRECTORY_SEPARATOR == '\\',
-			'mask' => 0666
+			'mask' => 0664
 		);
 		$this->assertEqual($expected, Cache::settings('sessions'));
 

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -339,19 +339,19 @@ class FileEngineTest extends CakeTestCase {
  * @return void
  */
 	public function testMaskSetting() {
-		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests'));
+		Cache::config('mask_test', array('engine' => 'File', 'path' => TMP . 'tests'));
 		$data = 'This is some test content';
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
-		$expected = '0666';
+		$expected = '0664';
 		$this->assertEqual($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0664, 'path' => TMP . 'tests'));
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests'));
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
-		$expected = '0664';
+		$expected = '0666';
 		$this->assertEqual($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -312,6 +312,8 @@ class FileEngineTest extends CakeTestCase {
 		$this->assertIdentical(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
 		$this->assertIdentical(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
+		Cache::delete('App.singleQuoteTest', 'file_test');
+		Cache::delete('App.doubleQuoteTest', 'file_test');
 	}
 
 /**
@@ -329,5 +331,37 @@ class FileEngineTest extends CakeTestCase {
 		));
 
 		Cache::drop('failure');
+	}
+
+/**
+ * Testing the mask setting in FileEngine
+ * 
+ * @return void
+ */
+	public function testMaskSetting() {
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 666, 'path' => TMP . 'tests'));
+		$data = 'This is some test content';
+		$write = Cache::write('masking_test', $data, 'mask_test');
+		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
+		$expected = '0666';
+		$this->assertEqual($result, $expected);
+		Cache::delete('masking_test', 'mask_test');
+		Cache::drop('mask_test');
+
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 664, 'path' => TMP . 'tests'));
+		$write = Cache::write('masking_test', $data, 'mask_test');
+		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
+		$expected = '0664';
+		$this->assertEqual($result, $expected);
+		Cache::delete('masking_test', 'mask_test');
+		Cache::drop('mask_test');
+
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 644, 'path' => TMP . 'tests'));
+		$write = Cache::write('masking_test', $data, 'mask_test');
+		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
+		$expected = '0644';
+		$this->assertEqual($result, $expected);
+		Cache::delete('masking_test', 'mask_test');
+		Cache::drop('mask_test');
 	}
 }

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -339,7 +339,7 @@ class FileEngineTest extends CakeTestCase {
  * @return void
  */
 	public function testMaskSetting() {
-		Cache::config('mask_test', array('engine' => 'File', 'mask' => 666, 'path' => TMP . 'tests'));
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests'));
 		$data = 'This is some test content';
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
@@ -348,7 +348,7 @@ class FileEngineTest extends CakeTestCase {
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Cache::config('mask_test', array('engine' => 'File', 'mask' => 664, 'path' => TMP . 'tests'));
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0664, 'path' => TMP . 'tests'));
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0664';
@@ -356,10 +356,18 @@ class FileEngineTest extends CakeTestCase {
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Cache::config('mask_test', array('engine' => 'File', 'mask' => 644, 'path' => TMP . 'tests'));
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0644, 'path' => TMP . 'tests'));
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0644';
+		$this->assertEqual($result, $expected);
+		Cache::delete('masking_test', 'mask_test');
+		Cache::drop('mask_test');
+
+		Cache::config('mask_test', array('engine' => 'File', 'mask' => 0640, 'path' => TMP . 'tests'));
+		$write = Cache::write('masking_test', $data, 'mask_test');
+		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
+		$expected = '0640';
 		$this->assertEqual($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');


### PR DESCRIPTION
I removed an unnessecary file handler in FileEngine::write() since an SplFileObject is already created in FileEngine::_setKey().

Also added a 'mask' setting in FileEngine::$settings to customize the file permissions with which the cache files are created.

Added test cases.
