### PR TITLE
fix in the constructor of the class CakeErrorController that does not run beforeFilter method

### DIFF
--- a/cake/libs/error.php
+++ b/cake/libs/error.php
@@ -50,6 +50,7 @@ class CakeErrorController extends AppController {
 		$this->_set(Router::getPaths());
 		$this->params = Router::getParams();
 		$this->constructClasses();
+		$this->startupProcess();
 		$this->Component->initialize($this);
 		$this->_set(array('cacheAction' => false, 'viewPath' => 'errors'));
 	}

--- a/cake/libs/error.php
+++ b/cake/libs/error.php
@@ -50,8 +50,8 @@ class CakeErrorController extends AppController {
 		$this->_set(Router::getPaths());
 		$this->params = Router::getParams();
 		$this->constructClasses();
-		$this->startupProcess();
 		$this->Component->initialize($this);
+		$this->beforeFilter();
 		$this->_set(array('cacheAction' => false, 'viewPath' => 'errors'));
 	}
 }


### PR DESCRIPTION
<code>CakeErrorController::__construct()</code> method does not perform the <code>beforeFilter</code> method of parent class (<code>AppController</code>).

This makes that after an error, the method <code>beforeRender</code> and view layer, don't has access to information defined in method <code>AppController::beforeFilter()</code>.

Use this AppController to reproduce the error:

``` php
class AppController extends Controller {

    var $components = array('Auth');

    function beforeFilter() {
        $this->Auth->userModel = 'Usuario';
    }

    public function beforeRender(){
        debug($this->Auth->userModel);
    }
}
```

The correct return of this code should be <code>Usuario</code> and not <code>User</code>
