### PR TITLE
Removed unnecessary ClassRegistry::flush() from test template.

### DIFF
--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -81,7 +81,6 @@ class <?php echo $fullClassName; ?>TestCase extends CakeTestCase {
  */
 	public function tearDown() {
 		unset($this-><?php echo $className;?>);
-		ClassRegistry::flush();
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
ClassRegistry::flush() is called in CakeTestCase::tearDown() anyway
