### PR TITLE
Refactoring PhpReader::read() to check for .php file first

### DIFF
--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -72,10 +72,10 @@ class PhpReader implements ConfigReaderInterface {
 		} else {
 			$file = $this->_path . $key;
 		}
-		if (!file_exists($file)) {
-			$file .= '.php';
-			if (!file_exists($file)) {
-				throw new ConfigureException(__d('cake_dev', 'Could not load configuration files: %s or %s', substr($file, 0, -4), $file));
+		$file .= '.php';
+		if (!is_file($file)) {
+			if (!is_file(substr($file, 0, -4))) {
+				throw new ConfigureException(__d('cake_dev', 'Could not load configuration files: %s or %s', $file, substr($file, 0, -4)));
 			}
 		}
 		include $file;


### PR DESCRIPTION
Performance optimization: 
PhpReader files are php files by default (including all `Cake/Config/` files). Try to include them first.

Fixed error when there's a directory with the same name.
Consider `APP/Config/config/` or `APP/Config/settings/`

Then `Configure::load('config');` should throw an exception by reader, not PHP warning.
- passes tests
