### PR TITLE
Enable Asset timestamp for image submit buttons ...

### DIFF
--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -1360,7 +1360,7 @@ class FormHelper extends AppHelper {
 			}
 			$out .= $before . sprintf(
 				$this->Html->tags['submitimage'],
-				$url,
+				$this->assetTimestamp($url),
 				$this->_parseAttributes($options, null, '', ' ')
 			) . $after;
 		} else {


### PR DESCRIPTION
I was asking, why there is no asset timestamping applied, if you use the built in image submit functionality. would be very easy to implement?
