### PR TITLE
Fixed notice when baking db config: Undefined variable 'driver'.

### DIFF
--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -283,7 +283,7 @@ class DbConfigTask extends Shell {
 
 				$oldConfigs[] = array(
 					'name' => $configName,
-					'driver' => $info['driver'],
+					'driver' => $info['datasource'],
 					'persistent' => $info['persistent'],
 					'host' => $info['host'],
 					'port' => $info['port'],


### PR DESCRIPTION
It happens when you already have database.php and try to add another config.
