### PR TITLE
2.0 fix from helper input

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1097,7 +1097,7 @@ class FormHelper extends AppHelper {
 		}
 
 		if ($type != 'hidden' && $error !== false) {
-			$errMsg = $this->error($fieldName, $error);
+			$errMsg = $this->error($fieldName, null, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, 'error');
 				$out['error'] = $errMsg;


### PR DESCRIPTION
$options['error'] did not work at FormHelper::input
