### PR TITLE
Added 'recursive' settings option to BaseAuthenticate and BasicAuthenticate

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -29,6 +29,7 @@ abstract class BaseAuthenticate {
  * - `userModel` The model name of the User, defaults to User.
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
+ * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
  *
  * @var array
  */
@@ -38,7 +39,8 @@ abstract class BaseAuthenticate {
 			'password' => 'password'
 		),
 		'userModel' => 'User',
-		'scope' => array()
+		'scope' => array(),
+		'recursive' => 0
 	);
 
 /**
@@ -80,7 +82,7 @@ abstract class BaseAuthenticate {
 		}
 		$result = ClassRegistry::init($userModel)->find('first', array(
 			'conditions' => $conditions,
-			'recursive' => 0
+			'recursive' => $this->settings['recursive']
 		));
 		if (empty($result) || empty($result[$model])) {
 			return false;

--- a/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
@@ -48,6 +48,7 @@ class BasicAuthenticate extends BaseAuthenticate {
  * - `userModel` The model name of the User, defaults to User.
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
+ * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
  * - `realm` The realm authentication is for.  Defaults the server name.
  *
  * @var array
@@ -59,6 +60,7 @@ class BasicAuthenticate extends BaseAuthenticate {
 		),
 		'userModel' => 'User',
 		'scope' => array(),
+		'recursive' => 0,
 		'realm' => '',
 	);
 

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -47,6 +47,7 @@ class BasicAuthenticateTest extends CakeTestCase {
 			'fields' => array('username' => 'user', 'password' => 'password'),
 			'userModel' => 'User',
 			'realm' => 'localhost',
+			'recursive' => 0
 		));
 
 		$password = Security::hash('password', null, true);


### PR DESCRIPTION
Added 'recursive' settings option to BaseAuthenticate and BasicAuthenticate to have a bit more fine grained control in custom Authenticate objects where checking of other related models would be required.
