### PR TITLE
2.1 Proposal. New function to register new package to default paths by App::build().

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -77,6 +77,13 @@ class App {
 	const PREPEND = 'prepend';
 
 /**
+ * Register package
+ *
+ * @constant REGISTER
+ */
+	const REGISTER = 'register';
+
+/**
  * Reset paths instead of merging
  *
  * @constant RESET
@@ -280,6 +287,24 @@ class App {
 		}
 
 		$packageFormat = self::_packageFormat();
+
+		if ($mode === App::REGISTER) {
+			if (empty($paths)) {
+				self::$_packageFormat = null;
+				$packageFormat = self::_packageFormat();
+			} else {
+				foreach ($paths as $package => $formats) {
+					if (!empty($packageFormat[$package])) {
+						$formats = array_merge($packageFormat[$package], $formats);
+					}
+
+					$packageFormat[$package] = array_values(array_unique($formats));
+				}
+
+				self::$_packageFormat = $packageFormat;
+				$paths = array();
+			}
+		}
 
 		$defaults = array();
 		foreach ($packageFormat as $package => $format) {

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -201,6 +201,31 @@ class AppTest extends CakeTestCase {
 	}
 
 /**
+ * test package build() with App::REGISTER.
+ *
+ * @return void
+ */
+	public function testBuildPackage() {
+		$paths = App::path('Service');
+		$this->assertEqual(array(), $paths);
+
+		App::build(array(
+			'Service' => array(
+				'%s' . 'Service' . DS,
+			),
+		), App::REGISTER);
+
+		$expected = array(
+			APP . 'Service' . DS,
+		);
+
+		$result = App::path('Service');
+		$this->assertEquals($expected, $result);
+
+		App::build(array(), App::REGISTER);
+	}
+
+/**
  * test path() with a plugin.
  *
  * @return void


### PR DESCRIPTION
For instance, adding new 'Service' package to app search paths.

App::build() usually cannot add new package. It can add path only to existing package.

This pull request will add the function to register new package.
