### PR TITLE
Camelize $type variable to check against valid test case types

### DIFF
--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -451,8 +451,8 @@ class TestTask extends BakeTask {
  */
 	public function testCaseFileName($type, $className) {
 		$path = $this->getPath() . 'Case' . DS;
-		if (isset($this->classTypes[$type])) {
-			$path .= $this->classTypes[$type] . DS;
+		if (isset($this->classTypes[Inflector::camelize($type)])) {
+			$path .= $this->classTypes[Inflector::camelize($type)] . DS;
 		}
 		$className = $this->getRealClassName($type, $className);
 		return str_replace('/', DS, $path) . Inflector::camelize($className) . 'Test.php';


### PR DESCRIPTION
Camelize type of test test required since on the command line we use:

"cake bake model ModelName" 

when classTypes and directories should be CamelCase.

This solves issue whereby model tests are written directly to Cases folder rather than into Cases/Model
