### PR TITLE
Fixing incorrect doc blocks regarding error handler.

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -65,7 +65,7 @@
  * - `handler` - callback - The callback to handle exceptions. You can set this to any callback type,
  *   including anonymous functions.
  * - `renderer` - string - The class responsible for rendering uncaught exceptions.  If you choose a custom class you
- *   should place the file for that class in app/Error. This class needs to implement a render method.
+ *   should place the file for that class in app/Lib/Error. This class needs to implement a render method.
  * - `log` - boolean - Should Exceptions be logged?
  *
  * @see ErrorHandler for more information on exception handling and configuration.

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -65,7 +65,7 @@
  * - `handler` - callback - The callback to handle exceptions. You can set this to any callback type,
  *   including anonymous functions.
  * - `renderer` - string - The class responsible for rendering uncaught exceptions.  If you choose a custom class you
- *   should place the file for that class in app/Error. This class needs to implement a render method.
+ *   should place the file for that class in app/Lib/Error. This class needs to implement a render method.
  * - `log` - boolean - Should Exceptions be logged?
  *
  * @see ErrorHandler for more information on exception handling and configuration.

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -60,7 +60,7 @@ App::uses('AppController', 'Controller');
  *
  * If you don't want to take control of the exception handling, but want to change how exceptions are
  * rendered you can use `Exception.renderer` to choose a class to render exception pages.  By default
- * `ExceptionRenderer` is used.  Your custom exception renderer class should be placed in app/Error.
+ * `ExceptionRenderer` is used.  Your custom exception renderer class should be placed in app/Lib/Error.
  *
  * Your custom renderer should expect an exception in its constructor, and implement a render method.
  * Failing to do so will cause additional errors.
@@ -100,7 +100,7 @@ class ErrorHandler {
 /**
  * Set as the default exception handler by the CakePHP bootstrap process.
  *
- * This will either use an AppError class if your application has one,
+ * This will either use custom exception renderer class if configured,
  * or use the default ExceptionRenderer.
  *
  * @param Exception $exception

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -426,7 +426,7 @@ class ConfigureException extends CakeException { }
 
 /**
  * Exception class for Socket. This exception will be thrown from CakeSocket, CakeEmail, HttpSocket
- * SmtpTransport and HttpResponse when it encounters an error.
+ * SmtpTransport, MailTransport and HttpResponse when it encounters an error.
  *
  * @package       Cake.Error
  */


### PR DESCRIPTION
Custom ExceptionRenderer goes to lib/Error:
https://github.com/cakephp/cakephp/blob/2.0/lib/Cake/Error/ErrorHandler.php#L123

If you merge this, I'll update documentation (book) too.
