### PR TITLE
Adding multidb fixture support

### DIFF
--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -354,7 +354,7 @@ class MissingDatasourceException extends CakeException {
  * @package       Cake.Error
  */
 class MissingTableException extends CakeException {
-	protected $_messageTemplate = 'Database table %s for model %s was not found.';
+	protected $_messageTemplate = 'Table %s for model %s was not found in datasource %s.';
 }
 
 /**

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1029,7 +1029,8 @@ class Model extends Object {
 			if (is_array($sources) && !in_array(strtolower($this->tablePrefix . $tableName), array_map('strtolower', $sources))) {
 				throw new MissingTableException(array(
 					'table' => $this->tablePrefix . $tableName,
-					'class' => $this->alias
+					'class' => $this->alias,
+					'ds' => $this->useDbConfig,
 				));
 			}
 			$this->_schema = null;

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -487,10 +487,10 @@ class ExceptionRendererTest extends CakeTestCase {
 				404
 			),
 			array(
-				new MissingTableException(array('table' => 'articles', 'class' => 'Article')),
+				new MissingTableException(array('table' => 'articles', 'class' => 'Article', 'ds' => 'test')),
 				array(
 					'/<h2>Missing Database Table<\/h2>/',
-					'/table <em>articles<\/em> for model <em>Article<\/em>/'
+					'/Table <em>articles<\/em> for model <em>Article<\/em> was not found in datasource <em>test<\/em>/'
 				),
 				500
 			),

--- a/lib/Cake/Test/Case/Model/ModelTestBase.php
+++ b/lib/Cake/Test/Case/Model/ModelTestBase.php
@@ -67,7 +67,8 @@ abstract class BaseModelTest extends CakeTestCase {
 		'core.counter_cache_user_nonstandard_primary_key',
 		'core.counter_cache_post_nonstandard_primary_key', 'core.uuidportfolio',
 		'core.uuiditems_uuidportfolio', 'core.uuiditems_uuidportfolio_numericid', 'core.fruit',
-		'core.fruits_uuid_tag', 'core.uuid_tag', 'core.product_update_all', 'core.group_update_all'
+		'core.fruits_uuid_tag', 'core.uuid_tag', 'core.product_update_all', 'core.group_update_all',
+		'core.player', 'core.guild', 'core.guilds_player', 'core.armor', 'core.armors_player',
 	);
 
 /**

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -4532,3 +4532,71 @@ class ScaffoldTag extends CakeTestModel {
  */
 	public $useTable = 'tags';
 }
+
+/**
+ * Player class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class Player extends CakeTestModel {
+	public $hasAndBelongsToMany = array(
+		'Guild' => array(
+			'with' => 'GuildsPlayer',
+			'unique' => true,
+			),
+		);
+}
+
+/**
+ * Guild class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class Guild extends CakeTestModel {
+	public $hasAndBelongsToMany = array(
+		'Player' => array(
+			'with' => 'GuildsPlayer',
+			'unique' => true,
+			),
+		);
+}
+
+/**
+ * GuildsPlayer class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class GuildsPlayer extends CakeTestModel {
+
+	public $useDbConfig = 'test2';
+
+	public $belongsTo = array(
+		'Player',
+		'Guild',
+		);
+}
+
+/**
+ * Armor class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class Armor extends CakeTestModel {
+
+	public $useDbConfig = 'test2';
+
+	public $hasAndBelongsToMany = array(
+		'Player' => array('with' => 'ArmorsPlayer'),
+		);
+}
+
+/**
+ * ArmorsPlayer class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class ArmorsPlayer extends CakeTestModel {
+
+	public $useDbConfig = 'test_database_three';
+
+}

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -124,6 +124,21 @@ class RegisterCategory extends ClassRegisterModel {
 }
 
 /**
+ * RegisterPrefixedDs class
+ *
+ * @package       Cake.Test.Case.Utility
+ */
+class RegisterPrefixedDs extends ClassRegisterModel {
+
+/**
+ * useDbConfig property
+ *
+ * @var string 'doesnotexist'
+ */
+	public $useDbConfig = 'doesnotexist';
+}
+
+/**
  * ClassRegistryTest class
  *
  * @package       Cake.Test.Case.Utility
@@ -268,6 +283,24 @@ class ClassRegistryTest extends CakeTestCase {
 		$this->assertTrue(is_a($PluginUserCopy, 'RegistryPluginAppModel'));
 		$this->assertSame($PluginUser, $PluginUserCopy);
 		CakePlugin::unload();
+	}
+
+/**
+ * Tests prefixed datasource names for test purposes
+ *
+ */
+	public function testPrefixedTestDatasource() {
+		$Model = ClassRegistry::init('RegisterPrefixedDs');
+		$this->assertEqual($Model->useDbConfig, 'test');
+		ClassRegistry::removeObject('RegisterPrefixedDs');
+
+		$testConfig = ConnectionManager::getDataSource('test')->config;
+		ConnectionManager::create('test_doesnotexist', $testConfig);
+
+		$Model = ClassRegistry::init('RegisterArticle');
+		$this->assertEqual($Model->useDbConfig, 'test');
+		$Model = ClassRegistry::init('RegisterPrefixedDs');
+		$this->assertEqual($Model->useDbConfig, 'test_doesnotexist');
 	}
 
 /**

--- a/lib/Cake/Test/Fixture/ArmorFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorFixture.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class ArmorFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Armor'
+ */
+	public $name = 'Armor';
+
+/**
+ * Datasource
+ *
+ * Used for Multi database fixture test
+ *
+ * @var string 'test2'
+ */
+	public $useDbConfig = 'test2';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'null' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime'
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('id' => 1, 'name' => 'Leather', 'created' => '2007-03-17 01:16:23'),
+		array('id' => 2, 'name' => 'Chainmail', 'created' => '2007-03-17 01:18:23'),
+		array('id' => 3, 'name' => 'Cloak', 'created' => '2007-03-17 01:20:23'),
+		array('id' => 4, 'name' => 'Bikini', 'created' => '2007-03-17 01:22:23'),
+	);
+}

--- a/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class ArmorsPlayerFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'ArmorsPlayer'
+ */
+	public $name = 'ArmorsPlayer';
+
+/**
+ * Datasource
+ *
+ * Used for Multi database fixture test
+ *
+ * @var string 'test_database_three'
+ */
+	public $useDbConfig = 'test_database_three';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'player_id' => array('type' => 'integer', 'null' => false),
+		'armor_id' => array('type' => 'integer', 'null' => false),
+		'broken' => array('type' => 'boolean', 'null' => false, 'default' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime'
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('id' => 1, 'player_id' => 1, 'armor_id' => 1, 'broken' => false),
+		array('id' => 2, 'player_id' => 2, 'armor_id' => 2, 'broken' => false),
+		array('id' => 3, 'player_id' => 3, 'armor_id' => 3, 'broken' => false),
+	);
+}

--- a/lib/Cake/Test/Fixture/GuildFixture.php
+++ b/lib/Cake/Test/Fixture/GuildFixture.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class GuildFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Guild'
+ */
+	public $name = 'Guild';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'null' => false),
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('id' => 1, 'name' => 'Warriors'),
+		array('id' => 2, 'name' => 'Rangers'),
+		array('id' => 3, 'name' => 'Wizards'),
+	);
+}

--- a/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class GuildsPlayerFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'GuildsPlayer'
+ */
+	public $name = 'GuildsPlayer';
+
+	public $useDbConfig = 'test2';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'player_id' => array('type' => 'integer', 'null' => false),
+		'guild_id' => array('type' => 'integer', 'null' => false),
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('id' => 1, 'player_id' => 1, 'guild_id' => 1),
+		array('id' => 2, 'player_id' => 1, 'guild_id' => 2),
+		array('id' => 3, 'player_id' => 4, 'guild_id' => 3),
+	);
+}

--- a/lib/Cake/Test/Fixture/PlayerFixture.php
+++ b/lib/Cake/Test/Fixture/PlayerFixture.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class PlayerFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'Player'
+ */
+	public $name = 'Player';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'null' => false),
+		'created' => 'datetime',
+		'updated' => 'datetime'
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('id' => 1, 'name' => 'mark', 'created' => '2007-03-17 01:16:23'),
+		array('id' => 2, 'name' => 'jack', 'created' => '2007-03-17 01:18:23'),
+		array('id' => 3, 'name' => 'larry', 'created' => '2007-03-17 01:20:23'),
+		array('id' => 4, 'name' => 'jose', 'created' => '2007-03-17 01:22:23'),
+	);
+}

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -84,7 +84,7 @@ class CakeFixtureManager {
 		$db = ConnectionManager::getDataSource('test');
 		$db->cacheSources = false;
 		$this->_db = $db;
-		ClassRegistry::config(array('ds' => 'test'));
+		ClassRegistry::config(array('ds' => 'test', 'testing' => true));
 		$this->_initialized = true;
 	}
 
@@ -131,7 +131,7 @@ class CakeFixtureManager {
 					$fixtureFile = $path . DS . $className . 'Fixture.php';
 					require_once($fixtureFile);
 					$fixtureClass = $className . 'Fixture';
-					$this->_loaded[$fixtureIndex] = new $fixtureClass($this->_db);
+					$this->_loaded[$fixtureIndex] = new $fixtureClass();
 					$this->_fixtureMap[$fixtureClass] = $this->_loaded[$fixtureIndex];
 					break;
 				}

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -149,9 +149,13 @@ class CakeFixtureManager {
  */
 	protected function _setupTable($fixture, $db = null, $drop = true) {
 		if (!$db) {
-			$db = $this->_db;
+			if (!empty($fixture->useDbConfig)) {
+				$db = ClassRegistry::getDataSource($fixture->useDbConfig);
+			} else {
+				$db = $this->_db;
+			}
 		}
-		if (!empty($fixture->created) && $fixture->created == $db->configKeyName) {
+		if (!empty($fixture->created) && in_array($db->configKeyName, $fixture->created)) {
 			return;
 		}
 
@@ -161,10 +165,8 @@ class CakeFixtureManager {
 		if ($drop && in_array($table, $sources)) {
 			$fixture->drop($db);
 			$fixture->create($db);
-			$fixture->created = $db->configKeyName;
 		} elseif (!in_array($table, $sources)) {
 			$fixture->create($db);
-			$fixture->created = $db->configKeyName;
 		}
 	}
 
@@ -187,8 +189,9 @@ class CakeFixtureManager {
 		foreach ($fixtures as $f) {
 			if (!empty($this->_loaded[$f])) {
 				$fixture = $this->_loaded[$f];
-				$this->_setupTable($fixture, $test->db, $test->dropTables);
-				$fixture->insert($test->db);
+				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
+				$this->_setupTable($fixture, $db, $test->dropTables);
+				$fixture->insert($db);
 			}
 		}
 		$test->db->commit();
@@ -206,7 +209,10 @@ class CakeFixtureManager {
 			if (isset($this->_loaded[$f])) {
 				$fixture = $this->_loaded[$f];
 				if (!empty($fixture->created)) {
-					$fixture->truncate($test->db);
+					foreach ($fixture->created as $ds) {
+						$db = ConnectionManager::getDataSource($ds);
+						$fixture->truncate($db);
+					}
 				}
 			}
 		}
@@ -222,10 +228,10 @@ class CakeFixtureManager {
 	public function loadSingle($name, $db = null) {
 		$name .= 'Fixture';
 		if (isset($this->_fixtureMap[$name])) {
-			if (!$db) {
-				$db = $this->_db;
-			}
 			$fixture = $this->_fixtureMap[$name];
+			if (!$db) {
+				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
+			}
 			$this->_setupTable($fixture, $db);
 			$fixture->truncate($db);
 			$fixture->insert($db);
@@ -242,8 +248,12 @@ class CakeFixtureManager {
 	public function shutDown() {
 		foreach ($this->_loaded as $fixture) {
 			if (!empty($fixture->created)) {
-				$fixture->drop($this->_db);
+				foreach ($fixture->created as $ds) {
+					$db = ConnectionManager::getDataSource($ds);
+					$fixture->drop($db);
+				}
 			}
 		}
 	}
+
 }

--- a/lib/Cake/View/Errors/missing_table.ctp
+++ b/lib/Cake/View/Errors/missing_table.ctp
@@ -19,7 +19,7 @@
 <h2><?php echo __d('cake_dev', 'Missing Database Table'); ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
-	<?php echo __d('cake_dev', 'Database table %1$s for model %2$s was not found.', '<em>' . $table . '</em>',  '<em>' . $class . '</em>'); ?>
+	<?php echo __d('cake_dev', 'Table %1$s for model %2$s was not found in datasource %3$s.', '<em>' . $table . '</em>',  '<em>' . $class . '</em>', '<em>' . $ds . '</em>'); ?>
 </p>
 <p class="notice">
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>


### PR DESCRIPTION
CakeTestFixture now has a $useDbConfig property, that is similar to Model::useDbConfig.  CakeFixtureManager now uses this property decide which connection to use.  CakeTestFixture::$created records datasources it was created on.
