### PR TITLE
Added enhancement to AuthComponent::deny(). 

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -461,16 +461,20 @@ class AuthComponent extends Component {
  */
 	public function deny($action = null) {
 		$args = func_get_args();
-		if (isset($args[0]) && is_array($args[0])) {
-			$args = $args[0];
-		}
-		foreach ($args as $arg) {
-			$i = array_search($arg, $this->allowedActions);
-			if (is_int($i)) {
-				unset($this->allowedActions[$i]);
+		if(empty($args) || $args == array('*')){
+			$this->allowedActions = array();
+		}else{
+			if (isset($args[0]) && is_array($args[0])) {
+				$args = $args[0];
 			}
+			foreach ($args as $arg) {
+				$i = array_search($arg, $this->allowedActions);
+				if (is_int($i)) {
+					unset($this->allowedActions[$i]);
+				}
+			}
+			$this->allowedActions = array_values($this->allowedActions);
 		}
-		$this->allowedActions = array_values($this->allowedActions);
 	}
 
 /**

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -452,7 +452,8 @@ class AuthComponent extends Component {
  * You can use deny with either an array, or var args.
  *
  * `$this->Auth->deny(array('edit', 'add'));` or
- * `$this->Auth->deny('edit', 'add');`
+ * `$this->Auth->deny('edit', 'add');` or
+ * `$this->Auth->deny();` to remove all items from the allowed list
  *
  * @param mixed $action,... Controller action name or array of actions
  * @return void
@@ -461,7 +462,7 @@ class AuthComponent extends Component {
  */
 	public function deny($action = null) {
 		$args = func_get_args();
-		if(empty($args) || $args == array('*')){
+		if(empty($args)){
 			$this->allowedActions = array();
 		}else{
 			if (isset($args[0]) && is_array($args[0])) {

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -636,6 +636,25 @@ class AuthComponentTest extends CakeTestCase {
 
 		$this->Controller->request['action'] = 'camelCase';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->Auth->allow('*');
+		$this->Controller->Auth->deny('*');
+
+		$this->Controller->request['action'] = 'camelCase';
+		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->request['action'] = 'add';
+		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->Auth->allow('camelCase');
+		$this->Controller->Auth->deny();
+
+		$this->Controller->request['action'] = 'camelCase';
+		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->request['action'] = 'login';
+		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -638,7 +638,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
 
 		$this->Controller->Auth->allow('*');
-		$this->Controller->Auth->deny('*');
+		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
@@ -654,6 +654,15 @@ class AuthComponentTest extends CakeTestCase {
 
 		$this->Controller->request['action'] = 'login';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->Auth->allow();
+		$this->Controller->Auth->deny('*');
+
+		$this->Controller->request['action'] = 'camelCase';
+		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+
+		$this->Controller->request['action'] = 'login';
+		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
 
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -654,16 +654,6 @@ class AuthComponentTest extends CakeTestCase {
 
 		$this->Controller->request['action'] = 'login';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
-
-		$this->Controller->Auth->allow();
-		$this->Controller->Auth->deny('*');
-
-		$this->Controller->request['action'] = 'camelCase';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
-
-		$this->Controller->request['action'] = 'login';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
-
 	}
 
 /**


### PR DESCRIPTION
Implemented possible to auth deny any action with single line.. $this->Auth->deny(); or $this->Auth->deny('*');

Ticket:
http://cakephp.lighthouseapp.com/projects/42648/tickets/2162-implement-authdeny-and-authdeny-in-cake-20
