### PR TITLE
Added missing 'write' param for schema dump shell. Fixes #2179. 

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -498,7 +498,7 @@ class SchemaShell extends Shell {
 		))->addSubcommand('dump', array(
 			'help' => __d('cake_console', 'Dump database SQL based on a schema file to stdout.'),
 			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection'),
+				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'write'),
 				'arguments' => compact('name')
 			)
 		))->addSubcommand('create', array(


### PR DESCRIPTION
Ticket:

http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2179
