### PR TITLE
return byte length in HTTP Content-Length

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -352,7 +352,11 @@ class CakeResponse {
 		$this->_sendHeader('Content-Type', "{$this->_contentType}; charset={$this->_charset}");
 		$shouldSetLength = empty($this->_headers['Content-Length']) && !in_array($this->_status, range(301, 307));
 		if ($shouldSetLength && !$this->outputCompressed()) {
-			$this->_headers['Content-Length'] = strlen($this->_body);
+			if (ini_get('mbstring.func_overload') & 2 && function_exists('mb_strlen')) {
+				$this->_headers['Content-Length'] = mb_strlen($this->_body, '8bit');
+			} else {
+				$this->_headers['Content-Length'] = strlen($this->_body);
+			}
 		}
 		foreach ($this->_headers as $header => $value) {
 			$this->_sendHeader($header, $value);

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -350,10 +350,9 @@ class CakeResponse {
 		$codeMessage = $this->_statusCodes[$this->_status];
 		$this->_sendHeader("{$this->_protocol} {$this->_status} {$codeMessage}");
 		$this->_sendHeader('Content-Type', "{$this->_contentType}; charset={$this->_charset}");
-		$shouldSetLength = empty($this->_headers['Content-Length']) && class_exists('Multibyte');
-		$shouldSetLength = $shouldSetLength && !in_array($this->_status, range(301, 307));
+		$shouldSetLength = empty($this->_headers['Content-Length']) && !in_array($this->_status, range(301, 307));
 		if ($shouldSetLength && !$this->outputCompressed()) {
-			$this->_headers['Content-Length'] = mb_strlen($this->_body);
+			$this->_headers['Content-Length'] = strlen($this->_body);
 		}
 		foreach ($this->_headers as $header => $value) {
 			$this->_sendHeader($header, $value);

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -17,8 +17,6 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-App::uses('Multibyte', 'I18n');
-
 /**
  * CakeResponse is responsible for managing the response text, status and headers of a HTTP response.
  *

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -396,7 +396,7 @@ class CakeResponseTest extends CakeTestCase {
 		$response->expects($this->at(1))
 			->method('_sendHeader')->with('Content-Type', 'text/html; charset=UTF-8');
 		$response->expects($this->at(2))
-			->method('_sendHeader')->with('Content-Length', mb_strlen($body));
+			->method('_sendHeader')->with('Content-Length', 116);
 		$response->send();
 
 		$response = $this->getMock('CakeResponse', array('_sendHeader', '_sendContent', 'outputCompressed'));


### PR DESCRIPTION
It needs to return byte length in HTTP Content-Length.

mb_strlen() returns number of multibyte characters. It works well only single byte contents, doesn't work well with multibyte contents.
