### PR TITLE
Enhancement Auth Component - Droped allow(*)

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -424,11 +424,8 @@ class AuthComponent extends Component {
  * You can use allow with either an array, or var args.
  *
  * `$this->Auth->allow(array('edit', 'add'));` or
- * `$this->Auth->allow('edit', 'add');`
- *
- * allow() also supports '*' as a wildcard to mean all actions.
- *
- * `$this->Auth->allow('*');`
+ * `$this->Auth->allow('edit', 'add');` or
+ * `$this->Auth->allow();` to allow all actions
  *
  * @param mixed $action,... Controller action name or array of actions
  * @return void
@@ -436,7 +433,7 @@ class AuthComponent extends Component {
  */
 	public function allow($action = null) {
 		$args = func_get_args();
-		if (empty($args) || $args == array('*')) {
+		if (empty($args)) {
 			$this->allowedActions = $this->_methods;
 		} else {
 			if (isset($args[0]) && is_array($args[0])) {

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -628,7 +628,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Controller->request['action'] = 'camelCase';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
 
-		$this->Controller->Auth->allow('*');
+		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny(array('add', 'camelCase'));
 
 		$this->Controller->request['action'] = 'delete';
@@ -637,7 +637,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Controller->request['action'] = 'camelCase';
 		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
 
-		$this->Controller->Auth->allow('*');
+		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
@@ -663,7 +663,7 @@ class AuthComponentTest extends CakeTestCase {
  */
 	public function testDenyWithCamelCaseMethods() {
 		$this->Controller->Auth->initialize($this->Controller);
-		$this->Controller->Auth->allow('*');
+		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny('add', 'camelCase');
 
 		$url = '/auth_test/camelCase';
@@ -685,7 +685,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Controller->Auth->initialize($this->Controller);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
-		$this->Controller->Auth->allow('*');
+		$this->Controller->Auth->allow();
 		$result = $this->Controller->Auth->startup($this->Controller);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 


### PR DESCRIPTION
Ticket:
http://cakephp.lighthouseapp.com/projects/42648/tickets/2162-implement-authdeny-and-authdeny-in-cake-20

I removed wildcard of allow. Dont make sense to allow support this wildcard and deny not. It will make allow / deny more consistent.
