### PR TITLE
MimeType audio/ogg added

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -186,6 +186,7 @@ class CakeResponse {
 		'mp2' => 'audio/mpeg',
 		'mp3' => 'audio/mpeg',
 		'mpga' => 'audio/mpeg',
+		'ogg' => 'audio/ogg',
 		'ra' => 'audio/x-realaudio',
 		'ram' => 'audio/x-pn-realaudio',
 		'rm' => 'audio/x-pn-realaudio',


### PR DESCRIPTION
Added ogg mimeType, which is only mimeType supported for HTML 5 audio tag in Firefox browser
