### PR TITLE
Adding the ability to change where Elements are stored

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -203,7 +203,15 @@ class View extends Object {
  * @see View::element()
  */
 	public $elementCache = 'default';
-
+	
+/**
+ * The name of the folder where elements are stored.
+ * 
+ * @var string
+ * @see View::element() 
+ */
+	public $elementFolder = 'Elements';
+	
 /**
  * List of variables to collect from the associated controller.
  *
@@ -725,10 +733,11 @@ class View extends Object {
 	protected function _getElementFileName($name, $plugin = null) {
 		$paths = $this->_paths($plugin);
 		$exts = $this->_getExtensions();
+		$elementFolder = $this->elementFolder;
 		foreach ($exts as $ext) {
 			foreach ($paths as $path) {
-				if (file_exists($path . 'Elements' . DS . $name . $ext)) {
-					return $path . 'Elements' . DS . $name . $ext;
+				if (file_exists($path . $elementFolder . DS . $name . $ext)) {
+					return $path . $elementFolder . DS . $name . $ext;
 				}
 			}
 		}


### PR DESCRIPTION
In some specific cases we may need an elements database table, and when that occurs it uses the View/Elements folder for its views. I would still like to use view elements, but I would not want them in the view folder for my elements controller. This commit simply gives the ability to specify where elements are located by adding $this->elementFolder = 'Snipets'; or whatever you'd like before your ->element() call. I think this adds more flexibility to cake by not hardcoding the folder name.  
