### PR TITLE
Adds the ability to change the folder where Elements are stored

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -203,7 +203,15 @@ class View extends Object {
  * @see View::element()
  */
 	public $elementCache = 'default';
-
+	
+/**
+ * The name of the folder where elements are stored.
+ * 
+ * @var string
+ * @see View::element() 
+ */
+	public $elementFolder = 'Elements';
+	
 /**
  * List of variables to collect from the associated controller
  *
@@ -725,10 +733,11 @@ class View extends Object {
 	protected function _getElementFileName($name, $plugin = null) {
 		$paths = $this->_paths($plugin);
 		$exts = $this->_getExtensions();
+		$elementFolder = $this->elementFolder;
 		foreach ($exts as $ext) {
 			foreach ($paths as $path) {
-				if (file_exists($path . 'Elements' . DS . $name . $ext)) {
-					return $path . 'Elements' . DS . $name . $ext;
+				if (file_exists($path . $elementFolder . DS . $name . $ext)) {
+					return $path . $elementFolder . DS . $name . $ext;
 				}
 			}
 		}


### PR DESCRIPTION
You can call $this->elementFolder = ''; before any $this->element(); call to change the folder name where elements are stored. This adds greater flexibility to cake.

Fixes RFC #2213
http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2213-i-would-like-to-be-allowed-to-change-where-elements-are-stored
