### PR TITLE
Fixing ignored '--exclude-plugins' option on Windows for Extract task.

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -606,7 +606,7 @@ class ExtractTask extends Shell {
 		if (!empty($this->_exclude)) {
 			$exclude = array();
 			foreach ($this->_exclude as $e) {
-				if ($e[0] !== DS) {
+				if (DS !== '\\' && $e[0] !== DS) {
 					$e = DS . $e;
 				}
 				$exclude[] = preg_quote($e, '/');


### PR DESCRIPTION
Fixes #2115

http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2115
