### PR TITLE
Fix for 'datasource' key when baking another db config.

### DIFF
--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -27,14 +27,14 @@
  * Database configuration class.
  * You can specify multiple configurations for production, development and testing.
  *
- * driver => The name of a supported driver; valid options are as follows:
+ * datasource => The name of a supported datasource; valid options are as follows:
  *		Database/Mysql 		- MySQL 4 & 5,
  *		Database/Sqlite		- SQLite (PHP5 only),
  *		Database/Postgres	- PostgreSQL 7 and higher,
  *		Database/Sqlserver	- Microsoft SQL Server 2005 and higher
  *
- * You can add custom database drivers (or override existing drivers) by adding the
- * appropriate file to app/Model/Datasource/Database.  Drivers should be named 'MyDriver.php',
+ * You can add custom database datasources (or override existing datasources) by adding the
+ * appropriate file to app/Model/Datasource/Database.  Datasources should be named 'MyDatasource.php',
  *
  *
  * persistent => true / false

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -104,7 +104,7 @@ class DbConfigTask extends Shell {
 				}
 			}
 
-			$driver = $this->in(__d('cake_console', 'Driver:'), array('Mysql', 'Postgres', 'Sqlite', 'Sqlserver'), 'Mysql');
+			$datasource = $this->in(__d('cake_console', 'Datasource:'), array('Mysql', 'Postgres', 'Sqlite', 'Sqlserver'), 'Mysql');
 
 			$persistent = $this->in(__d('cake_console', 'Persistent Connection?'), array('y', 'n'), 'n');
 			if (strtolower($persistent) == 'n') {
@@ -167,7 +167,7 @@ class DbConfigTask extends Shell {
 			}
 
 			$schema = '';
-			if ($driver == 'postgres') {
+			if ($datasource == 'postgres') {
 				while ($schema == '') {
 					$schema = $this->in(__d('cake_console', 'Table schema?'), null, 'n');
 				}
@@ -176,7 +176,7 @@ class DbConfigTask extends Shell {
 				$schema = null;
 			}
 
-			$config = compact('name', 'driver', 'persistent', 'host', 'login', 'password', 'database', 'prefix', 'encoding', 'port', 'schema');
+			$config = compact('name', 'datasource', 'persistent', 'host', 'login', 'password', 'database', 'prefix', 'encoding', 'port', 'schema');
 
 			while ($this->_verify($config) == false) {
 				$this->_interactive();
@@ -209,7 +209,7 @@ class DbConfigTask extends Shell {
 		$this->out(__d('cake_console', 'The following database configuration will be created:'));
 		$this->hr();
 		$this->out(__d('cake_console', "Name:         %s", $name));
-		$this->out(__d('cake_console', "Driver:       %s", $driver));
+		$this->out(__d('cake_console', "Datasource:       %s", $datasource));
 		$this->out(__d('cake_console', "Persistent:   %s", $persistent));
 		$this->out(__d('cake_console', "Host:         %s", $host));
 

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -314,7 +314,7 @@ class DbConfigTask extends Shell {
 			extract($config);
 
 			$out .= "\tpublic \${$name} = array(\n";
-			$out .= "\t\t'datasource' => 'Database/{$driver}',\n";
+			$out .= "\t\t'datasource' => 'Database/{$datasource}',\n";
 			$out .= "\t\t'persistent' => {$persistent},\n";
 			$out .= "\t\t'host' => '{$host}',\n";
 

--- a/lib/Cake/Console/Templates/skel/Config/database.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/database.php.default
@@ -27,14 +27,14 @@
  * Database configuration class.
  * You can specify multiple configurations for production, development and testing.
  *
- * driver => The name of a supported driver; valid options are as follows:
+ * datasource => The name of a supported datasource; valid options are as follows:
  *		Database/Mysql 		- MySQL 4 & 5,
  *		Database/Sqlite		- SQLite (PHP5 only),
  *		Database/Postgres	- PostgreSQL 7 and higher,
  *		Database/Sqlserver	- Microsoft SQL Server 2005 and higher
  *
- * You can add custom database drivers (or override existing drivers) by adding the
- * appropriate file to app/Model/Datasource/Database.  Drivers should be named 'MyDriver.php',
+ * You can add custom database datasources (or override existing datasources) by adding the
+ * appropriate file to app/Model/Datasource/Database.  Datasources should be named 'MyDatasource.php',
  *
  *
  * persistent => true / false

--- a/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
@@ -115,7 +115,7 @@ class DbConfigTaskTest extends CakeTestCase {
 			->with(array(
 				array(
 					'name' => 'default',
-					'driver' => 'mysql',
+					'datasource' => 'mysql',
 					'persistent' => 'false',
 					'host' => 'localhost',
 					'login' => 'root',

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -405,7 +405,7 @@ class DebuggerTest extends CakeTestCase {
  */
 	public function testNoDbCredentials() {
 		$config = array(
-			'driver' => 'mysql',
+			'datasource' => 'mysql',
 			'persistent' => false,
 			'host' => 'void.cakephp.org',
 			'login' => 'cakephp-user',
@@ -417,7 +417,7 @@ class DebuggerTest extends CakeTestCase {
 		$output = Debugger::exportVar($config);
 
 		$expectedArray = array(
-			'driver' => 'mysql',
+			'datasource' => 'mysql',
 			'persistent' => false,
 			'host' => '*****',
 			'login' => '*****',


### PR DESCRIPTION
It happens when you try to add another config:

```
Notice Error: Undefined variable: driver in 
[...\lib\Cake\Console\Command\Task\DbConfigTask.php, line 317]
```

So new config has wrong key:

```
'datasource' => 'Database/',
```
