### PR TITLE
Fixed inconsistent debug parameters and empty '(line )'

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -683,26 +683,156 @@ class BasicsTest extends CakeTestCase {
 		ob_start();
 			debug('this-is-a-test');
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .= '.*line.*' . (__LINE__ - 4) . '.*this-is-a-test.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+this-is-a-test
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>');
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', true);
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .= '.*line.*' . (__LINE__ -4) . '.*&lt;div&gt;this-is-a-test&lt;\/div&gt;.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', true, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', true, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', false);
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .=	'.*line.*' . (__LINE__ - 4) . '.*\<div\>this-is-a-test\<\/div\>.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', false, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', false, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+
+
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -683,7 +683,7 @@ class BasicsTest extends CakeTestCase {
 		ob_start();
 			debug('this-is-a-test');
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -691,13 +691,25 @@ this-is-a-test
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+this-is-a-test
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>');
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -705,7 +717,19 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
@@ -753,7 +777,7 @@ EXPECTED;
 		ob_start();
 			debug('<div>this-is-a-test</div>', null);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -761,13 +785,25 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
-			debug('<div>this-is-a-test</div>', null, true);
+			debug('<div>this-is-a-test</div>', null);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -775,13 +811,25 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', null, false);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 
 <pre class="cake-debug">
@@ -789,7 +837,19 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -76,6 +76,7 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 	if (Configure::read('debug') > 0) {
 		$file = '';
 		$line = '';
+		$lineInfo = '';
 		if ($showFrom) {
 			$calledFrom = debug_backtrace();
 			$file = substr(str_replace(ROOT, '', $calledFrom[0]['file']), 1);
@@ -83,32 +84,39 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 		}
 		$html = <<<HTML
 <div class="cake-debug-output">
-<span><strong>%s</strong> (line <strong>%s</strong>)</span>
+%s
 <pre class="cake-debug">
 %s
 </pre>
 </div>
 HTML;
-			$text = <<<TEXT
+		$text = <<<TEXT
 
-%s (line %s)
+%s
 ########## DEBUG ##########
 %s
 ###########################
 
 TEXT;
 		$template = $html;
-		if (php_sapi_name() == 'cli') {
+		if (php_sapi_name() == 'cli' || $showHtml === false) {
 			$template = $text;
+			if ($showFrom) {
+				$lineInfo = sprintf('%s (line %s)', $file, $line);
+			}
 		}
 		if ($showHtml === null && $template !== $text) {
 			$showHtml = true;
 		}
 		$var = print_r($var, true);
 		if ($showHtml) {
+			$template = $html;
 			$var = h($var);
+			if ($showFrom) {
+				$lineInfo = sprintf('<span><strong>%s</strong> (line <strong>%s</strong>)</span>', $file, $line);
+			}
 		}
-		printf($template, $file, $line, $var);
+		printf($template, $lineInfo, $var);
 	}
 }
 


### PR DESCRIPTION
- When `$showFrom` is false, not outputting empty `(line )` in the debug messages.
- If it's passed, `$useHtml` is obeyed regardless of the API used.
  - if `$useHtml == true` — HTML template is used.
  - if `$useHtml == false` — TEXT template is used.
  - default (null) — autodetect.
