### PR TITLE
2.0 upgradefix

### DIFF
--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -102,7 +102,7 @@ class UpgradeShell extends Shell {
 	public function tests() {
 		$this->_paths = array(APP . 'tests' . DS);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = App::pluginPath($this->params['plugin']) . 'tests' . DS;
+			$this->_paths = array(App::pluginPath($this->params['plugin']) . 'tests' . DS);
 		}
 		$patterns = array(
 			array(


### PR DESCRIPTION
UpgradeShell throws an error because $this->_paths is expected to be an array, and the array wrapper has been missed on this line.

EDIT: Note the similar lines in the other methods already have this wrapper.
