### PR TITLE
Fix View task generating only 'admin' methods views in non-interactive mode.

### DIFF
--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -143,7 +143,7 @@ class ViewTask extends BakeTask {
 		}
 		$adminRoute = $this->Project->getPrefix();
 		foreach ($methods as $i => $method) {
-			if ($adminRoute && isset($this->params['admin'])) {
+			if ($adminRoute && !empty($this->params['admin'])) {
 				if ($scaffoldActions) {
 					$methods[$i] = $adminRoute . $method;
 					continue;


### PR DESCRIPTION
```
cake bake view Posts
```

will bake only admin views because 'admin' param is set by option parser but it's empty.
