### PR TITLE
Remove 5.3 notice from Config/core timezone comment

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -225,8 +225,8 @@
 	Configure::write('Acl.database', 'default');
 
 /**
- * If you are on PHP 5.3 uncomment this line and correct your server timezone
- * to fix the date & time related errors.
+ * Uncomment this line and correct your server timezone to fix 
+ * any date & time related errors.
  */
 	//date_default_timezone_set('UTC');
 

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -225,8 +225,8 @@
 	Configure::write('Acl.database', 'default');
 
 /**
- * If you are on PHP 5.3 uncomment this line and correct your server timezone
- * to fix the date & time related errors.
+ * Uncomment this line and correct your server timezone to fix 
+ * any date & time related errors.
  */
 	//date_default_timezone_set('UTC');
 


### PR DESCRIPTION
The function date_default_timezone_set() is available to PHP 5.1.0+. The 5.3 notice is incorrect and was written in 2009: nate@729d8fdd

http://us2.php.net/manual/en/function.date-default-timezone-set.php
