### PR TITLE
2.0 upgradefix

### DIFF
--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -214,6 +214,9 @@ class UpgradeShell extends Shell {
 		}
 
 		$patterns = array();
+		App::build(array(
+			'View/Helper' => App::core('View/Helper'),
+		), App::APPEND);
 		$helpers = App::objects('helper');
 		$plugins = App::objects('plugin');
 		$pluginHelpers = array();

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -702,11 +702,11 @@ class UpgradeShell extends Shell {
  * @return void
  */
 	protected function _findFiles($extensions = '') {
+		$this->_files = array();
 		foreach ($this->_paths as $path) {
 			if (!is_dir($path)) {
 				continue;
 			}
-			$this->_files = array();
 			$Iterator = new RegexIterator(
 				new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path)),
 				'/^.+\.(' . $extensions . ')$/i',

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -547,7 +547,7 @@ class UpgradeShell extends Shell {
 			),
 			array(
 				'$this->cakeError("error500") -> throw new InternalErrorException()',
-				'/(\$this->cakeError\(["\']error404["\']\));/',
+				'/(\$this->cakeError\(["\']error500["\']\));/',
 				'throw new InternalErrorException();'
 			),
 		);


### PR DESCRIPTION
A few fixes to upgrade shell:
- fix for core helper discovery
- fix bug in _findFiles
- new method for replacing cakeError('error404') etc with the new exceptions. This is just basic, it won't detect advanced use of cakeError with extra parameters.
