### PR TITLE
Make View task use prefixed template before falling back to generic one

### DIFF
--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -393,6 +393,10 @@ class ViewTask extends BakeTask {
 		if (!empty($this->template) && $action != $this->template) {
 			return $this->template;
 		}
+		$themePath = $this->Template->getThemePath();
+		if (file_exists($themePath . 'views' . DS . $action . '.ctp')) {
+			return $action;
+		}
 		$template = $action;
 		$prefixes = Configure::read('Routing.prefixes');
 		foreach ((array)$prefixes as $prefix) {

--- a/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
@@ -230,6 +230,7 @@ class ViewTaskTest extends CakeTestCase {
 
 		$this->Task->path = TMP;
 		$this->Task->Template->params['theme'] = 'default';
+		$this->Task->Template->templatePaths = array('default' => CAKE . 'Console' . DS . 'Templates' . DS . 'default' .DS);
 	}
 
 /**
@@ -563,7 +564,7 @@ class ViewTaskTest extends CakeTestCase {
 	}
 
 /**
- * test `cake bake view $controller -admin`
+ * test `cake bake view $controller --admin`
  * Which only bakes admin methods, not non-admin methods.
  *
  * @return void
@@ -701,7 +702,7 @@ class ViewTaskTest extends CakeTestCase {
 	}
 
 /**
- * test getting templates, make sure noTemplateActions works
+ * test getting templates, make sure noTemplateActions works and prefixed template is used before generic one.
  *
  * @return void
  */
@@ -716,6 +717,14 @@ class ViewTaskTest extends CakeTestCase {
 
 		$result = $this->Task->getTemplate('admin_add');
 		$this->assertEqual($result, 'form');
+
+		$this->Task->Template->templatePaths = array(
+			'test' => CAKE . 'Test' . DS .  'test_app' . DS . 'Console' . DS . 'Templates' . DS . 'test' .DS
+		);
+		$this->Task->Template->params['theme'] = 'test';
+
+		$result = $this->Task->getTemplate('admin_edit');
+		$this->assertEqual($result, 'admin_edit');
 	}
 
 }

--- a/lib/Cake/Test/test_app/Console/Templates/test/views/admin_edit.ctp
+++ b/lib/Cake/Test/test_app/Console/Templates/test/views/admin_edit.ctp
@@ -1,0 +1,1 @@
+admin_edit template


### PR DESCRIPTION
It is possible now to create view templates for different prefixes like `admin_index.ctp` or `user_add.ctp`

This has been discussed in [pull #299](https://github.com/cakephp/cakephp/pull/299#issuecomment-2643078) and [ticket #1275](http://cakephp.lighthouseapp.com/projects/42648/tickets/1275-rfc-bake-viewtask-ignores-custom-templates-for-admin-actions#ticket-1275-5)
