### PR TITLE
change DataSource::listSources to Datasource::cachedListSources

### DIFF
--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -90,7 +90,7 @@ class DataSource extends Object {
  * @param mixed $data
  * @return array Array of sources available in this datasource.
  */
-	public function listSources($data = null) {
+	public function cachedListSources($data = null) {
 		if ($this->cacheSources === false) {
 			return null;
 		}

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -184,7 +184,7 @@ class Mysql extends DboSource {
  * @return array Array of tablenames in the database
  */
 	public function listSources($data = null) {
-		$cache = parent::listSources();
+		$cache = $this->cachedListSources();
 		if ($cache != null) {
 			return $cache;
 		}
@@ -201,7 +201,7 @@ class Mysql extends DboSource {
 			}
 
 			$result->closeCursor();
-			parent::listSources($tables);
+			$this->cachedListSources($tables);
 			return $tables;
 		}
 	}

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -156,7 +156,7 @@ class Postgres extends DboSource {
  * @return array Array of tablenames in the database
  */
 	public function listSources($data = null) {
-		$cache = parent::listSources();
+		$cache = $this->cachedListSources();
 
 		if ($cache != null) {
 			return $cache;
@@ -176,7 +176,7 @@ class Postgres extends DboSource {
 			}
 
 			$result->closeCursor();
-			parent::listSources($tables);
+			$this->cachedListSources($tables);
 			return $tables;
 		}
 	}

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -134,7 +134,7 @@ class Sqlite extends DboSource {
  * @return array Array of tablenames in the database
  */
 	public function listSources($data = null) {
-		$cache = parent::listSources();
+		$cache = $this->cachedListSources();
 		if ($cache != null) {
 			return $cache;
 		}
@@ -148,7 +148,7 @@ class Sqlite extends DboSource {
 			foreach ($result as $table) {
 				$tables[] = $table[0]['name'];
 			}
-			parent::listSources($tables);
+			$this->cachedListSources($tables);
 			return $tables;
 		}
 		return array();

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -170,7 +170,7 @@ class Sqlserver extends DboSource {
  * @return array Array of tablenames in the database
  */
 	public function listSources($data = null) {
-		$cache = parent::listSources();
+		$cache = $this->cachedListSources();
 		if ($cache !== null) {
 			return $cache;
 		}
@@ -187,7 +187,7 @@ class Sqlserver extends DboSource {
 			}
 
 			$result->closeCursor();
-			parent::listSources($tables);
+			$this->cachedListSources($tables);
 			return $tables;
 		}
 	}

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -346,6 +346,7 @@ class AppTest extends CakeTestCase {
 		App::build(array(
 			'plugins' => array($path)
 		), App::RESET);
+		var_dump($path . '.svn');
 		mkdir($path . '.svn');
 		$result = App::objects('plugin', null, false);
 		rmdir($path . '.svn');

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -346,7 +346,6 @@ class AppTest extends CakeTestCase {
 		App::build(array(
 			'plugins' => array($path)
 		), App::RESET);
-		var_dump($path . '.svn');
 		mkdir($path . '.svn');
 		$result = App::objects('plugin', null, false);
 		rmdir($path . '.svn');


### PR DESCRIPTION
I made this changes to avoid design errors when using a custom Datadsource (in my case forCouchDB) which doesn't have and doesn't need sources neither a schema :

When the _Model::setSource_ method is called there is a test : 

``` php
if (method_exists($db, 'listSources')) {
    $sources = $db->listSources();
    // check that $tableName is a source
    // reset the $this->_schema
}
```

In my case the _CouchdbDatasource_ shouldn't have this **listSources** method, but it actually has it through the _Datasource_ inheritence.

By looking at it, I saw its purpose is to cache results from "child calls", but it can't be used as replacement. 
This is why I think inheritence is not the best choice here, and I renamed it.
Calls from Core Datasource have also been changed accordingly. 
Unfortunately I'm aware it might affect other custom Datasources. So maybe it should go to a major release (?)

**Note :** The main reason to not implement _CouchdbDatasource::listSources_ is because the previous _Model::setSource_ reset the _Model::_schema_ to null when _listSources_ exists.
Which I don't want since CouchDb doesn't have any internal schema. 
In order to stick to the Model mechanism (especially at save), the $_schema is defined into each specific model definition.
