### PR TITLE
Patch for CakeSession php default

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -539,8 +539,7 @@ class CakeSession {
 				'cookieTimeout' => 240,
 				'ini' => array(
 					'session.use_trans_sid' => 0,
-					'session.cookie_path' => self::$path,
-					'session.save_handler' => 'files'
+					'session.cookie_path' => self::$path
 				)
 			),
 			'cake' => array(


### PR DESCRIPTION
When Session Config is set to 'defaults'=>'php', the session.save_handler is always assumed 'files' , and it will overwrite the actual php.ini configuration.
This creates problems when php session is configured to use another save_handler like memcached instead of "files".
