### PR TITLE
move 'redirect' to request, and allow to use int values as ttl

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -63,6 +63,7 @@ class HttpSocket extends CakeSocket {
 			'User-Agent' => 'CakePHP'
 		),
 		'raw' => null,
+		'redirect' => false,
 		'cookies' => array()
 	);
 
@@ -91,13 +92,13 @@ class HttpSocket extends CakeSocket {
 		'protocol' => 'tcp',
 		'port' => 80,
 		'timeout' => 30,
-		'redirect' => false,
 		'request' => array(
 			'uri' => array(
 				'scheme' => 'http',
 				'host' => 'localhost',
 				'port' => 80
 			),
+			'redirect' => false,
 			'cookies' => array()
 		)
 	);
@@ -378,8 +379,10 @@ class HttpSocket extends CakeSocket {
 			}
 			$this->config['request']['cookies'][$Host] = array_merge($this->config['request']['cookies'][$Host], $this->response->cookies);
 		}
-		if($this->config['redirect'] && $this->response->isRedirect()) {
+		
+		if($this->request['redirect'] && $this->response->isRedirect()) {
 			$request['uri'] = $this->response->getHeader('Location');
+			$request['redirect'] = is_int($this->request['redirect']) ? $this->request['redirect'] - 1 : $this->request['redirect'];
 			$this->response = $this->request($request);
 		}
 


### PR DESCRIPTION
following pull request #311 :
- the _redirect_ value is now used as part of the request (instead of config), and can be passed for each one.
- if _redirect_ is an integer, removes 1 from its value before to transmit to the recursiver call (the redirected request)
- if the _redirect_ value reaches **0**, considered as falsy and leads to not redirecting (~ ttl behavior)

=> if the max number of redirects is reached, there is no error or exception thrown, the last response will be returned, with its redirect code (one of the 3xx). The _$reponses->isOk()_ will still be **false**.

=> according documentation change will follow after validating this pull request
