### PR TITLE
FormHelper: Allow a boolean value for the disabled attribute in function radio

### DIFF
--- a/app/Config/Schema/db_acl.sql
+++ b/app/Config/Schema/db_acl.sql
@@ -1,0 +1,40 @@
+# $Id$
+#
+# Copyright 2005-2011, Cake Software Foundation, Inc.
+#
+# Licensed under The MIT License
+# Redistributions of files must retain the above copyright notice.
+# MIT License (http://www.opensource.org/licenses/mit-license.php)
+
+CREATE TABLE acos (
+  id INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  parent_id INTEGER(10) DEFAULT NULL,
+  model VARCHAR(255) DEFAULT '',
+  foreign_key INTEGER(10) UNSIGNED DEFAULT NULL,
+  alias VARCHAR(255) DEFAULT '',
+  lft INTEGER(10) DEFAULT NULL,
+  rght INTEGER(10) DEFAULT NULL,
+  PRIMARY KEY  (id)
+);
+
+CREATE TABLE aros_acos (
+  id INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  aro_id INTEGER(10) UNSIGNED NOT NULL,
+  aco_id INTEGER(10) UNSIGNED NOT NULL,
+  _create CHAR(2) NOT NULL DEFAULT 0,
+  _read CHAR(2) NOT NULL DEFAULT 0,
+  _update CHAR(2) NOT NULL DEFAULT 0,
+  _delete CHAR(2) NOT NULL DEFAULT 0,
+  PRIMARY KEY(id)
+);
+
+CREATE TABLE aros (
+  id INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  parent_id INTEGER(10) DEFAULT NULL,
+  model VARCHAR(255) DEFAULT '',
+  foreign_key INTEGER(10) UNSIGNED DEFAULT NULL,
+  alias VARCHAR(255) DEFAULT '',
+  lft INTEGER(10) DEFAULT NULL,
+  rght INTEGER(10) DEFAULT NULL,
+  PRIMARY KEY  (id)
+);

--- a/app/Config/Schema/i18n.sql
+++ b/app/Config/Schema/i18n.sql
@@ -1,0 +1,26 @@
+# $Id$
+#
+# Copyright 2005-2011, Cake Software Foundation, Inc.
+#
+# Licensed under The MIT License
+# Redistributions of files must retain the above copyright notice.
+# MIT License (http://www.opensource.org/licenses/mit-license.php)
+
+CREATE TABLE i18n (
+	id int(10) NOT NULL auto_increment,
+	locale varchar(6) NOT NULL,
+	model varchar(255) NOT NULL,
+	foreign_key int(10) NOT NULL,
+	field varchar(255) NOT NULL,
+	content mediumtext,
+	PRIMARY KEY	(id),
+#	UNIQUE INDEX I18N_LOCALE_FIELD(locale, model, foreign_key, field),
+#	INDEX I18N_LOCALE_ROW(locale, model, foreign_key),
+#	INDEX I18N_LOCALE_MODEL(locale, model),
+#	INDEX I18N_FIELD(model, foreign_key, field),
+#	INDEX I18N_ROW(model, foreign_key),
+	INDEX locale (locale),
+	INDEX model (model),
+	INDEX row_id (foreign_key),
+	INDEX field (field)
+);

--- a/app/Config/Schema/sessions.sql
+++ b/app/Config/Schema/sessions.sql
@@ -1,0 +1,16 @@
+# $Id$
+#
+# Copyright 2005-2011, Cake Software Foundation, Inc.
+#								1785 E. Sahara Avenue, Suite 490-204
+#								Las Vegas, Nevada 89104
+#
+# Licensed under The MIT License
+# Redistributions of files must retain the above copyright notice.
+# MIT License (http://www.opensource.org/licenses/mit-license.php)
+
+CREATE TABLE cake_sessions (
+  id varchar(255) NOT NULL default '',
+  data text,
+  expires int(11) default NULL,
+  PRIMARY KEY  (id)
+);

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -205,12 +205,14 @@ class TestTask extends BakeTask {
 			$this->out(++$key . '. ' . $option);
 			$keys[] = $key;
 		}
-		$selection = $this->in(__d('cake_console', 'Choose an existing class, or enter the name of a class that does not exist'));
-		if (isset($options[$selection - 1])) {
-			$selection = $options[$selection - 1];
-		}
-		if ($type !== 'Model') {
-			$selection = substr($selection, 0, $typeLength * - 1);
+		while (empty($selection)) {
+			$selection = $this->in(__d('cake_console', 'Choose an existing class, or enter the name of a class that does not exist'));
+			if (is_numeric($selection) && isset($options[$selection - 1])) {
+				$selection = $options[$selection - 1];
+			}
+			if ($type !== 'Model') {
+				$selection = substr($selection, 0, $typeLength * - 1);
+			}
 		}
 		return $selection;
 	}

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -337,8 +337,7 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Attempts to introspect the correct values for object properties including
- * $userModel and $sessionKey.
+ * Attempts to introspect the correct values for object properties.
  *
  * @return boolean
  */

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -353,7 +353,7 @@ class PaginatorComponent extends Component {
 					$order[$alias . '.' . $field] = $value;
 				} elseif ($object->hasField($key, true)) {
 					$order[$field] = $value;
-				} elseif (isset($object->{$alias}) && $object->{$alias}->hasField($field)) {
+				} elseif (isset($object->{$alias}) && $object->{$alias}->hasField($field, true)) {
 					$order[$alias . '.' . $field] = $value;
 				}
 			}

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -139,9 +139,9 @@ class RequestHandlerComponent extends Component {
 		}
 		$extensions = Router::extensions();
 		$preferred = array_shift($accept);
-		$preferredTypes = $this->mapType($preferred);
+		$preferredTypes = $this->response->mapType($preferred);
 		$similarTypes = array_intersect($extensions, $preferredTypes);
-		if (count($similarTypes) === 1 && !in_array('html', $preferredTypes)) {
+		if (count($similarTypes) === 1 && !in_array('xhtml', $preferredTypes) && !in_array('html', $preferredTypes)) {
 			$this->ext = array_shift($similarTypes);
 		}
 	}

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -208,6 +208,9 @@ class SecurityComponent extends Component {
 			}
 		}
 		$this->_generateToken($controller);
+		if ($isPost) {
+			unset($controller->request->data['_Token']);
+		}
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2590,6 +2590,10 @@ class DboSource extends DataSource {
 			if (is_object($model) && $model->isVirtualField($key)) {
 				$key =  '(' . $this->_quoteFields($model->getVirtualField($key)) . ')';
 			}
+			list($alias, $field) = pluginSplit($key);
+			if (is_object($model) && $alias !== $model->alias && is_object($model->{$alias}) && $model->{$alias}->isVirtualField($key)) {
+				$key =  '(' . $this->_quoteFields($model->{$alias}->getVirtualField($key)) . ')';
+			}
 
 			if (strpos($key, '.')) {
 				$key = preg_replace_callback('/([a-zA-Z0-9_-]{1,})\\.([a-zA-Z0-9_-]{1,})/', array(&$this, '_quoteMatchedField'), $key);

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -414,6 +414,17 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
+ * Magic isset method allows isset/empty checks
+ * on routing parameters.
+ *
+ * @param string $name The property being accessed.
+ * @return bool Existence
+ */
+	public function __isset($name) {
+		return isset($this->params[$name]);
+	}
+
+/**
  * Check whether or not a Request is a certain type.  Uses the built in detection rules
  * as well as additional rules defined with CakeRequest::addDetector().  Any detector can be called
  * as `is($type)` or `is$Type()`.

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -546,9 +546,9 @@ class CakeEmail {
 	}
 
 /**
- * Set Subject
+ * Get/Set Subject.
  *
- * @param string $subject
+ * @param null|string $subject
  * @return mixed
  */
 	public function subject($subject = null) {

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -214,7 +214,8 @@ class SmtpTransport extends AbstractTransport {
 			if (substr($response, -2) !== "\r\n") {
 				throw new SocketException(__d('cake_dev', 'SMTP timeout.'));
 			}
-			$response = end(explode("\r\n", rtrim($response, "\r\n")));
+			$responseLines = explode("\r\n", rtrim($response, "\r\n"));
+			$response = end($responseLines);
 
 			if (preg_match('/^(' . $checkCode . ')(.)/', $response, $code)) {
 				if ($code[2] === '-') {

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -683,26 +683,156 @@ class BasicsTest extends CakeTestCase {
 		ob_start();
 			debug('this-is-a-test');
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .= '.*line.*' . (__LINE__ - 4) . '.*this-is-a-test.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+this-is-a-test
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>');
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', true);
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .= '.*line.*' . (__LINE__ -4) . '.*&lt;div&gt;this-is-a-test&lt;\/div&gt;.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', true, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', true, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+<span><strong>%s</strong> (line <strong>%d</strong>)</span>
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', null, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+<div class="cake-debug-output">
+
+<pre class="cake-debug">
+&lt;div&gt;this-is-a-test&lt;/div&gt;
+</pre>
+</div>
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', false);
 		$result = ob_get_clean();
-		$pattern = '/(.+?Test(\/|\\\)Case(\/|\\\)BasicsTest\.php|';
-		$pattern .= preg_quote(substr(__FILE__, 1), '/') . ')';
-		$pattern .=	'.*line.*' . (__LINE__ - 4) . '.*\<div\>this-is-a-test\<\/div\>.*/s';
-		$this->assertRegExp($pattern, $result);
+$expected = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', false, true);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
+
+		ob_start();
+			debug('<div>this-is-a-test</div>', false, false);
+		$result = ob_get_clean();
+$expected = <<<EXPECTED
+
+
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEqual($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -60,24 +60,24 @@ class BasicsTest extends CakeTestCase {
 		$two = array('one' => 'one', 'two' => 'two');
 		$result = array_diff_key($one, $two);
 		$expected = array('three' => 3);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$one = array('one' => array('value', 'value-two'), 'two' => 2, 'three' => 3);
 		$two = array('two' => 'two');
 		$result = array_diff_key($one, $two);
 		$expected = array('one' => array('value', 'value-two'), 'three' => 3);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$one = array('one' => null, 'two' => 2, 'three' => '', 'four' => 0);
 		$two = array('two' => 'two');
 		$result = array_diff_key($one, $two);
 		$expected = array('one' => null, 'three' => '', 'four' => 0);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$one = array('minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true);
 		$two = array('minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true);
 		$result = array_diff_key($one, $two);
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 
 	}
 /**
@@ -92,48 +92,48 @@ class BasicsTest extends CakeTestCase {
 		$__ENV = $_ENV;
 
 		$_SERVER['HTTP_HOST'] = 'localhost';
-		$this->assertEqual(env('HTTP_BASE'), '.localhost');
+		$this->assertEquals(env('HTTP_BASE'), '.localhost');
 
 		$_SERVER['HTTP_HOST'] = 'com.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.com.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.com.ar');
 
 		$_SERVER['HTTP_HOST'] = 'example.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.example.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.example.ar');
 
 		$_SERVER['HTTP_HOST'] = 'example.com';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com');
 
 		$_SERVER['HTTP_HOST'] = 'www.example.com';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com');
 
 		$_SERVER['HTTP_HOST'] = 'subdomain.example.com';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com');
 
 		$_SERVER['HTTP_HOST'] = 'example.com.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com.ar');
 
 		$_SERVER['HTTP_HOST'] = 'www.example.com.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com.ar');
 
 		$_SERVER['HTTP_HOST'] = 'subdomain.example.com.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.example.com.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.example.com.ar');
 
 		$_SERVER['HTTP_HOST'] = 'double.subdomain.example.com';
-		$this->assertEqual(env('HTTP_BASE'), '.subdomain.example.com');
+		$this->assertEquals(env('HTTP_BASE'), '.subdomain.example.com');
 
 		$_SERVER['HTTP_HOST'] = 'double.subdomain.example.com.ar';
-		$this->assertEqual(env('HTTP_BASE'), '.subdomain.example.com.ar');
+		$this->assertEquals(env('HTTP_BASE'), '.subdomain.example.com.ar');
 
 		$_SERVER = $_ENV = array();
 
 		$_SERVER['SCRIPT_NAME'] = '/a/test/test.php';
-		$this->assertEqual(env('SCRIPT_NAME'), '/a/test/test.php');
+		$this->assertEquals(env('SCRIPT_NAME'), '/a/test/test.php');
 
 		$_SERVER = $_ENV = array();
 
 		$_ENV['CGI_MODE'] = 'BINARY';
 		$_ENV['SCRIPT_URL'] = '/a/test/test.php';
-		$this->assertEqual(env('SCRIPT_NAME'), '/a/test/test.php');
+		$this->assertEquals(env('SCRIPT_NAME'), '/a/test/test.php');
 
 		$_SERVER = $_ENV = array();
 
@@ -173,13 +173,13 @@ class BasicsTest extends CakeTestCase {
 		$this->assertNull(env('TEST_ME'));
 
 		$_ENV['TEST_ME'] = 'a';
-		$this->assertEqual(env('TEST_ME'), 'a');
+		$this->assertEquals(env('TEST_ME'), 'a');
 
 		$_SERVER['TEST_ME'] = 'b';
-		$this->assertEqual(env('TEST_ME'), 'b');
+		$this->assertEquals(env('TEST_ME'), 'b');
 
 		unset($_ENV['TEST_ME']);
-		$this->assertEqual(env('TEST_ME'), 'b');
+		$this->assertEquals(env('TEST_ME'), 'b');
 
 		$_SERVER = $__SERVER;
 		$_ENV = $__ENV;
@@ -193,24 +193,24 @@ class BasicsTest extends CakeTestCase {
 	public function testH() {
 		$string = '<foo>';
 		$result = h($string);
-		$this->assertEqual('&lt;foo&gt;', $result);
+		$this->assertEquals('&lt;foo&gt;', $result);
 
 		$in = array('this & that', '<p>Which one</p>');
 		$result = h($in);
 		$expected = array('this &amp; that', '&lt;p&gt;Which one&lt;/p&gt;');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<foo> & &nbsp;';
 		$result = h($string);
-		$this->assertEqual('&lt;foo&gt; &amp; &amp;nbsp;', $result);
+		$this->assertEquals('&lt;foo&gt; &amp; &amp;nbsp;', $result);
 
 		$string = '<foo> & &nbsp;';
 		$result = h($string, false);
-		$this->assertEqual('&lt;foo&gt; &amp; &nbsp;', $result);
+		$this->assertEquals('&lt;foo&gt; &amp; &nbsp;', $result);
 
 		$string = '<foo> & &nbsp;';
 		$result = h($string, 'UTF-8');
-		$this->assertEqual('&lt;foo&gt; &amp; &amp;nbsp;', $result);
+		$this->assertEquals('&lt;foo&gt; &amp; &amp;nbsp;', $result);
 
 		$arr = array('<foo>', '&nbsp;');
 		$result = h($arr);
@@ -218,7 +218,7 @@ class BasicsTest extends CakeTestCase {
 			'&lt;foo&gt;',
 			'&amp;nbsp;'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$arr = array('<foo>', '&nbsp;');
 		$result = h($arr, false);
@@ -226,7 +226,7 @@ class BasicsTest extends CakeTestCase {
 			'&lt;foo&gt;',
 			'&nbsp;'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$arr = array('f' => '<foo>', 'n' => '&nbsp;');
 		$result = h($arr, false);
@@ -234,7 +234,7 @@ class BasicsTest extends CakeTestCase {
 			'f' => '&lt;foo&gt;',
 			'n' => '&nbsp;'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$obj = new stdClass();
 		$result = h($obj);
@@ -253,11 +253,11 @@ class BasicsTest extends CakeTestCase {
 	public function testAm() {
 		$result = am(array('one', 'two'), 2, 3, 4);
 		$expected = array('one', 'two', 2, 3, 4);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = am(array('one' => array(2, 3), 'two' => array('foo')), array('one' => array(4, 5)));
 		$expected = array('one' => array(4, 5),'two' => array('foo'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -282,7 +282,7 @@ class BasicsTest extends CakeTestCase {
 		$this->assertTrue(file_exists(CACHE . 'basics_test'));
 
 		$result = cache('basics_test');
-		$this->assertEqual($result, 'simple cache write');
+		$this->assertEquals($result, 'simple cache write');
 		@unlink(CACHE . 'basics_test');
 
 		cache('basics_test', 'expired', '+1 second');
@@ -365,35 +365,35 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __('Plural Rule 1');
 		$expected = 'Plural Rule 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Plural Rule 1 (from core)');
 		$expected = 'Plural Rule 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Some string with %s', 'arguments');
 		$expected = 'Some string with arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Some string with %s %s', 'multiple', 'arguments');
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Some string with %s %s', array('multiple', 'arguments'));
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Testing %2$s %1$s', 'order', 'different');
 		$expected = 'Testing different order';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Testing %2$s %1$s', array('order', 'different'));
 		$expected = 'Testing different order';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __('Testing %.2f number', 1.2345);
 		$expected = 'Testing 1.23 number';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -406,27 +406,27 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __n('%d = 1', '%d = 0 or > 1', 0);
 		$expected = '%d = 0 or > 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __n('%d = 1', '%d = 0 or > 1', 1);
 		$expected = '%d = 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __n('%d = 1 (from core)', '%d = 0 or > 1 (from core)', 2);
 		$expected = '%d = 0 or > 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __n('%d item.', '%d items.', 1, 1);
 		$expected = '1 item.';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __n('%d item for id %s', '%d items for id %s', 2, 2, '1234');
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __n('%d item for id %s', '%d items for id %s', 2, array(2, '1234'));
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -439,27 +439,27 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __d('default', 'Plural Rule 1');
 		$expected = 'Plural Rule 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __d('core', 'Plural Rule 1');
 		$expected = 'Plural Rule 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __d('core', 'Plural Rule 1 (from core)');
 		$expected = 'Plural Rule 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __d('core', 'Some string with %s', 'arguments');
 		$expected = 'Some string with arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __d('core', 'Some string with %s %s', 'multiple', 'arguments');
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __d('core', 'Some string with %s %s', array('multiple', 'arguments'));
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -472,31 +472,31 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __dn('default', '%d = 1', '%d = 0 or > 1', 0);
 		$expected = '%d = 0 or > 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('core', '%d = 1', '%d = 0 or > 1', 0);
 		$expected = '%d = 0 or > 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('core', '%d = 1 (from core)', '%d = 0 or > 1 (from core)', 0);
 		$expected = '%d = 0 or > 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('default', '%d = 1', '%d = 0 or > 1', 1);
 		$expected = '%d = 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('core', '%d item.', '%d items.', 1, 1);
 		$expected = '1 item.';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('core', '%d item for id %s', '%d items for id %s', 2, 2, '1234');
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dn('core', '%d item for id %s', '%d items for id %s', 2, array(2, '1234'));
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -509,23 +509,23 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __c('Plural Rule 1', 6);
 		$expected = 'Plural Rule 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __c('Plural Rule 1 (from core)', 6);
 		$expected = 'Plural Rule 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __c('Some string with %s', 6, 'arguments');
 		$expected = 'Some string with arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __c('Some string with %s %s', 6, 'multiple', 'arguments');
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __c('Some string with %s %s', 6, array('multiple', 'arguments'));
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -538,31 +538,31 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __dc('default', 'Plural Rule 1', 6);
 		$expected = 'Plural Rule 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('default', 'Plural Rule 1 (from core)', 6);
 		$expected = 'Plural Rule 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('core', 'Plural Rule 1', 6);
 		$expected = 'Plural Rule 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('core', 'Plural Rule 1 (from core)', 6);
 		$expected = 'Plural Rule 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('core', 'Some string with %s', 6, 'arguments');
 		$expected = 'Some string with arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('core', 'Some string with %s %s', 6, 'multiple', 'arguments');
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dc('core', 'Some string with %s %s', 6, array('multiple', 'arguments'));
 		$expected = 'Some string with multiple arguments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -575,27 +575,27 @@ class BasicsTest extends CakeTestCase {
 
 		$result = __dcn('default', '%d = 1', '%d = 0 or > 1', 0, 6);
 		$expected = '%d = 0 or > 1 (translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dcn('default', '%d = 1 (from core)', '%d = 0 or > 1 (from core)', 1, 6);
 		$expected = '%d = 1 (from core translated)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dcn('core', '%d = 1', '%d = 0 or > 1', 0, 6);
 		$expected = '%d = 0 or > 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dcn('core', '%d item.', '%d items.', 1, 6, 1);
 		$expected = '1 item.';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dcn('core', '%d item for id %s', '%d items for id %s', 2, 6, 2, '1234');
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = __dcn('core', '%d item for id %s', '%d items for id %s', 2, 6, array(2, '1234'));
 		$expected = '2 items for id 1234';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -610,9 +610,9 @@ class BasicsTest extends CakeTestCase {
 		LogError("Testing with\nmulti-line\nstring");
 
 		$result = file_get_contents(LOGS . 'error.log');
-		$this->assertPattern('/Error: Testing LogError\(\) basic function/', $result);
-		$this->assertNoPattern("/Error: Testing with\nmulti-line\nstring/", $result);
-		$this->assertPattern('/Error: Testing with multi-line string/', $result);
+		$this->assertRegExp('/Error: Testing LogError\(\) basic function/', $result);
+		$this->assertNotRegExp("/Error: Testing with\nmulti-line\nstring/", $result);
+		$this->assertRegExp('/Error: Testing with multi-line string/', $result);
 	}
 
 /**
@@ -643,12 +643,12 @@ class BasicsTest extends CakeTestCase {
 
 		ini_set('include_path', $path . PATH_SEPARATOR . $folder1);
 
-		$this->assertEqual(fileExistsInPath('file1.php'), $file1);
-		$this->assertEqual(fileExistsInPath('file2.php'), $file2);
-		$this->assertEqual(fileExistsInPath('folder1' . DS . 'file2.php'), $file2);
-		$this->assertEqual(fileExistsInPath($file2), $file2);
-		$this->assertEqual(fileExistsInPath('file3.php'), $file3);
-		$this->assertEqual(fileExistsInPath($file4), $file4);
+		$this->assertEquals(fileExistsInPath('file1.php'), $file1);
+		$this->assertEquals(fileExistsInPath('file2.php'), $file2);
+		$this->assertEquals(fileExistsInPath('folder1' . DS . 'file2.php'), $file2);
+		$this->assertEquals(fileExistsInPath($file2), $file2);
+		$this->assertEquals(fileExistsInPath('file3.php'), $file3);
+		$this->assertEquals(fileExistsInPath($file4), $file4);
 
 		$this->assertFalse(fileExistsInPath('file1'));
 		$this->assertFalse(fileExistsInPath('file4.php'));
@@ -667,11 +667,11 @@ class BasicsTest extends CakeTestCase {
 	public function testConvertSlash() {
 		$result = convertSlash('\path\to\location\\');
 		$expected = '\path\to\location\\';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = convertSlash('/path/to/location/');
 		$expected = 'path_to_location';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -905,13 +905,13 @@ EXPECTED;
 			pr('this is a test');
 		$result = ob_get_clean();
 		$expected = "<pre>this is a test</pre>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			pr(array('this' => 'is', 'a' => 'test'));
 		$result = ob_get_clean();
 		$expected = "<pre>Array\n(\n    [this] => is\n    [a] => test\n)\n</pre>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -922,11 +922,11 @@ EXPECTED;
 	public function testStripslashesDeep() {
 		$this->skipIf(ini_get('magic_quotes_sybase') === '1', 'magic_quotes_sybase is on.');
 
-		$this->assertEqual(stripslashes_deep("tes\'t"), "tes't");
-		$this->assertEqual(stripslashes_deep('tes\\' . chr(0) .'t'), 'tes' . chr(0) .'t');
-		$this->assertEqual(stripslashes_deep('tes\"t'), 'tes"t');
-		$this->assertEqual(stripslashes_deep("tes\'t"), "tes't");
-		$this->assertEqual(stripslashes_deep('te\\st'), 'test');
+		$this->assertEquals(stripslashes_deep("tes\'t"), "tes't");
+		$this->assertEquals(stripslashes_deep('tes\\' . chr(0) .'t'), 'tes' . chr(0) .'t');
+		$this->assertEquals(stripslashes_deep('tes\"t'), 'tes"t');
+		$this->assertEquals(stripslashes_deep("tes\'t"), "tes't");
+		$this->assertEquals(stripslashes_deep('te\\st'), 'test');
 
 		$nested = array(
 			'a' => "tes\'t",
@@ -948,7 +948,7 @@ EXPECTED;
 				),
 			'g' => 'test'
 			);
-		$this->assertEqual(stripslashes_deep($nested), $expected);
+		$this->assertEquals(stripslashes_deep($nested), $expected);
 	}
 
 /**
@@ -959,7 +959,7 @@ EXPECTED;
 	public function testStripslashesDeepSybase() {
 		$this->skipUnless(ini_get('magic_quotes_sybase') === '1', 'magic_quotes_sybase is off');
 
-		$this->assertEqual(stripslashes_deep("tes\'t"), "tes\'t");
+		$this->assertEquals(stripslashes_deep("tes\'t"), "tes\'t");
 
 		$nested = array(
 			'a' => "tes't",
@@ -981,7 +981,7 @@ EXPECTED;
 				),
 			'g' => "te'''st"
 			);
-		$this->assertEqual(stripslashes_deep($nested), $expected);
+		$this->assertEquals(stripslashes_deep($nested), $expected);
 	}
 
 /**
@@ -991,24 +991,24 @@ EXPECTED;
  */
 	public function testPluginSplit() {
 		$result = pluginSplit('Something.else');
-		$this->assertEqual($result, array('Something', 'else'));
+		$this->assertEquals($result, array('Something', 'else'));
 
 		$result = pluginSplit('Something.else.more.dots');
-		$this->assertEqual($result, array('Something', 'else.more.dots'));
+		$this->assertEquals($result, array('Something', 'else.more.dots'));
 
 		$result = pluginSplit('Somethingelse');
-		$this->assertEqual($result, array(null, 'Somethingelse'));
+		$this->assertEquals($result, array(null, 'Somethingelse'));
 
 		$result = pluginSplit('Something.else', true);
-		$this->assertEqual($result, array('Something.', 'else'));
+		$this->assertEquals($result, array('Something.', 'else'));
 
 		$result = pluginSplit('Something.else.more.dots', true);
-		$this->assertEqual($result, array('Something.', 'else.more.dots'));
+		$this->assertEquals($result, array('Something.', 'else.more.dots'));
 
 		$result = pluginSplit('Post', false, 'Blog');
-		$this->assertEqual($result, array('Blog', 'Post'));
+		$this->assertEquals($result, array('Blog', 'Post'));
 
 		$result = pluginSplit('Blog.Post', false, 'Ultimate');
-		$this->assertEqual($result, array('Blog', 'Post'));
+		$this->assertEquals($result, array('Blog', 'Post'));
 	}
 }

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -683,7 +683,7 @@ class BasicsTest extends CakeTestCase {
 		ob_start();
 			debug('this-is-a-test');
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -691,13 +691,25 @@ this-is-a-test
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+this-is-a-test
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>');
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -705,7 +717,19 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
@@ -753,7 +777,7 @@ EXPECTED;
 		ob_start();
 			debug('<div>this-is-a-test</div>', null);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -761,13 +785,25 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
-			debug('<div>this-is-a-test</div>', null, true);
+			debug('<div>this-is-a-test</div>', null);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -775,13 +811,25 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+%s (line %d)
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', null, false);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 
 <pre class="cake-debug">
@@ -789,7 +837,19 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+$expectedText = <<<EXPECTED
+
+
+########## DEBUG ##########
+<div>this-is-a-test</div>
+###########################
+
+EXPECTED;
+		if (php_sapi_name() == 'cli') {
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+		} else {
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+		}
 		$this->assertEqual($expected, $result);
 
 		ob_start();

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -683,61 +683,21 @@ class BasicsTest extends CakeTestCase {
  */
 	public function testDebug() {
 		ob_start();
-			debug('this-is-a-test');
+			debug('this-is-a-test', false);
 		$result = ob_get_clean();
-$expectedHtml = <<<EXPECTED
-<div class="cake-debug-output">
-<span><strong>%s</strong> (line <strong>%d</strong>)</span>
-<pre class="cake-debug">
-this-is-a-test
-</pre>
-</div>
-EXPECTED;
 $expectedText = <<<EXPECTED
-
 %s (line %d)
 ########## DEBUG ##########
 this-is-a-test
 ###########################
-
 EXPECTED;
-		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
-		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
-		}
-		$this->assertEqual($expected, $result);
-
-		ob_start();
-			debug('<div>this-is-a-test</div>');
-		$result = ob_get_clean();
-$expectedHtml = <<<EXPECTED
-<div class="cake-debug-output">
-<span><strong>%s</strong> (line <strong>%d</strong>)</span>
-<pre class="cake-debug">
-&lt;div&gt;this-is-a-test&lt;/div&gt;
-</pre>
-</div>
-EXPECTED;
-$expectedText = <<<EXPECTED
-
-%s (line %d)
-########## DEBUG ##########
-<div>this-is-a-test</div>
-###########################
-
-EXPECTED;
-		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
-		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
-		}
-		$this->assertEqual($expected, $result);
+		$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', true);
 		$result = ob_get_clean();
-$expected = <<<EXPECTED
+$expectedHtml = <<<EXPECTED
 <div class="cake-debug-output">
 <span><strong>%s</strong> (line <strong>%d</strong>)</span>
 <pre class="cake-debug">
@@ -745,8 +705,8 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
-		$this->assertEqual($expected, $result);
+		$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', true, true);
@@ -774,7 +734,7 @@ $expected = <<<EXPECTED
 </div>
 EXPECTED;
 		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', null);
@@ -788,45 +748,17 @@ $expectedHtml = <<<EXPECTED
 </div>
 EXPECTED;
 $expectedText = <<<EXPECTED
-
 %s (line %d)
 ########## DEBUG ##########
 <div>this-is-a-test</div>
 ###########################
-
 EXPECTED;
 		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 17);
 		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
 		}
-		$this->assertEqual($expected, $result);
-
-		ob_start();
-			debug('<div>this-is-a-test</div>', null);
-		$result = ob_get_clean();
-$expectedHtml = <<<EXPECTED
-<div class="cake-debug-output">
-<span><strong>%s</strong> (line <strong>%d</strong>)</span>
-<pre class="cake-debug">
-&lt;div&gt;this-is-a-test&lt;/div&gt;
-</pre>
-</div>
-EXPECTED;
-$expectedText = <<<EXPECTED
-
-%s (line %d)
-########## DEBUG ##########
-<div>this-is-a-test</div>
-###########################
-
-EXPECTED;
-		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
-		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
-		}
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', null, false);
@@ -841,60 +773,52 @@ $expectedHtml = <<<EXPECTED
 EXPECTED;
 $expectedText = <<<EXPECTED
 
-
 ########## DEBUG ##########
 <div>this-is-a-test</div>
 ###########################
-
 EXPECTED;
 		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 17);
 		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 21);
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
 		}
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', false);
 		$result = ob_get_clean();
 $expected = <<<EXPECTED
-
 %s (line %d)
 ########## DEBUG ##########
 <div>this-is-a-test</div>
 ###########################
-
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
-		$this->assertEqual($expected, $result);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', false, true);
 		$result = ob_get_clean();
 $expected = <<<EXPECTED
-
 %s (line %d)
 ########## DEBUG ##########
 <div>this-is-a-test</div>
 ###########################
-
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
-		$this->assertEqual($expected, $result);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$this->assertEquals($expected, $result);
 
 		ob_start();
 			debug('<div>this-is-a-test</div>', false, false);
 		$result = ob_get_clean();
 $expected = <<<EXPECTED
 
-
 ########## DEBUG ##########
 <div>this-is-a-test</div>
 ###########################
-
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
-		$this->assertEqual($expected, $result);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -621,7 +621,9 @@ class BasicsTest extends CakeTestCase {
  * @return void
  */
 	public function testFileExistsInPath() {
-		$this->skipUnless(function_exists('ini_set'), '%s ini_set function not available');
+		if (!function_exists('ini_set')) {
+			$this->markTestSkipped('%s ini_set function not available');
+		}
 
 		$_includePath = ini_get('include_path');
 
@@ -957,7 +959,9 @@ EXPECTED;
  * @return void
  */
 	public function testStripslashesDeepSybase() {
-		$this->skipUnless(ini_get('magic_quotes_sybase') === '1', 'magic_quotes_sybase is off');
+		if (!(ini_get('magic_quotes_sybase') === '1')) {
+			$this->markTestSkipped('magic_quotes_sybase is off');
+		}
 
 		$this->assertEquals(stripslashes_deep("tes\'t"), "tes\'t");
 

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -57,7 +57,7 @@ class CacheTest extends CakeTestCase {
 	public function testConfig() {
 		$settings = array('engine' => 'File', 'path' => TMP . 'tests', 'prefix' => 'cake_test_');
 		$results = Cache::config('new', $settings);
-		$this->assertEqual($results, Cache::config('new'));
+		$this->assertEquals($results, Cache::config('new'));
 		$this->assertTrue(isset($results['engine']));
 		$this->assertTrue(isset($results['settings']));
 	}
@@ -93,11 +93,11 @@ class CacheTest extends CakeTestCase {
 
 		$settings = array('engine' => 'TestAppCache', 'path' => TMP, 'prefix' => 'cake_test_');
 		$result = Cache::config('libEngine', $settings);
-		$this->assertEqual($result, Cache::config('libEngine'));
+		$this->assertEquals($result, Cache::config('libEngine'));
 
 		$settings = array('engine' => 'TestPlugin.TestPluginCache', 'path' => TMP, 'prefix' => 'cake_test_');
 		$result = Cache::config('pluginLibEngine', $settings);
-		$this->assertEqual($result, Cache::config('pluginLibEngine'));
+		$this->assertEquals($result, Cache::config('pluginLibEngine'));
 
 		Cache::drop('libEngine');
 		Cache::drop('pluginLibEngine');
@@ -149,10 +149,10 @@ class CacheTest extends CakeTestCase {
 		$_cacheConfigTests = Cache::config('tests');
 
 		$result = Cache::config('sessions', array('engine'=> 'File', 'path' => TMP . 'sessions'));
-		$this->assertEqual($result['settings'], Cache::settings('sessions'));
+		$this->assertEquals($result['settings'], Cache::settings('sessions'));
 
 		$result = Cache::config('tests', array('engine'=> 'File', 'path' => TMP . 'tests'));
-		$this->assertEqual($result['settings'], Cache::settings('tests'));
+		$this->assertEquals($result['settings'], Cache::settings('tests'));
 
 		Cache::config('sessions', $_cacheConfigSessions['settings']);
 		Cache::config('tests', $_cacheConfigTests['settings']);
@@ -168,17 +168,17 @@ class CacheTest extends CakeTestCase {
 
 		Cache::write('value_one', 'I am cached', 'test_name');
 		$result = Cache::read('value_one', 'test_name');
-		$this->assertEqual($result, 'I am cached');
+		$this->assertEquals($result, 'I am cached');
 
 		$result = Cache::read('value_one');
-		$this->assertEqual($result, null);
+		$this->assertEquals($result, null);
 
 		Cache::write('value_one', 'I am in default config!');
 		$result = Cache::read('value_one');
-		$this->assertEqual($result, 'I am in default config!');
+		$this->assertEquals($result, 'I am in default config!');
 
 		$result = Cache::read('value_one', 'test_name');
-		$this->assertEqual($result, 'I am cached');
+		$this->assertEquals($result, 'I am cached');
 
 		Cache::delete('value_one', 'test_name');
 		Cache::delete('value_one', 'default');
@@ -205,7 +205,7 @@ class CacheTest extends CakeTestCase {
 			'isWindows' => DIRECTORY_SEPARATOR == '\\',
 			'mask' => 0664
 		);
-		$this->assertEqual($expected, Cache::settings('sessions'));
+		$this->assertEquals($expected, Cache::settings('sessions'));
 
 		Cache::config('sessions', $_cacheConfigSessions['settings']);
 	}
@@ -234,7 +234,7 @@ class CacheTest extends CakeTestCase {
 
 		$settings = Cache::settings();
 		$expecting = $override + $initial;
-		$this->assertEqual($settings, $expecting);
+		$this->assertEquals($settings, $expecting);
 	}
 
 /**
@@ -275,19 +275,19 @@ class CacheTest extends CakeTestCase {
  */
 	public function testWriteEmptyValues() {
 		Cache::write('App.falseTest', false);
-		$this->assertIdentical(Cache::read('App.falseTest'), false);
+		$this->assertSame(Cache::read('App.falseTest'), false);
 
 		Cache::write('App.trueTest', true);
-		$this->assertIdentical(Cache::read('App.trueTest'), true);
+		$this->assertSame(Cache::read('App.trueTest'), true);
 
 		Cache::write('App.nullTest', null);
-		$this->assertIdentical(Cache::read('App.nullTest'), null);
+		$this->assertSame(Cache::read('App.nullTest'), null);
 
 		Cache::write('App.zeroTest', 0);
-		$this->assertIdentical(Cache::read('App.zeroTest'), 0);
+		$this->assertSame(Cache::read('App.zeroTest'), 0);
 
 		Cache::write('App.zeroTest2', '0');
-		$this->assertIdentical(Cache::read('App.zeroTest2'), '0');
+		$this->assertSame(Cache::read('App.zeroTest2'), '0');
 	}
 
 /**
@@ -325,7 +325,7 @@ class CacheTest extends CakeTestCase {
 		Cache::config('test_cache_disable_1', array('engine'=> 'File', 'path' => TMP . 'tests'));
 
 		$this->assertTrue(Cache::write('key_1', 'hello', 'test_cache_disable_1'));
-		$this->assertIdentical(Cache::read('key_1', 'test_cache_disable_1'), 'hello');
+		$this->assertSame(Cache::read('key_1', 'test_cache_disable_1'), 'hello');
 
 		Configure::write('Cache.disable', true);
 
@@ -335,7 +335,7 @@ class CacheTest extends CakeTestCase {
 		Configure::write('Cache.disable', false);
 
 		$this->assertTrue(Cache::write('key_3', 'hello', 'test_cache_disable_1'));
-		$this->assertIdentical(Cache::read('key_3', 'test_cache_disable_1'), 'hello');
+		$this->assertSame(Cache::read('key_3', 'test_cache_disable_1'), 'hello');
 
 		Configure::write('Cache.disable', true);
 		Cache::config('test_cache_disable_2', array('engine'=> 'File', 'path' => TMP . 'tests'));
@@ -346,7 +346,7 @@ class CacheTest extends CakeTestCase {
 		Configure::write('Cache.disable', false);
 
 		$this->assertTrue(Cache::write('key_5', 'hello', 'test_cache_disable_2'));
-		$this->assertIdentical(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
+		$this->assertSame(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
 
 		Configure::write('Cache.disable', true);
 
@@ -372,7 +372,7 @@ class CacheTest extends CakeTestCase {
 
 		Cache::set(array('duration' => '+1 year'));
 		$data = Cache::read('test_cache');
-		$this->assertEqual($data, 'this is just a simple test of the cache system');
+		$this->assertEquals($data, 'this is just a simple test of the cache system');
 
 		Cache::delete('test_cache');
 

--- a/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
@@ -60,7 +60,7 @@ class ApcEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'apc');
 		$expecting = '';
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'apc');
@@ -68,7 +68,7 @@ class ApcEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'apc');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::delete('test', 'apc');
 	}
@@ -84,7 +84,7 @@ class ApcEngineTest extends CakeTestCase {
 		sleep(1);
 
 		$result = Cache::read('zero', 'apc');
-		$this->assertEqual('Should save', $result);
+		$this->assertEquals('Should save', $result);
 	}
 
 /**
@@ -147,16 +147,16 @@ class ApcEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::decrement('test_decrement', 1, 'apc');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::read('test_decrement', 'apc');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::decrement('test_decrement', 2, 'apc');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 		$result = Cache::read('test_decrement', 'apc');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 	}
 
@@ -172,16 +172,16 @@ class ApcEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::increment('test_increment', 1, 'apc');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::read('test_increment', 'apc');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::increment('test_increment', 2, 'apc');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 
 		$result = Cache::read('test_increment', 'apc');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -62,11 +62,11 @@ class FileEngineTest extends CakeTestCase {
  */
 	public function testCacheDirChange() {
 		$result = Cache::config('sessions', array('engine'=> 'File', 'path' => TMP . 'sessions'));
-		$this->assertEqual($result['settings'], Cache::settings('sessions'));
+		$this->assertEquals($result['settings'], Cache::settings('sessions'));
 
 		$result = Cache::config('sessions', array('engine'=> 'File', 'path' => TMP . 'tests'));
-		$this->assertEqual($result['settings'], Cache::settings('sessions'));
-		$this->assertNotEqual($result['settings'], Cache::settings('default'));
+		$this->assertEquals($result['settings'], Cache::settings('sessions'));
+		$this->assertNotEquals($result['settings'], Cache::settings('default'));
 	}
 
 /**
@@ -84,7 +84,7 @@ class FileEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = '';
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'file_test');
@@ -92,7 +92,7 @@ class FileEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::delete('test', 'file_test');
 	}
@@ -180,9 +180,9 @@ class FileEngineTest extends CakeTestCase {
 
 		$delete = Cache::delete('serialize_test', 'file_test');
 
-		$this->assertIdentical($read, serialize($data));
+		$this->assertSame($read, serialize($data));
 
-		$this->assertIdentical(unserialize($newread), $data);
+		$this->assertSame(unserialize($newread), $data);
 	}
 
 /**
@@ -243,11 +243,11 @@ class FileEngineTest extends CakeTestCase {
 		$FileOne->write('prefix_one_key_one', $data1, DAY);
 		$FileTwo->write('prefix_two_key_two', $data2, DAY);
 
-		$this->assertEqual($FileOne->read('prefix_one_key_one'), $expected);
-		$this->assertEqual($FileTwo->read('prefix_two_key_two'), $expected);
+		$this->assertEquals($FileOne->read('prefix_one_key_one'), $expected);
+		$this->assertEquals($FileTwo->read('prefix_two_key_two'), $expected);
 
 		$FileOne->clear(false);
-		$this->assertEqual($FileTwo->read('prefix_two_key_two'), $expected, 'secondary config was cleared by accident.');
+		$this->assertEquals($FileTwo->read('prefix_two_key_two'), $expected, 'secondary config was cleared by accident.');
 		$FileTwo->clear(false);
 	}
 
@@ -262,7 +262,7 @@ class FileEngineTest extends CakeTestCase {
 		$this->assertTrue(file_exists(CACHE . 'cake_views_countries_something'));
 
 		$result = Cache::read('views.countries.something', 'file_test');
-		$this->assertEqual($result, 'here');
+		$this->assertEquals($result, 'here');
 
 		$result = Cache::clear(false, 'file_test');
 		$this->assertTrue($result);
@@ -308,7 +308,7 @@ class FileEngineTest extends CakeTestCase {
 		Cache::write('test_dir_map', $expected, 'windows_test');
 		$data = Cache::read('test_dir_map', 'windows_test');
 		Cache::delete('test_dir_map', 'windows_test');
-		$this->assertEqual($expected, $data);
+		$this->assertEquals($expected, $data);
 
 		Cache::drop('windows_test');
 	}
@@ -321,14 +321,14 @@ class FileEngineTest extends CakeTestCase {
 	public function testWriteQuotedString() {
 		Cache::config('file_test', array('engine' => 'File', 'path' => TMP . 'tests'));
 		Cache::write('App.doubleQuoteTest', '"this is a quoted string"', 'file_test');
-		$this->assertIdentical(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
+		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
-		$this->assertIdentical(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
+		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
 
 		Cache::config('file_test', array('isWindows' => true, 'path' => TMP . 'tests'));
-		$this->assertIdentical(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
+		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
-		$this->assertIdentical(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
+		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
 		Cache::delete('App.singleQuoteTest', 'file_test');
 		Cache::delete('App.doubleQuoteTest', 'file_test');
 	}
@@ -361,7 +361,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0664';
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -369,7 +369,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0666';
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -377,7 +377,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0644';
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -385,7 +385,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0640';
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 	}

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -89,7 +89,7 @@ class MemcacheEngineTest extends CakeTestCase {
 			'engine' => 'Memcache',
 			'persistent' => true,
 		);
-		$this->assertEqual($settings, $expecting);
+		$this->assertEquals($settings, $expecting);
 	}
 
 /**
@@ -116,7 +116,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$servers = array_keys($Memcache->__Memcache->getExtendedStats());
 		$settings = $Memcache->settings();
-		$this->assertEqual($servers, $settings['servers']);
+		$this->assertEquals($servers, $settings['servers']);
 		Cache::drop('dual_server');
 	}
 
@@ -158,10 +158,10 @@ class MemcacheEngineTest extends CakeTestCase {
 	public function testParseServerStringNonLatin() {
 		$Memcache = new TestMemcacheEngine();
 		$result = $Memcache->parseServerString('schülervz.net:13211');
-		$this->assertEqual($result, array('schülervz.net', '13211'));
+		$this->assertEquals($result, array('schülervz.net', '13211'));
 
 		$result = $Memcache->parseServerString('sülül:1111');
-		$this->assertEqual($result, array('sülül', '1111'));
+		$this->assertEquals($result, array('sülül', '1111'));
 	}
 
 /**
@@ -172,7 +172,7 @@ class MemcacheEngineTest extends CakeTestCase {
     function testParseServerStringUnix() {
         $Memcache =& new TestMemcacheEngine();
         $result = $Memcache->parseServerString('unix:///path/to/memcached.sock');
-        $this->assertEqual($result, array('unix:///path/to/memcached.sock', 0));
+        $this->assertEquals($result, array('unix:///path/to/memcached.sock', 0));
     }
 
 /**
@@ -185,7 +185,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'memcache');
 		$expecting = '';
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'memcache');
@@ -193,7 +193,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'memcache');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::delete('test', 'memcache');
 	}
@@ -241,7 +241,7 @@ class MemcacheEngineTest extends CakeTestCase {
 		sleep(2);
 		$result = Cache::read('long_expiry_test', 'memcache');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::config('memcache', array('duration' => 3600));
 	}
@@ -270,16 +270,16 @@ class MemcacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::decrement('test_decrement', 1, 'memcache');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::read('test_decrement', 'memcache');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::decrement('test_decrement', 2, 'memcache');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 		$result = Cache::read('test_decrement', 'memcache');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 	}
 
 /**
@@ -292,16 +292,16 @@ class MemcacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::increment('test_increment', 1, 'memcache');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::read('test_increment', 'memcache');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::increment('test_increment', 2, 'memcache');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 
 		$result = Cache::read('test_increment', 'memcache');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 	}
 
 /**
@@ -325,11 +325,11 @@ class MemcacheEngineTest extends CakeTestCase {
 		$this->assertTrue(Cache::write('duration_test', 'yay', 'long_memcache'));
 		$this->assertTrue(Cache::write('short_duration_test', 'boo', 'short_memcache'));
 
-		$this->assertEqual(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
-		$this->assertEqual(Cache::read('short_duration_test', 'short_memcache'), 'boo', 'Value was not read %s');
+		$this->assertEquals(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
+		$this->assertEquals(Cache::read('short_duration_test', 'short_memcache'), 'boo', 'Value was not read %s');
 
 		sleep(1);
-		$this->assertEqual(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
+		$this->assertEquals(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
 
 		sleep(2);
 		$this->assertFalse(Cache::read('short_duration_test', 'short_memcache'), 'Cache was not invalidated %s');
@@ -375,7 +375,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$this->assertTrue($result, 'Could not write with duration 0');
 		$result = Cache::read('test_key', 'memcache');
-		$this->assertEqual($result, 'written!');
+		$this->assertEquals($result, 'written!');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
@@ -59,7 +59,7 @@ class WincacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'wincache');
 		$expecting = '';
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'wincache');
@@ -67,7 +67,7 @@ class WincacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'wincache');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::delete('test', 'wincache');
 	}
@@ -135,16 +135,16 @@ class WincacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::decrement('test_decrement', 1, 'wincache');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::read('test_decrement', 'wincache');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::decrement('test_decrement', 2, 'wincache');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 		$result = Cache::read('test_decrement', 'wincache');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 	}
 
@@ -163,16 +163,16 @@ class WincacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::increment('test_increment', 1, 'wincache');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::read('test_increment', 'wincache');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::increment('test_increment', 2, 'wincache');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 
 		$result = Cache::read('test_increment', 'wincache');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
@@ -32,7 +32,9 @@ class XcacheEngineTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
-		$this->skipUnless(function_exists('xcache_set'), 'Xcache is not installed or configured properly');
+		if (!function_exists('xcache_set')) {
+			$this->markTestSkipped('Xcache is not installed or configured properly');
+		}
 		$this->_cacheDisable = Configure::read('Cache.disable');
 		Configure::write('Cache.disable', false);
 		Cache::config('xcache', array('engine' => 'Xcache', 'prefix' => 'cake_'));

--- a/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
@@ -65,7 +65,7 @@ class XcacheEngineTest extends CakeTestCase {
 		$this->assertTrue(isset($settings['PHP_AUTH_PW']));
 
 		unset($settings['PHP_AUTH_USER'], $settings['PHP_AUTH_PW']);
-		$this->assertEqual($settings, $expecting);
+		$this->assertEquals($settings, $expecting);
 	}
 
 /**
@@ -78,7 +78,7 @@ class XcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test');
 		$expecting = '';
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data);
@@ -86,7 +86,7 @@ class XcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test');
 		$expecting = $data;
-		$this->assertEqual($result, $expecting);
+		$this->assertEquals($result, $expecting);
 
 		Cache::delete('test');
 	}
@@ -161,16 +161,16 @@ class XcacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::decrement('test_decrement');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::read('test_decrement');
-		$this->assertEqual(4, $result);
+		$this->assertEquals(4, $result);
 
 		$result = Cache::decrement('test_decrement', 2);
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 
 		$result = Cache::read('test_decrement');
-		$this->assertEqual(2, $result);
+		$this->assertEquals(2, $result);
 	}
 
 /**
@@ -183,15 +183,15 @@ class XcacheEngineTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = Cache::increment('test_increment');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::read('test_increment');
-		$this->assertEqual(6, $result);
+		$this->assertEquals(6, $result);
 
 		$result = Cache::increment('test_increment', 2);
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 
 		$result = Cache::read('test_increment');
-		$this->assertEqual(8, $result);
+		$this->assertEquals(8, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -114,10 +114,10 @@ class AclShellTest extends CakeTestCase {
 		$expected = array('model' => 'Model', 'foreign_key' => 'foreignKey');
 
 		$result = $this->Task->parseIdentifier('mySuperUser');
-		$this->assertEqual($result, 'mySuperUser');
+		$this->assertEquals($result, 'mySuperUser');
 
 		$result = $this->Task->parseIdentifier('111234');
-		$this->assertEqual($result, '111234');
+		$this->assertEquals($result, '111234');
 	}
 
 /**
@@ -136,9 +136,9 @@ class AclShellTest extends CakeTestCase {
 		$Aro = ClassRegistry::init('Aro');
 		$Aro->cacheQueries = false;
 		$result = $Aro->read();
-		$this->assertEqual($result['Aro']['model'], 'User');
-		$this->assertEqual($result['Aro']['foreign_key'], 1);
-		$this->assertEqual($result['Aro']['parent_id'], null);
+		$this->assertEquals($result['Aro']['model'], 'User');
+		$this->assertEquals($result['Aro']['foreign_key'], 1);
+		$this->assertEquals($result['Aro']['parent_id'], null);
 		$id = $result['Aro']['id'];
 
 		$this->Task->args = array('aro', 'User.1', 'User.3');
@@ -146,19 +146,19 @@ class AclShellTest extends CakeTestCase {
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read();
-		$this->assertEqual($result['Aro']['model'], 'User');
-		$this->assertEqual($result['Aro']['foreign_key'], 3);
-		$this->assertEqual($result['Aro']['parent_id'], $id);
+		$this->assertEquals($result['Aro']['model'], 'User');
+		$this->assertEquals($result['Aro']['foreign_key'], 3);
+		$this->assertEquals($result['Aro']['parent_id'], $id);
 
 		$this->Task->args = array('aro', 'root', 'somealias');
 		$this->Task->create();
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read();
-		$this->assertEqual($result['Aro']['alias'], 'somealias');
-		$this->assertEqual($result['Aro']['model'], null);
-		$this->assertEqual($result['Aro']['foreign_key'], null);
-		$this->assertEqual($result['Aro']['parent_id'], null);
+		$this->assertEquals($result['Aro']['alias'], 'somealias');
+		$this->assertEquals($result['Aro']['model'], null);
+		$this->assertEquals($result['Aro']['foreign_key'], null);
+		$this->assertEquals($result['Aro']['parent_id'], null);
 	}
 
 /**
@@ -188,7 +188,7 @@ class AclShellTest extends CakeTestCase {
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read(null, 4);
-		$this->assertEqual($result['Aro']['parent_id'], null);
+		$this->assertEquals($result['Aro']['parent_id'], null);
 	}
 
 /**
@@ -205,7 +205,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEqual($node['Aco'][0]['Permission']['_create'], 1);
+		$this->assertEquals($node['Aco'][0]['Permission']['_create'], 1);
 	}
 
 /**
@@ -223,7 +223,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->node(array('model' => 'AuthUser', 'foreign_key' => 2));
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEqual($node['Aco'][0]['Permission']['_create'], -1);
+		$this->assertEquals($node['Aco'][0]['Permission']['_create'], -1);
 	}
 
 /**
@@ -274,7 +274,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->node(array('model' => 'AuthUser', 'foreign_key' => 2));
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEqual($node['Aco'][0]['Permission']['_create'], 0);
+		$this->assertEquals($node['Aco'][0]['Permission']['_create'], 0);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -80,35 +80,35 @@ class CommandListShellTest extends CakeTestCase {
 		$output = $this->Shell->stdout->output;
 
 		$expected = "/example \[.*TestPlugin, TestPluginTwo.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/welcome \[.*TestPluginTwo.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 
 		$expected = "/acl \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/api \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/bake \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/console \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/i18n \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/schema \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/testsuite \[.*CORE.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/sample \[.*app.*\]/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 	}
 
 /**
@@ -123,16 +123,16 @@ class CommandListShellTest extends CakeTestCase {
 		$output = $this->Shell->stdout->output;
 
 		$expected = "/\[.*App.*\]\\v*[ ]+sample/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/\[.*TestPluginTwo.*\]\\v*[ ]+example, welcome/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/\[.*TestPlugin.*\]\\v*[ ]+example/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 
 		$expected = "/\[.*Core.*\]\\v*[ ]+acl, api, bake, command_list, console, i18n, schema, testsuite/";
-		$this->assertPattern($expected, $output);
+		$this->assertRegExp($expected, $output);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -135,18 +135,18 @@ class SchemaShellTest extends CakeTestCase {
 		$this->Shell->startup();
 		$this->assertTrue(isset($this->Shell->Schema));
 		$this->assertTrue(is_a($this->Shell->Schema, 'CakeSchema'));
-		$this->assertEqual(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
-		$this->assertEqual($this->Shell->Schema->file, 'schema.php');
+		$this->assertEquals(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
+		$this->assertEquals($this->Shell->Schema->file, 'schema.php');
 
 		$this->Shell->Schema = null;
 		$this->Shell->params = array(
 			'name' => 'TestSchema'
 		);
 		$this->Shell->startup();
-		$this->assertEqual($this->Shell->Schema->name, 'TestSchema');
-		$this->assertEqual($this->Shell->Schema->file, 'test_schema.php');
-		$this->assertEqual($this->Shell->Schema->connection, 'default');
-		$this->assertEqual($this->Shell->Schema->path, APP . 'Config' . DS . 'Schema');
+		$this->assertEquals($this->Shell->Schema->name, 'TestSchema');
+		$this->assertEquals($this->Shell->Schema->file, 'test_schema.php');
+		$this->assertEquals($this->Shell->Schema->connection, 'default');
+		$this->assertEquals($this->Shell->Schema->path, APP . 'Config' . DS . 'Schema');
 
 		$this->Shell->Schema = null;
 		$this->Shell->params = array(
@@ -155,10 +155,10 @@ class SchemaShellTest extends CakeTestCase {
 			'path' => '/test/path'
 		);
 		$this->Shell->startup();
-		$this->assertEqual(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
-		$this->assertEqual($this->Shell->Schema->file, 'other_file.php');
-		$this->assertEqual($this->Shell->Schema->connection, 'test');
-		$this->assertEqual($this->Shell->Schema->path, '/test/path');
+		$this->assertEquals(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
+		$this->assertEquals($this->Shell->Schema->file, 'other_file.php');
+		$this->assertEquals($this->Shell->Schema->connection, 'test');
+		$this->assertEquals($this->Shell->Schema->path, '/test/path');
 	}
 
 /**
@@ -217,14 +217,14 @@ class SchemaShellTest extends CakeTestCase {
 
 		$this->file = new File(TMP . 'tests' . DS . 'i18n.sql');
 		$contents = $this->file->read();
-		$this->assertPattern('/DROP TABLE/', $contents);
-		$this->assertPattern('/CREATE TABLE.*?i18n/', $contents);
-		$this->assertPattern('/id/', $contents);
-		$this->assertPattern('/model/', $contents);
-		$this->assertPattern('/field/', $contents);
-		$this->assertPattern('/locale/', $contents);
-		$this->assertPattern('/foreign_key/', $contents);
-		$this->assertPattern('/content/', $contents);
+		$this->assertRegExp('/DROP TABLE/', $contents);
+		$this->assertRegExp('/CREATE TABLE.*?i18n/', $contents);
+		$this->assertRegExp('/id/', $contents);
+		$this->assertRegExp('/model/', $contents);
+		$this->assertRegExp('/field/', $contents);
+		$this->assertRegExp('/locale/', $contents);
+		$this->assertRegExp('/foreign_key/', $contents);
+		$this->assertRegExp('/content/', $contents);
 	}
 
 /**
@@ -249,9 +249,9 @@ class SchemaShellTest extends CakeTestCase {
 		$this->file = new File(TMP . 'tests' . DS . 'dump_test.sql');
 		$contents = $this->file->read();
 
-		$this->assertPattern('/CREATE TABLE.*?test_plugin_acos/', $contents);
-		$this->assertPattern('/id/', $contents);
-		$this->assertPattern('/model/', $contents);
+		$this->assertRegExp('/CREATE TABLE.*?test_plugin_acos/', $contents);
+		$this->assertRegExp('/id/', $contents);
+		$this->assertRegExp('/model/', $contents);
 
 		$this->file->delete();
 		App::build();
@@ -352,13 +352,13 @@ class SchemaShellTest extends CakeTestCase {
 		$this->file = new File(TMP . 'tests' . DS . 'schema.php');
 		$contents = $this->file->read();
 
-		$this->assertPattern('/class TestPluginSchema/', $contents);
-		$this->assertPattern('/var \$posts/', $contents);
-		$this->assertPattern('/var \$auth_users/', $contents);
-		$this->assertPattern('/var \$authors/', $contents);
-		$this->assertPattern('/var \$test_plugin_comments/', $contents);
-		$this->assertNoPattern('/var \$users/', $contents);
-		$this->assertNoPattern('/var \$articles/', $contents);
+		$this->assertRegExp('/class TestPluginSchema/', $contents);
+		$this->assertRegExp('/var \$posts/', $contents);
+		$this->assertRegExp('/var \$auth_users/', $contents);
+		$this->assertRegExp('/var \$authors/', $contents);
+		$this->assertRegExp('/var \$test_plugin_comments/', $contents);
+		$this->assertNotRegExp('/var \$users/', $contents);
+		$this->assertNotRegExp('/var \$articles/', $contents);
 		CakePlugin::unload();
 	}
 
@@ -459,7 +459,7 @@ class SchemaShellTest extends CakeTestCase {
 		);
 		$this->Shell->startup();
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPlugin' . DS . 'Config' . DS . 'Schema';
-		$this->assertEqual($this->Shell->Schema->path, $expected);
+		$this->assertEquals($this->Shell->Schema->path, $expected);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/ShellTest.php
@@ -134,7 +134,7 @@ class ShellTest extends CakeTestCase {
  * @return void
  */
 	public function testConstruct() {
-		$this->assertEqual($this->Shell->name, 'ShellTestShell');
+		$this->assertEquals($this->Shell->name, 'ShellTestShell');
 		$this->assertInstanceOf('ConsoleInput', $this->Shell->stdin);
 		$this->assertInstanceOf('ConsoleOutput', $this->Shell->stdout);
 		$this->assertInstanceOf('ConsoleOutput', $this->Shell->stderr);
@@ -176,14 +176,14 @@ class ShellTest extends CakeTestCase {
 
 		$this->assertTrue(isset($this->Shell->TestPluginPost));
 		$this->assertInstanceOf('TestPluginPost', $this->Shell->TestPluginPost);
-		$this->assertEqual($this->Shell->modelClass, 'TestPluginPost');
+		$this->assertEquals($this->Shell->modelClass, 'TestPluginPost');
 		CakePlugin::unload('TestPlugin');
 
 		$this->Shell->uses = array('Comment');
 		$this->Shell->initialize();
 		$this->assertTrue(isset($this->Shell->Comment));
 		$this->assertInstanceOf('Comment', $this->Shell->Comment);
-		$this->assertEqual($this->Shell->modelClass, 'Comment');
+		$this->assertEquals($this->Shell->modelClass, 'Comment');
 
 		App::build();
 	}
@@ -219,22 +219,22 @@ class ShellTest extends CakeTestCase {
 			->will($this->returnValue('0'));
 
 		$result = $this->Shell->in('Just a test?', array('y', 'n'), 'n');
-		$this->assertEqual($result, 'n');
+		$this->assertEquals($result, 'n');
 
 		$result = $this->Shell->in('Just a test?', array('y', 'n'), 'n');
-		$this->assertEqual($result, 'Y');
+		$this->assertEquals($result, 'Y');
 
 		$result = $this->Shell->in('Just a test?', 'y,n', 'n');
-		$this->assertEqual($result, 'y');
+		$this->assertEquals($result, 'y');
 
 		$result = $this->Shell->in('Just a test?', 'y/n', 'n');
-		$this->assertEqual($result, 'y');
+		$this->assertEquals($result, 'y');
 
 		$result = $this->Shell->in('Just a test?', 'y', 'y');
-		$this->assertEqual($result, 'y');
+		$this->assertEquals($result, 'y');
 
 		$result = $this->Shell->in('Just a test?', array(0, 1, 2), '0');
-		$this->assertEqual($result, '0');
+		$this->assertEquals($result, '0');
 	}
 
 /**
@@ -246,7 +246,7 @@ class ShellTest extends CakeTestCase {
 		$this->Shell->interactive = false;
 
 		$result = $this->Shell->in('Just a test?', 'y/n', 'n');
-		$this->assertEqual($result, 'n');
+		$this->assertEquals($result, 'n');
 	}
 
 /**
@@ -359,11 +359,11 @@ class ShellTest extends CakeTestCase {
 		if (DS === '\\') {
 			$newLine = "\r\n";
 		}
-		$this->assertEqual($this->Shell->nl(), $newLine);
-		$this->assertEqual($this->Shell->nl(true), $newLine);
-		$this->assertEqual($this->Shell->nl(false), "");
-		$this->assertEqual($this->Shell->nl(2), $newLine . $newLine);
-		$this->assertEqual($this->Shell->nl(1), $newLine);
+		$this->assertEquals($this->Shell->nl(), $newLine);
+		$this->assertEquals($this->Shell->nl(true), $newLine);
+		$this->assertEquals($this->Shell->nl(false), "");
+		$this->assertEquals($this->Shell->nl(2), $newLine . $newLine);
+		$this->assertEquals($this->Shell->nl(1), $newLine);
 	}
 
 /**
@@ -412,12 +412,12 @@ class ShellTest extends CakeTestCase {
 			->with("Searched all...", 1);
 
 		$this->Shell->error('Foo Not Found');
-		$this->assertIdentical($this->Shell->stopped, 1);
+		$this->assertSame($this->Shell->stopped, 1);
 
 		$this->Shell->stopped = null;
 
 		$this->Shell->error('Foo Not Found', 'Searched all...');
-		$this->assertIdentical($this->Shell->stopped, 1);
+		$this->assertSame($this->Shell->stopped, 1);
 	}
 
 /**
@@ -482,38 +482,38 @@ class ShellTest extends CakeTestCase {
  */
 	public function testShortPath() {
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'cd';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'cd' . DS ;
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'index.php';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		// Shell::shortPath needs Folder::realpath
 		// $path = DS . 'tmp' . DS . 'ab' . DS . '..' . DS . 'cd';
 		// $expected = DS . 'tmp' . DS . 'cd';
-		// $this->assertEqual($this->Shell->shortPath($path), $expected);
+		// $this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = DS . 'tmp' . DS . 'ab' . DS . DS . 'cd';
 		$expected = DS . 'tmp' . DS . 'ab' . DS . 'cd';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = 'tmp' . DS . 'ab';
 		$expected = 'tmp' . DS . 'ab';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = 'tmp' . DS . 'ab';
 		$expected = 'tmp' . DS . 'ab';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = APP;
 		$expected = DS . basename(APP) . DS;
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 
 		$path = APP . 'index.php';
 		$expected = DS . basename(APP) . DS . 'index.php';
-		$this->assertEqual($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($this->Shell->shortPath($path), $expected);
 	}
 
 /**
@@ -535,13 +535,13 @@ class ShellTest extends CakeTestCase {
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		$contents = "<?php\necho 'another test';\n\$te = 'st';\n";
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		$Folder->delete();
 	}
@@ -573,14 +573,14 @@ class ShellTest extends CakeTestCase {
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		// no overwrite
 		$contents = 'new contents';
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertFalse($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertNotEqual($contents, file_get_contents($file));
+		$this->assertNotEquals($contents, file_get_contents($file));
 
 		// overwrite
 		$contents = 'more new contents';
@@ -611,13 +611,13 @@ class ShellTest extends CakeTestCase {
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		$contents = "<?php\r\necho 'another test';\r\n\$te = 'st';\r\n";
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		$Folder = new Folder($path);
 		$Folder->delete();
@@ -649,14 +649,14 @@ class ShellTest extends CakeTestCase {
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEqual(file_get_contents($file), $contents);
+		$this->assertEquals(file_get_contents($file), $contents);
 
 		// no overwrite
 		$contents = 'new contents';
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertFalse($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertNotEqual($contents, file_get_contents($file));
+		$this->assertNotEquals($contents, file_get_contents($file));
 
 		// overwrite
 		$contents = 'more new contents';
@@ -839,6 +839,6 @@ TEXT;
 		$this->Shell->tasks = array('TestApple');
 		$this->Shell->loadTasks();
 		$expected = 'TestApple';
-		$this->assertEqual($expected, $this->Shell->TestApple->name);
+		$this->assertEquals($expected, $this->Shell->TestApple->name);
 	}
 }

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -116,13 +116,13 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$expected = array('BakeArticles', 'BakeArticlesBakeTags', 'BakeComments', 'BakeTags');
 		$result = $this->Task->listAll('test');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Task->interactive = false;
 		$result = $this->Task->listAll();
 
 		$expected = array('bake_articles', 'bake_articles_bake_tags', 'bake_comments', 'bake_tags');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -142,11 +142,11 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$result = $this->Task->getName('test');
 		$expected = 'BakeComments';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Task->getName('test');
 		$expected = 'BakeArticles';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -173,7 +173,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoHelpersNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doHelpers();
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 	}
 
 /**
@@ -186,7 +186,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Javascript, Ajax, CustomOne  '));
 		$result = $this->Task->doHelpers();
 		$expected = array('Javascript', 'Ajax', 'CustomOne');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -199,7 +199,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Javascript, Ajax, CustomOne, , '));
 		$result = $this->Task->doHelpers();
 		$expected = array('Javascript', 'Ajax', 'CustomOne');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -210,7 +210,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoComponentsNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doComponents();
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 	}
 
 /**
@@ -224,7 +224,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$result = $this->Task->doComponents();
 		$expected = array('RequestHandler', 'Security');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -238,7 +238,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$result = $this->Task->doComponents();
 		$expected = array('RequestHandler', 'Security');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -287,7 +287,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$result = $this->Task->bake('Articles', '--actions--', array(), array());
 		$this->assertContains('class ArticlesController extends AppController', $result);
-		$this->assertIdentical(substr_count($result, '@property'), 1);
+		$this->assertSame(substr_count($result, '@property'), 1);
 		$this->assertNotContains('components', $result);
 		$this->assertNotContains('helpers', $result);
 		$this->assertContains('--actions--', $result);
@@ -415,9 +415,9 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->Test->expects($this->once())->method('bake')->with('Controller', 'BakeArticles');
 		$this->Task->bakeTest('BakeArticles');
 
-		$this->assertEqual($this->Task->plugin, $this->Task->Test->plugin);
-		$this->assertEqual($this->Task->connection, $this->Task->Test->connection);
-		$this->assertEqual($this->Task->interactive, $this->Task->Test->interactive);
+		$this->assertEquals($this->Task->plugin, $this->Task->Test->plugin);
+		$this->assertEquals($this->Task->connection, $this->Task->Test->connection);
+		$this->assertEquals($this->Task->interactive, $this->Task->Test->interactive);
 	}
 
 /**
@@ -494,7 +494,7 @@ class ControllerTaskTest extends CakeTestCase {
 		)->will($this->returnValue(true));
 
 		$result = $this->Task->execute();
-		$this->assertPattern('/admin_index/', $result);
+		$this->assertRegExp('/admin_index/', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -84,55 +84,55 @@ class ExtractTaskTest extends CakeTestCase {
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
 		$pattern = '/"Content-Type\: text\/plain; charset\=utf-8/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/"Content-Transfer-Encoding\: 8bit/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/"Plural-Forms\: nplurals\=INTEGER; plural\=EXPRESSION;/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		// home.ctp
 		$pattern = '/msgid "Your tmp directory is writable."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Your tmp directory is NOT writable."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "The %s is being used for caching. To change the config edit ';
 		$pattern .= 'APP\/config\/core.php "\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Your cache is NOT working. Please check ';
 		$pattern .= 'the settings in APP\/config\/core.php"\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Your database configuration file is present."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Your database configuration file is NOT present."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Rename config\/database.php.default to ';
 		$pattern .= 'config\/database.php"\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Cake is able to connect to the database."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Cake is NOT able to connect to the database."\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "Editing this Page"\nmsgstr ""\n/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "To change the content of this page, create: APP\/views\/pages\/home\.ctp/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/To change its layout, create: APP\/views\/layouts\/default\.ctp\./s';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		// extract.ctp
 		$pattern = '/\#: (\\\\|\/)extract\.ctp:6\n';
 		$pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/\#: (\\\\|\/)extract\.ctp:7\n';
 		$pattern .= 'msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/\#: (\\\\|\/)extract\.ctp:14\n';
 		$pattern .= '\#: (\\\\|\/)home\.ctp:99\n';
 		$pattern .= 'msgid "Editing this Page"\nmsgstr ""/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/\#: (\\\\|\/)extract\.ctp:17\nmsgid "';
 		$pattern .= 'Hot features!';
@@ -140,20 +140,20 @@ class ExtractTaskTest extends CakeTestCase {
 		$pattern .= '\\\n - Extremely Simple: Just look at the name...It\'s Cake';
 		$pattern .= '\\\n - Active, Friendly Community: Join us #cakephp on IRC. We\'d love to help you get started';
 		$pattern .= '"\nmsgstr ""/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		// extract.ctp - reading the domain.pot
 		$result = file_get_contents($this->path . DS . 'domain.pot');
 
 		$pattern = '/msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
-		$this->assertNoPattern($pattern, $result);
+		$this->assertNotRegExp($pattern, $result);
 		$pattern = '/msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."/';
-		$this->assertNoPattern($pattern, $result);
+		$this->assertNotRegExp($pattern, $result);
 
 		$pattern = '/msgid "You have %d new message \(domain\)."\nmsgid_plural "You have %d new messages \(domain\)."/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 		$pattern = '/msgid "You deleted %d message \(domain\)."\nmsgid_plural "You deleted %d messages \(domain\)."/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 	}
 
 /**
@@ -202,7 +202,7 @@ class ExtractTaskTest extends CakeTestCase {
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
 		$pattern = '/msgid "Add User"/';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 	}
 
 /**
@@ -228,7 +228,7 @@ class ExtractTaskTest extends CakeTestCase {
 
 		$this->Task->execute();
 		$result = file_get_contents($this->path . DS . 'default.pot');
-		$this->assertNoPattern('#TestPlugin#', $result);
+		$this->assertNotRegExp('#TestPlugin#', $result);
 	}
 
 /**
@@ -253,7 +253,7 @@ class ExtractTaskTest extends CakeTestCase {
 
 		$this->Task->execute();
 		$result = file_get_contents($this->path . DS . 'default.pot');
-		$this->assertNoPattern('#Pages#', $result);
+		$this->assertNotRegExp('#Pages#', $result);
 		$this->assertContains('translate.ctp:1', $result);
 		$this->assertContains('This is a translatable string', $result);
 	}
@@ -285,22 +285,22 @@ class ExtractTaskTest extends CakeTestCase {
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
 		$pattern = preg_quote('#Model' . DS . 'PersisterOne.php:validation for field title#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = preg_quote('#Model' . DS . 'PersisterOne.php:validation for field body#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post title is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "You may enter up to %s chars \(minimum is %s chars\)"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is super required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 	}
 
 /**
@@ -330,19 +330,19 @@ class ExtractTaskTest extends CakeTestCase {
 		$result = file_get_contents($this->path . DS . 'test_plugin.pot');
 
 		$pattern = preg_quote('#Plugin' . DS. 'TestPlugin' . DS. 'Model' . DS. 'TestPluginPost.php:validation for field title#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = preg_quote('#Plugin' . DS. 'TestPlugin' . DS. 'Model' . DS. 'TestPluginPost.php:validation for field body#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post title is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is super required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 	}
 
 
@@ -370,21 +370,21 @@ class ExtractTaskTest extends CakeTestCase {
 		$result = file_get_contents($this->path . DS . 'test_plugin.pot');
 
 		$pattern =  preg_quote('#Model' . DS. 'TestPluginPost.php:validation for field title#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern =  preg_quote('#Model' . DS. 'TestPluginPost.php:validation for field body#', '\\');
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post title is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#msgid "Post body is super required"#';
-		$this->assertPattern($pattern, $result);
+		$this->assertRegExp($pattern, $result);
 
 		$pattern = '#Plugin/TestPlugin/Model/TestPluginPost.php:validation for field title#';
-		$this->assertNoPattern($pattern, $result);
+		$this->assertNotRegExp($pattern, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -89,7 +89,7 @@ class FixtureTaskTest extends CakeTestCase {
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 
 		$Task = new FixtureTask($out, $out, $in);
-		$this->assertEqual($Task->path, APP . 'Test' . DS . 'Fixture' . DS);
+		$this->assertEquals($Task->path, APP . 'Test' . DS . 'Fixture' . DS);
 	}
 
 /**
@@ -103,7 +103,7 @@ class FixtureTaskTest extends CakeTestCase {
 
 		$result = $this->Task->importOptions('Article');
 		$expected = array('schema' => 'Article', 'records' => true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -118,7 +118,7 @@ class FixtureTaskTest extends CakeTestCase {
 
 		$result = $this->Task->importOptions('Article');
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -132,7 +132,7 @@ class FixtureTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(2))->method('in')->will($this->returnValue('y'));
 		$result = $this->Task->importOptions('Article');
 		$expected = array('fromTable' => true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -130,12 +130,12 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->listAll('test');
 		$expected = array('bake_articles', 'bake_articles_bake_tags', 'bake_comments', 'bake_tags', 'category_threads');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Task->connection = 'test';
 		$result = $this->Task->listAll();
 		$expected = array('bake_articles', 'bake_articles_bake_tags', 'bake_comments', 'bake_tags', 'category_threads');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -186,7 +186,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
 		$result = $this->Task->getTable('BakeArticle', 'test');
 		$expected = 'bake_articles';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -198,7 +198,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->expects($this->any())->method('in')->will($this->onConsecutiveCalls('n', 'my_table'));
 		$result = $this->Task->getTable('BakeArticle', 'test');
 		$expected = 'my_table';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -253,7 +253,7 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('notempty' => 'notempty', 'maxlength' => 'maxlength');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -274,7 +274,7 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('notempty' => 'notempty');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -290,7 +290,7 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
 		$expected = array('a_z_0_9' => '/^[a-z]{0,9}$/');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -351,7 +351,7 @@ class ModelTaskTest extends CakeTestCase {
 				'time' => 'time'
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -372,7 +372,7 @@ class ModelTaskTest extends CakeTestCase {
 
 		$result = $this->Task->findPrimaryKey($fields);
 		$expected = 'my_field';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -404,7 +404,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('y', 2));
 
 		$result = $this->Task->findDisplayField($fields);
-		$this->assertEqual($result, 'tagname');
+		$this->assertEquals($result, 'tagname');
 	}
 
 /**
@@ -429,7 +429,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$model = new Model(array('ds' => 'test', 'name' => 'CategoryThread'));
 		$result = $this->Task->findBelongsTo($model, array());
@@ -442,7 +442,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -471,7 +471,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$model = new Model(array('ds' => 'test', 'name' => 'CategoryThread'));
 		$result = $this->Task->findHasOneAndMany($model, array());
@@ -491,7 +491,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -515,7 +515,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -559,9 +559,9 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->Fixture->expects($this->at(0))->method('bake')->with('BakeArticle', 'bake_articles');
 		$this->Task->bakeFixture('BakeArticle', 'bake_articles');
 
-		$this->assertEqual($this->Task->plugin, $this->Task->Fixture->plugin);
-		$this->assertEqual($this->Task->connection, $this->Task->Fixture->connection);
-		$this->assertEqual($this->Task->interactive, $this->Task->Fixture->interactive);
+		$this->assertEquals($this->Task->plugin, $this->Task->Fixture->plugin);
+		$this->assertEquals($this->Task->connection, $this->Task->Fixture->connection);
+		$this->assertEquals($this->Task->interactive, $this->Task->Fixture->interactive);
 	}
 
 /**
@@ -575,9 +575,9 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->Test->expects($this->at(0))->method('bake')->with('Model', 'BakeArticle');
 		$this->Task->bakeTest('BakeArticle');
 
-		$this->assertEqual($this->Task->plugin, $this->Task->Test->plugin);
-		$this->assertEqual($this->Task->connection, $this->Task->Test->connection);
-		$this->assertEqual($this->Task->interactive, $this->Task->Test->interactive);
+		$this->assertEquals($this->Task->plugin, $this->Task->Test->plugin);
+		$this->assertEquals($this->Task->connection, $this->Task->Test->connection);
+		$this->assertEquals($this->Task->interactive, $this->Task->Test->interactive);
 	}
 
 /**
@@ -642,7 +642,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(6))->method('out')->with('3. three');
 		$this->Task->expects($this->at(7))->method('in')->will($this->returnValue(2));
 		$result = $this->Task->inOptions($options, 'Pick a number');
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 	}
 
 /**
@@ -666,8 +666,8 @@ class ModelTaskTest extends CakeTestCase {
 			)
 		);
 		$result = $this->Task->bake('BakeArticle', compact('validate'));
-		$this->assertPattern('/class BakeArticle extends AppModel \{/', $result);
-		$this->assertPattern('/\$validate \= array\(/', $result);
+		$this->assertRegExp('/class BakeArticle extends AppModel \{/', $result);
+		$this->assertRegExp('/\$validate \= array\(/', $result);
 		$expected = <<< STRINGEND
 array(
 			'notempty' => array(
@@ -679,7 +679,7 @@ array(
 				//'on' => 'create', // Limit validation to 'create' or 'update' operations
 			),
 STRINGEND;
-		$this->assertPattern('/' . preg_quote(str_replace("\r\n", "\n", $expected), '/') . '/', $result);
+		$this->assertRegExp('/' . preg_quote(str_replace("\r\n", "\n", $expected), '/') . '/', $result);
 	}
 
 /**
@@ -730,14 +730,14 @@ STRINGEND;
 		$this->assertContains(' * @property OtherModel $OtherModel', $result);
 		$this->assertContains(' * @property BakeComment $BakeComment', $result);
 		$this->assertContains(' * @property BakeTag $BakeTag', $result);
-		$this->assertPattern('/\$hasAndBelongsToMany \= array\(/', $result);
-		$this->assertPattern('/\$hasMany \= array\(/', $result);
-		$this->assertPattern('/\$belongsTo \= array\(/', $result);
-		$this->assertPattern('/\$hasOne \= array\(/', $result);
-		$this->assertPattern('/BakeTag/', $result);
-		$this->assertPattern('/OtherModel/', $result);
-		$this->assertPattern('/SomethingElse/', $result);
-		$this->assertPattern('/BakeComment/', $result);
+		$this->assertRegExp('/\$hasAndBelongsToMany \= array\(/', $result);
+		$this->assertRegExp('/\$hasMany \= array\(/', $result);
+		$this->assertRegExp('/\$belongsTo \= array\(/', $result);
+		$this->assertRegExp('/\$hasOne \= array\(/', $result);
+		$this->assertRegExp('/BakeTag/', $result);
+		$this->assertRegExp('/OtherModel/', $result);
+		$this->assertRegExp('/SomethingElse/', $result);
+		$this->assertRegExp('/BakeComment/', $result);
 	}
 
 /**
@@ -757,8 +757,8 @@ STRINGEND;
 		$result = $this->Task->bake('BakeArticle', array(), array());
 		$this->assertContains("App::uses('ControllerTestAppModel', 'ControllerTest.Model');", $result);
 
-		$this->assertEqual(count(ClassRegistry::keys()), 0);
-		$this->assertEqual(count(ClassRegistry::mapKeys()), 0);
+		$this->assertEquals(count(ClassRegistry::keys()), 0);
+		$this->assertEquals(count(ClassRegistry::mapKeys()), 0);
 	}
 
 /**
@@ -778,8 +778,8 @@ STRINGEND;
 
 		$this->Task->execute();
 
-		$this->assertEqual(count(ClassRegistry::keys()), 0);
-		$this->assertEqual(count(ClassRegistry::mapKeys()), 0);
+		$this->assertEquals(count(ClassRegistry::keys()), 0);
+		$this->assertEquals(count(ClassRegistry::mapKeys()), 0);
 	}
 
 /**
@@ -871,8 +871,8 @@ STRINGEND;
 
 		$this->Task->execute();
 
-		$this->assertEqual(count(ClassRegistry::keys()), 0);
-		$this->assertEqual(count(ClassRegistry::mapKeys()), 0);
+		$this->assertEquals(count(ClassRegistry::keys()), 0);
+		$this->assertEquals(count(ClassRegistry::mapKeys()), 0);
 	}
 
 /**
@@ -952,8 +952,8 @@ STRINGEND;
 
 		$this->Task->execute();
 
-		$this->assertEqual(count(ClassRegistry::keys()), 0);
-		$this->assertEqual(count(ClassRegistry::mapKeys()), 0);
+		$this->assertEquals(count(ClassRegistry::keys()), 0);
+		$this->assertEquals(count(ClassRegistry::mapKeys()), 0);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -199,7 +199,7 @@ class ProjectTaskTest extends CakeTestCase {
 
 		$File = new File($path . 'Config' . DS . 'core.php');
 		$contents = $File->read();
-		$this->assertNoPattern('/DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi/', $contents, 'Default Salt left behind. %s');
+		$this->assertNotRegExp('/DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi/', $contents, 'Default Salt left behind. %s');
 	}
 
 /**
@@ -216,7 +216,7 @@ class ProjectTaskTest extends CakeTestCase {
 
 		$File = new File($path . 'Config' . DS . 'core.php');
 		$contents = $File->read();
-		$this->assertNoPattern('/76859309657453542496749683645/', $contents, 'Default CipherSeed left behind. %s');
+		$this->assertNotRegExp('/76859309657453542496749683645/', $contents, 'Default CipherSeed left behind. %s');
 	}
 
 /**
@@ -232,10 +232,10 @@ class ProjectTaskTest extends CakeTestCase {
 
 		$File = new File($path . 'webroot' . DS . 'index.php');
 		$contents = $File->read();
-		$this->assertNoPattern('/define\(\'CAKE_CORE_INCLUDE_PATH\', ROOT/', $contents);
+		$this->assertNotRegExp('/define\(\'CAKE_CORE_INCLUDE_PATH\', ROOT/', $contents);
 		$File = new File($path . 'webroot' . DS . 'test.php');
 		$contents = $File->read();
-		$this->assertNoPattern('/define\(\'CAKE_CORE_INCLUDE_PATH\', ROOT/', $contents);
+		$this->assertNotRegExp('/define\(\'CAKE_CORE_INCLUDE_PATH\', ROOT/', $contents);
 	}
 
 /**
@@ -246,7 +246,7 @@ class ProjectTaskTest extends CakeTestCase {
 	public function testGetPrefix() {
 		Configure::write('Routing.prefixes', array('admin'));
 		$result = $this->Task->getPrefix();
-		$this->assertEqual($result, 'admin_');
+		$this->assertEquals($result, 'admin_');
 
 		Configure::write('Routing.prefixes', null);
 		$this->_setupTestProject();
@@ -254,7 +254,7 @@ class ProjectTaskTest extends CakeTestCase {
 		$this->Task->expects($this->once())->method('in')->will($this->returnValue('super_duper_admin'));
 
 		$result = $this->Task->getPrefix();
-		$this->assertEqual($result, 'super_duper_admin_');
+		$this->assertEquals($result, 'super_duper_admin_');
 
 		$File = new File($this->Task->configPath . 'core.php');
 		$File->delete();
@@ -276,7 +276,7 @@ class ProjectTaskTest extends CakeTestCase {
 		$result = $this->Task->cakeAdmin('my_prefix');
 		$this->assertTrue($result);
 
-		$this->assertEqual(Configure::read('Routing.prefixes'), array('my_prefix'));
+		$this->assertEquals(Configure::read('Routing.prefixes'), array('my_prefix'));
 		$File->delete();
 	}
 
@@ -292,7 +292,7 @@ class ProjectTaskTest extends CakeTestCase {
 		$this->Task->expects($this->once())->method('in')->will($this->returnValue(2));
 
 		$result = $this->Task->getPrefix();
-		$this->assertEqual($result, 'ninja_');
+		$this->assertEquals($result, 'ninja_');
 	}
 
 /**
@@ -334,6 +334,6 @@ class ProjectTaskTest extends CakeTestCase {
 
 		$File = new File($path . 'Console' . DS . 'cake.php');
 		$contents = $File->read();
-		$this->assertNoPattern('/__CAKE_PATH__/', $contents, 'Console path placeholder left behind.');
+		$this->assertNotRegExp('/__CAKE_PATH__/', $contents, 'Console path placeholder left behind.');
 	}
 }

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -66,19 +66,19 @@ class TemplateTaskTest extends CakeTestCase {
 	public function testSet() {
 		$this->Task->set('one', 'two');
 		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEqual($this->Task->templateVars['one'], 'two');
+		$this->assertEquals($this->Task->templateVars['one'], 'two');
 
 		$this->Task->set(array('one' => 'three', 'four' => 'five'));
 		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEqual($this->Task->templateVars['one'], 'three');
+		$this->assertEquals($this->Task->templateVars['one'], 'three');
 		$this->assertTrue(isset($this->Task->templateVars['four']));
-		$this->assertEqual($this->Task->templateVars['four'], 'five');
+		$this->assertEquals($this->Task->templateVars['four'], 'five');
 
 		$this->Task->templateVars = array();
 		$this->Task->set(array(3 => 'three', 4 => 'four'));
 		$this->Task->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEqual($this->Task->templateVars, $expected);
+		$this->assertEquals($this->Task->templateVars, $expected);
 	}
 
 /**
@@ -89,7 +89,7 @@ class TemplateTaskTest extends CakeTestCase {
 	public function testFindingInstalledThemesForBake() {
 		$consoleLibs = CAKE . 'Console' . DS;
 		$this->Task->initialize();
-		$this->assertEqual($this->Task->templatePaths['default'], $consoleLibs . 'Templates' . DS . 'default' . DS);
+		$this->assertEquals($this->Task->templatePaths['default'], $consoleLibs . 'Templates' . DS . 'default' . DS);
 	}
 
 /**
@@ -105,17 +105,17 @@ class TemplateTaskTest extends CakeTestCase {
 		$this->Task->expects($this->exactly(1))->method('in')->will($this->returnValue('1'));
 
 		$result = $this->Task->getThemePath();
-		$this->assertEqual($result, $defaultTheme);
+		$this->assertEquals($result, $defaultTheme);
 
 		$this->Task->templatePaths = array('default' => $defaultTheme, 'other' => '/some/path');
 		$this->Task->params['theme'] = 'other';
 		$result = $this->Task->getThemePath();
-		$this->assertEqual($result, '/some/path');
+		$this->assertEquals($result, '/some/path');
 
 		$this->Task->params = array();
 		$result = $this->Task->getThemePath();
-		$this->assertEqual($result, $defaultTheme);
-		$this->assertEqual($this->Task->params['theme'], 'default');
+		$this->assertEquals($result, $defaultTheme);
+		$this->assertEquals($this->Task->params['theme'], 'default');
 	}
 
 /**
@@ -134,7 +134,7 @@ class TemplateTaskTest extends CakeTestCase {
 
 		$result = $this->Task->generate('classes', 'test_object', array('test' => 'foo'));
 		$expected = "I got rendered\nfoo";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -160,6 +160,6 @@ class TemplateTaskTest extends CakeTestCase {
 			'schema' => ''
 		));
 		$result = $this->Task->generate('classes', 'fixture');
-		$this->assertPattern('/ArticleFixture extends CakeTestFixture/', $result);
+		$this->assertRegExp('/ArticleFixture extends CakeTestFixture/', $result);
 	}
 }

--- a/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
@@ -263,14 +263,14 @@ class ViewTaskTest extends CakeTestCase {
 		);
 		$result = $this->Task->getContent('view', $vars);
 
-		$this->assertPattern('/Delete Test View Model/', $result);
-		$this->assertPattern('/Edit Test View Model/', $result);
-		$this->assertPattern('/List Test View Models/', $result);
-		$this->assertPattern('/New Test View Model/', $result);
+		$this->assertRegExp('/Delete Test View Model/', $result);
+		$this->assertRegExp('/Edit Test View Model/', $result);
+		$this->assertRegExp('/List Test View Models/', $result);
+		$this->assertRegExp('/New Test View Model/', $result);
 
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'id\'\]/', $result);
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'name\'\]/', $result);
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'body\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'id\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'name\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'body\'\]/', $result);
 	}
 
 /**
@@ -295,19 +295,19 @@ class ViewTaskTest extends CakeTestCase {
 		);
 		$result = $this->Task->getContent('admin_view', $vars);
 
-		$this->assertPattern('/Delete Test View Model/', $result);
-		$this->assertPattern('/Edit Test View Model/', $result);
-		$this->assertPattern('/List Test View Models/', $result);
-		$this->assertPattern('/New Test View Model/', $result);
+		$this->assertRegExp('/Delete Test View Model/', $result);
+		$this->assertRegExp('/Edit Test View Model/', $result);
+		$this->assertRegExp('/List Test View Models/', $result);
+		$this->assertRegExp('/New Test View Model/', $result);
 
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'id\'\]/', $result);
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'name\'\]/', $result);
-		$this->assertPattern('/testViewModel\[\'TestViewModel\'\]\[\'body\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'id\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'name\'\]/', $result);
+		$this->assertRegExp('/testViewModel\[\'TestViewModel\'\]\[\'body\'\]/', $result);
 
 		$result = $this->Task->getContent('admin_add', $vars);
-		$this->assertPattern("/input\('name'\)/", $result);
-		$this->assertPattern("/input\('body'\)/", $result);
-		$this->assertPattern('/List Test View Models/', $result);
+		$this->assertRegExp("/input\('name'\)/", $result);
+		$this->assertRegExp("/input\('body'\)/", $result);
+		$this->assertRegExp('/List Test View Models/', $result);
 
 		Configure::write('Routing', $_back);
 	}
@@ -711,12 +711,12 @@ class ViewTaskTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $this->Task->getTemplate('add');
-		$this->assertEqual($result, 'form');
+		$this->assertEquals($result, 'form');
 
 		Configure::write('Routing.prefixes', array('admin'));
 
 		$result = $this->Task->getTemplate('admin_add');
-		$this->assertEqual($result, 'form');
+		$this->assertEquals($result, 'form');
 
 		$this->Task->Template->templatePaths = array(
 			'test' => CAKE . 'Test' . DS .  'test_app' . DS . 'Console' . DS . 'Templates' . DS . 'test' .DS
@@ -724,7 +724,7 @@ class ViewTaskTest extends CakeTestCase {
 		$this->Task->Template->params['theme'] = 'test';
 
 		$result = $this->Task->getTemplate('admin_edit');
-		$this->assertEqual($result, 'admin_edit');
+		$this->assertEquals($result, 'admin_edit');
 	}
 
 }

--- a/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
@@ -97,7 +97,7 @@ class ConsoleOutputTest extends CakeTestCase {
 	public function testStylesGet() {
 		$result = $this->output->styles('error');
 		$expected = array('text' => 'red', 'underline' => true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertNull($this->output->styles('made_up_goop'));
 

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -156,7 +156,7 @@ class ShellDispatcherTest extends CakeTestCase {
 			'root' => str_replace('/', DS,'/var/www/htdocs')
 		);
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array('cake.php');
 		$expected = array(
@@ -167,7 +167,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'cake.php',
@@ -182,7 +182,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'./cake.php',
@@ -202,7 +202,7 @@ class ShellDispatcherTest extends CakeTestCase {
 
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'./console/cake.php',
@@ -220,7 +220,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'./console/cake.php',
@@ -261,12 +261,12 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$expected = array(
 			'./console/cake.php', 'schema', 'run', 'create', '-dry', '-f', '-name', 'DbAcl'
 		);
-		$this->assertEqual($expected, $Dispatcher->args);
+		$this->assertEquals($expected, $Dispatcher->args);
 
 		$params = array(
 			'/cake/1.2.x.x/cake/console/cake.php',
@@ -287,7 +287,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'cake.php',
@@ -306,7 +306,7 @@ class ShellDispatcherTest extends CakeTestCase {
 
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'cake.php',
@@ -324,7 +324,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'cake.php',
@@ -344,7 +344,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'/home/amelo/dev/cake-common/cake/console/cake.php',
@@ -363,7 +363,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		);
 		$Dispatcher->params = $Dispatcher->args = array();
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		$params = array(
 			'/cake/1.2.x.x/cake/console/cake.php',
@@ -382,7 +382,7 @@ class ShellDispatcherTest extends CakeTestCase {
 			'root' => str_replace('/', DS,'/var/www/htdocs')
 		);
 		$Dispatcher->parseParams($params);
-		$this->assertEqual($expected, $Dispatcher->params);
+		$this->assertEquals($expected, $Dispatcher->params);
 
 		if (DS === '\\') {
 			$params = array(
@@ -401,7 +401,7 @@ class ShellDispatcherTest extends CakeTestCase {
 
 			$Dispatcher->params = $Dispatcher->args = array();
 			$Dispatcher->parseParams($params);
-			$this->assertEqual($expected, $Dispatcher->params);
+			$this->assertEquals($expected, $Dispatcher->params);
 		}
 	}
 
@@ -448,7 +448,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_with_main');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEqual($Dispatcher->args, array());
+		$this->assertEquals($Dispatcher->args, array());
 	}
 
 /**
@@ -496,7 +496,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_with_main_not_a');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEqual($Dispatcher->args, array());
+		$this->assertEquals($Dispatcher->args, array());
 
 		$Shell = new MockWithMainNotAShell($Dispatcher);
 		$this->mockObjects[] = $Shell;
@@ -529,7 +529,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_without_main_not_a');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEqual($Dispatcher->args, array());
+		$this->assertEquals($Dispatcher->args, array());
 
 		$Shell = new MockWithoutMainNotAShell($Dispatcher);
 		$this->mockObjects[] = $Shell;
@@ -551,24 +551,24 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 
 		$Dispatcher->args = array('a', 'b', 'c');
-		$this->assertEqual($Dispatcher->shiftArgs(), 'a');
-		$this->assertIdentical($Dispatcher->args, array('b', 'c'));
+		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertSame($Dispatcher->args, array('b', 'c'));
 
 		$Dispatcher->args = array('a' => 'b', 'c', 'd');
-		$this->assertEqual($Dispatcher->shiftArgs(), 'b');
-		$this->assertIdentical($Dispatcher->args, array('c', 'd'));
+		$this->assertEquals($Dispatcher->shiftArgs(), 'b');
+		$this->assertSame($Dispatcher->args, array('c', 'd'));
 
 		$Dispatcher->args = array('a', 'b' => 'c', 'd');
-		$this->assertEqual($Dispatcher->shiftArgs(), 'a');
-		$this->assertIdentical($Dispatcher->args, array('b' => 'c', 'd'));
+		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertSame($Dispatcher->args, array('b' => 'c', 'd'));
 
 		$Dispatcher->args = array(0 => 'a',  2 => 'b', 30 => 'c');
-		$this->assertEqual($Dispatcher->shiftArgs(), 'a');
-		$this->assertIdentical($Dispatcher->args, array(0 => 'b', 1 => 'c'));
+		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertSame($Dispatcher->args, array(0 => 'b', 1 => 'c'));
 
 		$Dispatcher->args = array();
 		$this->assertNull($Dispatcher->shiftArgs());
-		$this->assertIdentical($Dispatcher->args, array());
+		$this->assertSame($Dispatcher->args, array());
 	}
 
 }

--- a/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
@@ -73,7 +73,7 @@ class AclComponentTest extends CakeTestCase {
 		$implementation->expects($this->once())->method('initialize')->with($this->Acl);
 		$this->assertNull($this->Acl->adapter($implementation));
 
-		$this->assertEqual($this->Acl->adapter(), $implementation, 'Returned object is different %s');
+		$this->assertEquals($this->Acl->adapter(), $implementation, 'Returned object is different %s');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -290,7 +290,7 @@ DIGEST;
 			'opaque' => '5ccc069c403ebaf9f0171e9517f40e41'
 		);
 		$result = $this->auth->parseAuthData($digest);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -721,7 +721,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Controller->request->query['url'] = Router::normalize($url);
 		$this->Controller->Auth->initialize($this->Controller);
 		$this->Controller->Auth->allow('action_name', 'anotherAction');
-		$this->assertEqual($this->Controller->Auth->allowedActions, array('action_name', 'anotherAction'));
+		$this->assertEquals($this->Controller->Auth->allowedActions, array('action_name', 'anotherAction'));
 	}
 
 /**
@@ -747,7 +747,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize($this->Auth->loginRedirect);
-		$this->assertEqual($expected, $this->Auth->redirect());
+		$this->assertEquals($expected, $this->Auth->redirect());
 
 		$this->Auth->Session->delete('Auth');
 
@@ -772,7 +772,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('/AuthTest/login');
-		$this->assertEqual($expected, $this->Controller->testUrl);
+		$this->assertEquals($expected, $this->Controller->testUrl);
 
 		$this->Auth->Session->delete('Auth');
 		$_SERVER['HTTP_REFERER'] = $_ENV['HTTP_REFERER'] = Router::url('/admin', true);
@@ -786,7 +786,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginRedirect = false;
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('/admin');
-		$this->assertEqual($expected, $this->Auth->redirect());
+		$this->assertEquals($expected, $this->Auth->redirect());
 
 		//Ticket #4750
 		//named params
@@ -798,7 +798,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('posts/index/year:2008/month:feb');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
 		//passed args
 		$this->Auth->Session->delete('Auth');
@@ -809,7 +809,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('posts/view/1');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
         // QueryString parameters
 		$_back = $_GET;
@@ -827,7 +827,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('posts/index/29?print=true&refer=menu');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
 		$_GET = array(
 			'url' => '/posts/index/29',
@@ -843,7 +843,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('posts/index/29?print=true&refer=menu');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 		$_GET = $_back;
 
 		//external authed action
@@ -860,7 +860,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('/posts/edit/1');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
 		//external direct login link
 		$_SERVER['HTTP_REFERER'] = 'http://webmail.example.com/view/message';
@@ -873,7 +873,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('/');
-		$this->assertEqual($expected, $this->Auth->Session->read('Auth.redirect'));
+		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
 		$this->Auth->Session->delete('Auth');
 	}
@@ -937,7 +937,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 
 		$this->Auth->startup($this->Controller);
-		$this->assertEqual($this->Controller->testUrl, '/admin/auth_test/login');
+		$this->assertEquals($this->Controller->testUrl, '/admin/auth_test/login');
 
 		Configure::write('Routing.prefixes', $pref);
 	}
@@ -960,7 +960,7 @@ class AuthComponentTest extends CakeTestCase {
 		$Dispatcher->dispatch(new CakeRequest('/ajax_auth/add'), new CakeResponse(), array('return' => 1));
 		$result = ob_get_clean();
 
-		$this->assertEqual("Ajax!\nthis is the test element", str_replace("\r\n", "\n", $result));
+		$this->assertEquals("Ajax!\nthis is the test element", str_replace("\r\n", "\n", $result));
 		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
 	}
 
@@ -1060,8 +1060,8 @@ class AuthComponentTest extends CakeTestCase {
 			'loginAction' => array('controller' => 'people', 'action' => 'login'),
 			'logoutRedirect' => array('controller' => 'people', 'action' => 'login'),
 		);
-		$this->assertEqual($expected['loginAction'], $this->Controller->Auth->loginAction);
-		$this->assertEqual($expected['logoutRedirect'], $this->Controller->Auth->logoutRedirect);
+		$this->assertEquals($expected['loginAction'], $this->Controller->Auth->loginAction);
+		$this->assertEquals($expected['logoutRedirect'], $this->Controller->Auth->logoutRedirect);
 	}
 
 /**
@@ -1075,7 +1075,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->logoutRedirect = '/';
 		$result = $this->Auth->logout();
 
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 		$this->assertNull($this->Auth->Session->read('Auth.AuthUser'));
 		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
 	}

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -124,8 +124,8 @@ class CookieComponentTest extends CakeTestCase {
 			'path' => '/'
 		);
 		$Cookie = new CookieComponent(new ComponentCollection(), $settings);
-		$this->assertEqual($Cookie->time, $settings['time']);
-		$this->assertEqual($Cookie->path, $settings['path']);
+		$this->assertEquals($Cookie->time, $settings['time']);
+		$this->assertEquals($Cookie->path, $settings['path']);
 	}
 
 /**
@@ -134,7 +134,7 @@ class CookieComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testCookieName() {
-		$this->assertEqual($this->Cookie->name, 'CakeTestCookie');
+		$this->assertEquals($this->Cookie->name, 'CakeTestCookie');
 	}
 
 /**
@@ -146,11 +146,11 @@ class CookieComponentTest extends CakeTestCase {
 		$this->_setCookieData();
 		$data = $this->Cookie->read('Encrytped_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 	}
 
 /**
@@ -163,11 +163,11 @@ class CookieComponentTest extends CakeTestCase {
 
 		$data = $this->Cookie->read('Plain_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 	}
 
 /**
@@ -220,9 +220,9 @@ class CookieComponentTest extends CakeTestCase {
 	public function testWritePlainCookieArray() {
 		$this->Cookie->write(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!'), null, false);
 
-		$this->assertEqual($this->Cookie->read('name'), 'CakePHP');
-		$this->assertEqual($this->Cookie->read('version'), '1.2.0.x');
-		$this->assertEqual($this->Cookie->read('tag'), 'CakePHP Rocks!');
+		$this->assertEquals($this->Cookie->read('name'), 'CakePHP');
+		$this->assertEquals($this->Cookie->read('version'), '1.2.0.x');
+		$this->assertEquals($this->Cookie->read('tag'), 'CakePHP Rocks!');
 
 		$this->Cookie->delete('name');
 		$this->Cookie->delete('version');
@@ -267,7 +267,7 @@ class CookieComponentTest extends CakeTestCase {
 				'name' => 'CakePHP',
 				'version' => '1.2.0.x',
 				'tag' => 'CakePHP Rocks!'));
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 	}
 
 /**
@@ -280,7 +280,7 @@ class CookieComponentTest extends CakeTestCase {
 		$this->Cookie->delete('Encrytped_multi_cookies.name');
 		$data = $this->Cookie->read('Encrytped_multi_cookies');
 		$expected = array('version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$this->Cookie->delete('Encrytped_array');
 		$data = $this->Cookie->read('Encrytped_array');
@@ -289,7 +289,7 @@ class CookieComponentTest extends CakeTestCase {
 		$this->Cookie->delete('Plain_multi_cookies.name');
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('version' => '1.2.0.x', 'tag' =>'CakePHP Rocks!');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$this->Cookie->delete('Plain_array');
 		$data = $this->Cookie->read('Plain_array');
@@ -306,51 +306,51 @@ class CookieComponentTest extends CakeTestCase {
 
 		$data = $this->Cookie->read('Encrytped_array.name');
 		$expected = 'CakePHP';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_array.version');
 		$expected = '1.2.0.x';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_array.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.name');
 		$expected = 'CakePHP';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.version');
 		$expected = '1.2.0.x';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_array.name');
 		$expected = 'CakePHP';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_array.version');
 		$expected = '1.2.0.x';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_array.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.name');
 		$expected = 'CakePHP';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.version');
 		$expected = '1.2.0.x';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 	}
 
 /**
@@ -493,7 +493,7 @@ class CookieComponentTest extends CakeTestCase {
 			'User' => array('email' => 'example@example.com', 'name' => 'mark'),
 			'other' => 'value'
 		);
-		$this->assertEqual('mark', $this->Cookie->read('User.name'));
+		$this->assertEquals('mark', $this->Cookie->read('User.name'));
 
 		$this->Cookie->delete('User');
 		$this->assertNull($this->Cookie->read('User.email'));

--- a/lib/Cake/Test/Case/Controller/Component/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/DbAclTest.php
@@ -242,8 +242,8 @@ class DbAclTest extends CakeTestCase {
 			'parent_id' => $parent['AroTwoTest']['id']
 		));
 		$result = $this->Acl->Aro->findByAlias('Subordinate', null, null, -1);
-		$this->assertEqual($result['AroTwoTest']['lft'], 16);
-		$this->assertEqual($result['AroTwoTest']['rght'], 17);
+		$this->assertEquals($result['AroTwoTest']['lft'], 16);
+		$this->assertEquals($result['AroTwoTest']['rght'], 17);
 	}
 
 /**
@@ -384,7 +384,7 @@ class DbAclTest extends CakeTestCase {
 
 		$result = $this->Acl->Aro->Permission->find('all', array('conditions' => array('AroTwoTest.alias' => 'Samir')));
 		$expected = '-1';
-		$this->assertEqual($result[0]['PermissionTwoTest']['_delete'], $expected);
+		$this->assertEquals($result[0]['PermissionTwoTest']['_delete'], $expected);
 
 		$this->assertFalse($this->Acl->deny('Lumbergh', 'ROOT/tpsReports/DoesNotExist', 'create'));
 	}
@@ -401,7 +401,7 @@ class DbAclTest extends CakeTestCase {
 			array('AroTwoTest' => array('id' => '4', 'parent_id' => '1', 'model' => 'Group', 'foreign_key' => 3, 'alias' => 'users')),
 			array('AroTwoTest' => array('id' => '1', 'parent_id' => null, 'model' => null, 'foreign_key' => null, 'alias' => 'root'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Acl->Aco->node('ROOT/tpsReports/view/current');
 		$expected = array(
@@ -410,7 +410,7 @@ class DbAclTest extends CakeTestCase {
 			array('AcoTwoTest' => array('id' => '2', 'parent_id' => '1', 'model' => null, 'foreign_key' => null, 'alias' => 'tpsReports')),
 			array('AcoTwoTest' => array('id' => '1', 'parent_id' => null, 'model' => null, 'foreign_key' => null, 'alias' => 'ROOT')),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -212,18 +212,18 @@ MSGBLOC;
 		$this->Controller->EmailTest->sendAs = 'text';
 		$expect = str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(DebugCompTransport::$lastEmail, $this->__osFix($expect));
+		$this->assertEquals(DebugCompTransport::$lastEmail, $this->__osFix($expect));
 
 		$this->Controller->EmailTest->sendAs = 'html';
 		$expect = str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(DebugCompTransport::$lastEmail, $this->__osFix($expect));
+		$this->assertEquals(DebugCompTransport::$lastEmail, $this->__osFix($expect));
 
 		// TODO: better test for format of message sent?
 		$this->Controller->EmailTest->sendAs = 'both';
 		$expect = str_replace('{CONTENTTYPE}', 'multipart/alternative; boundary="alt-"', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(preg_replace('/alt-[a-z0-9]{32}/i', 'alt-', DebugCompTransport::$lastEmail), $this->__osFix($expect));
+		$this->assertEquals(preg_replace('/alt-[a-z0-9]{32}/i', 'alt-', DebugCompTransport::$lastEmail), $this->__osFix($expect));
 	}
 
 /**
@@ -289,12 +289,12 @@ HTMLBLOC;
 		$this->Controller->EmailTest->sendAs = 'text';
 		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $header) . $text . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(DebugCompTransport::$lastEmail, $this->__osFix($expect));
+		$this->assertEquals(DebugCompTransport::$lastEmail, $this->__osFix($expect));
 
 		$this->Controller->EmailTest->sendAs = 'html';
 		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(DebugCompTransport::$lastEmail, $this->__osFix($expect));
+		$this->assertEquals(DebugCompTransport::$lastEmail, $this->__osFix($expect));
 
 		$this->Controller->EmailTest->sendAs = 'both';
 		$expect = str_replace('{CONTENTTYPE}', 'multipart/alternative; boundary="alt-"', $header);
@@ -303,7 +303,7 @@ HTMLBLOC;
 		$expect = '<pre>' . $expect . '--alt---' . "\n\n" . '</pre>';
 
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual(preg_replace('/alt-[a-z0-9]{32}/i', 'alt-', DebugCompTransport::$lastEmail), $this->__osFix($expect));
+		$this->assertEquals(preg_replace('/alt-[a-z0-9]{32}/i', 'alt-', DebugCompTransport::$lastEmail), $this->__osFix($expect));
 
 		$html = <<<HTMLBLOC
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
@@ -324,7 +324,7 @@ HTMLBLOC;
 		$this->Controller->EmailTest->sendAs = 'html';
 		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message', 'default', 'thin'));
-		$this->assertEqual(DebugCompTransport::$lastEmail, $this->__osFix($expect));
+		$this->assertEquals(DebugCompTransport::$lastEmail, $this->__osFix($expect));
 	}
 
 /**
@@ -347,8 +347,8 @@ HTMLBLOC;
 
 		$this->Controller->EmailTest->send();
 		$result = DebugCompTransport::$lastEmail;
-		$this->assertPattern('/Test/', $result);
-		$this->assertPattern('/http\:\/\/example\.com/', $result);
+		$this->assertRegExp('/Test/', $result);
+		$this->assertRegExp('/http\:\/\/example\.com/', $result);
 	}
 
 /**
@@ -369,17 +369,17 @@ HTMLBLOC;
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/To: postmaster@example.com\n/', $result);
-		$this->assertPattern('/Subject: Cake Debug Test\n/', $result);
-		$this->assertPattern('/Reply-To: noreply@example.com\n/', $result);
-		$this->assertPattern('/From: noreply@example.com\n/', $result);
-		$this->assertPattern('/Cc: cc@example.com\n/', $result);
-		$this->assertPattern('/Bcc: bcc@example.com\n/', $result);
-		$this->assertPattern('/Date: ' . preg_quote(date(DATE_RFC2822)) . '\n/', $result);
-		$this->assertPattern('/X-Mailer: CakePHP Email Component\n/', $result);
-		$this->assertPattern('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
-		$this->assertPattern('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
-		$this->assertPattern('/This is the body of the message/', $result);
+		$this->assertRegExp('/To: postmaster@example.com\n/', $result);
+		$this->assertRegExp('/Subject: Cake Debug Test\n/', $result);
+		$this->assertRegExp('/Reply-To: noreply@example.com\n/', $result);
+		$this->assertRegExp('/From: noreply@example.com\n/', $result);
+		$this->assertRegExp('/Cc: cc@example.com\n/', $result);
+		$this->assertRegExp('/Bcc: bcc@example.com\n/', $result);
+		$this->assertRegExp('/Date: ' . preg_quote(date(DATE_RFC2822)) . '\n/', $result);
+		$this->assertRegExp('/X-Mailer: CakePHP Email Component\n/', $result);
+		$this->assertRegExp('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
+		$this->assertRegExp('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
+		$this->assertRegExp('/This is the body of the message/', $result);
 	}
 
 /**
@@ -400,15 +400,15 @@ HTMLBLOC;
 		$this->Controller->EmailTest->send('This is the body of the message');
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/To: postmaster@example.com\n/', $result);
-		$this->assertPattern('/Subject: Cake Debug Test\n/', $result);
-		$this->assertPattern('/Reply-To: noreply@example.com\n/', $result);
-		$this->assertPattern('/From: noreply@example.com\n/', $result);
-		$this->assertPattern('/Date: ' . preg_quote(date(DATE_RFC2822)) . '\n/', $result);
-		$this->assertPattern('/X-Mailer: CakePHP Email Component\n/', $result);
-		$this->assertPattern('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
-		$this->assertPattern('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
-		$this->assertPattern('/This is the body of the message/', $result);
+		$this->assertRegExp('/To: postmaster@example.com\n/', $result);
+		$this->assertRegExp('/Subject: Cake Debug Test\n/', $result);
+		$this->assertRegExp('/Reply-To: noreply@example.com\n/', $result);
+		$this->assertRegExp('/From: noreply@example.com\n/', $result);
+		$this->assertRegExp('/Date: ' . preg_quote(date(DATE_RFC2822)) . '\n/', $result);
+		$this->assertRegExp('/X-Mailer: CakePHP Email Component\n/', $result);
+		$this->assertRegExp('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
+		$this->assertRegExp('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
+		$this->assertRegExp('/This is the body of the message/', $result);
 		$this->Controller->Session = $session;
 	}
 
@@ -435,18 +435,18 @@ HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'both';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual($this->Controller->EmailTest->textMessage, $this->__osFix($text));
-		$this->assertEqual($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
+		$this->assertEquals($this->Controller->EmailTest->textMessage, $this->__osFix($text));
+		$this->assertEquals($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
 
 		$this->Controller->EmailTest->sendAs = 'text';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertEqual($this->Controller->EmailTest->textMessage, $this->__osFix($text));
+		$this->assertEquals($this->Controller->EmailTest->textMessage, $this->__osFix($text));
 		$this->assertNull($this->Controller->EmailTest->htmlMessage);
 
 		$this->Controller->EmailTest->sendAs = 'html';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$this->assertNull($this->Controller->EmailTest->textMessage);
-		$this->assertEqual($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
+		$this->assertEquals($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
 	}
 
 /**
@@ -495,18 +495,18 @@ HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'both';
 		$this->assertTrue($this->Controller->EmailTest->send());
-		$this->assertEqual($this->Controller->EmailTest->textMessage, $this->__osFix($text));
-		$this->assertEqual($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
+		$this->assertEquals($this->Controller->EmailTest->textMessage, $this->__osFix($text));
+		$this->assertEquals($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
 
 		$this->Controller->EmailTest->sendAs = 'text';
 		$this->assertTrue($this->Controller->EmailTest->send());
-		$this->assertEqual($this->Controller->EmailTest->textMessage, $this->__osFix($text));
+		$this->assertEquals($this->Controller->EmailTest->textMessage, $this->__osFix($text));
 		$this->assertNull($this->Controller->EmailTest->htmlMessage);
 
 		$this->Controller->EmailTest->sendAs = 'html';
 		$this->assertTrue($this->Controller->EmailTest->send());
 		$this->assertNull($this->Controller->EmailTest->textMessage);
-		$this->assertEqual($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
+		$this->assertEquals($this->Controller->EmailTest->htmlMessage, $this->__osFix($html));
 	}
 
 /**
@@ -554,16 +554,16 @@ HTMLBLOC;
 		$this->assertTrue($this->Controller->EmailTest->send($content));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/To: postmaster@example.com\n/', $result);
-		$this->assertPattern('/Subject: Cake Debug Test\n/', $result);
-		$this->assertPattern('/Reply-To: noreply@example.com\n/', $result);
-		$this->assertPattern('/From: noreply@example.com\n/', $result);
-		$this->assertPattern('/X-Mailer: CakePHP Email Component\n/', $result);
-		$this->assertPattern('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
-		$this->assertPattern('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
-		$this->assertPattern('/First line\n/', $result);
-		$this->assertPattern('/Second line\n/', $result);
-		$this->assertPattern('/Third line\n/', $result);
+		$this->assertRegExp('/To: postmaster@example.com\n/', $result);
+		$this->assertRegExp('/Subject: Cake Debug Test\n/', $result);
+		$this->assertRegExp('/Reply-To: noreply@example.com\n/', $result);
+		$this->assertRegExp('/From: noreply@example.com\n/', $result);
+		$this->assertRegExp('/X-Mailer: CakePHP Email Component\n/', $result);
+		$this->assertRegExp('/Content-Type: text\/plain; charset=UTF-8\n/', $result);
+		$this->assertRegExp('/Content-Transfer-Encoding: 8bitMessage:\n/', $result);
+		$this->assertRegExp('/First line\n/', $result);
+		$this->assertRegExp('/Second line\n/', $result);
+		$this->assertRegExp('/Third line\n/', $result);
 	}
 
 /**
@@ -581,7 +581,7 @@ HTMLBLOC;
 
 		$this->assertTrue($this->Controller->EmailTest->send('test message'));
 		$result = DebugCompTransport::$lastEmail;
-		$this->assertPattern('/Date: Today!\n/', $result);
+		$this->assertRegExp('/Date: Today!\n/', $result);
 	}
 
 /**
@@ -595,18 +595,18 @@ HTMLBLOC;
 
 		$result = $this->Controller->EmailTest->strip($content, true);
 		$expected = "Previous content\n--alt-\n text/html; utf-8\n 8bit\n\n<p>My own html content</p>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$content = '<p>Some HTML content with an <a href="mailto:test@example.com">email link</a>';
 		$result  = $this->Controller->EmailTest->strip($content, true);
 		$expected = $content;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$content  = '<p>Some HTML content with an ';
 		$content .= '<a href="mailto:test@example.com,test2@example.com">email link</a>';
 		$result  = $this->Controller->EmailTest->strip($content, true);
 		$expected = $content;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -634,10 +634,10 @@ HTMLBLOC;
 		$subject = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
 
 		preg_match('/Subject: (.*)Header:/s', DebugCompTransport::$lastEmail, $matches);
-		$this->assertEqual(trim($matches[1]), $subject);
+		$this->assertEquals(trim($matches[1]), $subject);
 
 		$result = mb_internal_encoding();
-		$this->assertEqual($result, 'ISO-8859-1');
+		$this->assertEquals($result, 'ISO-8859-1');
 
 		mb_internal_encoding($restore);
 	}
@@ -661,17 +661,17 @@ HTMLBLOC;
 		$this->Controller->EmailTest->sendAs = 'text';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		preg_match('/Subject: (.*)Header:/s', DebugCompTransport::$lastEmail, $matches);
-		$this->assertEqual(trim($matches[1]), $subject);
+		$this->assertEquals(trim($matches[1]), $subject);
 
 		$this->Controller->EmailTest->sendAs = 'html';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		preg_match('/Subject: (.*)Header:/s', DebugCompTransport::$lastEmail, $matches);
-		$this->assertEqual(trim($matches[1]), $subject);
+		$this->assertEquals(trim($matches[1]), $subject);
 
 		$this->Controller->EmailTest->sendAs = 'both';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		preg_match('/Subject: (.*)Header:/s', DebugCompTransport::$lastEmail, $matches);
-		$this->assertEqual(trim($matches[1]), $subject);
+		$this->assertEquals(trim($matches[1]), $subject);
 	}
 
 /**
@@ -695,8 +695,8 @@ HTMLBLOC;
 		$this->Controller->EmailTest->sendAs = 'text';
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$msg = DebugCompTransport::$lastEmail;
-		$this->assertPattern('/' . preg_quote('Content-Disposition: attachment; filename="EmailComponentTest.php"') . '/', $msg);
-		$this->assertPattern('/' . preg_quote('Content-Disposition: attachment; filename="some-name.php"') . '/', $msg);
+		$this->assertRegExp('/' . preg_quote('Content-Disposition: attachment; filename="EmailComponentTest.php"') . '/', $msg);
+		$this->assertRegExp('/' . preg_quote('Content-Disposition: attachment; filename="some-name.php"') . '/', $msg);
 	}
 
 /**
@@ -717,22 +717,22 @@ HTMLBLOC;
 		$this->Controller->EmailTest->sendAs = 'html';
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$msg = DebugCompTransport::$lastEmail;
-		$this->assertNoPattern('/text\/plain/', $msg);
-		$this->assertPattern('/text\/html/', $msg);
+		$this->assertNotRegExp('/text\/plain/', $msg);
+		$this->assertRegExp('/text\/html/', $msg);
 
 		$this->Controller->EmailTest->sendAs = 'text';
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$msg = DebugCompTransport::$lastEmail;
-		$this->assertPattern('/text\/plain/', $msg);
-		$this->assertNoPattern('/text\/html/', $msg);
+		$this->assertRegExp('/text\/plain/', $msg);
+		$this->assertNotRegExp('/text\/html/', $msg);
 
 		$this->Controller->EmailTest->sendAs = 'both';
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$msg = DebugCompTransport::$lastEmail;
 
-		$this->assertNoPattern('/text\/plain/', $msg);
-		$this->assertNoPattern('/text\/html/', $msg);
-		$this->assertPattern('/multipart\/alternative/', $msg);
+		$this->assertNotRegExp('/text\/plain/', $msg);
+		$this->assertNotRegExp('/text\/html/', $msg);
+		$this->assertRegExp('/multipart\/alternative/', $msg);
 	}
 
 /**
@@ -753,8 +753,8 @@ HTMLBLOC;
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$msg = DebugCompTransport::$lastEmail;
 
-		$this->assertNoPattern('/\n\nContent-Transfer-Encoding/', $msg);
-		$this->assertPattern('/\nContent-Transfer-Encoding/', $msg);
+		$this->assertNotRegExp('/\n\nContent-Transfer-Encoding/', $msg);
+		$this->assertRegExp('/\nContent-Transfer-Encoding/', $msg);
 	}
 
 /**
@@ -791,17 +791,17 @@ HTMLBLOC;
 		$this->Controller->EmailTest->reset();
 
 		$this->assertNull($this->Controller->EmailTest->template);
-		$this->assertIdentical($this->Controller->EmailTest->to, array());
+		$this->assertSame($this->Controller->EmailTest->to, array());
 		$this->assertNull($this->Controller->EmailTest->from);
 		$this->assertNull($this->Controller->EmailTest->replyTo);
 		$this->assertNull($this->Controller->EmailTest->return);
-		$this->assertIdentical($this->Controller->EmailTest->cc, array());
-		$this->assertIdentical($this->Controller->EmailTest->bcc, array());
+		$this->assertSame($this->Controller->EmailTest->cc, array());
+		$this->assertSame($this->Controller->EmailTest->bcc, array());
 		$this->assertNull($this->Controller->EmailTest->date);
 		$this->assertNull($this->Controller->EmailTest->subject);
 		$this->assertNull($this->Controller->EmailTest->additionalParams);
 		$this->assertNull($this->Controller->EmailTest->smtpError);
-		$this->assertIdentical($this->Controller->EmailTest->attachments, array());
+		$this->assertSame($this->Controller->EmailTest->attachments, array());
 		$this->assertNull($this->Controller->EmailTest->textMessage);
 		$this->assertTrue($this->Controller->EmailTest->messageId);
 	}
@@ -823,7 +823,7 @@ HTMLBLOC;
 		$this->assertTrue($this->Controller->EmailTest->send($body));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/Body of message/', $result);
+		$this->assertRegExp('/Body of message/', $result);
 
 	}
 
@@ -852,21 +852,21 @@ HTMLBLOC;
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/Message-ID: \<[a-f0-9]{8}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{12}@' . env('HTTP_HOST') . '\>\n/', $result);
+		$this->assertRegExp('/Message-ID: \<[a-f0-9]{8}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{4}[a-f0-9]{12}@' . env('HTTP_HOST') . '\>\n/', $result);
 
 		$this->Controller->EmailTest->messageId = '<22091985.998877@example.com>';
 
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertPattern('/Message-ID: <22091985.998877@example.com>\n/', $result);
+		$this->assertRegExp('/Message-ID: <22091985.998877@example.com>\n/', $result);
 
 		$this->Controller->EmailTest->messageId = false;
 
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$result = DebugCompTransport::$lastEmail;
 
-		$this->assertNoPattern('/Message-ID:/', $result);
+		$this->assertNotRegExp('/Message-ID:/', $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -88,6 +88,13 @@ class PaginatorControllerPost extends CakeTestModel {
 	public $lastQueries = array();
 
 /**
+ * belongsTo property
+ *
+ * @var array
+ */
+	public $belongsTo = array('PaginatorAuthor' => array('foreignKey' => 'author_id'));
+
+/**
  * beforeFind method
  *
  * @param mixed $query
@@ -183,6 +190,45 @@ class PaginatorControllerComment extends CakeTestModel {
 	public $alias = 'PaginatorControllerComment';
 }
 
+/**
+ * PaginatorAuthorclass
+ *
+ * @package       Cake.Test.Case.Controller.Component
+ */
+class PaginatorAuthor extends CakeTestModel {
+
+/**
+ * name property
+ *
+ * @var string 'PaginatorAuthor'
+ */
+	public $name = 'PaginatorAuthor';
+
+/**
+ * useTable property
+ *
+ * @var string 'authors'
+ */
+	public $useTable = 'authors';
+
+/**
+ * alias property
+ *
+ * @var string 'PaginatorAuthor'
+ */
+	public $alias = 'PaginatorAuthor';
+
+/**
+ * alias property
+ *
+ * @var string 'PaginatorAuthor'
+ */
+	public $virtualFields = array(
+			'joined_offset' => 'PaginatorAuthor.id + 1'
+		);
+
+}
+
 class PaginatorComponentTest extends CakeTestCase {
 
 /**
@@ -190,7 +236,7 @@ class PaginatorComponentTest extends CakeTestCase {
  *
  * @var array
  */
-	public $fixtures = array('core.post', 'core.comment');
+	public $fixtures = array('core.post', 'core.comment', 'core.author');
 
 /**
  * setup
@@ -488,6 +534,30 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->request->params['named'] = array('sort' => 'offset_test', 'direction' => 'asc');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
 		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(2, 3, 4));
+	}
+
+/**
+ * test paginate() and virtualField on joined model
+ *
+ * @return void
+ */
+	public function testPaginateOrderVirtualFieldJoinedModel() {
+		$Controller = new PaginatorTestController($this->request);
+		$Controller->uses = array('PaginatorControllerPost');
+		$Controller->params['url'] = array();
+		$Controller->constructClasses();
+		$Controller->PaginatorControllerPost->recursive = 0;
+		$Controller->Paginator->settings = array(
+			'order' => array('PaginatorAuthor.joined_offset' => 'DESC'),
+			'maxLimit' => 10,
+			'paramType' => 'named'
+		);
+		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
+		$this->assertEqual(Set::extract($result, '{n}.PaginatorAuthor.joined_offset'), array(4, 2, 2));
+
+		$Controller->request->params['named'] = array('sort' => 'PaginatorAuthor.joined_offset', 'direction' => 'asc');
+		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
+		$this->assertEqual(Set::extract($result, '{n}.PaginatorAuthor.joined_offset'), array(2, 2, 4));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -267,74 +267,74 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerComment'), '{n}.PaginatorControllerComment.id');
-		$this->assertEqual($results, array(1, 2, 3, 4, 5, 6));
+		$this->assertEquals($results, array(1, 2, 3, 4, 5, 6));
 
 		$Controller->modelClass = null;
 
 		$Controller->uses[0] = 'Plugin.PaginatorControllerPost';
 		$results = Set::extract($Controller->Paginator->paginate(), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$Controller->request->params['named'] = array('page' => '-1');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$Controller->request->params['named'] = array('sort' => 'PaginatorControllerPost.id', 'direction' => 'asc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$Controller->request->params['named'] = array('sort' => 'PaginatorControllerPost.id', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual($results, array(3, 2, 1));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals($results, array(3, 2, 1));
 
 		$Controller->request->params['named'] = array('sort' => 'id', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual($results, array(3, 2, 1));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals($results, array(3, 2, 1));
 
 		$Controller->request->params['named'] = array('sort' => 'NotExisting.field', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1, 'Invalid field in query %s');
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1, 'Invalid field in query %s');
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$Controller->request->params['named'] = array(
 			'sort' => 'PaginatorControllerPost.author_id', 'direction' => 'allYourBase'
 		);
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->PaginatorControllerPost->lastQueries[1]['order'][0], array('PaginatorControllerPost.author_id' => 'asc'));
-		$this->assertEqual($results, array(1, 3, 2));
+		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['order'][0], array('PaginatorControllerPost.author_id' => 'asc'));
+		$this->assertEquals($results, array(1, 3, 2));
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => 0, 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => 'garbage!', 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => '-1', 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
 
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['limit'], 1);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertIdentical($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['limit'], 1);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
+		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
 	}
 
 /**
@@ -382,8 +382,8 @@ class PaginatorComponentTest extends CakeTestCase {
 
 		$Controller->request->params['named'] = array('page' => '-1', 'contain' => array('PaginatorControllerComment'));
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
 		$this->assertTrue(!isset($Controller->PaginatorControllerPost->lastQueries[1]['contain']));
 
 		$Controller->request->params['named'] = array('page' => '-1');
@@ -395,8 +395,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			),
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
 		$this->assertTrue(isset($Controller->PaginatorControllerPost->lastQueries[1]['contain']));
 
 		$Controller->Paginator->settings = array(
@@ -405,16 +405,16 @@ class PaginatorComponentTest extends CakeTestCase {
 			),
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
-		$this->assertEqual($Controller->PaginatorControllerPost->lastQueries[1]['conditions'], array('PaginatorControllerPost.id > ' => '1'));
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
+		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['conditions'], array('PaginatorControllerPost.id > ' => '1'));
 
 		$Controller->request->params['named'] = array('limit' => 12);
 		$Controller->Paginator->settings = array('limit' => 30, 'maxLimit' => 100, 'paramType' => 'named');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
 		$paging = $Controller->params['paging']['PaginatorControllerPost'];
 
-		$this->assertEqual($Controller->PaginatorControllerPost->lastQueries[1]['limit'], 12);
-		$this->assertEqual($paging['options']['limit'], 12);
+		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['limit'], 12);
+		$this->assertEquals($paging['options']['limit'], 12);
 
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('ControllerPaginateModel');
@@ -435,8 +435,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'maxLimit' => 10,
 			'paramType' => 'named'
 		);
-		$this->assertEqual($Controller->ControllerPaginateModel->extra, $expected);
-		$this->assertEqual($Controller->ControllerPaginateModel->extraCount, $expected);
+		$this->assertEquals($Controller->ControllerPaginateModel->extra, $expected);
+		$this->assertEquals($Controller->ControllerPaginateModel->extraCount, $expected);
 
 		$Controller->Paginator->settings = array(
 			'ControllerPaginateModel' => array(
@@ -454,8 +454,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'maxLimit' => 10,
 			'paramType' => 'named'
 		);
-		$this->assertEqual($Controller->ControllerPaginateModel->extra, $expected);
-		$this->assertEqual($Controller->ControllerPaginateModel->extraCount, $expected);
+		$this->assertEquals($Controller->ControllerPaginateModel->extra, $expected);
+		$this->assertEquals($Controller->ControllerPaginateModel->extraCount, $expected);
 	}
 
 /**
@@ -480,8 +480,8 @@ class PaginatorComponentTest extends CakeTestCase {
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
 
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
-		$this->assertEqual(
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
+		$this->assertEquals(
 			$Controller->PaginatorControllerPost->lastQueries[1]['conditions'],
 			array('PaginatorControllerPost.id > ' => '1')
 		);
@@ -504,8 +504,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['order'], 'PaginatorControllerPost.id DESC');
-		$this->assertEqual($results, array(3, 2, 1));
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['order'], 'PaginatorControllerPost.id DESC');
+		$this->assertEquals($results, array(3, 2, 1));
 	}
 
 /**
@@ -529,11 +529,11 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(4, 3, 2));
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(4, 3, 2));
 
 		$Controller->request->params['named'] = array('sort' => 'offset_test', 'direction' => 'asc');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(2, 3, 4));
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(2, 3, 4));
 	}
 
 /**
@@ -814,26 +814,26 @@ class PaginatorComponentTest extends CakeTestCase {
 			'contain' => array('ControllerComment'), 'limit' => '1000'
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
 
 		$Controller->request->params['named'] = array(
 			'contain' => array('ControllerComment'), 'limit' => '1000', 'maxLimit' => 1000
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '10');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 10);
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 10);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '1000');
 		$Controller->paginate = array('maxLimit' => 2000, 'paramType' => 'named');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 1000);
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 1000);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '5000');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEqual($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 2000);
+		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 2000);
 	 }
 
 /**
@@ -862,7 +862,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		);
 		$Controller->passedArgs = array('sort' => 'PaginatorControllerPost.title', 'dir' => 'asc');
 		$result = $Controller->paginate('PaginatorControllerComment');
-		$this->assertEqual(Set::extract($result, '{n}.PaginatorControllerComment.id'), array(1, 2, 3, 4, 5, 6));
+		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerComment.id'), array(1, 2, 3, 4, 5, 6));
 	}
 
 }

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -142,7 +142,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$Collection = new ComponentCollection();
 		$Collection->init($this->Controller);
 		$RequestHandler = new RequestHandlerComponent($Collection, $settings);
-		$this->assertEqual($RequestHandler->ajaxLayout, 'test_ajax');
+		$this->assertEquals($RequestHandler->ajaxLayout, 'test_ajax');
 	}
 
 /**
@@ -154,7 +154,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->assertNull($this->RequestHandler->ext);
 		$this->Controller->request->params['ext'] = 'rss';
 		$this->RequestHandler->initialize($this->Controller);
-		$this->assertEqual($this->RequestHandler->ext, 'rss');
+		$this->assertEquals($this->RequestHandler->ext, 'rss');
 	}
 
 /**
@@ -275,7 +275,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->RequestHandler->initialize($this->Controller);
 		$this->Controller->beforeFilter();
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEqual($this->Controller->params['isAjax'], true);
+		$this->assertEquals($this->Controller->params['isAjax'], true);
 	}
 
 /**
@@ -288,7 +288,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->Controller->request->params['ext'] = 'rss';
 		$this->RequestHandler->initialize($this->Controller);
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEqual($this->Controller->ext, '.ctp');
+		$this->assertEquals($this->Controller->ext, '.ctp');
 	}
 
 
@@ -306,7 +306,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->Controller->request->params['ext'] = 'js';
 		$this->RequestHandler->initialize($this->Controller);
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertNotEqual($this->Controller->layout, 'ajax');
+		$this->assertNotEquals($this->Controller->layout, 'ajax');
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
 	}
@@ -385,7 +385,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 
 		$this->Controller->viewPath = 'request_handler_test\\rss';
 		$this->RequestHandler->renderAs($this->Controller, 'js');
-		$this->assertEqual($this->Controller->viewPath, 'request_handler_test' . DS . 'js');
+		$this->assertEquals($this->Controller->viewPath, 'request_handler_test' . DS . 'js');
 	}
 
 /**
@@ -470,12 +470,12 @@ class RequestHandlerComponentTest extends CakeTestCase {
  */
 	public function testRenderAsCalledTwice() {
 		$this->RequestHandler->renderAs($this->Controller, 'xml');
-		$this->assertEqual($this->Controller->viewPath, 'RequestHandlerTest' . DS . 'xml');
-		$this->assertEqual($this->Controller->layoutPath, 'xml');
+		$this->assertEquals($this->Controller->viewPath, 'RequestHandlerTest' . DS . 'xml');
+		$this->assertEquals($this->Controller->layoutPath, 'xml');
 
 		$this->RequestHandler->renderAs($this->Controller, 'js');
-		$this->assertEqual($this->Controller->viewPath, 'RequestHandlerTest' . DS . 'js');
-		$this->assertEqual($this->Controller->layoutPath, 'js');
+		$this->assertEquals($this->Controller->viewPath, 'RequestHandlerTest' . DS . 'js');
+		$this->assertEquals($this->Controller->layoutPath, 'js');
 		$this->assertTrue(in_array('Js', $this->Controller->helpers));
 	}
 
@@ -486,7 +486,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
  */
 	public function testRequestClientTypes() {
 		$_SERVER['HTTP_X_PROTOTYPE_VERSION'] = '1.5';
-		$this->assertEqual($this->RequestHandler->getAjaxVersion(), '1.5');
+		$this->assertEquals($this->RequestHandler->getAjaxVersion(), '1.5');
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['HTTP_X_PROTOTYPE_VERSION']);
 		$this->assertFalse($this->RequestHandler->getAjaxVersion());
@@ -518,10 +518,10 @@ class RequestHandlerComponentTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['CONTENT_TYPE'] = 'application/json';
-		$this->assertEqual($this->RequestHandler->requestedWith(), 'json');
+		$this->assertEquals($this->RequestHandler->requestedWith(), 'json');
 
 		$result = $this->RequestHandler->requestedWith(array('json', 'xml'));
-		$this->assertEqual($result, 'json');
+		$this->assertEquals($result, 'json');
 
 		$result =$this->RequestHandler->requestedWith(array('rss', 'atom'));
 		$this->assertFalse($result);
@@ -554,7 +554,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	public function testResponseContentType() {
 		$this->assertEquals('html', $this->RequestHandler->responseType());
 		$this->assertTrue($this->RequestHandler->respondAs('atom'));
-		$this->assertEqual($this->RequestHandler->responseType(), 'atom');
+		$this->assertEquals($this->RequestHandler->responseType(), 'atom');
 	}
 
 /**
@@ -658,22 +658,22 @@ class RequestHandlerComponentTest extends CakeTestCase {
  */
 	public function testPrefers() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*';
-		$this->assertNotEqual($this->RequestHandler->prefers(), 'rss');
+		$this->assertNotEquals($this->RequestHandler->prefers(), 'rss');
 		$this->RequestHandler->ext = 'rss';
-		$this->assertEqual($this->RequestHandler->prefers(), 'rss');
+		$this->assertEquals($this->RequestHandler->prefers(), 'rss');
 		$this->assertFalse($this->RequestHandler->prefers('xml'));
-		$this->assertEqual($this->RequestHandler->prefers(array('js', 'xml', 'xhtml')), 'xml');
+		$this->assertEquals($this->RequestHandler->prefers(array('js', 'xml', 'xhtml')), 'xml');
 		$this->assertFalse($this->RequestHandler->prefers(array('red', 'blue')));
-		$this->assertEqual($this->RequestHandler->prefers(array('js', 'json', 'xhtml')), 'xhtml');
+		$this->assertEquals($this->RequestHandler->prefers(array('js', 'json', 'xhtml')), 'xhtml');
 		$this->assertTrue($this->RequestHandler->prefers(array('rss')), 'Should return true if input matches ext.');
 		$this->assertFalse($this->RequestHandler->prefers(array('html')), 'No match with ext, return false.');
 
 		$_SERVER['HTTP_ACCEPT'] = 'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
 		$this->_init();
-		$this->assertEqual($this->RequestHandler->prefers(), 'xml');
+		$this->assertEquals($this->RequestHandler->prefers(), 'xml');
 
 		$_SERVER['HTTP_ACCEPT'] = '*/*;q=0.5';
-		$this->assertEqual($this->RequestHandler->prefers(), 'html');
+		$this->assertEquals($this->RequestHandler->prefers(), 'html');
 		$this->assertFalse($this->RequestHandler->prefers('rss'));
 	}
 
@@ -686,7 +686,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/x-mobile,text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5';
 		$this->RequestHandler->setContent('mobile', 'text/x-mobile');
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEqual($this->RequestHandler->prefers(), 'mobile');
+		$this->assertEquals($this->RequestHandler->prefers(), 'mobile');
 	}
 
 /**
@@ -728,7 +728,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 			$this->Controller, array('controller' => 'request_handler_test', 'action' => 'destination')
 		);
 		$result = ob_get_clean();
-		$this->assertPattern('/posts index/', $result, 'RequestAction redirect failed.');
+		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
 
 		App::build();
 	}
@@ -757,8 +757,8 @@ class RequestHandlerComponentTest extends CakeTestCase {
 			$this->Controller, array('controller' => 'request_handler_test', 'action' => 'ajax2_layout')
 		);
 		$result = ob_get_clean();
-		$this->assertPattern('/posts index/', $result, 'RequestAction redirect failed.');
-		$this->assertPattern('/Ajax!/', $result, 'Layout was not rendered.');
+		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
+		$this->assertRegExp('/Ajax!/', $result, 'Layout was not rendered.');
 
 		App::build();
 	}
@@ -790,7 +790,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second')
 		);
 		$result = ob_get_clean();
-		$this->assertEqual($result, 'one: first two: second');
+		$this->assertEquals($result, 'one: first two: second');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -214,6 +214,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->RequestHandler->initialize($this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 	}
+
 /**
  * Test that ext is not set with multiple accepted content types.
  *
@@ -223,6 +224,20 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/javascript, application/xml, */*; q=0.01';
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('xml', 'json');
+
+		$this->RequestHandler->initialize($this->Controller);
+		$this->assertNull($this->RequestHandler->ext);
+	}
+	
+/**
+ * Test that ext is not set with confusing android accepts headers.
+ *
+ * @return void
+ */
+	public function testInitializeAmbiguousAndroidAccepts() {
+		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
+		$this->assertNull($this->RequestHandler->ext);
+		Router::parseExtensions('html', 'xml');
 
 		$this->RequestHandler->initialize($this->Controller);
 		$this->assertNull($this->RequestHandler->ext);

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -175,10 +175,10 @@ class SecurityComponentTest extends CakeTestCase {
 		);
 		$Security = new SecurityComponent($this->Controller->Components, $settings);
 		$this->Controller->Security->initialize($this->Controller, $settings);
-		$this->assertEqual($Security->requirePost, $settings['requirePost']);
-		$this->assertEqual($Security->requireSecure, $settings['requireSecure']);
-		$this->assertEqual($Security->requireGet, $settings['requireGet']);
-		$this->assertEqual($Security->validatePost, $settings['validatePost']);
+		$this->assertEquals($Security->requirePost, $settings['requirePost']);
+		$this->assertEquals($Security->requireSecure, $settings['requireSecure']);
+		$this->assertEquals($Security->requireGet, $settings['requireGet']);
+		$this->assertEquals($Security->validatePost, $settings['validatePost']);
 	}
 
 /**
@@ -1038,7 +1038,7 @@ class SecurityComponentTest extends CakeTestCase {
 		unset($this->Controller->request->params['_Token']);
 
 		$this->Controller->Security->startup($this->Controller);
-		$this->assertEqual($this->Controller->request->params['_Token']['key'], $key);
+		$this->assertEquals($this->Controller->request->params['_Token']['key'], $key);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
@@ -142,10 +142,10 @@ class SessionComponentTest extends CakeTestCase {
 		$expected = $Session->id();
 
 		$result = $Object->requestAction('/session_test/session_id');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Object->requestAction('/orange_session_test/session_id');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -188,25 +188,25 @@ class SessionComponentTest extends CakeTestCase {
 		$this->assertNull($Session->read('Test'));
 
 		$this->assertTrue($Session->write('Test', 'some value'));
-		$this->assertEqual($Session->read('Test'), 'some value');
+		$this->assertEquals($Session->read('Test'), 'some value');
 		$this->assertFalse($Session->write('Test.key', 'some value'));
 		$Session->delete('Test');
 
 		$this->assertTrue($Session->write('Test.key.path', 'some value'));
-		$this->assertEqual($Session->read('Test.key.path'), 'some value');
-		$this->assertEqual($Session->read('Test.key'), array('path' => 'some value'));
+		$this->assertEquals($Session->read('Test.key.path'), 'some value');
+		$this->assertEquals($Session->read('Test.key'), array('path' => 'some value'));
 		$this->assertTrue($Session->write('Test.key.path2', 'another value'));
-		$this->assertEqual($Session->read('Test.key'), array('path' => 'some value', 'path2' => 'another value'));
+		$this->assertEquals($Session->read('Test.key'), array('path' => 'some value', 'path2' => 'another value'));
 		$Session->delete('Test');
 
 		$array = array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3');
 		$this->assertTrue($Session->write('Test', $array));
-		$this->assertEqual($Session->read('Test'), $array);
+		$this->assertEquals($Session->read('Test'), $array);
 		$Session->delete('Test');
 
 		$this->assertFalse($Session->write(array('Test'), 'some value'));
 		$this->assertTrue($Session->write(array('Test' => 'some value')));
-		$this->assertEqual($Session->read('Test'), 'some value');
+		$this->assertEquals($Session->read('Test'), 'some value');
 		$Session->delete('Test');
 	}
 
@@ -250,16 +250,16 @@ class SessionComponentTest extends CakeTestCase {
 		$this->assertNull($Session->read('Message.flash'));
 
 		$Session->setFlash('This is a test message');
-		$this->assertEqual($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
 
 		$Session->setFlash('This is a test message', 'test', array('name' => 'Joel Moss'));
-		$this->assertEqual($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')));
+		$this->assertEquals($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')));
 
 		$Session->setFlash('This is a test message', 'default', array(), 'myFlash');
-		$this->assertEqual($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
 
 		$Session->setFlash('This is a test message', 'non_existing_layout');
-		$this->assertEqual($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
 
 		$Session->delete('Message');
 	}
@@ -285,7 +285,7 @@ class SessionComponentTest extends CakeTestCase {
 		$Session = new SessionComponent($this->ComponentCollection);
 
 		$Session->write('Test', 'some value');
-		$this->assertEqual($Session->read('Test'), 'some value');
+		$this->assertEquals($Session->read('Test'), 'some value');
 		$Session->destroy('Test');
 		$this->assertNull($Session->read('Test'));
 	}

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -150,7 +150,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('flag', 'otherFlag', 'redirect' => false));
-		$this->assertEqual($Controller->components, $expected, 'Duplication of settings occured. %s');
+		$this->assertEquals($Controller->components, $expected, 'Duplication of settings occured. %s');
 	}
 
 /**
@@ -164,7 +164,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('flag', 'otherFlag', 'redirect' => true, 'remote'));
-		$this->assertEqual($Controller->components, $expected, 'Merging of settings is wrong. %s');
+		$this->assertEquals($Controller->components, $expected, 'Merging of settings is wrong. %s');
 	}
 
 /**
@@ -177,7 +177,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('format' => 'html', 'terse'));
-		$this->assertEqual($Controller->helpers, $expected, 'Duplication of settings occured. %s');
+		$this->assertEquals($Controller->helpers, $expected, 'Duplication of settings occured. %s');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -462,7 +462,7 @@ class ControllerTest extends CakeTestCase {
 		$this->assertTrue(is_a($Controller->ControllerPost, 'ControllerPost'));
 		$this->assertTrue(is_a($Controller->ControllerComment, 'ControllerComment'));
 
-		$this->assertEqual($Controller->ControllerComment->name, 'Comment');
+		$this->assertEquals($Controller->ControllerComment->name, 'Comment');
 
 		unset($Controller);
 
@@ -490,8 +490,8 @@ class ControllerTest extends CakeTestCase {
 		$Controller->uses = array('NameTest');
 		$Controller->constructClasses();
 
-		$this->assertEqual($Controller->NameTest->name, 'Name');
-		$this->assertEqual($Controller->NameTest->alias, 'Name');
+		$this->assertEquals($Controller->NameTest->name, 'Name');
+		$this->assertEquals($Controller->NameTest->alias, 'Name');
 
 		unset($Controller);
 	}
@@ -527,7 +527,7 @@ class ControllerTest extends CakeTestCase {
 		</html>';
 		$result = str_replace(array("\t", "\r\n", "\n"), "", $result);
 		$expected =  str_replace(array("\t", "\r\n", "\n"), "", $expected);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		App::build(array(
 			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS)
@@ -536,7 +536,7 @@ class ControllerTest extends CakeTestCase {
 		$Controller->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$Controller->flash('this should work', '/flash', 1, 'ajax2');
 		$result = $Controller->response->body();
-		$this->assertPattern('/Ajax!/', $result);
+		$this->assertRegExp('/Ajax!/', $result);
 		App::build();
 	}
 
@@ -567,19 +567,19 @@ class ControllerTest extends CakeTestCase {
 		$this->assertTrue(array_key_exists('ModelName', $Controller->viewVars));
 
 		$Controller->set('title', 'someTitle');
-		$this->assertIdentical($Controller->viewVars['title'], 'someTitle');
+		$this->assertSame($Controller->viewVars['title'], 'someTitle');
 		$this->assertTrue(empty($Controller->pageTitle));
 
 		$Controller->viewVars = array();
 		$expected = array('ModelName' => 'name', 'ModelName2' => 'name2');
 		$Controller->set(array('ModelName', 'ModelName2'), array('name', 'name2'));
-		$this->assertIdentical($Controller->viewVars, $expected);
+		$this->assertSame($Controller->viewVars, $expected);
 
 		$Controller->viewVars = array();
 		$Controller->set(array(3 => 'three', 4 => 'four'));
 		$Controller->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEqual($Controller->viewVars, $expected);
+		$this->assertEquals($Controller->viewVars, $expected);
 
 	}
 
@@ -600,14 +600,14 @@ class ControllerTest extends CakeTestCase {
 		$Controller->viewPath = 'Posts';
 
 		$result = $Controller->render('index');
-		$this->assertPattern('/posts index/', (string)$result);
+		$this->assertRegExp('/posts index/', (string)$result);
 
 		$Controller->view = 'index';
 		$result = $Controller->render();
-		$this->assertPattern('/posts index/', (string)$result);
+		$this->assertRegExp('/posts index/', (string)$result);
 
 		$result = $Controller->render('/Elements/test_element');
-		$this->assertPattern('/this is the test element/', (string)$result);
+		$this->assertRegExp('/this is the test element/', (string)$result);
 		$Controller->view = null;
 
 		$Controller = new TestController($request, new CakeResponse());
@@ -621,14 +621,14 @@ class ControllerTest extends CakeTestCase {
 		$result = $Controller->render('index');
 		$View = $Controller->View;
 		$this->assertTrue(isset($View->validationErrors['ControllerComment']));
-		$this->assertEqual($expected, $View->validationErrors['ControllerComment']);
+		$this->assertEquals($expected, $View->validationErrors['ControllerComment']);
 
 		$expectedModels = array(
 			'ControllerAlias' => array('plugin' => null, 'className' => 'ControllerAlias'),
 			'ControllerComment' => array('plugin' => 'TestPlugin', 'className' => 'ControllerComment'),
 			'ControllerPost' => array('plugin' => null, 'className' => 'ControllerPost')
 		);
-		$this->assertEqual($expectedModels, $Controller->request->params['models']);
+		$this->assertEquals($expectedModels, $Controller->request->params['models']);
 
 		ClassRegistry::flush();
 		App::build();
@@ -653,7 +653,7 @@ class ControllerTest extends CakeTestCase {
 		$Controller->viewPath = 'Posts';
 		$Controller->theme = 'TestTheme';
 		$result = $Controller->render('index');
-		$this->assertPattern('/default test_theme layout/', (string)$result);
+		$this->assertRegExp('/default test_theme layout/', (string)$result);
 		App::build();
 	}
 
@@ -853,9 +853,9 @@ class ControllerTest extends CakeTestCase {
 					? array_merge($appVars['uses'], $testVars['uses'])
 					: $testVars['uses'];
 
-		$this->assertEqual(count(array_diff_key($TestController->helpers, array_flip($helpers))), 0);
-		$this->assertEqual(count(array_diff($TestController->uses, $uses)), 0);
-		$this->assertEqual(count(array_diff_assoc(Set::normalize($TestController->components), Set::normalize($components))), 0);
+		$this->assertEquals(count(array_diff_key($TestController->helpers, array_flip($helpers))), 0);
+		$this->assertEquals(count(array_diff($TestController->uses, $uses)), 0);
+		$this->assertEquals(count(array_diff_assoc(Set::normalize($TestController->components), Set::normalize($components))), 0);
 
 		$expected = array('ControllerComment', 'ControllerAlias', 'ControllerPost');
 		$this->assertEquals($expected, $TestController->uses, '$uses was merged incorrectly, ControllerTestAppController models should be last.');
@@ -881,7 +881,7 @@ class ControllerTest extends CakeTestCase {
 
 
 		$this->assertTrue(in_array('ControllerPost', $appVars['uses']));
-		$this->assertEqual(array('ControllerPost'), $testVars['uses']);
+		$this->assertEquals(array('ControllerPost'), $testVars['uses']);
 
 		$this->assertTrue(isset($TestController->ControllerPost));
 		$this->assertTrue(isset($TestController->ControllerComment));
@@ -900,7 +900,7 @@ class ControllerTest extends CakeTestCase {
 		$expected = array('foo');
 		$TestController->components = array('Cookie' => $expected);
 		$TestController->constructClasses();
-		$this->assertEqual($TestController->components['Cookie'], $expected);
+		$this->assertEquals($TestController->components['Cookie'], $expected);
 	}
 
 /**
@@ -934,12 +934,12 @@ class ControllerTest extends CakeTestCase {
 
 		$Controller = new Controller($request);
 		$result = $Controller->referer(null, true);
-		$this->assertEqual($result, '/posts/index');
+		$this->assertEquals($result, '/posts/index');
 
 		$Controller = new Controller($request);
 		$request->setReturnValue('referer', '/', array(true));
 		$result = $Controller->referer(array('controller' => 'posts', 'action' => 'index'), true);
-		$this->assertEqual($result, '/posts/index');
+		$this->assertEquals($result, '/posts/index');
 
 		$request = $this->getMock('CakeRequest');
 
@@ -949,11 +949,11 @@ class ControllerTest extends CakeTestCase {
 
 		$Controller = new Controller($request);
 		$result = $Controller->referer();
-		$this->assertEqual($result, 'http://localhost/posts/index');
+		$this->assertEquals($result, 'http://localhost/posts/index');
 
 		$Controller = new Controller(null);
 		$result = $Controller->referer();
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 	}
 
 /**
@@ -983,7 +983,7 @@ class ControllerTest extends CakeTestCase {
 		$TestController = new TestController($request);
 		$TestController->constructClasses();
 		$this->assertFalse($TestController->validateErrors());
-		$this->assertEqual($TestController->validate(), 0);
+		$this->assertEquals($TestController->validate(), 0);
 
 		$TestController->ControllerComment->invalidate('some_field', 'error_message');
 		$TestController->ControllerComment->invalidate('some_field2', 'error_message2');
@@ -992,8 +992,8 @@ class ControllerTest extends CakeTestCase {
 		$comment->set('someVar', 'data');
 		$result = $TestController->validateErrors($comment);
 		$expected = array('some_field' => array('error_message'), 'some_field2' => array('error_message2'));
-		$this->assertIdentical($expected, $result);
-		$this->assertEqual($TestController->validate($comment), 2);
+		$this->assertSame($expected, $result);
+		$this->assertEquals($TestController->validate($comment), 2);
 	}
 
 /**
@@ -1010,7 +1010,7 @@ class ControllerTest extends CakeTestCase {
 		$result = $TestController->validateErrors($Post);
 
 		$expected = array('title' => array('This field cannot be left blank'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1034,7 +1034,7 @@ class ControllerTest extends CakeTestCase {
 			'Model3.field3' => '23',
 		);
 		$result = $Controller->postConditions($data);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 
 		$data = array();
@@ -1049,7 +1049,7 @@ class ControllerTest extends CakeTestCase {
 			'Model3.field3' => '23',
 		);
 		$result = $Controller->postConditions($data);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 
 		$data = array();
@@ -1075,7 +1075,7 @@ class ControllerTest extends CakeTestCase {
 			'Model3.field3 <=' => '23',
 		);
 		$result = $Controller->postConditions($data, $ops);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -1187,19 +1187,19 @@ class ControllerTest extends CakeTestCase {
 		$Controller->params['url'] = array();
 		$Controller->constructClasses();
 		$expected = array('page' => 1, 'limit' => 20, 'maxLimit' => 100, 'paramType' => 'named');
-		$this->assertEqual($Controller->paginate, $expected);
+		$this->assertEquals($Controller->paginate, $expected);
 
 		$results = Set::extract($Controller->paginate('ControllerPost'), '{n}.ControllerPost.id');
-		$this->assertEqual($results, array(1, 2, 3));
+		$this->assertEquals($results, array(1, 2, 3));
 
 		$Controller->passedArgs = array();
 		$Controller->paginate = array('limit' => '-1');
-		$this->assertEqual($Controller->paginate, array('limit' => '-1'));
+		$this->assertEquals($Controller->paginate, array('limit' => '-1'));
 		$Controller->paginate('ControllerPost');
-		$this->assertIdentical($Controller->params['paging']['ControllerPost']['page'], 1);
-		$this->assertIdentical($Controller->params['paging']['ControllerPost']['pageCount'], 3);
-		$this->assertIdentical($Controller->params['paging']['ControllerPost']['prevPage'], false);
-		$this->assertIdentical($Controller->params['paging']['ControllerPost']['nextPage'], true);
+		$this->assertSame($Controller->params['paging']['ControllerPost']['page'], 1);
+		$this->assertSame($Controller->params['paging']['ControllerPost']['pageCount'], 3);
+		$this->assertSame($Controller->params['paging']['ControllerPost']['prevPage'], false);
+		$this->assertSame($Controller->params['paging']['ControllerPost']['nextPage'], true);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/PagesControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/PagesControllerTest.php
@@ -41,13 +41,13 @@ class PagesControllerTest extends CakeTestCase {
 
 		$Pages->viewPath = 'Posts';
 		$Pages->display('index');
-		$this->assertPattern('/posts index/', $Pages->response->body());
-		$this->assertEqual($Pages->viewVars['page'], 'index');
+		$this->assertRegExp('/posts index/', $Pages->response->body());
+		$this->assertEquals($Pages->viewVars['page'], 'index');
 
 		$Pages->viewPath = 'Themed';
 		$Pages->display('TestTheme', 'Posts', 'index');
-		$this->assertPattern('/posts index themed view/', $Pages->response->body());
-		$this->assertEqual($Pages->viewVars['page'], 'TestTheme');
-		$this->assertEqual($Pages->viewVars['subpage'], 'Posts');
+		$this->assertRegExp('/posts index themed view/', $Pages->response->body());
+		$this->assertEquals($Pages->viewVars['page'], 'TestTheme');
+		$this->assertEquals($Pages->viewVars['subpage'], 'Posts');
 	}
 }

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -177,7 +177,7 @@ class ScaffoldTest extends CakeTestCase {
 		$this->Controller->constructClasses();
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 		$result = $Scaffold->getParams();
-		$this->assertEqual($result['action'], 'admin_edit');
+		$this->assertEquals($result['action'], 'admin_edit');
 	}
 
 /**
@@ -208,15 +208,15 @@ class ScaffoldTest extends CakeTestCase {
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 		$result = $Scaffold->controller->viewVars;
 
-		$this->assertEqual($result['title_for_layout'], 'Scaffold :: Admin Edit :: Scaffold Mock');
-		$this->assertEqual($result['singularHumanName'], 'Scaffold Mock');
-		$this->assertEqual($result['pluralHumanName'], 'Scaffold Mock');
-		$this->assertEqual($result['modelClass'], 'ScaffoldMock');
-		$this->assertEqual($result['primaryKey'], 'id');
-		$this->assertEqual($result['displayField'], 'title');
-		$this->assertEqual($result['singularVar'], 'scaffoldMock');
-		$this->assertEqual($result['pluralVar'], 'scaffoldMock');
-		$this->assertEqual($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated'));
+		$this->assertEquals($result['title_for_layout'], 'Scaffold :: Admin Edit :: Scaffold Mock');
+		$this->assertEquals($result['singularHumanName'], 'Scaffold Mock');
+		$this->assertEquals($result['pluralHumanName'], 'Scaffold Mock');
+		$this->assertEquals($result['modelClass'], 'ScaffoldMock');
+		$this->assertEquals($result['primaryKey'], 'id');
+		$this->assertEquals($result['displayField'], 'title');
+		$this->assertEquals($result['singularVar'], 'scaffoldMock');
+		$this->assertEquals($result['pluralVar'], 'scaffoldMock');
+		$this->assertEquals($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated'));
 	}
 
 /**
@@ -231,7 +231,7 @@ class ScaffoldTest extends CakeTestCase {
 		$this->Controller->constructClasses();
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 
-		$this->assertEqual($this->Controller->viewClass, 'Scaffold');
+		$this->assertEquals($this->Controller->viewClass, 'Scaffold');
 	}
 
 /**
@@ -271,7 +271,7 @@ class ScaffoldTest extends CakeTestCase {
 		new Scaffold($this->Controller, $this->Controller->request);
 		$this->Controller->response->send();
 		$result = ob_get_clean();
-		$this->assertPattern('/Scaffold Mock has been updated/', $result);
+		$this->assertRegExp('/Scaffold Mock has been updated/', $result);
 	}
 /**
  * test that habtm relationship keys get added to scaffoldFields.
@@ -303,10 +303,10 @@ class ScaffoldTest extends CakeTestCase {
 		$Scaffold = new Scaffold($this->Controller, $this->Controller->request);
 		$this->Controller->response->send();
 		$result = ob_get_clean();
-		$this->assertPattern('/name="data\[ScaffoldTag\]\[ScaffoldTag\]"/', $result);
+		$this->assertRegExp('/name="data\[ScaffoldTag\]\[ScaffoldTag\]"/', $result);
 
 		$result = $Scaffold->controller->viewVars;
-		$this->assertEqual($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'));
+		$this->assertEquals($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'));
 	}
 /**
  * test that the proper names and variable values are set by Scaffold
@@ -342,6 +342,6 @@ class ScaffoldTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertNoPattern('/textarea name="data\[ScaffoldMock\]\[body\]" cols="30" rows="6" id="ScaffoldMockBody"/', $result);
+		$this->assertNotRegExp('/textarea name="data\[ScaffoldMock\]\[body\]" cols="30" rows="6" id="ScaffoldMockBody"/', $result);
 	}
 }

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -44,7 +44,7 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $old);
+		$this->assertEquals($expected, $old);
 
 		App::build(array('Model' => array('/path/to/models/')));
 		$new = App::path('Model');
@@ -53,7 +53,7 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 
 		App::build();
 		App::build(array('Model' => array('/path/to/models/')), App::PREPEND);
@@ -63,7 +63,7 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 
 		App::build();
 		App::build(array('Model' => array('/path/to/models/')), App::APPEND);
@@ -73,7 +73,7 @@ class AppTest extends CakeTestCase {
 			APP . 'models' . DS,
 			'/path/to/models/'
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 
 		App::build();
 		App::build(array(
@@ -86,18 +86,18 @@ class AppTest extends CakeTestCase {
 			APP . 'models' . DS,
 			'/path/to/models/'
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 		$new = App::path('Controller');
 		$expected = array(
 			APP . 'Controller' . DS,
 			APP . 'controllers' . DS,
 			'/path/to/controllers/'
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 
 		App::build(); //reset defaults
 		$defaults = App::path('Model');
-		$this->assertEqual($old, $defaults);
+		$this->assertEquals($old, $defaults);
 	}
 
 /**
@@ -111,7 +111,7 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $old);
+		$this->assertEquals($expected, $old);
 
 		App::build(array('models' => array('/path/to/models/')));
 
@@ -122,8 +122,8 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $new);
-		$this->assertEqual($expected, App::path('Model'));
+		$this->assertEquals($expected, $new);
+		$this->assertEquals($expected, App::path('Model'));
 
 		App::build(array('datasources' => array('/path/to/datasources/')));
 		$expected = array(
@@ -132,8 +132,8 @@ class AppTest extends CakeTestCase {
 			APP . 'models' . DS . 'datasources' . DS
 		);
 		$result = App::path('datasources');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('Model/Datasource'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('Model/Datasource'));
 
 		App::build(array('behaviors' => array('/path/to/behaviors/')));
 		$expected = array(
@@ -142,8 +142,8 @@ class AppTest extends CakeTestCase {
 			APP . 'models' . DS . 'behaviors' . DS
 		);
 		$result = App::path('behaviors');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('Model/Behavior'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('Model/Behavior'));
 
 		App::build(array('controllers' => array('/path/to/controllers/')));
 		$expected = array(
@@ -152,8 +152,8 @@ class AppTest extends CakeTestCase {
 			APP . 'controllers' . DS
 		);
 		$result = App::path('controllers');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('Controller'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('Controller'));
 
 		App::build(array('components' => array('/path/to/components/')));
 		$expected = array(
@@ -162,8 +162,8 @@ class AppTest extends CakeTestCase {
 			APP . 'controllers' . DS . 'components' . DS
 		);
 		$result = App::path('components');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('Controller/Component'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('Controller/Component'));
 
 		App::build(array('views' => array('/path/to/views/')));
 		$expected = array(
@@ -172,8 +172,8 @@ class AppTest extends CakeTestCase {
 			APP . 'views' . DS
 		);
 		$result = App::path('views');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('View'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('View'));
 
 		App::build(array('helpers' => array('/path/to/helpers/')));
 		$expected = array(
@@ -182,8 +182,8 @@ class AppTest extends CakeTestCase {
 			APP . 'views' . DS . 'helpers' . DS
 		);
 		$result = App::path('helpers');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('View/Helper'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('View/Helper'));
 
 		App::build(array('shells' => array('/path/to/shells/')));
 		$expected = array(
@@ -192,12 +192,12 @@ class AppTest extends CakeTestCase {
 			APP . 'console' . DS . 'shells' . DS,
 		);
 		$result = App::path('shells');
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($expected, App::path('Console/Command'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($expected, App::path('Console/Command'));
 
 		App::build(); //reset defaults
 		$defaults = App::path('Model');
-		$this->assertEqual($old, $defaults);
+		$this->assertEquals($old, $defaults);
 	}
 
 /**
@@ -227,7 +227,7 @@ class AppTest extends CakeTestCase {
 			APP . 'Model' . DS,
 			APP . 'models' . DS
 		);
-		$this->assertEqual($expected, $old);
+		$this->assertEquals($expected, $old);
 
 		App::build(array('Model' => array('/path/to/models/')), App::RESET);
 
@@ -236,11 +236,11 @@ class AppTest extends CakeTestCase {
 		$expected = array(
 			'/path/to/models/'
 		);
-		$this->assertEqual($expected, $new);
+		$this->assertEquals($expected, $new);
 
 		App::build(); //reset defaults
 		$defaults = App::path('Model');
-		$this->assertEqual($old, $defaults);
+		$this->assertEquals($old, $defaults);
 	}
 
 /**
@@ -250,22 +250,22 @@ class AppTest extends CakeTestCase {
  */
 	public function testCore() {
 		$model = App::core('Model');
-		$this->assertEqual(array(CAKE . 'Model' . DS), $model);
+		$this->assertEquals(array(CAKE . 'Model' . DS), $model);
 
 		$view = App::core('View');
-		$this->assertEqual(array(CAKE . 'View' . DS), $view);
+		$this->assertEquals(array(CAKE . 'View' . DS), $view);
 
 		$controller = App::core('Controller');
-		$this->assertEqual(array(CAKE . 'Controller' . DS), $controller);
+		$this->assertEquals(array(CAKE . 'Controller' . DS), $controller);
 
 		$component = App::core('Controller/Component');
-		$this->assertEqual(array(CAKE . 'Controller' . DS . 'Component' . DS), str_replace('/', DS, $component));
+		$this->assertEquals(array(CAKE . 'Controller' . DS . 'Component' . DS), str_replace('/', DS, $component));
 
 		$auth = App::core('Controller/Component/Auth');
-		$this->assertEqual(array(CAKE . 'Controller' . DS . 'Component' . DS . 'Auth' . DS), str_replace('/', DS, $auth));
+		$this->assertEquals(array(CAKE . 'Controller' . DS . 'Component' . DS . 'Auth' . DS), str_replace('/', DS, $auth));
 
 		$datasource = App::core('Model/Datasource');
-		$this->assertEqual(array(CAKE . 'Model' . DS . 'Datasource' . DS), str_replace('/', DS, $datasource));
+		$this->assertEquals(array(CAKE . 'Model' . DS . 'Datasource' . DS), str_replace('/', DS, $datasource));
 	}
 
 /**
@@ -321,10 +321,10 @@ class AppTest extends CakeTestCase {
 
 		$result = App::objects('file', 'non_existing_configure');
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = App::objects('NonExistingType');
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 
 		App::build(array(
 			'plugins' => array(
@@ -416,11 +416,11 @@ class AppTest extends CakeTestCase {
 
 		$path = App::pluginPath('TestPlugin');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPlugin' . DS;
-		$this->assertEqual($path, $expected);
+		$this->assertEquals($path, $expected);
 
 		$path = App::pluginPath('TestPluginTwo');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS;
-		$this->assertEqual($path, $expected);
+		$this->assertEquals($path, $expected);
 		App::build();
 	}
 
@@ -435,11 +435,11 @@ class AppTest extends CakeTestCase {
 		));
 		$path = App::themePath('test_theme');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEqual($path, $expected);
+		$this->assertEquals($path, $expected);
 
 		$path = App::themePath('TestTheme');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEqual($path, $expected);
+		$this->assertEquals($path, $expected);
 
 		App::build();
 	}
@@ -711,7 +711,7 @@ class AppTest extends CakeTestCase {
 		$result = App::import('Vendor', 'css/TestAsset', array('ext' => 'css'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'this is the test asset css file');
+		$this->assertEquals($text, 'this is the test asset css file');
 
 		$result = App::import('Vendor', 'TestPlugin.sample/SamplePlugin');
 		$this->assertTrue($result);
@@ -725,31 +725,31 @@ class AppTest extends CakeTestCase {
 		$result = App::import('Vendor', 'SomeNameInSubfolder', array('file' => 'somename/some.name.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'This is a file with dot in file name');
+		$this->assertEquals($text, 'This is a file with dot in file name');
 
 		ob_start();
 		$result = App::import('Vendor', 'TestHello', array('file' => 'Test'.DS.'hello.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'This is the hello.php file in Test directory');
+		$this->assertEquals($text, 'This is the hello.php file in Test directory');
 
 		ob_start();
 		$result = App::import('Vendor', 'MyTest', array('file' => 'Test'.DS.'MyTest.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'This is the MyTest.php file');
+		$this->assertEquals($text, 'This is the MyTest.php file');
 
 		ob_start();
 		$result = App::import('Vendor', 'Welcome');
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'This is the welcome.php file in vendors directory');
+		$this->assertEquals($text, 'This is the welcome.php file in vendors directory');
 
 		ob_start();
 		$result = App::import('Vendor', 'TestPlugin.Welcome');
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEqual($text, 'This is the welcome.php file in test_plugin/vendors directory');
+		$this->assertEquals($text, 'This is the welcome.php file in test_plugin/vendors directory');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -80,10 +80,10 @@ class ConfigureTest extends CakeTestCase {
 		Configure::write('level1.level2.level3_1', $expected);
 		Configure::write('level1.level2.level3_2', 'something_else');
 		$result = Configure::read('level1.level2.level3_1');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Configure::read('level1.level2.level3_2');
-		$this->assertEqual($result, 'something_else');
+		$this->assertEquals($result, 'something_else');
 
 		$result = Configure::read('debug');
 		$this->assertTrue($result >= 0);
@@ -106,28 +106,28 @@ class ConfigureTest extends CakeTestCase {
 		$writeResult = Configure::write('SomeName.someKey', 'myvalue');
 		$this->assertTrue($writeResult);
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEqual($result, 'myvalue');
+		$this->assertEquals($result, 'myvalue');
 
 		$writeResult = Configure::write('SomeName.someKey', null);
 		$this->assertTrue($writeResult);
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEqual($result, null);
+		$this->assertEquals($result, null);
 
 		$expected = array('One' => array('Two' => array('Three' => array('Four' => array('Five' => 'cool')))));
 		$writeResult = Configure::write('Key', $expected);
 		$this->assertTrue($writeResult);
 
 		$result = Configure::read('Key');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Configure::read('Key.One');
-		$this->assertEqual($expected['One'], $result);
+		$this->assertEquals($expected['One'], $result);
 
 		$result = Configure::read('Key.One.Two');
-		$this->assertEqual($expected['One']['Two'], $result);
+		$this->assertEquals($expected['One']['Two'], $result);
 
 		$result = Configure::read('Key.One.Two.Three.Four.Five');
-		$this->assertEqual('cool', $result);
+		$this->assertEquals('cool', $result);
 
 		Configure::write('one.two.three.four', '4');
 		$result = Configure::read('one.two.three.four');
@@ -142,11 +142,11 @@ class ConfigureTest extends CakeTestCase {
 	public function testDebugSettingDisplayErrors() {
 		Configure::write('debug', 0);
 		$result = ini_get('display_errors');
-		$this->assertEqual($result, 0);
+		$this->assertEquals($result, 0);
 
 		Configure::write('debug', 2);
 		$result = ini_get('display_errors');
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 	}
 
 /**
@@ -157,7 +157,7 @@ class ConfigureTest extends CakeTestCase {
 	public function testDelete() {
 		Configure::write('SomeName.someKey', 'myvalue');
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEqual($result, 'myvalue');
+		$this->assertEquals($result, 'myvalue');
 
 		Configure::delete('SomeName.someKey');
 		$result = Configure::read('SomeName.someKey');
@@ -166,10 +166,10 @@ class ConfigureTest extends CakeTestCase {
 		Configure::write('SomeName', array('someKey' => 'myvalue', 'otherKey' => 'otherValue'));
 
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEqual($result, 'myvalue');
+		$this->assertEquals($result, 'myvalue');
 
 		$result = Configure::read('SomeName.otherKey');
-		$this->assertEqual($result, 'otherValue');
+		$this->assertEquals($result, 'otherValue');
 
 		Configure::delete('SomeName');
 
@@ -260,13 +260,13 @@ class ConfigureTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$expected = '/test_app/plugins/test_plugin/config/load.php';
 		$config = Configure::read('plugin_load');
-		$this->assertEqual($config, $expected);
+		$this->assertEquals($config, $expected);
 
 		$result = Configure::load('TestPlugin.more.load', 'test');
 		$this->assertTrue($result);
 		$expected = '/test_app/plugins/test_plugin/config/more.load.php';
 		$config = Configure::read('plugin_more_load');
-		$this->assertEqual($config, $expected);
+		$this->assertEquals($config, $expected);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Core/ObjectTest.php
+++ b/lib/Cake/Test/Case/Core/ObjectTest.php
@@ -325,21 +325,21 @@ class ObjectTest extends CakeTestCase {
 		$this->assertTrue($this->object->log('Test warning 1'));
 		$this->assertTrue($this->object->log(array('Test' => 'warning 2')));
 		$result = file(LOGS . 'error.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: Test warning 1$/', $result[0]);
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: Array$/', $result[1]);
-		$this->assertPattern('/^\($/', $result[2]);
-		$this->assertPattern('/\[Test\] => warning 2$/', $result[3]);
-		$this->assertPattern('/^\)$/', $result[4]);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: Test warning 1$/', $result[0]);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Error: Array$/', $result[1]);
+		$this->assertRegExp('/^\($/', $result[2]);
+		$this->assertRegExp('/\[Test\] => warning 2$/', $result[3]);
+		$this->assertRegExp('/^\)$/', $result[4]);
 		unlink(LOGS . 'error.log');
 
 		$this->assertTrue($this->object->log('Test warning 1', LOG_WARNING));
 		$this->assertTrue($this->object->log(array('Test' => 'warning 2'), LOG_WARNING));
 		$result = file(LOGS . 'error.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 1$/', $result[0]);
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Array$/', $result[1]);
-		$this->assertPattern('/^\($/', $result[2]);
-		$this->assertPattern('/\[Test\] => warning 2$/', $result[3]);
-		$this->assertPattern('/^\)$/', $result[4]);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 1$/', $result[0]);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Array$/', $result[1]);
+		$this->assertRegExp('/^\($/', $result[2]);
+		$this->assertRegExp('/\[Test\] => warning 2$/', $result[3]);
+		$this->assertRegExp('/^\)$/', $result[4]);
 		unlink(LOGS . 'error.log');
 	}
 
@@ -350,17 +350,17 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testSet() {
 		$this->object->set('a string');
-		$this->assertEqual($this->object->firstName, 'Joel');
+		$this->assertEquals($this->object->firstName, 'Joel');
 
 		$this->object->set(array('firstName'));
-		$this->assertEqual($this->object->firstName, 'Joel');
+		$this->assertEquals($this->object->firstName, 'Joel');
 
 		$this->object->set(array('firstName' => 'Ashley'));
-		$this->assertEqual($this->object->firstName, 'Ashley');
+		$this->assertEquals($this->object->firstName, 'Ashley');
 
 		$this->object->set(array('firstName' => 'Joel', 'lastName' => 'Moose'));
-		$this->assertEqual($this->object->firstName, 'Joel');
-		$this->assertEqual($this->object->lastName, 'Moose');
+		$this->assertEquals($this->object->firstName, 'Joel');
+		$this->assertEquals($this->object->lastName, 'Moose');
 	}
 
 /**
@@ -370,7 +370,7 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testToString() {
 		$result = strtolower($this->object->toString());
-		$this->assertEqual($result, 'testobject');
+		$this->assertEquals($result, 'testobject');
 	}
 
 /**
@@ -381,62 +381,62 @@ class ObjectTest extends CakeTestCase {
 	public function testMethodDispatching() {
 		$this->object->emptyMethod();
 		$expected = array('emptyMethod');
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->oneParamMethod('Hello');
 		$expected[] = array('oneParamMethod' => array('Hello'));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->twoParamMethod(true, false);
 		$expected[] = array('twoParamMethod' => array(true, false));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->threeParamMethod(true, false, null);
 		$expected[] = array('threeParamMethod' => array(true, false, null));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->crazyMethod(1, 2, 3, 4, 5, 6, 7);
 		$expected[] = array('crazyMethod' => array(1, 2, 3, 4, 5, 6, 7));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object = new TestObject();
-		$this->assertIdentical($this->object->methodCalls, array());
+		$this->assertSame($this->object->methodCalls, array());
 
 		$this->object->dispatchMethod('emptyMethod');
 		$expected = array('emptyMethod');
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('oneParamMethod', array('Hello'));
 		$expected[] = array('oneParamMethod' => array('Hello'));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('twoParamMethod', array(true, false));
 		$expected[] = array('twoParamMethod' => array(true, false));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('threeParamMethod', array(true, false, null));
 		$expected[] = array('threeParamMethod' => array(true, false, null));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('fourParamMethod', array(1, 2, 3, 4));
 		$expected[] = array('fourParamMethod' => array(1, 2, 3, 4));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('fiveParamMethod', array(1, 2, 3, 4, 5));
 		$expected[] = array('fiveParamMethod' => array(1, 2, 3, 4, 5));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('crazyMethod', array(1, 2, 3, 4, 5, 6, 7));
 		$expected[] = array('crazyMethod' => array(1, 2, 3, 4, 5, 6, 7));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('methodWithOptionalParam', array('Hello'));
 		$expected[] = array('methodWithOptionalParam' => array("Hello"));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 
 		$this->object->dispatchMethod('methodWithOptionalParam');
 		$expected[] = array('methodWithOptionalParam' => array(null));
-		$this->assertIdentical($this->object->methodCalls, $expected);
+		$this->assertSame($this->object->methodCalls, $expected);
 	}
 
 /**
@@ -457,26 +457,26 @@ class ObjectTest extends CakeTestCase {
 
 		$result = $this->object->requestAction('/request_action/test_request_action');
 		$expected = 'This is a test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/request_action/another_ra_test/2/5');
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/tests_apps/index', array('return'));
 		$expected = 'This is the TestsAppsController index view ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/tests_apps/some_method');
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/request_action/paginate_request_action');
 		$this->assertTrue($result);
 
 		$result = $this->object->requestAction('/request_action/normal_request_action');
 		$expected = 'Hello World';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertNull(Router::getRequest(), 'requests were not popped off the stack, this will break url generation');
 	}
@@ -495,27 +495,27 @@ class ObjectTest extends CakeTestCase {
 
 		$result = $this->object->requestAction('/test_plugin/tests/index', array('return'));
 		$expected = 'test plugin index';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/test_plugin/tests/index/some_param', array('return'));
 		$expected = 'test plugin index';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'tests', 'action' => 'index', 'plugin' => 'test_plugin'), array('return')
 		);
 		$expected = 'test plugin index';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/test_plugin/tests/some_method');
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'tests', 'action' => 'some_method', 'plugin' => 'test_plugin')
 		);
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -536,30 +536,30 @@ class ObjectTest extends CakeTestCase {
 			array('controller' => 'request_action', 'action' => 'test_request_action')
 		);
 		$expected = 'This is a test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'another_ra_test'),
 			array('pass' => array('5', '7'))
 		);
 		$expected = 12;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'tests_apps', 'action' => 'index'), array('return')
 		);
 		$expected = 'This is the TestsAppsController index view ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(array('controller' => 'tests_apps', 'action' => 'some_method'));
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'normal_request_action')
 		);
 		$expected = 'Hello World';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'paginate_request_action')
@@ -592,20 +592,20 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testRequestActionParamParseAndPass() {
 		$result = $this->object->requestAction('/request_action/params_pass');
-		$this->assertEqual($result->url, 'request_action/params_pass');
-		$this->assertEqual($result['controller'], 'request_action');
-		$this->assertEqual($result['action'], 'params_pass');
-		$this->assertEqual($result['plugin'], null);
+		$this->assertEquals($result->url, 'request_action/params_pass');
+		$this->assertEquals($result['controller'], 'request_action');
+		$this->assertEquals($result['action'], 'params_pass');
+		$this->assertEquals($result['plugin'], null);
 
 		$result = $this->object->requestAction('/request_action/params_pass/sort:desc/limit:5');
 		$expected = array('sort' => 'desc', 'limit' => 5,);
-		$this->assertEqual($result['named'], $expected);
+		$this->assertEquals($result['named'], $expected);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'params_pass'),
 			array('named' => array('sort' => 'desc', 'limit' => 5))
 		);
-		$this->assertEqual($result['named'], $expected);
+		$this->assertEquals($result['named'], $expected);
 	}
 
 /**
@@ -629,11 +629,11 @@ class ObjectTest extends CakeTestCase {
 			array('data' => $_POST['data'])
 		);
 		$expected = $_POST['data'];
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/request_action/post_pass');
 		$expected = $_POST['data'];
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$_POST = $_tmp;
 	}

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -77,9 +77,9 @@ class ErrorHandlerTest extends CakeTestCase {
 		$wrong .= '';
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<pre class="cake-error">/', $result);
-		$this->assertPattern('/<b>Notice<\/b>/', $result);
-		$this->assertPattern('/variable:\s+wrong/', $result);
+		$this->assertRegExp('/<pre class="cake-error">/', $result);
+		$this->assertRegExp('/<b>Notice<\/b>/', $result);
+		$this->assertRegExp('/variable:\s+wrong/', $result);
 	}
 
 /**
@@ -109,7 +109,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		trigger_error('Test error', $error);
 
 		$result = ob_get_clean();
-		$this->assertPattern('/<b>' . $expected . '<\/b>/', $result);
+		$this->assertRegExp('/<b>' . $expected . '<\/b>/', $result);
 	}
 
 /**
@@ -145,8 +145,8 @@ class ErrorHandlerTest extends CakeTestCase {
 		$out .= '';
 
 		$result = file(LOGS . 'debug.log');
-		$this->assertEqual(count($result), 1);
-		$this->assertPattern(
+		$this->assertEquals(count($result), 1);
+		$this->assertRegExp(
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (Notice|Debug): Notice \(8\): Undefined variable:\s+out in \[.+ line \d+\]$/',
 			$result[0]
 		);
@@ -171,12 +171,12 @@ class ErrorHandlerTest extends CakeTestCase {
 		$out .= '';
 
 		$result = file(LOGS . 'debug.log');
-		$this->assertPattern(
+		$this->assertRegExp(
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (Notice|Debug): Notice \(8\): Undefined variable:\s+out in \[.+ line \d+\]$/',
 			$result[0]
 		);
-		$this->assertPattern('/^Trace:/', $result[1]);
-		$this->assertPattern('/^ErrorHandlerTest\:\:testHandleErrorLoggingTrace\(\)/', $result[2]);
+		$this->assertRegExp('/^Trace:/', $result[1]);
+		$this->assertRegExp('/^ErrorHandlerTest\:\:testHandleErrorLoggingTrace\(\)/', $result[2]);
 		@unlink(LOGS . 'debug.log');
 	}
 
@@ -192,7 +192,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		ob_start();
 		ErrorHandler::handleException($error);
 		$result = ob_get_clean();
-		$this->assertPattern('/Kaboom!/', $result, 'message missing.');
+		$this->assertRegExp('/Kaboom!/', $result, 'message missing.');
 	}
 
 /**
@@ -212,11 +212,11 @@ class ErrorHandlerTest extends CakeTestCase {
 		ob_start();
 		ErrorHandler::handleException($error);
 		$result = ob_get_clean();
-		$this->assertPattern('/Kaboom!/', $result, 'message missing.');
+		$this->assertRegExp('/Kaboom!/', $result, 'message missing.');
 
 		$log = file(LOGS . 'error.log');
-		$this->assertPattern('/\[NotFoundException\] Kaboom!/', $log[0], 'message missing.');
-		$this->assertPattern('/\#0.*ErrorHandlerTest->testHandleExceptionLog/', $log[1], 'Stack trace missing.');
+		$this->assertRegExp('/\[NotFoundException\] Kaboom!/', $log[0], 'message missing.');
+		$this->assertRegExp('/\#0.*ErrorHandlerTest->testHandleExceptionLog/', $log[1], 'Stack trace missing.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -203,7 +203,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertEqual($result, 'widget thing is missing');
+		$this->assertEquals($result, 'widget thing is missing');
 	}
 
 /**
@@ -216,13 +216,13 @@ class ExceptionRendererTest extends CakeTestCase {
 		$exception = new MissingWidgetThingException('Widget not found');
 		$ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
 
-		$this->assertEqual('missingWidgetThing', $ExceptionRenderer->method);
+		$this->assertEquals('missingWidgetThing', $ExceptionRenderer->method);
 
 		ob_start();
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertEqual($result, 'widget thing is missing', 'Method declared in subclass converted to error400');
+		$this->assertEquals($result, 'widget thing is missing', 'Method declared in subclass converted to error400');
 	}
 
 /**
@@ -236,13 +236,13 @@ class ExceptionRendererTest extends CakeTestCase {
 		$exception = new MissingControllerException('PostsController');
 		$ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
 
-		$this->assertEqual('error400', $ExceptionRenderer->method);
+		$this->assertEquals('error400', $ExceptionRenderer->method);
 
 		ob_start();
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/Not Found/', $result, 'Method declared in error handler not converted to error400. %s');
+		$this->assertRegExp('/Not Found/', $result, 'Method declared in error handler not converted to error400. %s');
 	}
 
 /**
@@ -378,8 +378,8 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>Custom message<\/h2>/', $result);
-		$this->assertPattern("/<strong>'.*?\/posts\/view\/1000'<\/strong>/", $result);
+		$this->assertRegExp('/<h2>Custom message<\/h2>/', $result);
+		$this->assertRegExp("/<strong>'.*?\/posts\/view\/1000'<\/strong>/", $result);
 	}
 
 /**
@@ -424,8 +424,8 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertNoPattern('#<script>document#', $result);
-		$this->assertNoPattern('#alert\(t\);</script>#', $result);
+		$this->assertNotRegExp('#<script>document#', $result);
+		$this->assertNotRegExp('#alert\(t\);</script>#', $result);
 	}
 
 /**
@@ -443,7 +443,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>An Internal Error Has Occurred<\/h2>/', $result);
+		$this->assertRegExp('/<h2>An Internal Error Has Occurred<\/h2>/', $result);
 	}
 
 /**
@@ -459,8 +459,8 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>Missing Controller<\/h2>/', $result);
-		$this->assertPattern('/<em>PostsController<\/em>/', $result);
+		$this->assertRegExp('/<h2>Missing Controller<\/h2>/', $result);
+		$this->assertRegExp('/<em>PostsController<\/em>/', $result);
 	}
 
 /**
@@ -614,7 +614,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$result = ob_get_clean();
 
 		foreach ($patterns as $pattern) {
-			$this->assertPattern($pattern, $result);
+			$this->assertRegExp($pattern, $result);
 		}
 	}
 
@@ -687,9 +687,9 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>Database Error<\/h2>/', $result);
-		$this->assertPattern('/There was an error in the SQL query/', $result);
-		$this->assertPattern('/SELECT \* from poo_query < 5 and :seven/', $result);
-		$this->assertPattern('/"seven" => 7/', $result);
+		$this->assertRegExp('/<h2>Database Error<\/h2>/', $result);
+		$this->assertRegExp('/There was an error in the SQL query/', $result);
+		$this->assertRegExp('/SELECT \* from poo_query < 5 and :seven/', $result);
+		$this->assertRegExp('/"seven" => 7/', $result);
 	}
 }

--- a/lib/Cake/Test/Case/I18n/I18nTest.php
+++ b/lib/Cake/Test/Case/I18n/I18nTest.php
@@ -2358,7 +2358,7 @@ class I18nTest extends CakeTestCase {
 		$this->assertEqual('Po (translated)', $singular);
 
 		$coreSingular = $this->__singularFromCore();
-		$this->assertNotEqual('Po (from core translated)', $coreSingular);
+		$this->assertNotEquals('Po (from core translated)', $coreSingular);
 
 		$corePlurals = $this->__pluralFromCore();
 		$this->assertFalse(in_array('0 everything else (from core translated)', $corePlurals));

--- a/lib/Cake/Test/Case/I18n/MultibyteTest.php
+++ b/lib/Cake/Test/Case/I18n/MultibyteTest.php
@@ -37,13 +37,13 @@ class MultibyteTest extends CakeTestCase {
 								58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82,
 								83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
 								106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = Multibyte::utf8($string);
 		$expected = array(161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
 								182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = Multibyte::utf8($string);
@@ -52,7 +52,7 @@ class MultibyteTest extends CakeTestCase {
 								243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263,
 								264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284,
 								285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = Multibyte::utf8($string);
@@ -61,7 +61,7 @@ class MultibyteTest extends CakeTestCase {
 								343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363,
 								364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384,
 								385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = Multibyte::utf8($string);
@@ -70,7 +70,7 @@ class MultibyteTest extends CakeTestCase {
 								443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463,
 								464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484,
 								485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = Multibyte::utf8($string);
@@ -79,30 +79,30 @@ class MultibyteTest extends CakeTestCase {
 								643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663,
 								664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684,
 								685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = Multibyte::utf8($string);
 		$expected = array(1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
 								1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = Multibyte::utf8($string);
 		$expected = array(1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
 								1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
 								1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'չպջռսվտ';
 		$result = Multibyte::utf8($string);
 		$expected = array(1401, 1402, 1403, 1404, 1405, 1406, 1407);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = Multibyte::utf8($string);
 		$expected = array(1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = Multibyte::utf8($string);
@@ -110,7 +110,7 @@ class MultibyteTest extends CakeTestCase {
 								10045, 10046, 10047, 10048, 10049, 10050, 10051, 10052, 10053, 10054, 10055, 10056, 10057,
 								10058, 10059, 10060, 10061, 10062, 10063, 10064, 10065, 10066, 10067, 10068, 10069, 10070,
 								10071, 10072, 10073, 10074, 10075, 10076, 10077, 10078);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = Multibyte::utf8($string);
@@ -120,7 +120,7 @@ class MultibyteTest extends CakeTestCase {
 								11953, 11954, 11955, 11956, 11957, 11958, 11959, 11960, 11961, 11962, 11963, 11964, 11965, 11966, 11967, 11968,
 								11969, 11970, 11971, 11972, 11973, 11974, 11975, 11976, 11977, 11978, 11979, 11980, 11981, 11982, 11983, 11984,
 								11985, 11986, 11987, 11988, 11989, 11990, 11991, 11992, 11993, 11994, 11995, 11996, 11997, 11998, 11999, 12000);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = Multibyte::utf8($string);
@@ -128,7 +128,7 @@ class MultibyteTest extends CakeTestCase {
 								12117, 12118, 12119, 12120, 12121, 12122, 12123, 12124, 12125, 12126, 12127, 12128, 12129, 12130, 12131, 12132,
 								12133, 12134, 12135, 12136, 12137, 12138, 12139, 12140, 12141, 12142, 12143, 12144, 12145, 12146, 12147, 12148,
 								12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = Multibyte::utf8($string);
@@ -139,7 +139,7 @@ class MultibyteTest extends CakeTestCase {
 								45665, 45666, 45667, 45668, 45669, 45670, 45671, 45672, 45673, 45674, 45675, 45676, 45677, 45678, 45679, 45680,
 								45681, 45682, 45683, 45684, 45685, 45686, 45687, 45688, 45689, 45690, 45691, 45692, 45693, 45694, 45695, 45696,
 								45697, 45698, 45699, 45700);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = Multibyte::utf8($string);
@@ -148,7 +148,7 @@ class MultibyteTest extends CakeTestCase {
 								65168, 65169, 65170, 65171, 65172, 65173, 65174, 65175, 65176, 65177, 65178, 65179, 65180, 65181, 65182, 65183,
 								65184, 65185, 65186, 65187, 65188, 65189, 65190, 65191, 65192, 65193, 65194, 65195, 65196, 65197, 65198, 65199,
 								65200);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = Multibyte::utf8($string);
@@ -157,104 +157,104 @@ class MultibyteTest extends CakeTestCase {
 								65233, 65234, 65235, 65236, 65237, 65238, 65239, 65240, 65241, 65242, 65243, 65244, 65245, 65246, 65247, 65248,
 								65249, 65250, 65251, 65252, 65253, 65254, 65255, 65256, 65257, 65258, 65259, 65260, 65261, 65262, 65263, 65264,
 								65265, 65266, 65267, 65268, 65269, 65270, 65271, 65272, 65273, 65274, 65275, 65276);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = Multibyte::utf8($string);
 		$expected = array(65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
 								65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = Multibyte::utf8($string);
 		$expected = array(65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
 								65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = Multibyte::utf8($string);
 		$expected = array(65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
 								65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
 								65433, 65434, 65435, 65436, 65437, 65438);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::utf8($string);
 		$expected = array(292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = Multibyte::utf8($string);
 		$expected = array(72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¨';
 		$result = Multibyte::utf8($string);
 		$expected = array(168);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¿';
 		$result = Multibyte::utf8($string);
 		$expected = array(191);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$result = Multibyte::utf8($string);
 		$expected = array(269, 105, 110, 105);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = Multibyte::utf8($string);
 		$expected = array(109, 111, 263, 105);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = Multibyte::utf8($string);
 		$expected = array(100, 114, 382, 97, 118, 110, 105);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = Multibyte::utf8($string);
 		$expected = array(25226, 30334, 24230, 35774, 20026, 39318, 39029);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::utf8($string);
 		$expected = array(19968, 20108, 19977, 21608, 27704, 40845);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԀԂԄԆԈԊԌԎԐԒ';
 		$result = Multibyte::utf8($string);
 		$expected = array(1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԁԃԅԇԉԋԍԏԐԒ';
 		$result = Multibyte::utf8($string);
 		$expected = array(1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
 		$result = Multibyte::utf8($string);
 		$expected = array(1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346,
 								1347, 1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364,
 								1365, 1366, 1415);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
 		$result = Multibyte::utf8($string);
 		$expected = array(1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
 								1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
 								1413, 1414, 1415);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
 		$result = Multibyte::utf8($string);
 		$expected = array(4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273,
 								4274, 4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291,
 								4292, 4293);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
 		$result = Multibyte::utf8($string);
@@ -265,7 +265,7 @@ class MultibyteTest extends CakeTestCase {
 								7824, 7826, 7828, 7830, 7831, 7832, 7833, 7834,       7840, 7842, 7844, 7846, 7848, 7850, 7852, 7854, 7856,
 								7858, 7860, 7862, 7864, 7866, 7868, 7870, 7872, 7874, 7876, 7878, 7880, 7882, 7884, 7886, 7888, 7890, 7892,
 								7894, 7896, 7898, 7900, 7902, 7904, 7906, 7908, 7910, 7912, 7914, 7916, 7918, 7920, 7922, 7924, 7926,  7928);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
 		$result = Multibyte::utf8($string);
@@ -276,39 +276,39 @@ class MultibyteTest extends CakeTestCase {
 									7825, 7827, 7829, 7830, 7831, 7832, 7833, 7834, 7841, 7843, 7845, 7847, 7849, 7851, 7853, 7855, 7857, 7859,
 									7861, 7863, 7865, 7867, 7869, 7871, 7873, 7875, 7877, 7879, 7881, 7883, 7885, 7887, 7889, 7891, 7893, 7895,
 									7897, 7899, 7901, 7903, 7905, 7907, 7909, 7911, 7913, 7915, 7917, 7919, 7921, 7923, 7925, 7927, 7929);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅℲ';
 		$result = Multibyte::utf8($string);
 		$expected = array(8486, 8490, 8491, 8498);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ωkåⅎ';
 		$result = Multibyte::utf8($string);
 		$expected = array(969, 107, 229, 8526);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
 		$result = Multibyte::utf8($string);
 		$expected = array(8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
 		$result = Multibyte::utf8($string);
 		$expected = array(8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
 		$result = Multibyte::utf8($string);
 		$expected = array(9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
 								9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
 		$result = Multibyte::utf8($string);
 		$expected = array(9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
 								9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
 		$result = Multibyte::utf8($string);
@@ -316,14 +316,14 @@ class MultibyteTest extends CakeTestCase {
 								11279, 11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293,
 								11294, 11295, 11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308,
 								11309, 11310);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
 		$result = Multibyte::utf8($string);
 		$expected = array(11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
 								11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
 								11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
 		$result = Multibyte::utf8($string);
@@ -331,7 +331,7 @@ class MultibyteTest extends CakeTestCase {
 									11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
 									11452, 11454, 11456, 11458, 11460, 11462, 11464, 11466, 11468, 11470, 11472, 11474, 11476, 11478, 11480,
 									11482, 11484, 11486, 11488, 11490);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
 		$result = Multibyte::utf8($string);
@@ -339,13 +339,13 @@ class MultibyteTest extends CakeTestCase {
 								11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
 								11457, 11459, 11461, 11463, 11465, 11467, 11469, 11471, 11473, 11475, 11477, 11479, 11481, 11483, 11485, 11487,
 								11489, 11491);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = Multibyte::utf8($string);
 		$expected = array(64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -361,14 +361,14 @@ class MultibyteTest extends CakeTestCase {
 		$result = Multibyte::ascii($utf8);
 
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181,
 								182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200);
 		$result = Multibyte::ascii($utf8);
 
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221,
 								222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242,
@@ -377,7 +377,7 @@ class MultibyteTest extends CakeTestCase {
 								285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
 								322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342,
@@ -386,7 +386,7 @@ class MultibyteTest extends CakeTestCase {
 								385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421,
 								422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442,
@@ -395,7 +395,7 @@ class MultibyteTest extends CakeTestCase {
 								485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621,
 								622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642,
@@ -404,30 +404,30 @@ class MultibyteTest extends CakeTestCase {
 								685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041,
 								1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051);
 		$expected = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069,
 								1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087,
 								1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100);
 		$expected = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1401, 1402, 1403, 1404, 1405, 1406, 1407);
 		$expected = 'չպջռսվտ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610, 1611, 1612, 1613, 1614, 1615);
 		$expected = 'فقكلمنهوىيًٌٍَُ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(10032, 10033, 10034, 10035, 10036, 10037, 10038, 10039, 10040, 10041, 10042, 10043, 10044,
 								10045, 10046, 10047, 10048, 10049, 10050, 10051, 10052, 10053, 10054, 10055, 10056, 10057,
@@ -435,7 +435,7 @@ class MultibyteTest extends CakeTestCase {
 								10071, 10072, 10073, 10074, 10075, 10076, 10077, 10078);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(11904, 11905, 11906, 11907, 11908, 11909, 11910, 11911, 11912, 11913, 11914, 11915, 11916, 11917, 11918, 11919,
 								11920, 11921, 11922, 11923, 11924, 11925, 11926, 11927, 11928, 11929, 11931, 11932, 11933, 11934, 11935, 11936,
@@ -445,7 +445,7 @@ class MultibyteTest extends CakeTestCase {
 								11985, 11986, 11987, 11988, 11989, 11990, 11991, 11992, 11993, 11994, 11995, 11996, 11997, 11998, 11999, 12000);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(12101, 12102, 12103, 12104, 12105, 12106, 12107, 12108, 12109, 12110, 12111, 12112, 12113, 12114, 12115, 12116,
 								12117, 12118, 12119, 12120, 12121, 12122, 12123, 12124, 12125, 12126, 12127, 12128, 12129, 12130, 12131, 12132,
@@ -453,7 +453,7 @@ class MultibyteTest extends CakeTestCase {
 								12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(45601, 45602, 45603, 45604, 45605, 45606, 45607, 45608, 45609, 45610, 45611, 45612, 45613, 45614, 45615, 45616,
 								45617, 45618, 45619, 45620, 45621, 45622, 45623, 45624, 45625, 45626, 45627, 45628, 45629, 45630, 45631, 45632,
@@ -464,7 +464,7 @@ class MultibyteTest extends CakeTestCase {
 								45697, 45698, 45699, 45700);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(65136, 65137, 65138, 65139, 65140, 65141, 65142, 65143, 65144, 65145, 65146, 65147, 65148, 65149, 65150, 65151,
 								65152, 65153, 65154, 65155, 65156, 65157, 65158, 65159, 65160, 65161, 65162, 65163, 65164, 65165, 65166, 65167,
@@ -473,7 +473,7 @@ class MultibyteTest extends CakeTestCase {
 								65200);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(65201, 65202, 65203, 65204, 65205, 65206, 65207, 65208, 65209, 65210, 65211, 65212, 65213, 65214, 65215, 65216,
 								65217, 65218, 65219, 65220, 65221, 65222, 65223, 65224, 65225, 65226, 65227, 65228, 65229, 65230, 65231, 65232,
@@ -482,101 +482,101 @@ class MultibyteTest extends CakeTestCase {
 								65265, 65266, 65267, 65268, 65269, 65270, 65271, 65272, 65273, 65274, 65275, 65276);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(65345, 65346, 65347, 65348, 65349, 65350, 65351, 65352, 65353, 65354, 65355, 65356, 65357, 65358, 65359, 65360,
 								65361, 65362, 65363, 65364, 65365, 65366, 65367, 65368, 65369, 65370);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(65377, 65378, 65379, 65380, 65381, 65382, 65383, 65384, 65385, 65386, 65387, 65388, 65389, 65390, 65391, 65392,
 								65393, 65394, 65395, 65396, 65397, 65398, 65399, 65400);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(65401, 65402, 65403, 65404, 65405, 65406, 65407, 65408, 65409, 65410, 65411, 65412, 65413, 65414, 65415, 65416,
 								65417, 65418, 65419, 65420, 65421, 65422, 65423, 65424, 65425, 65426, 65427, 65428, 65429, 65430, 65431, 65432,
 								65433, 65434, 65435, 65436, 65437, 65438);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(292, 275, 314, 316, 335, 44, 32, 372, 337, 345, 316, 271, 33);
 		$expected = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33);
 		$expected = 'Hello, World!';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(168);
 		$expected = '¨';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(191);
 		$expected = '¿';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(269, 105, 110, 105);
 		$expected = 'čini';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(109, 111, 263, 105);
 		$expected = 'moći';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(100, 114, 382, 97, 118, 110, 105);
 		$expected = 'državni';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(25226, 30334, 24230, 35774, 20026, 39318, 39029);
 		$expected = '把百度设为首页';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(19968, 20108, 19977, 21608, 27704, 40845);
 		$expected = '一二三周永龍';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1280, 1282, 1284, 1286, 1288, 1290, 1292, 1294, 1296, 1298);
 		$expected = 'ԀԂԄԆԈԊԌԎԐԒ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1281, 1283, 1285, 1287, 1289, 1291, 1293, 1295, 1296, 1298);
 		$expected = 'ԁԃԅԇԉԋԍԏԐԒ';
 		$result = Multibyte::ascii($utf8);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1338, 1339, 1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347,
 							1348, 1349, 1350, 1351, 1352, 1353, 1354, 1355, 1356, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365,
 							1366, 1415);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(1377, 1378, 1379, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394,
 								1395, 1396, 1397, 1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405, 1406, 1407, 1408, 1409, 1410, 1411, 1412,
 								1413, 1414, 1415);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(4256, 4257, 4258, 4259, 4260, 4261, 4262, 4263, 4264, 4265, 4266, 4267, 4268, 4269, 4270, 4271, 4272, 4273, 4274,
 							4275, 4276, 4277, 4278, 4279, 4280, 4281, 4282, 4283, 4284, 4285, 4286, 4287, 4288, 4289, 4290, 4291, 4292, 4293);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(7680, 7682, 7684, 7686, 7688, 7690, 7692, 7694, 7696, 7698, 7700, 7702, 7704, 7706, 7708, 7710, 7712, 7714,
 								7716, 7718, 7720, 7722, 7724, 7726, 7728, 7730, 7732, 7734, 7736, 7738, 7740, 7742, 7744, 7746, 7748, 7750,
@@ -587,7 +587,7 @@ class MultibyteTest extends CakeTestCase {
 								7894, 7896, 7898, 7900, 7902, 7904, 7906, 7908, 7910, 7912, 7914, 7916, 7918, 7920, 7922, 7924, 7926,  7928);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(7681, 7683, 7685, 7687, 7689, 7691, 7693, 7695, 7697, 7699, 7701, 7703, 7705, 7707, 7709, 7711, 7713, 7715,
 							7717, 7719, 7721, 7723, 7725, 7727, 7729, 7731, 7733, 7735, 7737, 7739, 7741, 7743, 7745, 7747, 7749, 7751,
@@ -598,53 +598,53 @@ class MultibyteTest extends CakeTestCase {
 							7897, 7899, 7901, 7903, 7905, 7907, 7909, 7911, 7913, 7915, 7917, 7919, 7921, 7923, 7925, 7927, 7929);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(8486, 8490, 8491, 8498);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ΩKÅℲ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(969, 107, 229, 8526);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ωkåⅎ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(8544, 8545, 8546, 8547, 8548, 8549, 8550, 8551, 8552, 8553, 8554, 8555, 8556, 8557, 8558, 8559, 8579);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(8560, 8561, 8562, 8563, 8564, 8565, 8566, 8567, 8568, 8569, 8570, 8571, 8572, 8573, 8574, 8575, 8580);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(9398, 9399, 9400, 9401, 9402, 9403, 9404, 9405, 9406, 9407, 9408, 9409, 9410, 9411, 9412, 9413, 9414,
 							9415, 9416, 9417, 9418, 9419, 9420, 9421, 9422, 9423);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(9424, 9425, 9426, 9427, 9428, 9429, 9430, 9431, 9432, 9433, 9434, 9435, 9436, 9437, 9438, 9439, 9440, 9441,
 							9442, 9443, 9444, 9445, 9446, 9447, 9448, 9449);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(11264, 11265, 11266, 11267, 11268, 11269, 11270, 11271, 11272, 11273, 11274, 11275, 11276, 11277, 11278, 11279,
 							11280, 11281, 11282, 11283, 11284, 11285, 11286, 11287, 11288, 11289, 11290, 11291, 11292, 11293, 11294, 11295,
 							11296, 11297, 11298, 11299, 11300, 11301, 11302, 11303, 11304, 11305, 11306, 11307, 11308, 11309, 11310);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(11312, 11313, 11314, 11315, 11316, 11317, 11318, 11319, 11320, 11321, 11322, 11323, 11324, 11325, 11326, 11327,
 							11328, 11329, 11330, 11331, 11332, 11333, 11334, 11335, 11336, 11337, 11338, 11339, 11340, 11341, 11342, 11343,
 							11344, 11345, 11346, 11347, 11348, 11349, 11350, 11351, 11352, 11353, 11354, 11355, 11356, 11357, 11358);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(11392, 11394, 11396, 11398, 11400, 11402, 11404, 11406, 11408, 11410, 11412, 11414, 11416, 11418, 11420,
 									11422, 11424, 11426, 11428, 11430, 11432, 11434, 11436, 11438, 11440, 11442, 11444, 11446, 11448, 11450,
@@ -652,7 +652,7 @@ class MultibyteTest extends CakeTestCase {
 									11482, 11484, 11486, 11488, 11490);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(11393, 11395, 11397, 11399, 11401, 11403, 11405, 11407, 11409, 11411, 11413, 11415, 11417, 11419, 11421, 11423,
 							11425, 11427, 11429, 11431, 11433, 11435, 11437, 11439, 11441, 11443, 11445, 11447, 11449, 11451, 11453, 11455,
@@ -660,12 +660,12 @@ class MultibyteTest extends CakeTestCase {
 							11489, 11491);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$utf8 = array(64256, 64257, 64258, 64259, 64260, 64261, 64262, 64275, 64276, 64277, 64278, 64279);
 		$result = Multibyte::ascii($utf8);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -678,241 +678,241 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'f';
 		$result = mb_stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'f';
 		$result = mb_stripos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = mb_stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = mb_stripos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = mb_stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = mb_stripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = mb_stripos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = mb_stripos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'É';
 		$result = mb_stripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_stripos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_stripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_stripos($string, $find, 40);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = mb_stripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = mb_stripos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_stripos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_stripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_stripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_stripos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_stripos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_stripos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_stripos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_stripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = mb_stripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_stripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_stripos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_stripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = mb_stripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = mb_stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = mb_stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_stripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_stripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'DŽ';
 		$result = mb_stripos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -925,241 +925,241 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'f';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'f';
 		$result = Multibyte::stripos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = Multibyte::stripos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = Multibyte::stripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'É';
 		$result = Multibyte::stripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::stripos($string, $find, 40);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::stripos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::stripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'DŽ';
 		$result = Multibyte::stripos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1172,384 +1172,384 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'f';
 		$result = mb_stristr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'f';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = mb_stristr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = mb_stristr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = mb_stristr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = mb_stristr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = mb_stristr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'þ';
 		$result = mb_stristr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'þ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = mb_stristr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_stristr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_stristr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_stristr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_stristr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_stristr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_stristr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_stristr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_stristr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_stristr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_stristr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_stristr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_stristr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = mb_stristr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'Ĥē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = mb_stristr($string, $find);
 		$expected = 'o, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'Hell';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_stristr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_stristr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_stristr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = mb_stristr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = mb_stristr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = mb_stristr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = mb_stristr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_stristr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_stristr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_stristr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_stristr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '二周';
 		$result = mb_stristr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1562,384 +1562,384 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'f';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'f';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'å';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'ċ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'f';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'Μ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'þ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'þ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'Ʀ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'ї';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'Ő';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'Ĥē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'o, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'O';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'Hell';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'N';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'Ć';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = Multibyte::stristr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'Ž';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::stristr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::stristr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '二周';
 		$result = Multibyte::stristr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1951,142 +1951,142 @@ class MultibyteTest extends CakeTestCase {
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = mb_strlen($string);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = mb_strlen($string);
 		$expected = 30;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$result = mb_strlen($string);
 		$expected = 61;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = mb_strlen($string);
 		$expected = 94;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = mb_strlen($string);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = mb_strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = mb_strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = mb_strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = mb_strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = mb_strlen($string);
 		$expected = 28;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = mb_strlen($string);
 		$expected = 49;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = mb_strlen($string);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = mb_strlen($string);
 		$expected = 47;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = mb_strlen($string);
 		$expected = 96;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = mb_strlen($string);
 		$expected = 59;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = mb_strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = mb_strlen($string);
 		$expected = 65;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = mb_strlen($string);
 		$expected = 76;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = mb_strlen($string);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = mb_strlen($string);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = mb_strlen($string);
 		$expected = 38;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = mb_strlen($string);
 		$expected = 13;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = mb_strlen($string);
 		$expected = 13;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$result = mb_strlen($string);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = mb_strlen($string);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = mb_strlen($string);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = mb_strlen($string);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = mb_strlen($string);
 		$expected = 6;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2098,142 +2098,142 @@ class MultibyteTest extends CakeTestCase {
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = Multibyte::strlen($string);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = Multibyte::strlen($string);
 		$expected = 30;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$result = Multibyte::strlen($string);
 		$expected = 61;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = Multibyte::strlen($string);
 		$expected = 94;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = Multibyte::strlen($string);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = Multibyte::strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = Multibyte::strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = Multibyte::strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = Multibyte::strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = Multibyte::strlen($string);
 		$expected = 28;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = Multibyte::strlen($string);
 		$expected = 49;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = Multibyte::strlen($string);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = Multibyte::strlen($string);
 		$expected = 47;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = Multibyte::strlen($string);
 		$expected = 96;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = Multibyte::strlen($string);
 		$expected = 59;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = Multibyte::strlen($string);
 		$expected = 100;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = Multibyte::strlen($string);
 		$expected = 65;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = Multibyte::strlen($string);
 		$expected = 76;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = Multibyte::strlen($string);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = Multibyte::strlen($string);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = Multibyte::strlen($string);
 		$expected = 38;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::strlen($string);
 		$expected = 13;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = Multibyte::strlen($string);
 		$expected = 13;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$result = Multibyte::strlen($string);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = Multibyte::strlen($string);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = Multibyte::strlen($string);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = Multibyte::strlen($string);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::strlen($string);
 		$expected = 6;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2246,241 +2246,241 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strpos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strpos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strpos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strpos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strpos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = mb_strpos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strpos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = mb_strpos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strpos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = mb_strpos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strpos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strpos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strpos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strpos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strpos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'őř';
 		$result = mb_strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strpos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '一周';
 		$result = mb_strpos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2493,241 +2493,241 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strpos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strpos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strpos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = Multibyte::strpos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'őř';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strpos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '一周';
 		$result = Multibyte::strpos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2740,378 +2740,378 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strrchr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strrchr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strrchr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strrchr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strrchr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strrchr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strrchr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strrchr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrchr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrchr($string, $find);
 		$expected = 'orld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'Hello, W';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strrchr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strrchr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strrchr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrchr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strrchr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strrchr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strrchr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strrchr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strrchr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周龍';
 		$result = mb_strrchr($string, $find, true);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3124,378 +3124,378 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'orld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'Hello, W';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strrchr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周龍';
 		$result = Multibyte::strrchr($string, $find, true);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3508,378 +3508,378 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strrichr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strrichr($string, $find);
 		$expected = 'fghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcde';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'þÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strrichr($string, $find);
 		$expected = 'рстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмноп';
 		$find = 'Р';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strrichr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strrichr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strrichr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strrichr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strrichr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrichr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrichr($string, $find);
 		$expected = 'orld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'Hello, W';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strrichr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strrichr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strrichr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrichr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strrichr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strrichr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strrichr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strrichr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strrichr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '百设';
 		$result = mb_strrichr($string, $find, true);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3892,378 +3892,378 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'fghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcde';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'þÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'рстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмноп';
 		$find = 'Р';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'orld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'Hello, W';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strrichr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '百设';
 		$result = Multibyte::strrichr($string, $find, true);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4276,241 +4276,241 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strripos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strripos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'ÓÔ';
 		$result = mb_strripos($string, $find);
 		$expected = 19;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strripos($string, $find);
 		$expected = 69;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strripos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = mb_strripos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strripos($string, $find);
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strripos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = mb_strripos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strripos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strripos($string, $find);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = mb_strripos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strripos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strripos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strripos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strripos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐ';
 		$result = mb_strripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strripos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strripos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'dž';
@@ -4528,247 +4528,247 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strripos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strripos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'ÓÔ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 19;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strripos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 69;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = Multibyte::strripos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strripos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'dž';
 		$result = Multibyte::strripos($string, $find);
 		$expected = 0;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4783,247 +4783,247 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strrpos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'ÙÚ';
 		$result = mb_strrpos($string, $find);
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strrpos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strrpos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strrpos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strrpos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = mb_strrpos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strrpos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strrpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = mb_strrpos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strrpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strrpos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strrpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = mb_strrpos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strrpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strrpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strrpos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strrpos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strrpos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strrpos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strrpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐ';
 		$result = mb_strrpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strrpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strrpos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strrpos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strrpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strrpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'H';
 		$result = mb_strrpos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5036,247 +5036,247 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strrpos($string, $find, 6);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strrpos($string, $find, 6);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞ';
 		$find = 'ÙÚ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 25;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strrpos($string, $find, 6);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 37;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 20;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'é';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 32;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 24;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 40;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 39;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'р';
 		$result = Multibyte::strrpos($string, $find, 5);
 		$expected = 36;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 31;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 26;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 46;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 45;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 10;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 16;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 17;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strrpos($string, $find, 5);
 		$expected = 8;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'H';
 		$result = Multibyte::strrpos($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5289,390 +5289,390 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = mb_strstr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strstr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strstr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = mb_strstr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strstr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = mb_strstr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strstr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strstr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strstr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strstr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strstr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_strstr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strstr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_strstr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strstr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_strstr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strstr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = mb_strstr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = mb_strstr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_strstr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strstr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strstr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'Ĥē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strstr($string, $find);
 		$expected = 'o, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'Hell';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strstr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strstr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strstr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strstr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strstr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strstr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_strstr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strstr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_strstr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strstr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_strstr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '二周';
 		$result = mb_strstr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5685,390 +5685,390 @@ class MultibyteTest extends CakeTestCase {
 		$find = 'F';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ0123456789';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$find = 'F';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ÀÁÂÃÄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ĀĂĄĆĈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$find = 'µ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'Þßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$find = 'Þ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'Ņ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$find = 'Ƹ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ЀЁЂЃЄЅІ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'РСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'МНОП';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'نهوىيًٌٍَُ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'فقكلم';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눻';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ａｂｃｄｅｆｇｈｉｊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'Ｋ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ｱｲｳｴｵｶｷｸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'őřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'Ĥēĺļŏ, Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'Ĥē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'o, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'Hell';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'Wo';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'Hello, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'llo, World!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'll';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'He';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'rld!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rld';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'Hello, Wo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'či';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'ći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'mo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strstr($string, $find);
 		$expected = 'žavni';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '设为首页';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '把百度';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strstr($string, $find);
 		$expected = '周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::strstr($string, $find, true);
 		$expected = '一二三';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '二周';
 		$result = Multibyte::strstr($string, $find);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6080,519 +6080,519 @@ class MultibyteTest extends CakeTestCase {
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~';
 		$result = mb_strtolower($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@';
 		$result = mb_strtolower($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'À';
 		$result = mb_strtolower($string);
 		$expected = 'à';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Á';
 		$result = mb_strtolower($string);
 		$expected = 'á';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Â';
 		$result = mb_strtolower($string);
 		$expected = 'â';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ã';
 		$result = mb_strtolower($string);
 		$expected = 'ã';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ä';
 		$result = mb_strtolower($string);
 		$expected = 'ä';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Å';
 		$result = mb_strtolower($string);
 		$expected = 'å';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Æ';
 		$result = mb_strtolower($string);
 		$expected = 'æ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ç';
 		$result = mb_strtolower($string);
 		$expected = 'ç';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'È';
 		$result = mb_strtolower($string);
 		$expected = 'è';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'É';
 		$result = mb_strtolower($string);
 		$expected = 'é';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ê';
 		$result = mb_strtolower($string);
 		$expected = 'ê';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ë';
 		$result = mb_strtolower($string);
 		$expected = 'ë';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ì';
 		$result = mb_strtolower($string);
 		$expected = 'ì';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Í';
 		$result = mb_strtolower($string);
 		$expected = 'í';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Î';
 		$result = mb_strtolower($string);
 		$expected = 'î';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ï';
 		$result = mb_strtolower($string);
 		$expected = 'ï';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ð';
 		$result = mb_strtolower($string);
 		$expected = 'ð';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ñ';
 		$result = mb_strtolower($string);
 		$expected = 'ñ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ò';
 		$result = mb_strtolower($string);
 		$expected = 'ò';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ó';
 		$result = mb_strtolower($string);
 		$expected = 'ó';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ô';
 		$result = mb_strtolower($string);
 		$expected = 'ô';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Õ';
 		$result = mb_strtolower($string);
 		$expected = 'õ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ö';
 		$result = mb_strtolower($string);
 		$expected = 'ö';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ø';
 		$result = mb_strtolower($string);
 		$expected = 'ø';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ù';
 		$result = mb_strtolower($string);
 		$expected = 'ù';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ú';
 		$result = mb_strtolower($string);
 		$expected = 'ú';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Û';
 		$result = mb_strtolower($string);
 		$expected = 'û';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ü';
 		$result = mb_strtolower($string);
 		$expected = 'ü';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ý';
 		$result = mb_strtolower($string);
 		$expected = 'ý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Þ';
 		$result = mb_strtolower($string);
 		$expected = 'þ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = mb_strtolower($string);
 		$expected = 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ā';
 		$result = mb_strtolower($string);
 		$expected = 'ā';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ă';
 		$result = mb_strtolower($string);
 		$expected = 'ă';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ą';
 		$result = mb_strtolower($string);
 		$expected = 'ą';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ć';
 		$result = mb_strtolower($string);
 		$expected = 'ć';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĉ';
 		$result = mb_strtolower($string);
 		$expected = 'ĉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ċ';
 		$result = mb_strtolower($string);
 		$expected = 'ċ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Č';
 		$result = mb_strtolower($string);
 		$expected = 'č';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ď';
 		$result = mb_strtolower($string);
 		$expected = 'ď';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Đ';
 		$result = mb_strtolower($string);
 		$expected = 'đ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ē';
 		$result = mb_strtolower($string);
 		$expected = 'ē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĕ';
 		$result = mb_strtolower($string);
 		$expected = 'ĕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ė';
 		$result = mb_strtolower($string);
 		$expected = 'ė';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ę';
 		$result = mb_strtolower($string);
 		$expected = 'ę';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ě';
 		$result = mb_strtolower($string);
 		$expected = 'ě';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĝ';
 		$result = mb_strtolower($string);
 		$expected = 'ĝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ğ';
 		$result = mb_strtolower($string);
 		$expected = 'ğ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ġ';
 		$result = mb_strtolower($string);
 		$expected = 'ġ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ģ';
 		$result = mb_strtolower($string);
 		$expected = 'ģ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥ';
 		$result = mb_strtolower($string);
 		$expected = 'ĥ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ħ';
 		$result = mb_strtolower($string);
 		$expected = 'ħ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĩ';
 		$result = mb_strtolower($string);
 		$expected = 'ĩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ī';
 		$result = mb_strtolower($string);
 		$expected = 'ī';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĭ';
 		$result = mb_strtolower($string);
 		$expected = 'ĭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Į';
 		$result = mb_strtolower($string);
 		$expected = 'į';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĳ';
 		$result = mb_strtolower($string);
 		$expected = 'ĳ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĵ';
 		$result = mb_strtolower($string);
 		$expected = 'ĵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ķ';
 		$result = mb_strtolower($string);
 		$expected = 'ķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĺ';
 		$result = mb_strtolower($string);
 		$expected = 'ĺ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ļ';
 		$result = mb_strtolower($string);
 		$expected = 'ļ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ľ';
 		$result = mb_strtolower($string);
 		$expected = 'ľ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŀ';
 		$result = mb_strtolower($string);
 		$expected = 'ŀ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ł';
 		$result = mb_strtolower($string);
 		$expected = 'ł';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ń';
 		$result = mb_strtolower($string);
 		$expected = 'ń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ņ';
 		$result = mb_strtolower($string);
 		$expected = 'ņ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ň';
 		$result = mb_strtolower($string);
 		$expected = 'ň';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŋ';
 		$result = mb_strtolower($string);
 		$expected = 'ŋ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ō';
 		$result = mb_strtolower($string);
 		$expected = 'ō';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŏ';
 		$result = mb_strtolower($string);
 		$expected = 'ŏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ő';
 		$result = mb_strtolower($string);
 		$expected = 'ő';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Œ';
 		$result = mb_strtolower($string);
 		$expected = 'œ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŕ';
 		$result = mb_strtolower($string);
 		$expected = 'ŕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŗ';
 		$result = mb_strtolower($string);
 		$expected = 'ŗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ř';
 		$result = mb_strtolower($string);
 		$expected = 'ř';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ś';
 		$result = mb_strtolower($string);
 		$expected = 'ś';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŝ';
 		$result = mb_strtolower($string);
 		$expected = 'ŝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ş';
 		$result = mb_strtolower($string);
 		$expected = 'ş';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Š';
 		$result = mb_strtolower($string);
 		$expected = 'š';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ţ';
 		$result = mb_strtolower($string);
 		$expected = 'ţ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ť';
 		$result = mb_strtolower($string);
 		$expected = 'ť';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŧ';
 		$result = mb_strtolower($string);
 		$expected = 'ŧ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ũ';
 		$result = mb_strtolower($string);
 		$expected = 'ũ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ū';
 		$result = mb_strtolower($string);
 		$expected = 'ū';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŭ';
 		$result = mb_strtolower($string);
 		$expected = 'ŭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ů';
 		$result = mb_strtolower($string);
 		$expected = 'ů';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ű';
 		$result = mb_strtolower($string);
 		$expected = 'ű';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ų';
 		$result = mb_strtolower($string);
 		$expected = 'ų';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŵ';
 		$result = mb_strtolower($string);
 		$expected = 'ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŷ';
 		$result = mb_strtolower($string);
 		$expected = 'ŷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ź';
 		$result = mb_strtolower($string);
 		$expected = 'ź';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ż';
 		$result = mb_strtolower($string);
 		$expected = 'ż';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ž';
 		$result = mb_strtolower($string);
 		$expected = 'ž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$result = mb_strtolower($string);
 		$expected = 'āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįĳĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷźżž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĤĒĹĻŎ, ŴŐŘĻĎ!';
 		$result = mb_strtolower($string);
 		$expected = 'ĥēĺļŏ, ŵőřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĥēĺļŏ, ŵőřļď!';
 		$result = mb_strtolower($string);
 		$expected = 'ĥēĺļŏ, ŵőřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ἈΙ';
 		$result = mb_strtolower($string);
 		$expected = 'ἀι';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 /*
 	The tests below are flaky across different platforms.
 
 		$string = 'ԀԂԄԆԈԊԌԎԐԒ';
 		$result = mb_strtolower($string);
 		$expected = 'ԁԃԅԇԉԋԍԏԑԓ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
 		$result = mb_strtolower($string);
 		$expected = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
 		$result = mb_strtolower($string);
 		$expected = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅ';
 		$result = mb_strtolower($string);
 		$expected = 'ωkå';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅ';
 		$result = mb_strtolower($string);
 		$expected = 'ωkå';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 /*
 mb_strtolower does not work for these strings.
@@ -6600,27 +6600,27 @@ mb_strtolower does not work for these strings.
 		$string = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
 		$result = mb_strtolower($string);
 		$expected = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
 		$result = mb_strtolower($string);
 		$expected = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
 		$result = mb_strtolower($string);
 		$expected = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
 		$result = mb_strtolower($string);
 		$expected = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 */
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = mb_strtolower($string);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6632,552 +6632,552 @@ mb_strtolower does not work for these strings.
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~';
 		$result = Multibyte::strtolower($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@';
 		$result = Multibyte::strtolower($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'À';
 		$result = Multibyte::strtolower($string);
 		$expected = 'à';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Á';
 		$result = Multibyte::strtolower($string);
 		$expected = 'á';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Â';
 		$result = Multibyte::strtolower($string);
 		$expected = 'â';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ã';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ã';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ä';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ä';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Å';
 		$result = Multibyte::strtolower($string);
 		$expected = 'å';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Æ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'æ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ç';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ç';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'È';
 		$result = Multibyte::strtolower($string);
 		$expected = 'è';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'É';
 		$result = Multibyte::strtolower($string);
 		$expected = 'é';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ê';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ê';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ë';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ë';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ì';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ì';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Í';
 		$result = Multibyte::strtolower($string);
 		$expected = 'í';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Î';
 		$result = Multibyte::strtolower($string);
 		$expected = 'î';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ï';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ï';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ð';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ð';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ñ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ñ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ò';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ò';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ó';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ó';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ô';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ô';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Õ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'õ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ö';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ö';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ø';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ø';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ù';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ù';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ú';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ú';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Û';
 		$result = Multibyte::strtolower($string);
 		$expected = 'û';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ü';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ü';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ý';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Þ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'þ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ā';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ā';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ă';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ă';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ą';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ą';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ć';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ć';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĉ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ċ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ċ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Č';
 		$result = Multibyte::strtolower($string);
 		$expected = 'č';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ď';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ď';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Đ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'đ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ē';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĕ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ė';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ė';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ę';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ę';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ě';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ě';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĝ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ğ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ğ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ġ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ġ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ģ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ģ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĥ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ħ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ħ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĩ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ī';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ī';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĭ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Į';
 		$result = Multibyte::strtolower($string);
 		$expected = 'į';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĳ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĳ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĵ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ķ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĺ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĺ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ļ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ļ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ľ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ľ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŀ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŀ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ł';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ł';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ń';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ņ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ņ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ň';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ň';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŋ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŋ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ō';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ō';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŏ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ő';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ő';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Œ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'œ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŕ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŗ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ř';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ř';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ś';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ś';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŝ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ş';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ş';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Š';
 		$result = Multibyte::strtolower($string);
 		$expected = 'š';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ţ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ţ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ť';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ť';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŧ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŧ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ũ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ũ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ū';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ū';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŭ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ů';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ů';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ű';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ű';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ų';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ų';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŵ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ŷ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ŷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ź';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ź';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ż';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ż';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ž';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįĳĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷźżž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĤĒĹĻŎ, ŴŐŘĻĎ!';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĥēĺļŏ, ŵőřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĥēĺļŏ, ŵőřļď!';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ĥēĺļŏ, ŵőřļď!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ἈΙ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ἀι';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԀԂԄԆԈԊԌԎԐԒ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ԁԃԅԇԉԋԍԏԑԓ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
 		$result = Multibyte::strtolower($string);
 		$expected = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅℲ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ωkåⅎ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ωkå';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ΩKÅ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ωkå';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = Multibyte::strtolower($string);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -7189,512 +7189,512 @@ mb_strtolower does not work for these strings.
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = mb_strtoupper($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@';
 		$result = mb_strtoupper($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'à';
 		$result = mb_strtoupper($string);
 		$expected = 'À';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'á';
 		$result = mb_strtoupper($string);
 		$expected = 'Á';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'â';
 		$result = mb_strtoupper($string);
 		$expected = 'Â';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ã';
 		$result = mb_strtoupper($string);
 		$expected = 'Ã';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ä';
 		$result = mb_strtoupper($string);
 		$expected = 'Ä';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'å';
 		$result = mb_strtoupper($string);
 		$expected = 'Å';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'æ';
 		$result = mb_strtoupper($string);
 		$expected = 'Æ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ç';
 		$result = mb_strtoupper($string);
 		$expected = 'Ç';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'è';
 		$result = mb_strtoupper($string);
 		$expected = 'È';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'é';
 		$result = mb_strtoupper($string);
 		$expected = 'É';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ê';
 		$result = mb_strtoupper($string);
 		$expected = 'Ê';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ë';
 		$result = mb_strtoupper($string);
 		$expected = 'Ë';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ì';
 		$result = mb_strtoupper($string);
 		$expected = 'Ì';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'í';
 		$result = mb_strtoupper($string);
 		$expected = 'Í';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'î';
 		$result = mb_strtoupper($string);
 		$expected = 'Î';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ï';
 		$result = mb_strtoupper($string);
 		$expected = 'Ï';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ð';
 		$result = mb_strtoupper($string);
 		$expected = 'Ð';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ñ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ñ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ò';
 		$result = mb_strtoupper($string);
 		$expected = 'Ò';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ó';
 		$result = mb_strtoupper($string);
 		$expected = 'Ó';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ô';
 		$result = mb_strtoupper($string);
 		$expected = 'Ô';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'õ';
 		$result = mb_strtoupper($string);
 		$expected = 'Õ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ö';
 		$result = mb_strtoupper($string);
 		$expected = 'Ö';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ø';
 		$result = mb_strtoupper($string);
 		$expected = 'Ø';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ù';
 		$result = mb_strtoupper($string);
 		$expected = 'Ù';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ú';
 		$result = mb_strtoupper($string);
 		$expected = 'Ú';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'û';
 		$result = mb_strtoupper($string);
 		$expected = 'Û';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ü';
 		$result = mb_strtoupper($string);
 		$expected = 'Ü';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ý';
 		$result = mb_strtoupper($string);
 		$expected = 'Ý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'þ';
 		$result = mb_strtoupper($string);
 		$expected = 'Þ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ';
 		$result = mb_strtoupper($string);
 		$expected = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ā';
 		$result = mb_strtoupper($string);
 		$expected = 'Ā';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ă';
 		$result = mb_strtoupper($string);
 		$expected = 'Ă';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ą';
 		$result = mb_strtoupper($string);
 		$expected = 'Ą';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ć';
 		$result = mb_strtoupper($string);
 		$expected = 'Ć';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĉ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ċ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ċ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'č';
 		$result = mb_strtoupper($string);
 		$expected = 'Č';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ď';
 		$result = mb_strtoupper($string);
 		$expected = 'Ď';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'đ';
 		$result = mb_strtoupper($string);
 		$expected = 'Đ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ē';
 		$result = mb_strtoupper($string);
 		$expected = 'Ē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĕ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ė';
 		$result = mb_strtoupper($string);
 		$expected = 'Ė';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ę';
 		$result = mb_strtoupper($string);
 		$expected = 'Ę';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ě';
 		$result = mb_strtoupper($string);
 		$expected = 'Ě';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĝ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ğ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ğ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ġ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ġ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ģ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ģ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĥ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĥ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ħ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ħ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĩ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ī';
 		$result = mb_strtoupper($string);
 		$expected = 'Ī';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'į';
 		$result = mb_strtoupper($string);
 		$expected = 'Į';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĳ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĳ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĵ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ķ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĺ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ĺ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ļ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ļ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ľ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ľ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŀ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŀ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ł';
 		$result = mb_strtoupper($string);
 		$expected = 'Ł';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ń';
 		$result = mb_strtoupper($string);
 		$expected = 'Ń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ņ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ņ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ň';
 		$result = mb_strtoupper($string);
 		$expected = 'Ň';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŋ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŋ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ō';
 		$result = mb_strtoupper($string);
 		$expected = 'Ō';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŏ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ő';
 		$result = mb_strtoupper($string);
 		$expected = 'Ő';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'œ';
 		$result = mb_strtoupper($string);
 		$expected = 'Œ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŕ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŗ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ř';
 		$result = mb_strtoupper($string);
 		$expected = 'Ř';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ś';
 		$result = mb_strtoupper($string);
 		$expected = 'Ś';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŝ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ş';
 		$result = mb_strtoupper($string);
 		$expected = 'Ş';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'š';
 		$result = mb_strtoupper($string);
 		$expected = 'Š';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ţ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ţ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ť';
 		$result = mb_strtoupper($string);
 		$expected = 'Ť';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŧ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŧ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ũ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ũ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ū';
 		$result = mb_strtoupper($string);
 		$expected = 'Ū';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŭ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ů';
 		$result = mb_strtoupper($string);
 		$expected = 'Ů';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ű';
 		$result = mb_strtoupper($string);
 		$expected = 'Ű';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ų';
 		$result = mb_strtoupper($string);
 		$expected = 'Ų';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŵ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŷ';
 		$result = mb_strtoupper($string);
 		$expected = 'Ŷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ź';
 		$result = mb_strtoupper($string);
 		$expected = 'Ź';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ż';
 		$result = mb_strtoupper($string);
 		$expected = 'Ż';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ž';
 		$result = mb_strtoupper($string);
 		$expected = 'Ž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįĳĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷźżž';
 		$result = mb_strtoupper($string);
 		$expected = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = mb_strtoupper($string);
 		$expected = 'ĤĒĹĻŎ, ŴŐŘĻĎ!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ἀι';
 		$result = mb_strtoupper($string);
 		$expected = 'ἈΙ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԁԃԅԇԉԋԍԏԐԒ';
 		$result = mb_strtoupper($string);
 		$expected = 'ԀԂԄԆԈԊԌԎԐԒ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
 		$result = mb_strtoupper($string);
 		$expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
 		$result = mb_strtoupper($string);
 		$expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
 		$result = mb_strtoupper($string);
 		$expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ωkå';
 		$result = mb_strtoupper($string);
 		$expected = 'ΩKÅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 /*
 mb_strtoupper does not work for these strings.
@@ -7702,27 +7702,27 @@ mb_strtoupper does not work for these strings.
 		$string = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
 		$result = mb_strtoupper($string);
 		$expected = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
 		$result = mb_strtoupper($string);
 		$expected = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
 		$result = mb_strtoupper($string);
 		$expected = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
 		$result = mb_strtoupper($string);
 		$expected = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 */
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = mb_strtoupper($string);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -7734,547 +7734,547 @@ mb_strtoupper does not work for these strings.
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = Multibyte::strtoupper($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@';
 		$result = Multibyte::strtoupper($string);
 		$expected = '!"#$%&\'()*+,-./0123456789:;<=>?@';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'à';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'À';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'á';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Á';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'â';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Â';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ã';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ã';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ä';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ä';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'å';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Å';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'æ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Æ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ç';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ç';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'è';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'È';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'é';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'É';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ê';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ê';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ë';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ë';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ì';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ì';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'í';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Í';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'î';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Î';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ï';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ï';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ð';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ð';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ñ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ñ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ò';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ò';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ó';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ó';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ô';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ô';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'õ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Õ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ö';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ö';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ø';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ø';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ù';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ù';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ú';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ú';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'û';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Û';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ü';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ü';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ý';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ý';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'þ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Þ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ā';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ā';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ă';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ă';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ą';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ą';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ć';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ć';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĉ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĉ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ċ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ċ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'č';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Č';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ď';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ď';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'đ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Đ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ē';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ē';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĕ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ė';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ė';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ę';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ę';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ě';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ě';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĝ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ğ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ğ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ġ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ġ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ģ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ģ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĥ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĥ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ħ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ħ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĩ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĩ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ī';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ī';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'į';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Į';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĳ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĳ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĵ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ķ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĺ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ĺ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ļ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ļ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ľ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ľ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŀ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŀ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ł';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ł';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ń';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ń';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ņ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ņ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ň';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ň';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŋ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŋ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ō';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ō';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŏ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ő';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ő';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'œ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Œ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŕ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŕ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŗ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ř';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ř';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ś';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ś';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŝ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŝ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ş';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ş';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'š';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Š';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ţ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ţ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ť';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ť';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŧ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŧ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ũ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ũ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ū';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ū';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŭ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŭ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ů';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ů';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ű';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ű';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ų';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ų';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŵ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŵ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ŷ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ŷ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ź';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ź';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ż';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ż';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ž';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'Ž';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįĳĵķĺļľŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷźżž';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ĤĒĹĻŎ, ŴŐŘĻĎ!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ἀι';
 		$result = mb_strtoupper($string);
 		$expected = 'ἈΙ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ἀι';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ἈΙ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ԁԃԅԇԉԋԍԏԐԒ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ԀԂԄԆԈԊԌԎԐԒ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփքօֆև';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ԱԲԳԴԵԶԷԸԹԺԻԼԽԾԿՀՁՂՃՄՅՆՇՈՉՊՋՌՍՎՏՐՑՒՓՔՕՖև';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ႠႡႢႣႤႥႦႧႨႩႪႫႬႭႮႯႰႱႲႳႴႵႶႷႸႹႺႻႼႽႾႿჀჁჂჃჄჅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕẖẗẘẙẚạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔẖẗẘẙẚẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ωkåⅎ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ΩKÅℲ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ωkå';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ΩKÅ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹⅺⅻⅼⅽⅾⅿↄ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫⅬⅭⅮⅯↃ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⰰⰱⰲⰳⰴⰵⰶⰷⰸⰹⰺⰻⰼⰽⰾⰿⱀⱁⱂⱃⱄⱅⱆⱇⱈⱉⱊⱋⱌⱍⱎⱏⱐⱑⱒⱓⱔⱕⱖⱗⱘⱙⱚⱛⱜⱝⱞ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ⰀⰁⰂⰃⰄⰅⰆⰇⰈⰉⰊⰋⰌⰍⰎⰏⰐⰑⰒⰓⰔⰕⰖⰗⰘⰙⰚⰛⰜⰝⰞⰟⰠⰡⰢⰣⰤⰥⰦⰧⰨⰩⰪⰫⰬⰭⰮ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ⲁⲃⲅⲇⲉⲋⲍⲏⲑⲓⲕⲗⲙⲛⲝⲟⲡⲣⲥⲧⲩⲫⲭⲯⲱⲳⲵⲷⲹⲻⲽⲿⳁⳃⳅⳇⳉⳋⳍⳏⳑⳓⳕⳗⳙⳛⳝⳟⳡⳣ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ⲀⲂⲄⲆⲈⲊⲌⲎⲐⲒⲔⲖⲘⲚⲜⲞⲠⲢⲤⲦⲨⲪⲬⲮⲰⲲⲴⲶⲸⲺⲼⲾⳀⳂⳄⳆⳈⳊⳌⳎⳐⳒⳔⳖⳘⳚⳜⳞⳠⳢ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
 		$result = Multibyte::strtoupper($string);
 		$expected = 'ﬀﬁﬂﬃﬄﬅﬆﬓﬔﬕﬖﬗ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -8287,247 +8287,247 @@ mb_strtoupper does not work for these strings.
 		$find = 'F';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSFTUVWXYZ0F12345F6789';
 		$find = 'F';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÅÊËÌÍÎÏÐÑÒÓÔÅÕÖØÅÙÚÛÅÜÝÞ';
 		$find = 'Å';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÙÚÂÃÄÅÆÇÈÙÚÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞÙÚ';
 		$find = 'ÙÚ';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊÅËÌÍÎÏÐÑÒÓÔÕÅÖØÅÙÚÅÛÜÅÝÞÅ';
 		$find = 'Å';
 		$result = mb_substr_count($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĊĀĂĄĆĈĊČĎĐĒĔĖĊĘĚĜĞĠĢĤĦĨĪĬĮĊĲĴĶĹĻĽĿŁŃŅŇŊŌĊŎŐŒŔŖŘŚŜŞŠŢĊŤŦŨŪŬŮŰĊŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_substr_count($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĊĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅĊŇŊŌŎŐŒŔŖĊŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./012F34567F89:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghiFjklmnopqFrstuvwFxyz{|}~';
 		$find = 'F';
 		$result = mb_substr_count($string, $find);
 		$expected = 6;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥µ¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁµÂÃµÄÅÆÇµÈ';
 		$find = 'µ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôÕÖõö÷øùúûüýþÿĀāĂăĄąĆćĈĉÕÖĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝÕÖĞğĠġĢģĤĥĦÕÖħĨĩĪīĬ';
 		$find = 'ÕÖ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōĵĶķĸĹŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšĵĶķĸĹŢţŤťŦŧŨũŪūŬŭŮůŰűŲųĵĶķĸĹŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'ĵĶķĸĹ';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƸƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊƸǋǌǍǎǏǐǑǒǓƸǔǕǖǗǘǙǚƸǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƹƠơƢƣƤƥƦƧƨƩƹƪƫƬƭƮƯưƱƲƳƴƹƵƶƷƸƹƺƻƼƽƾƿǀǁǂƹǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞʀɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʀʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʀʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʀʻʼ';
 		$find = 'ʀ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЇЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = mb_substr_count($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСРТУФХЦЧШЩЪЫЬРЭЮЯабРвгдежзийклРмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСрТУФХЦЧШЩЪЫрЬЭЮЯабвгдежзийклмнопррстуфхцчшщъыь';
 		$find = 'р';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فنقكلنمنهونىينًٌٍَُ';
 		$find = 'ن';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✿✴✵✶✷✸✿✹✺✻✼✽✾✿❀❁❂❃❄❅❆✿❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺐⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺐⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⺐⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽤⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽤⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = mb_substr_count($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눺눻눼눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕눺눻눼뉖뉗뉘뉙뉚뉛뉜뉝눺눻눼뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눺눻눼';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺞﺟﺠﺡﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺞﺟﺠﺡﺆﺇﺞﺟﺠﺡﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞﺟﺠﺡ';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﻞﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻞﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻞﻸﻹﻺﻞﻻﻼ';
 		$find = 'ﻞ';
 		$result = mb_substr_count($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｋｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｋｙｚ';
 		$find = 'ｋ';
 		$result = mb_substr_count($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｋｌｍｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｋｌｍｗｘｙｚ';
 		$find = 'ｋｌｍ';
 		$result = mb_substr_count($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｐｐｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐｅ';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = mb_substr_count($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rl';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ničiničiini';
 		$find = 'n';
 		$result = mb_substr_count($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moćimoćimoćmćioći';
 		$find = 'ći';
 		$result = mb_substr_count($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = mb_substr_count($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'H';
 		$result = mb_substr_count($string, $find);
 		$expected = 0;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -8540,247 +8540,247 @@ mb_strtoupper does not work for these strings.
 		$find = 'F';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ABCDEFGHIJKLMNOPQFRSFTUVWXYZ0F12345F6789';
 		$find = 'F';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÅÊËÌÍÎÏÐÑÒÓÔÅÕÖØÅÙÚÛÅÜÝÞ';
 		$find = 'Å';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÙÚÂÃÄÅÆÇÈÙÚÉÊËÌÍÎÏÐÑÒÓÔÕÖØÅÙÚÛÜÝÞÙÚ';
 		$find = 'ÙÚ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊÅËÌÍÎÏÐÑÒÓÔÕÅÖØÅÙÚÅÛÜÅÝÞÅ';
 		$find = 'Å';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĊĀĂĄĆĈĊČĎĐĒĔĖĊĘĚĜĞĠĢĤĦĨĪĬĮĊĲĴĶĹĻĽĿŁŃŅŇŊŌĊŎŐŒŔŖŘŚŜŞŠŢĊŤŦŨŪŬŮŰĊŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 7;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĊĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁĊŃŅĊŇŊŌŎŐŒŔŖĊŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./012F34567F89:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghiFjklmnopqFrstuvwFxyz{|}~';
 		$find = 'F';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 6;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥µ¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁµÂÃµÄÅÆÇµÈ';
 		$find = 'µ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôÕÖõö÷øùúûüýþÿĀāĂăĄąĆćĈĉÕÖĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝÕÖĞğĠġĢģĤĥĦÕÖħĨĩĪīĬ';
 		$find = 'ÕÖ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōĵĶķĸĹŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšĵĶķĸĹŢţŤťŦŧŨũŪūŬŭŮůŰűŲųĵĶķĸĹŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$find = 'ĵĶķĸĹ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƸƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊƸǋǌǍǎǏǐǑǒǓƸǔǕǖǗǘǙǚƸǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'Ƹ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƹƠơƢƣƤƥƦƧƨƩƹƪƫƬƭƮƯưƱƲƳƴƹƵƶƷƸƹƺƻƼƽƾƿǀǁǂƹǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$find = 'ƹ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞʀɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʀʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʀʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʀʻʼ';
 		$find = 'ʀ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЇЎЏАБВГДЕЖЗИЙКЛ';
 		$find = 'Ї';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСРТУФХЦЧШЩЪЫЬРЭЮЯабРвгдежзийклРмнопрстуфхцчшщъыь';
 		$find = 'Р';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСрТУФХЦЧШЩЪЫрЬЭЮЯабвгдежзийклмнопррстуфхцчшщъыь';
 		$find = 'р';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فنقكلنمنهونىينًٌٍَُ';
 		$find = 'ن';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✿✴✵✶✷✸✿✹✺✻✼✽✾✿❀❁❂❃❄❅❆✿❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$find = '✿';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺐⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺐⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⺐⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$find = '⺐';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽤⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽤⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$find = '⽤';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눺눻눼눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕눺눻눼뉖뉗뉘뉙뉚뉛뉜뉝눺눻눼뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$find = '눺눻눼';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺞﺟﺠﺡﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺞﺟﺠﺡﺆﺇﺞﺟﺠﺡﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$find = 'ﺞﺟﺠﺡ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﻞﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻞﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻞﻸﻹﻺﻞﻻﻼ';
 		$find = 'ﻞ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 5;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｋｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｋｙｚ';
 		$find = 'ｋ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｋｌｍｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｋｌｍｗｘｙｚ';
 		$find = 'ｋｌｍ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｐｐｅｆｇｈｉｊｋｌｍｎｏｐｐｑｒｓｔｕｖｗｘｙｚ';
 		$find = 'ｐｐｅ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$find = 'ｱ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$find = 'ﾊ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ő';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'ĺļ';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'o';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$find = 'rl';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$find = 'n';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ničiničiini';
 		$find = 'n';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$find = 'ć';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moćimoćimoćmćioći';
 		$find = 'ći';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$find = 'ž';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$find = '设';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$find = '周';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$find = 'H';
 		$result = Multibyte::substrCount($string, $find);
 		$expected = 0;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -8792,153 +8792,153 @@ mb_strtoupper does not work for these strings.
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = mb_substr($string, 4, 7);
 		$expected = 'EFGHIJK';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = mb_substr($string, 4, 7);
 		$expected = 'ÄÅÆÇÈÉÊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = mb_substr($string, 4, 7);
 		$expected = 'ĈĊČĎĐĒĔ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = mb_substr($string, 4, 7);
 		$expected = '%&\'()*+';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = mb_substr($string, 4);
 		$expected = '¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = mb_substr($string, 4, 7);
 		$expected = 'ÍÎÏÐÑÒÓ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = mb_substr($string, 4, 7);
 		$expected = 'ıĲĳĴĵĶķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = mb_substr($string, 25);
 		$expected = 'ƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = mb_substr($string, 3);
 		$expected = 'ɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = mb_substr($string, 3);
 		$expected = 'ЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = mb_substr($string, 3, 16);
 		$expected = 'ПРСТУФХЦЧШЩЪЫЬЭЮ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = mb_substr($string, 3, 6);
 		$expected = 'لمنهوى';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = mb_substr($string, 6, 14);
 		$expected = '✶✷✸✹✺✻✼✽✾✿❀❁❂❃';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = mb_substr($string, 8, 13);
 		$expected = '⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = mb_substr($string, 12, 24);
 		$expected = '⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = mb_substr($string, 12, 24);
 		$expected = '눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = mb_substr($string, 12);
 		$expected = 'ﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = mb_substr($string, 24, 12);
 		$expected = 'ﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = mb_substr($string, 11, 2);
 		$expected = 'ｌｍ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = mb_substr($string, 7, 11);
 		$expected = 'ｨｩｪｫｬｭｮｯｰｱｲ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = mb_substr($string, 13, 13);
 		$expected = 'ﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = mb_substr($string, 3, 4);
 		$expected = 'ļŏ, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = mb_substr($string, 3, 4);
 		$expected = 'lo, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$result = mb_substr($string, 3);
 		$expected = 'i';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = mb_substr($string, 1);
 		$expected = 'oći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = mb_substr($string, 0, 2);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = mb_substr($string, 3, 3);
 		$expected = '设为首';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = mb_substr($string, 0, 1);
 		$expected = '一';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = mb_substr($string, 6);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = mb_substr($string, 0);
 		$expected = '一二三周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -8950,153 +8950,153 @@ mb_strtoupper does not work for these strings.
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = 'EFGHIJK';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = 'ÄÅÆÇÈÉÊ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$find = 'Ċ';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = 'ĈĊČĎĐĒĔ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = '%&\'()*+';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = Multibyte::substr($string, 4);
 		$expected = '¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = 'ÍÎÏÐÑÒÓ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = Multibyte::substr($string, 4, 7);
 		$expected = 'ıĲĳĴĵĶķ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = Multibyte::substr($string, 25);
 		$expected = 'ƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = Multibyte::substr($string, 3);
 		$expected = 'ɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = Multibyte::substr($string, 3);
 		$expected = 'ЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = Multibyte::substr($string, 3, 16);
 		$expected = 'ПРСТУФХЦЧШЩЪЫЬЭЮ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = Multibyte::substr($string, 3, 6);
 		$expected = 'لمنهوى';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = Multibyte::substr($string, 6, 14);
 		$expected = '✶✷✸✹✺✻✼✽✾✿❀❁❂❃';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = Multibyte::substr($string, 8, 13);
 		$expected = '⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = Multibyte::substr($string, 12, 24);
 		$expected = '⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = Multibyte::substr($string, 12, 24);
 		$expected = '눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = Multibyte::substr($string, 12);
 		$expected = 'ﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = Multibyte::substr($string, 24, 12);
 		$expected = 'ﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = Multibyte::substr($string, 11, 2);
 		$expected = 'ｌｍ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = Multibyte::substr($string, 7, 11);
 		$expected = 'ｨｩｪｫｬｭｮｯｰｱｲ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = Multibyte::substr($string, 13, 13);
 		$expected = 'ﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::substr($string, 3, 4);
 		$expected = 'ļŏ, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = Multibyte::substr($string, 3, 4);
 		$expected = 'lo, ';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'čini';
 		$result = Multibyte::substr($string, 3);
 		$expected = 'i';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = Multibyte::substr($string, 1);
 		$expected = 'oći';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = Multibyte::substr($string, 0, 2);
 		$expected = 'dr';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = Multibyte::substr($string, 3, 3);
 		$expected = '设为首';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::substr($string, 0, 1);
 		$expected = '一';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::substr($string, 6);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::substr($string, 0);
 		$expected = '一二三周永龍';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -9107,37 +9107,37 @@ mb_strtoupper does not work for these strings.
 	public function testMultibyteMimeEncode() {
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = Multibyte::mimeEncode($string);
-		$this->assertEqual($result, $string);
+		$this->assertEquals($result, $string);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?w4DDgcOCw4PDhMOFw4bDh8OIw4nDisOLw4zDjcOOw4/DkMORw5LDk8OUw5U=?=' . "\r\n" .
 					' =?UTF-8?B?w5bDmMOZw5rDm8Ocw53Dng==?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$result = Multibyte::mimeEncode($string, null, "\n");
 		$expected = '=?UTF-8?B?w4DDgcOCw4PDhMOFw4bDh8OIw4nDisOLw4zDjcOOw4/DkMORw5LDk8OUw5U=?=' . "\n" .
 					' =?UTF-8?B?w5bDmMOZw5rDm8Ocw53Dng==?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮĲĴĶĹĻĽĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŹŻŽ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?xIDEgsSExIbEiMSKxIzEjsSQxJLElMSWxJjEmsScxJ7EoMSixKTEpsSoxKo=?=' . "\r\n" .
 					' =?UTF-8?B?xKzErsSyxLTEtsS5xLvEvcS/xYHFg8WFxYfFisWMxY7FkMWSxZTFlsWYxZo=?=' . "\r\n" .
 					' =?UTF-8?B?xZzFnsWgxaLFpMWmxajFqsWsxa7FsMWyxbTFtsW5xbvFvQ==?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?ISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xN?=' . "\r\n" .
 					' =?UTF-8?B?Tk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6?=' . "\r\n" .
 					' =?UTF-8?B?e3x9fg==?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?wqHCosKjwqTCpcKmwqfCqMKpwqrCq8Kswq3CrsKvwrDCscKywrPCtMK1wrY=?=' . "\r\n" .
 					' =?UTF-8?B?wrfCuMK5wrrCu8K8wr3CvsK/w4DDgcOCw4PDhMOFw4bDh8OI?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬ';
 		$result = Multibyte::mimeEncode($string);
@@ -9146,7 +9146,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?w7XDtsO3w7jDucO6w7vDvMO9w77Dv8SAxIHEgsSDxITEhcSGxIfEiMSJxIo=?=' . "\r\n" .
 					' =?UTF-8?B?xIvEjMSNxI7Ej8SQxJHEksSTxJTElcSWxJfEmMSZxJrEm8ScxJ3EnsSfxKA=?=' . "\r\n" .
 					' =?UTF-8?B?xKHEosSjxKTEpcSmxKfEqMSpxKrEq8Ss?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐ';
 		$result = Multibyte::mimeEncode($string);
@@ -9155,7 +9155,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?xZnFmsWbxZzFncWexZ/FoMWhxaLFo8WkxaXFpsWnxajFqcWqxavFrMWtxa4=?=' . "\r\n" .
 					' =?UTF-8?B?xa/FsMWxxbLFs8W0xbXFtsW3xbjFucW6xbvFvMW9xb7Fv8aAxoHGgsaDxoQ=?=' . "\r\n" .
 					' =?UTF-8?B?xoXGhsaHxojGicaKxovGjMaNxo7Gj8aQ?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴ';
 		$result = Multibyte::mimeEncode($string);
@@ -9164,7 +9164,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?xr3Gvsa/x4DHgceCx4PHhMeFx4bHh8eIx4nHiseLx4zHjceOx4/HkMeRx5I=?=' . "\r\n" .
 					' =?UTF-8?B?x5PHlMeVx5bHl8eYx5nHmsebx5zHnceex5/HoMehx6LHo8ekx6XHpsenx6g=?=' . "\r\n" .
 					' =?UTF-8?B?x6nHqserx6zHrceux6/HsMexx7LHs8e0?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'əɚɛɜɝɞɟɠɡɢɣɤɥɦɧɨɩɪɫɬɭɮɯɰɱɲɳɴɵɶɷɸɹɺɻɼɽɾɿʀʁʂʃʄʅʆʇʈʉʊʋʌʍʎʏʐʑʒʓʔʕʖʗʘʙʚʛʜʝʞʟʠʡʢʣʤʥʦʧʨʩʪʫʬʭʮʯʰʱʲʳʴʵʶʷʸʹʺʻʼ';
 		$result = Multibyte::mimeEncode($string);
@@ -9173,25 +9173,25 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?yoXKhsqHyojKicqKyovKjMqNyo7Kj8qQypHKksqTypTKlcqWypfKmMqZypo=?=' . "\r\n" .
 					' =?UTF-8?B?ypvKnMqdyp7Kn8qgyqHKosqjyqTKpcqmyqfKqMqpyqrKq8qsyq3KrsqvyrA=?=' . "\r\n" .
 					' =?UTF-8?B?yrHKssqzyrTKtcq2yrfKuMq5yrrKu8q8?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏАБВГДЕЖЗИЙКЛ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?0IDQgdCC0IPQhNCF0IbQh9CI0InQitCL0IzQjdCO0I/QkNCR0JLQk9CU0JU=?=' . "\r\n" .
 					' =?UTF-8?B?0JbQl9CY0JnQmtCb?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'МНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?0JzQndCe0J/QoNCh0KLQo9Ck0KXQptCn0KjQqdCq0KvQrNCt0K7Qr9Cw0LE=?=' . "\r\n" .
 					' =?UTF-8?B?0LLQs9C00LXQttC30LjQudC60LvQvNC90L7Qv9GA0YHRgtGD0YTRhdGG0Yc=?=' . "\r\n" .
 					' =?UTF-8?B?0YjRidGK0YvRjA==?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'فقكلمنهوىيًٌٍَُ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?2YHZgtmD2YTZhdmG2YfZiNmJ2YrZi9mM2Y3ZjtmP?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '✰✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿❀❁❂❃❄❅❆❇❈❉❊❋❌❍❎❏❐❑❒❓❔❕❖❗❘❙❚❛❜❝❞';
 		$result = Multibyte::mimeEncode($string);
@@ -9199,7 +9199,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?4py/4p2A4p2B4p2C4p2D4p2E4p2F4p2G4p2H4p2I4p2J4p2K4p2L4p2M4p2N?=' . "\r\n" .
 					' =?UTF-8?B?4p2O4p2P4p2Q4p2R4p2S4p2T4p2U4p2V4p2W4p2X4p2Y4p2Z4p2a4p2b4p2c?=' . "\r\n" .
 					' =?UTF-8?B?4p2d4p2e?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⺀⺁⺂⺃⺄⺅⺆⺇⺈⺉⺊⺋⺌⺍⺎⺏⺐⺑⺒⺓⺔⺕⺖⺗⺘⺙⺛⺜⺝⺞⺟⺠⺡⺢⺣⺤⺥⺦⺧⺨⺩⺪⺫⺬⺭⺮⺯⺰⺱⺲⺳⺴⺵⺶⺷⺸⺹⺺⺻⺼⺽⺾⺿⻀⻁⻂⻃⻄⻅⻆⻇⻈⻉⻊⻋⻌⻍⻎⻏⻐⻑⻒⻓⻔⻕⻖⻗⻘⻙⻚⻛⻜⻝⻞⻟⻠';
 		$result = Multibyte::mimeEncode($string);
@@ -9210,7 +9210,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?4rq94rq+4rq/4ruA4ruB4ruC4ruD4ruE4ruF4ruG4ruH4ruI4ruJ4ruK4ruL?=' . "\r\n" .
 					' =?UTF-8?B?4ruM4ruN4ruO4ruP4ruQ4ruR4ruS4ruT4ruU4ruV4ruW4ruX4ruY4ruZ4rua?=' . "\r\n" .
 					' =?UTF-8?B?4rub4ruc4rud4rue4ruf4rug?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '⽅⽆⽇⽈⽉⽊⽋⽌⽍⽎⽏⽐⽑⽒⽓⽔⽕⽖⽗⽘⽙⽚⽛⽜⽝⽞⽟⽠⽡⽢⽣⽤⽥⽦⽧⽨⽩⽪⽫⽬⽭⽮⽯⽰⽱⽲⽳⽴⽵⽶⽷⽸⽹⽺⽻⽼⽽⽾⽿';
 		$result = Multibyte::mimeEncode($string);
@@ -9218,7 +9218,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?4r2U4r2V4r2W4r2X4r2Y4r2Z4r2a4r2b4r2c4r2d4r2e4r2f4r2g4r2h4r2i?=' . "\r\n" .
 					' =?UTF-8?B?4r2j4r2k4r2l4r2m4r2n4r2o4r2p4r2q4r2r4r2s4r2t4r2u4r2v4r2w4r2x?=' . "\r\n" .
 					' =?UTF-8?B?4r2y4r2z4r204r214r224r234r244r254r264r274r284r294r2+4r2/?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '눡눢눣눤눥눦눧눨눩눪눫눬눭눮눯눰눱눲눳눴눵눶눷눸눹눺눻눼눽눾눿뉀뉁뉂뉃뉄뉅뉆뉇뉈뉉뉊뉋뉌뉍뉎뉏뉐뉑뉒뉓뉔뉕뉖뉗뉘뉙뉚뉛뉜뉝뉞뉟뉠뉡뉢뉣뉤뉥뉦뉧뉨뉩뉪뉫뉬뉭뉮뉯뉰뉱뉲뉳뉴뉵뉶뉷뉸뉹뉺뉻뉼뉽뉾뉿늀늁늂늃늄';
 		$result = Multibyte::mimeEncode($string);
@@ -9229,7 +9229,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?64md64me64mf64mg64mh64mi64mj64mk64ml64mm64mn64mo64mp64mq64mr?=' . "\r\n" .
 					' =?UTF-8?B?64ms64mt64mu64mv64mw64mx64my64mz64m064m164m264m364m464m564m6?=' . "\r\n" .
 					' =?UTF-8?B?64m764m864m964m+64m/64qA64qB64qC64qD64qE?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﹰﹱﹲﹳﹴ﹵ﹶﹷﹸﹹﹺﹻﹼﹽﹾﹿﺀﺁﺂﺃﺄﺅﺆﺇﺈﺉﺊﺋﺌﺍﺎﺏﺐﺑﺒﺓﺔﺕﺖﺗﺘﺙﺚﺛﺜﺝﺞﺟﺠﺡﺢﺣﺤﺥﺦﺧﺨﺩﺪﺫﺬﺭﺮﺯﺰ';
 		$result = Multibyte::mimeEncode($string);
@@ -9238,7 +9238,7 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?77qO77qP77qQ77qR77qS77qT77qU77qV77qW77qX77qY77qZ77qa77qb77qc?=' . "\r\n" .
 					' =?UTF-8?B?77qd77qe77qf77qg77qh77qi77qj77qk77ql77qm77qn77qo77qp77qq77qr?=' . "\r\n" .
 					' =?UTF-8?B?77qs77qt77qu77qv77qw?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ﺱﺲﺳﺴﺵﺶﺷﺸﺹﺺﺻﺼﺽﺾﺿﻀﻁﻂﻃﻄﻅﻆﻇﻈﻉﻊﻋﻌﻍﻎﻏﻐﻑﻒﻓﻔﻕﻖﻗﻘﻙﻚﻛﻜﻝﻞﻟﻠﻡﻢﻣﻤﻥﻦﻧﻨﻩﻪﻫﻬﻭﻮﻯﻰﻱﻲﻳﻴﻵﻶﻷﻸﻹﻺﻻﻼ';
 		$result = Multibyte::mimeEncode($string);
@@ -9248,59 +9248,59 @@ mb_strtoupper does not work for these strings.
 					' =?UTF-8?B?77ue77uf77ug77uh77ui77uj77uk77ul77um77un77uo77up77uq77ur77us?=' . "\r\n" .
 					' =?UTF-8?B?77ut77uu77uv77uw77ux77uy77uz77u077u177u277u377u477u577u677u7?=' . "\r\n" .
 					' =?UTF-8?B?77u8?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?772B772C772D772E772F772G772H772I772J772K772L772M772N772O772P?=' . "\r\n" .
 					' =?UTF-8?B?772Q772R772S772T772U772V772W772X772Y772Z772a?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '｡｢｣､･ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?772h772i772j772k772l772m772n772o772p772q772r772s772t772u772v?=' . "\r\n" .
 					' =?UTF-8?B?772w772x772y772z77207721772277237724?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'ｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝﾞ';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?77257726772777287729772+772/776A776B776C776D776E776F776G776H?=' . "\r\n" .
 					' =?UTF-8?B?776I776J776K776L776M776N776O776P776Q776R776S776T776U776V776W?=' . "\r\n" .
 					' =?UTF-8?B?776X776Y776Z776a776b776c776d776e?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Ĥēĺļŏ, Ŵőřļď!';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?xKTEk8S6xLzFjywgxbTFkcWZxLzEjyE=?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'Hello, World!';
 		$result = Multibyte::mimeEncode($string);
-		$this->assertEqual($result, $string);
+		$this->assertEquals($result, $string);
 
 		$string = 'čini';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?xI1pbmk=?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'moći';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?bW/Eh2k=?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'državni';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?ZHLFvmF2bmk=?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '把百度设为首页';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?5oqK55m+5bqm6K6+5Li66aaW6aG1?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '一二三周永龍';
 		$result = Multibyte::mimeEncode($string);
 		$expected = '=?UTF-8?B?5LiA5LqM5LiJ5ZGo5rC46b6N?=';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -56,13 +56,13 @@ class CakeLogTest extends CakeTestCase {
 			'engine' => 'TestAppLog'
 		));
 		$this->assertTrue($result);
-		$this->assertEqual(CakeLog::configured(), array('libtest'));
+		$this->assertEquals(CakeLog::configured(), array('libtest'));
 
 		$result = CakeLog::config('plugintest', array(
 			'engine' => 'TestPlugin.TestPluginLog'
 		));
 		$this->assertTrue($result);
-		$this->assertEqual(CakeLog::configured(), array('libtest', 'plugintest'));
+		$this->assertEquals(CakeLog::configured(), array('libtest', 'plugintest'));
 
 		App::build();
 		CakePlugin::unload();
@@ -102,7 +102,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 
 		$result = CakeLog::configured();
-		$this->assertEqual($result, array('default'));
+		$this->assertEquals($result, array('default'));
 		unlink(LOGS . 'error.log');
 	}
 
@@ -117,7 +117,7 @@ class CakeLogTest extends CakeTestCase {
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
-		$this->assertEqual($result, array('file'));
+		$this->assertEquals($result, array('file'));
 
 		if (file_exists(LOGS . 'error.log')) {
 			@unlink(LOGS . 'error.log');
@@ -126,7 +126,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 
 		$result = file_get_contents(LOGS . 'error.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
 		unlink(LOGS . 'error.log');
 	}
 
@@ -141,11 +141,11 @@ class CakeLogTest extends CakeTestCase {
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
-		$this->assertEqual($result, array('file'));
+		$this->assertEquals($result, array('file'));
 
 		CakeLog::drop('file');
 		$result = CakeLog::configured();
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 	}
 
 /**
@@ -165,8 +165,8 @@ class CakeLogTest extends CakeTestCase {
 		CakeLog::write(LOG_WARNING, 'Test warning 1');
 		CakeLog::write(LOG_WARNING, 'Test warning 2');
 		$result = file_get_contents(LOGS . 'error.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 1/', $result);
-		$this->assertPattern('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 2$/', $result);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 1/', $result);
+		$this->assertRegExp('/2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning 2$/', $result);
 		unlink(LOGS . 'error.log');
 	}
 

--- a/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
@@ -39,7 +39,7 @@ class FileLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 
 		$result = file_get_contents(LOGS . 'error.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Warning: Test warning/', $result);
 		unlink(LOGS . 'error.log');
 
 		if (file_exists(LOGS . 'debug.log')) {
@@ -49,7 +49,7 @@ class FileLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'debug.log'));
 
 		$result = file_get_contents(LOGS . 'debug.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Debug: Test warning/', $result);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Debug: Test warning/', $result);
 		unlink(LOGS . 'debug.log');
 
 		if (file_exists(LOGS . 'random.log')) {
@@ -59,7 +59,7 @@ class FileLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'random.log'));
 
 		$result = file_get_contents(LOGS . 'random.log');
-		$this->assertPattern('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Random: Test warning/', $result);
+		$this->assertRegExp('/^2[0-9]{3}-[0-9]+-[0-9]+ [0-9]+:[0-9]+:[0-9]+ Random: Test warning/', $result);
 		unlink(LOGS . 'random.log');
 	}
 

--- a/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
@@ -236,12 +236,12 @@ class AclBehaviorTest extends CakeTestCase {
 	public function testSetup() {
 		$User = new AclUser();
 		$this->assertTrue(isset($User->Behaviors->Acl->settings['User']));
-		$this->assertEqual($User->Behaviors->Acl->settings['User']['type'], 'requester');
+		$this->assertEquals($User->Behaviors->Acl->settings['User']['type'], 'requester');
 		$this->assertTrue(is_object($User->Aro));
 
 		$Post = new AclPost();
 		$this->assertTrue(isset($Post->Behaviors->Acl->settings['Post']));
-		$this->assertEqual($Post->Behaviors->Acl->settings['Post']['type'], 'controlled');
+		$this->assertEquals($Post->Behaviors->Acl->settings['Post']['type'], 'controlled');
 		$this->assertTrue(is_object($Post->Aco));
 	}
 
@@ -253,7 +253,7 @@ class AclBehaviorTest extends CakeTestCase {
 	public function testSetupMulti() {
 		$User = new AclPerson();
 		$this->assertTrue(isset($User->Behaviors->Acl->settings['AclPerson']));
-		$this->assertEqual($User->Behaviors->Acl->settings['AclPerson']['type'], 'both');
+		$this->assertEquals($User->Behaviors->Acl->settings['AclPerson']['type'], 'both');
 		$this->assertTrue(is_object($User->Aro));
 		$this->assertTrue(is_object($User->Aco));
 	}
@@ -278,8 +278,8 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aco.model' => 'Post', 'Aco.foreign_key' => $Post->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($result['Aco']['model'], 'Post');
-		$this->assertEqual($result['Aco']['foreign_key'], $Post->id);
+		$this->assertEquals($result['Aco']['model'], 'Post');
+		$this->assertEquals($result['Aco']['foreign_key'], $Post->id);
 
 		$aroData = array(
 			'Aro' => array(
@@ -312,12 +312,12 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($result['Aro']['parent_id'], 5);
+		$this->assertEquals($result['Aro']['parent_id'], 5);
 
 		$node = $Person->node(array('model' => 'AclPerson', 'foreign_key' => 8), 'Aro');
-		$this->assertEqual(count($node), 2);
-		$this->assertEqual($node[0]['Aro']['parent_id'], 5);
-		$this->assertEqual($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(count($node), 2);
+		$this->assertEquals($node[0]['Aro']['parent_id'], 5);
+		$this->assertEquals($node[1]['Aro']['parent_id'], null);
 
 		$aroData = array(
 			'Aro' => array(
@@ -343,12 +343,12 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($result['Aro']['parent_id'], 7);
+		$this->assertEquals($result['Aro']['parent_id'], 7);
 
 		$node = $Person->node(array('model' => 'AclPerson', 'foreign_key' => 8), 'Aro');
-		$this->assertEqual(sizeof($node), 2);
-		$this->assertEqual($node[0]['Aro']['parent_id'], 7);
-		$this->assertEqual($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(sizeof($node), 2);
+		$this->assertEquals($node[0]['Aro']['parent_id'], 7);
+		$this->assertEquals($node[1]['Aro']['parent_id'], null);
 	}
 
 /**
@@ -389,13 +389,13 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($result['Aro']['parent_id'], 5);
+		$this->assertEquals($result['Aro']['parent_id'], 5);
 
 		$Person->save(array('id' => $Person->id, 'name' => 'Bruce'));
 		$result = $this->Aro->find('first', array(
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
-		$this->assertEqual($result['Aro']['parent_id'], 5);
+		$this->assertEquals($result['Aro']['parent_id'], 5);
 	}
 
 /**
@@ -433,9 +433,9 @@ class AclBehaviorTest extends CakeTestCase {
 		$Person->save($data);
 		$id = $Person->id;
 		$node = $Person->node(null, 'Aro');
-		$this->assertEqual(count($node), 2);
-		$this->assertEqual($node[0]['Aro']['parent_id'], 5);
-		$this->assertEqual($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(count($node), 2);
+		$this->assertEquals($node[0]['Aro']['parent_id'], 5);
+		$this->assertEquals($node[1]['Aro']['parent_id'], null);
 
 		$Person->delete($id);
 		$result = $this->Aro->find('first', array(
@@ -487,6 +487,6 @@ class AclBehaviorTest extends CakeTestCase {
 		$Person->id = 2;
 		$result = $Person->node(null, 'Aro');
 		$this->assertTrue(is_array($result));
-		$this->assertEqual(count($result), 1);
+		$this->assertEquals(count($result), 1);
 	}
 }

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -148,7 +148,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 /**
  * testInvalidContainments method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
+ * @expectedException PHPUnit_Framework_Error
  * @return void
  */
 	public function testInvalidContainments() {
@@ -239,7 +239,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 /**
  * testBeforeFindWithNonExistingBinding method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
+ * @expectedException PHPUnit_Framework_Error
  * @return void
  */
 	public function testBeforeFindWithNonExistingBinding() {
@@ -2891,7 +2891,8 @@ class ContainableBehaviorTest extends CakeTestCase {
 	public function testEmbeddedFindFields() {
 		$result = $this->Article->find('all', array(
 			'contain' => array('User(user)'),
-			'fields' => array('title')
+			'fields' => array('title'),
+			'order' => array('Article.id' => 'ASC')
 		));
 		$expected = array(
 			array('Article' => array('title' => 'First Article'), 'User' => array('user' => 'mariano', 'id' => 1)),
@@ -2902,7 +2903,8 @@ class ContainableBehaviorTest extends CakeTestCase {
 
 		$result = $this->Article->find('all', array(
 			'contain' => array('User(id, user)'),
-			'fields' => array('title')
+			'fields' => array('title'),
+			'order' => array('Article.id' => 'ASC')
 		));
 		$expected = array(
 			array('Article' => array('title' => 'First Article'), 'User' => array('user' => 'mariano', 'id' => 1)),
@@ -2915,7 +2917,8 @@ class ContainableBehaviorTest extends CakeTestCase {
 			'contain' => array(
 				'Comment(comment, published)' => 'Attachment(attachment)', 'User(user)'
 			),
-			'fields' => array('title')
+			'fields' => array('title'),
+			'order' => array('Article.id' => 'ASC')
 		));
 		if (!empty($result)) {
 			foreach($result as $i=>$article) {
@@ -2999,7 +3002,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'conditions' => array('created >=' => '2007-03-18 12:24')
 			)
 		));
-		$result = $this->Article->find('all', array('fields' => array('title')));
+		$result = $this->Article->find('all', array('fields' => array('title'), 'order' => array('Article.id' => 'ASC')));
 		$expected = array(
 			array(
 				'Article' => array('id' => 1, 'title' => 'First Article'),
@@ -3020,7 +3023,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertEqual($expected, $result);
 
 		$this->Article->contain(array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created'))));
-		$result = $this->Article->find('all', array('fields' => array('title')));
+		$result = $this->Article->find('all', array('fields' => array('title'), 'order' => array('Article.id' => 'ASC')));
 		$expected = array(
 			array(
 				'Article' => array('id' => 1, 'title' => 'First Article'),
@@ -3048,7 +3051,8 @@ class ContainableBehaviorTest extends CakeTestCase {
 
 		$result = $this->Article->find('all', array(
 			'fields' => array('title'),
-			'contain' => array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created')))
+			'contain' => array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created'))),
+			'order' => array('Article.id' => 'ASC')
 		));
 		$expected = array(
 			array(
@@ -3082,7 +3086,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'conditions' => array('created >=' => '2007-03-18 12:24')
 			)
 		));
-		$result = $this->Article->find('all', array('fields' => array('title')));
+		$result = $this->Article->find('all', array('fields' => array('title'), 'order' => array('Article.id' => 'ASC')));
 		$expected = array(
 			array(
 				'Article' => array('id' => 1, 'title' => 'First Article'),

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -92,7 +92,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					'Category' => 'name'
 				)
 		)));
-		$this->assertEqual(Set::extract('/ArticleFeatured/keep/Featured/fields', $r), array('id'));
+		$this->assertEquals(Set::extract('/ArticleFeatured/keep/Featured/fields', $r), array('id'));
 
 		$r = $this->__containments($this->Article, array(
 			'Comment' => array(
@@ -109,37 +109,37 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertTrue(Set::matches('/User', $r));
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
 		$this->assertTrue(Set::matches('/Article/keep/User', $r));
-		$this->assertEqual(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
-		$this->assertEqual(Set::extract('/Article/keep/User/fields', $r), array('user'));
+		$this->assertEquals(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
+		$this->assertEquals(Set::extract('/Article/keep/User/fields', $r), array('user'));
 		$this->assertTrue(Set::matches('/Comment/keep/Attachment', $r));
-		$this->assertEqual(Set::extract('/Comment/keep/Attachment/fields', $r), array('attachment'));
+		$this->assertEquals(Set::extract('/Comment/keep/Attachment/fields', $r), array('attachment'));
 
 		$r = $this->__containments($this->Article, array('Comment' => array('limit' => 1)));
-		$this->assertEqual(array_keys($r), array('Comment', 'Article'));
+		$this->assertEquals(array_keys($r), array('Comment', 'Article'));
 		$result = Set::extract('/Comment/keep', $r);
-		$this->assertEqual(array_shift($result), array('keep' => array()));
+		$this->assertEquals(array_shift($result), array('keep' => array()));
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
 		$result = Set::extract('/Article/keep/Comment/.', $r);
-		$this->assertEqual(array_shift($result), array('limit' => 1));
+		$this->assertEquals(array_shift($result), array('limit' => 1));
 
 		$r = $this->__containments($this->Article, array('Comment.User'));
-		$this->assertEqual(array_keys($r), array('User', 'Comment', 'Article'));
+		$this->assertEquals(array_keys($r), array('User', 'Comment', 'Article'));
 
 		$result = Set::extract('/User/keep', $r);
-		$this->assertEqual(array_shift($result), array('keep' => array()));
+		$this->assertEquals(array_shift($result), array('keep' => array()));
 
 		$result = Set::extract('/Comment/keep', $r);
-		$this->assertEqual(array_shift($result), array('keep' => array('User' => array())));
+		$this->assertEquals(array_shift($result), array('keep' => array('User' => array())));
 
 		$result = Set::extract('/Article/keep', $r);
-		$this->assertEqual(array_shift($result), array('keep' => array('Comment' => array())));
+		$this->assertEquals(array_shift($result), array('keep' => array('Comment' => array())));
 
 		$r = $this->__containments($this->Tag, array('Article' => array('User' => array('Comment' => array(
 			'Attachment' => array('conditions' => array('Attachment.id >' => 1))
 		)))));
 		$this->assertTrue(Set::matches('/Attachment', $r));
 		$this->assertTrue(Set::matches('/Comment/keep/Attachment/conditions', $r));
-		$this->assertEqual($r['Comment']['keep']['Attachment']['conditions'], array('Attachment.id >' => 1));
+		$this->assertEquals($r['Comment']['keep']['Attachment']['conditions'], array('Attachment.id >' => 1));
 		$this->assertTrue(Set::matches('/User/keep/Comment', $r));
 		$this->assertTrue(Set::matches('/Article/keep/User', $r));
 		$this->assertTrue(Set::matches('/Tag/keep/Article', $r));
@@ -194,7 +194,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$r = $this->Article->find('all', array('contain' => 'Comment.id DESC'));
 		$ids = $descIds = Set::extract('/Comment[1]/id', $r);
 		rsort($descIds);
-		$this->assertEqual($ids, $descIds);
+		$this->assertEquals($ids, $descIds);
 
 		$r = $this->Article->find('all', array('contain' => 'Comment'));
 		$this->assertTrue(Set::matches('/Comment[user_id!=2]', $r));
@@ -282,7 +282,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
 			))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -325,7 +325,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain('User', 'Comment');
 		$result = $this->Article->find('all', array('recursive' => 1));
@@ -390,7 +390,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Comment' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -432,7 +432,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('contain' => array('User', 'Comment')));
 		$expected = array(
@@ -496,7 +496,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Comment' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -580,7 +580,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Comment' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User' => 'ArticleFeatured'));
 		$result = $this->Article->find('all', array('recursive' => 2));
@@ -642,7 +642,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User' => array('ArticleFeatured', 'Comment')));
 		$result = $this->Article->find('all', array('recursive' => 2));
@@ -733,7 +733,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User' => array('ArticleFeatured')), 'Tag', array('Comment' => 'Attachment'));
 		$result = $this->Article->find('all', array('recursive' => 2));
@@ -842,7 +842,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -925,7 +925,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Comment' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('contain' => array('User' => 'ArticleFeatured')));
 		$expected = array(
@@ -986,7 +986,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('contain' => array('User' => array('ArticleFeatured', 'Comment'))));
 		$expected = array(
@@ -1076,7 +1076,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('contain' => array('User' => 'ArticleFeatured', 'Tag', 'Comment' => 'Attachment')));
 		$expected = array(
@@ -1184,7 +1184,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1256,7 +1256,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->User->contain(array('ArticleFeatured' => array('Featured' => 'Category', 'Comment' => array('Article', 'Attachment'))));
 		$result = $this->User->find('all', array('recursive' => 3));
@@ -1383,7 +1383,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->User->contain(array('ArticleFeatured' => array('Featured' => 'Category', 'Comment' => 'Attachment'), 'Article'));
 		$result = $this->User->find('all', array('recursive' => 3));
@@ -1504,7 +1504,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1575,7 +1575,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->User->find('all', array('contain' => array('ArticleFeatured' => array('Featured' => 'Category', 'Comment' => array('Article', 'Attachment')))));
 		$expected = array(
@@ -1701,7 +1701,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->User->find('all', array('contain' => array('ArticleFeatured' => array('Featured' => 'Category', 'Comment' => 'Attachment'), 'Article')));
 		$expected = array(
@@ -1821,7 +1821,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1890,7 +1890,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$r = $this->User->find('all', array('contain' => array(
 			'ArticleFeatured' => array(
@@ -1996,7 +1996,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$orders = array(
 			'title DESC', 'title DESC, published DESC',
@@ -2066,7 +2066,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					'ArticleFeatured' => array()
 				)
 			);
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 		}
 	}
 
@@ -2139,7 +2139,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->User->resetBindings();
 
@@ -2268,7 +2268,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->User->resetBindings();
 
@@ -2391,7 +2391,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2462,7 +2462,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->__assertBindings($this->User, array('hasMany' => array('ArticleFeatured')));
 		$this->__assertBindings($this->User->ArticleFeatured, array('hasOne' => array('Featured')));
@@ -2599,7 +2599,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->__assertBindings($this->User, array('hasMany' => array('ArticleFeatured')));
 		$this->__assertBindings($this->User->ArticleFeatured, array('hasOne' => array('Featured'), 'hasMany' => array('Comment')));
@@ -2736,7 +2736,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->__assertBindings($this->User, array('hasMany' => array('ArticleFeatured')));
 		$this->__assertBindings($this->User->ArticleFeatured, array('hasOne' => array('Featured'), 'hasMany' => array('Comment')));
@@ -2867,7 +2867,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'ArticleFeatured' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->__assertBindings($this->User, array('hasMany' => array('Article', 'ArticleFeatured')));
 		$this->__assertBindings($this->User->Article);
@@ -2899,7 +2899,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array('Article' => array('title' => 'Second Article'), 'User' => array('user' => 'larry', 'id' => 3)),
 			array('Article' => array('title' => 'Third Article'), 'User' => array('user' => 'mariano', 'id' => 1)),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array(
 			'contain' => array('User(id, user)'),
@@ -2911,7 +2911,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array('Article' => array('title' => 'Second Article'), 'User' => array('user' => 'larry', 'id' => 3)),
 			array('Article' => array('title' => 'Third Article'), 'User' => array('user' => 'mariano', 'id' => 1)),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array(
 			'contain' => array(
@@ -2954,7 +2954,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Comment' => array()
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3020,7 +3020,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created'))));
 		$result = $this->Article->find('all', array('fields' => array('title'), 'order' => array('Article.id' => 'ASC')));
@@ -3047,7 +3047,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array(
 			'fields' => array('title'),
@@ -3077,7 +3077,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array(
 			'User(id,user)',
@@ -3104,7 +3104,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertTrue(empty($this->User->Article->hasAndBelongsToMany['Tag']['conditions']));
 
@@ -3137,15 +3137,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 	public function testOtherFinds() {
 		$result = $this->Article->find('count');
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('count', array('conditions' => array('Article.id >' => '1')));
 		$expected = 2;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('count', array('contain' => array()));
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created'), 'conditions' => array('created >=' => '2007-03-18 12:24'))));
 		$result = $this->Article->find('first', array('fields' => array('title')));
@@ -3154,7 +3154,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			'User' => array('id' => 1, 'user' => 'mariano'),
 			'Tag' => array(array('tag' => 'tag2', 'created' => '2007-03-18 12:24:23'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(array('User(id,user)', 'Tag' => array('fields' => array('tag', 'created'))));
 		$result = $this->Article->find('first', array('fields' => array('title')));
@@ -3166,7 +3166,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array('tag' => 'tag2', 'created' => '2007-03-18 12:24:23')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('first', array(
 			'fields' => array('title'),
@@ -3178,7 +3178,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			'User' => array('id' => 1, 'user' => 'mariano'),
 			'Tag' => array()
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('list', array(
 			'contain' => array('User(id,user)'),
@@ -3189,7 +3189,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			2 => 'Second Article',
 			3 => 'Third Article'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3219,7 +3219,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		));
 
 		$result = $this->Article->Comment->find('all', $options);
-		$this->assertEqual($result, $firstResult);
+		$this->assertEquals($result, $firstResult);
 
 		$this->Article->unbindModel(array('hasMany' => array('Comment'), 'belongsTo' => array('User'), 'hasAndBelongsToMany' => array('Tag')), false);
 		$this->Article->bindModel(array('hasMany' => array('Comment'), 'belongsTo' => array('User')), false);
@@ -3248,7 +3248,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array('comment' => 'Fourth Comment for First Article', 'article_id' => 1)
 			)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('fields' => array('title', 'User.id', 'User.user'), 'limit' => 1, 'page' => 2, 'order' => 'Article.id ASC'));
 		$expected = array(array(
@@ -3259,7 +3259,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array('comment' => 'Second Comment for Second Article', 'article_id' => 2)
 			)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Article->find('all', array('fields' => array('title', 'User.id', 'User.user'), 'limit' => 1, 'page' => 3, 'order' => 'Article.id ASC'));
 		$expected = array(array(
@@ -3267,7 +3267,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			'User' => array('id' => 1, 'user' => 'mariano'),
 			'Comment' => array()
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Article->contain(false, array('User' => array('fields' => 'user'), 'Comment'));
 		$result = $this->Article->find('all');
@@ -3303,9 +3303,9 @@ class ContainableBehaviorTest extends CakeTestCase {
 
 		$expected = array('Article', 'ArticlesTag');
 		$this->assertTrue(!empty($result));
-		$this->assertEqual('First Article', $result['Article']['title']);
+		$this->assertEquals('First Article', $result['Article']['title']);
 		$this->assertTrue(!empty($result['ArticlesTag']));
-		$this->assertEqual($expected, array_keys($result));
+		$this->assertEquals($expected, array_keys($result));
 
 		$this->assertTrue(empty($this->Article->hasMany['ArticlesTag']));
 
@@ -3322,7 +3322,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$result = $this->JoinA->hasOne;
 		$this->JoinA->find('all');
 		$resultAfter = $this->JoinA->hasOne;
-		$this->assertEqual($result, $resultAfter);
+		$this->assertEquals($result, $resultAfter);
 	}
 
 /**
@@ -3353,7 +3353,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		);
 		$result = $this->Article->Comment->find('all', $findOptions);
 		$result = $this->Article->Comment->find('all', $initialOptions);
-		$this->assertEqual($result, $initialModels);
+		$this->assertEquals($result, $initialModels);
 	}
 
 /**
@@ -3369,7 +3369,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->Article->User->bindModel($userHasOne, false);
 		$expected = $this->Article->User->hasOne;
 		$this->Article->find('all');
-		$this->assertEqual($expected, $this->Article->User->hasOne);
+		$this->assertEquals($expected, $this->Article->User->hasOne);
 
 		$this->Article->User->bindModel($userHasOne, false);
 		$expected = $this->Article->User->hasOne;
@@ -3378,7 +3378,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'User' => array('ArticleFeatured', 'Comment')
 			)
 		));
-		$this->assertEqual($expected, $this->Article->User->hasOne);
+		$this->assertEquals($expected, $this->Article->User->hasOne);
 
 		$this->Article->User->bindModel($userHasOne, false);
 		$expected = $this->Article->User->hasOne;
@@ -3390,7 +3390,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		));
-		$this->assertEqual($expected, $this->Article->User->hasOne);
+		$this->assertEquals($expected, $this->Article->User->hasOne);
 
 		$this->Article->User->bindModel($userHasOne, false);
 		$expected = $this->Article->User->hasOne;
@@ -3401,7 +3401,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				)
 			)
 		));
-		$this->assertEqual($expected, $this->Article->User->hasOne);
+		$this->assertEquals($expected, $this->Article->User->hasOne);
 
 		$this->Article->User->bindModel($userHasOne, false);
 		$expected = $this->Article->User->hasOne;
@@ -3413,7 +3413,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				'User.Comment'
 			)
 		));
-		$this->assertEqual($expected, $this->Article->User->hasOne);
+		$this->assertEquals($expected, $this->Article->User->hasOne);
 	}
 
 /**
@@ -3444,67 +3444,67 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all');
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => 'Tag.tag'));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => 'Tag'));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('Tag' => array('fields' => array(null)))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('Tag' => array('fields' => array('Tag.tag')))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('Tag' => array('fields' => array('Tag.tag', 'Tag.created')))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => 'ShortTag.tag'));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => 'ShortTag'));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('ShortTag' => array('fields' => array(null)))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('ShortTag' => array('fields' => array('ShortTag.tag')))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 
 		$this->Article->resetBindings();
 		$this->Article->bindModel($articleHabtm, false);
 		$expected = $this->Article->hasAndBelongsToMany;
 		$this->Article->find('all', array('contain' => array('ShortTag' => array('fields' => array('ShortTag.tag', 'ShortTag.created')))));
-		$this->assertEqual($expected, $this->Article->hasAndBelongsToMany);
+		$this->assertEquals($expected, $this->Article->hasAndBelongsToMany);
 	}
 
 /**
@@ -3538,7 +3538,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$result = $this->Article->find('all', array('limit' => 1, 'contain' => array('ArticlesTag', 'Tag')));
 
 		$associated = $this->Article->getAssociated();
-		$this->assertEqual('hasAndBelongsToMany', $associated['Tag']);
+		$this->assertEquals('hasAndBelongsToMany', $associated['Tag']);
 		$this->assertFalse(isset($associated['ArticleTag']));
 	}
 
@@ -3577,7 +3577,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->Article->recursive = -1;
 		$result = $this->Article->field('title', array('Article.title' => 'First Article'));
 		$this->assertNoErrors();
-		$this->assertEqual($result, 'First Article', 'Field is wrong');
+		$this->assertEquals($result, 'First Article', 'Field is wrong');
 	}
 
 /**
@@ -3647,7 +3647,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$expected = array_merge(array('belongsTo' => array(), 'hasOne' => array(), 'hasMany' => array(), 'hasAndBelongsToMany' => array()), $expected);
 
 		foreach($expected as $binding => $expect) {
-			$this->assertEqual(array_keys($Model->$binding), $expect);
+			$this->assertEquals(array_keys($Model->$binding), $expect);
 		}
 	}
 

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -69,24 +69,24 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->translateTable = 'another_i18n';
 		$TestModel->Behaviors->attach('Translate', array('title'));
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEqual($translateModel->name, 'I18nModel');
-		$this->assertEqual($translateModel->useTable, 'another_i18n');
+		$this->assertEquals($translateModel->name, 'I18nModel');
+		$this->assertEquals($translateModel->useTable, 'another_i18n');
 
 		$TestModel = new User();
 		$TestModel->Behaviors->attach('Translate', array('title'));
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEqual($translateModel->name, 'I18nModel');
-		$this->assertEqual($translateModel->useTable, 'i18n');
+		$this->assertEquals($translateModel->name, 'I18nModel');
+		$this->assertEquals($translateModel->useTable, 'i18n');
 
 		$TestModel = new TranslatedArticle();
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEqual($translateModel->name, 'TranslateArticleModel');
-		$this->assertEqual($translateModel->useTable, 'article_i18n');
+		$this->assertEquals($translateModel->name, 'TranslateArticleModel');
+		$this->assertEquals($translateModel->useTable, 'article_i18n');
 
 		$TestModel = new TranslatedItem();
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEqual($translateModel->name, 'TranslateTestModel');
-		$this->assertEqual($translateModel->useTable, 'i18n');
+		$this->assertEquals($translateModel->name, 'TranslateTestModel');
+		$this->assertEquals($translateModel->useTable, 'i18n');
 	}
 
 /**
@@ -102,7 +102,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 
 		$result = $TestModel->read(null, 1);
 		$expected = array('TranslatedItem' => array('id' => 1, 'slug' => 'first_translated'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => array('slug')));
 		$expected = array(
@@ -110,7 +110,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 			array('TranslatedItem' => array('slug' => 'second_translated')),
 			array('TranslatedItem' => array('slug' => 'third_translated'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -141,7 +141,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				array('id' => 6, 'locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Obsah #1')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->hasMany['Title']['fields'] = $TestModel->hasMany['Content']['fields'] = array('content');
 		$TestModel->hasMany['Title']['conditions']['locale'] = $TestModel->hasMany['Content']['conditions']['locale'] = 'eng';
@@ -164,7 +164,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'Content' => array(array('foreign_key' => 3, 'content' => 'Content #3'))
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -188,7 +188,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'content' => 'Content #1'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all');
 		$expected = array(
@@ -220,7 +220,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -245,7 +245,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('conditions' => "TranslatedItem.slug = 'first_translated'"));
 		$expected = array(
@@ -259,7 +259,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -296,7 +296,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				array('id' => 6, 'locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Obsah #1')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->hasMany['Title']['fields'] = $TestModel->hasMany['Content']['fields'] = array('content');
 		$TestModel->hasMany['Title']['conditions']['locale'] = $TestModel->hasMany['Content']['conditions']['locale'] = 'eng';
@@ -319,7 +319,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'Content' => array(array('foreign_key' => 3, 'content' => 'Content #3'))
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -344,7 +344,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'content' => 'Inhalt #1'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => array('slug', 'title', 'content')));
 		$expected = array(
@@ -401,7 +401,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'content' => ''
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -417,7 +417,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->displayField = 'title';
 		$result = $TestModel->find('list', array('recursive' => 1));
 		$expected = array(1 => 'Titel #1', 2 => 'Titel #2', 3 => 'Titel #3');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// SQL Server trigger an error and stops the page even if the debug = 0
 		if ($this->db instanceof Sqlserver) {
@@ -425,16 +425,16 @@ class TranslateBehaviorTest extends CakeTestCase {
 			Configure::write('debug', 0);
 
 			$result = $TestModel->find('list', array('recursive' => 1, 'callbacks' => false));
-			$this->assertEqual($result, array());
+			$this->assertEquals($result, array());
 
 			$result = $TestModel->find('list', array('recursive' => 1, 'callbacks' => 'after'));
-			$this->assertEqual($result, array());
+			$this->assertEquals($result, array());
 			Configure::write('debug', $debug);
 		}
 
 		$result = $TestModel->find('list', array('recursive' => 1, 'callbacks' => 'before'));
 		$expected = array(1 => null, 2 => null, 3 => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -453,10 +453,10 @@ class TranslateBehaviorTest extends CakeTestCase {
 			array('TranslatedItem' => array('slug' => 'second_translated', 'locale' => 'eng', 'content' => 'Content #2')),
 			array('TranslatedItem' => array('slug' => 'third_translated', 'locale' => 'eng', 'content' => 'Content #3'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => array('TranslatedItem.slug', 'content')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->locale = array('eng', 'deu', 'cze');
 		$delete = array(array('locale' => 'deu'), array('field' => 'content', 'locale' => 'eng'));
@@ -469,7 +469,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 			array('TranslatedItem' => array('locale' => 'eng', 'title' => 'Title #2', 'content' => 'Obsah #2')),
 			array('TranslatedItem' => array('locale' => 'eng', 'title' => 'Title #3', 'content' => 'Obsah #3'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -487,7 +487,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->save();
 		$result = $TestModel->read();
 		$expected = array('TranslatedItem' => array_merge($data, array('id' => $TestModel->id, 'locale' => 'spa')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -509,7 +509,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->save();
 		$result = $TestModel->read(null, $id);
 		$expected = array('TranslatedItem' => array_merge($oldData, $newData, array('locale' => 'spa')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -547,7 +547,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				array('id' => 20, 'locale' => 'spa', 'model' => 'TranslatedItem', 'foreign_key' => 4, 'field' => 'content', 'content' => 'Nuevo contenido')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -586,7 +586,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				array('id' => 6, 'locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Novy Obsah #1')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->unbindTranslation($translations);
 		$TestModel->bindTranslation(array('title', 'content'), false);
@@ -630,7 +630,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				array('id' => 6, 'locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Upraveny obsah #1')
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -651,7 +651,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		));
 		$TestModel->create();
 		$this->assertFalse($TestModel->save($data));
-		$this->assertEqual($TestModel->validationErrors['title'], array('This field cannot be left blank'));
+		$this->assertEquals($TestModel->validationErrors['title'], array('This field cannot be left blank'));
 
 		$TestModel->locale = 'eng';
 		$TestModel->validate['title'] = '/Only this title/';
@@ -681,12 +681,12 @@ class TranslateBehaviorTest extends CakeTestCase {
 
 		$result = array_keys($TestModel->hasMany);
 		$expected = array('Title', 'Content');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->Behaviors->detach('Translate');
 		$result = array_keys($TestModel->hasMany);
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = isset($TestModel->Behaviors->Translate);
 		$this->assertFalse($result);
@@ -700,7 +700,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->Behaviors->attach('Translate', array('title' => 'Title', 'content' => 'Content'));
 		$result = array_keys($TestModel->hasMany);
 		$expected = array('Title', 'Content');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = isset($TestModel->Behaviors->Translate);
 		$this->assertTrue($result);
@@ -734,7 +734,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'content' => 'Another Content #1'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -769,7 +769,7 @@ class TranslateBehaviorTest extends CakeTestCase {
             	'updated' => '2007-03-17 01:18:31'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('recursive' => -1));
 		$expected = array(
@@ -810,8 +810,8 @@ class TranslateBehaviorTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->recursive, $recursive);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->recursive, $recursive);
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->read(null, 1);
@@ -827,7 +827,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'body' => 'Body (eng) #1'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * testTranslateTableWithPrefix method
@@ -847,7 +847,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 			'content' => 'Content #1',
 			'title' => 'Title #1'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
@@ -66,11 +66,11 @@ class TreeBehaviorAfterTest extends CakeTestCase {
 		$expected = array('AfterTree' => array('name' => 'Six and One Half Changed in AfterTree::afterSave() but not in database', 'parent_id' => 6, 'lft' => 11, 'rght' => 12));
 		$result = $this->Tree->save(array('AfterTree' => array('name' => 'Six and One Half', 'parent_id' => 6)));
 		$expected['AfterTree']['id'] = $this->Tree->id;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = array('AfterTree' => array('name' => 'Six and One Half', 'parent_id' => 6, 'lft' => 11, 'rght' => 12, 'id' => 8));
 		$result = $this->Tree->find('all');
-		$this->assertEqual($result[7], $expected);
+		$this->assertEquals($result[7], $expected);
 	}
 }
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -67,10 +67,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->find('count');
-		$this->assertEqual($result, 7);
+		$this->assertEquals($result, 7);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -90,13 +90,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$this->Tree->save($save);
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -116,13 +116,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$this->Tree->save($save);
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -141,13 +141,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->updateAll(array($parentField => null), array('id' => $result[$modelClass]['id']));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -164,13 +164,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->updateAll(array($parentField => 999999), array('id' => $result[$modelClass]['id']));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover('MPTT');
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -187,13 +187,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->updateAll(array($parentField => 999999), array('id' => $result[$modelClass]['id']));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -209,13 +209,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->updateAll(array($parentField => null));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -231,12 +231,12 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->updateAll(array($leftField => 0, $rightField => 0));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$this->Tree->recover();
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 	}
 
 /**
@@ -257,7 +257,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($rightField . ' >' => $result[$modelClass][$leftField]));
 
 		$result = $this->Tree->verify();
-		$this->assertNotIdentical($result, true);
+		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
 		$this->assertTrue($result);
@@ -279,10 +279,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
 		$result = $this->Tree->find('first', array('fields' => array('name', $parentField), 'order' => $modelClass . '.' . $leftField . ' desc'));
 		$expected = array($modelClass => array('name' => 'testAddOrphan', $parentField => null));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -301,21 +301,21 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->create();
 		$result = $this->Tree->save(array($modelClass => array('name' => 'testAddMiddle', $parentField => $data[$modelClass]['id'])));
 		$expected = array_merge(array($modelClass => array('name' => 'testAddMiddle', $parentField => '2')), $result);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$laterCount = $this->Tree->find('count');
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount + 1, $laterCount);
+		$this->assertEquals($initialCount + 1, $laterCount);
 
 		$children = $this->Tree->children($data[$modelClass]['id'], true, array('name'));
 		$expects = array(array($modelClass => array('name' => '1.1.1')),
 			array($modelClass => array('name' => '1.1.2')),
 			array($modelClass => array('name' => 'testAddMiddle')));
-		$this->assertIdentical($children, $expects);
+		$this->assertSame($children, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -333,13 +333,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
 
 		$saveSuccess = $this->Tree->save(array($modelClass => array('name' => 'testAddInvalid', $parentField => 99999)));
-		$this->assertIdentical($saveSuccess, false);
+		$this->assertSame($saveSuccess, false);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertIdentical($initialCount, $laterCount);
+		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -355,10 +355,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array('name' => 'testAddNotIndexed', $parentField => null));
 		$result = $this->Tree->find('first', array('fields' => array('name', $parentField), 'order' => $modelClass . '.' . $leftField . ' desc'));
 		$expected = array($modelClass => array('name' => 'testAddNotIndexed', $parentField => null));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 }
 
 /**
@@ -382,9 +382,9 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('id' => 2, 'name' => '1.1', $parentField => 1, $leftField => 2, $rightField => 5)),
 			array($modelClass => array('id' => 5, 'name' => '1.2', $parentField => 1, $leftField => 6, $rightField => 11)),
 			array($modelClass => array('id' => 3, 'name' => '1.1.1', $parentField => 1, $leftField => 12, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -410,7 +410,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expected = array(array($modelClass => array('id' => 2, 'name' => '1.1', $parentField => 1, $leftField => 2, $rightField => 5)),
 			array($modelClass => array('id' => 5, 'name' => '1.2', $parentField => 1, $leftField => 6, $rightField => 11)),
 			array($modelClass => array('id' => 3, 'name' => '1.1.1', $parentField => 1, $leftField => 12, $rightField => 13)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertTrue($this->Tree->verify());
 	}
 
@@ -428,8 +428,8 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
 		$result = $this->Tree->findByName('testAddOrphan', array('name', $parentField, $leftField, $rightField));
 		$expected = array('name' => 'testAddOrphan', $parentField => null, $leftField => '15', $rightField => 16);
-		$this->assertEqual($result[$modelClass], $expected);
-		$this->assertIdentical($this->Tree->verify(), true);
+		$this->assertEquals($result[$modelClass], $expected);
+		$this->assertSame($this->Tree->verify(), true);
 	}
 
 /**
@@ -454,10 +454,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1.1.1')),
 			array($modelClass => array('name' => '1.1.2')),
 			array($modelClass => array('name' => '1.2')));
-		$this->assertEqual($result, $expects);
+		$this->assertEquals($result, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -482,10 +482,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1.2.1')),
 			array($modelClass => array('name' => '1.2.2')),
 			array($modelClass => array('name' => '1.1')));
-		$this->assertEqual($result, $expects);
+		$this->assertEquals($result, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -514,11 +514,11 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$results = $this->Tree->find('all');
 		$after = $this->Tree->read(null, $data[$modelClass]['id']);
 
-		$this->assertEqual($results, $expects);
-		$this->assertEqual($before, $after);
+		$this->assertEquals($results, $expects);
+		$this->assertEquals($before, $after);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -539,12 +539,12 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->id = $data[$modelClass]['id'];
 		$this->Tree->saveField($parentField, 999999);
 
-		//$this->assertIdentical($saveSuccess, false);
+		//$this->assertSame($saveSuccess, false);
 		$laterCount = $this->Tree->find('count');
-		$this->assertIdentical($initialCount, $laterCount);
+		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -565,12 +565,12 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->id = $data[$modelClass]['id'];
 		$saveSuccess = $this->Tree->saveField($parentField, $this->Tree->id);
 
-		$this->assertIdentical($saveSuccess, false);
+		$this->assertSame($saveSuccess, false);
 		$laterCount = $this->Tree->find('count');
-		$this->assertIdentical($initialCount, $laterCount);
+		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -591,7 +591,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->children(null, true, array('name'));
 		$expected = array(array($modelClass => array('name' => '1.2', )),
 			array($modelClass => array('name' => '1.1', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -613,7 +613,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->children(null, true, array('name'));
 		$expected = array(array($modelClass => array('name' => '1.1', )),
 			array($modelClass => array('name' => '1.2', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -643,7 +643,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.8', )),
 			array($modelClass => array('name' => '1.9', )),
 			array($modelClass => array('name' => '1.10', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -673,7 +673,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.8', )),
 			array($modelClass => array('name' => '1.9', )),
 			array($modelClass => array('name' => '1.10', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -694,7 +694,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->children(null, true, array('name'));
 		$expected = array(array($modelClass => array('name' => '1.2', )),
 			array($modelClass => array('name' => '1.1', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -715,7 +715,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->children(null, true, array('name'));
 		$expected = array(array($modelClass => array('name' => '1.1', )),
 			array($modelClass => array('name' => '1.2', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -745,7 +745,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.9', )),
 			array($modelClass => array('name' => '1.10', )),
 			array($modelClass => array('name' => '1.5', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -775,7 +775,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.8', )),
 			array($modelClass => array('name' => '1.9', )),
 			array($modelClass => array('name' => '1.10', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -805,7 +805,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.8', )),
 			array($modelClass => array('name' => '1.9', )),
 			array($modelClass => array('name' => '1.10', )));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -822,14 +822,14 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array($parentField => null));
 
 		$result = $this->Tree->verify();
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$this->Tree->moveUp();
 
 		$result = $this->Tree->find('all', array('fields' => 'name', 'order' => $modelClass . '.' . $leftField . ' ASC'));
 		$expected = array(array($modelClass => array('name' => '1.1')),
 			array($modelClass => array('name' => '1. Root')));
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -846,25 +846,25 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->findByName('1.1.1');
 
 		$return = $this->Tree->delete($result[$modelClass]['id']);
-		$this->assertEqual($return, true);
+		$this->assertEquals($return, true);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount - 1, $laterCount);
+		$this->assertEquals($initialCount - 1, $laterCount);
 
 		$validTree= $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 
 		$initialCount = $this->Tree->find('count');
 		$result= $this->Tree->findByName('1.1');
 
 		$return = $this->Tree->delete($result[$modelClass]['id']);
-		$this->assertEqual($return, true);
+		$this->assertEquals($return, true);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount - 2, $laterCount);
+		$this->assertEquals($initialCount - 2, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -882,21 +882,21 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id']);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount, $laterCount);
+		$this->assertEquals($initialCount, $laterCount);
 
 		$children = $this->Tree->children($result[$modelClass][$parentField], true, array('name'));
 		$expects = array(array($modelClass => array('name' => '1.1.1')),
 			array($modelClass => array('name' => '1.1.2')),
 			array($modelClass => array('name' => '1.2')));
-		$this->assertEqual($children, $expects);
+		$this->assertEquals($children, $expects);
 
 		$topNodes = $this->Tree->children(false, true,array('name'));
 		$expects = array(array($modelClass => array('name' => '1. Root')),
 			array($modelClass => array('name' => '1.1')));
-		$this->assertEqual($topNodes, $expects);
+		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -918,18 +918,18 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$laterCount = $this->Tree->find('count');
 		$laterTopNodes = $this->Tree->childCount(false);
 
-		$this->assertEqual($initialCount, $laterCount);
-		$this->assertEqual($initialTopNodes, $laterTopNodes);
+		$this->assertEquals($initialCount, $laterCount);
+		$this->assertEquals($initialTopNodes, $laterTopNodes);
 
 		$topNodes = $this->Tree->children(false, true,array('name'));
 		$expects = array(array($modelClass => array('name' => '1.1')),
 			array($modelClass => array('name' => '1.2')),
 			array($modelClass => array('name' => '1. Root')));
 
-		$this->assertEqual($topNodes, $expects);
+		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -947,7 +947,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id']);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount, $laterCount);
+		$this->assertEquals($initialCount, $laterCount);
 
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 		$expects = array(
@@ -960,10 +960,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			3 => '1.1.1',
 		);
 
-		$this->assertEqual($nodes, $expects);
+		$this->assertEquals($nodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -982,20 +982,20 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id'], true);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount-1, $laterCount);
+		$this->assertEquals($initialCount-1, $laterCount);
 
 		$children = $this->Tree->children($result[$modelClass][$parentField], true, array('name'), $leftField . ' asc');
 		$expects= array(array($modelClass => array('name' => '1.1.1')),
 			array($modelClass => array('name' => '1.1.2')),
 			array($modelClass => array('name' => '1.2')));
-		$this->assertEqual($children, $expects);
+		$this->assertEquals($children, $expects);
 
 		$topNodes = $this->Tree->children(false, true,array('name'));
 		$expects = array(array($modelClass => array('name' => '1. Root')));
-		$this->assertEqual($topNodes, $expects);
+		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -1013,7 +1013,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id'], true);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount - 1, $laterCount);
+		$this->assertEquals($initialCount - 1, $laterCount);
 
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 		$expects = array(
@@ -1024,10 +1024,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			6 => '1.2.1',
 			7 => '1.2.2',
 		);
-		$this->assertEqual($nodes, $expects);
+		$this->assertEquals($nodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -1046,7 +1046,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$direct = $this->Tree->children(null, true, array('id', 'name', $parentField, $leftField, $rightField));
 		$expects = array(array($modelClass => array('id' => 2, 'name' => '1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
 			array($modelClass => array('id' => 5, 'name' => '1.2', $parentField => 1, $leftField => 8, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 
 		$total = $this->Tree->children(null, null, array('id', 'name', $parentField, $leftField, $rightField));
 		$expects = array(array($modelClass => array('id' => 2, 'name' => '1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
@@ -1055,9 +1055,9 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('id' => 5, 'name' => '1.2', $parentField => 1, $leftField => 8, $rightField => 13)),
 			array($modelClass => array( 'id' => 6, 'name' => '1.2.1', $parentField => 5, $leftField => 9, $rightField => 10)),
 			array($modelClass => array('id' => 7, 'name' => '1.2.2', $parentField => 5, $leftField => 11, $rightField => 12)));
-		$this->assertEqual($total, $expects);
+		$this->assertEquals($total, $expects);
 
-		$this->assertEqual(array(), $this->Tree->children(10000));
+		$this->assertEquals(array(), $this->Tree->children(10000));
 	}
 
 /**
@@ -1074,15 +1074,15 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->id = $data[$modelClass]['id'];
 
 		$direct = $this->Tree->childCount(null, true);
-		$this->assertEqual($direct, 2);
+		$this->assertEquals($direct, 2);
 
 		$total = $this->Tree->childCount();
-		$this->assertEqual($total, 6);
+		$this->assertEquals($total, 6);
 
 		$this->Tree->read(null, $data[$modelClass]['id']);
 		$id = $this->Tree->field('id', array($modelClass . '.name' => '1.2'));
 		$total = $this->Tree->childCount($id);
-		$this->assertEqual($total, 2);
+		$this->assertEquals($total, 2);
 	}
 
 /**
@@ -1100,7 +1100,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$result = $this->Tree->getParentNode(null, array('name'));
 		$expects = array($modelClass => array('name' => '1.2'));
-		$this->assertIdentical($result, $expects);
+		$this->assertSame($result, $expects);
 	}
 
 /**
@@ -1120,7 +1120,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1. Root')),
 			array($modelClass => array('name' => '1.2')),
 			array($modelClass => array('name' => '1.2.2')));
-		$this->assertIdentical($result, $expects);
+		$this->assertSame($result, $expects);
 	}
 
 /**
@@ -1141,7 +1141,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$direct = $this->Tree->children(null, true, array('id', 'name', $parentField, $leftField, $rightField));
 		$expects = array(array($modelClass => array('id' => 2, 'name' => '1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
 			array($modelClass => array('id' => 5, 'name' => '1.2', $parentField => 1, $leftField => 8, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 
 		$total = $this->Tree->children(null, null, array('id', 'name', $parentField, $leftField, $rightField));
 		$expects = array(
@@ -1152,7 +1152,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array( 'id' => 6, 'name' => '1.2.1', $parentField => 5, $leftField => 9, $rightField => 10)),
 			array($modelClass => array('id' => 7, 'name' => '1.2.2', $parentField => 5, $leftField => 11, $rightField => 12))
 		);
-		$this->assertEqual($total, $expects);
+		$this->assertEquals($total, $expects);
 	}
 
 /**
@@ -1181,7 +1181,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$this->Tree->reorder();
 		$sortedNodes = $this->Tree->find('list', array('order' => $leftField));
-		$this->assertIdentical($nodes, $sortedNodes);
+		$this->assertSame($nodes, $sortedNodes);
 	}
 
 /**
@@ -1216,7 +1216,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$result = $this->Tree->generateTreeList();
 		$expected = array(1 => '1. Root', 2 => '_1.1', 3 => '__1.1.1', 4 => '__1.1.2', 5 => '_1.2', 6 => '__1.2.1', 7 => '__1.2.2');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -1228,8 +1228,8 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
 		$this->Tree->initialize(3, 3);
-		$this->assertIdentical($this->Tree->childCount(2), $this->Tree->childCount(array('id' => 2)));
-		$this->assertIdentical($this->Tree->getParentNode(2), $this->Tree->getParentNode(array('id' => 2)));
-		$this->assertIdentical($this->Tree->getPath(4), $this->Tree->getPath(array('id' => 4)));
+		$this->assertSame($this->Tree->childCount(2), $this->Tree->childCount(array('id' => 2)));
+		$this->assertSame($this->Tree->getParentNode(2), $this->Tree->getParentNode(array('id' => 2)));
+		$this->assertSame($this->Tree->getPath(4), $this->Tree->getPath(array('id' => 4)));
 	}
 }

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -76,20 +76,20 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			array('FlagTree' => array('id' => '4', 'name' => '1.1.2', 'parent_id' => '2', 'lft' => '5', 'rght' => '6', 'flag' => '0')),
 			array('FlagTree' => array('id' => '5', 'name' => '1.1.3', 'parent_id' => '2', 'lft' => '7', 'rght' => '8', 'flag' => '0'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
-		$this->assertEqual($this->Tree->children(), array());
+		$this->assertEquals($this->Tree->children(), array());
 
 		$this->Tree->id = 1;
 		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
 
 		$result = $this->Tree->children();
 		$expected = array(array('FlagTree' => array('id' => '2', 'name' => '1.1', 'parent_id' => '1', 'lft' => '2', 'rght' => '9', 'flag' => '1')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertTrue($this->Tree->delete());
-		$this->assertEqual($this->Tree->find('count'), 11);
+		$this->assertEquals($this->Tree->find('count'), 11);
 	}
 
 /**
@@ -112,20 +112,20 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			array('FlagTree' => array('id' => '4', 'name' => '1.1.2', 'parent_id' => '2', 'lft' => '5', 'rght' => '6', 'flag' => '0')),
 			array('FlagTree' => array('id' => '5', 'name' => '1.1.3', 'parent_id' => '2', 'lft' => '7', 'rght' => '8', 'flag' => '0'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
-		$this->assertEqual($this->Tree->children(), array());
+		$this->assertEquals($this->Tree->children(), array());
 
 		$this->Tree->id = 1;
 		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
 
 		$result = $this->Tree->children();
 		$expected = array(array('FlagTree' => array('id' => '2', 'name' => '1.1', 'parent_id' => '1', 'lft' => '2', 'rght' => '9', 'flag' => '1')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertTrue($this->Tree->delete());
-		$this->assertEqual($this->Tree->find('count'), 11);
+		$this->assertEquals($this->Tree->find('count'), 11);
 	}
 
 /**
@@ -140,8 +140,8 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 
 		$this->Ad->id = 4;
 		$result = $this->Ad->children();
-		$this->assertEqual(Set::extract('/Ad/id', $result), array(6, 5));
-		$this->assertEqual(Set::extract('/Campaign/id', $result), array(2, 2));
+		$this->assertEquals(Set::extract('/Ad/id', $result), array(6, 5));
+		$this->assertEquals(Set::extract('/Campaign/id', $result), array(2, 2));
 	}
 
 /**
@@ -156,8 +156,8 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 
 		$this->Ad->id = 4;
 		$result = $this->Ad->children();
-		$this->assertEqual(Set::extract('/Ad/id', $result), array(5, 6));
-		$this->assertEqual(Set::extract('/Campaign/id', $result), array(2, 2));
+		$this->assertEquals(Set::extract('/Ad/id', $result), array(5, 6));
+		$this->assertEquals(Set::extract('/Campaign/id', $result), array(2, 2));
 	}
 
 /**
@@ -189,7 +189,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			'flag' => 0,
 			'locale' => 'eng',
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		//update existing record, same locale
 		$this->Tree->create();
@@ -206,7 +206,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			'flag' => 0,
 			'locale' => 'eng',
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		//update different locale, same record
 		$this->Tree->create();
@@ -231,7 +231,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			'flag' => 0,
 			'locale' => 'deu',
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		//Save with bindTranslation
 		$this->Tree->locale = 'eng';
@@ -255,7 +255,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			array('id' => 22, 'locale' => 'spa', 'model' => 'FlagTree', 'foreign_key' => 2, 'field' => 'name', 'content' => 'Nuevo leyenda')
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -311,6 +311,6 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 			'lft' => 1,
 			'rght' => 2
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -77,9 +77,9 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1.1', $leftField => 2, $rightField => 5)),
 			array($modelClass => array('name' => '1.2', $leftField => 6, $rightField => 11)),
 			array($modelClass => array('name' => '1.1.1', $leftField => 12, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -105,7 +105,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$expected = array(array($modelClass => array('name' => '1.1', $leftField => 2, $rightField => 5)),
 			array($modelClass => array('name' => '1.2', $leftField => 6, $rightField => 11)),
 			array($modelClass => array('name' => '1.1.1', $leftField => 12, $rightField => 13)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertTrue($this->Tree->verify());
 	}
 
@@ -124,7 +124,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id']);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount, $laterCount);
+		$this->assertEquals($initialCount, $laterCount);
 
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 		$expects = array(
@@ -137,10 +137,10 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 			'1.1.1',
 		);
 
-		$this->assertEqual(array_values($nodes), $expects);
+		$this->assertEquals(array_values($nodes), $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -158,7 +158,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$this->Tree->removeFromTree($result[$modelClass]['id'], true);
 
 		$laterCount = $this->Tree->find('count');
-		$this->assertEqual($initialCount - 1, $laterCount);
+		$this->assertEquals($initialCount - 1, $laterCount);
 
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 		$expects = array(
@@ -169,10 +169,10 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 			'1.2.1',
 			'1.2.2',
 		);
-		$this->assertEqual(array_values($nodes), $expects);
+		$this->assertEquals(array_values($nodes), $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertIdentical($validTree, true);
+		$this->assertSame($validTree, true);
 	}
 
 /**
@@ -191,7 +191,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$direct = $this->Tree->children(null, true, array('name', $leftField, $rightField));
 		$expects = array(array($modelClass => array('name' => '1.1', $leftField => 2, $rightField => 7)),
 			array($modelClass => array('name' => '1.2', $leftField => 8, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 
 		$total = $this->Tree->children(null, null, array('name', $leftField, $rightField));
 		$expects = array(array($modelClass => array('name' => '1.1', $leftField => 2, $rightField => 7)),
@@ -200,7 +200,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.2', $leftField => 8, $rightField => 13)),
 			array($modelClass => array('name' => '1.2.1', $leftField => 9, $rightField => 10)),
 			array($modelClass => array('name' => '1.2.2', $leftField => 11, $rightField => 12)));
-		$this->assertEqual($total, $expects);
+		$this->assertEquals($total, $expects);
 	}
 
 /**
@@ -222,7 +222,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$direct = $this->Tree->children(null, true, array('name', $leftField, $rightField));
 		$expects = array(array($modelClass => array('name' => '1.1', $leftField => 2, $rightField => 7)),
 			array($modelClass => array('name' => '1.2', $leftField => 8, $rightField => 13)));
-		$this->assertEqual($direct, $expects);
+		$this->assertEquals($direct, $expects);
 
 		$total = $this->Tree->children(null, null, array('name', $leftField, $rightField));
 		$expects = array(
@@ -233,7 +233,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.2.1', $leftField => 9, $rightField => 10)),
 			array($modelClass => array('name' => '1.2.2', $leftField => 11, $rightField => 12))
 		);
-		$this->assertEqual($total, $expects);
+		$this->assertEquals($total, $expects);
 	}
 
 /**
@@ -250,6 +250,6 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 
 		$result = $this->Tree->generateTreeList();
 		$expected = array('1. Root', '_1.1', '__1.1.1', '__1.1.2', '_1.2', '__1.2.1', '__1.2.2');
-		$this->assertIdentical(array_values($result), $expected);
+		$this->assertSame(array_values($result), $expected);
 	}
 }

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -426,10 +426,10 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testLoadAlias() {
 		$Apple = new Apple();
-		$this->assertIdentical($Apple->Behaviors->attached(), array());
+		$this->assertSame($Apple->Behaviors->attached(), array());
 
 		$Apple->Behaviors->load('Test', array('className' => 'TestAlias', 'somesetting' => true));
-		$this->assertIdentical($Apple->Behaviors->attached(), array('Test'));
+		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
 		$this->assertInstanceOf('TestAliasBehavior', $Apple->Behaviors->Test);
 		$this->assertTrue($Apple->Behaviors->Test->settings['Apple']['somesetting']);
 
@@ -455,62 +455,62 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testBehaviorBinding() {
 		$Apple = new Apple();
-		$this->assertIdentical($Apple->Behaviors->attached(), array());
+		$this->assertSame($Apple->Behaviors->attached(), array());
 
 		$Apple->Behaviors->attach('Test', array('key' => 'value'));
-		$this->assertIdentical($Apple->Behaviors->attached(), array('Test'));
-		$this->assertEqual(strtolower(get_class($Apple->Behaviors->Test)), 'testbehavior');
+		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
+		$this->assertEquals(strtolower(get_class($Apple->Behaviors->Test)), 'testbehavior');
 		$expected = array('beforeFind' => 'on', 'afterFind' => 'off', 'key' => 'value');
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $expected);
-		$this->assertEqual(array_keys($Apple->Behaviors->Test->settings), array('Apple'));
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals(array_keys($Apple->Behaviors->Test->settings), array('Apple'));
 
-		$this->assertIdentical($Apple->Sample->Behaviors->attached(), array());
+		$this->assertSame($Apple->Sample->Behaviors->attached(), array());
 		$Apple->Sample->Behaviors->attach('Test', array('key2' => 'value2'));
-		$this->assertIdentical($Apple->Sample->Behaviors->attached(), array('Test'));
-		$this->assertEqual($Apple->Sample->Behaviors->Test->settings['Sample'], array('beforeFind' => 'on', 'afterFind' => 'off', 'key2' => 'value2'));
+		$this->assertSame($Apple->Sample->Behaviors->attached(), array('Test'));
+		$this->assertEquals($Apple->Sample->Behaviors->Test->settings['Sample'], array('beforeFind' => 'on', 'afterFind' => 'off', 'key2' => 'value2'));
 
-		$this->assertEqual(array_keys($Apple->Behaviors->Test->settings), array('Apple', 'Sample'));
-		$this->assertIdentical(
+		$this->assertEquals(array_keys($Apple->Behaviors->Test->settings), array('Apple', 'Sample'));
+		$this->assertSame(
 			$Apple->Sample->Behaviors->Test->settings,
 			$Apple->Behaviors->Test->settings
 		);
-		$this->assertNotIdentical($Apple->Behaviors->Test->settings['Apple'], $Apple->Sample->Behaviors->Test->settings['Sample']);
+		$this->assertNotSame($Apple->Behaviors->Test->settings['Apple'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$Apple->Behaviors->attach('Test', array('key2' => 'value2', 'key3' => 'value3', 'beforeFind' => 'off'));
 		$Apple->Sample->Behaviors->attach('Test', array('key' => 'value', 'key3' => 'value3', 'beforeFind' => 'off'));
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], array('beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'value', 'key2' => 'value2', 'key3' => 'value3'));
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $Apple->Sample->Behaviors->Test->settings['Sample']);
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], array('beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'value', 'key2' => 'value2', 'key3' => 'value3'));
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$this->assertFalse(isset($Apple->Child->Behaviors->Test));
 		$Apple->Child->Behaviors->attach('Test', array('key' => 'value', 'key2' => 'value2', 'key3' => 'value3', 'beforeFind' => 'off'));
-		$this->assertEqual($Apple->Child->Behaviors->Test->settings['Child'], $Apple->Sample->Behaviors->Test->settings['Sample']);
+		$this->assertEquals($Apple->Child->Behaviors->Test->settings['Child'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$this->assertFalse(isset($Apple->Parent->Behaviors->Test));
 		$Apple->Parent->Behaviors->attach('Test', array('key' => 'value', 'key2' => 'value2', 'key3' => 'value3', 'beforeFind' => 'off'));
-		$this->assertEqual($Apple->Parent->Behaviors->Test->settings['Parent'], $Apple->Sample->Behaviors->Test->settings['Sample']);
+		$this->assertEquals($Apple->Parent->Behaviors->Test->settings['Parent'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$Apple->Parent->Behaviors->attach('Test', array('key' => 'value', 'key2' => 'value', 'key3' => 'value', 'beforeFind' => 'off'));
-		$this->assertNotEqual($Apple->Parent->Behaviors->Test->settings['Parent'], $Apple->Sample->Behaviors->Test->settings['Sample']);
+		$this->assertNotEquals($Apple->Parent->Behaviors->Test->settings['Parent'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$Apple->Behaviors->attach('Plugin.Test', array('key' => 'new value'));
 		$expected = array(
 			'beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'new value',
 			'key2' => 'value2', 'key3' => 'value3'
 		);
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
 
 		$current = $Apple->Behaviors->Test->settings['Apple'];
 		$expected = array_merge($current, array('mangle' => 'trigger mangled'));
 		$Apple->Behaviors->attach('Test', array('mangle' => 'trigger'));
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
 
 		$Apple->Behaviors->attach('Test');
 		$expected = array_merge($current, array('mangle' => 'trigger mangled mangled'));
 
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
 		$Apple->Behaviors->attach('Test', array('mangle' => 'trigger'));
 		$expected = array_merge($current, array('mangle' => 'trigger mangled'));
-		$this->assertEqual($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
 	}
 
 /**
@@ -522,17 +522,17 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEqual($Apple->Behaviors->attached(), array('Test'));
+		$this->assertEquals($Apple->Behaviors->attached(), array('Test'));
 
 		$Apple->Behaviors->detach('Plugin.Test');
-		$this->assertEqual($Apple->Behaviors->attached(), array());
+		$this->assertEquals($Apple->Behaviors->attached(), array());
 
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEqual($Apple->Behaviors->attached(), array('Test'));
+		$this->assertEquals($Apple->Behaviors->attached(), array('Test'));
 
 		$Apple->Behaviors->detach('Test');
-		$this->assertEqual($Apple->Behaviors->attached(), array());
+		$this->assertEquals($Apple->Behaviors->attached(), array());
 	}
 
 /**
@@ -554,31 +554,31 @@ class BehaviorCollectionTest extends CakeTestCase {
 	public function testBehaviorToggling() {
 		$Apple = new Apple();
 		$expected = $Apple->find('all');
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Behaviors->init('Apple', array('Test' => array('key' => 'value')));
-		$this->assertIdentical($Apple->Behaviors->enabled(), array('Test'));
+		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');
-		$this->assertIdentical($Apple->Behaviors->attached(), array('Test'));
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Sample->Behaviors->attach('Test');
-		$this->assertIdentical($Apple->Sample->Behaviors->enabled('Test'), true);
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Sample->Behaviors->enabled('Test'), true);
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Behaviors->enable('Test');
-		$this->assertIdentical($Apple->Behaviors->attached('Test'), true);
-		$this->assertIdentical($Apple->Behaviors->enabled(), array('Test'));
+		$this->assertSame($Apple->Behaviors->attached('Test'), true);
+		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 		$Apple->Behaviors->attach('Test', array('enabled' => true));
-		$this->assertIdentical($Apple->Behaviors->enabled(), array('Test'));
+		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 		$Apple->Behaviors->attach('Test', array('enabled' => false));
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 		$Apple->Behaviors->detach('Test');
-		$this->assertIdentical($Apple->Behaviors->enabled(), array());
+		$this->assertSame($Apple->Behaviors->enabled(), array());
 	}
 
 /**
@@ -593,13 +593,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$expected = $Apple->find('all');
 
 		$Apple->Behaviors->attach('Test');
-		$this->assertIdentical($Apple->find('all'), null);
+		$this->assertSame($Apple->find('all'), null);
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'test'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'modify'));
 		$expected2 = array(
@@ -608,23 +608,23 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('Apple' => array('id' => '3', 'name' => 'green blue', 'mytime' => '22:57:17'))
 		);
 		$result = $Apple->find('all', array('conditions' => array('Apple.id <' => '4')));
-		$this->assertEqual($expected2, $result);
+		$this->assertEquals($expected2, $result);
 
 		$Apple->Behaviors->disable('Test');
 		$result = $Apple->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off', 'afterFind' => 'on'));
-		$this->assertIdentical($Apple->find('all'), array());
+		$this->assertSame($Apple->find('all'), array());
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'off'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'test'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'test2'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'modify'));
 		$expected = array(
@@ -636,7 +636,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('id' => '6', 'apple_id' => '4', 'color' => 'My new appleOrange', 'name' => 'My new apple', 'created' => '2006-12-25 05:29:39', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:29:39', 'mytime' => '22:57:17'),
 			array('id' => '7', 'apple_id' => '6', 'color' => 'Some wierd color', 'name' => 'Some odd color', 'created' => '2006-12-25 05:34:21', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:34:21', 'mytime' => '22:57:17')
 		);
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 	}
 
 /**
@@ -653,13 +653,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$wellBehaved = $Apple->find('all');
 		$Apple->Child->Behaviors->attach('Test', array('afterFind' => 'modify'));
 		$Apple->unbindModel(array('hasMany' => array('Child')));
-		$this->assertIdentical($Apple->find('all'), $wellBehaved);
+		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$expected2 = array(
 			array(
@@ -679,23 +679,23 @@ class BehaviorCollectionTest extends CakeTestCase {
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'modify'));
 		$result = $Apple->find('all', array('fields' => array('Apple.id'), 'conditions' => array('Apple.id <' => '4')));
-		//$this->assertEqual($expected, $result2);
+		//$this->assertEquals($expected, $result2);
 
 		$Apple->Child->Behaviors->disable('Test');
 		$result = $Apple->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'off', 'after' => 'on'));
-		//$this->assertIdentical($Apple->find('all'), array());
+		//$this->assertSame($Apple->find('all'), array());
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'modify'));
 		$expected = array(
@@ -707,7 +707,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('id' => '6', 'apple_id' => '4', 'color' => 'My new appleOrange', 'name' => 'My new apple', 'created' => '2006-12-25 05:29:39', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:29:39', 'mytime' => '22:57:17'),
 			array('id' => '7', 'apple_id' => '6', 'color' => 'Some wierd color', 'name' => 'Some odd color', 'created' => '2006-12-25 05:34:21', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:34:21', 'mytime' => '22:57:17')
 		);
-		//$this->assertEqual($Apple->find('all'), $expected);
+		//$this->assertEquals($Apple->find('all'), $expected);
 
 	}
 	/**
@@ -724,13 +724,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$wellBehaved = $Apple->find('all');
 		$Apple->Sample->Behaviors->attach('Test');
 		$Apple->unbindModel(array('hasOne' => array('Sample')));
-		$this->assertIdentical($Apple->find('all'), $wellBehaved);
+		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'modify'));
 		$expected2 = array(
@@ -749,23 +749,23 @@ class BehaviorCollectionTest extends CakeTestCase {
 				'Child' => array())
 		);
 		$result = $Apple->find('all', array('fields' => array('Apple.id'), 'conditions' => array('Apple.id <' => '4')));
-		//$this->assertEqual($expected, $result2);
+		//$this->assertEquals($expected, $result2);
 
 		$Apple->Sample->Behaviors->disable('Test');
 		$result = $Apple->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'off', 'after' => 'on'));
-		//$this->assertIdentical($Apple->find('all'), array());
+		//$this->assertSame($Apple->find('all'), array());
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'modify'));
 		$expected = array(
@@ -777,7 +777,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('id' => '6', 'apple_id' => '4', 'color' => 'My new appleOrange', 'name' => 'My new apple', 'created' => '2006-12-25 05:29:39', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:29:39', 'mytime' => '22:57:17'),
 			array('id' => '7', 'apple_id' => '6', 'color' => 'Some wierd color', 'name' => 'Some odd color', 'created' => '2006-12-25 05:34:21', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:34:21', 'mytime' => '22:57:17')
 		);
-		//$this->assertEqual($Apple->find('all'), $expected);
+		//$this->assertEquals($Apple->find('all'), $expected);
 	}
 	/**
  * testBehaviorBelongsToFindCallbacks method
@@ -795,13 +795,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$wellBehaved = $Apple->find('all');
 		$Apple->Parent->Behaviors->attach('Test');
 		$Apple->unbindModel(array('belongsTo' => array('Parent')));
-		$this->assertIdentical($Apple->find('all'), $wellBehaved);
+		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertIdentical($Apple->find('all'), $expected);
+		$this->assertSame($Apple->find('all'), $expected);
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'modify'));
 		$expected2 = array(
@@ -819,20 +819,20 @@ class BehaviorCollectionTest extends CakeTestCase {
 			'fields' => array('Apple.id', 'Parent.id', 'Parent.name', 'Parent.mytime'),
 			'conditions' => array('Apple.id <' => '4')
 		));
-		$this->assertEqual($expected2, $result2);
+		$this->assertEquals($expected2, $result2);
 
 		$Apple->Parent->Behaviors->disable('Test');
 		$result = $Apple->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEqual($Apple->find('all'), $expected);
+		$this->assertEquals($Apple->find('all'), $expected);
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'modify'));
 		$expected = array(
@@ -844,7 +844,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('id' => '6', 'apple_id' => '4', 'color' => 'My new appleOrange', 'name' => 'My new apple', 'created' => '2006-12-25 05:29:39', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:29:39', 'mytime' => '22:57:17'),
 			array('id' => '7', 'apple_id' => '6', 'color' => 'Some wierd color', 'name' => 'Some odd color', 'created' => '2006-12-25 05:34:21', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:34:21', 'mytime' => '22:57:17')
 		);
-		//$this->assertEqual($Apple->find('all'), $expected);
+		//$this->assertEquals($Apple->find('all'), $expected);
 	}
 
 /**
@@ -858,59 +858,59 @@ class BehaviorCollectionTest extends CakeTestCase {
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'on'));
 		$Sample->create();
-		$this->assertIdentical($Sample->save($record), false);
+		$this->assertSame($Sample->save($record), false);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'off'));
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected = $record;
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'test'));
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected = $record;
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'modify'));
 		$expected = Set::insert($record, 'Sample.name', 'sample99 modified before');
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->disable('Test');
-		$this->assertIdentical($Sample->save($record), $record);
+		$this->assertSame($Sample->save($record), $record);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'off', 'afterSave' => 'on'));
 		$expected = Set::merge($record, array('Sample' => array('aftersave' => 'modified after on create')));
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'modify', 'afterSave' => 'modify'));
 		$expected = Set::merge($record, array('Sample' => array('name' => 'sample99 modified before modified after on create')));
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'off', 'afterSave' => 'test'));
 		$Sample->create();
 		$expected = $record;
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('afterSave' => 'test2'));
 		$Sample->create();
 		$expected = $record;
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertIdentical($result, $expected);
+		$this->assertSame($result, $expected);
 
 		$Sample->Behaviors->attach('Test', array('beforeFind' => 'off', 'afterFind' => 'off'));
 		$Sample->recursive = -1;
@@ -919,12 +919,12 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Sample->Behaviors->attach('Test', array('afterSave' => 'on'));
 		$expected = Set::merge($record2, array('Sample' => array('aftersave' => 'modified after')));
 		$Sample->create();
-		$this->assertIdentical($Sample->save($record2), $expected);
+		$this->assertSame($Sample->save($record2), $expected);
 
 		$Sample->Behaviors->attach('Test', array('afterSave' => 'modify'));
 		$expected = Set::merge($record2, array('Sample' => array('name' => 'sample1 modified after')));
 		$Sample->create();
-		$this->assertIdentical($Sample->save($record2), $expected);
+		$this->assertSame($Sample->save($record2), $expected);
 	}
 
 /**
@@ -936,29 +936,29 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off', 'beforeDelete' => 'off'));
-		$this->assertIdentical($Apple->delete(6), true);
+		$this->assertSame($Apple->delete(6), true);
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'on'));
-		$this->assertIdentical($Apple->delete(4), false);
+		$this->assertSame($Apple->delete(4), false);
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'test2'));
 
 		ob_start();
 		$results = $Apple->delete(4);
-		$this->assertIdentical(trim(ob_get_clean()), 'beforeDelete success (cascading)');
-		$this->assertIdentical($results, true);
+		$this->assertSame(trim(ob_get_clean()), 'beforeDelete success (cascading)');
+		$this->assertSame($results, true);
 
 		ob_start();
 		$results = $Apple->delete(3, false);
-		$this->assertIdentical(trim(ob_get_clean()), 'beforeDelete success');
-		$this->assertIdentical($results, true);
+		$this->assertSame(trim(ob_get_clean()), 'beforeDelete success');
+		$this->assertSame($results, true);
 
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'off', 'afterDelete' => 'on'));
 		ob_start();
 		$results = $Apple->delete(2, false);
-		$this->assertIdentical(trim(ob_get_clean()), 'afterDelete success');
-		$this->assertIdentical($results, true);
+		$this->assertSame(trim(ob_get_clean()), 'afterDelete success');
+		$this->assertSame($results, true);
 	}
 
 /**
@@ -972,7 +972,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off', 'onError' => 'on'));
 		ob_start();
 		$Apple->Behaviors->Test->onError($Apple, '');
-		$this->assertIdentical(trim(ob_get_clean()), 'onError trigger success');
+		$this->assertSame(trim(ob_get_clean()), 'onError trigger success');
 	}
 
 /**
@@ -984,23 +984,23 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 
 		$Apple->Behaviors->attach('Test');
-		$this->assertIdentical($Apple->validates(), true);
+		$this->assertSame($Apple->validates(), true);
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'on'));
-		$this->assertIdentical($Apple->validates(), false);
-		$this->assertIdentical($Apple->validationErrors, array('name' => array(true)));
+		$this->assertSame($Apple->validates(), false);
+		$this->assertSame($Apple->validationErrors, array('name' => array(true)));
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'stop'));
-		$this->assertIdentical($Apple->validates(), false);
-		$this->assertIdentical($Apple->validationErrors, array('name' => array(true, true)));
+		$this->assertSame($Apple->validates(), false);
+		$this->assertSame($Apple->validationErrors, array('name' => array(true, true)));
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'whitelist'));
 		$Apple->validates();
-		$this->assertIdentical($Apple->whitelist, array());
+		$this->assertSame($Apple->whitelist, array());
 
 		$Apple->whitelist = array('unknown');
 		$Apple->validates();
-		$this->assertIdentical($Apple->whitelist, array('unknown', 'name'));
+		$this->assertSame($Apple->whitelist, array('unknown', 'name'));
 	}
 
 /**
@@ -1014,7 +1014,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->validate['color'] = 'validateField';
 
 		$result = $Apple->save(array('name' => 'Genetically Modified Apple', 'color' => 'Orange'));
-		$this->assertEqual(array_keys($result['Apple']), array('name', 'color', 'modified', 'created', 'id'));
+		$this->assertEquals(array_keys($result['Apple']), array('name', 'color', 'modified', 'created', 'id'));
 
 		$Apple->create();
 		$result = $Apple->save(array('name' => 'Regular Apple', 'color' => 'Red'));
@@ -1031,19 +1031,19 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->Behaviors->attach('Test');
 
 		$expected = 'working';
-		$this->assertEqual($Apple->testMethod(), $expected);
-		$this->assertEqual($Apple->Behaviors->dispatchMethod($Apple, 'testMethod'), $expected);
+		$this->assertEquals($Apple->testMethod(), $expected);
+		$this->assertEquals($Apple->Behaviors->dispatchMethod($Apple, 'testMethod'), $expected);
 
 		$result = $Apple->Behaviors->dispatchMethod($Apple, 'wtf');
-		$this->assertEqual($result, array('unhandled'));
+		$this->assertEquals($result, array('unhandled'));
 
 		$result = $Apple->{'look for the remote'}('in the couch');
 		$expected = "Item.name = 'the remote' AND Location.name = 'the couch'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Apple->{'look for THE REMOTE'}('in the couch');
 		$expected = "Item.name = 'THE REMOTE' AND Location.name = 'the couch'";
-		$this->assertEqual($expected, $result, 'Mapped method was lowercased.');
+		$this->assertEquals($expected, $result, 'Mapped method was lowercased.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -505,11 +505,11 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaName() {
 		$Schema = new CakeSchema();
-		$this->assertEqual(strtolower($Schema->name), strtolower(APP_DIR));
+		$this->assertEquals(strtolower($Schema->name), strtolower(APP_DIR));
 
 		Configure::write('App.dir', 'Some.name.with.dots');
 		$Schema = new CakeSchema();
-		$this->assertEqual($Schema->name, 'SomeNameWithDots');
+		$this->assertEquals($Schema->name, 'SomeNameWithDots');
 
 		Configure::write('App.dir', 'app');
 	}
@@ -532,22 +532,22 @@ class CakeSchemaTest extends CakeTestCase {
 			$this->assertTrue(isset($read['tables'][$table]), 'Missing table ' . $table);
 		}
 		foreach ($this->Schema->tables as $table => $fields) {
-			$this->assertEqual(array_keys($fields), array_keys($read['tables'][$table]));
+			$this->assertEquals(array_keys($fields), array_keys($read['tables'][$table]));
 		}
 
 		if (isset($read['tables']['datatypes']['float_field']['length'])) {
-			$this->assertEqual(
+			$this->assertEquals(
 				$read['tables']['datatypes']['float_field']['length'],
 				$this->Schema->tables['datatypes']['float_field']['length']
 			);
 		}
 
-		$this->assertEqual(
+		$this->assertEquals(
 			$read['tables']['datatypes']['float_field']['type'],
 			$this->Schema->tables['datatypes']['float_field']['type']
 		);
 
-		$this->assertEqual(
+		$this->assertEquals(
 			$read['tables']['datatypes']['float_field']['null'],
 			$this->Schema->tables['datatypes']['float_field']['null']
 		);
@@ -741,7 +741,7 @@ class CakeSchemaTest extends CakeTestCase {
 			'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 		);
 		$result = $this->Schema->generateTable('posts', $posts);
-		$this->assertPattern('/var \$posts/', $result);
+		$this->assertRegExp('/var \$posts/', $result);
 	}
 /**
  * testSchemaWrite method
@@ -751,11 +751,11 @@ class CakeSchemaTest extends CakeTestCase {
 	public function testSchemaWrite() {
 		$write = $this->Schema->write(array('name' => 'MyOtherApp', 'tables' => $this->Schema->tables, 'path' => TMP . 'tests'));
 		$file = file_get_contents(TMP . 'tests' . DS .'schema.php');
-		$this->assertEqual($write, $file);
+		$this->assertEquals($write, $file);
 
 		require_once( TMP . 'tests' . DS .'schema.php');
 		$OtherSchema = new MyOtherAppSchema();
-		$this->assertEqual($this->Schema->tables, $OtherSchema->tables);
+		$this->assertEquals($this->Schema->tables, $OtherSchema->tables);
 	}
 
 /**
@@ -794,9 +794,9 @@ class CakeSchemaTest extends CakeTestCase {
 				)
 			),
 		);
-		$this->assertEqual($expected, $compare);
+		$this->assertEquals($expected, $compare);
 		$this->assertNull($New->getVar('comments'));
-		$this->assertEqual($New->getVar('_foo'), array('bar'));
+		$this->assertEquals($New->getVar('_foo'), array('bar'));
 
 		$tables = array(
 			'missing' => array(
@@ -835,7 +835,7 @@ class CakeSchemaTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $compare);
+		$this->assertEquals($expected, $compare);
 	}
 
 /**
@@ -864,7 +864,7 @@ class CakeSchemaTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual($expected, $compare);
+		$this->assertEquals($expected, $compare);
 	}
 
 /**
@@ -965,8 +965,8 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaLoading() {
 		$Other = $this->Schema->load(array('name' => 'MyOtherApp', 'path' => TMP . 'tests'));
-		$this->assertEqual($Other->name, 'MyOtherApp');
-		$this->assertEqual($Other->tables, $this->Schema->tables);
+		$this->assertEquals($Other->name, 'MyOtherApp');
+		$this->assertEquals($Other->tables, $this->Schema->tables);
 	}
 
 /**
@@ -980,8 +980,8 @@ class CakeSchemaTest extends CakeTestCase {
 		));
 		CakePlugin::load('TestPlugin');
 		$Other = $this->Schema->load(array('name' => 'TestPluginApp', 'plugin' => 'TestPlugin'));
-		$this->assertEqual($Other->name, 'TestPluginApp');
-		$this->assertEqual(array_keys($Other->tables), array('test_plugin_acos'));
+		$this->assertEquals($Other->name, 'TestPluginApp');
+		$this->assertEquals(array_keys($Other->tables), array('test_plugin_acos'));
 
 		App::build();
 	}
@@ -1008,11 +1008,11 @@ class CakeSchemaTest extends CakeTestCase {
 		$col = $Schema->tables['testdescribes']['int_null'];
 		$col['name'] = 'int_null';
 		$column = $this->db->buildColumn($col);
-		$this->assertPattern('/' . preg_quote($column, '/') . '/', $sql);
+		$this->assertRegExp('/' . preg_quote($column, '/') . '/', $sql);
 
 		$col = $Schema->tables['testdescribes']['int_not_null'];
 		$col['name'] = 'int_not_null';
 		$column = $this->db->buildColumn($col);
-		$this->assertPattern('/' . preg_quote($column, '/') . '/', $sql);
+		$this->assertRegExp('/' . preg_quote($column, '/') . '/', $sql);
 	}
 }

--- a/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
+++ b/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
@@ -96,8 +96,8 @@ class ConnectionManagerTest extends CakeTestCase {
 		$connection = ConnectionManager::create($name, $config);
 
 		$this->assertTrue(class_exists('TestSource'));
-		$this->assertEqual($connection->configKeyName, $name);
-		$this->assertEqual($connection->config, $config);
+		$this->assertEquals($connection->configKeyName, $name);
+		$this->assertEquals($connection->config, $config);
 
 		ConnectionManager::drop($name);
 	}
@@ -119,8 +119,8 @@ class ConnectionManagerTest extends CakeTestCase {
 
 		$this->assertTrue(class_exists('TestSource'));
 		$this->assertTrue(class_exists('TestDriver'));
-		$this->assertEqual($connection->configKeyName, $name);
-		$this->assertEqual($connection->config, $config);
+		$this->assertEquals($connection->configKeyName, $name);
+		$this->assertEquals($connection->config, $config);
 
 		ConnectionManager::drop($name);
 	}
@@ -142,7 +142,7 @@ class ConnectionManagerTest extends CakeTestCase {
 
 		$this->assertTrue(class_exists('DboSource'));
 		$this->assertTrue(class_exists('DboDummy'));
-		$this->assertEqual($connection->configKeyName, $name);
+		$this->assertEquals($connection->configKeyName, $name);
 
 		ConnectionManager::drop($name);
 	}
@@ -167,8 +167,8 @@ class ConnectionManagerTest extends CakeTestCase {
 
 		$this->assertTrue(class_exists('TestSource'));
 		$this->assertTrue(class_exists('TestLocalDriver'));
-		$this->assertEqual($connection->configKeyName, $name);
-		$this->assertEqual($connection->config, $config);
+		$this->assertEquals($connection->configKeyName, $name);
+		$this->assertEquals($connection->config, $config);
 		ConnectionManager::drop($name);
 	}
 
@@ -194,7 +194,7 @@ class ConnectionManagerTest extends CakeTestCase {
 		$source = ConnectionManager::getDataSource('test');
 		$result = ConnectionManager::getSourceName($source);
 
-		$this->assertEqual('test', $result);
+		$this->assertEquals('test', $result);
 
 		$source = new StdClass();
 		$result = ConnectionManager::getSourceName($source);
@@ -216,7 +216,7 @@ class ConnectionManagerTest extends CakeTestCase {
 		foreach ($connections as $connection) {
 			$exists = class_exists($connection['classname']);
 			$loaded = ConnectionManager::loadDataSource($connection);
-			$this->assertEqual($loaded, !$exists, "Failed loading the {$connection['classname']} datasource");
+			$this->assertEquals($loaded, !$exists, "Failed loading the {$connection['classname']} datasource");
 		}
 	}
 
@@ -249,18 +249,18 @@ class ConnectionManagerTest extends CakeTestCase {
 		$connection = ConnectionManager::create($name, $config);
 
 		$this->assertTrue(is_object($connection));
-		$this->assertEqual($name, $connection->configKeyName);
-		$this->assertEqual($name, ConnectionManager::getSourceName($connection));
+		$this->assertEquals($name, $connection->configKeyName);
+		$this->assertEquals($name, ConnectionManager::getSourceName($connection));
 
 		$source = ConnectionManager::create(null, array());
-		$this->assertEqual($source, null);
+		$this->assertEquals($source, null);
 
 		$source = ConnectionManager::create('another_test', array());
-		$this->assertEqual($source, null);
+		$this->assertEquals($source, null);
 
 		$config = array('classname' => 'DboMysql', 'filename' => 'dbo' . DS . 'dbo_mysql');
 		$source = ConnectionManager::create(null, $config);
-		$this->assertEqual($source, null);
+		$this->assertEquals($source, null);
 	}
 
 /**
@@ -282,45 +282,45 @@ class ConnectionManagerTest extends CakeTestCase {
 
 		ConnectionManager::create('connection1', array('datasource' => 'Test2Source'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual($expected, $connections['connection1']);
+		$this->assertEquals($expected, $connections['connection1']);
 		ConnectionManager::drop('connection1');
 
 		ConnectionManager::create('connection2', array('datasource' => 'Test2Source'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual($expected, $connections['connection2']);
+		$this->assertEquals($expected, $connections['connection2']);
 		ConnectionManager::drop('connection2');
 
 		ConnectionManager::create('connection3', array('datasource' => 'TestPlugin.TestSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
 		$expected['datasource'] = 'TestPlugin.TestSource';
-		$this->assertEqual($expected, $connections['connection3']);
+		$this->assertEquals($expected, $connections['connection3']);
 		ConnectionManager::drop('connection3');
 
 		ConnectionManager::create('connection4', array('datasource' => 'TestPlugin.TestSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual($expected, $connections['connection4']);
+		$this->assertEquals($expected, $connections['connection4']);
 		ConnectionManager::drop('connection4');
 
 		ConnectionManager::create('connection5', array('datasource' => 'Test2OtherSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
 		$expected['datasource'] = 'Test2OtherSource';
-		$this->assertEqual($expected, $connections['connection5']);
+		$this->assertEquals($expected, $connections['connection5']);
 		ConnectionManager::drop('connection5');
 
 		ConnectionManager::create('connection6', array('datasource' => 'Test2OtherSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual($expected, $connections['connection6']);
+		$this->assertEquals($expected, $connections['connection6']);
 		ConnectionManager::drop('connection6');
 
 		ConnectionManager::create('connection7', array('datasource' => 'TestPlugin.TestOtherSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
 		$expected['datasource'] = 'TestPlugin.TestOtherSource';
-		$this->assertEqual($expected, $connections['connection7']);
+		$this->assertEquals($expected, $connections['connection7']);
 		ConnectionManager::drop('connection7');
 
 		ConnectionManager::create('connection8', array('datasource' => 'TestPlugin.TestOtherSource'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual($expected, $connections['connection8']);
+		$this->assertEquals($expected, $connections['connection8']);
 		ConnectionManager::drop('connection8');
 	}
 
@@ -337,7 +337,7 @@ class ConnectionManagerTest extends CakeTestCase {
 		));
 		ConnectionManager::create('droppable', array('datasource' => 'Test2Source'));
 		$connections = ConnectionManager::enumConnectionObjects();
-		$this->assertEqual(array('datasource' => 'Test2Source'), $connections['droppable']);
+		$this->assertEquals(array('datasource' => 'Test2Source'), $connections['droppable']);
 
 		$this->assertTrue(ConnectionManager::drop('droppable'));
 		$connections = ConnectionManager::enumConnectionObjects();

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -353,7 +353,7 @@ class CakeSessionTest extends CakeTestCase {
 		TestCakeSession::destroy();
 
 		$this->assertFalse(TestCakeSession::check('bulletProof'));
-		$this->assertNotEqual($id, TestCakeSession::id());
+		$this->assertNotEquals($id, TestCakeSession::id());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -105,36 +105,36 @@ class MysqlTest extends CakeTestCase {
 			'`MysqlTestModel`.`created`',
 			'`MysqlTestModel`.`updated`'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 1.2;
 		$result = $this->Dbo->value(1.2, 'float');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = "'1,2'";
 		$result = $this->Dbo->value('1,2', 'float');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = "'4713e29446'";
 		$result = $this->Dbo->value('4713e29446');
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 'NULL';
 		$result = $this->Dbo->value('', 'integer');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = "'0'";
 		$result = $this->Dbo->value('', 'boolean');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 10010001;
 		$result = $this->Dbo->value(10010001);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = "'00010010001'";
 		$result = $this->Dbo->value('00010010001');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -180,10 +180,10 @@ class MysqlTest extends CakeTestCase {
  */
 	function testScientificNotation() {
 		$result = $this->db->value(2.2E-54, 'float');
-		$this->assertEqual('2.2E-54', (string)$result);
+		$this->assertEquals('2.2E-54', (string)$result);
 
 		$result = $this->db->value(2.2E-54);
-		$this->assertEqual('2.2E-54', (string)$result);
+		$this->assertEquals('2.2E-54', (string)$result);
 	}
 
 /**
@@ -202,25 +202,25 @@ class MysqlTest extends CakeTestCase {
 		));
 
 		$result = $this->model->schema();
-		$this->assertEqual($result['bool']['type'], 'boolean');
-		$this->assertEqual($result['small_int']['type'], 'integer');
+		$this->assertEquals($result['bool']['type'], 'boolean');
+		$this->assertEquals($result['small_int']['type'], 'integer');
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 5, 'small_int' => 5)));
 		$result = $this->model->find('first');
-		$this->assertIdentical($result['Tinyint']['bool'], true);
-		$this->assertIdentical($result['Tinyint']['small_int'], '5');
+		$this->assertSame($result['Tinyint']['bool'], true);
+		$this->assertSame($result['Tinyint']['small_int'], '5');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 0, 'small_int' => 100)));
 		$result = $this->model->find('first');
-		$this->assertIdentical($result['Tinyint']['bool'], false);
-		$this->assertIdentical($result['Tinyint']['small_int'], '100');
+		$this->assertSame($result['Tinyint']['bool'], false);
+		$this->assertSame($result['Tinyint']['small_int'], '100');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => true, 'small_int' => 0)));
 		$result = $this->model->find('first');
-		$this->assertIdentical($result['Tinyint']['bool'], true);
-		$this->assertIdentical($result['Tinyint']['small_int'], '0');
+		$this->assertSame($result['Tinyint']['bool'], true);
+		$this->assertSame($result['Tinyint']['small_int'], '0');
 		$this->model->deleteAll(true);
 
 		$this->Dbo->rawQuery('DROP TABLE ' . $this->Dbo->fullTableName($tableName));
@@ -241,11 +241,11 @@ class MysqlTest extends CakeTestCase {
 		));
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 5, 'small_int' => 5)));
-		$this->assertEqual(1, $this->model->find('count'));
+		$this->assertEquals(1, $this->model->find('count'));
 		$this->model->deleteAll(true);
 		$result = $this->Dbo->lastAffected();
-		$this->assertEqual(1, $result);
-		$this->assertEqual(0, $this->model->find('count'));
+		$this->assertEquals(1, $result);
+		$this->assertEquals(0, $this->model->find('count'));
 
 		$this->Dbo->rawQuery('DROP TABLE ' . $this->Dbo->fullTableName($tableName));
 	}
@@ -264,7 +264,7 @@ class MysqlTest extends CakeTestCase {
 		$expected = array('PRIMARY' => array('column' => 'id', 'unique' => 1));
 		$result = $this->Dbo->index('simple', false);
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$name = $this->Dbo->fullTableName('with_a_key');
@@ -275,7 +275,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index('with_a_key', false);
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$name = $this->Dbo->fullTableName('with_two_keys');
 		$this->Dbo->rawQuery('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ));');
@@ -286,7 +286,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index('with_two_keys', false);
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$name = $this->Dbo->fullTableName('with_compound_keys');
 		$this->Dbo->rawQuery('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ), KEY `one_way` ( `bool`, `small_int` ));');
@@ -298,7 +298,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index('with_compound_keys', false);
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$name = $this->Dbo->fullTableName('with_multiple_compound_keys');
 		$this->Dbo->rawQuery('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ), KEY `pointless_small_int` ( `small_int` ), KEY `one_way` ( `bool`, `small_int` ), KEY `other_way` ( `small_int`, `bool` ));');
@@ -311,7 +311,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index('with_multiple_compound_keys', false);
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -332,7 +332,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`testName`  DEFAULT NULL COMMENT \'test\'';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'testName',
@@ -345,7 +345,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`testName`  CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->Dbo->columns = $restore;
 	}
 
@@ -451,7 +451,7 @@ class MysqlTest extends CakeTestCase {
 			'pointless_small_int' => array('column' => 'small_int', 'unique' => 0),
 			'one_way' => array('column' => array('bool', 'small_int'), 'unique' => 0),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -462,43 +462,43 @@ class MysqlTest extends CakeTestCase {
 	public function testColumn() {
 		$result = $this->Dbo->column('varchar(50)');
 		$expected = 'string';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('text');
 		$expected = 'text';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('int(11)');
 		$expected = 'integer';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('int(11) unsigned');
 		$expected = 'integer';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('tinyint(1)');
 		$expected = 'boolean';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('boolean');
 		$expected = 'boolean';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('float');
 		$expected = 'float';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('float unsigned');
 		$expected = 'float';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('double unsigned');
 		$expected = 'float';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('decimal(14,7) unsigned');
 		$expected = 'float';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -587,7 +587,7 @@ class MysqlTest extends CakeTestCase {
 		$this->assertEquals($result, $query->queryString);
 
 		// Compare us to ourself.
-		$this->assertEqual($schema3->compare($schema3), array());
+		$this->assertEquals($schema3->compare($schema3), array());
 
 		// Drop the indexes
 		$result = $this->Dbo->alterSchema($schema1->compare($schema3));
@@ -616,7 +616,7 @@ class MysqlTest extends CakeTestCase {
 		$model->save(compact('data'));
 
 		$result = $model->find('first');
-		$this->assertEqual($result['BinaryTest']['data'], $data);
+		$this->assertEquals($result['BinaryTest']['data'], $data);
 	}
 
 /**
@@ -661,9 +661,9 @@ class MysqlTest extends CakeTestCase {
 
 		$this->Dbo->rawQuery($result);
 		$result = $this->Dbo->listDetailedSources($this->Dbo->fullTableName('altertest', false));
-		$this->assertEqual($result['Collation'], 'utf8_general_ci');
-		$this->assertEqual($result['Engine'], 'InnoDB');
-		$this->assertEqual($result['charset'], 'utf8');
+		$this->assertEquals($result['Collation'], 'utf8_general_ci');
+		$this->assertEquals($result['Engine'], 'InnoDB');
+		$this->assertEquals($result['charset'], 'utf8');
 
 		$this->Dbo->rawQuery($this->Dbo->dropSchema($schema1));
 	}
@@ -699,7 +699,7 @@ class MysqlTest extends CakeTestCase {
 			)
 		));
 		$result = $this->Dbo->alterSchema($schema2->compare($schema1));
-		$this->assertEqual(2, substr_count($result, 'field_two'), 'Too many fields');
+		$this->assertEquals(2, substr_count($result, 'field_two'), 'Too many fields');
 	}
 
 /**
@@ -718,7 +718,7 @@ class MysqlTest extends CakeTestCase {
 			'charset' => 'utf8',
 			'collate' => 'utf8_unicode_ci',
 			'engine' => 'InnoDB');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$table = $this->Dbo->fullTableName($tableName);
 		$this->Dbo->rawQuery('CREATE TABLE ' . $table . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id)) ENGINE=MyISAM DEFAULT CHARSET=cp1250 COLLATE=cp1250_general_ci;');
@@ -728,7 +728,7 @@ class MysqlTest extends CakeTestCase {
 			'charset' => 'cp1250',
 			'collate' => 'cp1250_general_ci',
 			'engine' => 'MyISAM');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -747,7 +747,7 @@ class MysqlTest extends CakeTestCase {
 			'DEFAULT CHARSET=utf8',
 			'COLLATE=utf8_unicode_ci',
 			'ENGINE=InnoDB');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -758,9 +758,9 @@ class MysqlTest extends CakeTestCase {
 	public function testGetCharsetName() {
 		$this->Dbo->cacheSources = $this->Dbo->testing = false;
 		$result = $this->Dbo->getCharsetName('utf8_unicode_ci');
-		$this->assertEqual($result, 'utf8');
+		$this->assertEquals($result, 'utf8');
 		$result = $this->Dbo->getCharsetName('cp1250_general_ci');
-		$this->assertEqual($result, 'cp1250');
+		$this->assertEquals($result, 'cp1250');
 	}
 
 /**
@@ -779,7 +779,7 @@ class MysqlTest extends CakeTestCase {
 		$result = $this->Dbo->fields($model, null, array('data', 'other__field'));
 
 		$expected = array('`BinaryTest`.`data`', '(SUM(id)) AS  `BinaryTest_$_other__field`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -833,9 +833,9 @@ class MysqlTest extends CakeTestCase {
 		$result = $model->getDataSource()->describe($model);
 		$this->Dbo->execute($this->Dbo->dropSchema($schema));
 
-		$this->assertEqual($result['stringy']['collate'], 'cp1250_general_ci');
-		$this->assertEqual($result['stringy']['charset'], 'cp1250');
-		$this->assertEqual($result['other_col']['comment'], 'Test Comment');
+		$this->assertEquals($result['stringy']['collate'], 'cp1250_general_ci');
+		$this->assertEquals($result['stringy']['charset'], 'cp1250');
+		$this->assertEquals($result['other_col']['comment'], 'Test Comment');
 	}
 
 /**
@@ -860,7 +860,7 @@ class MysqlTest extends CakeTestCase {
 			->will($this->returnValue(null));
 
 		$tables = $db->listSources();
-		$this->assertEqual($tables, array('cake_table', 'another_table'));
+		$this->assertEquals($tables, array('cake_table', 'another_table'));
 	}
 
 /**
@@ -907,7 +907,7 @@ class MysqlTest extends CakeTestCase {
 			->will($this->returnValue($result));
 
 		$encoding = $db->getEncoding();
-		$this->assertEqual('utf-8', $encoding);
+		$this->assertEquals('utf-8', $encoding);
 	}
 
 /**
@@ -923,9 +923,9 @@ class MysqlTest extends CakeTestCase {
 			->method('getDataSource')
 			->will($this->returnValue($test));
 
-		$this->assertEqual($this->Model->escapeField(), '`Article`.`id`');
+		$this->assertEquals($this->Model->escapeField(), '`Article`.`id`');
 		$result = $test->fields($this->Model, null, $this->Model->escapeField());
-		$this->assertEqual($result, array('`Article`.`id`'));
+		$this->assertEquals($result, array('`Article`.`id`'));
 
 		$test->expects($this->at(0))->method('execute')
 			->with('SELECT `Article`.`id` FROM `articles` AS `Article`   WHERE 1 = 1');
@@ -938,10 +938,10 @@ class MysqlTest extends CakeTestCase {
 
 		$test->startQuote = '[';
 		$test->endQuote = ']';
-		$this->assertEqual($this->Model->escapeField(), '[Article].[id]');
+		$this->assertEquals($this->Model->escapeField(), '[Article].[id]');
 
 		$result = $test->fields($this->Model, null, $this->Model->escapeField());
-		$this->assertEqual($result, array('[Article].[id]'));
+		$this->assertEquals($result, array('[Article].[id]'));
 
 		$test->expects($this->at(0))->method('execute')
 			->with('SELECT [Article].[id] FROM [' . $test->fullTableName('articles', false) . '] AS [Article]   WHERE 1 = 1');
@@ -986,7 +986,7 @@ class MysqlTest extends CakeTestCase {
 		}
 
 		$query = $this->Dbo->generateAssociationQuery($this->Model->Category2, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+(.+)FROM(.+)`Category2`\.`group_id`\s+=\s+`Group`\.`id`\)\s+LEFT JOIN(.+)WHERE\s+1 = 1\s*$/', $query);
+		$this->assertRegExp('/^SELECT\s+(.+)FROM(.+)`Category2`\.`group_id`\s+=\s+`Group`\.`id`\)\s+LEFT JOIN(.+)WHERE\s+1 = 1\s*$/', $query);
 
 		$this->Model = new TestModel4();
 		$this->Model->schema();
@@ -1030,19 +1030,19 @@ class MysqlTest extends CakeTestCase {
 			'callbacks' => null
 		);
 		$queryData['joins'][0]['table'] = $this->Dbo->fullTableName($queryData['joins'][0]['table']);
-		$this->assertEqual($queryData, $expected);
+		$this->assertEquals($queryData, $expected);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+1 = 1\s+$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
+		$this->assertRegExp('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+1 = 1\s+$/', $result);
 
 		$params['assocData']['type'] = 'INNER';
 		$this->Model->belongsTo['TestModel4Parent']['type'] = 'INNER';
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $_queryData, $params['external'], $resultSet);
 		$this->assertTrue($result);
-		$this->assertEqual($_queryData['joins'][0]['type'], 'INNER');
+		$this->assertEquals($_queryData['joins'][0]['type'], 'INNER');
 	}
 
 /**
@@ -1138,10 +1138,10 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`, `TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model8` AS `TestModel8`\s+LEFT JOIN\s+`test_model9` AS `TestModel9`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel9`\.`name` != \'mariano\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`, `TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`\s+/', $result);
+		$this->assertRegExp('/FROM\s+`test_model8` AS `TestModel8`\s+LEFT JOIN\s+`test_model9` AS `TestModel9`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel9`\.`name` != \'mariano\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1164,10 +1164,10 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`, `TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model9` AS `TestModel9`\s+LEFT JOIN\s+`test_model8` AS `TestModel8`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel8`\.`name` != \'larry\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel9`\.`id`, `TestModel9`\.`test_model8_id`, `TestModel9`\.`name`, `TestModel9`\.`created`, `TestModel9`\.`updated`, `TestModel8`\.`id`, `TestModel8`\.`test_model9_id`, `TestModel8`\.`name`, `TestModel8`\.`created`, `TestModel8`\.`updated`\s+/', $result);
+		$this->assertRegExp('/FROM\s+`test_model9` AS `TestModel9`\s+LEFT JOIN\s+`test_model8` AS `TestModel8`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel8`\.`name` != \'larry\'\s+AND\s+`TestModel9`.`test_model8_id` = `TestModel8`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1191,10 +1191,10 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue($result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
-		$this->assertPattern('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?`TestModel4Parent`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
+		$this->assertRegExp('/FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model4` AS `TestModel4Parent`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4`.`parent_id` = `TestModel4Parent`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?`TestModel4Parent`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 
 		$this->Featured2 = new Featured2();
 		$this->Featured2->schema();
@@ -1221,7 +1221,7 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$result = $this->Dbo->generateAssociationQuery($this->Featured2, $null, null, null, null, $queryData, false, $null);
 
-		$this->assertPattern(
+		$this->assertRegExp(
 			'/^SELECT\s+`Featured2`\.`id`, `Featured2`\.`article_id`, `Featured2`\.`category_id`, `Featured2`\.`name`,\s+'.
 			'`ArticleFeatured2`\.`id`, `ArticleFeatured2`\.`title`, `ArticleFeatured2`\.`user_id`, `ArticleFeatured2`\.`published`\s+' .
 			'FROM\s+`featured2` AS `Featured2`\s+LEFT JOIN\s+`article_featured` AS `ArticleFeatured2`' .
@@ -1254,13 +1254,13 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN `test_model5` AS `TestModel5` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEqual(trim($result), trim($expected));
+		$this->assertEquals(trim($result), trim($expected));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+/', $result);
-		$this->assertPattern('/`test_model5` AS `TestModel5`\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+/', $result);
+		$this->assertRegExp('/`test_model5` AS `TestModel5`\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1286,10 +1286,10 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model5` AS `TestModel5`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id`\s+=\s+`TestModel4`.`id`\)\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*`TestModel5`.`name`\s+!=\s+\'mariano\'\s*(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+LEFT JOIN\s+`test_model5` AS `TestModel5`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel5`.`test_model4_id`\s+=\s+`TestModel4`.`id`\)\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?\s*`TestModel5`.`name`\s+!=\s+\'mariano\'\s*(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1314,13 +1314,13 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN `test_model4` AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEqual(trim($result), trim($expected));
+		$this->assertEquals(trim($result), trim($expected));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1345,13 +1345,13 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN `test_model4` AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEqual(trim($result), trim($expected));
+		$this->assertEquals(trim($result), trim($expected));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+`TestModel5`.`name` != \'mariano\'\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+LEFT JOIN\s+`test_model4` AS `TestModel4`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel5`.`test_model4_id` = `TestModel4`.`id`\)\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+`TestModel5`.`name` != \'mariano\'\s*$/', $result);
 	}
 
 /**
@@ -1373,14 +1373,14 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+`TestModel6`.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+`TestModel6`.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?\s*1 = 1\s*(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1403,7 +1403,7 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern(
+		$this->assertRegExp(
 			'/^SELECT\s+' .
 			'`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+'.
 			'FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+' .
@@ -1413,7 +1413,7 @@ class MysqlTest extends CakeTestCase {
 		);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern(
+		$this->assertRegExp(
 			'/^SELECT\s+'.
 			'`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+'.
 			'FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+'.
@@ -1440,14 +1440,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?`TestModel5`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?`TestModel5`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1474,15 +1474,15 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
-		$this->assertPattern('/\s+LIMIT 2,\s*5\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/\s+LIMIT 2,\s*5\s*$/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6'] = $__backup;
 	}
@@ -1510,15 +1510,15 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
-		$this->assertPattern('/\s+LIMIT 5,\s*5\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/\s+LIMIT 5,\s*5\s*$/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6'] = $__backup;
 	}
@@ -1541,14 +1541,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$binding = array('type' => 'hasMany', 'model' => 'TestModel6');
 		$queryData = array('fields' => array('`TestModel5`.`id`, `TestModel5`.`name`'));
@@ -1558,14 +1558,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$binding = array('type' => 'hasMany', 'model' => 'TestModel6');
 		$queryData = array('fields' => array('`TestModel5`.`name`', '`TestModel5`.`created`'));
@@ -1575,14 +1575,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`test_model5_id`, `TestModel6`\.`name`, `TestModel6`\.`created`, `TestModel6`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasMany['TestModel6']['fields'] = array('name');
 
@@ -1594,14 +1594,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
 
@@ -1615,14 +1615,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`id`, `TestModel6`\.`name`, `TestModel6`\.`test_model5_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
 
@@ -1636,14 +1636,14 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel6`\.`test_model5_id`, `TestModel6`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel6`\.`test_model5_id`, `TestModel6`\.`name`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model6` AS `TestModel6`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?`TestModel6`\.`test_model5_id`\s+=\s+\({\$__cakeID__\$}\)(?:\))?/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`name`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model5` AS `TestModel5`\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		unset($this->Model->hasMany['TestModel6']['fields']);
 	}
@@ -1667,7 +1667,7 @@ class MysqlTest extends CakeTestCase {
 		$this->Model->recursive = 0;
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, $params['type'], $params['assoc'], $params['assocData'], $queryData, false, $resultSet);
-		$this->assertPattern('/^SELECT\s+MIN\(`TestModel5`\.`test_model4_id`\)\s+FROM/', $result);
+		$this->assertRegExp('/^SELECT\s+MIN\(`TestModel5`\.`test_model4_id`\)\s+FROM/', $result);
 	}
 
 /**
@@ -1689,16 +1689,16 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
 		$assocTable = $this->Dbo->fullTableName($this->Model->TestModel4TestModel7, false);
-		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7` AS `TestModel7`\s+JOIN\s+`' . $assocTable . '`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+AND/', $result);
-		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)/', $result);
-		$this->assertPattern('/WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model7` AS `TestModel7`\s+JOIN\s+`' . $assocTable . '`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+AND/', $result);
+		$this->assertRegExp('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)/', $result);
+		$this->assertRegExp('/WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE/', $result);
-		$this->assertPattern('/\s+WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE/', $result);
+		$this->assertRegExp('/\s+WHERE\s+(?:\()?1 = 1(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1719,14 +1719,14 @@ class MysqlTest extends CakeTestCase {
 		$params = $this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
-		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
+		$this->assertRegExp('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?`TestModel4`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?`TestModel4`.`name`\s+!=\s+\'mariano\'(?:\))?\s*$/', $result);
 	}
 
 /**
@@ -1752,15 +1752,15 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+/', $result);
-		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 2,\s*5\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}\s+/', $result);
+		$this->assertRegExp('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 2,\s*5\s*$/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasAndBelongsToMany['TestModel7'] = $__backup;
 	}
@@ -1788,15 +1788,15 @@ class MysqlTest extends CakeTestCase {
 		$params = &$this->_prepareAssociationQuery($this->Model, $queryData, $binding);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $queryData, $params['external'], $resultSet);
-		$this->assertPattern('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
-		$this->assertPattern('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
-		$this->assertPattern('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
-		$this->assertPattern('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 5,\s*5\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel7`\.`id`, `TestModel7`\.`name`, `TestModel7`\.`created`, `TestModel7`\.`updated`, `TestModel4TestModel7`\.`test_model4_id`, `TestModel4TestModel7`\.`test_model7_id`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model7`\s+AS\s+`TestModel7`\s+JOIN\s+`test_model4_test_model7`\s+AS\s+`TestModel4TestModel7`/', $result);
+		$this->assertRegExp('/\s+ON\s+\(`TestModel4TestModel7`\.`test_model4_id`\s+=\s+{\$__cakeID__\$}/', $result);
+		$this->assertRegExp('/\s+AND\s+`TestModel4TestModel7`\.`test_model7_id`\s+=\s+`TestModel7`\.`id`\)\s+WHERE\s+/', $result);
+		$this->assertRegExp('/\s+(?:\()?1\s+=\s+1(?:\))?\s*\s+LIMIT 5,\s*5\s*$/', $result);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
-		$this->assertPattern('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
-		$this->assertPattern('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
+		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
+		$this->assertRegExp('/\s+FROM\s+`test_model4` AS `TestModel4`\s+WHERE\s+(?:\()?1\s+=\s+1(?:\))?\s*$/', $result);
 
 		$this->Model->hasAndBelongsToMany['TestModel7'] = $__backup;
 	}
@@ -1810,7 +1810,7 @@ class MysqlTest extends CakeTestCase {
 		$this->Model = new TestModel4();
 		$result = $this->Dbo->fields($this->Model, 'Vendor', "DISTINCT Vendor.id, Vendor.name");
 		$expected = array('DISTINCT `Vendor`.`id`', '`Vendor`.`name`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1821,117 +1821,117 @@ class MysqlTest extends CakeTestCase {
 	public function testStringConditionsParsing() {
 		$result = $this->Dbo->conditions("ProjectBid.project_id = Project.id");
 		$expected = " WHERE `ProjectBid`.`project_id` = `Project`.`id`";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("Candy.name LIKE 'a' AND HardCandy.name LIKE 'c'");
 		$expected = " WHERE `Candy`.`name` LIKE 'a' AND `HardCandy`.`name` LIKE 'c'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("HardCandy.name LIKE 'a' AND Candy.name LIKE 'c'");
 		$expected = " WHERE `HardCandy`.`name` LIKE 'a' AND `Candy`.`name` LIKE 'c'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("Post.title = '1.1'");
 		$expected = " WHERE `Post`.`title` = '1.1'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("User.id != 0 AND User.user LIKE '%arr%'");
 		$expected = " WHERE `User`.`id` != 0 AND `User`.`user` LIKE '%arr%'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("SUM(Post.comments_count) > 500");
 		$expected = " WHERE SUM(`Post`.`comments_count`) > 500";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("(Post.created < '" . date('Y-m-d H:i:s') . "') GROUP BY YEAR(Post.created), MONTH(Post.created)");
 		$expected = " WHERE (`Post`.`created` < '" . date('Y-m-d H:i:s') . "') GROUP BY YEAR(`Post`.`created`), MONTH(`Post`.`created`)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("score BETWEEN 90.1 AND 95.7");
 		$expected = " WHERE score BETWEEN 90.1 AND 95.7";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score' => array(2=>1, 2, 10)));
 		$expected = " WHERE score IN (1, 2, 10)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("Aro.rght = Aro.lft + 1.1");
 		$expected = " WHERE `Aro`.`rght` = `Aro`.`lft` + 1.1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("(Post.created < '" . date('Y-m-d H:i:s') . "') GROUP BY YEAR(Post.created), MONTH(Post.created)");
 		$expected = " WHERE (`Post`.`created` < '" . date('Y-m-d H:i:s') . "') GROUP BY YEAR(`Post`.`created`), MONTH(`Post`.`created`)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('Sportstaette.sportstaette LIKE "%ru%" AND Sportstaette.sportstaettenart_id = 2');
 		$expected = ' WHERE `Sportstaette`.`sportstaette` LIKE "%ru%" AND `Sportstaette`.`sportstaettenart_id` = 2';
-		$this->assertPattern('/\s*WHERE\s+`Sportstaette`\.`sportstaette`\s+LIKE\s+"%ru%"\s+AND\s+`Sports/', $result);
-		$this->assertEqual($expected, $result);
+		$this->assertRegExp('/\s*WHERE\s+`Sportstaette`\.`sportstaette`\s+LIKE\s+"%ru%"\s+AND\s+`Sports/', $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('Sportstaette.sportstaettenart_id = 2 AND Sportstaette.sportstaette LIKE "%ru%"');
 		$expected = ' WHERE `Sportstaette`.`sportstaettenart_id` = 2 AND `Sportstaette`.`sportstaette` LIKE "%ru%"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('SUM(Post.comments_count) > 500 AND NOT Post.title IS NULL AND NOT Post.extended_title IS NULL');
 		$expected = ' WHERE SUM(`Post`.`comments_count`) > 500 AND NOT `Post`.`title` IS NULL AND NOT `Post`.`extended_title` IS NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('NOT Post.title IS NULL AND NOT Post.extended_title IS NULL AND SUM(Post.comments_count) > 500');
 		$expected = ' WHERE NOT `Post`.`title` IS NULL AND NOT `Post`.`extended_title` IS NULL AND SUM(`Post`.`comments_count`) > 500';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('NOT Post.extended_title IS NULL AND NOT Post.title IS NULL AND Post.title != "" AND SPOON(SUM(Post.comments_count) + 1.1) > 500');
 		$expected = ' WHERE NOT `Post`.`extended_title` IS NULL AND NOT `Post`.`title` IS NULL AND `Post`.`title` != "" AND SPOON(SUM(`Post`.`comments_count`) + 1.1) > 500';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('NOT Post.title_extended IS NULL AND NOT Post.title IS NULL AND Post.title_extended != Post.title');
 		$expected = ' WHERE NOT `Post`.`title_extended` IS NULL AND NOT `Post`.`title` IS NULL AND `Post`.`title_extended` != `Post`.`title`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("Comment.id = 'a'");
 		$expected = " WHERE `Comment`.`id` = 'a'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("lower(Article.title) LIKE 'a%'");
 		$expected = " WHERE lower(`Article`.`title`) LIKE 'a%'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('((MATCH(Video.title) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 2) + (MATCH(Video.description) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 0.4) + (MATCH(Video.tags) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 1.5))');
 		$expected = ' WHERE ((MATCH(`Video`.`title`) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 2) + (MATCH(`Video`.`description`) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 0.4) + (MATCH(`Video`.`tags`) AGAINST(\'My Search*\' IN BOOLEAN MODE) * 1.5))';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('DATEDIFF(NOW(),Article.published) < 1 && Article.live=1');
 		$expected = " WHERE DATEDIFF(NOW(),`Article`.`published`) < 1 && `Article`.`live`=1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('file = "index.html"');
 		$expected = ' WHERE file = "index.html"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions("file = 'index.html'");
 		$expected = " WHERE file = 'index.html'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$letter = $letter = 'd.a';
 		$conditions = array('Company.name like ' => $letter . '%');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `Company`.`name` like 'd.a%'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('Artist.name' => 'JUDY and MARY');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `Artist`.`name` = 'JUDY and MARY'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('Artist.name' => 'JUDY AND MARY');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `Artist`.`name` = 'JUDY AND MARY'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('Company.name similar to ' => 'a word');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `Company`.`name` similar to 'a word'";
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 	}
 
 /**
@@ -1942,20 +1942,20 @@ class MysqlTest extends CakeTestCase {
 	public function testQuotesInStringConditions() {
 		$result = $this->Dbo->conditions('Member.email = \'mariano@cricava.com\'');
 		$expected = ' WHERE `Member`.`email` = \'mariano@cricava.com\'';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('Member.email = "mariano@cricava.com"');
 		$expected = ' WHERE `Member`.`email` = "mariano@cricava.com"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions('Member.email = \'mariano@cricava.com\' AND Member.user LIKE \'mariano.iglesias%\'');
 		$expected = ' WHERE `Member`.`email` = \'mariano@cricava.com\' AND `Member`.`user` LIKE \'mariano.iglesias%\'';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$result = $this->Dbo->conditions('Member.email = "mariano@cricava.com" AND Member.user LIKE "mariano.iglesias%"');
 		$expected = ' WHERE `Member`.`email` = "mariano@cricava.com" AND `Member`.`user` LIKE "mariano.iglesias%"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1965,46 +1965,46 @@ class MysqlTest extends CakeTestCase {
  */
 	public function testParenthesisInStringConditions() {
 		$result = $this->Dbo->conditions('Member.name = \'(lu\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(lu\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \')lu\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\)lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\)lu\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'va(lu\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'va)lu\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\)lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\)lu\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'va(lu)\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'va(lu)e\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)e\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)e\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano)\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano)iglesias\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano) iglesias\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\) iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\) iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano word) iglesias\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano word\) iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano word\) iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano.iglesias)\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\)\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'Mariano Iglesias (mariano.iglesias)\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\)\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'Mariano Iglesias (mariano.iglesias) CakePHP\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\) CakePHP\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\) CakePHP\'$/', $result);
 
 		$result = $this->Dbo->conditions('Member.name = \'(mariano.iglesias) CakePHP\'');
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\) CakePHP\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\) CakePHP\'$/', $result);
 	}
 
 /**
@@ -2014,46 +2014,46 @@ class MysqlTest extends CakeTestCase {
  */
 	public function testParenthesisInArrayConditions() {
 		$result = $this->Dbo->conditions(array('Member.name' => '(lu'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(lu\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => ')lu'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\)lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\)lu\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'va(lu'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'va)lu'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\)lu\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\)lu\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'va(lu)'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'va(lu)e'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)e\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'va\(lu\)e\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano)'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano)iglesias'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\)iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano) iglesias'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\) iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano\) iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano word) iglesias'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano word\) iglesias\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano word\) iglesias\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano.iglesias)'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\)\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'Mariano Iglesias (mariano.iglesias)'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\)\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\)\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => 'Mariano Iglesias (mariano.iglesias) CakePHP'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\) CakePHP\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'Mariano Iglesias \(mariano.iglesias\) CakePHP\'$/', $result);
 
 		$result = $this->Dbo->conditions(array('Member.name' => '(mariano.iglesias) CakePHP'));
-		$this->assertPattern('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\) CakePHP\'$/', $result);
+		$this->assertRegExp('/^\s+WHERE\s+`Member`.`name`\s+=\s+\'\(mariano.iglesias\) CakePHP\'$/', $result);
 	}
 
 /**
@@ -2064,78 +2064,78 @@ class MysqlTest extends CakeTestCase {
 	public function testArrayConditionsParsing() {
 		$this->loadFixtures('Post', 'Author');
 		$result = $this->Dbo->conditions(array('Stereo.type' => 'in dash speakers'));
-		$this->assertPattern("/^\s+WHERE\s+`Stereo`.`type`\s+=\s+'in dash speakers'/", $result);
+		$this->assertRegExp("/^\s+WHERE\s+`Stereo`.`type`\s+=\s+'in dash speakers'/", $result);
 
 		$result = $this->Dbo->conditions(array('Candy.name LIKE' => 'a', 'HardCandy.name LIKE' => 'c'));
-		$this->assertPattern("/^\s+WHERE\s+`Candy`.`name` LIKE\s+'a'\s+AND\s+`HardCandy`.`name`\s+LIKE\s+'c'/", $result);
+		$this->assertRegExp("/^\s+WHERE\s+`Candy`.`name` LIKE\s+'a'\s+AND\s+`HardCandy`.`name`\s+LIKE\s+'c'/", $result);
 
 		$result = $this->Dbo->conditions(array('HardCandy.name LIKE' => 'a', 'Candy.name LIKE' => 'c'));
 		$expected = " WHERE `HardCandy`.`name` LIKE 'a' AND `Candy`.`name` LIKE 'c'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('HardCandy.name LIKE' => 'a%', 'Candy.name LIKE' => '%c%'));
 		$expected = " WHERE `HardCandy`.`name` LIKE 'a%' AND `Candy`.`name` LIKE '%c%'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('HardCandy.name LIKE' => 'to be or%', 'Candy.name LIKE' => '%not to be%'));
 		$expected = " WHERE `HardCandy`.`name` LIKE 'to be or%' AND `Candy`.`name` LIKE '%not to be%'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score BETWEEN ? AND ?' => array(90.1, 95.7)));
 		$expected = " WHERE `score` BETWEEN 90.1 AND 95.7";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Post.title' => 1.1));
 		$expected = " WHERE `Post`.`title` = 1.1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Post.title' => 1.1), true, true, new Post());
 		$expected = " WHERE `Post`.`title` = '1.1'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('SUM(Post.comments_count) >' => '500'));
 		$expected = " WHERE SUM(`Post`.`comments_count`) > '500'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('MAX(Post.rating) >' => '50'));
 		$expected = " WHERE MAX(`Post`.`rating`) > '50'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('lower(Article.title)' =>  'secrets'));
 		$expected = " WHERE lower(`Article`.`title`) = 'secrets'";
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 
 		$result = $this->Dbo->conditions(array('title LIKE' => '%hello'));
 		$expected = " WHERE `title` LIKE '%hello'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Post.name' => 'mad(g)ik'));
 		$expected = " WHERE `Post`.`name` = 'mad(g)ik'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score' => array(1, 2, 10)));
 		$expected = " WHERE score IN (1, 2, 10)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score' => array()));
 		$expected = " WHERE `score` IS NULL";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score !=' => array()));
 		$expected = " WHERE `score` IS NOT NULL";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score !=' => '20'));
 		$expected = " WHERE `score` != '20'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('score >' => '20'));
 		$expected = " WHERE `score` > '20'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('client_id >' => '20'), true, true, new TestModel());
 		$expected = " WHERE `client_id` > 20";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('OR' => array(
 			array('User.user' => 'mariano'),
@@ -2143,76 +2143,76 @@ class MysqlTest extends CakeTestCase {
 		)));
 
 		$expected = " WHERE ((`User`.`user` = 'mariano') OR (`User`.`user` = 'nate'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('or' => array(
 			'score BETWEEN ? AND ?' => array('4', '5'), 'rating >' => '20'
 		)));
 		$expected = " WHERE ((`score` BETWEEN '4' AND '5') OR (`rating` > '20'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('or' => array(
 			'score BETWEEN ? AND ?' => array('4', '5'), array('score >' => '20')
 		)));
 		$expected = " WHERE ((`score` BETWEEN '4' AND '5') OR (`score` > '20'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('and' => array(
 			'score BETWEEN ? AND ?' => array('4', '5'), array('score >' => '20')
 		)));
 		$expected = " WHERE ((`score` BETWEEN '4' AND '5') AND (`score` > '20'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'published' => 1, 'or' => array('score >' => '2', array('score >' => '20'))
 		));
 		$expected = " WHERE `published` = 1 AND ((`score` > '2') OR (`score` > '20'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(array('Project.removed' => false)));
 		$expected = " WHERE `Project`.`removed` = '0'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(array('Project.removed' => true)));
 		$expected = " WHERE `Project`.`removed` = '1'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(array('Project.removed' => null)));
 		$expected = " WHERE `Project`.`removed` IS NULL";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(array('Project.removed !=' => null)));
 		$expected = " WHERE `Project`.`removed` IS NOT NULL";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('(Usergroup.permissions) & 4' => 4));
 		$expected = " WHERE (`Usergroup`.`permissions`) & 4 = 4";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('((Usergroup.permissions) & 4)' => 4));
 		$expected = " WHERE ((`Usergroup`.`permissions`) & 4) = 4";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Post.modified >=' => 'DATE_SUB(NOW(), INTERVAL 7 DAY)'));
 		$expected = " WHERE `Post`.`modified` >= 'DATE_SUB(NOW(), INTERVAL 7 DAY)'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Post.modified >= DATE_SUB(NOW(), INTERVAL 7 DAY)'));
 		$expected = " WHERE `Post`.`modified` >= DATE_SUB(NOW(), INTERVAL 7 DAY)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'NOT' => array('Course.id' => null, 'Course.vet' => 'N', 'level_of_education_id' => array(912,999)),
 			'Enrollment.yearcompleted >' => '0')
 		);
-		$this->assertPattern('/^\s*WHERE\s+\(NOT\s+\(`Course`\.`id` IS NULL\)\s+AND NOT\s+\(`Course`\.`vet`\s+=\s+\'N\'\)\s+AND NOT\s+\(level_of_education_id IN \(912, 999\)\)\)\s+AND\s+`Enrollment`\.`yearcompleted`\s+>\s+\'0\'\s*$/', $result);
+		$this->assertRegExp('/^\s*WHERE\s+\(NOT\s+\(`Course`\.`id` IS NULL\)\s+AND NOT\s+\(`Course`\.`vet`\s+=\s+\'N\'\)\s+AND NOT\s+\(level_of_education_id IN \(912, 999\)\)\)\s+AND\s+`Enrollment`\.`yearcompleted`\s+>\s+\'0\'\s*$/', $result);
 
 		$result = $this->Dbo->conditions(array('id <>' => '8'));
-		$this->assertPattern('/^\s*WHERE\s+`id`\s+<>\s+\'8\'\s*$/', $result);
+		$this->assertRegExp('/^\s*WHERE\s+`id`\s+<>\s+\'8\'\s*$/', $result);
 
 		$result = $this->Dbo->conditions(array('TestModel.field =' => 'gribe$@()lu'));
 		$expected = " WHERE `TestModel`.`field` = 'gribe$@()lu'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions['NOT'] = array('Listing.expiration BETWEEN ? AND ?' => array("1", "100"));
 		$conditions[0]['OR'] = array(
@@ -2227,74 +2227,74 @@ class MysqlTest extends CakeTestCase {
 		$expected = " WHERE NOT (`Listing`.`expiration` BETWEEN '1' AND '100') AND" .
 		" ((`Listing`.`title` LIKE '%term%') OR (`Listing`.`description` LIKE '%term%')) AND" .
 		" ((`Listing`.`title` LIKE '%term_2%') OR (`Listing`.`description` LIKE '%term_2%'))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('MD5(CONCAT(Reg.email,Reg.id))' => 'blah'));
 		$expected = " WHERE MD5(CONCAT(`Reg`.`email`,`Reg`.`id`)) = 'blah'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'MD5(CONCAT(Reg.email,Reg.id))' => array('blah', 'blahblah')
 		));
 		$expected = " WHERE MD5(CONCAT(`Reg`.`email`,`Reg`.`id`)) IN ('blah', 'blahblah')";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('id' => array(2, 5, 6, 9, 12, 45, 78, 43, 76));
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE id IN (2, 5, 6, 9, 12, 45, 78, 43, 76)";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('title' => 'user(s)');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `title` = 'user(s)'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('title' => 'user(s) data');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `title` = 'user(s) data'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('title' => 'user(s,arg) data');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `title` = 'user(s,arg) data'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array("Book.book_name" => 'Java(TM)'));
 		$expected = " WHERE `Book`.`book_name` = 'Java(TM)'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array("Book.book_name" => 'Java(TM) '));
 		$expected = " WHERE `Book`.`book_name` = 'Java(TM) '";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array("Book.id" => 0));
 		$expected = " WHERE `Book`.`id` = 0";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array("Book.id" => null));
 		$expected = " WHERE `Book`.`id` IS NULL";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('MysqlModel.id' => '');
 		$result = $this->Dbo->conditions($conditions, true, true, $this->model);
 		$expected = " WHERE `MysqlModel`.`id` IS NULL";
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 
 		$result = $this->Dbo->conditions(array('Listing.beds >=' => 0));
 		$expected = " WHERE `Listing`.`beds` >= 0";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'ASCII(SUBSTRING(keyword, 1, 1)) BETWEEN ? AND ?' => array(65, 90)
 		));
 		$expected = ' WHERE ASCII(SUBSTRING(keyword, 1, 1)) BETWEEN 65 AND 90';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('or' => array(
 			'? BETWEEN Model.field1 AND Model.field2' => '2009-03-04'
 		)));
 		$expected = " WHERE '2009-03-04' BETWEEN Model.field1 AND Model.field2";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2307,19 +2307,19 @@ class MysqlTest extends CakeTestCase {
 			'CAST(Book.created AS DATE)' => '2008-08-02'
 		));
 		$expected = " WHERE CAST(`Book`.`created` AS DATE) = '2008-08-02'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'CAST(Book.created AS DATE) <=' => '2008-08-02'
 		));
 		$expected = " WHERE CAST(`Book`.`created` AS DATE) <= '2008-08-02'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array(
 			'(Stats.clicks * 100) / Stats.views >' => 50
 		));
 		$expected = " WHERE (`Stats`.`clicks` * 100) / `Stats`.`views` > 50";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2332,7 +2332,7 @@ class MysqlTest extends CakeTestCase {
 		$conditions[] = array('User.last_name' => 'Lastname');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `User`.`first_name` = 'Firstname' AND `User`.`last_name` = 'Lastname'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array(
 			'Thread.project_id' => 5,
@@ -2340,7 +2340,7 @@ class MysqlTest extends CakeTestCase {
 			'1=1 GROUP BY Thread.project_id'
 		);
 		$result = $this->Dbo->conditions($conditions);
-		$this->assertPattern('/^\s*WHERE\s+`Thread`.`project_id`\s*=\s*5\s+AND\s+`Thread`.`buyer_id`\s*=\s*14\s+AND\s+1\s*=\s*1\s+GROUP BY `Thread`.`project_id`$/', $result);
+		$this->assertRegExp('/^\s*WHERE\s+`Thread`.`project_id`\s*=\s*5\s+AND\s+`Thread`.`buyer_id`\s*=\s*14\s+AND\s+1\s*=\s*1\s+GROUP BY `Thread`.`project_id`$/', $result);
 	}
 
 /**
@@ -2350,10 +2350,10 @@ class MysqlTest extends CakeTestCase {
  */
 	public function testConditionsOptionalArguments() {
 		$result = $this->Dbo->conditions( array('Member.name' => 'Mariano'), true, false);
-		$this->assertPattern('/^\s*`Member`.`name`\s*=\s*\'Mariano\'\s*$/', $result);
+		$this->assertRegExp('/^\s*`Member`.`name`\s*=\s*\'Mariano\'\s*$/', $result);
 
 		$result = $this->Dbo->conditions( array(), true, false);
-		$this->assertPattern('/^\s*1\s*=\s*1\s*$/', $result);
+		$this->assertRegExp('/^\s*1\s*=\s*1\s*$/', $result);
 	}
 
 /**
@@ -2366,27 +2366,27 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->conditions(array('Article2.viewed >=' => 0), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`viewed` >= 0";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Article2.viewed >=' => '0'), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`viewed` >= 0";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Article2.viewed >=' => '1'), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`viewed` >= 1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Article2.rate_sum BETWEEN ? AND ?' => array(0, 10)), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`rate_sum` BETWEEN 0 AND 10";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Article2.rate_sum BETWEEN ? AND ?' => array('0', '10')), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`rate_sum` BETWEEN 0 AND 10";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Article2.rate_sum BETWEEN ? AND ?' => array('1', '10')), true, true, $this->Model);
 		$expected = " WHERE `Article2`.`rate_sum` BETWEEN 1 AND 10";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2398,39 +2398,39 @@ class MysqlTest extends CakeTestCase {
 		$this->Model = new TestModel();
 		$result = $this->Dbo->fields($this->Model, 'Vendor', "Vendor.id, COUNT(Model.vendor_id) AS `Vendor`.`count`");
 		$expected = array('`Vendor`.`id`', 'COUNT(`Model`.`vendor_id`) AS `Vendor`.`count`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Vendor', "`Vendor`.`id`, COUNT(`Model`.`vendor_id`) AS `Vendor`.`count`");
 		$expected = array('`Vendor`.`id`', 'COUNT(`Model`.`vendor_id`) AS `Vendor`.`count`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Post', "CONCAT(REPEAT(' ', COUNT(Parent.name) - 1), Node.name) AS name, Node.created");
 		$expected = array("CONCAT(REPEAT(' ', COUNT(`Parent`.`name`) - 1), Node.name) AS name", "`Node`.`created`");
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'round( (3.55441 * fooField), 3 ) AS test');
-		$this->assertEqual($result, array('round( (3.55441 * fooField), 3 ) AS test'));
+		$this->assertEquals($result, array('round( (3.55441 * fooField), 3 ) AS test'));
 
 		$result = $this->Dbo->fields($this->Model, null, 'ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating');
-		$this->assertEqual($result, array('ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating'));
+		$this->assertEquals($result, array('ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating'));
 
 		$result = $this->Dbo->fields($this->Model, null, 'ROUND(Rating.rate_total / Rating.rate_count,2) AS rating');
-		$this->assertEqual($result, array('ROUND(Rating.rate_total / Rating.rate_count,2) AS rating'));
+		$this->assertEquals($result, array('ROUND(Rating.rate_total / Rating.rate_count,2) AS rating'));
 
 		$result = $this->Dbo->fields($this->Model, 'Post', "Node.created, CONCAT(REPEAT(' ', COUNT(Parent.name) - 1), Node.name) AS name");
 		$expected = array("`Node`.`created`", "CONCAT(REPEAT(' ', COUNT(`Parent`.`name`) - 1), Node.name) AS name");
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Post', "2.2,COUNT(*), SUM(Something.else) as sum, Node.created, CONCAT(REPEAT(' ', COUNT(Parent.name) - 1), Node.name) AS name,Post.title,Post.1,1.1");
 		$expected = array(
 			'2.2', 'COUNT(*)', 'SUM(`Something`.`else`) as sum', '`Node`.`created`',
 			"CONCAT(REPEAT(' ', COUNT(`Parent`.`name`) - 1), Node.name) AS name", '`Post`.`title`', '`Post`.`1`', '1.1'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, "(`Provider`.`star_total` / `Provider`.`total_ratings`) as `rating`");
 		$expected = array("(`Provider`.`star_total` / `Provider`.`total_ratings`) as `rating`");
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Post');
 		$expected = array(
@@ -2440,7 +2440,7 @@ class MysqlTest extends CakeTestCase {
 			'`Post`.`url`', '`Post`.`email`', '`Post`.`comments`', '`Post`.`last_login`',
 			'`Post`.`created`', '`Post`.`updated`'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Other');
 		$expected = array(
@@ -2450,27 +2450,27 @@ class MysqlTest extends CakeTestCase {
 			'`Other`.`url`', '`Other`.`email`', '`Other`.`comments`', '`Other`.`last_login`',
 			'`Other`.`created`', '`Other`.`updated`'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array(), false);
 		$expected = array('id', 'client_id', 'name', 'login', 'passwd', 'addr_1', 'addr_2', 'zip_code', 'city', 'country', 'phone', 'fax', 'url', 'email', 'comments', 'last_login', 'created', 'updated');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'COUNT(*)');
 		$expected = array('COUNT(*)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'SUM(Thread.unread_buyer) AS ' . $this->Dbo->name('sum_unread_buyer'));
 		$expected = array('SUM(`Thread`.`unread_buyer`) AS `sum_unread_buyer`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'name, count(*)');
 		$expected = array('`TestModel`.`name`', 'count(*)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'count(*), name');
 		$expected = array('count(*)', '`TestModel`.`name`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields(
 			$this->Model, null, 'field1, field2, field3, count(*), name'
@@ -2479,29 +2479,29 @@ class MysqlTest extends CakeTestCase {
 			'`TestModel`.`field1`', '`TestModel`.`field2`',
 			'`TestModel`.`field3`', 'count(*)', '`TestModel`.`name`'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array('dayofyear(now())'));
 		$expected = array('dayofyear(now())');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array('MAX(Model.field) As Max'));
 		$expected = array('MAX(`Model`.`field`) As Max');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array('Model.field AS AnotherName'));
 		$expected = array('`Model`.`field` AS `AnotherName`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array('field AS AnotherName'));
 		$expected = array('`field` AS `AnotherName`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array(
 			'TestModel.field AS AnotherName'
 		));
 		$expected = array('`TestModel`.`field` AS `AnotherName`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Foo', array(
 			'id', 'title', '(user_count + discussion_count + post_count) AS score'
@@ -2511,7 +2511,7 @@ class MysqlTest extends CakeTestCase {
 			'`Foo`.`title`',
 			'(user_count + discussion_count + post_count) AS score'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2527,7 +2527,7 @@ class MysqlTest extends CakeTestCase {
 			'`TestModel`.`id`',
 			"CASE Sample.id WHEN 1 THEN 'Id One' ELSE 'Other Id' END AS case_col"
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2540,19 +2540,19 @@ class MysqlTest extends CakeTestCase {
 			'fields' => 'id', 'table' => 'table', 'conditions' => 'WHERE 1=1',
 			'alias' => '', 'joins' => '', 'order' => '', 'limit' => '', 'group' => ''
 		));
-		$this->assertPattern('/^\s*SELECT\s+id\s+FROM\s+table\s+WHERE\s+1=1\s*$/', $result);
+		$this->assertRegExp('/^\s*SELECT\s+id\s+FROM\s+table\s+WHERE\s+1=1\s*$/', $result);
 
 		$result = $this->Dbo->renderStatement('update', array('fields' => 'value=2', 'table' => 'table', 'conditions' => 'WHERE 1=1', 'alias' => ''));
-		$this->assertPattern('/^\s*UPDATE\s+table\s+SET\s+value=2\s+WHERE\s+1=1\s*$/', $result);
+		$this->assertRegExp('/^\s*UPDATE\s+table\s+SET\s+value=2\s+WHERE\s+1=1\s*$/', $result);
 
 		$result = $this->Dbo->renderStatement('update', array('fields' => 'value=2', 'table' => 'table', 'conditions' => 'WHERE 1=1', 'alias' => 'alias', 'joins' => ''));
-		$this->assertPattern('/^\s*UPDATE\s+table\s+AS\s+alias\s+SET\s+value=2\s+WHERE\s+1=1\s*$/', $result);
+		$this->assertRegExp('/^\s*UPDATE\s+table\s+AS\s+alias\s+SET\s+value=2\s+WHERE\s+1=1\s*$/', $result);
 
 		$result = $this->Dbo->renderStatement('delete', array('fields' => 'value=2', 'table' => 'table', 'conditions' => 'WHERE 1=1', 'alias' => ''));
-		$this->assertPattern('/^\s*DELETE\s+FROM\s+table\s+WHERE\s+1=1\s*$/', $result);
+		$this->assertRegExp('/^\s*DELETE\s+FROM\s+table\s+WHERE\s+1=1\s*$/', $result);
 
 		$result = $this->Dbo->renderStatement('delete', array('fields' => 'value=2', 'table' => 'table', 'conditions' => 'WHERE 1=1', 'alias' => 'alias', 'joins' => ''));
-		$this->assertPattern('/^\s*DELETE\s+alias\s+FROM\s+table\s+AS\s+alias\s+WHERE\s+1=1\s*$/', $result);
+		$this->assertRegExp('/^\s*DELETE\s+alias\s+FROM\s+table\s+AS\s+alias\s+WHERE\s+1=1\s*$/', $result);
 	}
 
 /**
@@ -2568,7 +2568,7 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue(empty($result));
 
 		$result = $this->Dbo->dropSchema($Schema, 'table');
-		$this->assertPattern('/^\s*DROP TABLE IF EXISTS\s+' . $this->Dbo->fullTableName('table') . ';\s*$/s', $result);
+		$this->assertRegExp('/^\s*DROP TABLE IF EXISTS\s+' . $this->Dbo->fullTableName('table') . ';\s*$/s', $result);
 	}
 
 /**
@@ -2589,71 +2589,71 @@ class MysqlTest extends CakeTestCase {
 	public function testOrderParsing() {
 		$result = $this->Dbo->order("ADDTIME(Event.time_begin, '-06:00:00') ASC");
 		$expected = " ORDER BY ADDTIME(`Event`.`time_begin`, '-06:00:00') ASC";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->order("title, id");
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
 
 		$result = $this->Dbo->order("title desc, id desc");
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+desc,\s+`id`\s+desc\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+desc,\s+`id`\s+desc\s*$/', $result);
 
 		$result = $this->Dbo->order(array("title desc, id desc"));
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+desc,\s+`id`\s+desc\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+desc,\s+`id`\s+desc\s*$/', $result);
 
 		$result = $this->Dbo->order(array("title", "id"));
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
 
 		$result = $this->Dbo->order(array(array('title'), array('id')));
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+ASC,\s+`id`\s+ASC\s*$/', $result);
 
 		$result = $this->Dbo->order(array("Post.title" => 'asc', "Post.id" => 'desc'));
-		$this->assertPattern('/^\s*ORDER BY\s+`Post`.`title`\s+asc,\s+`Post`.`id`\s+desc\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`Post`.`title`\s+asc,\s+`Post`.`id`\s+desc\s*$/', $result);
 
 		$result = $this->Dbo->order(array(array("Post.title" => 'asc', "Post.id" => 'desc')));
-		$this->assertPattern('/^\s*ORDER BY\s+`Post`.`title`\s+asc,\s+`Post`.`id`\s+desc\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`Post`.`title`\s+asc,\s+`Post`.`id`\s+desc\s*$/', $result);
 
 		$result = $this->Dbo->order(array("title"));
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+ASC\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+ASC\s*$/', $result);
 
 		$result = $this->Dbo->order(array(array("title")));
-		$this->assertPattern('/^\s*ORDER BY\s+`title`\s+ASC\s*$/', $result);
+		$this->assertRegExp('/^\s*ORDER BY\s+`title`\s+ASC\s*$/', $result);
 
 		$result = $this->Dbo->order("Dealer.id = 7 desc, Dealer.id = 3 desc, Dealer.title asc");
 		$expected = " ORDER BY `Dealer`.`id` = 7 desc, `Dealer`.`id` = 3 desc, `Dealer`.`title` asc";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->order(array("Page.name" => "='test' DESC"));
-		$this->assertPattern("/^\s*ORDER BY\s+`Page`\.`name`\s*='test'\s+DESC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+`Page`\.`name`\s*='test'\s+DESC\s*$/", $result);
 
 		$result = $this->Dbo->order("Page.name = 'view' DESC");
-		$this->assertPattern("/^\s*ORDER BY\s+`Page`\.`name`\s*=\s*'view'\s+DESC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+`Page`\.`name`\s*=\s*'view'\s+DESC\s*$/", $result);
 
 		$result = $this->Dbo->order("(Post.views)");
-		$this->assertPattern("/^\s*ORDER BY\s+\(`Post`\.`views`\)\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+\(`Post`\.`views`\)\s+ASC\s*$/", $result);
 
 		$result = $this->Dbo->order("(Post.views)*Post.views");
-		$this->assertPattern("/^\s*ORDER BY\s+\(`Post`\.`views`\)\*`Post`\.`views`\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+\(`Post`\.`views`\)\*`Post`\.`views`\s+ASC\s*$/", $result);
 
 		$result = $this->Dbo->order("(Post.views) * Post.views");
-		$this->assertPattern("/^\s*ORDER BY\s+\(`Post`\.`views`\) \* `Post`\.`views`\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+\(`Post`\.`views`\) \* `Post`\.`views`\s+ASC\s*$/", $result);
 
 		$result = $this->Dbo->order("(Model.field1 + Model.field2) * Model.field3");
-		$this->assertPattern("/^\s*ORDER BY\s+\(`Model`\.`field1` \+ `Model`\.`field2`\) \* `Model`\.`field3`\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+\(`Model`\.`field1` \+ `Model`\.`field2`\) \* `Model`\.`field3`\s+ASC\s*$/", $result);
 
 		$result = $this->Dbo->order("Model.name+0 ASC");
-		$this->assertPattern("/^\s*ORDER BY\s+`Model`\.`name`\+0\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+`Model`\.`name`\+0\s+ASC\s*$/", $result);
 
 		$result = $this->Dbo->order("Anuncio.destaque & 2 DESC");
 		$expected = ' ORDER BY `Anuncio`.`destaque` & 2 DESC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->order("3963.191 * id");
 		$expected = ' ORDER BY 3963.191 * id ASC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->order(array('Property.sale_price IS NULL'));
 		$expected = ' ORDER BY `Property`.`sale_price` IS NULL ASC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2663,7 +2663,7 @@ class MysqlTest extends CakeTestCase {
  */
 	public function testComplexSortExpression() {
 		$result = $this->Dbo->order(array('(Model.field > 100) DESC', 'Model.field ASC'));
-		$this->assertPattern("/^\s*ORDER BY\s+\(`Model`\.`field`\s+>\s+100\)\s+DESC,\s+`Model`\.`field`\s+ASC\s*$/", $result);
+		$this->assertRegExp("/^\s*ORDER BY\s+\(`Model`\.`field`\s+>\s+100\)\s+DESC,\s+`Model`\.`field`\s+ASC\s*$/", $result);
 	}
 
 /**
@@ -2674,38 +2674,38 @@ class MysqlTest extends CakeTestCase {
 	public function testCalculations() {
 		$this->Model = new TestModel();
 		$result = $this->Dbo->calculate($this->Model, 'count');
-		$this->assertEqual($result, 'COUNT(*) AS `count`');
+		$this->assertEquals($result, 'COUNT(*) AS `count`');
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('id'));
-		$this->assertEqual($result, 'COUNT(`id`) AS `count`');
+		$this->assertEquals($result, 'COUNT(`id`) AS `count`');
 
 		$result = $this->Dbo->calculate(
 			$this->Model,
 			'count',
 			array($this->Dbo->expression('DISTINCT id'))
 		);
-		$this->assertEqual($result, 'COUNT(DISTINCT id) AS `count`');
+		$this->assertEquals($result, 'COUNT(DISTINCT id) AS `count`');
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('id', 'id_count'));
-		$this->assertEqual($result, 'COUNT(`id`) AS `id_count`');
+		$this->assertEquals($result, 'COUNT(`id`) AS `id_count`');
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('Model.id', 'id_count'));
-		$this->assertEqual($result, 'COUNT(`Model`.`id`) AS `id_count`');
+		$this->assertEquals($result, 'COUNT(`Model`.`id`) AS `id_count`');
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('id'));
-		$this->assertEqual($result, 'MAX(`id`) AS `id`');
+		$this->assertEquals($result, 'MAX(`id`) AS `id`');
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('Model.id', 'id'));
-		$this->assertEqual($result, 'MAX(`Model`.`id`) AS `id`');
+		$this->assertEquals($result, 'MAX(`Model`.`id`) AS `id`');
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('`Model`.`id`', 'id'));
-		$this->assertEqual($result, 'MAX(`Model`.`id`) AS `id`');
+		$this->assertEquals($result, 'MAX(`Model`.`id`) AS `id`');
 
 		$result = $this->Dbo->calculate($this->Model, 'min', array('`Model`.`id`', 'id'));
-		$this->assertEqual($result, 'MIN(`Model`.`id`) AS `id`');
+		$this->assertEquals($result, 'MIN(`Model`.`id`) AS `id`');
 
 		$result = $this->Dbo->calculate($this->Model, 'min', 'left');
-		$this->assertEqual($result, 'MIN(`left`) AS `left`');
+		$this->assertEquals($result, 'MIN(`left`) AS `left`');
 	}
 
 /**
@@ -2716,38 +2716,38 @@ class MysqlTest extends CakeTestCase {
 	public function testLength() {
 		$result = $this->Dbo->length('varchar(255)');
 		$expected = 255;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length('int(11)');
 		$expected = 11;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length('float(5,3)');
 		$expected = '5,3';
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length('decimal(5,2)');
 		$expected = '5,2';
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length("enum('test','me','now')");
 		$expected = 4;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length("set('a','b','cd')");
 		$expected = 2;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length(false);
 		$this->assertTrue($result === null);
 
 		$result = $this->Dbo->length('datetime');
 		$expected = null;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->Dbo->length('text');
 		$expected = null;
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -2761,21 +2761,21 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildIndex($data);
 		$expected = array('PRIMARY KEY  (`id`)');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$data = array(
 			'MyIndex' => array('column' => 'id', 'unique' => true)
 		);
 		$result = $this->Dbo->buildIndex($data);
 		$expected = array('UNIQUE KEY `MyIndex` (`id`)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'MyIndex' => array('column' => array('id', 'name'), 'unique' => true)
 		);
 		$result = $this->Dbo->buildIndex($data);
 		$expected = array('UNIQUE KEY `MyIndex` (`id`, `name`)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2794,7 +2794,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`testName` varchar(255) DEFAULT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'int_field',
@@ -2807,7 +2807,7 @@ class MysqlTest extends CakeTestCase {
 		$this->Dbo->columns = array('integer' => array('name' => 'int', 'limit' => '11', 'formatter' => 'intval'), );
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`int_field` int(11) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Dbo->fieldParameters['param'] = array(
 			'value' => 'COLLATE',
@@ -2826,7 +2826,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`int_field` int(11) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'int_field',
@@ -2837,7 +2837,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`int_field` int(11) COLLATE GOOD NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Dbo->columns = $restore;
 
@@ -2849,7 +2849,7 @@ class MysqlTest extends CakeTestCase {
  		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`created` timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'created',
@@ -2859,7 +2859,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`created` timestamp DEFAULT CURRENT_TIMESTAMP';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'modified',
@@ -2868,7 +2868,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`modified` timestamp NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'modified',
@@ -2878,7 +2878,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '`modified` timestamp NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2954,28 +2954,28 @@ class MysqlTest extends CakeTestCase {
 			"(SELECT COUNT(*) FROM $commentsTable WHERE `Article`.`id` = `$commentsTable`.`article_id`) AS  `Article__comment_count`"
 		);
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('this_moment', 'title'));
 		$expected = array(
 			'`Article`.`title`',
 			'(NOW()) AS  `Article__this_moment`',
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('Article.title', 'Article.this_moment'));
 		$expected = array(
 			'`Article`.`title`',
 			'(NOW()) AS  `Article__this_moment`',
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('Article.this_moment', 'Article.title'));
 		$expected = array(
 			'`Article`.`title`',
 			'(NOW()) AS  `Article__this_moment`',
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('Article.*'));
 		$expected = array(
@@ -2984,7 +2984,7 @@ class MysqlTest extends CakeTestCase {
 			'(1 + 1) AS  `Article__two`',
 			"(SELECT COUNT(*) FROM $commentsTable WHERE `Article`.`id` = `$commentsTable`.`article_id`) AS  `Article__comment_count`"
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('*'));
 		$expected = array(
@@ -2993,7 +2993,7 @@ class MysqlTest extends CakeTestCase {
 			'(1 + 1) AS  `Article__two`',
 			"(SELECT COUNT(*) FROM $commentsTable WHERE `Article`.`id` = `$commentsTable`.`article_id`) AS  `Article__comment_count`"
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3014,22 +3014,22 @@ class MysqlTest extends CakeTestCase {
 		$conditions = array('two' => 2);
 		$result = $this->Dbo->conditions($conditions, true, false, $Article);
 		$expected = '(1 + 1) = 2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('this_moment BETWEEN ? AND ?' => array(1,2));
 		$expected = 'NOW() BETWEEN 1 AND 2';
 		$result = $this->Dbo->conditions($conditions, true, false, $Article);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('comment_count >' => 5);
 		$expected = "(SELECT COUNT(*) FROM $commentsTable WHERE `Article`.`id` = `$commentsTable`.`article_id`) > 5";
 		$result = $this->Dbo->conditions($conditions, true, false, $Article);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$conditions = array('NOT' => array('two' => 2));
 		$result = $this->Dbo->conditions($conditions, true, false, $Article);
 		$expected = 'NOT ((1 + 1) = 2)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3050,9 +3050,9 @@ class MysqlTest extends CakeTestCase {
 		$conditions = array('distance >=' => 20);
 		$result = $this->Dbo->conditions($conditions, true, true, $Article);
 
-		$this->assertPattern('/\) >= 20/', $result);
-		$this->assertPattern('/[`\'"]Article[`\'"].[`\'"]latitude[`\'"]/', $result);
-		$this->assertPattern('/[`\'"]Article[`\'"].[`\'"]longitude[`\'"]/', $result);
+		$this->assertRegExp('/\) >= 20/', $result);
+		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]latitude[`\'"]/', $result);
+		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]longitude[`\'"]/', $result);
 	}
 
 /**
@@ -3072,11 +3072,11 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->calculate($Article, 'count', array('this_moment'));
 		$expected = 'COUNT(NOW()) AS `count`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->calculate($Article, 'max', array('comment_count'));
 		$expected = "MAX(SELECT COUNT(*) FROM $commentsTable WHERE `Article`.`id` = `$commentsTable`.`article_id`) AS `comment_count`";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3094,7 +3094,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->fields($Article, null, array());
 		$result = $this->Dbo->fields($Article, $Article->alias, $result);
-		$this->assertPattern('/[`\"]User[`\"]\.[`\"]id[`\"] \+ [`\"]User[`\"]\.[`\"]id[`\"]/', $result[7]);
+		$this->assertRegExp('/[`\"]User[`\"]\.[`\"]id[`\"] \+ [`\"]User[`\"]\.[`\"]id[`\"]/', $result[7]);
 	}
 
 /**
@@ -3111,7 +3111,7 @@ class MysqlTest extends CakeTestCase {
 		$result = $this->Dbo->group('this_year', $Article);
 
 		$expected = " GROUP BY (YEAR(`Article`.`created`))";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3135,10 +3135,10 @@ class MysqlTest extends CakeTestCase {
 		$qs = $this->Dbo->startQuote;
 		$qe = $this->Dbo->endQuote;
 
-		$this->assertEqual($result[0], "{$qs}Article{$qe}.{$qs}id{$qe}");
-		$this->assertPattern('/Article__distance/', $result[1]);
-		$this->assertPattern('/[`\'"]Article[`\'"].[`\'"]latitude[`\'"]/', $result[1]);
-		$this->assertPattern('/[`\'"]Article[`\'"].[`\'"]longitude[`\'"]/', $result[1]);
+		$this->assertEquals($result[0], "{$qs}Article{$qe}.{$qs}id{$qe}");
+		$this->assertRegExp('/Article__distance/', $result[1]);
+		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]latitude[`\'"]/', $result[1]);
+		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]longitude[`\'"]/', $result[1]);
 	}
 
 /**
@@ -3182,7 +3182,7 @@ class MysqlTest extends CakeTestCase {
 		$expected = array(array(
 			'Article' => array('id' => 1, 'comment_count' => 4)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3224,158 +3224,158 @@ class MysqlTest extends CakeTestCase {
  * @return void
  */
 	public function testIntrospectType() {
-		$this->assertEqual($this->Dbo->introspectType(0), 'integer');
-		$this->assertEqual($this->Dbo->introspectType(2), 'integer');
-		$this->assertEqual($this->Dbo->introspectType('2'), 'string');
-		$this->assertEqual($this->Dbo->introspectType('2.2'), 'string');
-		$this->assertEqual($this->Dbo->introspectType(2.2), 'float');
-		$this->assertEqual($this->Dbo->introspectType('stringme'), 'string');
-		$this->assertEqual($this->Dbo->introspectType('0stringme'), 'string');
+		$this->assertEquals($this->Dbo->introspectType(0), 'integer');
+		$this->assertEquals($this->Dbo->introspectType(2), 'integer');
+		$this->assertEquals($this->Dbo->introspectType('2'), 'string');
+		$this->assertEquals($this->Dbo->introspectType('2.2'), 'string');
+		$this->assertEquals($this->Dbo->introspectType(2.2), 'float');
+		$this->assertEquals($this->Dbo->introspectType('stringme'), 'string');
+		$this->assertEquals($this->Dbo->introspectType('0stringme'), 'string');
 
 		$data = array(2.2);
-		$this->assertEqual($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals($this->Dbo->introspectType($data), 'float');
 
 		$data = array('2.2');
-		$this->assertEqual($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals($this->Dbo->introspectType($data), 'float');
 
 		$data = array(2);
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array('2');
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array('string');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array(2.2, '2.2');
-		$this->assertEqual($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals($this->Dbo->introspectType($data), 'float');
 
 		$data = array(2, '2');
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array('string one', 'string two');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array('2.2', 3);
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array('2.2', '0stringme');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array(2.2, 3);
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array(2.2, '0stringme');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array(2, 'stringme');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array(2, '2.2', 'stringgme');
-		$this->assertEqual($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals($this->Dbo->introspectType($data), 'string');
 
 		$data = array(2, '2.2');
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 		$data = array(2, 2.2);
-		$this->assertEqual($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
 
 
 		// NULL
 		$result = $this->Dbo->value(null, 'boolean');
-		$this->assertEqual($result, 'NULL');
+		$this->assertEquals($result, 'NULL');
 
 		// EMPTY STRING
 		$result = $this->Dbo->value('', 'boolean');
-		$this->assertEqual($result, "'0'");
+		$this->assertEquals($result, "'0'");
 
 
 		// BOOLEAN
 		$result = $this->Dbo->value('true', 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value('false', 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value(true, 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value(false, 'boolean');
-		$this->assertEqual($result, "'0'");
+		$this->assertEquals($result, "'0'");
 
 		$result = $this->Dbo->value(1, 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value(0, 'boolean');
-		$this->assertEqual($result, "'0'");
+		$this->assertEquals($result, "'0'");
 
 		$result = $this->Dbo->value('abc', 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value(1.234, 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		$result = $this->Dbo->value('1.234e05', 'boolean');
-		$this->assertEqual($result, "'1'");
+		$this->assertEquals($result, "'1'");
 
 		// NUMBERS
 		$result = $this->Dbo->value(123, 'integer');
-		$this->assertEqual($result, 123);
+		$this->assertEquals($result, 123);
 
 		$result = $this->Dbo->value('123', 'integer');
-		$this->assertEqual($result, '123');
+		$this->assertEquals($result, '123');
 
 		$result = $this->Dbo->value('0123', 'integer');
-		$this->assertEqual($result, "'0123'");
+		$this->assertEquals($result, "'0123'");
 
 		$result = $this->Dbo->value('0x123ABC', 'integer');
-		$this->assertEqual($result, "'0x123ABC'");
+		$this->assertEquals($result, "'0x123ABC'");
 
 		$result = $this->Dbo->value('0x123', 'integer');
-		$this->assertEqual($result, "'0x123'");
+		$this->assertEquals($result, "'0x123'");
 
 		$result = $this->Dbo->value(1.234, 'float');
-		$this->assertEqual($result, 1.234);
+		$this->assertEquals($result, 1.234);
 
 		$result = $this->Dbo->value('1.234', 'float');
-		$this->assertEqual($result, '1.234');
+		$this->assertEquals($result, '1.234');
 
 		$result = $this->Dbo->value(' 1.234 ', 'float');
-		$this->assertEqual($result, "' 1.234 '");
+		$this->assertEquals($result, "' 1.234 '");
 
 		$result = $this->Dbo->value('1.234e05', 'float');
-		$this->assertEqual($result, "'1.234e05'");
+		$this->assertEquals($result, "'1.234e05'");
 
 		$result = $this->Dbo->value('1.234e+5', 'float');
-		$this->assertEqual($result, "'1.234e+5'");
+		$this->assertEquals($result, "'1.234e+5'");
 
 		$result = $this->Dbo->value('1,234', 'float');
-		$this->assertEqual($result, "'1,234'");
+		$this->assertEquals($result, "'1,234'");
 
 		$result = $this->Dbo->value('FFF', 'integer');
-		$this->assertEqual($result, "'FFF'");
+		$this->assertEquals($result, "'FFF'");
 
 		$result = $this->Dbo->value('abc', 'integer');
-		$this->assertEqual($result, "'abc'");
+		$this->assertEquals($result, "'abc'");
 
 		// STRINGS
 		$result = $this->Dbo->value('123', 'string');
-		$this->assertEqual($result, "'123'");
+		$this->assertEquals($result, "'123'");
 
 		$result = $this->Dbo->value(123, 'string');
-		$this->assertEqual($result, "'123'");
+		$this->assertEquals($result, "'123'");
 
 		$result = $this->Dbo->value(1.234, 'string');
-		$this->assertEqual($result, "'1.234'");
+		$this->assertEquals($result, "'1.234'");
 
 		$result = $this->Dbo->value('abc', 'string');
-		$this->assertEqual($result, "'abc'");
+		$this->assertEquals($result, "'abc'");
 
 		$result = $this->Dbo->value(' abc ', 'string');
-		$this->assertEqual($result, "' abc '");
+		$this->assertEquals($result, "' abc '");
 
 		$result = $this->Dbo->value('a bc', 'string');
-		$this->assertEqual($result, "'a bc'");
+		$this->assertEquals($result, "'a bc'");
 	}
 
 /**
@@ -3397,7 +3397,7 @@ class MysqlTest extends CakeTestCase {
 			'color' => 'Red 1',
 			'name' => 'Red Apple 1'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fetchAll('SELECT name FROM ' . $this->Dbo->fullTableName('apples') . ' ORDER BY id');
 		$expected = array(
@@ -3409,14 +3409,14 @@ class MysqlTest extends CakeTestCase {
 			array($this->Dbo->fullTableName('apples', false) => array('name' => 'My new apple')),
 			array($this->Dbo->fullTableName('apples', false) => array('name' => 'Some odd color'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->field($this->Dbo->fullTableName('apples', false), 'SELECT color, name FROM ' . $this->Dbo->fullTableName('apples') . ' ORDER BY id');
 		$expected = array(
 			'color' => 'Red 1',
 			'name' => 'Red Apple 1'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Apple->unbindModel(array(), false);
 		$result = $this->Dbo->read($Apple, array(
@@ -3433,7 +3433,7 @@ class MysqlTest extends CakeTestCase {
 			array('Apple' => array('name' => 'My new apple')),
 			array('Apple' => array('name' => 'Some odd color'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->read($Article, array(
 			'fields' => array('id', 'user_id', 'title'),

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -269,17 +269,17 @@ class PostgresTest extends CakeTestCase {
 
 		$result = $this->Dbo->fields($this->model);
 		$expected = $fields;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->model, null, 'PostgresTestModel.*');
 		$expected = $fields;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->model, null, array('*', 'AnotherModel.id', 'AnotherModel.name'));
 		$expected = array_merge($fields, array(
 			'"AnotherModel"."id" AS "AnotherModel__id"',
 			'"AnotherModel"."name" AS "AnotherModel__name"'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->model, null, array('*', 'PostgresClientTestModel.*'));
 		$expected = array_merge($fields, array(
@@ -288,7 +288,7 @@ class PostgresTest extends CakeTestCase {
     		'"PostgresClientTestModel"."email" AS "PostgresClientTestModel__email"',
     		'"PostgresClientTestModel"."created" AS "PostgresClientTestModel__created"',
     		'"PostgresClientTestModel"."updated" AS "PostgresClientTestModel__updated"'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -297,12 +297,12 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testColumnParsing() {
-		$this->assertEqual($this->Dbo2->column('text'), 'text');
-		$this->assertEqual($this->Dbo2->column('date'), 'date');
-		$this->assertEqual($this->Dbo2->column('boolean'), 'boolean');
-		$this->assertEqual($this->Dbo2->column('character varying'), 'string');
-		$this->assertEqual($this->Dbo2->column('time without time zone'), 'time');
-		$this->assertEqual($this->Dbo2->column('timestamp without time zone'), 'datetime');
+		$this->assertEquals($this->Dbo2->column('text'), 'text');
+		$this->assertEquals($this->Dbo2->column('date'), 'date');
+		$this->assertEquals($this->Dbo2->column('boolean'), 'boolean');
+		$this->assertEquals($this->Dbo2->column('character varying'), 'string');
+		$this->assertEquals($this->Dbo2->column('time without time zone'), 'time');
+		$this->assertEquals($this->Dbo2->column('timestamp without time zone'), 'datetime');
 	}
 
 /**
@@ -311,30 +311,30 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testValueQuoting() {
-		$this->assertEqual($this->Dbo->value(1.2, 'float'), "1.200000");
-		$this->assertEqual($this->Dbo->value('1,2', 'float'), "'1,2'");
+		$this->assertEquals($this->Dbo->value(1.2, 'float'), "1.200000");
+		$this->assertEquals($this->Dbo->value('1,2', 'float'), "'1,2'");
 
-		$this->assertEqual($this->Dbo->value('0', 'integer'), "0");
-		$this->assertEqual($this->Dbo->value('', 'integer'), 'NULL');
-		$this->assertEqual($this->Dbo->value('', 'float'), 'NULL');
-		$this->assertEqual($this->Dbo->value('', 'integer', false), "NULL");
-		$this->assertEqual($this->Dbo->value('', 'float', false), "NULL");
-		$this->assertEqual($this->Dbo->value('0.0', 'float'), "'0.0'");
+		$this->assertEquals($this->Dbo->value('0', 'integer'), "0");
+		$this->assertEquals($this->Dbo->value('', 'integer'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'float'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'integer', false), "NULL");
+		$this->assertEquals($this->Dbo->value('', 'float', false), "NULL");
+		$this->assertEquals($this->Dbo->value('0.0', 'float'), "'0.0'");
 
-		$this->assertEqual($this->Dbo->value('t', 'boolean'), "'TRUE'");
-		$this->assertEqual($this->Dbo->value('f', 'boolean'), "'FALSE'");
-		$this->assertEqual($this->Dbo->value(true), "'TRUE'");
-		$this->assertEqual($this->Dbo->value(false), "'FALSE'");
-		$this->assertEqual($this->Dbo->value('t'), "'t'");
-		$this->assertEqual($this->Dbo->value('f'), "'f'");
-		$this->assertEqual($this->Dbo->value('true', 'boolean'), "'TRUE'");
-		$this->assertEqual($this->Dbo->value('false', 'boolean'), "'FALSE'");
-		$this->assertEqual($this->Dbo->value('', 'boolean'), "'FALSE'");
-		$this->assertEqual($this->Dbo->value(0, 'boolean'), "'FALSE'");
-		$this->assertEqual($this->Dbo->value(1, 'boolean'), "'TRUE'");
-		$this->assertEqual($this->Dbo->value('1', 'boolean'), "'TRUE'");
-		$this->assertEqual($this->Dbo->value(null, 'boolean'), "NULL");
-		$this->assertEqual($this->Dbo->value(array()), "NULL");
+		$this->assertEquals($this->Dbo->value('t', 'boolean'), "'TRUE'");
+		$this->assertEquals($this->Dbo->value('f', 'boolean'), "'FALSE'");
+		$this->assertEquals($this->Dbo->value(true), "'TRUE'");
+		$this->assertEquals($this->Dbo->value(false), "'FALSE'");
+		$this->assertEquals($this->Dbo->value('t'), "'t'");
+		$this->assertEquals($this->Dbo->value('f'), "'f'");
+		$this->assertEquals($this->Dbo->value('true', 'boolean'), "'TRUE'");
+		$this->assertEquals($this->Dbo->value('false', 'boolean'), "'FALSE'");
+		$this->assertEquals($this->Dbo->value('', 'boolean'), "'FALSE'");
+		$this->assertEquals($this->Dbo->value(0, 'boolean'), "'FALSE'");
+		$this->assertEquals($this->Dbo->value(1, 'boolean'), "'TRUE'");
+		$this->assertEquals($this->Dbo->value('1', 'boolean'), "'TRUE'");
+		$this->assertEquals($this->Dbo->value(null, 'boolean'), "NULL");
+		$this->assertEquals($this->Dbo->value(array()), "NULL");
 	}
 
 /**
@@ -361,17 +361,17 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testDateAndTimeAsNull() {
-		$this->assertEqual($this->Dbo->value(null, 'date'), 'NULL');
-		$this->assertEqual($this->Dbo->value('', 'date'), 'NULL');
+		$this->assertEquals($this->Dbo->value(null, 'date'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'date'), 'NULL');
 
-		$this->assertEqual($this->Dbo->value('', 'datetime'), 'NULL');
-		$this->assertEqual($this->Dbo->value(null, 'datetime'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'datetime'), 'NULL');
+		$this->assertEquals($this->Dbo->value(null, 'datetime'), 'NULL');
 
-		$this->assertEqual($this->Dbo->value('', 'timestamp'), 'NULL');
-		$this->assertEqual($this->Dbo->value(null, 'timestamp'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'timestamp'), 'NULL');
+		$this->assertEquals($this->Dbo->value(null, 'timestamp'), 'NULL');
 
-		$this->assertEqual($this->Dbo->value('', 'time'), 'NULL');
-		$this->assertEqual($this->Dbo->value(null, 'time'), 'NULL');
+		$this->assertEquals($this->Dbo->value('', 'time'), 'NULL');
+		$this->assertEquals($this->Dbo->value(null, 'time'), 'NULL');
 	}
 
 /**
@@ -405,7 +405,7 @@ class PostgresTest extends CakeTestCase {
 
 		$model = new Model(array('name' => 'Datatype', 'table' => 'datatypes', 'ds' => 'test'));
 		$model->create();
-		$this->assertIdentical(false, $model->data['Datatype']['bool']);
+		$this->assertSame(false, $model->data['Datatype']['bool']);
 	}
 
 /**
@@ -423,10 +423,10 @@ class PostgresTest extends CakeTestCase {
 			"INSERT INTO {$table} (\"user\", password) VALUES ('mariano', '{$password}')"
 		);
 
-		$this->assertEqual($db1->lastInsertId($table), 5);
+		$this->assertEquals($db1->lastInsertId($table), 5);
 
 		$db1->execute("INSERT INTO {$table} (\"user\", password) VALUES ('hoge', '{$password}')");
-		$this->assertEqual($db1->lastInsertId($table), 6);
+		$this->assertEquals($db1->lastInsertId($table), 6);
 	}
 
 /**
@@ -438,11 +438,11 @@ class PostgresTest extends CakeTestCase {
 	public function testColumnUseLength() {
 		$result = array('name' => 'foo', 'type' => 'string', 'length' => 100, 'default' => 'FOO');
 		$expected = '"foo" varchar(100) DEFAULT \'FOO\'';
-		$this->assertEqual($this->Dbo->buildColumn($result), $expected);
+		$this->assertEquals($this->Dbo->buildColumn($result), $expected);
 
 		$result = array('name' => 'foo', 'type' => 'text', 'length' => 100, 'default' => 'FOO');
 		$expected = '"foo" text DEFAULT \'FOO\'';
-		$this->assertEqual($this->Dbo->buildColumn($result), $expected);
+		$this->assertEquals($this->Dbo->buildColumn($result), $expected);
 	}
 
 /**
@@ -475,7 +475,7 @@ class PostgresTest extends CakeTestCase {
 		$model->save(compact('data'));
 
 		$result = $model->find('first');
-		$this->assertEqual($result['BinaryTest']['data'], $data);
+		$this->assertEquals($result['BinaryTest']['data'], $data);
 	}
 
 /**
@@ -507,7 +507,7 @@ class PostgresTest extends CakeTestCase {
 		));
 
 		$result = $this->Dbo->createSchema($schema);
-		$this->assertNoPattern('/^CREATE INDEX(.+);,$/', $result);
+		$this->assertNotRegExp('/^CREATE INDEX(.+);,$/', $result);
 	}
 
 /**
@@ -541,9 +541,9 @@ class PostgresTest extends CakeTestCase {
 		$result = $db1->createSchema($schema, 'datatype_tests');
 
 
-		$this->assertNoPattern('/timestamp DEFAULT/', $result);
-		$this->assertPattern('/\"full_length\"\s*text\s.*,/', $result);
-		$this->assertPattern('/timestamp\s*,/', $result);
+		$this->assertNotRegExp('/timestamp DEFAULT/', $result);
+		$this->assertRegExp('/\"full_length\"\s*text\s.*,/', $result);
+		$this->assertRegExp('/timestamp\s*,/', $result);
 
 
 		$db1->query('DROP TABLE ' . $db1->fullTableName('datatype_tests'));
@@ -555,7 +555,7 @@ class PostgresTest extends CakeTestCase {
 		));
 		$schema->tables = array('datatype_tests' => $result2['tables']['missing']['datatype_tests']);
 		$result2 = $db1->createSchema($schema, 'datatype_tests');
-		$this->assertEqual($result, $result2);
+		$this->assertEquals($result, $result2);
 
 		$db1->query('DROP TABLE ' . $db1->fullTableName('datatype_tests'));
 	}
@@ -577,7 +577,7 @@ class PostgresTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index($name);
 		$this->Dbo->query('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$name = $this->Dbo->fullTableName('index_test_2', false);
 		$this->Dbo->query('CREATE TABLE ' . $name . ' ("id" serial NOT NULL PRIMARY KEY, "bool" integer, "small_char" varchar(50), "description" varchar(40) )');
@@ -588,7 +588,7 @@ class PostgresTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->index($name);
 		$this->Dbo->query('DROP TABLE ' . $name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -631,10 +631,10 @@ class PostgresTest extends CakeTestCase {
 		$result = $model->schema();
 		$this->assertTrue(isset($result['status']));
 		$this->assertFalse(isset($result['published']));
-		$this->assertEqual($result['body']['type'], 'string');
-		$this->assertEqual($result['status']['default'], 1);
-		$this->assertEqual($result['author_id']['null'], true);
-		$this->assertEqual($result['title']['null'], false);
+		$this->assertEquals($result['body']['type'], 'string');
+		$this->assertEquals($result['status']['default'], 1);
+		$this->assertEquals($result['author_id']['null'], true);
+		$this->assertEquals($result['title']['null'], false);
 
 		$this->Dbo->query($this->Dbo->dropSchema($New));
 
@@ -652,7 +652,7 @@ class PostgresTest extends CakeTestCase {
 			)
 		));
 		$result = $this->Dbo->alterSchema($New->compare($Old), 'alter_posts');
-		$this->assertNoPattern('/varchar\(36\) NOT NULL/i', $result);
+		$this->assertNotRegExp('/varchar\(36\) NOT NULL/i', $result);
 	}
 
 /**
@@ -695,7 +695,7 @@ class PostgresTest extends CakeTestCase {
 		$this->Dbo->query($this->Dbo->alterSchema($schema2->compare($schema1)));
 
 		$indexes = $this->Dbo->index('altertest');
-		$this->assertEqual($schema2->tables['altertest']['indexes'], $indexes);
+		$this->assertEquals($schema2->tables['altertest']['indexes'], $indexes);
 
 		// Change three indexes, delete one and add another one
 		$schema3 = new CakeSchema(array(
@@ -716,16 +716,16 @@ class PostgresTest extends CakeTestCase {
 		$this->Dbo->query($this->Dbo->alterSchema($schema3->compare($schema2)));
 
 		$indexes = $this->Dbo->index('altertest');
-		$this->assertEqual($schema3->tables['altertest']['indexes'], $indexes);
+		$this->assertEquals($schema3->tables['altertest']['indexes'], $indexes);
 
 		// Compare us to ourself.
-		$this->assertEqual($schema3->compare($schema3), array());
+		$this->assertEquals($schema3->compare($schema3), array());
 
 		// Drop the indexes
 		$this->Dbo->query($this->Dbo->alterSchema($schema1->compare($schema3)));
 
 		$indexes = $this->Dbo->index('altertest');
-		$this->assertEqual(array(), $indexes);
+		$this->assertEquals(array(), $indexes);
 
 		$this->Dbo->query($this->Dbo->dropSchema($schema1));
 	}
@@ -745,10 +745,10 @@ class PostgresTest extends CakeTestCase {
 			'subquery' => 'SELECT count(*) FROM ' . $Article->Comment->table
 		);
 		$result = $Article->find('first');
-		$this->assertEqual($result['Article']['next_id'], 2);
-		$this->assertEqual($result['Article']['complex'], $result['Article']['title'] . $result['Article']['body']);
-		$this->assertEqual($result['Article']['functional'], $result['User']['user']);
-		$this->assertEqual($result['Article']['subquery'], 6);
+		$this->assertEquals($result['Article']['next_id'], 2);
+		$this->assertEquals($result['Article']['complex'], $result['Article']['title'] . $result['Article']['body']);
+		$this->assertEquals($result['Article']['functional'], $result['User']['user']);
+		$this->assertEquals($result['Article']['subquery'], 6);
 	}
 
 /**
@@ -778,7 +778,7 @@ class PostgresTest extends CakeTestCase {
 	public function testOrderAdditionalParams() {
 		$result = $this->Dbo->order(array('title' => 'DESC NULLS FIRST', 'body' => 'DESC'));
 		$expected = ' ORDER BY "title" DESC NULLS FIRST, "body" DESC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -789,15 +789,15 @@ class PostgresTest extends CakeTestCase {
 		$Article = new Article;
 		$result = $this->Dbo->fields($Article, null, array('COUNT(DISTINCT Article.id)'));
 		$expected = array('COUNT(DISTINCT "Article"."id")');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('COUNT(DISTINCT id)'));
 		$expected = array('COUNT(DISTINCT "id")');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($Article, null, array('COUNT(DISTINCT FUNC(id))'));
 		$expected = array('COUNT(DISTINCT FUNC("id"))');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -814,7 +814,7 @@ class PostgresTest extends CakeTestCase {
 		$result = $Article->find('count', array(
 			'conditions' => array('Article.title' => 'Awesome')
 		));
-		$this->assertEqual($result, 1, 'Article count is wrong or fixture has changed.');
+		$this->assertEquals($result, 1, 'Article count is wrong or fixture has changed.');
 	}
 
 /**
@@ -848,7 +848,7 @@ class PostgresTest extends CakeTestCase {
 			)
 		));
 		$result = $this->db->alterSchema($schema2->compare($schema1));
-		$this->assertEqual(2, substr_count($result, 'field_two'), 'Too many fields');
+		$this->assertEquals(2, substr_count($result, 'field_two'), 'Too many fields');
 		$this->assertFalse(strpos(';ALTER', $result), 'Too many semi colons');
 	}
 	
@@ -862,12 +862,12 @@ class PostgresTest extends CakeTestCase {
 		$this->assertTrue($result) ;
 		
 		$result = $this->Dbo->getEncoding();
-		$this->assertEqual('utf8', $result) ;
+		$this->assertEquals('utf8', $result) ;
 		
 		$result = $this->Dbo->setEncoding('EUC-JP');
 		$this->assertTrue($result) ;
 		
 		$result = $this->Dbo->getEncoding();
-		$this->assertEqual('EUC-JP', $result) ;
+		$this->assertEquals('EUC-JP', $result) ;
 	}
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -139,7 +139,7 @@ class SqliteTest extends CakeTestCase {
 
 		);
 		$result = $this->Dbo->index($name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->Dbo->query('DROP TABLE ' . $name);
 
 		$this->Dbo->query('CREATE TABLE ' . $name . ' ("id" int(11) PRIMARY KEY, "bool" int(1), "small_char" varchar(50), "description" varchar(40) );');
@@ -149,7 +149,7 @@ class SqliteTest extends CakeTestCase {
 			'multi_col' => array('column' => array('small_char', 'bool'), 'unique' => 1),
 		);
 		$result = $this->Dbo->index($name);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->Dbo->query('DROP TABLE ' . $name);
 	}
 
@@ -170,13 +170,13 @@ class SqliteTest extends CakeTestCase {
 		$db->execute("CREATE TABLE test_list (id VARCHAR(255));");
 
 		$db->cacheSources = true;
-		$this->assertEqual($db->listSources(), array('test_list'));
+		$this->assertEquals($db->listSources(), array('test_list'));
 		$db->cacheSources = false;
 
 		$fileName = '_' . preg_replace('/[^A-Za-z0-9_\-+]/', '_', TMP . $dbName) . '_list';
 
 		$result = Cache::read($fileName, '_cake_model_');
-		$this->assertEqual($result, array('test_list'));
+		$this->assertEquals($result, array('test_list'));
 
 		Cache::delete($fileName, '_cake_model_');
 		Configure::write('Cache.disable', true);
@@ -195,7 +195,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"int_field" integer NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'name',
@@ -205,7 +205,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"name" varchar(20) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'testName',
@@ -217,7 +217,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"testName" varchar(20) DEFAULT NULL COLLATE NOCASE';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'testName',
@@ -228,7 +228,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"testName" varchar(20) DEFAULT \'test-value\' NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'testName',
@@ -239,7 +239,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"testName" integer(10) DEFAULT 10 NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'name' => 'testName',
@@ -251,7 +251,7 @@ class SqliteTest extends CakeTestCase {
 		);
 		$result = $this->Dbo->buildColumn($data);
 		$expected = '"testName" integer(10) DEFAULT 10 NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -319,7 +319,7 @@ class SqliteTest extends CakeTestCase {
 			'default' => null,
 			'key' => 'primary',
 		);
-		$this->assertEqual($result['id'], $expected);
+		$this->assertEquals($result['id'], $expected);
 		$this->Dbo->query('DROP TABLE ' . $tableName);
 
 		$tableName = 'uuid_tests';
@@ -333,7 +333,7 @@ class SqliteTest extends CakeTestCase {
 			'default' => null,
 			'key' => 'primary',
 		);
-		$this->assertEqual($result['id'], $expected);
+		$this->assertEquals($result['id'], $expected);
 		$this->Dbo->query('DROP TABLE ' . $tableName);
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -284,23 +284,23 @@ class SqlserverTest extends CakeTestCase {
 	public function testQuoting() {
 		$expected = "1.200000";
 		$result = $this->db->value(1.2, 'float');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = "'1,2'";
 		$result = $this->db->value('1,2', 'float');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = 'NULL';
 		$result = $this->db->value('', 'integer');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = 'NULL';
 		$result = $this->db->value('', 'float');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = "''";
 		$result = $this->db->value('', 'binary');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 /**
  * testFields method
@@ -331,19 +331,19 @@ class SqlserverTest extends CakeTestCase {
 
 		$result = $this->db->fields($this->model);
 		$expected = $fields;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->db->clearFieldMappings();
 		$result = $this->db->fields($this->model, null, 'SqlserverTestModel.*');
 		$expected = $fields;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->db->clearFieldMappings();
 		$result = $this->db->fields($this->model, null, array('*', 'AnotherModel.id', 'AnotherModel.name'));
 		$expected = array_merge($fields, array(
 			'[AnotherModel].[id] AS [AnotherModel__id]',
 			'[AnotherModel].[name] AS [AnotherModel__name]'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->db->clearFieldMappings();
 		$result = $this->db->fields($this->model, null, array('*', 'SqlserverClientTestModel.*'));
@@ -353,7 +353,7 @@ class SqlserverTest extends CakeTestCase {
 			'[SqlserverClientTestModel].[email] AS [SqlserverClientTestModel__email]',
 			'CONVERT(VARCHAR(20), [SqlserverClientTestModel].[created], 20) AS [SqlserverClientTestModel__created]',
 			'CONVERT(VARCHAR(20), [SqlserverClientTestModel].[updated], 20) AS [SqlserverClientTestModel__updated]'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -364,11 +364,11 @@ class SqlserverTest extends CakeTestCase {
 	public function testDistinctFields() {
 		$result = $this->db->fields($this->model, null, array('DISTINCT Car.country_code'));
 		$expected = array('DISTINCT [Car].[country_code] AS [Car__country_code]');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->fields($this->model, null, 'DISTINCT Car.country_code');
 		$expected = array('DISTINCT [Car].[country_code] AS [Car__country_code]');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -382,7 +382,7 @@ class SqlserverTest extends CakeTestCase {
 			'limit' => 5
 		));
 		$result = $this->db->getLastQuery();
-		$this->assertPattern('/^SELECT DISTINCT TOP 5/', $result);
+		$this->assertRegExp('/^SELECT DISTINCT TOP 5/', $result);
 	}
 
 /**
@@ -457,7 +457,7 @@ class SqlserverTest extends CakeTestCase {
 				'key' => 'primary'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * testBuildColumn
@@ -468,58 +468,58 @@ class SqlserverTest extends CakeTestCase {
 		$column = array('name' => 'id', 'type' => 'integer', 'null' => false, 'default' => '', 'length' => '8', 'key' => 'primary');
 		$result = $this->db->buildColumn($column);
 		$expected = '[id] int IDENTITY (1, 1) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'client_id', 'type' => 'integer', 'null' => false, 'default' => '0', 'length' => '11');
 		$result = $this->db->buildColumn($column);
 		$expected = '[client_id] int DEFAULT 0 NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'client_id', 'type' => 'integer', 'null' => true);
 		$result = $this->db->buildColumn($column);
 		$expected = '[client_id] int NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// 'name' => 'type' format for columns
 		$column = array('type' => 'integer', 'name' => 'client_id');
 		$result = $this->db->buildColumn($column);
 		$expected = '[client_id] int NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('type' => 'string', 'name' => 'name');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'name', 'type' => 'string', 'null' => false, 'default' => '', 'length' => '255');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) DEFAULT \'\' NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'name', 'type' => 'string', 'null' => false, 'length' => '255');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'name', 'type' => 'string', 'null' => false, 'default' => null, 'length' => '255');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) NOT NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'name', 'type' => 'string', 'null' => true, 'default' => null, 'length' => '255');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) NULL';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'name', 'type' => 'string', 'null' => true, 'default' => '', 'length' => '255');
 		$result = $this->db->buildColumn($column);
 		$expected = '[name] nvarchar(255) DEFAULT \'\'';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$column = array('name' => 'body', 'type' => 'text');
 		$result = $this->db->buildColumn($column);
 		$expected = '[body] nvarchar(MAX)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * testBuildIndex method
@@ -536,16 +536,16 @@ class SqlserverTest extends CakeTestCase {
 			'PRIMARY KEY ([id])',
 			'ALTER TABLE items ADD CONSTRAINT client_id UNIQUE([client_id]);'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$indexes = array('client_id' => array('column' => 'client_id'));
 		$result = $this->db->buildIndex($indexes, 'items');
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 
 		$indexes = array('client_id' => array('column' => array('client_id', 'period_id'), 'unique' => 1));
 		$result = $this->db->buildIndex($indexes, 'items');
 		$expected = array('ALTER TABLE items ADD CONSTRAINT client_id UNIQUE([client_id], [period_id]);');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * testUpdateAllSyntax method
@@ -558,9 +558,9 @@ class SqlserverTest extends CakeTestCase {
 		$this->db->update($this->model, $fields, null, $conditions);
 
 		$result = $this->db->getLastQuery();
-		$this->assertNoPattern('/SqlserverTestModel/', $result);
-		$this->assertPattern('/^UPDATE \[sqlserver_test_models\]/', $result);
-		$this->assertPattern('/SET \[client_id\] = \[client_id\] \+ 1/', $result);
+		$this->assertNotRegExp('/SqlserverTestModel/', $result);
+		$this->assertRegExp('/^UPDATE \[sqlserver_test_models\]/', $result);
+		$this->assertRegExp('/SET \[client_id\] = \[client_id\] \+ 1/', $result);
 	}
 
 /**
@@ -573,7 +573,7 @@ class SqlserverTest extends CakeTestCase {
 
 		$this->db->describe = $schema;
 		$result = $this->db->getPrimaryKey($this->model);
-		$this->assertEqual($result, 'id');
+		$this->assertEquals($result, 'id');
 
 		unset($schema['id']['key']);
 		$this->db->describe = $schema;
@@ -602,7 +602,7 @@ class SqlserverTest extends CakeTestCase {
 			"INSERT INTO [sqlserver_test_models] ([id], [name], [login]) VALUES (2, N'Renan', N'renan.saddam')",
 			'SET IDENTITY_INSERT [sqlserver_test_models] OFF'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$fields = array('name', 'login');
 		$values = array(
@@ -615,7 +615,7 @@ class SqlserverTest extends CakeTestCase {
 			"INSERT INTO [sqlserver_test_models] ([name], [login]) VALUES (N'Larry', N'PhpNut')",
 			"INSERT INTO [sqlserver_test_models] ([name], [login]) VALUES (N'Renan', N'renan.saddam')",
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -111,22 +111,22 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testBooleanNullConditionsParsing() {
 		$result = $this->testDb->conditions(true);
-		$this->assertEqual($result, ' WHERE 1 = 1', 'true conditions failed %s');
+		$this->assertEquals($result, ' WHERE 1 = 1', 'true conditions failed %s');
 
 		$result = $this->testDb->conditions(false);
-		$this->assertEqual($result, ' WHERE 0 = 1', 'false conditions failed %s');
+		$this->assertEquals($result, ' WHERE 0 = 1', 'false conditions failed %s');
 
 		$result = $this->testDb->conditions(null);
-		$this->assertEqual($result, ' WHERE 1 = 1', 'null conditions failed %s');
+		$this->assertEquals($result, ' WHERE 1 = 1', 'null conditions failed %s');
 
 		$result = $this->testDb->conditions(array());
-		$this->assertEqual($result, ' WHERE 1 = 1', 'array() conditions failed %s');
+		$this->assertEquals($result, ' WHERE 1 = 1', 'array() conditions failed %s');
 
 		$result = $this->testDb->conditions('');
-		$this->assertEqual($result, ' WHERE 1 = 1', '"" conditions failed %s');
+		$this->assertEquals($result, ' WHERE 1 = 1', '"" conditions failed %s');
 
 		$result = $this->testDb->conditions(' ', '"  " conditions failed %s');
-		$this->assertEqual($result, ' WHERE 1 = 1');
+		$this->assertEquals($result, ' WHERE 1 = 1');
 	}
 
 /**
@@ -138,7 +138,7 @@ class DboSourceTest extends CakeTestCase {
 		$expression = $this->testDb->expression("CASE Sample.id WHEN 1 THEN 'Id One' ELSE 'Other Id' END AS case_col");
 		$result = $this->testDb->order($expression);
 		$expected = " ORDER BY CASE Sample.id WHEN 1 THEN 'Id One' ELSE 'Other Id' END AS case_col";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -168,7 +168,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Topic', 'hasOne');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array('Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
@@ -191,7 +191,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'User2', 'belongsTo');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article2' => array(
@@ -206,7 +206,7 @@ class DboSourceTest extends CakeTestCase {
 			'Comment' => array()
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article' => array(
@@ -239,7 +239,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article' => array(
@@ -284,7 +284,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article' => array(
@@ -339,7 +339,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article' => array(
@@ -380,7 +380,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Tag', 'hasAndBelongsToMany');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 
 		$data = array(
 			'Article' => array(
@@ -411,7 +411,7 @@ class DboSourceTest extends CakeTestCase {
 			'Tag' => array('id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31')
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Tag', 'hasOne');
-		$this->assertEqual($data, $expected);
+		$this->assertEquals($data, $expected);
 	}
 
 
@@ -426,14 +426,14 @@ class DboSourceTest extends CakeTestCase {
 			'conditions' => array('TestModel.field_name' => 'value'),
 			'fields' => null, 'order' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findByFindBy', array('value'), $this->Model);
 		$expected = array('first', array(
 			'conditions' => array('TestModel.find_by' => 'value'),
 			'fields' => null, 'order' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findAllByFieldName', array('value'), $this->Model);
 		$expected = array('all', array(
@@ -441,7 +441,7 @@ class DboSourceTest extends CakeTestCase {
 			'fields' => null, 'order' => null, 'limit' => null,
 			'page' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findAllById', array('a'), $this->Model);
 		$expected = array('all', array(
@@ -449,32 +449,32 @@ class DboSourceTest extends CakeTestCase {
 			'fields' => null, 'order' => null, 'limit' => null,
 			'page' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findByFieldName', array(array('value1', 'value2', 'value3')), $this->Model);
 		$expected = array('first', array(
 			'conditions' => array('TestModel.field_name' => array('value1', 'value2', 'value3')),
 			'fields' => null, 'order' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findByFieldName', array(null), $this->Model);
 		$expected = array('first', array(
 			'conditions' => array('TestModel.field_name' => null),
 			'fields' => null, 'order' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findByFieldName', array('= a'), $this->Model);
 		$expected = array('first', array(
 			'conditions' => array('TestModel.field_name' => '= a'),
 			'fields' => null, 'order' => null, 'recursive' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->db->query('findByFieldName', array(), $this->Model);
 		$expected = false;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -494,11 +494,11 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testValue() {
 		$result = $this->db->value('{$__cakeForeignKey__$}');
-		$this->assertEqual($result, '{$__cakeForeignKey__$}');
+		$this->assertEquals($result, '{$__cakeForeignKey__$}');
 
 		$result = $this->db->value(array('first', 2, 'third'));
 		$expected = array('\'first\'', 2, '\'third\'');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -509,7 +509,7 @@ class DboSourceTest extends CakeTestCase {
 	public function testReconnect() {
 		$this->testDb->reconnect(array('prefix' => 'foo'));
 		$this->assertTrue($this->testDb->connected);
-		$this->assertEqual($this->testDb->config['prefix'], 'foo');
+		$this->assertEquals($this->testDb->config['prefix'], 'foo');
 	}
 
 /**
@@ -520,55 +520,55 @@ class DboSourceTest extends CakeTestCase {
 	public function testName() {
 		$result = $this->testDb->name('name');
 		$expected = '`name`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name(array('name', 'Model.*'));
 		$expected = array('`name`', '`Model`.*');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('MTD()');
 		$expected = 'MTD()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('(sm)');
 		$expected = '(sm)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('name AS x');
 		$expected = '`name` AS `x`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('Model.name AS x');
 		$expected = '`Model`.`name` AS `x`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('Function(Something.foo)');
 		$expected = 'Function(`Something`.`foo`)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('Function(SubFunction(Something.foo))');
 		$expected = 'Function(SubFunction(`Something`.`foo`))';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('Function(Something.foo) AS x');
 		$expected = 'Function(`Something`.`foo`) AS `x`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('name-with-minus');
 		$expected = '`name-with-minus`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name(array('my-name', 'Foo-Model.*'));
 		$expected = array('`my-name`', '`Foo-Model`.*');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name(array('Team.P%', 'Team.G/G'));
 		$expected = array('`Team`.`P%`', '`Team`.`G/G`');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->testDb->name('Model.name as y');
 		$expected = '`Model`.`name` AS `y`';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -579,10 +579,10 @@ class DboSourceTest extends CakeTestCase {
 	public function testCacheMethod() {
 		$this->testDb->cacheMethods = true;
 		$result = $this->testDb->cacheMethod('name', 'some-key', 'stuff');
-		$this->assertEqual($result, 'stuff');
+		$this->assertEquals($result, 'stuff');
 
 		$result = $this->testDb->cacheMethod('name', 'some-key');
-		$this->assertEqual($result, 'stuff');
+		$this->assertEquals($result, 'stuff');
 
 		$result = $this->testDb->cacheMethod('conditions', 'some-key');
 		$this->assertNull($result);
@@ -592,7 +592,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$this->testDb->cacheMethods = false;
 		$result = $this->testDb->cacheMethod('name', 'some-key', 'stuff');
-		$this->assertEqual($result, 'stuff');
+		$this->assertEquals($result, 'stuff');
 
 		$result = $this->testDb->cacheMethod('name', 'some-key');
 		$this->assertNull($result);
@@ -611,7 +611,7 @@ class DboSourceTest extends CakeTestCase {
 		$log = $this->testDb->getLog(false, false);
 		$result = Set::extract($log['log'], '/query');
 		$expected = array('Query 1', 'Query 2');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$oldDebug = Configure::read('debug');
 		Configure::write('debug', 2);
@@ -619,15 +619,15 @@ class DboSourceTest extends CakeTestCase {
 		$this->testDb->showLog();
 		$contents = ob_get_clean();
 
-		$this->assertPattern('/Query 1/s', $contents);
-		$this->assertPattern('/Query 2/s', $contents);
+		$this->assertRegExp('/Query 1/s', $contents);
+		$this->assertRegExp('/Query 2/s', $contents);
 
 		ob_start();
 		$this->testDb->showLog(true);
 		$contents = ob_get_clean();
 
-		$this->assertPattern('/Query 1/s', $contents);
-		$this->assertPattern('/Query 2/s', $contents);
+		$this->assertRegExp('/Query 1/s', $contents);
+		$this->assertRegExp('/Query 2/s', $contents);
 
 		Configure::write('debug', $oldDebug);
 	}
@@ -643,9 +643,9 @@ class DboSourceTest extends CakeTestCase {
 
 		$log = $this->testDb->getLog();
 		$expected = array('query' => 'Query 1', 'affected' => '', 'numRows' => '', 'took' => '');
-		$this->assertEqual($log['log'][0], $expected);
+		$this->assertEquals($log['log'][0], $expected);
 		$expected = array('query' => 'Query 2', 'affected' => '', 'numRows' => '', 'took' => '');
-		$this->assertEqual($log['log'][1], $expected);
+		$this->assertEquals($log['log'][1], $expected);
 		$expected = array('query' => 'Error 1', 'affected' => '', 'numRows' => '', 'took' => '');
 	}
 
@@ -680,12 +680,12 @@ class DboSourceTest extends CakeTestCase {
 		$order = array('two', 'this_moment');
 		$result = $this->db->order($order, 'ASC', $Article);
 		$expected = ' ORDER BY (1 + 1) ASC, (NOW()) ASC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$order = array('Article.two', 'Article.this_moment');
 		$result = $this->db->order($order, 'ASC', $Article);
 		$expected = ' ORDER BY (1 + 1) ASC, (NOW()) ASC';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 
@@ -698,16 +698,16 @@ class DboSourceTest extends CakeTestCase {
 	public function testFullTablePermutations() {
 		$Article = ClassRegistry::init('Article');
 		$result = $this->testDb->fullTableName($Article, false);
-		$this->assertEqual($result, 'articles');
+		$this->assertEquals($result, 'articles');
 
 		$Article->tablePrefix = 'tbl_';
 		$result = $this->testDb->fullTableName($Article, false);
-		$this->assertEqual($result, 'tbl_articles');
+		$this->assertEquals($result, 'tbl_articles');
 
 		$Article->useTable = $Article->table = 'with spaces';
 		$Article->tablePrefix = '';
 		$result = $this->testDb->fullTableName($Article);
-		$this->assertEqual($result, '`with spaces`');
+		$this->assertEquals($result, '`with spaces`');
 	}
 
 /**
@@ -754,27 +754,27 @@ class DboSourceTest extends CakeTestCase {
 		$result = $this->testDb->update($Article, array('field1'), array('value1'));
 		$this->assertFalse($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . '\s+SET\s+`field1`\s*=\s*\'value1\'\s+WHERE\s+1 = 1\s*$/', $result);
+		$this->assertRegExp('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . '\s+SET\s+`field1`\s*=\s*\'value1\'\s+WHERE\s+1 = 1\s*$/', $result);
 
 		$result = $this->testDb->update($Article, array('field1'), array('2'), '2=2');
 		$this->assertFalse($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . ' AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+SET\s+`Article`\.`field1`\s*=\s*2\s+WHERE\s+2\s*=\s*2\s*$/', $result);
+		$this->assertRegExp('/^\s*UPDATE\s+' . $this->testDb->fullTableName('articles') . ' AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+SET\s+`Article`\.`field1`\s*=\s*2\s+WHERE\s+2\s*=\s*2\s*$/', $result);
 
 		$result = $this->testDb->delete($Article);
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+WHERE\s+1 = 1\s*$/', $result);
+		$this->assertRegExp('/^\s*DELETE\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+WHERE\s+1 = 1\s*$/', $result);
 
 		$result = $this->testDb->delete($Article, true);
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+1\s*=\s*1\s*$/', $result);
+		$this->assertRegExp('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+1\s*=\s*1\s*$/', $result);
 
 		$result = $this->testDb->delete($Article, '2=2');
 		$this->assertTrue($result);
 		$result = $this->testDb->getLastQuery();
-		$this->assertPattern('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+2\s*=\s*2\s*$/', $result);
+		$this->assertRegExp('/^\s*DELETE\s+`Article`\s+FROM\s+' . $this->testDb->fullTableName('articles') . '\s+AS `Article`\s+LEFT JOIN\s+' . $this->testDb->fullTableName('users') . ' AS `User` ON \(`Article`.`user_id` = `User`.`id`\)\s+WHERE\s+2\s*=\s*2\s*$/', $result);
 
 		$result = $this->testDb->hasAny($Article, '1=2');
 		$this->assertFalse($result);
@@ -787,7 +787,7 @@ class DboSourceTest extends CakeTestCase {
  */
 	function testGroupNoModel() {
 		$result = $this->db->group('created');
-		$this->assertEqual(' GROUP BY created', $result);
+		$this->assertEquals(' GROUP BY created', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -733,11 +733,11 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testFieldsUsingMethodCache() {
 		$this->testDb->cacheMethods = false;
-		$this->assertTrue(empty($this->testDb->methodCache['fields']), 'Cache not empty');
+		DboTestSource::$methodCache = array();
 
 		$Article = ClassRegistry::init('Article');
 		$this->testDb->fields($Article, null, array('title', 'body', 'published'));
-		$this->assertTrue(empty($this->testDb->methodCache['fields']), 'Cache not empty');
+		$this->assertTrue(empty(DboTestSource::$methodCache['fields']), 'Cache not empty');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/DbAclTest.php
+++ b/lib/Cake/Test/Case/Model/DbAclTest.php
@@ -255,27 +255,27 @@ class AclNodeTest extends CakeTestCase {
 		$Aco = new DbAcoTest();
 		$result = Set::extract($Aco->node('Controller1'), '{n}.DbAcoTest.id');
 		$expected = array(2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller1/action1'), '{n}.DbAcoTest.id');
 		$expected = array(3, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller2/action1'), '{n}.DbAcoTest.id');
 		$expected = array(7, 6, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller1/action2'), '{n}.DbAcoTest.id');
 		$expected = array(5, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller1/action1/record1'), '{n}.DbAcoTest.id');
 		$expected = array(4, 3, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller2/action1/record1'), '{n}.DbAcoTest.id');
 		$expected = array(8, 7, 6, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($Aco->node('Controller2/action3'), '{n}.DbAcoTest.id');
 		$this->assertNull($result);
@@ -284,7 +284,7 @@ class AclNodeTest extends CakeTestCase {
 		$this->assertNull($result);
 
 		$result = $Aco->node('');
-		$this->assertEqual($result, null);
+		$this->assertEquals($result, null);
 	}
 
 /**
@@ -295,7 +295,7 @@ class AclNodeTest extends CakeTestCase {
 	public function testNodeWithDuplicatePathSegments() {
 		$Aco = new DbAcoTest();
 		$nodes = $Aco->node('ROOT/Users');
-		$this->assertEqual($nodes[0]['DbAcoTest']['parent_id'], 1, 'Parent id does not point at ROOT. %s');
+		$this->assertEquals($nodes[0]['DbAcoTest']['parent_id'], 1, 'Parent id does not point at ROOT. %s');
 	}
 
 /**
@@ -308,12 +308,12 @@ class AclNodeTest extends CakeTestCase {
 		Configure::write('DbAclbindMode', 'string');
 		$result = Set::extract($Aro->node(array('DbAroUserTest' => array('id' => '1', 'foreign_key' => '1'))), '{n}.DbAroTest.id');
 		$expected = array(3, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('DbAclbindMode', 'array');
 		$result = Set::extract($Aro->node(array('DbAroUserTest' => array('id' => 4, 'foreign_key' => 2))), '{n}.DbAroTest.id');
 		$expected = array(4);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 	/**
  * testNodeObjectFind method
@@ -326,12 +326,12 @@ class AclNodeTest extends CakeTestCase {
 		$Model->id = 1;
 		$result = Set::extract($Aro->node($Model), '{n}.DbAroTest.id');
 		$expected = array(3, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Model->id = 2;
 		$result = Set::extract($Aro->node($Model), '{n}.DbAroTest.id');
 		$expected = array(4, 2, 1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -356,6 +356,6 @@ class AclNodeTest extends CakeTestCase {
 			array('DbAcoTest' => array('id' => '1', 'parent_id' => null, 'model' => null, 'foreign_key' => null, 'alias' => 'Application', 'lft' => '1', 'rght' => '4'), 'DbAroTest' => array()),
 			array('DbAcoTest' => array('id' => '2', 'parent_id' => '1', 'model' => null, 'foreign_key' => null, 'alias' => 'Pages', 'lft' => '2', 'rght' => '3', ), 'DbAroTest' => array())
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -70,7 +70,7 @@ class ModelDeleteTest extends BaseModelTest {
 					'item_id' => 5,
 					'portfolio_id' => 1
 		)));
-		$this->assertEqual($result['Item'], $expected);
+		$this->assertEquals($result['Item'], $expected);
 
 		$result = $Portfolio->ItemsPortfolio->find('all', array(
 			'conditions' => array('ItemsPortfolio.portfolio_id' => 1)
@@ -100,7 +100,7 @@ class ModelDeleteTest extends BaseModelTest {
 					'item_id' => 5,
 					'portfolio_id' => 1
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Portfolio->delete(1);
 
@@ -131,7 +131,7 @@ class ModelDeleteTest extends BaseModelTest {
 			array('ArticlesTag' => array('article_id' => '2', 'tag_id' => '1')),
 			array('ArticlesTag' => array('article_id' => '2', 'tag_id' => '3'))
 			);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->delete(1);
 		$result = $TestModel->ArticlesTag->find('all');
@@ -140,7 +140,7 @@ class ModelDeleteTest extends BaseModelTest {
 			array('ArticlesTag' => array('article_id' => '2', 'tag_id' => '1')),
 			array('ArticlesTag' => array('article_id' => '2', 'tag_id' => '3'))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -169,7 +169,7 @@ class ModelDeleteTest extends BaseModelTest {
 		)));
 
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Book->delete(1);
 
@@ -179,7 +179,7 @@ class ModelDeleteTest extends BaseModelTest {
 		$expected = array();
 
 		$this->assertTrue(is_array($result));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -210,7 +210,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'id' => 3,
 				'title' => 'Third Article'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->delete(3);
 		$this->assertTrue($result);
@@ -228,7 +228,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'title' => 'First Article'
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// make sure deleting a non-existent record doesn't break save()
 		// ticket #6293
@@ -257,7 +257,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'id' => '8208C7FE-E89C-47C5-B378-DED6C271F9B8')),
 			array('Uuid' => array(
 				'id' => 'B607DAB9-88A2-46CF-B57C-842CA9E3B3B3')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 
@@ -272,10 +272,10 @@ class ModelDeleteTest extends BaseModelTest {
 
 		$User->Post->delete(3);
 		$result = $User->read(null, 301);
-		$this->assertEqual($result['User']['post_count'], 0);
+		$this->assertEquals($result['User']['post_count'], 0);
 
 		$result = $User->read(null, 66);
-		$this->assertEqual($result['User']['post_count'], 2);
+		$this->assertEquals($result['User']['post_count'], 2);
 	}
 
 /**
@@ -356,7 +356,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'published' => 'N'
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->deleteAll(array('Article.published' => 'N'));
 		$this->assertTrue($result);
@@ -390,7 +390,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'title' => 'Fifth Article',
 				'published' => 'Y'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Article.user_id' => array(2, 3));
 		$result = $TestModel->deleteAll($data, true, true);
@@ -413,7 +413,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'title' => 'Third Article',
 				'published' => 'Y'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->deleteAll(array('Article.user_id' => 999));
 		$this->assertTrue($result, 'deleteAll returned false when all no records matched conditions. %s');
@@ -458,13 +458,13 @@ class ModelDeleteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $TestModel->find('count');
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$result = $TestModel->Comment->find('count');
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$result = $TestModel->Comment->Attachment->find('count');
-		$this->assertEqual($result, 0);
+		$this->assertEquals($result, 0);
 	}
 
 /**
@@ -477,12 +477,12 @@ class ModelDeleteTest extends BaseModelTest {
 		$TestModel = new Article10();
 
 		$result = $TestModel->find('all');
-		$this->assertEqual(count($result[0]['Comment']), 4);
-		$this->assertEqual(count($result[1]['Comment']), 2);
-		$this->assertEqual($TestModel->Comment->find('count'), 6);
+		$this->assertEquals(count($result[0]['Comment']), 4);
+		$this->assertEquals(count($result[1]['Comment']), 2);
+		$this->assertEquals($TestModel->Comment->find('count'), 6);
 
 		$TestModel->delete(1);
-		$this->assertEqual($TestModel->Comment->find('count'), 2);
+		$this->assertEquals($TestModel->Comment->find('count'), 2);
 	}
 
 /**
@@ -512,7 +512,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'article_id' => '2',
 				'tag_id' => '3'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->delete(1);
 		$result = $TestModel->ArticlesTag->find('all');
@@ -526,7 +526,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'article_id' => '2',
 				'tag_id' => '3'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->deleteAll(array('Article.user_id' => 999));
 		$this->assertTrue($result, 'deleteAll returned false when all no records matched conditions. %s');
@@ -576,12 +576,12 @@ class ModelDeleteTest extends BaseModelTest {
 		$joinedBs = $JoinA->JoinAsJoinB->find('count', array(
 			'conditions' => array('JoinAsJoinB.join_a_id' => 1)
 		));
-		$this->assertEqual($joinedBs, 0, 'JoinA/JoinB link records left over. %s');
+		$this->assertEquals($joinedBs, 0, 'JoinA/JoinB link records left over. %s');
 
 		$joinedBs = $JoinA->JoinAsJoinC->find('count', array(
 			'conditions' => array('JoinAsJoinC.join_a_id' => 1)
 		));
-		$this->assertEqual($joinedBs, 0, 'JoinA/JoinC link records left over. %s');
+		$this->assertEquals($joinedBs, 0, 'JoinA/JoinC link records left over. %s');
 	}
 
 /**
@@ -610,7 +610,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 
 		$ThePaper = new ThePaper();
 		$ThePaper->id = 2;
@@ -630,7 +630,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 
 		$ThePaper->delete(1);
 		$result = $ThePaper->findById(2);
@@ -647,7 +647,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 	}
 
 /**
@@ -691,7 +691,7 @@ class ModelDeleteTest extends BaseModelTest {
 	    $before = $Article->find("all", array(
 			"conditions" => array("Article.id" => 1),
 		));
-		$this->assertEqual(count($before[0]['Tag']), 2, 'Tag count for Article.id = 1 is incorrect, should be 2 %s');
+		$this->assertEquals(count($before[0]['Tag']), 2, 'Tag count for Article.id = 1 is incorrect, should be 2 %s');
 
 		// From now on, Tag #1 is only associated with Post #1
 		$submitted_data = array(
@@ -720,7 +720,7 @@ class ModelDeleteTest extends BaseModelTest {
 		));
 
 		// Removing Article #2 from Tag #1 is all that should have happened.
-		$this->assertEqual(count($before[0]["Tag"]), count($after[0]["Tag"]));
+		$this->assertEquals(count($before[0]["Tag"]), count($after[0]["Tag"]));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -149,7 +149,7 @@ class ModelIntegrationTest extends BaseModelTest {
 	public function testPkInHabtmLinkModelArticleB() {
 		$this->loadFixtures('Article', 'Tag', 'ArticlesTag');
 		$TestModel2 = new ArticleB();
-		$this->assertEqual($TestModel2->ArticlesTag->primaryKey, 'article_id');
+		$this->assertEquals($TestModel2->ArticlesTag->primaryKey, 'article_id');
 	}
 
 /**
@@ -181,21 +181,21 @@ class ModelIntegrationTest extends BaseModelTest {
 		//Test Nonconformant Models
 		$this->loadFixtures('Content', 'ContentAccount', 'Account', 'JoinC', 'JoinAC', 'ItemsPortfolio');
 		$TestModel = new Content();
-		$this->assertEqual($TestModel->ContentAccount->primaryKey, 'iContentAccountsId');
+		$this->assertEquals($TestModel->ContentAccount->primaryKey, 'iContentAccountsId');
 
 		//test conformant models with no PK in the join table
 		$this->loadFixtures('Article', 'Tag');
 		$TestModel2 = new Article();
-		$this->assertEqual($TestModel2->ArticlesTag->primaryKey, 'article_id');
+		$this->assertEquals($TestModel2->ArticlesTag->primaryKey, 'article_id');
 
 		//test conformant models with PK in join table
 		$TestModel3 = new Portfolio();
-		$this->assertEqual($TestModel3->ItemsPortfolio->primaryKey, 'id');
+		$this->assertEquals($TestModel3->ItemsPortfolio->primaryKey, 'id');
 
 		//test conformant models with PK in join table - join table contains extra field
 		$this->loadFixtures('JoinA', 'JoinB', 'JoinAB');
 		$TestModel4 = new JoinA();
-		$this->assertEqual($TestModel4->JoinAsJoinB->primaryKey, 'id');
+		$this->assertEquals($TestModel4->JoinAsJoinB->primaryKey, 'id');
 
 	}
 
@@ -207,11 +207,11 @@ class ModelIntegrationTest extends BaseModelTest {
 	public function testDynamicBehaviorAttachment() {
 		$this->loadFixtures('Apple', 'Sample', 'Author');
 		$TestModel = new Apple();
-		$this->assertEqual($TestModel->Behaviors->attached(), array());
+		$this->assertEquals($TestModel->Behaviors->attached(), array());
 
 		$TestModel->Behaviors->attach('Tree', array('left' => 'left_field', 'right' => 'right_field'));
 		$this->assertTrue(is_object($TestModel->Behaviors->Tree));
-		$this->assertEqual($TestModel->Behaviors->attached(), array('Tree'));
+		$this->assertEquals($TestModel->Behaviors->attached(), array('Tree'));
 
 		$expected = array(
 			'parent' => 'parent_id',
@@ -223,15 +223,15 @@ class ModelIntegrationTest extends BaseModelTest {
 			'recursive' => -1
 		);
 
-		$this->assertEqual($TestModel->Behaviors->Tree->settings['Apple'], $expected);
+		$this->assertEquals($TestModel->Behaviors->Tree->settings['Apple'], $expected);
 
 		$expected['enabled'] = false;
 		$TestModel->Behaviors->attach('Tree', array('enabled' => false));
-		$this->assertEqual($TestModel->Behaviors->Tree->settings['Apple'], $expected);
-		$this->assertEqual($TestModel->Behaviors->attached(), array('Tree'));
+		$this->assertEquals($TestModel->Behaviors->Tree->settings['Apple'], $expected);
+		$this->assertEquals($TestModel->Behaviors->attached(), array('Tree'));
 
 		$TestModel->Behaviors->detach('Tree');
-		$this->assertEqual($TestModel->Behaviors->attached(), array());
+		$this->assertEquals($TestModel->Behaviors->attached(), array());
 		$this->assertFalse(isset($TestModel->Behaviors->Tree));
 	}
 
@@ -271,7 +271,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			array('User' => array('user' => 'mariano'), 'Article' => array('published' => 'Y')),
 			array('User' => array('user' => 'nate'), 'Article' => array('published' => ''))
 		);
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 	}
 
 /**
@@ -429,12 +429,12 @@ class ModelIntegrationTest extends BaseModelTest {
 				'Comment' => array(),
 				'Tag' => array()
 		));
-		$this->assertEqual($TestModel->find('all'), $expected);
+		$this->assertEquals($TestModel->find('all'), $expected);
 
 		$db2 = ConnectionManager::getDataSource('test2');
 		$this->fixtureManager->loadSingle('User', $db2);
 		$this->fixtureManager->loadSingle('Comment', $db2);
-		$this->assertEqual($TestModel->find('count'), 3);
+		$this->assertEquals($TestModel->find('count'), 3);
 
 		$TestModel->User->setDataSource('test2');
 		$TestModel->Comment->setDataSource('test2');
@@ -446,7 +446,7 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$TestModel->recursive = 0;
 		$result = $TestModel->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		foreach ($expected as $key => $value) {
 			unset($value['Comment'], $value['Tag']);
@@ -455,11 +455,11 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$TestModel->recursive = 0;
 		$result = $TestModel->find('all');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($TestModel->User->find('all'), '{n}.User.id');
-		$this->assertEqual($result, array('1', '2', '3', '4'));
-		$this->assertEqual($TestModel->find('all'), $expected);
+		$this->assertEquals($result, array('1', '2', '3', '4'));
+		$this->assertEquals($TestModel->find('all'), $expected);
 
 		$TestModel->Comment->unbindModel(array('hasOne' => array('Attachment')));
 		$expected = array(
@@ -619,7 +619,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'created' => '2007-03-18 10:41:23',
 					'updated' => '2007-03-18 10:43:31'
 		)));
-		$this->assertEqual($TestModel->Comment->find('all'), $expected);
+		$this->assertEquals($TestModel->Comment->find('all'), $expected);
 	}
 
 /**
@@ -633,9 +633,9 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Comment = new Comment();
 		$Person = new Person();
 
-		$this->assertEqual($Post->displayField, 'title');
-		$this->assertEqual($Person->displayField, 'name');
-		$this->assertEqual($Comment->displayField, 'id');
+		$this->assertEquals($Post->displayField, 'title');
+		$this->assertEquals($Person->displayField, 'name');
+		$this->assertEquals($Comment->displayField, 'id');
 	}
 
 /**
@@ -648,16 +648,16 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$result = $Post->schema();
 		$columns = array('id', 'author_id', 'title', 'body', 'published', 'created', 'updated');
-		$this->assertEqual(array_keys($result), $columns);
+		$this->assertEquals(array_keys($result), $columns);
 
 		$types = array('integer', 'integer', 'string', 'text', 'string', 'datetime', 'datetime');
-		$this->assertEqual(Set::extract(array_values($result), '{n}.type'), $types);
+		$this->assertEquals(Set::extract(array_values($result), '{n}.type'), $types);
 
 		$result = $Post->schema('body');
-		$this->assertEqual($result['type'], 'text');
+		$this->assertEquals($result['type'], 'text');
 		$this->assertNull($Post->schema('foo'));
 
-		$this->assertEqual($Post->getColumnTypes(), array_combine($columns, $types));
+		$this->assertEquals($Post->getColumnTypes(), array_combine($columns, $types));
 	}
 
 /**
@@ -679,7 +679,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '';
@@ -689,7 +689,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> ''));
-		$this->assertEqual($TestModel->data, $expected, 'Empty values are not returning properly. %s');
+		$this->assertEquals($TestModel->data, $expected, 'Empty values are not returning properly. %s');
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '12';
@@ -699,7 +699,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> '00:00:00'));
-		$this->assertEqual($TestModel->data, $expected, 'Midnight is not returning proper values. %s');
+		$this->assertEquals($TestModel->data, $expected, 'Midnight is not returning proper values. %s');
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '00';
@@ -708,7 +708,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> '00:00:00'));
-		$this->assertEqual($TestModel->data, $expected, 'Midnight is not returning proper values. %s');
+		$this->assertEquals($TestModel->data, $expected, 'Midnight is not returning proper values. %s');
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '03';
@@ -718,7 +718,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> '03:04:04'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '3';
@@ -728,7 +728,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('mytime'=> '03:04:04'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['mytime']['hour'] = '03';
@@ -738,14 +738,14 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('mytime'=> '03:04:04'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$db = ConnectionManager::getDataSource('test');
 		$data = array();
 		$data['Apple']['mytime'] = $db->expression('NOW()');
 		$TestModel->data = null;
 		$TestModel->set($data);
-		$this->assertEqual($TestModel->data, $data);
+		$this->assertEquals($TestModel->data, $data);
 	}
 
 /**
@@ -770,7 +770,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['date']['year'] = '';
@@ -780,7 +780,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('date'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -793,7 +793,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> '2007-08-20 00:00:00'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -806,7 +806,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> '2007-08-20 10:12:00'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -819,7 +819,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '20';
@@ -828,7 +828,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '20';
@@ -838,7 +838,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '13';
@@ -854,7 +854,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			'created'=> '',
 			'date'=> '2006-12-25'
 		));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -874,7 +874,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'created'=> '2007-08-20 10:12:09',
 				'date'=> '2006-12-25'
 		));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '--';
@@ -890,7 +890,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> '', 'date'=> ''));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -906,7 +906,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('created'=> '', 'date'=> '2006-12-25'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$data = array();
 		$data['Apple']['date']['year'] = '2006';
@@ -916,14 +916,14 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple'=> array('date'=> '2006-12-25'));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 
 		$db = ConnectionManager::getDataSource('test');
 		$data = array();
 		$data['Apple']['modified'] = $db->expression('NOW()');
 		$TestModel->data = null;
 		$TestModel->set($data);
-		$this->assertEqual($TestModel->data, $data);
+		$this->assertEquals($TestModel->data, $data);
 	}
 
 /**
@@ -944,39 +944,39 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$TestModel = new Apple();
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($this->db->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($db2->fullTableName($TestModel, false), 'aaa_apples');
 
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'bbb_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'bbb_apples');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'bbb_apples');
+		$this->assertEquals($this->db->fullTableName($TestModel, false), 'bbb_apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'bbb_apples');
+		$this->assertEquals($db2->fullTableName($TestModel, false), 'bbb_apples');
 
 		$TestModel = new Apple();
 		$TestModel->tablePrefix = 'custom_';
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'custom_apples');
+		$this->assertEquals($this->db->fullTableName($TestModel, false), 'custom_apples');
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'custom_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'custom_apples');
+		$this->assertEquals($this->db->fullTableName($TestModel, false), 'custom_apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'custom_apples');
 
 		$TestModel = new Apple();
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($this->db->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($this->db->fullTableName($TestModel, false), 'aaa_apples');
 		$TestModel->tablePrefix = '';
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'apples');
+		$this->assertEquals($db2->fullTableName($TestModel, false), 'apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'apples');
 
 		$TestModel->tablePrefix = null;
 		$TestModel->setDataSource('database1');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'aaa_apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($db2->fullTableName($TestModel, false), 'aaa_apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'aaa_apples');
 
 		$TestModel->tablePrefix = false;
 		$TestModel->setDataSource('database2');
-		$this->assertEqual($db2->fullTableName($TestModel, false), 'apples');
-		$this->assertEqual($db1->fullTableName($TestModel, false), 'apples');
+		$this->assertEquals($db2->fullTableName($TestModel, false), 'apples');
+		$this->assertEquals($db1->fullTableName($TestModel, false), 'apples');
 	}
 
 /**
@@ -1025,7 +1025,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Article->id = 2;
 		$Article->saveField('title', 'Staying alive');
 		$result = $Article->read(null, 2);
-		$this->assertEqual($result['Article']['title'], 'Staying alive');
+		$this->assertEquals($result['Article']['title'], 'Staying alive');
 	}
 
 /**
@@ -1173,7 +1173,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'TestPluginComment' => array()
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1187,19 +1187,19 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$assocTypes = array('hasMany', 'hasOne', 'belongsTo', 'hasAndBelongsToMany');
 		foreach ($assocTypes as $type) {
-			 $this->assertEqual($Article->getAssociated($type), array_keys($Article->{$type}));
+			 $this->assertEquals($Article->getAssociated($type), array_keys($Article->{$type}));
 		}
 
 		$Article->bindModel(array('hasMany' => array('Category')));
-		$this->assertEqual($Article->getAssociated('hasMany'), array('Comment', 'Category'));
+		$this->assertEquals($Article->getAssociated('hasMany'), array('Comment', 'Category'));
 
 		$results = $Article->getAssociated();
 		$results = array_keys($results);
 		sort($results);
-		$this->assertEqual($results, array('Category', 'Comment', 'Tag', 'User'));
+		$this->assertEquals($results, array('Category', 'Comment', 'Tag', 'User'));
 
 		$Article->unbindModel(array('hasAndBelongsToMany' => array('Tag')));
-		$this->assertEqual($Article->getAssociated('hasAndBelongsToMany'), array());
+		$this->assertEquals($Article->getAssociated('hasAndBelongsToMany'), array());
 
 		$result = $Article->getAssociated('Category');
 		$expected = array(
@@ -1216,7 +1216,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			'counterQuery' => '',
 			'association' => 'hasMany',
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1240,7 +1240,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'conditions' => '', 'fields' => '', 'order' => '', 'limit' => '', 'offset' => '',
 				'finderQuery' => '', 'deleteQuery' => '', 'insertQuery' => ''
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new ArticleFeatured();
 		$TestFakeModel = new ArticleFeatured(array('table' => false));
@@ -1255,13 +1255,13 @@ class ModelIntegrationTest extends BaseModelTest {
 				'conditions' => '', 'fields' => '', 'order' => '', 'counterCache' => ''
 			)
 		);
-		$this->assertIdentical($TestModel->belongsTo, $expected);
-		$this->assertIdentical($TestFakeModel->belongsTo, $expected);
+		$this->assertSame($TestModel->belongsTo, $expected);
+		$this->assertSame($TestFakeModel->belongsTo, $expected);
 
-		$this->assertEqual($TestModel->User->name, 'User');
-		$this->assertEqual($TestFakeModel->User->name, 'User');
-		$this->assertEqual($TestModel->Category->name, 'Category');
-		$this->assertEqual($TestFakeModel->Category->name, 'Category');
+		$this->assertEquals($TestModel->User->name, 'User');
+		$this->assertEquals($TestFakeModel->User->name, 'User');
+		$this->assertEquals($TestModel->Category->name, 'Category');
+		$this->assertEquals($TestFakeModel->Category->name, 'Category');
 
 		$expected = array(
 			'Featured' => array(
@@ -1273,11 +1273,11 @@ class ModelIntegrationTest extends BaseModelTest {
 				'dependent' => ''
 		));
 
-		$this->assertIdentical($TestModel->hasOne, $expected);
-		$this->assertIdentical($TestFakeModel->hasOne, $expected);
+		$this->assertSame($TestModel->hasOne, $expected);
+		$this->assertSame($TestFakeModel->hasOne, $expected);
 
-		$this->assertEqual($TestModel->Featured->name, 'Featured');
-		$this->assertEqual($TestFakeModel->Featured->name, 'Featured');
+		$this->assertEquals($TestModel->Featured->name, 'Featured');
+		$this->assertEquals($TestFakeModel->Featured->name, 'Featured');
 
 		$expected = array(
 			'Comment' => array(
@@ -1294,11 +1294,11 @@ class ModelIntegrationTest extends BaseModelTest {
 				'counterQuery' => ''
 		));
 
-		$this->assertIdentical($TestModel->hasMany, $expected);
-		$this->assertIdentical($TestFakeModel->hasMany, $expected);
+		$this->assertSame($TestModel->hasMany, $expected);
+		$this->assertSame($TestFakeModel->hasMany, $expected);
 
-		$this->assertEqual($TestModel->Comment->name, 'Comment');
-		$this->assertEqual($TestFakeModel->Comment->name, 'Comment');
+		$this->assertEquals($TestModel->Comment->name, 'Comment');
+		$this->assertEquals($TestFakeModel->Comment->name, 'Comment');
 
 		$expected = array(
 			'Tag' => array(
@@ -1319,11 +1319,11 @@ class ModelIntegrationTest extends BaseModelTest {
 				'insertQuery' => ''
 		));
 
-		$this->assertIdentical($TestModel->hasAndBelongsToMany, $expected);
-		$this->assertIdentical($TestFakeModel->hasAndBelongsToMany, $expected);
+		$this->assertSame($TestModel->hasAndBelongsToMany, $expected);
+		$this->assertSame($TestFakeModel->hasAndBelongsToMany, $expected);
 
-		$this->assertEqual($TestModel->Tag->name, 'Tag');
-		$this->assertEqual($TestFakeModel->Tag->name, 'Tag');
+		$this->assertEquals($TestModel->Tag->name, 'Tag');
+		$this->assertEquals($TestFakeModel->Tag->name, 'Tag');
 	}
 
 /**
@@ -1351,13 +1351,13 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->loadFixtures('Post');
 
 		$TestModel = ClassRegistry::init('MergeVarPluginPost');
-		$this->assertEqual($TestModel->actsAs, array('Containable' => null, 'Tree' => null));
+		$this->assertEquals($TestModel->actsAs, array('Containable' => null, 'Tree' => null));
 		$this->assertTrue(isset($TestModel->Behaviors->Containable));
 		$this->assertTrue(isset($TestModel->Behaviors->Tree));
 
 		$TestModel = ClassRegistry::init('MergeVarPluginComment');
 		$expected = array('Containable' => array('some_settings'));
-		$this->assertEqual($TestModel->actsAs, $expected);
+		$this->assertEquals($TestModel->actsAs, $expected);
 		$this->assertTrue(isset($TestModel->Behaviors->Containable));
 	}
 
@@ -1372,11 +1372,11 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel = ClassRegistry::init(array(
 			'class' => 'DoesntMatter', 'ds' => 'test', 'table' => false
 		));
-		$this->assertEqual('test', $TestModel->useDbConfig);
+		$this->assertEquals('test', $TestModel->useDbConfig);
 
 		//deprecated but test it anyway
 		$NewVoid = new TheVoid(null, false, 'other');
-		$this->assertEqual('other', $NewVoid->useDbConfig);
+		$this->assertEquals('other', $NewVoid->useDbConfig);
 	}
 
 /**
@@ -1386,15 +1386,15 @@ class ModelIntegrationTest extends BaseModelTest {
  */
 	public function testColumnTypeFetching() {
 		$model = new Test();
-		$this->assertEqual($model->getColumnType('id'), 'integer');
-		$this->assertEqual($model->getColumnType('notes'), 'text');
-		$this->assertEqual($model->getColumnType('updated'), 'datetime');
-		$this->assertEqual($model->getColumnType('unknown'), null);
+		$this->assertEquals($model->getColumnType('id'), 'integer');
+		$this->assertEquals($model->getColumnType('notes'), 'text');
+		$this->assertEquals($model->getColumnType('updated'), 'datetime');
+		$this->assertEquals($model->getColumnType('unknown'), null);
 
 		$model = new Article();
-		$this->assertEqual($model->getColumnType('User.created'), 'datetime');
-		$this->assertEqual($model->getColumnType('Tag.id'), 'integer');
-		$this->assertEqual($model->getColumnType('Article.id'), 'integer');
+		$this->assertEquals($model->getColumnType('User.created'), 'datetime');
+		$this->assertEquals($model->getColumnType('Tag.id'), 'integer');
+		$this->assertEquals($model->getColumnType('Article.id'), 'integer');
 	}
 
 /**
@@ -1416,17 +1416,17 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel = new Test();
 		$result = $TestModel->alias;
 		$expected = 'Test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new TestAlias();
 		$result = $TestModel->alias;
 		$expected = 'TestAlias';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new Test(array('alias' => 'AnotherTest'));
 		$result = $TestModel->alias;
 		$expected = 'AnotherTest';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1515,7 +1515,7 @@ class ModelIntegrationTest extends BaseModelTest {
 							'created' => '2007-03-18 10:41:23',
 							'updated' => '2007-03-18 10:43:31'
 		)))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all');
 		$expected = array(
@@ -1585,7 +1585,7 @@ class ModelIntegrationTest extends BaseModelTest {
 							'something_id' => '3',
 							'something_else_id' => '1'
 		)))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->findById(1);
 		$expected = array(
@@ -1610,13 +1610,13 @@ class ModelIntegrationTest extends BaseModelTest {
 						'something_id' => '1',
 						'something_else_id' => '2'
 		))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = $TestModel->findById(1);
 		$TestModel->set($expected);
 		$TestModel->save();
 		$result = $TestModel->findById(1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->hasAndBelongsToMany['SomethingElse']['unique'] = false;
 		$TestModel->create(array(
@@ -1682,7 +1682,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			);
 		$this->assertTrue($result['Something']['updated'] >= $ts);
 		unset($result['Something']['updated']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1738,7 +1738,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'father_id' => 0
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = 3;
 		$result = $TestModel->read(null, 1);
@@ -1791,7 +1791,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'Father' => array()
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1898,7 +1898,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'updated' => '2007-03-18 10:57:31'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1911,7 +1911,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel = new Test();
 		$result = $TestModel->create();
 		$expected = array('Test' => array('notes' => 'write some notes here'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$TestModel = new User();
 		$result = $TestModel->schema();
 
@@ -1961,12 +1961,12 @@ class ModelIntegrationTest extends BaseModelTest {
 				'length' => null
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new Article();
 		$result = $TestModel->create();
 		$expected = array('Article' => array('published' => 'N'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$FeaturedModel = new Featured();
 		$data = array(
@@ -1991,7 +1991,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'end_date' => '2008-06-20 00:00:00'
 		));
 
-		$this->assertEqual($FeaturedModel->create($data), $expected);
+		$this->assertEquals($FeaturedModel->create($data), $expected);
 
 		$data = array(
 			'published_date' => array(
@@ -2016,7 +2016,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'category_id' => 1
 		));
 
-		$this->assertEqual($FeaturedModel->create($data), $expected);
+		$this->assertEquals($FeaturedModel->create($data), $expected);
 	}
 
 /**
@@ -2031,15 +2031,15 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$result = $TestModel->escapeField('test_field');
 		$expected = $db->name('Test.test_field');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->escapeField('TestField');
 		$expected = $db->name('Test.TestField');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->escapeField('DomainHandle', 'Domain');
 		$expected = $db->name('Domain.DomainHandle');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		ConnectionManager::create('mock', array('datasource' => 'DboMock'));
 		$TestModel->setDataSource('mock');
@@ -2047,7 +2047,7 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$result = $TestModel->escapeField('DomainHandle', 'Domain');
 		$expected = $db->name('Domain.DomainHandle');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -997,13 +997,13 @@ class ModelIntegrationTest extends BaseModelTest {
 	public function testLoadModelSecondIteration() {
 		$this->loadFixtures('Apple', 'Message', 'Thread', 'Bid');
 		$model = new ModelA();
-		$this->assertIsA($model,'ModelA');
+		$this->assertInstanceOf('ModelA', $model);
 
-		$this->assertIsA($model->ModelB, 'ModelB');
-		$this->assertIsA($model->ModelB->ModelD, 'ModelD');
+		$this->assertInstanceOf('ModelB', $model->ModelB);
+		$this->assertInstanceOf('ModelD', $model->ModelB->ModelD);
 
-		$this->assertIsA($model->ModelC, 'ModelC');
-		$this->assertIsA($model->ModelC->ModelD, 'ModelD');
+		$this->assertInstanceOf('ModelC', $model->ModelC);
+		$this->assertInstanceOf('ModelD', $model->ModelC->ModelD);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7544,6 +7544,50 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * testVirtualFieldsOrder()
+ *
+ * Test correct order on virtual fields
+ *
+ * @return void
+ */
+	public function testVirtualFieldsOrder() {
+		$this->loadFixtures('Post', 'Author');
+		$Post = ClassRegistry::init('Post');
+		$Post->virtualFields = array('other_field' => '10 - Post.id');
+		$result = $Post->find('list', array('order' => array('Post.other_field' => 'ASC')));
+		$expected = array(
+			'3' => 'Third Post',
+			'2' => 'Second Post',
+			'1' => 'First Post'
+		);
+		$this->assertEqual($result, $expected);
+
+		$result = $Post->find('list', array('order' => array('Post.other_field' => 'DESC')));
+		$expected = array(
+			'1' => 'First Post',
+			'2' => 'Second Post',
+			'3' => 'Third Post'
+		);
+		$this->assertEqual($result, $expected);
+
+		$Post->Author->virtualFields = array('joined' => 'Post.id * Author.id');
+		$result = $Post->find('all');
+		$result = Set::extract('{n}.Author.joined', $result);
+		$expected = array(1, 6, 3);
+		$this->assertEqual($result, $expected);
+
+		$result = $Post->find('all', array('order' => array('Author.joined' => 'ASC')));
+		$result = Set::extract('{n}.Author.joined', $result);
+		$expected = array(1, 3, 6);
+		$this->assertEqual($result, $expected);
+
+		$result = $Post->find('all', array('order' => array('Author.joined' => 'DESC')));
+		$result = Set::extract('{n}.Author.joined', $result);
+		$expected = array(6, 3, 1);
+		$this->assertEqual($result, $expected);
+	}
+
+/**
  * testVirtualFieldsMysql()
  *
  * Test correct fetching of virtual fields

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -55,12 +55,12 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = $Something->JoinThing->find('all', array('conditions' => array('something_else_id' => 2)));
 
-		$this->assertEqual($result[0]['JoinThing']['doomed'], true);
-		$this->assertEqual($result[1]['JoinThing']['doomed'], false);
+		$this->assertEquals($result[0]['JoinThing']['doomed'], true);
+		$this->assertEquals($result[1]['JoinThing']['doomed'], false);
 
 		$result = $Something->find('first');
 
-		$this->assertEqual(count($result['SomethingElse']), 2);
+		$this->assertEquals(count($result['SomethingElse']), 2);
 
 		$doomed = Set::extract('/JoinThing/doomed', $result['SomethingElse']);
 		$this->assertTrue(in_array(true, $doomed));
@@ -124,7 +124,7 @@ class ModelReadTest extends BaseModelTest {
 						'thread_id' => 3,
 						'name' => 'Thread 3, Message 1'
 		))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$rows = $Thread->find('all', array(
 			'group' => 'Thread.project_id',
@@ -138,7 +138,7 @@ class ModelReadTest extends BaseModelTest {
 			1 => 2,
 			2 => 1
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$rows = $Thread->find('all', array(
 			'group' => 'Thread.project_id',
@@ -153,7 +153,7 @@ class ModelReadTest extends BaseModelTest {
 			1 => 2,
 			2 => 1
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
@@ -176,37 +176,37 @@ class ModelReadTest extends BaseModelTest {
 						'thread_id' => 1,
 						'name' => 'Thread 1, Message 1'
 		))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
 			'group' => 'Thread.project_id, Project.id'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
 			'group' => 'project_id'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
 			'group' => array('project_id')
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
 			'group' => array('project_id', 'Project.id')
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Thread->find('all', array(
 			'conditions' => array('Thread.project_id' => 1),
 			'group' => array('Thread.project_id', 'Project.id')
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = array(
 			array('Product' => array('type' => 'Clothing'), array('price' => 32)),
@@ -219,13 +219,13 @@ class ModelReadTest extends BaseModelTest {
 			'group'=> 'Product.type',
 			'order' => 'Product.type ASC'
 			));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Product->find('all', array(
 			'fields'=>array('Product.type', 'MIN(Product.price) as price'),
 			'group'=> array('Product.type'),
 			'order' => 'Product.type ASC'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -243,7 +243,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$results = $Article->query($query);
 		$this->assertTrue(is_array($results));
-		$this->assertEqual(count($results), 2);
+		$this->assertEquals(count($results), 2);
 
 		$query  = 'SELECT title, body FROM ';
 		$query .= $this->db->fullTableName('articles');
@@ -291,7 +291,7 @@ class ModelReadTest extends BaseModelTest {
 			unset($expected[0][$this->db->fullTableName('articles', false)]);
 		}
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$result = $this->db->getQueryCache($query, $params);
 		$this->assertFalse(empty($result));
 
@@ -1065,7 +1065,7 @@ class ModelReadTest extends BaseModelTest {
 					'name' => ''
 				),
 				'Child' => array()));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->Parent->unbindModel(array('hasOne' => array('Sample')));
 		$this->assertTrue($result);
@@ -1731,7 +1731,7 @@ class ModelReadTest extends BaseModelTest {
 				'Child' => array()
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->Parent->unbindModel(array('hasOne' => array('Sample')));
 		$this->assertTrue($result);
@@ -2160,7 +2160,7 @@ class ModelReadTest extends BaseModelTest {
 				'name' => ''
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->unbindModel(array('hasMany' => array('Child')));
 		$this->assertTrue($result);
@@ -2579,7 +2579,7 @@ class ModelReadTest extends BaseModelTest {
 					'apple_id' => '',
 					'name' => ''
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->Parent->unbindModel(array('belongsTo' => array('Parent')));
 		$this->assertTrue($result);
@@ -2964,7 +2964,7 @@ class ModelReadTest extends BaseModelTest {
 					'apple_id' => '',
 					'name' => ''
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2991,7 +2991,7 @@ class ModelReadTest extends BaseModelTest {
 		if (PHP_VERSION === '5.1.6') {
 			$this->assertFalse($afterFindModel != $duplicateModel);
 		}
-		$this->assertEqual($afterFindData, $noAfterFindData);
+		$this->assertEquals($afterFindData, $noAfterFindData);
 	}
 
 /**
@@ -3082,7 +3082,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'conditions' => array('Category.name LIKE' => 'Category 1%')
@@ -3135,7 +3135,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'fields' => 'id, parent_id, name'
@@ -3203,7 +3203,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array('order' => 'id DESC'));
 
@@ -3285,7 +3285,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'conditions' => array('Category.name LIKE' => 'Category 3%')
@@ -3313,7 +3313,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'conditions' => array('Category.name LIKE' => 'Category 1.1%')
@@ -3341,7 +3341,7 @@ class ModelReadTest extends BaseModelTest {
 								'created' => '2007-03-18 15:30:23',
 								'updated' => '2007-03-18 15:32:31'),
 								'children' => array()))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'fields' => 'id, parent_id, name',
@@ -3391,7 +3391,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'fields' => 'id, name, parent_id',
@@ -3433,7 +3433,7 @@ class ModelReadTest extends BaseModelTest {
 				'name' => 'Category 1.1.2',
 				'parent_id' => '2'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('threaded', array(
 			'fields' => 'id, parent_id, name',
@@ -3467,7 +3467,7 @@ class ModelReadTest extends BaseModelTest {
 				'children' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3483,9 +3483,9 @@ class ModelReadTest extends BaseModelTest {
 		$result = $TestModel->find('neighbors', array('fields' => array('id')));
 
 		$this->assertNull($result['prev']);
-		$this->assertEqual($result['next']['Article'], array('id' => 2));
-		$this->assertEqual(count($result['next']['Comment']), 2);
-		$this->assertEqual(count($result['next']['Tag']), 2);
+		$this->assertEquals($result['next']['Article'], array('id' => 2));
+		$this->assertEquals(count($result['next']['Comment']), 2);
+		$this->assertEquals(count($result['next']['Tag']), 2);
 
 		$TestModel->id = 2;
 		$TestModel->recursive = 0;
@@ -3502,16 +3502,16 @@ class ModelReadTest extends BaseModelTest {
 				'Article' => array(
 					'id' => 3
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 3;
 		$TestModel->recursive = 1;
 		$result = $TestModel->find('neighbors', array('fields' => array('id')));
 
 		$this->assertNull($result['next']);
-		$this->assertEqual($result['prev']['Article'], array('id' => 2));
-		$this->assertEqual(count($result['prev']['Comment']), 2);
-		$this->assertEqual(count($result['prev']['Tag']), 2);
+		$this->assertEquals($result['prev']['Article'], array('id' => 2));
+		$this->assertEquals(count($result['prev']['Comment']), 2);
+		$this->assertEquals(count($result['prev']['Tag']), 2);
 
 		$TestModel->id = 1;
 		$result = $TestModel->find('neighbors', array('recursive' => -1));
@@ -3529,7 +3529,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 2;
 		$result = $TestModel->find('neighbors', array('recursive' => -1));
@@ -3557,7 +3557,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 3;
 		$result = $TestModel->find('neighbors', array('recursive' => -1));
@@ -3575,7 +3575,7 @@ class ModelReadTest extends BaseModelTest {
 			),
 			'next' => null
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = 0;
 		$TestModel->id = 1;
@@ -3588,17 +3588,17 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel->id = 1;
 		$result = $TestModel->find('neighbors');
 		$expected = array('prev' => null, 'next' => $two);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 2;
 		$result = $TestModel->find('neighbors');
 		$expected = array('prev' => $one, 'next' => $three);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 3;
 		$result = $TestModel->find('neighbors');
 		$expected = array('prev' => $two, 'next' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = 2;
 		$TestModel->id = 1;
@@ -3611,17 +3611,17 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel->id = 1;
 		$result = $TestModel->find('neighbors', array('recursive' => 2));
 		$expected = array('prev' => null, 'next' => $two);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 2;
 		$result = $TestModel->find('neighbors', array('recursive' => 2));
 		$expected = array('prev' => $one, 'next' => $three);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 3;
 		$result = $TestModel->find('neighbors', array('recursive' => 2));
 		$expected = array('prev' => $two, 'next' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3899,7 +3899,7 @@ class ModelReadTest extends BaseModelTest {
 				),
 				'Child' => array()
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3956,7 +3956,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3995,7 +3995,7 @@ class ModelReadTest extends BaseModelTest {
 		$recursive = -1;
 		$order = 'Article.id ASC';
 		$result = $TestModel->find('all', compact('conditions', 'recursive', 'order'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->skipIf($this->db instanceof Postgres, 'The rest of testFindAllWithConditionsHavingMixedDataTypes test is not compatible with Postgres.');
 
@@ -4037,7 +4037,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4061,7 +4061,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = $TestModel->hasMany;
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array('hasMany' => array('Comment')));
 		$this->assertTrue($result);
@@ -4150,11 +4150,11 @@ class ModelReadTest extends BaseModelTest {
 						'updated' => '2007-03-18 10:49:31'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->resetAssociations();
 		$result = $TestModel->hasMany;
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 
 		$result = $TestModel->bindModel(array('hasMany' => array('Comment')), false);
 		$this->assertTrue($result);
@@ -4244,7 +4244,7 @@ class ModelReadTest extends BaseModelTest {
 						'updated' => '2007-03-18 10:49:31'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->hasMany;
 		$expected = array(
@@ -4261,14 +4261,14 @@ class ModelReadTest extends BaseModelTest {
 				'finderQuery' => null,
 				'counterQuery' => null
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->unbindModel(array('hasMany' => array('Comment')));
 		$this->assertTrue($result);
 
 		$result = $TestModel->hasMany;
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'fields' => 'User.id, User.user'
@@ -4278,7 +4278,7 @@ class ModelReadTest extends BaseModelTest {
 			array('User' => array('id' => '2', 'user' => 'nate')),
 			array('User' => array('id' => '3', 'user' => 'larry')),
 			array('User' => array('id' => '4', 'user' => 'garrett')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'fields' => 'User.id, User.user'
@@ -4364,7 +4364,7 @@ class ModelReadTest extends BaseModelTest {
 						'created' => '2007-03-18 10:47:23',
 						'updated' => '2007-03-18 10:49:31'
 		))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->unbindModel(array('hasMany' => array('Comment')), false);
 		$this->assertTrue($result);
@@ -4375,11 +4375,11 @@ class ModelReadTest extends BaseModelTest {
 			array('User' => array('id' => '2', 'user' => 'nate')),
 			array('User' => array('id' => '3', 'user' => 'larry')),
 			array('User' => array('id' => '4', 'user' => 'garrett')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->hasMany;
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array('hasMany' => array(
 			'Comment' => array('className' => 'Comment', 'conditions' => 'Comment.published = \'Y\'')
@@ -4459,7 +4459,7 @@ class ModelReadTest extends BaseModelTest {
 						'updated' => '2007-03-18 10:49:31'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel2 = new DeviceType();
 
@@ -4471,7 +4471,7 @@ class ModelReadTest extends BaseModelTest {
 			'order' => '',
 			'counterCache' => ''
 		);
-		$this->assertEqual($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
 
 		$TestModel2->bindModel(array(
 			'belongsTo' => array(
@@ -4482,7 +4482,7 @@ class ModelReadTest extends BaseModelTest {
 			)
 		));
 		$expected['conditions'] = array('active' => true);
-		$this->assertEqual($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
 
 		$TestModel2->bindModel(array(
 			'belongsTo' => array(
@@ -4495,7 +4495,7 @@ class ModelReadTest extends BaseModelTest {
 		));
 		$expected['conditions'] = array('Feature.name' => 'DeviceType.name');
 		$expected['foreignKey'] = false;
-		$this->assertEqual($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
 
 		$TestModel2->bindModel(array(
 			'hasMany' => array(
@@ -4519,7 +4519,7 @@ class ModelReadTest extends BaseModelTest {
 			'finderQuery' => '',
 			'counterQuery' => ''
 		);
-		$this->assertEqual($TestModel2->hasMany['NewFeatureSet'], $expected);
+		$this->assertEquals($TestModel2->hasMany['NewFeatureSet'], $expected);
 		$this->assertTrue(is_object($TestModel2->NewFeatureSet));
 	}
 
@@ -4534,7 +4534,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = $TestModel->hasMany;
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array(
 			'hasMany' => array(
@@ -4626,7 +4626,7 @@ class ModelReadTest extends BaseModelTest {
 							'created' => '2007-03-18 10:47:23',
 							'updated' => '2007-03-18 10:49:31'
 		))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array(
 			'hasMany' => array(
@@ -4692,7 +4692,7 @@ class ModelReadTest extends BaseModelTest {
 				'Items' => array()
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4722,7 +4722,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = $TestModel->hasMany;
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array(
 			'hasMany' => array('Comment')
@@ -4736,13 +4736,13 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = array_keys($TestModel->hasMany);
 		$expected = array('Comment', 'Article');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->resetAssociations();
 
 		$result = array_keys($TestModel->hasMany);
 		$expected = array('Article');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4792,7 +4792,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = array_keys($TestModel->belongsTo);
 		$expected = array('Article', 'User');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->unbindModel(array(
 			'belongsTo' => array('User')
@@ -4806,13 +4806,13 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = array_keys($TestModel->belongsTo);
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->resetAssociations();
 
 		$result = array_keys($TestModel->belongsTo);
 		$expected = array('User');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4879,7 +4879,7 @@ class ModelReadTest extends BaseModelTest {
 					'updated' => '2007-03-17 01:18:31',
 					'test' => 'working'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		unset($TestModel);
 
 		$Author = new Author();
@@ -4904,7 +4904,7 @@ class ModelReadTest extends BaseModelTest {
 			'updated' => '2007-03-18 10:47:31',
 			'callback' => 'Fire'
 		);
-		$this->assertEqual($result[0]['Post'][0]['Comment'][0], $expected);
+		$this->assertEquals($result[0]['Post'][0]['Comment'][0], $expected);
 	}
 
 /**
@@ -4918,19 +4918,19 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = Set::extract($TestModel->find('all'), '/Author/user');
 		$expected = array('mariano (CakePHP)', 'nate (CakePHP)', 'larry (CakePHP)', 'garrett (CakePHP)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($TestModel->find('all', array('callbacks' => 'after')), '/Author/user');
 		$expected = array('mariano (CakePHP)', 'nate (CakePHP)', 'larry (CakePHP)', 'garrett (CakePHP)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($TestModel->find('all', array('callbacks' => 'before')), '/Author/user');
 		$expected = array('mariano', 'nate', 'larry', 'garrett');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($TestModel->find('all', array('callbacks' => false)), '/Author/user');
 		$expected = array('mariano', 'nate', 'larry', 'garrett');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4994,7 +4994,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:16:23',
 					'updated' => '2007-03-17 01:18:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		unset($TestModel);
 
 		$Author = new Author();
@@ -5019,7 +5019,7 @@ class ModelReadTest extends BaseModelTest {
 			'created' => '2007-03-18 10:45:23',
 			'updated' => '2007-03-18 10:47:31'
 		);
-		$this->assertEqual($result[0]['Post'][0]['Comment'][0], $expected);
+		$this->assertEquals($result[0]['Post'][0]['Comment'][0], $expected);
 	}
 
 /**
@@ -5031,7 +5031,7 @@ class ModelReadTest extends BaseModelTest {
 	public function testCallbackSourceChange() {
 		$this->loadFixtures('Post');
 		$TestModel = new Post();
-		$this->assertEqual(3, count($TestModel->find('all')));
+		$this->assertEquals(3, count($TestModel->find('all')));
 	}
 
 /**
@@ -5141,7 +5141,7 @@ class ModelReadTest extends BaseModelTest {
 					'typ' => 2
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5199,7 +5199,7 @@ class ModelReadTest extends BaseModelTest {
 						'Image' => array()
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5299,7 +5299,7 @@ class ModelReadTest extends BaseModelTest {
 				),
 				'Tag' => array()
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5347,7 +5347,7 @@ class ModelReadTest extends BaseModelTest {
 				'tag' => 'tag2'
 		));
 
-		$this->assertEqual($result['Tag'], $expected);
+		$this->assertEquals($result['Tag'], $expected);
 	}
 
 /**
@@ -5411,13 +5411,13 @@ class ModelReadTest extends BaseModelTest {
 					'updated' => '2007-03-18 12:28:31'
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->hasAndBelongsToMany['Tag']['limit'] = 1;
 		$result = $TestModel->read(null, 2);
 		unset($expected['Tag'][1]);
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5531,7 +5531,7 @@ class ModelReadTest extends BaseModelTest {
 				'Thread' => array()
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5637,7 +5637,7 @@ class ModelReadTest extends BaseModelTest {
 							'updated' => '2007-03-18 10:43:31'
 		)))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5769,7 +5769,7 @@ class ModelReadTest extends BaseModelTest {
 		)))))));
 
 		$this->db->fullDebug = $fullDebug;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5833,7 +5833,7 @@ class ModelReadTest extends BaseModelTest {
 		)))))));
 
 		$this->db->fullDebug = $fullDebug;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6053,7 +6053,7 @@ class ModelReadTest extends BaseModelTest {
 		))))))));
 
 		$this->db->fullDebug = $fullDebug;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6097,7 +6097,7 @@ class ModelReadTest extends BaseModelTest {
 			'callbacks' => true,
 			'returnQuery' => true);
 		$result = $TestModel->buildQuery('all', array('returnQuery' => true, 'conditions' => array('user' => 'larry')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6144,7 +6144,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:22:23',
 					'updated' => '2007-03-17 01:24:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('conditions' => 'User.id > 2'));
 		$expected = array(
@@ -6164,7 +6164,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:22:23',
 					'updated' => '2007-03-17 01:24:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'conditions' => array('User.id !=' => '0', 'User.user LIKE' => '%arr%')
@@ -6186,11 +6186,11 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:22:23',
 					'updated' => '2007-03-17 01:24:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('conditions' => array('User.id' => '0')));
 		$expected = array();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'conditions' => array('or' => array('User.id' => '0', 'User.user LIKE' => '%a%')
@@ -6229,7 +6229,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:22:23',
 					'updated' => '2007-03-17 01:24:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => 'User.id, User.user'));
 		$expected = array(
@@ -6237,7 +6237,7 @@ class ModelReadTest extends BaseModelTest {
 				array('User' => array('id' => '2', 'user' => 'nate')),
 				array('User' => array('id' => '3', 'user' => 'larry')),
 				array('User' => array('id' => '4', 'user' => 'garrett')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => 'User.user', 'order' => 'User.user ASC'));
 		$expected = array(
@@ -6245,7 +6245,7 @@ class ModelReadTest extends BaseModelTest {
 				array('User' => array('user' => 'larry')),
 				array('User' => array('user' => 'mariano')),
 				array('User' => array('user' => 'nate')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('fields' => 'User.user', 'order' => 'User.user DESC'));
 		$expected = array(
@@ -6253,7 +6253,7 @@ class ModelReadTest extends BaseModelTest {
 				array('User' => array('user' => 'mariano')),
 				array('User' => array('user' => 'larry')),
 				array('User' => array('user' => 'garrett')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array('limit' => 3, 'page' => 1));
 
@@ -6282,7 +6282,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:20:23',
 					'updated' => '2007-03-17 01:22:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$ids = array(4 => 1, 5 => 3);
 		$result = $TestModel->find('all', array(
@@ -6306,7 +6306,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-17 01:20:23',
 					'updated' => '2007-03-17 01:22:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// These tests are expected to fail on SQL Server since the LIMIT/OFFSET
 		// hack can't handle small record counts.
@@ -6321,11 +6321,11 @@ class ModelReadTest extends BaseModelTest {
 						'created' => '2007-03-17 01:22:23',
 						'updated' => '2007-03-17 01:24:31'
 			)));
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 
 			$result = $TestModel->find('all', array('limit' => 3, 'page' => 3));
 			$expected = array();
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 		}
 	}
 
@@ -6349,7 +6349,7 @@ class ModelReadTest extends BaseModelTest {
 			2 => 'Second Article',
 			3 => 'Third Article'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$db = ConnectionManager::getDataSource('test');
 		if ($db instanceof Mysql) {
@@ -6361,7 +6361,7 @@ class ModelReadTest extends BaseModelTest {
 				3 => 'Third Article',
 				2 => 'Second Article'
 			);
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 		}
 
 		$result = Set::combine(
@@ -6376,7 +6376,7 @@ class ModelReadTest extends BaseModelTest {
 			2 => 'Second Article',
 			3 => 'Third Article'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::combine(
 			$TestModel->find('all', array(
@@ -6413,7 +6413,7 @@ class ModelReadTest extends BaseModelTest {
 				'updated' => '2007-03-18 10:45:31'
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::combine(
 			$TestModel->find('all', array(
@@ -6452,7 +6452,7 @@ class ModelReadTest extends BaseModelTest {
 					'updated' => '2007-03-18 10:43:31'
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::combine(
 			$TestModel->find('all', array(
@@ -6470,7 +6470,7 @@ class ModelReadTest extends BaseModelTest {
 			3 => array(
 				2 => 'Second Article'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new Apple();
 		$expected = array(
@@ -6483,8 +6483,8 @@ class ModelReadTest extends BaseModelTest {
 			7 => 'Some odd color'
 		);
 
-		$this->assertEqual($TestModel->find('list'), $expected);
-		$this->assertEqual($TestModel->Parent->find('list'), $expected);
+		$this->assertEquals($TestModel->find('list'), $expected);
+		$this->assertEquals($TestModel->Parent->find('list'), $expected);
 
 		$TestModel = new Post();
 		$result = $TestModel->find('list', array(
@@ -6495,7 +6495,7 @@ class ModelReadTest extends BaseModelTest {
 			2 => 'Second Post',
 			3 => 'Third Post'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => 'title'
@@ -6505,7 +6505,7 @@ class ModelReadTest extends BaseModelTest {
 			2 => 'Second Post',
 			3 => 'Third Post'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => array('title', 'id')
@@ -6515,7 +6515,7 @@ class ModelReadTest extends BaseModelTest {
 			'Second Post' => '2',
 			'Third Post' => '3'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => array('title', 'id', 'created')
@@ -6531,7 +6531,7 @@ class ModelReadTest extends BaseModelTest {
 				'Third Post' => '3'
 			),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => array('Post.body')
@@ -6541,7 +6541,7 @@ class ModelReadTest extends BaseModelTest {
 			2 => 'Second Post Body',
 			3 => 'Third Post Body'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => array('Post.title', 'Post.body')
@@ -6551,7 +6551,7 @@ class ModelReadTest extends BaseModelTest {
 			'Second Post' => 'Second Post Body',
 			'Third Post' => 'Third Post Body'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('list', array(
 			'fields' => array('Post.id', 'Post.title', 'Author.user'),
@@ -6565,7 +6565,7 @@ class ModelReadTest extends BaseModelTest {
 			'larry' => array(
 				2 => 'Second Post'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new User();
 		$result = $TestModel->find('list', array(
@@ -6577,7 +6577,7 @@ class ModelReadTest extends BaseModelTest {
 			'larry' => '5f4dcc3b5aa765d61d8327deb882cf99',
 			'garrett' => '5f4dcc3b5aa765d61d8327deb882cf99'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new ModifiedAuthor();
 		$result = $TestModel->find('list', array(
@@ -6589,7 +6589,7 @@ class ModelReadTest extends BaseModelTest {
 			3 => 'larry (CakePHP)',
 			4 => 'garrett (CakePHP)'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new Article();
 		$TestModel->displayField = 'title';
@@ -6601,7 +6601,7 @@ class ModelReadTest extends BaseModelTest {
 			1 => 'First Article',
 			3 => 'Third Article'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6615,22 +6615,22 @@ class ModelReadTest extends BaseModelTest {
 
 		$TestModel->id = 1;
 		$result = $TestModel->field('user');
-		$this->assertEqual($result, 'mariano');
+		$this->assertEquals($result, 'mariano');
 
 		$result = $TestModel->field('User.user');
-		$this->assertEqual($result, 'mariano');
+		$this->assertEquals($result, 'mariano');
 
 		$TestModel->id = false;
 		$result = $TestModel->field('user', array(
 			'user' => 'mariano'
 		));
-		$this->assertEqual($result, 'mariano');
+		$this->assertEquals($result, 'mariano');
 
 		$result = $TestModel->field('COUNT(*) AS count', true);
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$result = $TestModel->field('COUNT(*)', true);
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 	}
 
 /**
@@ -6666,18 +6666,18 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel = new User();
 		$this->db->getLog(false, true);
 		$result = $TestModel->find('count');
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$this->db->getLog(false, true);
 		$fullDebug = $this->db->fullDebug;
 		$this->db->fullDebug = true;
 		$TestModel->order = 'User.id';
 		$result = $TestModel->find('count');
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$log = $this->db->getLog();
 		$this->assertTrue(isset($log['log'][0]['query']));
-		$this->assertNoPattern('/ORDER\s+BY/', $log['log'][0]['query']);
+		$this->assertNotRegExp('/ORDER\s+BY/', $log['log'][0]['query']);
 
 		$Article = new Article();
 		$Article->recursive = -1;
@@ -6701,7 +6701,7 @@ class ModelReadTest extends BaseModelTest {
 		$Project->id = 3;
 		$result = $Project->find('first');
 
-		$this->assertEqual($result['Project']['name'], 'Project 1', 'Wrong record retrieved');
+		$this->assertEquals($result['Project']['name'], 'Project 1', 'Wrong record retrieved');
 	}
 
 /**
@@ -6720,7 +6720,7 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel->create(array('name' => 'project')) && $TestModel->save();
 
 		$result = $TestModel->find('count', array('fields' => 'DISTINCT name'));
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 	}
 
 /**
@@ -6738,12 +6738,12 @@ class ModelReadTest extends BaseModelTest {
 		$result = $TestModel->find('count', array('conditions' => array(
 			$db->expression('Project.name = \'Project 3\'')
 		)));
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 
 		$result = $TestModel->find('count', array('conditions' => array(
 			'Project.name' => $db->expression('\'Project 3\'')
 		)));
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 	}
 
 /**
@@ -6764,7 +6764,7 @@ class ModelReadTest extends BaseModelTest {
 				'created' => '2007-03-17 01:16:23',
 				'updated' => '2007-03-17 01:18:31'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->findByPassword('5f4dcc3b5aa765d61d8327deb882cf99');
 		$expected = array('User' => array(
@@ -6774,7 +6774,7 @@ class ModelReadTest extends BaseModelTest {
 			'created' => '2007-03-17 01:16:23',
 			'updated' => '2007-03-17 01:18:31'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6799,7 +6799,7 @@ class ModelReadTest extends BaseModelTest {
 				'created' => '2007-03-17 01:18:23',
 				'updated' => '2007-03-17 01:20:31'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->read(null, 2);
 		$expected = array(
@@ -6810,12 +6810,12 @@ class ModelReadTest extends BaseModelTest {
 				'created' => '2007-03-17 01:18:23',
 				'updated' => '2007-03-17 01:20:31'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 2;
 		$result = $TestModel->read(array('id', 'user'));
 		$expected = array('User' => array('id' => '2', 'user' => 'nate'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->read('id, user', 2);
 		$expected = array(
@@ -6823,7 +6823,7 @@ class ModelReadTest extends BaseModelTest {
 				'id' => '2',
 				'user' => 'nate'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->bindModel(array('hasMany' => array('Article')));
 		$this->assertTrue($result);
@@ -6854,7 +6854,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-18 10:43:23',
 					'updated' => '2007-03-18 10:45:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -6882,7 +6882,7 @@ class ModelReadTest extends BaseModelTest {
 		$expected = array(
 			'User' => array('id' => '1', 'user' => 'mariano'),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = 1;
 		$result = $TestModel->read('id, user', 1);
@@ -6910,7 +6910,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-18 10:43:23',
 					'updated' => '2007-03-18 10:45:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = 2;
 		$result = $TestModel->read('id, user', 3);
@@ -6967,7 +6967,7 @@ class ModelReadTest extends BaseModelTest {
 							'created' => '2007-03-18 12:26:23',
 							'updated' => '2007-03-18 12:28:31'
 		)))));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testRecursiveFindAll() {
@@ -7076,7 +7076,7 @@ class ModelReadTest extends BaseModelTest {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->find('all', array(
 			'conditions' => array('Article.user_id' => 3),
@@ -7176,7 +7176,7 @@ class ModelReadTest extends BaseModelTest {
 						'updated' => '2007-03-18 12:28:31'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Featured = new Featured();
 
@@ -7279,7 +7279,7 @@ class ModelReadTest extends BaseModelTest {
 					'created' => '2007-03-18 15:30:23',
 					'updated' => '2007-03-18 15:32:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -7368,7 +7368,7 @@ class ModelReadTest extends BaseModelTest {
 				'Tag' => array()
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->hasMany['Comment']['limit'] = 1;
 
@@ -7445,7 +7445,7 @@ class ModelReadTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * Testing availability of $this->findQueryType in Model callbacks
@@ -7456,9 +7456,9 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('Comment');
 		$Comment = new AgainModifiedComment();
 		$comments = $Comment->find('all');
-		$this->assertEqual($comments[0]['Comment']['querytype'], 'all');
+		$this->assertEquals($comments[0]['Comment']['querytype'], 'all');
 		$comments = $Comment->find('first');
-		$this->assertEqual($comments['Comment']['querytype'], 'first');
+		$this->assertEquals($comments['Comment']['querytype'], 'first');
 	}
 
 /**
@@ -7474,13 +7474,13 @@ class ModelReadTest extends BaseModelTest {
 		$Post = ClassRegistry::init('Post');
 		$Post->virtualFields = array('two' => "1 + 1");
 		$result = $Post->find('first');
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 
 		// SQL Server does not support operators in expressions
 		if (!($this->db instanceof Sqlserver)) {
 			$Post->Author->virtualFields = array('false' => '1 = 2');
 			$result = $Post->find('first');
-			$this->assertEqual($result['Post']['two'], 2);
+			$this->assertEquals($result['Post']['two'], 2);
 			$this->assertFalse((bool)$result['Author']['false']);
 		}
 
@@ -7489,33 +7489,33 @@ class ModelReadTest extends BaseModelTest {
 		$this->assertFalse(isset($result['Author']['false']));
 
 		$result = $Post->find('first',array('fields' => array('author_id', 'two')));
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 		$this->assertFalse(isset($result['Author']['false']));
 
 		$result = $Post->find('first',array('fields' => array('two')));
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 
 		$Post->id = 1;
 		$result = $Post->field('two');
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('two' => 2),
 			'limit' => 1
 		));
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('two <' => 3),
 			'limit' => 1
 		));
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('NOT' => array('two >' => 3)),
 			'limit' => 1
 		));
-		$this->assertEqual($result['Post']['two'], 2);
+		$this->assertEquals($result['Post']['two'], 2);
 
 		$dbo = $Post->getDataSource();
 		$Post->virtualFields = array('other_field' => 'Post.id + 1');
@@ -7523,24 +7523,24 @@ class ModelReadTest extends BaseModelTest {
 			'conditions' => array('other_field' => 3),
 			'limit' => 1
 		));
-		$this->assertEqual($result['Post']['id'], 2);
+		$this->assertEquals($result['Post']['id'], 2);
 
 		$Post->virtualFields = array('other_field' => 'Post.id + 1');
 		$result = $Post->find('all', array(
 			'fields' => array($dbo->calculate($Post, 'max', array('other_field')))
 		));
-		$this->assertEqual($result[0][0]['other_field'], 4);
+		$this->assertEquals($result[0][0]['other_field'], 4);
 
 		ClassRegistry::flush();
 		$Writing = ClassRegistry::init(array('class' => 'Post', 'alias' => 'Writing'), 'Model');
 		$Writing->virtualFields = array('two' => "1 + 1");
 		$result = $Writing->find('first');
-		$this->assertEqual($result['Writing']['two'], 2);
+		$this->assertEquals($result['Writing']['two'], 2);
 
 		$Post->create();
 		$Post->virtualFields = array('other_field' => 'COUNT(Post.id) + 1');
 		$result = $Post->field('other_field');
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 	}
 
 /**
@@ -7618,7 +7618,7 @@ class ModelReadTest extends BaseModelTest {
 			'group' => array('low_title')
 		));
 
-		$this->assertEqual($result, $expectation);
+		$this->assertEquals($result, $expectation);
 
 
 		$Author = ClassRegistry::init('Author');
@@ -7684,7 +7684,7 @@ class ModelReadTest extends BaseModelTest {
 		$Post = ClassRegistry::init('Post');
 		$Post->virtualFields = array('other_field' => 'COUNT(Post.id) + 1');
 
-		$this->assertEqual($Post->getVirtualField('other_field'), $Post->virtualFields['other_field']);
-		$this->assertEqual($Post->getVirtualField('Post.other_field'), $Post->virtualFields['other_field']);
+		$this->assertEquals($Post->getVirtualField('other_field'), $Post->virtualFields['other_field']);
+		$this->assertEquals($Post->getVirtualField('Post.other_field'), $Post->virtualFields['other_field']);
 	}
 }

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -53,7 +53,7 @@ class ModelValidationTest extends BaseModelTest {
 			'or' => true,
 			'ignore_on_same' => 'id'
 		);
-		$this->assertEqual($TestModel->validatorParams, $expected);
+		$this->assertEquals($TestModel->validatorParams, $expected);
 
 		$TestModel->validate['title'] = array(
 			'rule' => 'customValidatorWithMessage',
@@ -63,7 +63,7 @@ class ModelValidationTest extends BaseModelTest {
 			'title' => array('This field will *never* validate! Muhahaha!')
 		);
 
-		$this->assertEqual($TestModel->invalidFields(), $expected);
+		$this->assertEquals($TestModel->invalidFields(), $expected);
 
 		$TestModel->validate['title'] = array(
 			'rule' => array('customValidatorWithSixParams', 'one', 'two', null, 'four'),
@@ -88,7 +88,7 @@ class ModelValidationTest extends BaseModelTest {
 			),
 			'six' => 6
 		);
-		$this->assertEqual($TestModel->validatorParams, $expected);
+		$this->assertEquals($TestModel->validatorParams, $expected);
 
 		$TestModel->validate['title'] = array(
 			'rule' => array('customValidatorWithSixParams', 'one', array('two'), null, 'four', array('five' => 5)),
@@ -113,7 +113,7 @@ class ModelValidationTest extends BaseModelTest {
 				'required' => true
 			)
 		);
-		$this->assertEqual($TestModel->validatorParams, $expected);
+		$this->assertEquals($TestModel->validatorParams, $expected);
 	}
 
 /**
@@ -137,14 +137,14 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'title' => array('This field cannot be left blank')
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name')));
 		$expected = array(
 			'name' => array('This field cannot be left blank')
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name', 'title')));
@@ -152,15 +152,15 @@ class ModelValidationTest extends BaseModelTest {
 			'name' => array('This field cannot be left blank'),
 			'title' => array('This field cannot be left blank')
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 		$TestModel->validationErrors = array();
 
 		$TestModel->whitelist = array('name');
 		$TestModel->invalidFields();
 		$expected = array('name' => array('This field cannot be left blank'));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 
-		$this->assertEqual($TestModel->validate, $validate);
+		$this->assertEquals($TestModel->validate, $validate);
 	}
 
 /**
@@ -184,7 +184,7 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel->save(array('name' => '#$$#', 'title' => '$$$$'));
 
 		$expected = array('name' => array('This field cannot be left blank'));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 	}
 
 /**
@@ -515,7 +515,7 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'title' => array('tooShort')
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array(
 			'title' => array(
@@ -536,7 +536,7 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'title' => array('tooShort', 'onlyLetters')
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -569,9 +569,9 @@ class ModelValidationTest extends BaseModelTest {
 		$Something->create();
 		$result = $Something->save($data);
 		$this->assertFalse($result, 'Save occured even when with models failed. %s');
-		$this->assertEqual($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($JoinThing->validationErrors, $expectedError);
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
-		$this->assertIdentical($count, 0);
+		$this->assertSame($count, 0);
 
 		$data = array(
 			'Something' => array(
@@ -592,7 +592,7 @@ class ModelValidationTest extends BaseModelTest {
 		$joinRecords = $JoinThing->find('count', array(
 			'conditions' => array('JoinThing.something_id' => $data['Something']['id'])
 		));
-		$this->assertEqual($joinRecords, 0, 'Records were saved on the join table. %s');
+		$this->assertEquals($joinRecords, 0, 'Records were saved on the join table. %s');
 	}
 
 /**
@@ -621,20 +621,20 @@ class ModelValidationTest extends BaseModelTest {
 		$Something->create();
 		$result = $Something->saveAll($data, array('validate' => 'only'));
 		$this->assertFalse($result);
-		$this->assertEqual($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($JoinThing->validationErrors, $expectedError);
 
 		$Something->create();
 		$result = $Something->saveAll($data, array('validate' => 'first'));
 		$this->assertFalse($result);
-		$this->assertEqual($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($JoinThing->validationErrors, $expectedError);
 
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
-		$this->assertIdentical($count, 0);
+		$this->assertSame($count, 0);
 
 		$joinRecords = $JoinThing->find('count', array(
 			'conditions' => array('JoinThing.something_id' => $data['Something']['id'])
 		));
-		$this->assertEqual($joinRecords, 0, 'Records were saved on the join table. %s');
+		$this->assertEquals($joinRecords, 0, 'Records were saved on the join table. %s');
 	}
 
 /**
@@ -671,12 +671,12 @@ class ModelValidationTest extends BaseModelTest {
 
 		$id = $Author->id;
 		$count = $Author->find('count', array('conditions' => array('Author.id' => $id)));
-		$this->assertIdentical($count, 1);
+		$this->assertSame($count, 1);
 
 		$count = $Post->find('count', array(
 			'conditions' => array('Post.author_id' => $id)
 		));
-		$this->assertEqual($count, count($data['Post']));
+		$this->assertEquals($count, count($data['Post']));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -4779,6 +4779,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Post', 'Author', 'Comment', 'Attachment');
 		$TestModel = new Post();
 
+		$ts = date('Y-m-d H:i:s');
 		$data = array(
 			array(
 				'id' => '1',
@@ -4799,7 +4800,6 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($TestModel->saveMany($data));
 
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
-		$ts = date('Y-m-d H:i:s');
 		$expected = array(
 			array(
 				'Post' => array(

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -1558,6 +1558,145 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * testSaveHabtmNoPrimaryData method
+ *
+ * @return void
+ */
+	public function testSaveHabtmNoPrimaryData() {
+		$this->loadFixtures('Article', 'User', 'Comment', 'Tag', 'ArticlesTag');
+		$TestModel = new Article();
+
+		$TestModel->unbindModel(array('belongsTo' => array('User'), 'hasMany' => array('Comment')), false);
+		$result = $TestModel->findById(2);
+		$expected = array(
+			'Article' => array(
+				'id' => '2',
+				'user_id' => '3',
+				'title' => 'Second Article',
+				'body' => 'Second Article Body',
+				'published' => 'Y',
+				'created' => '2007-03-18 10:41:23',
+				'updated' => '2007-03-18 10:43:31'
+			),
+			'Tag' => array(
+				array(
+					'id' => '1',
+					'tag' => 'tag1',
+					'created' => '2007-03-18 12:22:23',
+					'updated' => '2007-03-18 12:24:31'
+				),
+				array(
+					'id' => '3',
+					'tag' => 'tag3',
+					'created' => '2007-03-18 12:26:23',
+					'updated' => '2007-03-18 12:28:31'
+				)
+			)
+		);
+		$this->assertEqual($expected, $result);
+
+		$ts = date('Y-m-d H:i:s');
+		$TestModel->id = 2;
+		$data = array('Tag' => array('Tag' => array(2)));
+		$TestModel->save($data);
+
+		$result = $TestModel->findById(2);
+		$expected = array(
+			'Article' => array(
+				'id' => '2',
+				'user_id' => '3',
+				'title' => 'Second Article',
+				'body' => 'Second Article Body',
+				'published' => 'Y',
+				'created' => '2007-03-18 10:41:23',
+				'updated' => $ts
+			),
+			'Tag' => array(
+				array(
+					'id' => '2',
+					'tag' => 'tag2',
+					'created' => '2007-03-18 12:24:23',
+					'updated' => '2007-03-18 12:26:31'
+				)
+			)
+		);
+		$this->assertEqual($expected, $result);
+
+		$this->loadFixtures('Portfolio', 'Item', 'ItemsPortfolio');
+		$TestModel = new Portfolio();
+		$result = $TestModel->findById(2);
+		$expected = array(
+			'Portfolio' => array(
+				'id' => 2,
+				'seller_id' => 1,
+				'name' => 'Portfolio 2'
+			),
+			'Item' => array(
+				array(
+					'id' => 2,
+					'syfile_id' => 2,
+					'published' => '',
+					'name' => 'Item 2',
+					'ItemsPortfolio' => array(
+						'id' => 2,
+						'item_id' => 2,
+						'portfolio_id' => 2
+					)
+				),
+				array(
+					'id' => 6,
+					'syfile_id' => 6,
+					'published' => '',
+					'name' => 'Item 6',
+					'ItemsPortfolio' => array(
+						'id' => 6,
+						'item_id' => 6,
+						'portfolio_id' => 2
+					)
+				)
+			)
+		);
+		$this->assertEqual($expected, $result);
+
+		$data = array('Item' => array('Item' => array(1, 2)));
+		$TestModel->id = 2;
+		$TestModel->save($data);
+		$result = $TestModel->findById(2);
+		$expected = array(
+			'Portfolio' => array(
+				'id' => 2,
+				'seller_id' => 1,
+				'name' => 'Portfolio 2'
+			),
+			'Item' => array(
+				array(
+					'id' => 2,
+					'syfile_id' => 2,
+					'published' => '',
+					'name' => 'Item 2',
+					'ItemsPortfolio' => array(
+						'id' => 8,
+						'item_id' => 2,
+						'portfolio_id' => 2
+					)
+				),
+				array(
+					'id' => 1,
+					'syfile_id' => 1,
+					'published' => '',
+					'name' => 'Item 1',
+					'ItemsPortfolio' => array(
+						'id' => 7,
+						'item_id' => 1,
+						'portfolio_id' => 2
+					)
+				)
+			)
+		);
+		$this->assertEqual($expected, $result);
+	}
+
+/**
  * testSaveHabtmCustomKeys method
  *
  * @return void

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -1662,6 +1662,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->id = 2;
 		$TestModel->save($data);
 		$result = $TestModel->findById(2);
+		$result['Item'] = Set::sort($result['Item'], '{n}.id', 'asc');
 		$expected = array(
 			'Portfolio' => array(
 				'id' => 2,
@@ -1670,17 +1671,6 @@ class ModelWriteTest extends BaseModelTest {
 			),
 			'Item' => array(
 				array(
-					'id' => 2,
-					'syfile_id' => 2,
-					'published' => '',
-					'name' => 'Item 2',
-					'ItemsPortfolio' => array(
-						'id' => 8,
-						'item_id' => 2,
-						'portfolio_id' => 2
-					)
-				),
-				array(
 					'id' => 1,
 					'syfile_id' => 1,
 					'published' => '',
@@ -1688,6 +1678,17 @@ class ModelWriteTest extends BaseModelTest {
 					'ItemsPortfolio' => array(
 						'id' => 7,
 						'item_id' => 1,
+						'portfolio_id' => 2
+					)
+				),
+				array(
+					'id' => 2,
+					'syfile_id' => 2,
+					'published' => '',
+					'name' => 'Item 2',
+					'ItemsPortfolio' => array(
+						'id' => 8,
+						'item_id' => 2,
 						'portfolio_id' => 2
 					)
 				)

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -44,7 +44,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2008-01-03 10:56:33',
 					'updated' => '2008-01-03 10:56:33'
 			));
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 
 			$TestModel->JoinAsJoinB->create();
 			$data = array(
@@ -70,7 +70,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2008-01-03 10:56:33',
 					'updated' => '2008-01-03 10:56:33'
 			));
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 
 			$updatedValue = 'UPDATED Data for Join A 1 Join B 2';
 			$TestModel->JoinAsJoinB->id = 1;
@@ -78,7 +78,7 @@ class ModelWriteTest extends BaseModelTest {
 			$this->assertFalse(empty($result));
 
 			$result = $TestModel->JoinAsJoinB->findById(1);
-			$this->assertEqual($result['JoinAsJoinB']['other'], $updatedValue);
+			$this->assertEquals($result['JoinAsJoinB']['other'], $updatedValue);
 		}
 
 /**
@@ -107,8 +107,8 @@ class ModelWriteTest extends BaseModelTest {
 
 		$testResult = $Article->find('first', array('conditions' => array('Article.title' => 'Test Title')));
 
-		$this->assertEqual($testResult['Article']['title'], $data['Article']['title']);
-		$this->assertEqual($testResult['Article']['created'], '2008-01-01 00:00:00');
+		$this->assertEquals($testResult['Article']['title'], $data['Article']['title']);
+		$this->assertEquals($testResult['Article']['created'], '2008-01-01 00:00:00');
 
 	}
 
@@ -122,7 +122,7 @@ class ModelWriteTest extends BaseModelTest {
 		$UnderscoreField = new UnderscoreField();
 
 		$currentCount = $UnderscoreField->find('count');
-		$this->assertEqual($currentCount, 3);
+		$this->assertEquals($currentCount, 3);
 		$data = array('UnderscoreField' => array(
 			'user_id' => '1',
 			'my_model_has_a_field' => 'Content here',
@@ -134,7 +134,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($ret));
 
 		$currentCount = $UnderscoreField->find('count');
-		$this->assertEqual($currentCount, 4);
+		$this->assertEquals($currentCount, 4);
 	}
 
 /**
@@ -151,11 +151,11 @@ class ModelWriteTest extends BaseModelTest {
 
 		$TestModel->save(array('title' => 'Test record'));
 		$result = $TestModel->findByTitle('Test record');
-		$this->assertEqual(
+		$this->assertEquals(
 			array_keys($result['Uuid']),
 			array('id', 'title', 'count', 'created', 'updated')
 		);
-		$this->assertEqual(strlen($result['Uuid']['id']), 36);
+		$this->assertEquals(strlen($result['Uuid']['id']), 36);
 	}
 
 /**
@@ -173,11 +173,11 @@ class ModelWriteTest extends BaseModelTest {
 
 		$TestModel->save(array('title' => 'Test record', 'id' => null));
 		$result = $TestModel->findByTitle('Test record');
-		$this->assertEqual(
+		$this->assertEquals(
 			array_keys($result['Uuid']),
 			array('id', 'title', 'count', 'created', 'updated')
 		);
-		$this->assertEqual(strlen($result['Uuid']['id']), 36);
+		$this->assertEquals(strlen($result['Uuid']['id']), 36);
 	}
 
 /**
@@ -215,7 +215,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'foo',
 				'bar' => 'baz'
 		));
-		$this->assertEqual($TestModel->data, $expected);
+		$this->assertEquals($TestModel->data, $expected);
 	}
 
 /**
@@ -268,7 +268,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel2 = new Item();
 
 		$result = $TestModel->findById(1);
-		$this->assertIdentical($result['Syfile']['item_count'], null);
+		$this->assertSame($result['Syfile']['item_count'], null);
 
 		$TestModel2->save(array(
 			'name' => 'Item 7',
@@ -316,7 +316,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $user[$User->alias]['post_count'];
 		$expected = 3;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -337,7 +337,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $user[$User->alias]['post_count'];
 		$expected = 1;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -358,8 +358,8 @@ class ModelWriteTest extends BaseModelTest {
 		$Post->save($data);
 
 		$users = $User->find('all',array('order' => 'User.id'));
-		$this->assertEqual($users[0]['User']['post_count'], 1);
-		$this->assertEqual($users[1]['User']['post_count'], 2);
+		$this->assertEquals($users[0]['User']['post_count'], 1);
+		$this->assertEquals($users[1]['User']['post_count'], 2);
 	}
 
 /**
@@ -385,8 +385,8 @@ class ModelWriteTest extends BaseModelTest {
 		$Post->save($data);
 
 		$users = $User->find('all',array('order' => 'User.uid'));
-		$this->assertEqual($users[0]['User']['post_count'], 1);
-		$this->assertEqual($users[1]['User']['post_count'], 2);
+		$this->assertEquals($users[0]['User']['post_count'], 1);
+		$this->assertEquals($users[1]['User']['post_count'], 2);
 	}
 
 /**
@@ -414,7 +414,7 @@ class ModelWriteTest extends BaseModelTest {
 		$Category->updateCounterCache(array('parent_id' => 5));
 		$result = Set::extract($Category->find('all', array('conditions' => array('CategoryThread.id' => 5))), '{n}.CategoryThread.child_count');
 		$expected = array(1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -430,7 +430,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel2->belongsTo['Syfile']['counterScope'] = array('published' => true);
 
 		$result = $TestModel->findById(1);
-		$this->assertIdentical($result['Syfile']['item_count'], null);
+		$this->assertSame($result['Syfile']['item_count'], null);
 
 		$TestModel2->save(array(
 			'name' => 'Item 7',
@@ -579,7 +579,7 @@ class ModelWriteTest extends BaseModelTest {
 			'title' => 'New First Article',
 			'body' => 'First Article Body'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 1;
 		$result = $TestModel->saveField('title', '');
@@ -594,7 +594,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'First Article Body'
 		));
 		$result['Article']['title'] = trim($result['Article']['title']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->id = 1;
 		$TestModel->set('body', 'Messed up data');
@@ -607,7 +607,7 @@ class ModelWriteTest extends BaseModelTest {
 			'title' => 'First Article',
 			'body' => 'First Article Body'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body'), 1);
@@ -620,11 +620,11 @@ class ModelWriteTest extends BaseModelTest {
 		$Node = new Node();
 		$Node->set('id', 1);
 		$result = $Node->read();
-		$this->assertEqual(Set::extract('/ParentNode/name', $result), array('Second'));
+		$this->assertEquals(Set::extract('/ParentNode/name', $result), array('Second'));
 
 		$Node->saveField('state', 10);
 		$result = $Node->read();
-		$this->assertEqual(Set::extract('/ParentNode/name', $result), array('Second'));
+		$this->assertEquals(Set::extract('/ParentNode/name', $result), array('Second'));
 	}
 
 /**
@@ -688,7 +688,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'First Article Body',
 			'published' => 'N'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Article' => array(
 			'id' => 1,
@@ -709,7 +709,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'First Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Article' => array(
@@ -758,7 +758,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Comment' => array(
 			'article_id' => '4',
@@ -845,7 +845,7 @@ class ModelWriteTest extends BaseModelTest {
 					'updated' => '2007-03-18 12:28:31'
 		)));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -872,7 +872,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $User->save();
 		$this->assertFalse(empty($result));
 		$result = $User->read();
-		$this->assertEqual($User->data['User']['password'], 'something');
+		$this->assertEquals($User->data['User']['password'], 'something');
 	}
 
 /**
@@ -906,7 +906,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fourth Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// Create new record just to overlap Model->id on previously created record
 
@@ -928,7 +928,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fifth Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// Go back and edit the first article we created, starting by checking it's still there
 
@@ -941,7 +941,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fourth Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		// And now do the update with set()
 
@@ -962,7 +962,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fourth Article Body',
 			'published' => 'N'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body', 'published'), 5);
@@ -973,7 +973,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fifth Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Article' => array('id' => '5', 'title' => 'Fifth Article - New Title 5'));
 		$result = ($TestModel->set($data) && $TestModel->save());
@@ -988,7 +988,7 @@ class ModelWriteTest extends BaseModelTest {
 			'body' => 'Fifth Article Body',
 			'published' => 'Y'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->find('all', array('fields' => array('id', 'title')));
@@ -999,7 +999,7 @@ class ModelWriteTest extends BaseModelTest {
 			array('Article' => array('id' => 4, 'title' => 'Fourth Article - New Title' )),
 			array('Article' => array('id' => 5, 'title' => 'Fifth Article - New Title 5' ))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1030,7 +1030,7 @@ class ModelWriteTest extends BaseModelTest {
 			'published' => 'N'
 		));
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body', 'published'), 4);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'user_id' => '1',
@@ -1050,7 +1050,7 @@ class ModelWriteTest extends BaseModelTest {
 			'published' => 'N'
 		));
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body', 'published'), 5);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1141,7 +1141,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Article' => array(
@@ -1178,7 +1178,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:24:23',
 					'updated' => '2007-03-18 12:26:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Article' => array('id' => '2'), 'Tag' => array('Tag' => array(2, 3)));
 		$result = $TestModel->set($data);
@@ -1212,7 +1212,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Tag' => array('Tag' => array(1, 2, 3)));
 
@@ -1253,7 +1253,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Tag' => array('Tag' => array()));
 		$result = $TestModel->set($data);
@@ -1283,7 +1283,7 @@ class ModelWriteTest extends BaseModelTest {
 			),
 			'Tag' => array()
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Tag' => array('Tag' => array(2, 3)));
 		$result = $TestModel->set($data);
@@ -1317,7 +1317,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Tag' => array(
@@ -1357,7 +1357,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:24:23',
 					'updated' => '2007-03-18 12:26:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Tag' => array(
@@ -1399,7 +1399,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Tag' => array(
@@ -1441,7 +1441,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Tag' => array(
@@ -1481,7 +1481,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'Article' => array(
@@ -1530,7 +1530,7 @@ class ModelWriteTest extends BaseModelTest {
 					'created' => '2007-03-18 12:26:23',
 					'updated' => '2007-03-18 12:28:31'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$this->loadFixtures('JoinA', 'JoinC', 'JoinAC', 'JoinB', 'JoinAB');
@@ -1552,9 +1552,9 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save($data);
 		$result = $TestModel->read(null, 1);
 		$expected = array(4, 5);
-		$this->assertEqual(Set::extract('/JoinC/JoinAsJoinC/id', $result), $expected);
+		$this->assertEquals(Set::extract('/JoinC/JoinAsJoinC/id', $result), $expected);
 		$expected = array('new record', 'new record');
-		$this->assertEqual(Set::extract('/JoinC/JoinAsJoinC/other', $result), $expected);
+		$this->assertEquals(Set::extract('/JoinC/JoinAsJoinC/other', $result), $expected);
 	}
 
 /**
@@ -1593,7 +1593,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$ts = date('Y-m-d H:i:s');
 		$TestModel->id = 2;
@@ -1620,7 +1620,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->loadFixtures('Portfolio', 'Item', 'ItemsPortfolio');
 		$TestModel = new Portfolio();
@@ -1656,7 +1656,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array('Item' => array('Item' => array(1, 2)));
 		$TestModel->id = 2;
@@ -1694,7 +1694,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1744,7 +1744,7 @@ class ModelWriteTest extends BaseModelTest {
 				),
 				'Tag' => array()
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1776,7 +1776,7 @@ class ModelWriteTest extends BaseModelTest {
 		), false);
 		$result = $Something->read(null, 1);
 		$this->assertTrue(empty($result['NotDoomedSomethingElse']));
-		$this->assertEqual(count($result['DoomedSomethingElse']), 1);
+		$this->assertEquals(count($result['DoomedSomethingElse']), 1);
 
 		$data = array(
 			'Something' => array('id' => 1),
@@ -1792,8 +1792,8 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Something->read(null, 1);
-		$this->assertEqual(count($result['NotDoomedSomethingElse']), 2);
-		$this->assertEqual(count($result['DoomedSomethingElse']), 1);
+		$this->assertEquals(count($result['NotDoomedSomethingElse']), 2);
+		$this->assertEquals(count($result['DoomedSomethingElse']), 1);
 	}
 /**
  * testHabtmSaveKeyResolution method
@@ -1821,7 +1821,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 
 		$ThePaper->id = 2;
 		$ThePaper->save(array('Monkey' => array(1, 2, 3)));
@@ -1846,7 +1846,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 
 		$ThePaper->id = 2;
 		$ThePaper->save(array('Monkey' => array(1, 3)));
@@ -1865,7 +1865,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 			));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 
 		$result = $ThePaper->findById(1);
 		$expected = array(
@@ -1881,7 +1881,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEqual($result['Monkey'], $expected);
+		$this->assertEquals($result['Monkey'], $expected);
 	}
 
 /**
@@ -1892,15 +1892,15 @@ class ModelWriteTest extends BaseModelTest {
 	public function testCreationOfEmptyRecord() {
 		$this->loadFixtures('Author');
 		$TestModel = new Author();
-		$this->assertEqual($TestModel->find('count'), 4);
+		$this->assertEquals($TestModel->find('count'), 4);
 
 		$TestModel->deleteAll(true, false, false);
-		$this->assertEqual($TestModel->find('count'), 0);
+		$this->assertEquals($TestModel->find('count'), 0);
 
 		$result = $TestModel->save();
 		$this->assertTrue(isset($result['Author']['created']));
 		$this->assertTrue(isset($result['Author']['updated']));
-		$this->assertEqual($TestModel->find('count'), 1);
+		$this->assertEquals($TestModel->find('count'), 1);
 	}
 
 /**
@@ -1927,8 +1927,8 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Some text'
 		));
 
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->id, 5);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->id, 5);
 
 		$result = $TestModel->create($data, true);
 		$expected = array(
@@ -1940,7 +1940,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Some text'
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($TestModel->id);
 
 		$result = $TestModel->create(array('Article' => $data), true);
@@ -1953,7 +1953,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Some text'
 		));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($TestModel->id);
 
 		$data = array(
@@ -1978,8 +1978,8 @@ class ModelWriteTest extends BaseModelTest {
 				'updated' => '1970-01-01 12:00:00',
 				'modified' => '1970-01-01 12:00:00'
 		));
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->id, 6);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->id, 6);
 
 		$result = $TestModel->create(array(
 			'Article' => array_diff_key($data, array(
@@ -1995,7 +1995,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'My article',
 				'body' => 'Some text'
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($TestModel->id);
 	}
 
@@ -2017,7 +2017,7 @@ class ModelWriteTest extends BaseModelTest {
 		$comments = $Comment->find('all', array(
 			'fields' => array('id','article_id','user_id','comment','published'), 'recursive' => -1));
 
-		$this->assertEqual($articles, array(
+		$this->assertEquals($articles, array(
 			array('Article' => array(
 				'id' => 1,
 				'title' => 'First Article'
@@ -2031,7 +2031,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'Third Article'
 		))));
 
-		$this->assertEqual($comments, array(
+		$this->assertEquals($comments, array(
 			array('Comment' => array(
 				'id' => 1,
 				'article_id' => 1,
@@ -2103,7 +2103,7 @@ class ModelWriteTest extends BaseModelTest {
 			'recursive' => -1
 		));
 
-		$this->assertEqual($articles, array(
+		$this->assertEquals($articles, array(
 			array('Article' => array(
 				'id' => 1,
 				'title' => 'First Article'
@@ -2117,7 +2117,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'Third Article'
 		))));
 
-		$this->assertEqual($comments, array(
+		$this->assertEquals($comments, array(
 			array('Comment' => array(
 				'id' => 1,
 				'article_id' => 1,
@@ -2181,7 +2181,7 @@ class ModelWriteTest extends BaseModelTest {
 		$SecondaryArticle = new Article();
 
 		$result = $Article->field('title', array('id' => 1));
-		$this->assertEqual($result, 'First Article');
+		$this->assertEquals($result, 'First Article');
 
 		$data = array(
 			'Article' => array(
@@ -2202,14 +2202,14 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue(!empty($result));
 
 		$result = $Article->field('title', array('id' => 1));
-		$this->assertEqual($result, 'First Article');
+		$this->assertEquals($result, 'First Article');
 
 		$articles = $Article->find('all', array(
 			'fields' => array('id','title'),
 			'recursive' => -1
 		));
 
-		$this->assertEqual($articles, array(
+		$this->assertEquals($articles, array(
 			array('Article' => array(
 				'id' => 1,
 				'title' => 'First Article'
@@ -2239,7 +2239,7 @@ class ModelWriteTest extends BaseModelTest {
 		$Secondary = new PrimaryModel();
 
 		$result = $Primary->field('primary_name', array('id' => 1));
-		$this->assertEqual($result, 'Primary Name Existing');
+		$this->assertEquals($result, 'Primary Name Existing');
 
 		$data = array(
 			'PrimaryModel' => array(
@@ -2254,16 +2254,16 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Primary->field('primary_name', array('id' => 1));
-		$this->assertEqual($result, 'Primary Name Existing');
+		$this->assertEquals($result, 'Primary Name Existing');
 
 		$result = $Primary->getInsertID();
 		$this->assertTrue(!empty($result));
 
 		$result = $Primary->field('primary_name', array('id' => $result));
-		$this->assertEqual($result, 'Primary Name New');
+		$this->assertEquals($result, 'Primary Name New');
 
 		$result = $Primary->find('count');
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 	}
 
 /**
@@ -2321,11 +2321,11 @@ class ModelWriteTest extends BaseModelTest {
 			'User' => array(
 				'user' => 'updated user'
 		)));
-		$this->assertEqual($TestModel->id, $id);
+		$this->assertEquals($TestModel->id, $id);
 
 		$result = $TestModel->findById($id);
-		$this->assertEqual($result['User']['user'], 'updated user');
-		$this->assertEqual($result['User']['password'], 'some password');
+		$this->assertEquals($result['User']['user'], 'updated user');
+		$this->assertEquals($result['User']['password'], 'some password');
 
 		$Article = new Article();
 		$Comment = new Comment();
@@ -2363,8 +2363,8 @@ class ModelWriteTest extends BaseModelTest {
 		));
 		$this->assertTrue((bool)$result);
 		$result = $Article->find('first', array('conditions' => array('Article.id' => 1)));
-		$this->assertEqual('', $result['Article']['title'], 'Title is not blank');
-		$this->assertEqual('', $result['Article']['body'], 'Body is not blank');
+		$this->assertEquals('', $result['Article']['title'], 'Title is not blank');
+		$this->assertEquals('', $result['Article']['body'], 'Body is not blank');
 	}
 
 /**
@@ -2377,12 +2377,12 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Comment();
 		$result = Set::extract($TestModel->find('all'), '{n}.Comment.user_id');
 		$expected = array('2', '4', '1', '1', '1', '2');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->updateAll(array('Comment.user_id' => 5), array('Comment.user_id' => 2));
 		$result = Set::combine($TestModel->find('all'), '{n}.Comment.id', '{n}.Comment.user_id');
 		$expected = array(1 => 5, 2 => 4, 3 => 1, 4 => 1, 5 => 1, 6 => 5);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $TestModel->updateAll(
 			array('Comment.comment' => "'Updated today'"),
@@ -2397,7 +2397,7 @@ class ModelWriteTest extends BaseModelTest {
 			'{n}.Comment.comment'
 		);
 		$expected = array_fill(0, 2, 'Updated today');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2415,8 +2415,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save();
 		$id = $TestModel->id;
 		$result = $TestModel->read(null, $id);
-		$this->assertEqual(1, count($result['Uuiditem']));
-		$this->assertEqual(strlen($result['Uuiditem'][0]['UuiditemsUuidportfolio']['id']), 36);
+		$this->assertEquals(1, count($result['Uuiditem']));
+		$this->assertEquals(strlen($result['Uuiditem'][0]['UuiditemsUuidportfolio']['id']), 36);
 	}
 
 /**
@@ -2484,7 +2484,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save();
 		$id = $TestModel->id;
 		$result = $TestModel->read(null, $id);
-		$this->assertEqual(1, count($result['Uuidportfolio']));
+		$this->assertEquals(1, count($result['Uuidportfolio']));
 	}
 
 /**
@@ -2534,7 +2534,7 @@ class ModelWriteTest extends BaseModelTest {
 						'updated' => '2008-01-03 10:57:22'
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$ts = date('Y-m-d H:i:s');
 		$TestModel->id = 1;
@@ -2602,7 +2602,7 @@ class ModelWriteTest extends BaseModelTest {
 						'updated' => $ts
 		))));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2615,7 +2615,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Post();
 
 		$result = $TestModel->find('all');
-		$this->assertEqual(count($result), 3);
+		$this->assertEquals(count($result), 3);
 		$this->assertFalse(isset($result[3]));
 		$ts = date('Y-m-d H:i:s');
 
@@ -2650,11 +2650,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[3]['Author']['updated'] >= $ts);
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 		unset($result[3]['Author']['created'], $result[3]['Author']['updated']);
-		$this->assertEqual($result[3], $expected);
-		$this->assertEqual(count($result), 4);
+		$this->assertEquals($result[3], $expected);
+		$this->assertEquals(count($result), 4);
 
 		$TestModel->deleteAll(true);
-		$this->assertEqual($TestModel->find('all'), array());
+		$this->assertEquals($TestModel->find('all'), array());
 
 		// SQLite seems to reset the PK counter when that happens, so we need this to make the tests pass
 		$this->db->truncate($TestModel);
@@ -2699,7 +2699,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[1]['Post']['updated'] >= $ts);
 		unset($result[0]['Post']['created'], $result[0]['Post']['updated']);
 		unset($result[1]['Post']['created'], $result[1]['Post']['updated']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel = new Comment();
 		$ts = date('Y-m-d H:i:s');
@@ -2726,7 +2726,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Comment']['created'] >= $ts);
 		$this->assertTrue($result[6]['Comment']['updated'] >= $ts);
 		unset($result[6]['Comment']['created'], $result[6]['Comment']['updated']);
-		$this->assertEqual($result[6]['Comment'], $expected);
+		$this->assertEquals($result[6]['Comment'], $expected);
 
 
 		$expected = array(
@@ -2737,7 +2737,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Attachment']['created'] >= $ts);
 		$this->assertTrue($result[6]['Attachment']['updated'] >= $ts);
 		unset($result[6]['Attachment']['created'], $result[6]['Attachment']['updated']);
-		$this->assertEqual($result[6]['Attachment'], $expected);
+		$this->assertEquals($result[6]['Attachment'], $expected);
 	}
 
 /**
@@ -2765,10 +2765,10 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Article->read();
-		$this->assertEqual(count($result['Tag']), 2);
-		$this->assertEqual($result['Tag'][0]['tag'], 'tag1');
-		$this->assertEqual(count($result['Comment']), 1);
-		$this->assertEqual(count($result['Comment'][0]['comment']['Article comment']), 1);
+		$this->assertEquals(count($result['Tag']), 2);
+		$this->assertEquals($result['Tag'][0]['tag'], 'tag1');
+		$this->assertEquals(count($result['Comment']), 1);
+		$this->assertEquals(count($result['Comment'][0]['comment']['Article comment']), 1);
 	}
 
 /**
@@ -2798,7 +2798,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		$result = $Something->read();
 
-		$this->assertEqual(count($result['SomethingElse']), 3);
+		$this->assertEquals(count($result['SomethingElse']), 3);
 		$this->assertTrue(Set::matches('/Something[id=4]', $result));
 
 		$this->assertTrue(Set::matches('/SomethingElse[id=1]', $result));
@@ -2822,10 +2822,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllHasOne() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEqual($model->Attachment->find('all'), array());
+		$this->assertEquals($model->Attachment->find('all'), array());
 
 		$this->assertTrue($model->saveAll(array(
 			'Comment' => array(
@@ -2850,7 +2850,7 @@ class ModelWriteTest extends BaseModelTest {
 				'comment_id' => '1',
 				'attachment' => 'some_file.zip'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')), false);
@@ -2874,10 +2874,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllBelongsTo() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Article->deleteAll(true);
-		$this->assertEqual($model->Article->find('all'), array());
+		$this->assertEquals($model->Article->find('all'), array());
 
 		$this->assertTrue($model->saveAll(array(
 			'Comment' => array(
@@ -2902,7 +2902,7 @@ class ModelWriteTest extends BaseModelTest {
 				'id' => '1',
 				'title' => 'Model Associations 101'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2913,10 +2913,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllHasOneValidation() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEqual($model->Attachment->find('all'), array());
+		$this->assertEquals($model->Attachment->find('all'), array());
 
 		$model->validate = array('comment' => 'notEmpty');
 		$model->Attachment->validate = array('attachment' => 'notEmpty');
@@ -2937,8 +2937,8 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array('comment' => array('This field cannot be left blank')),
 			'Attachment' => array('attachment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($model->validationErrors, $expected['Comment']);
-		$this->assertEqual($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($model->validationErrors, $expected['Comment']);
+		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
 
 		$this->assertFalse($model->saveAll(
 			array(
@@ -2947,8 +2947,8 @@ class ModelWriteTest extends BaseModelTest {
 			),
 			array('validate' => 'only')
 		));
-		$this->assertEqual($model->validationErrors, $expected['Comment']);
-		$this->assertEqual($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($model->validationErrors, $expected['Comment']);
+		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
 	}
 
 /**
@@ -2970,7 +2970,7 @@ class ModelWriteTest extends BaseModelTest {
 				array('comment' => 'First new comment', 'user_id' => 2))
 		), array('atomic' => false));
 
-		$this->assertIdentical($result, array('Article' => true, 'Comment' => array(true)));
+		$this->assertSame($result, array('Article' => true, 'Comment' => array(true)));
 
 		$result = $TestModel->saveAll(array(
 			array(
@@ -2989,7 +2989,7 @@ class ModelWriteTest extends BaseModelTest {
 				'user_id' => 2
 			)
 		), array('atomic' => false));
-		$this->assertIdentical($result, array(true, true, true));
+		$this->assertSame($result, array(true, true, true));
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$result = $TestModel->saveAll(array(
@@ -3006,7 +3006,7 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		), array('validate' => true, 'atomic' => false));
 
-		$this->assertIdentical($result, array(true, false));
+		$this->assertSame($result, array(true, false));
 
 		$result = $TestModel->saveAll(array(
 			'Article' => array('id' => 2),
@@ -3022,7 +3022,7 @@ class ModelWriteTest extends BaseModelTest {
 					'user_id' => 2
 			))
 		), array('validate' => true, 'atomic' => false));
-		$this->assertIdentical($result, array('Article' => true, 'Comment' => array(true, true)));
+		$this->assertSame($result, array('Article' => true, 'Comment' => array(true, true)));
 	}
 
 /**
@@ -3052,7 +3052,7 @@ class ModelWriteTest extends BaseModelTest {
 			'First new comment',
 			'Second new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 
 		$result = $TestModel->saveAll(
 			array(
@@ -3075,7 +3075,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 
 		$TestModel->beforeSaveReturn = false;
 		$result = $TestModel->saveAll(
@@ -3089,7 +3089,7 @@ class ModelWriteTest extends BaseModelTest {
 			))),
 			array('atomic' => false)
 		);
-		$this->assertEqual($result, array('Article' => false));
+		$this->assertEquals($result, array('Article' => false));
 
 		$result = $TestModel->findById(2);
 		$expected = array(
@@ -3099,7 +3099,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 	}
 
 /**
@@ -3124,11 +3124,11 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array('Comment' => array(
 			array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 		$expected = array(
 			array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
 
 		$result = $TestModel->saveAll(array(
 			'Article' => array('id' => 2),
@@ -3312,12 +3312,12 @@ class ModelWriteTest extends BaseModelTest {
 					'updated' => $ts
 			));
 
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 			// Skip the rest of the transactional tests
 			return;
 		}
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
@@ -3381,7 +3381,7 @@ class ModelWriteTest extends BaseModelTest {
 					'updated' => $ts
 			));
 		}
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty');
 		$data = array(
@@ -3433,7 +3433,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => '',
 				'published' => 'N'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3509,7 +3509,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[3]['Post']['updated'] >= $ts);
 		unset($result[0]['Post']['updated'], $result[1]['Post']['updated']);
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$data = array(
@@ -3535,7 +3535,7 @@ class ModelWriteTest extends BaseModelTest {
 			$this->assertTrue(Set::matches('/Post[2][title=Just update the title]', $result));
 		}
 
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$data = array(
@@ -3552,7 +3552,7 @@ class ModelWriteTest extends BaseModelTest {
 		));
 		$newTs = date('Y-m-d H:i:s');
 		$result = $TestModel->saveAll($data, array('validate' => true, 'atomic' => false));
-		$this->assertEqual($result, array(true, false));
+		$this->assertEquals($result, array(true, false));
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
 		$errors = array(1 => array('title' => array('This field cannot be left blank')));
 		$expected = array(
@@ -3606,8 +3606,8 @@ class ModelWriteTest extends BaseModelTest {
 			$result[0]['Post']['updated'], $result[1]['Post']['updated'],
 			$result[3]['Post']['updated'], $result[3]['Post']['created']
 		);
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 
 		$data = array(
 			array(
@@ -3628,8 +3628,8 @@ class ModelWriteTest extends BaseModelTest {
 			$result[0]['Post']['updated'], $result[1]['Post']['updated'],
 			$result[3]['Post']['updated'], $result[3]['Post']['created']
 		);
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 	}
 
 /**
@@ -3668,7 +3668,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			0 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 
 		$result = $TestModel->saveAll(
 			array(
@@ -3682,7 +3682,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			1 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 	}
 
 /**
@@ -3710,14 +3710,14 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $model->find('all');
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 		$expected = array('Comment' => array(
 			1 => array('comment' => array('This field cannot be left blank'))
 		));
 
-		$this->assertEqual($model->Comment->validationErrors, $expected['Comment']);
+		$this->assertEquals($model->Comment->validationErrors, $expected['Comment']);
 
-		$this->assertIdentical($model->Comment->find('count'), 0);
+		$this->assertSame($model->Comment->find('count'), 0);
 
 		$result = $model->saveAll(
 			array(
@@ -3734,10 +3734,10 @@ class ModelWriteTest extends BaseModelTest {
 			array('validate' => 'first')
 		);
 
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $model->Comment->find('all');
-		$this->assertIdentical(count($result), 1);
+		$this->assertSame(count($result), 1);
 		$result = Set::extract('/Comment/article_id', $result);
 		$this->assertEquals($result[0], 4);
 
@@ -3757,11 +3757,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $model->find('all');
-		$this->assertEqual(
+		$this->assertEquals(
 			$result[0]['Article']['title'],
 			'Post with Author saveAlled from comment'
 		);
-		$this->assertEqual($result[0]['Comment'][0]['comment'], 'Only new comment');
+		$this->assertEquals($result[0]['Comment'][0]['comment'], 'Only new comment');
 	}
 
 /**
@@ -3799,7 +3799,7 @@ class ModelWriteTest extends BaseModelTest {
 			'validate' => 'first',
 		));
 		$expected = array(true, false);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Something = new Something();
 		$validData = array(
@@ -3820,7 +3820,7 @@ class ModelWriteTest extends BaseModelTest {
 			'validate' => 'first',
 		));
 		$expected = array(true, true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3884,19 +3884,19 @@ class ModelWriteTest extends BaseModelTest {
 			'Article' => true,
 			'Comment' => array(false, true, false)
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = array('Comment' => array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 
 		$expected = array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
 	}
 
 /**
@@ -3928,7 +3928,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Post();
 
 		$result = $TestModel->find('all');
-		$this->assertEqual(count($result), 3);
+		$this->assertEquals(count($result), 3);
 		$this->assertFalse(isset($result[3]));
 		$ts = date('Y-m-d H:i:s');
 
@@ -3965,8 +3965,8 @@ class ModelWriteTest extends BaseModelTest {
 			$result[3]['Post']['updated'], $result[3]['Post']['created'],
 			$result[3]['Author']['updated'], $result[3]['Author']['created']
 		);
-		$this->assertEqual($result[3], $expected);
-		$this->assertEqual(count($result), 4);
+		$this->assertEquals($result[3], $expected);
+		$this->assertEquals(count($result), 4);
 
 		$ts = date('Y-m-d H:i:s');
 
@@ -3995,7 +3995,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Comment']['updated'] >= $ts);
 		$this->assertTrue($result[6]['Comment']['created'] >= $ts);
 		unset($result[6]['Comment']['updated'], $result[6]['Comment']['created']);
-		$this->assertEqual($result[6]['Comment'], $expected);
+		$this->assertEquals($result[6]['Comment'], $expected);
 
 
 		$expected = array(
@@ -4006,7 +4006,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Attachment']['updated'] >= $ts);
 		$this->assertTrue($result[6]['Attachment']['created'] >= $ts);
 		unset($result[6]['Attachment']['updated'], $result[6]['Attachment']['created']);
-		$this->assertEqual($result[6]['Attachment'], $expected);
+		$this->assertEquals($result[6]['Attachment'], $expected);
 	}
 
 /**
@@ -4018,7 +4018,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Post');
 		$TestModel = new Post();
 		$TestModel->deleteAll(true);
-		$this->assertEqual($TestModel->find('all'), array());
+		$this->assertEquals($TestModel->find('all'), array());
 
 		// SQLite seems to reset the PK counter when that happens, so we need this to make the tests pass
 		$this->db->truncate($TestModel);
@@ -4066,7 +4066,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[1]['Post']['created'] >= $ts);
 		unset($result[0]['Post']['updated'], $result[0]['Post']['created']);
 		unset($result[1]['Post']['updated'], $result[1]['Post']['created']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4094,10 +4094,10 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Article->read();
-		$this->assertEqual(count($result['Tag']), 2);
-		$this->assertEqual($result['Tag'][0]['tag'], 'tag1');
-		$this->assertEqual(count($result['Comment']), 1);
-		$this->assertEqual(count($result['Comment'][0]['comment']['Article comment']), 1);
+		$this->assertEquals(count($result['Tag']), 2);
+		$this->assertEquals($result['Tag'][0]['tag'], 'tag1');
+		$this->assertEquals(count($result['Comment']), 1);
+		$this->assertEquals(count($result['Comment'][0]['comment']['Article comment']), 1);
 	}
 
 /**
@@ -4127,7 +4127,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		$result = $Something->read();
 
-		$this->assertEqual(count($result['SomethingElse']), 3);
+		$this->assertEquals(count($result['SomethingElse']), 3);
 		$this->assertTrue(Set::matches('/Something[id=4]', $result));
 
 		$this->assertTrue(Set::matches('/SomethingElse[id=1]', $result));
@@ -4151,10 +4151,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedHasOne() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEqual($model->Attachment->find('all'), array());
+		$this->assertEquals($model->Attachment->find('all'), array());
 
 		$this->assertTrue($model->saveAssociated(array(
 			'Comment' => array(
@@ -4179,7 +4179,7 @@ class ModelWriteTest extends BaseModelTest {
 				'comment_id' => '1',
 				'attachment' => 'some_file.zip'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')), false);
@@ -4203,10 +4203,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedBelongsTo() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Article->deleteAll(true);
-		$this->assertEqual($model->Article->find('all'), array());
+		$this->assertEquals($model->Article->find('all'), array());
 
 		$this->assertTrue($model->saveAssociated(array(
 			'Comment' => array(
@@ -4231,7 +4231,7 @@ class ModelWriteTest extends BaseModelTest {
 				'id' => '1',
 				'title' => 'Model Associations 101'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4242,10 +4242,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedHasOneValidation() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEqual($model->find('all'), array());
+		$this->assertEquals($model->find('all'), array());
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEqual($model->Attachment->find('all'), array());
+		$this->assertEquals($model->Attachment->find('all'), array());
 
 		$model->validate = array('comment' => 'notEmpty');
 		$model->Attachment->validate = array('attachment' => 'notEmpty');
@@ -4266,8 +4266,8 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array('comment' => array('This field cannot be left blank')),
 			'Attachment' => array('attachment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($model->validationErrors, $expected['Comment']);
-		$this->assertEqual($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($model->validationErrors, $expected['Comment']);
+		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
 	}
 
 /**
@@ -4289,7 +4289,7 @@ class ModelWriteTest extends BaseModelTest {
 				array('comment' => 'First new comment', 'user_id' => 2))
 		), array('atomic' => false));
 
-		$this->assertIdentical($result, array('Article' => true, 'Comment' => array(true)));
+		$this->assertSame($result, array('Article' => true, 'Comment' => array(true)));
 
 		$result = $TestModel->saveAssociated(array(
 			'Article' => array('id' => 2),
@@ -4305,7 +4305,7 @@ class ModelWriteTest extends BaseModelTest {
 					'user_id' => 2
 			))
 		), array('validate' => true, 'atomic' => false));
-		$this->assertIdentical($result, array('Article' => true, 'Comment' => array(true, true)));
+		$this->assertSame($result, array('Article' => true, 'Comment' => array(true, true)));
 	}
 
 /**
@@ -4334,7 +4334,7 @@ class ModelWriteTest extends BaseModelTest {
 				'user_id' => 2
 			)
 		), array('atomic' => false));
-		$this->assertIdentical($result, array(true, true, true));
+		$this->assertSame($result, array(true, true, true));
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$result = $TestModel->saveMany(array(
@@ -4351,7 +4351,7 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		), array('validate' => true, 'atomic' => false));
 
-		$this->assertIdentical($result, array(true, false));
+		$this->assertSame($result, array(true, false));
 
 	}
 
@@ -4381,7 +4381,7 @@ class ModelWriteTest extends BaseModelTest {
 			'First new comment',
 			'Second new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 
 		$result = $TestModel->saveAssociated(
 			array(
@@ -4404,7 +4404,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 
 		$TestModel->beforeSaveReturn = false;
 		$result = $TestModel->saveAssociated(
@@ -4418,7 +4418,7 @@ class ModelWriteTest extends BaseModelTest {
 			))),
 			array('atomic' => false)
 		);
-		$this->assertEqual($result, array('Article' => false));
+		$this->assertEquals($result, array('Article' => false));
 
 		$result = $TestModel->findById(2);
 		$expected = array(
@@ -4428,7 +4428,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEqual(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
 	}
 
 /**
@@ -4453,11 +4453,11 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array('Comment' => array(
 			array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 		$expected = array(
 			array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
 
 		$result = $TestModel->saveAssociated(array(
 			'Article' => array('id' => 2),
@@ -4644,12 +4644,12 @@ class ModelWriteTest extends BaseModelTest {
 			$this->assertTrue($result[4]['Post']['updated'] >= $ts);
 			unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 			unset($result[4]['Post']['created'], $result[4]['Post']['updated']);
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 			// Skip the rest of the transactional tests
 			return;
 		}
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
@@ -4715,7 +4715,7 @@ class ModelWriteTest extends BaseModelTest {
 			unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 			unset($result[4]['Post']['created'], $result[4]['Post']['updated']);
 		}
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty');
 		$data = array(
@@ -4767,7 +4767,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => '',
 				'published' => 'N'
 		)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -4848,7 +4848,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[3]['Post']['updated'] >= $ts);
 		unset($result[0]['Post']['updated'], $result[1]['Post']['updated']);
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$data = array(
@@ -4874,7 +4874,7 @@ class ModelWriteTest extends BaseModelTest {
 			$this->assertTrue(Set::matches('/Post[2][title=Just update the title]', $result));
 		}
 
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
 		$data = array(
@@ -4890,7 +4890,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Trying to get away with an empty title'
 		));
 		$result = $TestModel->saveMany($data, array('validate' => true, 'atomic' => false));
-		$this->assertEqual($result, array(true, false));
+		$this->assertEquals($result, array(true, false));
 
 		$result = $TestModel->find('all', array(
 			'fields' => array('id', 'author_id', 'title', 'body', 'published'),
@@ -4931,8 +4931,8 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Fourth post body',
 					'published' => 'N',
 		)));
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 
 		$data = array(
 			array(
@@ -4953,8 +4953,8 @@ class ModelWriteTest extends BaseModelTest {
 			'recursive' => -1,
 			'order' => 'Post.id ASC'
 		));
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($TestModel->validationErrors, $errors);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($TestModel->validationErrors, $errors);
 	}
 
 /**
@@ -4975,7 +4975,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			0 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 
 		$result = $TestModel->validateMany(
 			array(
@@ -4987,7 +4987,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			1 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 	}
 
 /**
@@ -5015,14 +5015,14 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $model->find('all');
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 		$expected = array('Comment' => array(
 			1 => array('comment' => array('This field cannot be left blank'))
 		));
 
-		$this->assertEqual($model->Comment->validationErrors, $expected['Comment']);
+		$this->assertEquals($model->Comment->validationErrors, $expected['Comment']);
 
-		$this->assertIdentical($model->Comment->find('count'), 0);
+		$this->assertSame($model->Comment->find('count'), 0);
 
 		$result = $model->saveAssociated(
 			array(
@@ -5039,10 +5039,10 @@ class ModelWriteTest extends BaseModelTest {
 			array('validate' => 'first')
 		);
 
-		$this->assertIdentical($result, true);
+		$this->assertSame($result, true);
 
 		$result = $model->Comment->find('all');
-		$this->assertIdentical(count($result), 1);
+		$this->assertSame(count($result), 1);
 		$result = Set::extract('/Comment/article_id', $result);
 		$this->assertEquals($result[0], 4);
 
@@ -5062,11 +5062,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $model->find('all');
-		$this->assertEqual(
+		$this->assertEquals(
 			$result[0]['Article']['title'],
 			'Post with Author saveAlled from comment'
 		);
-		$this->assertEqual($result[0]['Comment'][0]['comment'], 'Only new comment');
+		$this->assertEquals($result[0]['Comment'][0]['comment'], 'Only new comment');
 	}
 
 /**
@@ -5104,7 +5104,7 @@ class ModelWriteTest extends BaseModelTest {
 			'validate' => 'first',
 		));
 		$expected = array(true, false);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Something = new Something();
 		$validData = array(
@@ -5125,7 +5125,7 @@ class ModelWriteTest extends BaseModelTest {
 			'validate' => 'first',
 		));
 		$expected = array(true, true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -5200,19 +5200,19 @@ class ModelWriteTest extends BaseModelTest {
 			'Article' => true,
 			'Comment' => array(false, true, false)
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$expected = array('Comment' => array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEqual($TestModel->validationErrors, $expected);
+		$this->assertEquals($TestModel->validationErrors, $expected);
 
 		$expected = array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEqual($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
 	}
 
 /**
@@ -5271,15 +5271,15 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEqual($result, array(5, 3, 4, 1));
+		$this->assertEquals($result, array(5, 3, 4, 1));
 
 		$this->assertTrue($model->updateAll(array('count' => 'count + 2')));
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEqual($result, array(7, 5, 6, 3));
+		$this->assertEquals($result, array(7, 5, 6, 3));
 
 		$this->assertTrue($model->updateAll(array('DataTest.count' => 'DataTest.count - 1')));
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEqual($result, array(6, 4, 5, 2));
+		$this->assertEquals($result, array(6, 4, 5, 2));
 	}
 
 /**
@@ -5341,8 +5341,8 @@ class ModelWriteTest extends BaseModelTest {
 				)
 
 			);
-		$this->assertEqual($results, $expected);
-		$this->assertEqual($resultsFkFalse, $expected);
+		$this->assertEquals($results, $expected);
+		$this->assertEquals($resultsFkFalse, $expected);
 	}
 
 /**
@@ -5403,7 +5403,7 @@ class ModelWriteTest extends BaseModelTest {
 					'name' => 'group one',
 					'code' => 120)));
 
-		$this->assertEqual($results, $expected);
+		$this->assertEquals($results, $expected);
 	}
 
 /**
@@ -5455,7 +5455,7 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => 1,
 					'name' => 'group one',
 					'code' => 120)));
-		$this->assertEqual($resultsFkFalse, $expected);
+		$this->assertEquals($resultsFkFalse, $expected);
 	}
 
 /**
@@ -5492,7 +5492,7 @@ class ModelWriteTest extends BaseModelTest {
 			'published' => 'Y'
 		));
 		$result = $TestModel->save($data);
-		$this->assertIdentical($result['Article']['id'], $TestModel->id);
+		$this->assertSame($result['Article']['id'], $TestModel->id);
 	}
 
 }

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -3550,7 +3550,6 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => '',
 				'body' => 'Trying to get away with an empty title'
 		));
-		$newTs = date('Y-m-d H:i:s');
 		$result = $TestModel->saveAll($data, array('validate' => true, 'atomic' => false));
 		$this->assertEquals($result, array(true, false));
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
@@ -3598,10 +3597,10 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		);
 
-		$this->assertTrue($result[0]['Post']['updated'] >= $newTs);
-		$this->assertTrue($result[1]['Post']['updated'] >= $newTs);
-		$this->assertTrue($result[3]['Post']['updated'] >= $newTs);
-		$this->assertTrue($result[3]['Post']['created'] >= $newTs);
+		$this->assertTrue($result[0]['Post']['updated'] >= $ts);
+		$this->assertTrue($result[1]['Post']['updated'] >= $ts);
+		$this->assertTrue($result[3]['Post']['updated'] >= $ts);
+		$this->assertTrue($result[3]['Post']['created'] >= $ts);
 		unset(
 			$result[0]['Post']['updated'], $result[1]['Post']['updated'],
 			$result[3]['Post']['updated'], $result[3]['Post']['created']

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -84,15 +84,15 @@ class CakeRequestTest extends CakeTestCase {
 			'two' => 'banana'
 		);
 		$request = new CakeRequest('some/path');
-		$this->assertEqual($request->query, $_GET);
+		$this->assertEquals($request->query, $_GET);
 
 		$_GET = array(
 			'one' => 'param',
 			'two' => 'banana',
 		);
 		$request = new CakeRequest('some/path');
-		$this->assertEqual($request->query, $_GET);
-		$this->assertEqual($request->url, 'some/path');
+		$this->assertEquals($request->query, $_GET);
+		$this->assertEquals($request->url, 'some/path');
 	}
 
 /**
@@ -104,7 +104,7 @@ class CakeRequestTest extends CakeTestCase {
 		$_GET = array();
 		$request = new CakeRequest('some/path?one=something&two=else');
 		$expected = array('one' => 'something', 'two' => 'else');
-		$this->assertEqual($request->query, $expected);
+		$this->assertEquals($request->query, $expected);
 		$this->assertEquals('some/path?one=something&two=else', $request->url);
 
 	}
@@ -119,11 +119,11 @@ class CakeRequestTest extends CakeTestCase {
 		$request->params = array('controller' => 'posts', 'action' => 'view');
 		$result = $request->addParams(array('plugin' => null, 'action' => 'index'));
 
-		$this->assertIdentical($result, $request, 'Method did not return itself. %s');
+		$this->assertSame($result, $request, 'Method did not return itself. %s');
 
-		$this->assertEqual($request->controller, 'posts');
-		$this->assertEqual($request->action, 'index');
-		$this->assertEqual($request->plugin, null);
+		$this->assertEquals($request->controller, 'posts');
+		$this->assertEquals($request->action, 'index');
+		$this->assertEquals($request->plugin, null);
 	}
 
 /**
@@ -138,11 +138,11 @@ class CakeRequestTest extends CakeTestCase {
 			'random' => '/something', 'webroot' => '/', 'here' => '/', 'base' => '/base_dir'
 		));
 
-		$this->assertIdentical($result, $request, 'Method did not return itself. %s');
+		$this->assertSame($result, $request, 'Method did not return itself. %s');
 
-		$this->assertEqual($request->webroot, '/');
-		$this->assertEqual($request->base, '/base_dir');
-		$this->assertEqual($request->here, '/');
+		$this->assertEquals($request->webroot, '/');
+		$this->assertEquals($request->base, '/base_dir');
+		$this->assertEquals($request->here, '/');
 		$this->assertFalse(isset($request->random));
 	}
 
@@ -157,7 +157,7 @@ class CakeRequestTest extends CakeTestCase {
 			'Article' => array('title')
 		));
 		$request = new CakeRequest('some/path');
-		$this->assertEqual($request->data, $_POST['data']);
+		$this->assertEquals($request->data, $_POST['data']);
 
 		$_POST = array('one' => 1, 'two' => 'three');
 		$request = new CakeRequest('some/path');
@@ -258,7 +258,7 @@ class CakeRequestTest extends CakeTestCase {
 				'size' => 80469,
 			))
 		);
-		$this->assertEqual($request->data, $expected);
+		$this->assertEquals($request->data, $expected);
 
 		$_FILES = array(
 			'data' => array(
@@ -386,7 +386,7 @@ class CakeRequestTest extends CakeTestCase {
 				),
 			)
 		);
-		$this->assertEqual($request->data, $expected);
+		$this->assertEquals($request->data, $expected);
 
 
 		$_FILES = array(
@@ -409,7 +409,7 @@ class CakeRequestTest extends CakeTestCase {
 				'size' => 123
 			)
 		);
-		$this->assertEqual($request->data, $expected);
+		$this->assertEquals($request->data, $expected);
 
 		$_FILES = array(
 			'something' => array(
@@ -421,7 +421,7 @@ class CakeRequestTest extends CakeTestCase {
 			)
 		);
 		$request = new CakeRequest('some/path');
-		$this->assertEqual($request->params['form'], $_FILES);
+		$this->assertEquals($request->params['form'], $_FILES);
 
 	}
 
@@ -433,15 +433,15 @@ class CakeRequestTest extends CakeTestCase {
 	public function testMethodOverrides() {
 		$_POST = array('_method' => 'POST');
 		$request = new CakeRequest('some/path');
-		$this->assertEqual(env('REQUEST_METHOD'), 'POST');
+		$this->assertEquals(env('REQUEST_METHOD'), 'POST');
 
 		$_POST = array('_method' => 'DELETE');
 		$request = new CakeRequest('some/path');
-		$this->assertEqual(env('REQUEST_METHOD'), 'DELETE');
+		$this->assertEquals(env('REQUEST_METHOD'), 'DELETE');
 
 		$_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
 		$request = new CakeRequest('some/path');
-		$this->assertEqual(env('REQUEST_METHOD'), 'PUT');
+		$this->assertEquals(env('REQUEST_METHOD'), 'PUT');
 	}
 
 /**
@@ -454,17 +454,17 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.3';
 		$request = new CakeRequest('some/path');
-		$this->assertEqual($request->clientIp(false), '192.168.1.5');
-		$this->assertEqual($request->clientIp(), '192.168.1.2');
+		$this->assertEquals($request->clientIp(false), '192.168.1.5');
+		$this->assertEquals($request->clientIp(), '192.168.1.2');
 
 		unset($_SERVER['HTTP_X_FORWARDED_FOR']);
-		$this->assertEqual($request->clientIp(), '192.168.1.2');
+		$this->assertEquals($request->clientIp(), '192.168.1.2');
 
 		unset($_SERVER['HTTP_CLIENT_IP']);
-		$this->assertEqual($request->clientIp(), '192.168.1.3');
+		$this->assertEquals($request->clientIp(), '192.168.1.3');
 
 		$_SERVER['HTTP_CLIENTADDRESS'] = '10.0.1.2, 10.0.1.1';
-		$this->assertEqual($request->clientIp(), '10.0.1.2');
+		$this->assertEquals($request->clientIp(), '10.0.1.2');
 	}
 
 /**
@@ -478,31 +478,31 @@ class CakeRequestTest extends CakeTestCase {
 
 		$_SERVER['HTTP_REFERER'] = 'http://cakephp.org';
 		$result = $request->referer();
-		$this->assertIdentical($result, 'http://cakephp.org');
+		$this->assertSame($result, 'http://cakephp.org');
 
 		$_SERVER['HTTP_REFERER'] = '';
 		$result = $request->referer();
-		$this->assertIdentical($result, '/');
+		$this->assertSame($result, '/');
 
 		$_SERVER['HTTP_REFERER'] = FULL_BASE_URL . '/some/path';
 		$result = $request->referer(true);
-		$this->assertIdentical($result, '/some/path');
+		$this->assertSame($result, '/some/path');
 
 		$_SERVER['HTTP_REFERER'] = FULL_BASE_URL . '/some/path';
 		$result = $request->referer(false);
-		$this->assertIdentical($result, FULL_BASE_URL . '/some/path');
+		$this->assertSame($result, FULL_BASE_URL . '/some/path');
 
 		$_SERVER['HTTP_REFERER'] = FULL_BASE_URL . '/some/path';
 		$result = $request->referer(true);
-		$this->assertIdentical($result, '/some/path');
+		$this->assertSame($result, '/some/path');
 
 		$_SERVER['HTTP_REFERER'] = FULL_BASE_URL . '/recipes/add';
 		$result = $request->referer(true);
-		$this->assertIdentical($result, '/recipes/add');
+		$this->assertSame($result, '/recipes/add');
 
 		$_SERVER['HTTP_X_FORWARDED_HOST'] = 'cakephp.org';
 		$result = $request->referer();
-		$this->assertIdentical($result, 'cakephp.org');
+		$this->assertSame($result, 'cakephp.org');
 	}
 
 /**
@@ -676,10 +676,10 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest('some/path');
 		$request->params = array('controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs');
 
-		$this->assertEqual($request->controller, 'posts');
-		$this->assertEqual($request->action, 'view');
-		$this->assertEqual($request->plugin, 'blogs');
-		$this->assertIdentical($request->banana, null);
+		$this->assertEquals($request->controller, 'posts');
+		$this->assertEquals($request->action, 'view');
+		$this->assertEquals($request->plugin, 'blogs');
+		$this->assertSame($request->banana, null);
 	}
 
 /**
@@ -711,11 +711,11 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest('some/path');
 		$request->params = array('controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs');
 
-		$this->assertEqual($request['controller'], 'posts');
+		$this->assertEquals($request['controller'], 'posts');
 
 		$request['slug'] = 'speedy-slug';
-		$this->assertEqual($request->slug, 'speedy-slug');
-		$this->assertEqual($request['slug'], 'speedy-slug');
+		$this->assertEquals($request->slug, 'speedy-slug');
+		$this->assertEquals($request['slug'], 'speedy-slug');
 
 		$this->assertTrue(isset($request['action']));
 		$this->assertFalse(isset($request['wrong-param']));
@@ -730,7 +730,7 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertTrue(isset($request['url']['one']));
 
 		$request->data = array('Post' => array('title' => 'something'));
-		$this->assertEqual($request['data']['Post']['title'], 'something');
+		$this->assertEquals($request['data']['Post']['title'], 'something');
 	}
 
 /**
@@ -876,9 +876,9 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PATH_INFO'] = '/posts/view/1';
 
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/1.2.x.x');
-		$this->assertEqual($request->webroot, '/1.2.x.x/');
-		$this->assertEqual($request->url, 'posts/view/1');
+		$this->assertEquals($request->base, '/1.2.x.x');
+		$this->assertEquals($request->webroot, '/1.2.x.x/');
+		$this->assertEquals($request->url, 'posts/view/1');
 
 
 		$_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/app/webroot';
@@ -886,24 +886,24 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PATH_INFO'] = '/posts/add';
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '');
-		$this->assertEqual($request->webroot, '/');
-		$this->assertEqual($request->url, 'posts/add');
+		$this->assertEquals($request->base, '');
+		$this->assertEquals($request->webroot, '/');
+		$this->assertEquals($request->url, 'posts/add');
 
 		$_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/test/';
 		$_SERVER['SCRIPT_NAME'] = '/webroot/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEqual('', $request->base);
-		$this->assertEqual('/', $request->webroot);
+		$this->assertEquals('', $request->base);
+		$this->assertEquals('/', $request->webroot);
 
 
 		$_SERVER['DOCUMENT_ROOT'] = '/some/apps/where';
 		$_SERVER['SCRIPT_NAME'] = '/app/webroot/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '');
-		$this->assertEqual($request->webroot, '/');
+		$this->assertEquals($request->base, '');
+		$this->assertEquals($request->webroot, '/');
 
 		Configure::write('App.dir', 'auth');
 
@@ -912,8 +912,8 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/demos/auth');
-		$this->assertEqual($request->webroot, '/demos/auth/');
+		$this->assertEquals($request->base, '/demos/auth');
+		$this->assertEquals($request->webroot, '/demos/auth/');
 
 		Configure::write('App.dir', 'code');
 
@@ -921,8 +921,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['SCRIPT_NAME'] = '/clients/PewterReport/code/webroot/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/clients/PewterReport/code');
-		$this->assertEqual($request->webroot, '/clients/PewterReport/code/');
+		$this->assertEquals($request->base, '/clients/PewterReport/code');
+		$this->assertEquals($request->webroot, '/clients/PewterReport/code/');
 	}
 
 /**
@@ -938,8 +938,8 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/control');
-		$this->assertEqual($request->webroot, '/control/');
+		$this->assertEquals($request->base, '/control');
+		$this->assertEquals($request->webroot, '/control/');
 
 		Configure::write('App.base', false);
 		Configure::write('App.dir', 'affiliate');
@@ -949,8 +949,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['SCRIPT_NAME'] = '/newaffiliate/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/newaffiliate');
-		$this->assertEqual($request->webroot, '/newaffiliate/');
+		$this->assertEquals($request->base, '/newaffiliate');
+		$this->assertEquals($request->webroot, '/newaffiliate/');
 	}
 
 /**
@@ -972,9 +972,9 @@ class CakeRequestTest extends CakeTestCase {
 		));
 
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/cake/index.php');
-		$this->assertEqual($request->webroot, '/cake/app/webroot/');
-		$this->assertEqual($request->url, 'posts/index');
+		$this->assertEquals($request->base, '/cake/index.php');
+		$this->assertEquals($request->webroot, '/cake/app/webroot/');
+		$this->assertEquals($request->url, 'posts/index');
 	}
 
 /**
@@ -987,43 +987,43 @@ class CakeRequestTest extends CakeTestCase {
 		Configure::write('App.baseUrl', '/app/webroot/index.php');
 
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/app/webroot/index.php');
-		$this->assertEqual($request->webroot, '/app/webroot/');
+		$this->assertEquals($request->base, '/app/webroot/index.php');
+		$this->assertEquals($request->webroot, '/app/webroot/');
 
 		Configure::write('App.baseUrl', '/app/webroot/test.php');
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/app/webroot/test.php');
-		$this->assertEqual($request->webroot, '/app/webroot/');
+		$this->assertEquals($request->base, '/app/webroot/test.php');
+		$this->assertEquals($request->webroot, '/app/webroot/');
 
 		Configure::write('App.baseUrl', '/app/index.php');
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/app/index.php');
-		$this->assertEqual($request->webroot, '/app/webroot/');
+		$this->assertEquals($request->base, '/app/index.php');
+		$this->assertEquals($request->webroot, '/app/webroot/');
 
 		Configure::write('App.baseUrl', '/CakeBB/app/webroot/index.php');
 		$request = new CakeRequest();
-		$this->assertEqual($request->base, '/CakeBB/app/webroot/index.php');
-		$this->assertEqual($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals($request->base, '/CakeBB/app/webroot/index.php');
+		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
 
 		Configure::write('App.baseUrl', '/CakeBB/app/index.php');
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/CakeBB/app/index.php');
-		$this->assertEqual($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals($request->base, '/CakeBB/app/index.php');
+		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
 
 		Configure::write('App.baseUrl', '/CakeBB/index.php');
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/CakeBB/index.php');
-		$this->assertEqual($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals($request->base, '/CakeBB/index.php');
+		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
 
 		Configure::write('App.baseUrl', '/dbhauser/index.php');
 		$_SERVER['DOCUMENT_ROOT'] = '/kunden/homepages/4/d181710652/htdocs/joomla';
 		$_SERVER['SCRIPT_FILENAME'] = '/kunden/homepages/4/d181710652/htdocs/joomla/dbhauser/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEqual($request->base, '/dbhauser/index.php');
-		$this->assertEqual($request->webroot, '/dbhauser/app/webroot/');
+		$this->assertEquals($request->base, '/dbhauser/index.php');
+		$this->assertEquals($request->webroot, '/dbhauser/app/webroot/');
 	}
 
 /**
@@ -1037,8 +1037,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/index.php';
 
 		$request = new CakeRequest();
-		$this->assertEqual('/index.php', $request->base);
-		$this->assertEqual('/app/webroot/', $request->webroot);
+		$this->assertEquals('/index.php', $request->base);
+		$this->assertEquals('/app/webroot/', $request->webroot);
 	}
 
 /**
@@ -1052,8 +1052,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['SCRIPT_FILENAME'] = '/Users/markstory/Sites/cake_dev/app/webroot/index.php';
 
 		$request = new CakeRequest();
-		$this->assertEqual('/index.php', $request->base);
-		$this->assertEqual('/', $request->webroot);
+		$this->assertEquals('/index.php', $request->base);
+		$this->assertEquals('/', $request->webroot);
 	}
 
 /**
@@ -1421,7 +1421,7 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertEquals($expected['base'], $request->base, "base error");
 		$this->assertEquals($expected['webroot'], $request->webroot, "webroot error");
 		if (isset($expected['urlParams'])) {
-			$this->assertEqual($request->query, $expected['urlParams'], "GET param mismatch");
+			$this->assertEquals($request->query, $expected['urlParams'], "GET param mismatch");
 		}
 	}
 

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -683,6 +683,26 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test isset()/empty() with overloaded properties.
+ *
+ * @return void
+ */
+	public function test__isset() {
+		$request = new CakeRequest('some/path');
+		$request->params = array(
+			'controller' => 'posts',
+			'action' => 'view',
+			'plugin' => 'blogs',
+			'named' => array()
+		);
+
+		$this->assertTrue(isset($request->controller));
+		$this->assertFalse(isset($request->notthere));
+		$this->assertFalse(empty($request->controller));
+		$this->assertTrue(empty($request->named));
+	}
+
+/**
  * test the array access implementation
  *
  * @return void

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -334,11 +334,11 @@ class CakeResponseTest extends CakeTestCase {
 	public function testHttpCodes() {
 		$response = new CakeResponse();
 		$result = $response->httpCodes();
-		$this->assertEqual(count($result), 39);
+		$this->assertEquals(count($result), 39);
 
 		$result =  $response->httpCodes(100);
 		$expected = array(100 => 'Continue');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$codes = array(
 			1337 => 'Undefined Unicorn',
@@ -347,20 +347,20 @@ class CakeResponseTest extends CakeTestCase {
 
 		$result =  $response->httpCodes($codes);
 		$this->assertTrue($result);
-		$this->assertEqual(count($response->httpCodes()), 41);
+		$this->assertEquals(count($response->httpCodes()), 41);
 
 		$result = $response->httpCodes(1337);
 		$expected = array(1337 => 'Undefined Unicorn');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$codes = array(404 => 'Sorry Bro');
 		$result = $response->httpCodes($codes);
 		$this->assertTrue($result);
-		$this->assertEqual(count($response->httpCodes()), 41);
+		$this->assertEquals(count($response->httpCodes()), 41);
 
 		$result = $response->httpCodes(404);
 		$expected = array(404 => 'Sorry Bro');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -54,7 +54,7 @@ class CakeSocketTest extends CakeTestCase {
 	public function testConstruct() {
 		$this->Socket = new CakeSocket();
 		$config = $this->Socket->config;
-		$this->assertIdentical($config, array(
+		$this->assertSame($config, array(
 			'persistent'	=> false,
 			'host'			=> 'localhost',
 			'protocol'		=> getprotobyname('tcp'),
@@ -65,7 +65,7 @@ class CakeSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 		$this->Socket->__construct(array('host' => 'foo-bar'));
 		$config['host'] = 'foo-bar';
-		$this->assertIdentical($this->Socket->config, $config);
+		$this->assertSame($this->Socket->config, $config);
 
 		$this->Socket = new CakeSocket(array('host' => 'www.cakephp.org', 'port' => 23, 'protocol' => 'udp'));
 		$config = $this->Socket->config;
@@ -74,7 +74,7 @@ class CakeSocketTest extends CakeTestCase {
 		$config['port'] = 23;
 		$config['protocol'] = 17;
 
-		$this->assertIdentical($this->Socket->config, $config);
+		$this->assertSame($this->Socket->config, $config);
 	}
 
 /**
@@ -130,16 +130,16 @@ class CakeSocketTest extends CakeTestCase {
 	public function testSocketHost() {
 		$this->Socket = new CakeSocket();
 		$this->Socket->connect();
-		$this->assertEqual($this->Socket->address(), '127.0.0.1');
-		$this->assertEqual(gethostbyaddr('127.0.0.1'), $this->Socket->host());
-		$this->assertEqual($this->Socket->lastError(), null);
+		$this->assertEquals($this->Socket->address(), '127.0.0.1');
+		$this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
+		$this->assertEquals($this->Socket->lastError(), null);
 		$this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
 
 		$this->Socket = new CakeSocket(array('host' => '127.0.0.1'));
 		$this->Socket->connect();
-		$this->assertEqual($this->Socket->address(), '127.0.0.1');
-		$this->assertEqual(gethostbyaddr('127.0.0.1'), $this->Socket->host());
-		$this->assertEqual($this->Socket->lastError(), null);
+		$this->assertEquals($this->Socket->address(), '127.0.0.1');
+		$this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
+		$this->assertEquals($this->Socket->lastError(), null);
 		$this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
 	}
 
@@ -161,13 +161,13 @@ class CakeSocketTest extends CakeTestCase {
 	public function testSocketReading() {
 		$this->Socket = new CakeSocket(array('timeout' => 5));
 		$this->Socket->connect();
-		$this->assertEqual($this->Socket->read(26), null);
+		$this->assertEquals($this->Socket->read(26), null);
 
 		$config = array('host' => 'google.com', 'port' => 80, 'timeout' => 1);
 		$this->Socket = new CakeSocket($config);
 		$this->assertTrue($this->Socket->connect());
-		$this->assertEqual($this->Socket->read(26), null);
-		$this->assertEqual($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
+		$this->assertEquals($this->Socket->read(26), null);
+		$this->assertEquals($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
 	}
 
 /**
@@ -182,7 +182,7 @@ class CakeSocketTest extends CakeTestCase {
 
 		$config = array('host' => '127.0.0.1', 'timeout' => 0.00001);
 		$this->assertFalse($this->Socket->read(1024 * 1024));
-		$this->assertEqual($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
+		$this->assertEquals($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
 	}
 
 /**
@@ -193,7 +193,7 @@ class CakeSocketTest extends CakeTestCase {
 	public function testLastError() {
 		$this->Socket = new CakeSocket();
 		$this->Socket->setLastError(4, 'some error here');
-		$this->assertEqual($this->Socket->lastError(), '4: some error here');
+		$this->assertEquals($this->Socket->lastError(), '4: some error here');
 	}
 
 /**
@@ -211,6 +211,6 @@ class CakeSocketTest extends CakeTestCase {
 		);
 		$anotherSocket = new CakeSocket($config);
 		$anotherSocket->reset();
-		$this->assertEqual(array(), $anotherSocket->config);
+		$this->assertEquals(array(), $anotherSocket->config);
 	}
 }

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -390,10 +390,6 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->subject(1);
 		$this->assertIdentical($this->CakeEmail->subject(), '1');
 
-		$result = $this->CakeEmail->subject(array('something'));
-		$this->assertIdentical($this->CakeEmail->subject(), 'Array');
-		$this->assertIdentical($this->CakeEmail, $result);
-
 		$this->CakeEmail->subject('هذه رسالة بعنوان طويل مرسل للمستلم');
 		$expected = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
 		$this->assertIdentical($this->CakeEmail->subject(), $expected);

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -495,7 +495,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertSame($this->CakeEmail->getHeaders(array('from' => true, 'to' => true)), $expected);
 
 		$result = $this->CakeEmail->setHeaders(array());
-		$this->assertIsA($result, 'CakeEmail');
+		$this->assertInstanceOf('CakeEmail', $result);
 	}
 
 /**
@@ -616,7 +616,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertSame($this->CakeEmail->transport(), 'Debug');
 
 		$result = $this->CakeEmail->transportClass();
-		$this->assertIsA($result, 'DebugTransport');
+		$this->assertInstanceOf('DebugTransport', $result);
 
 		$this->setExpectedException('SocketException');
 		$this->CakeEmail->transport('Invalid');
@@ -674,7 +674,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertEquals($configs->test['transport'], $result);
 
 		$result = $this->CakeEmail->transportClass();
-		$this->assertIsA($result, 'DebugTransport');
+		$this->assertInstanceOf('DebugTransport', $result);
 	}
 /**
  * testSendWithContent method
@@ -879,7 +879,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->viewVars(array('time' => $timestamp));
 
 		$result = $this->CakeEmail->helpers(array('Time'));
-		$this->assertIsA($result, 'CakeEmail');
+		$this->assertInstanceOf('CakeEmail', $result);
 
 		$result = $this->CakeEmail->send();
 		$this->assertTrue((bool)strpos($result['message'], 'Right now: ' . date('Y-m-d\TH:i:s\Z', $timestamp)));
@@ -1001,7 +1001,7 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testDeliver() {
 		$instance = CakeEmail::deliver('all@cakephp.org', 'About', 'Everything ok', array('from' => 'root@cakephp.org'), false);
-		$this->assertIsA($instance, 'CakeEmail');
+		$this->assertInstanceOf('CakeEmail', $instance);
 		$this->assertSame($instance->to(), array('all@cakephp.org' => 'all@cakephp.org'));
 		$this->assertSame($instance->subject(), 'About');
 		$this->assertSame($instance->from(), array('root@cakephp.org' => 'root@cakephp.org'));
@@ -1223,7 +1223,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertEquals('View', $result);
 
 		$result = $this->CakeEmail->viewRender('Theme');
-		$this->assertIsA($result, 'CakeEmail');
+		$this->assertInstanceOf('CakeEmail', $result);
 
 		$result = $this->CakeEmail->viewRender();
 		$this->assertEquals('Theme', $result);
@@ -1239,7 +1239,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertEquals('text', $result);
 
 		$result = $this->CakeEmail->emailFormat('html');
-		$this->assertIsA($result, 'CakeEmail');
+		$this->assertInstanceOf('CakeEmail', $result);
 
 		$result = $this->CakeEmail->emailFormat();
 		$this->assertEquals('html', $result);

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -130,22 +130,22 @@ class CakeEmailTest extends CakeTestCase {
  * @return void
  */
 	public function testFrom() {
-		$this->assertIdentical($this->CakeEmail->from(), array());
+		$this->assertSame($this->CakeEmail->from(), array());
 
 		$this->CakeEmail->from('cake@cakephp.org');
 		$expected = array('cake@cakephp.org' => 'cake@cakephp.org');
-		$this->assertIdentical($this->CakeEmail->from(), $expected);
+		$this->assertSame($this->CakeEmail->from(), $expected);
 
 		$this->CakeEmail->from(array('cake@cakephp.org'));
-		$this->assertIdentical($this->CakeEmail->from(), $expected);
+		$this->assertSame($this->CakeEmail->from(), $expected);
 
 		$this->CakeEmail->from('cake@cakephp.org', 'CakePHP');
 		$expected = array('cake@cakephp.org' => 'CakePHP');
-		$this->assertIdentical($this->CakeEmail->from(), $expected);
+		$this->assertSame($this->CakeEmail->from(), $expected);
 
 		$result = $this->CakeEmail->from(array('cake@cakephp.org' => 'CakePHP'));
-		$this->assertIdentical($this->CakeEmail->from(), $expected);
-		$this->assertIdentical($this->CakeEmail, $result);
+		$this->assertSame($this->CakeEmail->from(), $expected);
+		$this->assertSame($this->CakeEmail, $result);
 
 		$this->setExpectedException('SocketException');
 		$result = $this->CakeEmail->from(array('cake@cakephp.org' => 'CakePHP', 'fail@cakephp.org' => 'From can only be one address'));
@@ -158,20 +158,20 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testSender() {
 		$this->CakeEmail->reset();
-		$this->assertIdentical($this->CakeEmail->sender(), array());
+		$this->assertSame($this->CakeEmail->sender(), array());
 
 		$this->CakeEmail->sender('cake@cakephp.org', 'Name');
 		$expected = array('cake@cakephp.org' => 'Name');
-		$this->assertIdentical($this->CakeEmail->sender(), $expected);
+		$this->assertSame($this->CakeEmail->sender(), $expected);
 
 		$headers = $this->CakeEmail->getHeaders(array('from' => true, 'sender' => true));
-		$this->assertIdentical($headers['From'], false);
-		$this->assertIdentical($headers['Sender'], 'Name <cake@cakephp.org>');
+		$this->assertSame($headers['From'], false);
+		$this->assertSame($headers['Sender'], 'Name <cake@cakephp.org>');
 
 		$this->CakeEmail->from('cake@cakephp.org', 'CakePHP');
 		$headers = $this->CakeEmail->getHeaders(array('from' => true, 'sender' => true));
-		$this->assertIdentical($headers['From'], 'CakePHP <cake@cakephp.org>');
-		$this->assertIdentical($headers['Sender'], '');
+		$this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
+		$this->assertSame($headers['Sender'], '');
 	}
 
 /**
@@ -180,16 +180,16 @@ class CakeEmailTest extends CakeTestCase {
  * @return void
  */
 	public function testTo() {
-		$this->assertIdentical($this->CakeEmail->to(), array());
+		$this->assertSame($this->CakeEmail->to(), array());
 
 		$result = $this->CakeEmail->to('cake@cakephp.org');
 		$expected = array('cake@cakephp.org' => 'cake@cakephp.org');
-		$this->assertIdentical($this->CakeEmail->to(), $expected);
-		$this->assertIdentical($this->CakeEmail, $result);
+		$this->assertSame($this->CakeEmail->to(), $expected);
+		$this->assertSame($this->CakeEmail, $result);
 
 		$this->CakeEmail->to('cake@cakephp.org', 'CakePHP');
 		$expected = array('cake@cakephp.org' => 'CakePHP');
-		$this->assertIdentical($this->CakeEmail->to(), $expected);
+		$this->assertSame($this->CakeEmail->to(), $expected);
 
 		$list = array(
 			'cake@cakephp.org' => 'Cake PHP',
@@ -202,7 +202,7 @@ class CakeEmailTest extends CakeTestCase {
 			'cake-php@googlegroups.com' => 'Cake Groups',
 			'root@cakephp.org' => 'root@cakephp.org'
 		);
-		$this->assertIdentical($this->CakeEmail->to(), $expected);
+		$this->assertSame($this->CakeEmail->to(), $expected);
 
 		$this->CakeEmail->addTo('jrbasso@cakephp.org');
 		$this->CakeEmail->addTo('mark_story@cakephp.org', 'Mark Story');
@@ -216,8 +216,8 @@ class CakeEmailTest extends CakeTestCase {
 			'phpnut@cakephp.org' => 'PhpNut',
 			'jose_zap@cakephp.org' => 'jose_zap@cakephp.org'
 		);
-		$this->assertIdentical($this->CakeEmail->to(), $expected);
-		$this->assertIdentical($this->CakeEmail, $result);
+		$this->assertSame($this->CakeEmail->to(), $expected);
+		$this->assertSame($this->CakeEmail, $result);
 	}
 
 /**
@@ -267,23 +267,23 @@ class CakeEmailTest extends CakeTestCase {
 	public function testFormatAddress() {
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => 'cake@cakephp.org'));
 		$expected = array('cake@cakephp.org');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => 'cake@cakephp.org', 'php@cakephp.org' => 'php@cakephp.org'));
 		$expected = array('cake@cakephp.org', 'php@cakephp.org');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => 'CakePHP', 'php@cakephp.org' => 'Cake'));
 		$expected = array('CakePHP <cake@cakephp.org>', 'Cake <php@cakephp.org>');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => 'ÄÖÜTest'));
 		$expected = array('=?UTF-8?B?w4TDlsOcVGVzdA==?= <cake@cakephp.org>');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => '日本語Test'));
 		$expected = array('=?UTF-8?B?5pel5pys6KqeVGVzdA==?= <cake@cakephp.org>');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -297,7 +297,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->headerCharset = 'ISO-2022-JP';
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => '日本語Test'));
 		$expected = array('=?ISO-2022-JP?B?GyRCRnxLXDhsGyhCVGVzdA==?= <cake@cakephp.org>');
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$result = $this->CakeEmail->formatAddress(array('cake@cakephp.org' => '寿限無寿限無五劫の擦り切れ海砂利水魚の水行末雲来末風来末食う寝る処に住む処やぶら小路の藪柑子パイポパイポパイポのシューリンガンシューリンガンのグーリンダイグーリンダイのポンポコピーのポンポコナーの長久命の長助'));
 		$expected = array("=?ISO-2022-JP?B?GyRCPHc4Qkw1PHc4Qkw1OF45ZSROOyQkakBaJGwzJDo9TXg/ZTV7GyhC?=\r\n"
@@ -306,7 +306,7 @@ class CakeEmailTest extends CakeTestCase {
 						  ." =?ISO-2022-JP?B?GyRCJV0kTiU3JWUhPCVqJXMlLCVzJTclZSE8JWolcyUsJXMkTiUwGyhC?=\r\n"
 						  ." =?ISO-2022-JP?B?GyRCITwlaiVzJUAlJCUwITwlaiVzJUAlJCROJV0lcyVdJTMlVCE8GyhC?=\r\n"
 						  ." =?ISO-2022-JP?B?GyRCJE4lXSVzJV0lMyVKITwkTkQ5NVdMPyRORDk9dRsoQg==?= <cake@cakephp.org>");
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -327,22 +327,22 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->addCc('cc2@cakephp.org', 'Cc2 CakePHP');
 		$this->CakeEmail->addBcc('bcc2@cakephp.org', 'Bcc2 CakePHP');
 
-		$this->assertIdentical($this->CakeEmail->from(), array('cake@cakephp.org' => 'CakePHP'));
-		$this->assertIdentical($this->CakeEmail->replyTo(), array('replyto@cakephp.org' => 'ReplyTo CakePHP'));
-		$this->assertIdentical($this->CakeEmail->readReceipt(), array('readreceipt@cakephp.org' => 'ReadReceipt CakePHP'));
-		$this->assertIdentical($this->CakeEmail->returnPath(), array('returnpath@cakephp.org' => 'ReturnPath CakePHP'));
-		$this->assertIdentical($this->CakeEmail->to(), array('to@cakephp.org' => 'To CakePHP', 'to2@cakephp.org' => 'To2 CakePHP'));
-		$this->assertIdentical($this->CakeEmail->cc(), array('cc@cakephp.org' => 'Cc CakePHP', 'cc2@cakephp.org' => 'Cc2 CakePHP'));
-		$this->assertIdentical($this->CakeEmail->bcc(), array('bcc@cakephp.org' => 'Bcc CakePHP', 'bcc2@cakephp.org' => 'Bcc2 CakePHP'));
+		$this->assertSame($this->CakeEmail->from(), array('cake@cakephp.org' => 'CakePHP'));
+		$this->assertSame($this->CakeEmail->replyTo(), array('replyto@cakephp.org' => 'ReplyTo CakePHP'));
+		$this->assertSame($this->CakeEmail->readReceipt(), array('readreceipt@cakephp.org' => 'ReadReceipt CakePHP'));
+		$this->assertSame($this->CakeEmail->returnPath(), array('returnpath@cakephp.org' => 'ReturnPath CakePHP'));
+		$this->assertSame($this->CakeEmail->to(), array('to@cakephp.org' => 'To CakePHP', 'to2@cakephp.org' => 'To2 CakePHP'));
+		$this->assertSame($this->CakeEmail->cc(), array('cc@cakephp.org' => 'Cc CakePHP', 'cc2@cakephp.org' => 'Cc2 CakePHP'));
+		$this->assertSame($this->CakeEmail->bcc(), array('bcc@cakephp.org' => 'Bcc CakePHP', 'bcc2@cakephp.org' => 'Bcc2 CakePHP'));
 
 		$headers = $this->CakeEmail->getHeaders(array_fill_keys(array('from', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'bcc'), true));
-		$this->assertIdentical($headers['From'], 'CakePHP <cake@cakephp.org>');
-		$this->assertIdentical($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
-		$this->assertIdentical($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
-		$this->assertIdentical($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
-		$this->assertIdentical($headers['To'], 'To CakePHP <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');
-		$this->assertIdentical($headers['Cc'], 'Cc CakePHP <cc@cakephp.org>, Cc2 CakePHP <cc2@cakephp.org>');
-		$this->assertIdentical($headers['Bcc'], 'Bcc CakePHP <bcc@cakephp.org>, Bcc2 CakePHP <bcc2@cakephp.org>');
+		$this->assertSame($headers['From'], 'CakePHP <cake@cakephp.org>');
+		$this->assertSame($headers['Reply-To'], 'ReplyTo CakePHP <replyto@cakephp.org>');
+		$this->assertSame($headers['Disposition-Notification-To'], 'ReadReceipt CakePHP <readreceipt@cakephp.org>');
+		$this->assertSame($headers['Return-Path'], 'ReturnPath CakePHP <returnpath@cakephp.org>');
+		$this->assertSame($headers['To'], 'To CakePHP <to@cakephp.org>, To2 CakePHP <to2@cakephp.org>');
+		$this->assertSame($headers['Cc'], 'Cc CakePHP <cc@cakephp.org>, Cc2 CakePHP <cc2@cakephp.org>');
+		$this->assertSame($headers['Bcc'], 'Bcc CakePHP <bcc@cakephp.org>, Bcc2 CakePHP <bcc2@cakephp.org>');
 	}
 
 /**
@@ -360,12 +360,12 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertFalse(isset($result['Message-ID']));
 
 		$result = $this->CakeEmail->messageId('<my-email@localhost>');
-		$this->assertIdentical($this->CakeEmail, $result);
+		$this->assertSame($this->CakeEmail, $result);
 		$result = $this->CakeEmail->getHeaders();
-		$this->assertIdentical($result['Message-ID'], '<my-email@localhost>');
+		$this->assertSame($result['Message-ID'], '<my-email@localhost>');
 
 		$result = $this->CakeEmail->messageId();
-		$this->assertIdentical($result, '<my-email@localhost>');
+		$this->assertSame($result, '<my-email@localhost>');
 	}
 
 /**
@@ -385,14 +385,14 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testSubject() {
 		$this->CakeEmail->subject('You have a new message.');
-		$this->assertIdentical($this->CakeEmail->subject(), 'You have a new message.');
+		$this->assertSame($this->CakeEmail->subject(), 'You have a new message.');
 
 		$this->CakeEmail->subject(1);
-		$this->assertIdentical($this->CakeEmail->subject(), '1');
+		$this->assertSame($this->CakeEmail->subject(), '1');
 
 		$this->CakeEmail->subject('هذه رسالة بعنوان طويل مرسل للمستلم');
 		$expected = '=?UTF-8?B?2YfYsNmHINix2LPYp9mE2Kkg2KjYudmG2YjYp9mGINi32YjZitmEINmF2LE=?=' . "\r\n" . ' =?UTF-8?B?2LPZhCDZhNmE2YXYs9iq2YTZhQ==?=';
-		$this->assertIdentical($this->CakeEmail->subject(), $expected);
+		$this->assertSame($this->CakeEmail->subject(), $expected);
 	}
 
 /**
@@ -407,13 +407,13 @@ class CakeEmailTest extends CakeTestCase {
         $this->CakeEmail->headerCharset = 'ISO-2022-JP';
 		$this->CakeEmail->subject('日本語のSubjectにも対応するよ');
         $expected = '=?ISO-2022-JP?B?GyRCRnxLXDhsJE4bKEJTdWJqZWN0GyRCJEskYkJQMX4kOSRrJGgbKEI=?=';
-		$this->assertIdentical($this->CakeEmail->subject(), $expected);
+		$this->assertSame($this->CakeEmail->subject(), $expected);
 
 		$this->CakeEmail->subject('長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？');
         $expected = "=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n"
                    ." =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n"
                    ." =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=";
-		$this->assertIdentical($this->CakeEmail->subject(), $expected);
+		$this->assertSame($this->CakeEmail->subject(), $expected);
     }
 
 
@@ -433,7 +433,7 @@ class CakeEmailTest extends CakeTestCase {
 			'Content-Type' => 'text/plain; charset=UTF-8',
 			'Content-Transfer-Encoding' => '8bit'
 		);
-		$this->assertIdentical($this->CakeEmail->getHeaders(), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(), $expected);
 
 		$this->CakeEmail->addHeaders(array('X-Something' => 'very nice', 'X-Other' => 'cool'));
 		$expected = array(
@@ -445,10 +445,10 @@ class CakeEmailTest extends CakeTestCase {
 			'Content-Type' => 'text/plain; charset=UTF-8',
 			'Content-Transfer-Encoding' => '8bit'
 		);
-		$this->assertIdentical($this->CakeEmail->getHeaders(), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(), $expected);
 
 		$this->CakeEmail->from('cake@cakephp.org');
-		$this->assertIdentical($this->CakeEmail->getHeaders(), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(), $expected);
 
 		$expected = array(
 			'From' => 'cake@cakephp.org',
@@ -460,11 +460,11 @@ class CakeEmailTest extends CakeTestCase {
 			'Content-Type' => 'text/plain; charset=UTF-8',
 			'Content-Transfer-Encoding' => '8bit'
 		);
-		$this->assertIdentical($this->CakeEmail->getHeaders(array('from' => true)), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(array('from' => true)), $expected);
 
 		$this->CakeEmail->from('cake@cakephp.org', 'CakePHP');
 		$expected['From'] = 'CakePHP <cake@cakephp.org>';
-		$this->assertIdentical($this->CakeEmail->getHeaders(array('from' => true)), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(array('from' => true)), $expected);
 
 		$this->CakeEmail->to(array('cake@cakephp.org', 'php@cakephp.org' => 'CakePHP'));
 		$expected = array(
@@ -478,7 +478,7 @@ class CakeEmailTest extends CakeTestCase {
 			'Content-Type' => 'text/plain; charset=UTF-8',
 			'Content-Transfer-Encoding' => '8bit'
 		);
-		$this->assertIdentical($this->CakeEmail->getHeaders(array('from' => true, 'to' => true)), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(array('from' => true, 'to' => true)), $expected);
 
 		$this->CakeEmail->charset = 'ISO-2022-JP';
 		$expected = array(
@@ -492,7 +492,7 @@ class CakeEmailTest extends CakeTestCase {
 			'Content-Type' => 'text/plain; charset=ISO-2022-JP',
 			'Content-Transfer-Encoding' => '7bit'
 		);
-		$this->assertIdentical($this->CakeEmail->getHeaders(array('from' => true, 'to' => true)), $expected);
+		$this->assertSame($this->CakeEmail->getHeaders(array('from' => true, 'to' => true)), $expected);
 
 		$result = $this->CakeEmail->setHeaders(array());
 		$this->assertIsA($result, 'CakeEmail');
@@ -543,19 +543,19 @@ class CakeEmailTest extends CakeTestCase {
 	public function testTemplate() {
 		$this->CakeEmail->template('template', 'layout');
 		$expected = array('template' => 'template', 'layout' => 'layout');
-		$this->assertIdentical($this->CakeEmail->template(), $expected);
+		$this->assertSame($this->CakeEmail->template(), $expected);
 
 		$this->CakeEmail->template('new_template');
 		$expected = array('template' => 'new_template', 'layout' => 'layout');
-		$this->assertIdentical($this->CakeEmail->template(), $expected);
+		$this->assertSame($this->CakeEmail->template(), $expected);
 
 		$this->CakeEmail->template('template', null);
 		$expected = array('template' => 'template', 'layout' => null);
-		$this->assertIdentical($this->CakeEmail->template(), $expected);
+		$this->assertSame($this->CakeEmail->template(), $expected);
 
 		$this->CakeEmail->template(null, null);
 		$expected = array('template' => null, 'layout' => null);
-		$this->assertIdentical($this->CakeEmail->template(), $expected);
+		$this->assertSame($this->CakeEmail->template(), $expected);
 	}
 
 /**
@@ -564,16 +564,16 @@ class CakeEmailTest extends CakeTestCase {
  * @return void
  */
 	public function testViewVars() {
-		$this->assertIdentical($this->CakeEmail->viewVars(), array());
+		$this->assertSame($this->CakeEmail->viewVars(), array());
 
 		$this->CakeEmail->viewVars(array('value' => 12345));
-		$this->assertIdentical($this->CakeEmail->viewVars(), array('value' => 12345));
+		$this->assertSame($this->CakeEmail->viewVars(), array('value' => 12345));
 
 		$this->CakeEmail->viewVars(array('name' => 'CakePHP'));
-		$this->assertIdentical($this->CakeEmail->viewVars(), array('value' => 12345, 'name' => 'CakePHP'));
+		$this->assertSame($this->CakeEmail->viewVars(), array('value' => 12345, 'name' => 'CakePHP'));
 
 		$this->CakeEmail->viewVars(array('value' => 4567));
-		$this->assertIdentical($this->CakeEmail->viewVars(), array('value' => 4567, 'name' => 'CakePHP'));
+		$this->assertSame($this->CakeEmail->viewVars(), array('value' => 4567, 'name' => 'CakePHP'));
 	}
 
 /**
@@ -584,10 +584,10 @@ class CakeEmailTest extends CakeTestCase {
 	public function testAttachments() {
 		$this->CakeEmail->attachments(CAKE . 'basics.php');
 		$expected = array('basics.php' => array('file' => CAKE . 'basics.php', 'mimetype' => 'application/octet-stream'));
-		$this->assertIdentical($this->CakeEmail->attachments(), $expected);
+		$this->assertSame($this->CakeEmail->attachments(), $expected);
 
 		$this->CakeEmail->attachments(array());
-		$this->assertIdentical($this->CakeEmail->attachments(), array());
+		$this->assertSame($this->CakeEmail->attachments(), array());
 
 		$this->CakeEmail->attachments(array(array('file' => CAKE . 'basics.php', 'mimetype' => 'text/plain')));
 		$this->CakeEmail->addAttachments(CAKE . 'bootstrap.php');
@@ -599,7 +599,7 @@ class CakeEmailTest extends CakeTestCase {
 			'other.txt' => array('file' => CAKE . 'bootstrap.php', 'mimetype' => 'application/octet-stream'),
 			'license' => array('file' => CAKE . 'LICENSE.txt', 'mimetype' => 'application/octet-stream')
 		);
-		$this->assertIdentical($this->CakeEmail->attachments(), $expected);
+		$this->assertSame($this->CakeEmail->attachments(), $expected);
 
 		$this->setExpectedException('SocketException');
 		$this->CakeEmail->attachments(array(array('nofile' => CAKE . 'basics.php', 'mimetype' => 'text/plain')));
@@ -612,8 +612,8 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testTransport() {
 		$result = $this->CakeEmail->transport('Debug');
-		$this->assertIdentical($this->CakeEmail, $result);
-		$this->assertIdentical($this->CakeEmail->transport(), 'Debug');
+		$this->assertSame($this->CakeEmail, $result);
+		$this->assertSame($this->CakeEmail->transport(), 'Debug');
 
 		$result = $this->CakeEmail->transportClass();
 		$this->assertIsA($result, 'DebugTransport');
@@ -644,11 +644,11 @@ class CakeEmailTest extends CakeTestCase {
 
 		$config = array('test' => 'ok', 'test2' => true);
 		$this->CakeEmail->config($config);
-		$this->assertIdentical($transportClass->config(), $config);
-		$this->assertIdentical($this->CakeEmail->config(), $config);
+		$this->assertSame($transportClass->config(), $config);
+		$this->assertSame($this->CakeEmail->config(), $config);
 
 		$this->CakeEmail->config(array());
-		$this->assertIdentical($transportClass->config(), array());
+		$this->assertSame($transportClass->config(), array());
 
 	}
 
@@ -701,7 +701,7 @@ class CakeEmailTest extends CakeTestCase {
 
 		$result = $this->CakeEmail->send("Other body");
 		$expected = "Other body\r\n\r\n";
-		$this->assertIdentical($result['message'], $expected);
+		$this->assertSame($result['message'], $expected);
 		$this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
 		$this->assertTrue((bool)strpos($result['headers'], 'To: '));
 
@@ -713,7 +713,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->config(array('empty'));
 		$result = $this->CakeEmail->send(array('Sending content', 'As array'));
 		$expected = "Sending content\r\nAs array\r\n\r\n\r\n";
-		$this->assertIdentical($result['message'], $expected);
+		$this->assertSame($result['message'], $expected);
 	}
 
 /**
@@ -1002,9 +1002,9 @@ class CakeEmailTest extends CakeTestCase {
 	public function testDeliver() {
 		$instance = CakeEmail::deliver('all@cakephp.org', 'About', 'Everything ok', array('from' => 'root@cakephp.org'), false);
 		$this->assertIsA($instance, 'CakeEmail');
-		$this->assertIdentical($instance->to(), array('all@cakephp.org' => 'all@cakephp.org'));
-		$this->assertIdentical($instance->subject(), 'About');
-		$this->assertIdentical($instance->from(), array('root@cakephp.org' => 'root@cakephp.org'));
+		$this->assertSame($instance->to(), array('all@cakephp.org' => 'all@cakephp.org'));
+		$this->assertSame($instance->subject(), 'About');
+		$this->assertSame($instance->from(), array('root@cakephp.org' => 'root@cakephp.org'));
 
 		$config = array(
 			'from' => 'cake@cakephp.org',
@@ -1016,12 +1016,12 @@ class CakeEmailTest extends CakeTestCase {
 			'cc' => array('cake@cakephp.org' => 'Myself')
 		);
 		$instance = CakeEmail::deliver(null, null, array('name' => 'CakePHP'), $config, false);
-		$this->assertIdentical($instance->from(), array('cake@cakephp.org' => 'cake@cakephp.org'));
-		$this->assertIdentical($instance->to(), array('debug@cakephp.org' => 'debug@cakephp.org'));
-		$this->assertIdentical($instance->subject(), 'Update ok');
-		$this->assertIdentical($instance->template(), array('template' => 'custom', 'layout' => 'custom_layout'));
-		$this->assertIdentical($instance->viewVars(), array('value' => 123, 'name' => 'CakePHP'));
-		$this->assertIdentical($instance->cc(), array('cake@cakephp.org' => 'Myself'));
+		$this->assertSame($instance->from(), array('cake@cakephp.org' => 'cake@cakephp.org'));
+		$this->assertSame($instance->to(), array('debug@cakephp.org' => 'debug@cakephp.org'));
+		$this->assertSame($instance->subject(), 'Update ok');
+		$this->assertSame($instance->template(), array('template' => 'custom', 'layout' => 'custom_layout'));
+		$this->assertSame($instance->viewVars(), array('value' => 123, 'name' => 'CakePHP'));
+		$this->assertSame($instance->cc(), array('cake@cakephp.org' => 'Myself'));
 
 		$configs = array('from' => 'root@cakephp.org', 'message' => 'Message from configs', 'transport' => 'Debug');
 		$instance = CakeEmail::deliver('all@cakephp.org', 'About', null, $configs, true);
@@ -1077,10 +1077,10 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testReset() {
 		$this->CakeEmail->to('cake@cakephp.org');
-		$this->assertIdentical($this->CakeEmail->to(), array('cake@cakephp.org' => 'cake@cakephp.org'));
+		$this->assertSame($this->CakeEmail->to(), array('cake@cakephp.org' => 'cake@cakephp.org'));
 
 		$this->CakeEmail->reset();
-		$this->assertIdentical($this->CakeEmail->to(), array());
+		$this->assertSame($this->CakeEmail->to(), array());
 	}
 
 /**
@@ -1096,7 +1096,7 @@ class CakeEmailTest extends CakeTestCase {
 			'non commodo odio. Morbi nibh nisi, vehicula pellentesque accumsan amet.',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$text = 'Lorem ipsum dolor sit amet, consectetur < adipiscing elit. Donec ac turpis orci, non commodo odio. Morbi nibh nisi, vehicula > pellentesque accumsan amet.';
 		$result = $this->CakeEmail->wrap($text);
@@ -1106,7 +1106,7 @@ class CakeEmailTest extends CakeTestCase {
 			'amet.',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$text = '<p>Lorem ipsum dolor sit amet,<br> consectetur adipiscing elit.<br> Donec ac turpis orci, non <b>commodo</b> odio. <br /> Morbi nibh nisi, vehicula pellentesque accumsan amet.<hr></p>';
 		$result = $this->CakeEmail->wrap($text);
@@ -1116,7 +1116,7 @@ class CakeEmailTest extends CakeTestCase {
 			'pellentesque accumsan amet.<hr></p>',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ac <a href="http://cakephp.org">turpis</a> orci, non commodo odio. Morbi nibh nisi, vehicula pellentesque accumsan amet.';
 		$result = $this->CakeEmail->wrap($text);
@@ -1126,7 +1126,7 @@ class CakeEmailTest extends CakeTestCase {
 			'nisi, vehicula pellentesque accumsan amet.',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$text = 'Lorem ipsum <a href="http://www.cakephp.org/controller/action/param1/param2" class="nice cool fine amazing awesome">ok</a>';
 		$result = $this->CakeEmail->wrap($text);
@@ -1136,7 +1136,7 @@ class CakeEmailTest extends CakeTestCase {
 			'ok</a>',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$text = 'Lorem ipsum withonewordverybigMorethanthelineshouldsizeofrfcspecificationbyieeeavailableonieeesite ok.';
 		$result = $this->CakeEmail->wrap($text);
@@ -1146,7 +1146,7 @@ class CakeEmailTest extends CakeTestCase {
 			'ok.',
 			''
 		);
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 
 /**
@@ -1348,13 +1348,13 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->headerCharset = 'ISO-2022-JP';
 		$result = $this->CakeEmail->encode('日本語');
 		$expected = '=?ISO-2022-JP?B?GyRCRnxLXDhsGyhC?=';
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 
 		$this->CakeEmail->headerCharset = 'ISO-2022-JP';
 		$result = $this->CakeEmail->encode('長い長い長いSubjectの場合はfoldingするのが正しいんだけどいったいどうなるんだろう？');
 		$expected = "=?ISO-2022-JP?B?GyRCRDkkJEQ5JCREOSQkGyhCU3ViamVjdBskQiROPmw5ZyRPGyhCZm9s?=\r\n"
                   . " =?ISO-2022-JP?B?ZGluZxskQiQ5JGskTiQsQDUkNyQkJHMkQCQxJEkkJCRDJD8kJCRJGyhC?=\r\n"
 			      . " =?ISO-2022-JP?B?GyRCJCYkSiRrJHMkQCRtJCYhKRsoQg==?=";
-		$this->assertIdentical($expected, $result);
+		$this->assertSame($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -41,7 +41,7 @@ class BasicAuthenticationTest extends CakeTestCase {
 		);
 
 		BasicAuthentication::authentication($http, $auth);
-		$this->assertEqual($http->request['header']['Authorization'], 'Basic bWFyazpzZWNyZXQ=');
+		$this->assertEquals($http->request['header']['Authorization'], 'Basic bWFyazpzZWNyZXQ=');
 	}
 
 /**
@@ -58,7 +58,7 @@ class BasicAuthenticationTest extends CakeTestCase {
 		);
 
 		BasicAuthentication::proxyAuthentication($http, $proxy);
-		$this->assertEqual($http->request['header']['Proxy-Authorization'], 'Basic bWFyazpzZWNyZXQ=');
+		$this->assertEquals($http->request['header']['Proxy-Authorization'], 'Basic bWFyazpzZWNyZXQ=');
 	}
 
 }

--- a/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
@@ -93,8 +93,8 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(isset($this->HttpSocket->request['header']['Authorization']));
-		$this->assertEqual($auth['realm'], 'The batcave');
-		$this->assertEqual($auth['nonce'], '4cded326c6c51');
+		$this->assertEquals($auth['realm'], 'The batcave');
+		$this->assertEquals($auth['nonce'], '4cded326c6c51');
 	}
 
 /**
@@ -107,7 +107,7 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$expected = 'Digest username="admin", realm="The batcave", nonce="4cded326c6c51", uri="/", response="da7e2a46b471d77f70a9bb3698c8902b"';
-		$this->assertEqual($expected, $this->HttpSocket->request['header']['Authorization']);
+		$this->assertEquals($expected, $this->HttpSocket->request['header']['Authorization']);
 		$this->assertFalse(isset($auth['qop']));
 		$this->assertFalse(isset($auth['nc']));
 
@@ -115,9 +115,9 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$expected = '@Digest username="admin", realm="The batcave", nonce="4cded326c6c51", uri="/", response="[a-z0-9]{32}", qop="auth", nc=00000001, cnonce="[a-z0-9]+"@';
-		$this->assertPattern($expected, $this->HttpSocket->request['header']['Authorization']);
-		$this->assertEqual($auth['qop'], 'auth');
-		$this->assertEqual($auth['nc'], 2);
+		$this->assertRegExp($expected, $this->HttpSocket->request['header']['Authorization']);
+		$this->assertEquals($auth['qop'], 'auth');
+		$this->assertEquals($auth['nc'], 2);
 	}
 
 /**
@@ -147,21 +147,21 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000001') > 0);
-		$this->assertEqual($auth['nc'], 2);
+		$this->assertEquals($auth['nc'], 2);
 
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000002') > 0);
-		$this->assertEqual($auth['nc'], 3);
+		$this->assertEquals($auth['nc'], 3);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$response = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
 
 		$this->HttpSocket->nextHeader = '';
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000003') > 0);
-		$this->assertEqual($auth['nc'], 4);
+		$this->assertEquals($auth['nc'], 4);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$response2 = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
-		$this->assertNotEqual($response, $response2);
+		$this->assertNotEquals($response, $response2);
 	}
 
 /**
@@ -176,7 +176,7 @@ class DigestAuthenticationTest extends CakeTestCase {
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$response = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
-		$this->assertNotEqual($response, 'da7e2a46b471d77f70a9bb3698c8902b');
+		$this->assertNotEquals($response, 'da7e2a46b471d77f70a9bb3698c8902b');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -101,10 +101,10 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testBody() {
 		$this->HttpResponse->body = 'testing';
-		$this->assertEqual($this->HttpResponse->body(), 'testing');
+		$this->assertEquals($this->HttpResponse->body(), 'testing');
 
 		$this->HttpResponse->body = null;
-		$this->assertIdentical($this->HttpResponse->body(), '');
+		$this->assertSame($this->HttpResponse->body(), '');
 	}
 
 /**
@@ -114,12 +114,12 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testToString() {
 		$this->HttpResponse->body = 'other test';
-		$this->assertEqual($this->HttpResponse->body(), 'other test');
-		$this->assertEqual((string)$this->HttpResponse, 'other test');
+		$this->assertEquals($this->HttpResponse->body(), 'other test');
+		$this->assertEquals((string)$this->HttpResponse, 'other test');
 		$this->assertTrue(strpos($this->HttpResponse, 'test') > 0);
 
 		$this->HttpResponse->body = null;
-		$this->assertEqual((string)$this->HttpResponse, '');
+		$this->assertEquals((string)$this->HttpResponse, '');
 	}
 
 /**
@@ -135,15 +135,15 @@ class HttpResponseTest extends CakeTestCase {
 			'content-Type' => 'text/plain'
 		);
 
-		$this->assertEqual($this->HttpResponse->getHeader('foo'), 'Bar');
-		$this->assertEqual($this->HttpResponse->getHeader('Foo'), 'Bar');
-		$this->assertEqual($this->HttpResponse->getHeader('FOO'), 'Bar');
-		$this->assertEqual($this->HttpResponse->getHeader('header'), 'value');
-		$this->assertEqual($this->HttpResponse->getHeader('Content-Type'), 'text/plain');
-		$this->assertIdentical($this->HttpResponse->getHeader(0), null);
+		$this->assertEquals($this->HttpResponse->getHeader('foo'), 'Bar');
+		$this->assertEquals($this->HttpResponse->getHeader('Foo'), 'Bar');
+		$this->assertEquals($this->HttpResponse->getHeader('FOO'), 'Bar');
+		$this->assertEquals($this->HttpResponse->getHeader('header'), 'value');
+		$this->assertEquals($this->HttpResponse->getHeader('Content-Type'), 'text/plain');
+		$this->assertSame($this->HttpResponse->getHeader(0), null);
 
-		$this->assertEqual($this->HttpResponse->getHeader('foo', false), 'Bar');
-		$this->assertEqual($this->HttpResponse->getHeader('foo', array('foo' => 'not from class')), 'not from class');
+		$this->assertEquals($this->HttpResponse->getHeader('foo', false), 'Bar');
+		$this->assertEquals($this->HttpResponse->getHeader('foo', array('foo' => 'not from class')), 'not from class');
 	}
 
 /**
@@ -428,17 +428,17 @@ class HttpResponseTest extends CakeTestCase {
 				'value' => 'not=nice',
 			)
 		);
-		$this->assertEqual($cookies, $expected);
+		$this->assertEquals($cookies, $expected);
 
 		$header['Set-Cookie'][] = 'cakephp=great; Secure';
 		$expected['cakephp'] = array('value' => 'great', 'secure' => true);
 		$cookies = $this->HttpResponse->parseCookies($header);
-		$this->assertEqual($cookies, $expected);
+		$this->assertEquals($cookies, $expected);
 
 		$header['Set-Cookie'] = 'foo=bar';
 		unset($expected['people'], $expected['cakephp'], $expected['google']);
 		$cookies = $this->HttpResponse->parseCookies($header);
-		$this->assertEqual($cookies, $expected);
+		$this->assertEquals($cookies, $expected);
 	}
 
 /**
@@ -485,38 +485,38 @@ class HttpResponseTest extends CakeTestCase {
 		$this->HttpResponse->raw = "HTTP/1.1 200 OK\r\nServer: CakePHP\r\nContEnt-Type: text/plain\r\n\r\nThis is a test!";
 
 		$expected1 = "HTTP/1.1 200 OK\r\n";
-		$this->assertEqual($this->HttpResponse['raw']['status-line'], $expected1);
+		$this->assertEquals($this->HttpResponse['raw']['status-line'], $expected1);
 		$expected2 = "Server: CakePHP\r\nContEnt-Type: text/plain\r\n";
-		$this->assertEqual($this->HttpResponse['raw']['header'], $expected2);
+		$this->assertEquals($this->HttpResponse['raw']['header'], $expected2);
 		$expected3 = 'This is a test!';
-		$this->assertEqual($this->HttpResponse['raw']['body'], $expected3);
+		$this->assertEquals($this->HttpResponse['raw']['body'], $expected3);
 		$expected = $expected1 . $expected2 . "\r\n" . $expected3;
-		$this->assertEqual($this->HttpResponse['raw']['response'], $expected);
+		$this->assertEquals($this->HttpResponse['raw']['response'], $expected);
 
 		$expected = 'HTTP/1.1';
-		$this->assertEqual($this->HttpResponse['status']['http-version'], $expected);
+		$this->assertEquals($this->HttpResponse['status']['http-version'], $expected);
 		$expected = 200;
-		$this->assertEqual($this->HttpResponse['status']['code'], $expected);
+		$this->assertEquals($this->HttpResponse['status']['code'], $expected);
 		$expected = 'OK';
-		$this->assertEqual($this->HttpResponse['status']['reason-phrase'], $expected);
+		$this->assertEquals($this->HttpResponse['status']['reason-phrase'], $expected);
 
 		$expected = array(
 			'Server' => 'CakePHP',
 			'ContEnt-Type' => 'text/plain'
 		);
-		$this->assertEqual($this->HttpResponse['header'], $expected);
+		$this->assertEquals($this->HttpResponse['header'], $expected);
 
 		$expected = 'This is a test!';
-		$this->assertEqual($this->HttpResponse['body'], $expected);
+		$this->assertEquals($this->HttpResponse['body'], $expected);
 
 		$expected = array(
 			'foo' => array('value' => 'bar'),
 			'bar' => array('value' => 'foo')
 		);
-		$this->assertEqual($this->HttpResponse['cookies'], $expected);
+		$this->assertEquals($this->HttpResponse['cookies'], $expected);
 
 		$this->HttpResponse->raw = "HTTP/1.1 200 OK\r\n\r\nThis is a test!";
-		$this->assertIdentical($this->HttpResponse['raw']['header'], null);
+		$this->assertSame($this->HttpResponse['raw']['header'], null);
 	}
 
 }

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -709,7 +709,7 @@ class HttpSocketTest extends CakeTestCase {
 
 		$this->Socket->responseClass = 'CustomResponse';
 		$response = $this->Socket->request('http://www.cakephp.org/');
-		$this->assertIsA($response, 'CustomResponse');
+		$this->assertInstanceOf('CustomResponse', $response);
 		$this->assertEquals($response->first10, 'HTTP/1.x 2');
 	}
 

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -596,8 +596,8 @@ class HttpSocketTest extends CakeTestCase {
 				'value' => 'bar'
 			)
 		);
-		$this->assertEqual($result, $expect);
-		$this->assertEqual($this->Socket->config['request']['cookies']['www.cakephp.org'], $expect);
+		$this->assertEquals($result, $expect);
+		$this->assertEquals($this->Socket->config['request']['cookies']['www.cakephp.org'], $expect);
 		$this->assertFalse($this->Socket->connected);
 	}
 
@@ -646,15 +646,15 @@ class HttpSocketTest extends CakeTestCase {
 
 		$this->Socket->setContentResource($f);
 		$result = (string)$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($result, '');
-		$this->assertEqual($this->Socket->response['header']['Server'], 'CakeHttp Server');
+		$this->assertEquals($result, '');
+		$this->assertEquals($this->Socket->response['header']['Server'], 'CakeHttp Server');
 		fclose($f);
-		$this->assertEqual(file_get_contents(TMP . 'download.txt'), '<h1>This is a test!</h1>');
+		$this->assertEquals(file_get_contents(TMP . 'download.txt'), '<h1>This is a test!</h1>');
 		unlink(TMP . 'download.txt');
 
 		$this->Socket->setContentResource(false);
 		$result = (string)$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($result, '<h1>This is a test!</h1>');
+		$this->assertEquals($result, '<h1>This is a test!</h1>');
 	}
 
 /**
@@ -671,21 +671,21 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$expected = array('www.cakephp.org' => array('foo' => array('value' => 'bar')));
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: bar=foo\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$this->Socket->request('http://www.cakephp.org/other');
-		$this->assertEqual($this->Socket->request['cookies'], array('foo' => array('value' => 'bar')));
+		$this->assertEquals($this->Socket->request['cookies'], array('foo' => array('value' => 'bar')));
 		$expected['www.cakephp.org'] += array('bar' => array('value' => 'foo'));
-		$this->assertEqual($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$this->Socket->request('/other2');
-		$this->assertEqual($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: foobar=ok\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
@@ -693,7 +693,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->request('http://www.cake.com');
 		$this->assertTrue(empty($this->Socket->request['cookies']));
 		$expected['www.cake.com'] = array('foobar' => array('value' => 'ok'));
-		$this->assertEqual($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
 	}
 
 /**
@@ -710,7 +710,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->responseClass = 'CustomResponse';
 		$response = $this->Socket->request('http://www.cakephp.org/');
 		$this->assertIsA($response, 'CustomResponse');
-		$this->assertEqual($response->first10, 'HTTP/1.x 2');
+		$this->assertEquals($response->first10, 'HTTP/1.x 2');
 	}
 
 /**
@@ -726,9 +726,9 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->configProxy('proxy.server', 123);
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n";
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($this->Socket->request['raw'], $expected);
-		$this->assertEqual($this->Socket->config['host'], 'proxy.server');
-		$this->assertEqual($this->Socket->config['port'], 123);
+		$this->assertEquals($this->Socket->request['raw'], $expected);
+		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
+		$this->assertEquals($this->Socket->config['port'], 123);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -736,13 +736,13 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => null,
 			'pass' => null
 		);
-		$this->assertEqual($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($this->Socket->request['proxy'], $expected);
 
 		$expected = "GET http://www.cakephp.org/bakery HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n";
 		$this->Socket->request('/bakery');
-		$this->assertEqual($this->Socket->request['raw'], $expected);
-		$this->assertEqual($this->Socket->config['host'], 'proxy.server');
-		$this->assertEqual($this->Socket->config['port'], 123);
+		$this->assertEquals($this->Socket->request['raw'], $expected);
+		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
+		$this->assertEquals($this->Socket->config['port'], 123);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -750,14 +750,14 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => null,
 			'pass' => null
 		);
-		$this->assertEqual($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($this->Socket->request['proxy'], $expected);
 
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\nProxy-Authorization: Test mark.secret\r\n\r\n";
 		$this->Socket->configProxy('proxy.server', 123, 'Test', 'mark', 'secret');
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($this->Socket->request['raw'], $expected);
-		$this->assertEqual($this->Socket->config['host'], 'proxy.server');
-		$this->assertEqual($this->Socket->config['port'], 123);
+		$this->assertEquals($this->Socket->request['raw'], $expected);
+		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
+		$this->assertEquals($this->Socket->config['port'], 123);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -765,12 +765,12 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => 'mark',
 			'pass' => 'secret'
 		);
-		$this->assertEqual($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($this->Socket->request['proxy'], $expected);
 
 		$this->Socket->configAuth('Test', 'login', 'passwd');
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\nProxy-Authorization: Test mark.secret\r\nAuthorization: Test login.passwd\r\n\r\n";
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEqual($this->Socket->request['raw'], $expected);
+		$this->assertEquals($this->Socket->request['raw'], $expected);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -778,14 +778,14 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => 'mark',
 			'pass' => 'secret'
 		);
-		$this->assertEqual($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($this->Socket->request['proxy'], $expected);
 		$expected = array(
 			'Test' => array(
 				'user' => 'login',
 				'pass' => 'passwd'
 			)
 		);
-		$this->assertEqual($this->Socket->request['auth'], $expected);
+		$this->assertEquals($this->Socket->request['auth'], $expected);
 	}
 
 /**
@@ -904,8 +904,8 @@ class HttpSocketTest extends CakeTestCase {
 	public function testConsecutiveGetResetsAuthCredentials() {
 		$socket = new MockHttpSocket();
 		$socket->get('http://mark:secret@example.com/test');
-		$this->assertEqual($socket->request['uri']['user'], 'mark');
-		$this->assertEqual($socket->request['uri']['pass'], 'secret');
+		$this->assertEquals($socket->request['uri']['user'], 'mark');
+		$this->assertEquals($socket->request['uri']['pass'], 'secret');
 		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
 		$socket->get('/test2');
@@ -1407,7 +1407,7 @@ class HttpSocketTest extends CakeTestCase {
 		);
 		$expect = "Cookie: foo=bar; people=jim,jack,johnny\";\"\r\n";
 		$result = $this->Socket->buildCookies($cookies);
-		$this->assertEqual($result, $expect);
+		$this->assertEquals($result, $expect);
 	}
 
 /**
@@ -1425,14 +1425,14 @@ class HttpSocketTest extends CakeTestCase {
 			'\x1e','\x1f','\x7f'
 		);
 		$r = $this->Socket->tokenEscapeChars();
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		foreach ($expected as $key => $char) {
 			$expected[$key] = chr(hexdec(substr($char, 2)));
 		}
 
 		$r = $this->Socket->tokenEscapeChars(false);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -642,7 +642,9 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->connected = true;
 
 		$f = fopen(TMP . 'download.txt', 'w');
-		$this->skipUnless($f, 'Can not write in TMP directory.');
+		if (!$f) {
+			$this->markTestSkipped('Can not write in TMP directory.');
+		}
 
 		$this->Socket->setContentResource($f);
 		$result = (string)$this->Socket->request('http://www.cakephp.org/');

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -552,11 +552,11 @@ class DispatcherTest extends CakeTestCase {
 		$Dispatcher = new Dispatcher();
 
 		$test = $Dispatcher->parseParams(new CakeRequest("/testcontroller/testaction/params1/params2/params3"));
-		$this->assertIdentical($test['controller'], 'testcontroller');
-		$this->assertIdentical($test['action'], 'testaction');
-		$this->assertIdentical($test['pass'][0], 'params1');
-		$this->assertIdentical($test['pass'][1], 'params2');
-		$this->assertIdentical($test['pass'][2], 'params3');
+		$this->assertSame($test['controller'], 'testcontroller');
+		$this->assertSame($test['action'], 'testaction');
+		$this->assertSame($test['pass'][0], 'params1');
+		$this->assertSame($test['pass'][1], 'params2');
+		$this->assertSame($test['pass'][2], 'params3');
 		$this->assertFalse(!empty($test['form']));
 	}
 
@@ -581,11 +581,11 @@ class DispatcherTest extends CakeTestCase {
 	public function testParseParamsWithSingleZero() {
 		$Dispatcher = new Dispatcher();
 		$test = $Dispatcher->parseParams(new CakeRequest("/testcontroller/testaction/1/0/23"));
-		$this->assertIdentical($test['controller'], 'testcontroller');
-		$this->assertIdentical($test['action'], 'testaction');
-		$this->assertIdentical($test['pass'][0], '1');
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][1]);
-		$this->assertIdentical($test['pass'][2], '23');
+		$this->assertSame($test['controller'], 'testcontroller');
+		$this->assertSame($test['action'], 'testaction');
+		$this->assertSame($test['pass'][0], '1');
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][1]);
+		$this->assertSame($test['pass'][2], '23');
 	}
 
 /**
@@ -596,12 +596,12 @@ class DispatcherTest extends CakeTestCase {
 	public function testParseParamsWithManySingleZeros() {
 		$Dispatcher = new Dispatcher();
 		$test = $Dispatcher->parseParams(new CakeRequest("/testcontroller/testaction/0/0/0/0/0/0"));
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][0]);
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][1]);
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][2]);
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][3]);
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][4]);
-		$this->assertPattern('/\\A(?:0)\\z/', $test['pass'][5]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][0]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][1]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][2]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][3]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][4]);
+		$this->assertRegExp('/\\A(?:0)\\z/', $test['pass'][5]);
 	}
 
 /**
@@ -613,12 +613,12 @@ class DispatcherTest extends CakeTestCase {
 		$Dispatcher = new Dispatcher();
 		$request = new CakeRequest("/testcontroller/testaction/000/0000/00000/000000/000000/0000000");
 		$test = $Dispatcher->parseParams($request);
-		$this->assertPattern('/\\A(?:000)\\z/', $test['pass'][0]);
-		$this->assertPattern('/\\A(?:0000)\\z/', $test['pass'][1]);
-		$this->assertPattern('/\\A(?:00000)\\z/', $test['pass'][2]);
-		$this->assertPattern('/\\A(?:000000)\\z/', $test['pass'][3]);
-		$this->assertPattern('/\\A(?:000000)\\z/', $test['pass'][4]);
-		$this->assertPattern('/\\A(?:0000000)\\z/', $test['pass'][5]);
+		$this->assertRegExp('/\\A(?:000)\\z/', $test['pass'][0]);
+		$this->assertRegExp('/\\A(?:0000)\\z/', $test['pass'][1]);
+		$this->assertRegExp('/\\A(?:00000)\\z/', $test['pass'][2]);
+		$this->assertRegExp('/\\A(?:000000)\\z/', $test['pass'][3]);
+		$this->assertRegExp('/\\A(?:000000)\\z/', $test['pass'][4]);
+		$this->assertRegExp('/\\A(?:0000000)\\z/', $test['pass'][5]);
 	}
 
 /**
@@ -631,12 +631,12 @@ class DispatcherTest extends CakeTestCase {
 
 		$request = new CakeRequest("/testcontroller/testaction/01/0403/04010/000002/000030/0000400");
 		$test = $Dispatcher->parseParams($request);
-		$this->assertPattern('/\\A(?:01)\\z/', $test['pass'][0]);
-		$this->assertPattern('/\\A(?:0403)\\z/', $test['pass'][1]);
-		$this->assertPattern('/\\A(?:04010)\\z/', $test['pass'][2]);
-		$this->assertPattern('/\\A(?:000002)\\z/', $test['pass'][3]);
-		$this->assertPattern('/\\A(?:000030)\\z/', $test['pass'][4]);
-		$this->assertPattern('/\\A(?:0000400)\\z/', $test['pass'][5]);
+		$this->assertRegExp('/\\A(?:01)\\z/', $test['pass'][0]);
+		$this->assertRegExp('/\\A(?:0403)\\z/', $test['pass'][1]);
+		$this->assertRegExp('/\\A(?:04010)\\z/', $test['pass'][2]);
+		$this->assertRegExp('/\\A(?:000002)\\z/', $test['pass'][3]);
+		$this->assertRegExp('/\\A(?:000030)\\z/', $test['pass'][4]);
+		$this->assertRegExp('/\\A(?:0000400)\\z/', $test['pass'][5]);
 	}
 
 /**
@@ -654,8 +654,8 @@ class DispatcherTest extends CakeTestCase {
 		$Dispatcher = new Dispatcher();
 		$uri = new CakeRequest('posts/home/?coffee=life&sleep=sissies');
 		$result = $Dispatcher->parseParams($uri);
-		$this->assertPattern('/posts/', $result['controller']);
-		$this->assertPattern('/home/', $result['action']);
+		$this->assertRegExp('/posts/', $result['controller']);
+		$this->assertRegExp('/home/', $result['action']);
 		$this->assertTrue(isset($result['url']['sleep']));
 		$this->assertTrue(isset($result['url']['coffee']));
 
@@ -663,11 +663,11 @@ class DispatcherTest extends CakeTestCase {
 		$uri = new CakeRequest('/?coffee=life&sleep=sissy');
 
 		$result = $Dispatcher->parseParams($uri);
-		$this->assertPattern('/pages/', $result['controller']);
-		$this->assertPattern('/display/', $result['action']);
+		$this->assertRegExp('/pages/', $result['controller']);
+		$this->assertRegExp('/display/', $result['action']);
 		$this->assertTrue(isset($result['url']['sleep']));
 		$this->assertTrue(isset($result['url']['coffee']));
-		$this->assertEqual($result['url']['coffee'], 'life');
+		$this->assertEquals($result['url']['coffee'], 'life');
 	}
 
 /**
@@ -739,10 +739,10 @@ class DispatcherTest extends CakeTestCase {
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 		$expected = 'Pages';
-		$this->assertEqual($expected, $controller->name);
+		$this->assertEquals($expected, $controller->name);
 
 		$expected = array('0' => 'home', 'param' => 'value', 'param2' => 'value2');
-		$this->assertIdentical($expected, $controller->passedArgs);
+		$this->assertSame($expected, $controller->passedArgs);
 
 		Configure::write('App.baseUrl','/pages/index.php');
 
@@ -750,14 +750,14 @@ class DispatcherTest extends CakeTestCase {
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
 		$expected = 'Pages';
-		$this->assertEqual($expected, $controller->name);
+		$this->assertEquals($expected, $controller->name);
 
 		$url = new CakeRequest('pages/home/');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 		$this->assertNull($controller->plugin);
 
 		$expected = 'Pages';
-		$this->assertEqual($expected, $controller->name);
+		$this->assertEquals($expected, $controller->name);
 
 		unset($Dispatcher);
 
@@ -769,21 +769,21 @@ class DispatcherTest extends CakeTestCase {
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
 		$expected = 'Timesheets';
-		$this->assertEqual($expected, $controller->name);
+		$this->assertEquals($expected, $controller->name);
 
 		$url = new CakeRequest('timesheets/');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertEqual('Timesheets', $controller->name);
-		$this->assertEqual('/timesheets/index.php', $url->base);
+		$this->assertEquals('Timesheets', $controller->name);
+		$this->assertEquals('/timesheets/index.php', $url->base);
 
 		$url = new CakeRequest('test_dispatch_pages/camelCased');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual('TestDispatchPages', $controller->name);
+		$this->assertEquals('TestDispatchPages', $controller->name);
 
 		$url = new CakeRequest('test_dispatch_pages/camelCased/something. .');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual($controller->params['pass'][0], 'something. .', 'Period was chopped off. %s');
+		$this->assertEquals($controller->params['pass'][0], 'something. .', 'Period was chopped off. %s');
 	}
 
 /**
@@ -820,16 +820,16 @@ class DispatcherTest extends CakeTestCase {
 		Router::reload();
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertEqual($controller->name, 'TestDispatchPages');
+		$this->assertEquals($controller->name, 'TestDispatchPages');
 
-		$this->assertIdentical($controller->passedArgs, array('param' => 'value', 'param2' => 'value2'));
+		$this->assertSame($controller->passedArgs, array('param' => 'value', 'param2' => 'value2'));
 		$this->assertTrue($controller->params['admin']);
 
 		$expected = '/cake/repo/branches/1.2.x.x/index.php/admin/test_dispatch_pages/index/param:value/param2:value2';
-		$this->assertIdentical($expected, $controller->here);
+		$this->assertSame($expected, $controller->here);
 
 		$expected = '/cake/repo/branches/1.2.x.x/index.php';
-		$this->assertIdentical($expected, $controller->base);
+		$this->assertSame($expected, $controller->base);
 	}
 
 /**
@@ -858,13 +858,13 @@ class DispatcherTest extends CakeTestCase {
 			'controller'=> 'some_pages', 'action'=> 'display'
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch ' . $key . ' %');
+			$this->assertEquals($result[$key], $value, 'Value mismatch ' . $key . ' %');
 		}
 
-		$this->assertIdentical($controller->plugin, 'MyPlugin');
-		$this->assertIdentical($controller->name, 'SomePages');
-		$this->assertIdentical($controller->params['controller'], 'some_pages');
-		$this->assertIdentical($controller->passedArgs, array('0' => 'home', 'param'=>'value', 'param2'=>'value2'));
+		$this->assertSame($controller->plugin, 'MyPlugin');
+		$this->assertSame($controller->name, 'SomePages');
+		$this->assertSame($controller->params['controller'], 'some_pages');
+		$this->assertSame($controller->passedArgs, array('0' => 'home', 'param'=>'value', 'param2'=>'value2'));
 	}
 
 /**
@@ -889,16 +889,16 @@ class DispatcherTest extends CakeTestCase {
 		$response = $this->getMock('CakeResponse');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertIdentical($controller->plugin, 'MyPlugin');
-		$this->assertIdentical($controller->name, 'OtherPages');
-		$this->assertIdentical($controller->action, 'index');
-		$this->assertIdentical($controller->passedArgs, array('param' => 'value', 'param2' => 'value2'));
+		$this->assertSame($controller->plugin, 'MyPlugin');
+		$this->assertSame($controller->name, 'OtherPages');
+		$this->assertSame($controller->action, 'index');
+		$this->assertSame($controller->passedArgs, array('param' => 'value', 'param2' => 'value2'));
 
 		$expected = '/cake/repo/branches/1.2.x.x/my_plugin/other_pages/index/param:value/param2:value2';
-		$this->assertIdentical($expected, $url->here);
+		$this->assertSame($expected, $url->here);
 
 		$expected = '/cake/repo/branches/1.2.x.x';
-		$this->assertIdentical($expected, $url->base);
+		$this->assertSame($expected, $url->base);
 	}
 
 /**
@@ -922,10 +922,10 @@ class DispatcherTest extends CakeTestCase {
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertIdentical($controller->plugin, 'MyPlugin');
-		$this->assertIdentical($controller->name, 'MyPlugin');
-		$this->assertIdentical($controller->action, 'add');
-		$this->assertEqual($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
+		$this->assertSame($controller->plugin, 'MyPlugin');
+		$this->assertSame($controller->name, 'MyPlugin');
+		$this->assertSame($controller->action, 'add');
+		$this->assertEquals($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
 
 
 		Router::reload();
@@ -941,12 +941,12 @@ class DispatcherTest extends CakeTestCase {
 
 		$url = new CakeRequest($pluginUrl);
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertIdentical($controller->plugin, 'MyPlugin');
-		$this->assertIdentical($controller->name, 'MyPlugin');
-		$this->assertIdentical($controller->action, 'index');
+		$this->assertSame($controller->plugin, 'MyPlugin');
+		$this->assertSame($controller->name, 'MyPlugin');
+		$this->assertSame($controller->action, 'index');
 
 		$expected = $pluginUrl;
-		$this->assertEqual($controller->params['controller'], $expected);
+		$this->assertEquals($controller->params['controller'], $expected);
 
 
 		Configure::write('Routing.prefixes', array('admin'));
@@ -960,17 +960,17 @@ class DispatcherTest extends CakeTestCase {
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertEqual($controller->params['plugin'], 'my_plugin');
-		$this->assertEqual($controller->params['controller'], 'my_plugin');
-		$this->assertEqual($controller->params['action'], 'admin_add');
-		$this->assertEqual($controller->params['pass'], array(5));
-		$this->assertEqual($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
-		$this->assertIdentical($controller->plugin, 'MyPlugin');
-		$this->assertIdentical($controller->name, 'MyPlugin');
-		$this->assertIdentical($controller->action, 'admin_add');
+		$this->assertEquals($controller->params['plugin'], 'my_plugin');
+		$this->assertEquals($controller->params['controller'], 'my_plugin');
+		$this->assertEquals($controller->params['action'], 'admin_add');
+		$this->assertEquals($controller->params['pass'], array(5));
+		$this->assertEquals($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
+		$this->assertSame($controller->plugin, 'MyPlugin');
+		$this->assertSame($controller->name, 'MyPlugin');
+		$this->assertSame($controller->action, 'admin_add');
 
 		$expected = array(0 => 5, 'param'=>'value', 'param2'=>'value2');
-		$this->assertEqual($controller->passedArgs, $expected);
+		$this->assertEquals($controller->passedArgs, $expected);
 
 		Configure::write('Routing.prefixes', array('admin'));
 		CakePlugin::load('ArticlesTest', array('path' => '/fake/path'));
@@ -980,9 +980,9 @@ class DispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestDispatcher();
 
 		$controller = $Dispatcher->dispatch(new CakeRequest('admin/articles_test'), $response, array('return' => 1));
-		$this->assertIdentical($controller->plugin, 'ArticlesTest');
-		$this->assertIdentical($controller->name, 'ArticlesTest');
-		$this->assertIdentical($controller->action, 'admin_index');
+		$this->assertSame($controller->plugin, 'ArticlesTest');
+		$this->assertSame($controller->name, 'ArticlesTest');
+		$this->assertSame($controller->action, 'admin_index');
 
 		$expected = array(
 			'pass'=> array(),
@@ -995,7 +995,7 @@ class DispatcherTest extends CakeTestCase {
 			'return' => 1
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($controller->request[$key], $expected[$key], 'Value mismatch ' . $key);
+			$this->assertEquals($controller->request[$key], $expected[$key], 'Value mismatch ' . $key);
 		}
 	}
 
@@ -1016,9 +1016,9 @@ class DispatcherTest extends CakeTestCase {
 		$response = $this->getMock('CakeResponse');
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual($controller->params['controller'], 'my_plugin');
-		$this->assertEqual($controller->params['plugin'], 'my_plugin');
-		$this->assertEqual($controller->params['action'], 'index');
+		$this->assertEquals($controller->params['controller'], 'my_plugin');
+		$this->assertEquals($controller->params['plugin'], 'my_plugin');
+		$this->assertEquals($controller->params['action'], 'index');
 		$this->assertFalse(isset($controller->params['pass'][0]));
 	}
 
@@ -1045,24 +1045,24 @@ class DispatcherTest extends CakeTestCase {
 		$response = $this->getMock('CakeResponse');
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual($controller->params['controller'], 'test_plugin');
-		$this->assertEqual($controller->params['plugin'], 'test_plugin');
-		$this->assertEqual($controller->params['action'], 'index');
+		$this->assertEquals($controller->params['controller'], 'test_plugin');
+		$this->assertEquals($controller->params['plugin'], 'test_plugin');
+		$this->assertEquals($controller->params['action'], 'index');
 		$this->assertFalse(isset($controller->params['pass'][0]));
 
 		$url = new CakeRequest('/test_plugin/tests/index');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual($controller->params['controller'], 'tests');
-		$this->assertEqual($controller->params['plugin'], 'test_plugin');
-		$this->assertEqual($controller->params['action'], 'index');
+		$this->assertEquals($controller->params['controller'], 'tests');
+		$this->assertEquals($controller->params['plugin'], 'test_plugin');
+		$this->assertEquals($controller->params['action'], 'index');
 		$this->assertFalse(isset($controller->params['pass'][0]));
 
 		$url = new CakeRequest('/test_plugin/tests/index/some_param');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEqual($controller->params['controller'], 'tests');
-		$this->assertEqual($controller->params['plugin'], 'test_plugin');
-		$this->assertEqual($controller->params['action'], 'index');
-		$this->assertEqual($controller->params['pass'][0], 'some_param');
+		$this->assertEquals($controller->params['controller'], 'tests');
+		$this->assertEquals($controller->params['plugin'], 'test_plugin');
+		$this->assertEquals($controller->params['action'], 'index');
+		$this->assertEquals($controller->params['pass'][0], 'some_param');
 
 		App::build();
 	}
@@ -1123,9 +1123,9 @@ class DispatcherTest extends CakeTestCase {
 		$this->assertTrue(class_exists('TestPluginAppController'));
 		$this->assertTrue(class_exists('PluginsComponentComponent'));
 
-		$this->assertEqual($result->params['controller'], 'tests');
-		$this->assertEqual($result->params['plugin'], 'test_plugin');
-		$this->assertEqual($result->params['action'], 'index');
+		$this->assertEquals($result->params['controller'], 'tests');
+		$this->assertEquals($result->params['plugin'], 'test_plugin');
+		$this->assertEquals($result->params['action'], 'index');
 
 		App::build();
 	}
@@ -1151,13 +1151,13 @@ class DispatcherTest extends CakeTestCase {
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
 		$expected = 'SomePosts';
-		$this->assertEqual($expected, $controller->name);
+		$this->assertEquals($expected, $controller->name);
 
 		$expected = 'change';
-		$this->assertEqual($expected, $controller->action);
+		$this->assertEquals($expected, $controller->action);
 
 		$expected = array('changed');
-		$this->assertIdentical($expected, $controller->params['pass']);
+		$this->assertSame($expected, $controller->params['pass']);
 	}
 
 /**
@@ -1405,7 +1405,7 @@ class DispatcherTest extends CakeTestCase {
 		$cached = preg_replace('/<!--+[^<>]+-->/', '', $cached);
 		$expected =  str_replace(array("\t", "\r\n", "\n"), "", $cached);
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$filename = $this->__cachePath($request->here);
 		unlink($filename);
@@ -1426,7 +1426,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts'));
 		$expected = array('pass' => array(), 'named' => array(), 'plugin' => null, 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST');
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -1443,7 +1443,7 @@ class DispatcherTest extends CakeTestCase {
 			'[method]' => 'PUT'
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
 		}
 
 		unset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
@@ -1452,7 +1452,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts/5'));
 		$expected = array('pass' => array('5'), 'named' => array(), 'id' => '5', 'plugin' => null, 'controller' => 'posts', 'action' => 'view', '[method]' => 'GET');
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_POST['_method'] = 'PUT';
@@ -1460,7 +1460,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts/5'));
 		$expected = array('pass' => array('5'), 'named' => array(), 'id' => '5', 'plugin' => null, 'controller' => 'posts', 'action' => 'edit', '[method]' => 'PUT');
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_POST['_method'] = 'POST';
@@ -1474,7 +1474,7 @@ class DispatcherTest extends CakeTestCase {
 			'[method]' => 'POST', 'data' => array('extra' => 'data', 'Post' => array('title' => 'New Post')),
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEqual($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
 		}
 
 		unset($_POST['_method']);

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -44,9 +44,9 @@ class CakeRouteTest extends CakeTestCase {
 	public function testConstruction() {
 		$route = new CakeRoute('/:controller/:action/:id', array(), array('id' => '[0-9]+'));
 
-		$this->assertEqual($route->template, '/:controller/:action/:id');
-		$this->assertEqual($route->defaults, array());
-		$this->assertEqual($route->options, array('id' => '[0-9]+'));
+		$this->assertEquals($route->template, '/:controller/:action/:id');
+		$this->assertEquals($route->defaults, array());
+		$this->assertEquals($route->options, array('id' => '[0-9]+'));
 		$this->assertFalse($route->compiled());
 	}
 
@@ -59,32 +59,32 @@ class CakeRouteTest extends CakeTestCase {
 		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		$result = $route->compile();
 		$expected = '#^/*$#';
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($route->keys, array());
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($route->keys, array());
 
 		$route = new CakeRoute('/:controller/:action', array('controller' => 'posts'));
 		$result = $route->compile();
 
-		$this->assertPattern($result, '/posts/edit');
-		$this->assertPattern($result, '/posts/super_delete');
-		$this->assertNoPattern($result, '/posts');
-		$this->assertNoPattern($result, '/posts/super_delete/1');
+		$this->assertRegExp($result, '/posts/edit');
+		$this->assertRegExp($result, '/posts/super_delete');
+		$this->assertNotRegExp($result, '/posts');
+		$this->assertNotRegExp($result, '/posts/super_delete/1');
 
 		$route = new CakeRoute('/posts/foo:id', array('controller' => 'posts', 'action' => 'view'));
 		$result = $route->compile();
 
-		$this->assertPattern($result, '/posts/foo:1');
-		$this->assertPattern($result, '/posts/foo:param');
-		$this->assertNoPattern($result, '/posts');
-		$this->assertNoPattern($result, '/posts/');
+		$this->assertRegExp($result, '/posts/foo:1');
+		$this->assertRegExp($result, '/posts/foo:param');
+		$this->assertNotRegExp($result, '/posts');
+		$this->assertNotRegExp($result, '/posts/');
 
-		$this->assertEqual($route->keys, array('id'));
+		$this->assertEquals($route->keys, array('id'));
 
 		$route = new CakeRoute('/:plugin/:controller/:action/*', array('plugin' => 'test_plugin', 'action' => 'index'));
 		$result = $route->compile();
-		$this->assertPattern($result, '/test_plugin/posts/index');
-		$this->assertPattern($result, '/test_plugin/posts/edit/5');
-		$this->assertPattern($result, '/test_plugin/posts/edit/5/name:value/nick:name');
+		$this->assertRegExp($result, '/test_plugin/posts/index');
+		$this->assertRegExp($result, '/test_plugin/posts/edit/5');
+		$this->assertRegExp($result, '/test_plugin/posts/edit/5/name:value/nick:name');
 	}
 
 /**
@@ -95,11 +95,11 @@ class CakeRouteTest extends CakeTestCase {
 	public function testRouteParameterOverlap() {
 		$route = new CakeRoute('/invoices/add/:idd/:id', array('controller' => 'invoices', 'action' => 'add'));
 		$result = $route->compile();
-		$this->assertPattern($result, '/invoices/add/1/3');
+		$this->assertRegExp($result, '/invoices/add/1/3');
 
 		$route = new CakeRoute('/invoices/add/:id/:idd', array('controller' => 'invoices', 'action' => 'add'));
 		$result = $route->compile();
-		$this->assertPattern($result, '/invoices/add/1/3');
+		$this->assertRegExp($result, '/invoices/add/1/3');
 	}
 
 /**
@@ -114,11 +114,11 @@ class CakeRouteTest extends CakeTestCase {
 			array('id' => Router::ID)
 		);
 		$result = $route->compile();
-		$this->assertPattern($result, '/posts/edit/1');
-		$this->assertPattern($result, '/posts/view/518098');
-		$this->assertNoPattern($result, '/posts/edit/name-of-post');
-		$this->assertNoPattern($result, '/posts/edit/4/other:param');
-		$this->assertEqual($route->keys, array('controller', 'action', 'id'));
+		$this->assertRegExp($result, '/posts/edit/1');
+		$this->assertRegExp($result, '/posts/view/518098');
+		$this->assertNotRegExp($result, '/posts/edit/name-of-post');
+		$this->assertNotRegExp($result, '/posts/edit/4/other:param');
+		$this->assertEquals($route->keys, array('controller', 'action', 'id'));
 
 		$route = new CakeRoute(
 			'/:lang/:controller/:action/:id',
@@ -126,22 +126,22 @@ class CakeRouteTest extends CakeTestCase {
 			array('id' => Router::ID, 'lang' => '[a-z]{3}')
 		);
 		$result = $route->compile();
-		$this->assertPattern($result, '/eng/posts/edit/1');
-		$this->assertPattern($result, '/cze/articles/view/1');
-		$this->assertNoPattern($result, '/language/articles/view/2');
-		$this->assertNoPattern($result, '/eng/articles/view/name-of-article');
-		$this->assertEqual($route->keys, array('lang', 'controller', 'action', 'id'));
+		$this->assertRegExp($result, '/eng/posts/edit/1');
+		$this->assertRegExp($result, '/cze/articles/view/1');
+		$this->assertNotRegExp($result, '/language/articles/view/2');
+		$this->assertNotRegExp($result, '/eng/articles/view/name-of-article');
+		$this->assertEquals($route->keys, array('lang', 'controller', 'action', 'id'));
 
 		foreach (array(':', '@', ';', '$', '-') as $delim) {
 			$route = new CakeRoute('/posts/:id' . $delim . ':title');
 			$result = $route->compile();
 
-			$this->assertPattern($result, '/posts/1' . $delim . 'name-of-article');
-			$this->assertPattern($result, '/posts/13244' . $delim . 'name-of_Article[]');
-			$this->assertNoPattern($result, '/posts/11!nameofarticle');
-			$this->assertNoPattern($result, '/posts/11');
+			$this->assertRegExp($result, '/posts/1' . $delim . 'name-of-article');
+			$this->assertRegExp($result, '/posts/13244' . $delim . 'name-of_Article[]');
+			$this->assertNotRegExp($result, '/posts/11!nameofarticle');
+			$this->assertNotRegExp($result, '/posts/11');
 
-			$this->assertEqual($route->keys, array('id', 'title'));
+			$this->assertEquals($route->keys, array('id', 'title'));
 		}
 
 		$route = new CakeRoute(
@@ -150,12 +150,12 @@ class CakeRouteTest extends CakeTestCase {
 			array('id' => Router::ID, 'year' => Router::YEAR, 'title' => '[a-z-_]+')
 		);
 		$result = $route->compile();
-		$this->assertPattern($result, '/posts/1:name-of-article/2009/');
-		$this->assertPattern($result, '/posts/13244:name-of-article/1999');
-		$this->assertNoPattern($result, '/posts/hey_now:nameofarticle');
-		$this->assertNoPattern($result, '/posts/:nameofarticle/2009');
-		$this->assertNoPattern($result, '/posts/:nameofarticle/01');
-		$this->assertEqual($route->keys, array('id', 'title', 'year'));
+		$this->assertRegExp($result, '/posts/1:name-of-article/2009/');
+		$this->assertRegExp($result, '/posts/13244:name-of-article/1999');
+		$this->assertNotRegExp($result, '/posts/hey_now:nameofarticle');
+		$this->assertNotRegExp($result, '/posts/:nameofarticle/2009');
+		$this->assertNotRegExp($result, '/posts/:nameofarticle/01');
+		$this->assertEquals($route->keys, array('id', 'title', 'year'));
 
 		$route = new CakeRoute(
 			'/posts/:url_title-(uuid::id)',
@@ -163,12 +163,12 @@ class CakeRouteTest extends CakeTestCase {
 			array('pass' => array('id', 'url_title'), 'id' => Router::ID)
 		);
 		$result = $route->compile();
-		$this->assertPattern($result, '/posts/some_title_for_article-(uuid:12534)/');
-		$this->assertPattern($result, '/posts/some_title_for_article-(uuid:12534)');
-		$this->assertNoPattern($result, '/posts/');
-		$this->assertNoPattern($result, '/posts/nameofarticle');
-		$this->assertNoPattern($result, '/posts/nameofarticle-12347');
-		$this->assertEqual($route->keys, array('url_title', 'id'));
+		$this->assertRegExp($result, '/posts/some_title_for_article-(uuid:12534)/');
+		$this->assertRegExp($result, '/posts/some_title_for_article-(uuid:12534)');
+		$this->assertNotRegExp($result, '/posts/');
+		$this->assertNotRegExp($result, '/posts/nameofarticle');
+		$this->assertNotRegExp($result, '/posts/nameofarticle-12347');
+		$this->assertEquals($route->keys, array('url_title', 'id'));
 	}
 
 /**
@@ -184,15 +184,15 @@ class CakeRouteTest extends CakeTestCase {
 			array('year' => Router::YEAR, 'month' => Router::MONTH, 'day' => Router::DAY)
 		);
 		$result = $route->compile();
-		$this->assertPattern($result, '/posts/08/01/2007/title-of-post');
+		$this->assertRegExp($result, '/posts/08/01/2007/title-of-post');
 		$result = $route->parse('/posts/08/01/2007/title-of-post');
 
-		$this->assertEqual(count($result), 7);
-		$this->assertEqual($result['controller'], 'posts');
-		$this->assertEqual($result['action'], 'view');
-		$this->assertEqual($result['year'], '2007');
-		$this->assertEqual($result['month'], '08');
-		$this->assertEqual($result['day'], '01');
+		$this->assertEquals(count($result), 7);
+		$this->assertEquals($result['controller'], 'posts');
+		$this->assertEquals($result['action'], 'view');
+		$this->assertEquals($result['year'], '2007');
+		$this->assertEquals($result['month'], '08');
+		$this->assertEquals($result['day'], '01');
 		$this->assertEquals($result['pass'][0], 'title-of-post');
 
 
@@ -203,15 +203,15 @@ class CakeRouteTest extends CakeTestCase {
 		);
 		$result = $route->compile();
 
-		$this->assertPattern($result, '/some_extra/page/this_is_the_slug');
-		$this->assertPattern($result, '/page/this_is_the_slug');
-		$this->assertEqual($route->keys, array('extra', 'slug'));
-		$this->assertEqual($route->options, array('extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'));
+		$this->assertRegExp($result, '/some_extra/page/this_is_the_slug');
+		$this->assertRegExp($result, '/page/this_is_the_slug');
+		$this->assertEquals($route->keys, array('extra', 'slug'));
+		$this->assertEquals($route->options, array('extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'));
 		$expected = array(
 			'controller' => 'pages',
 			'action' => 'view'
 		);
-		$this->assertEqual($route->defaults, $expected);
+		$this->assertEquals($route->defaults, $expected);
 
 		$route = new CakeRoute(
 			'/:controller/:action/*',
@@ -224,11 +224,11 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($route->parse('/chaw_test/wiki'));
 
 		$result = $route->compile();
-		$this->assertNoPattern($result, '/some_project/source');
-		$this->assertPattern($result, '/source/view');
-		$this->assertPattern($result, '/source/view/other/params');
-		$this->assertNoPattern($result, '/chaw_test/wiki');
-		$this->assertNoPattern($result, '/source/wierd_action');
+		$this->assertNotRegExp($result, '/some_project/source');
+		$this->assertRegExp($result, '/source/view');
+		$this->assertRegExp($result, '/source/view/other/params');
+		$this->assertNotRegExp($result, '/chaw_test/wiki');
+		$this->assertNotRegExp($result, '/source/wierd_action');
 	}
 
 /**
@@ -245,11 +245,11 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 1));
-		$this->assertEqual($result, '/posts/view/1');
+		$this->assertEquals($result, '/posts/view/1');
 
 		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'about'));
 		$this->assertFalse($result);
@@ -257,15 +257,15 @@ class CakeRouteTest extends CakeTestCase {
 
 		$route = new CakeRoute('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEqual($result, '/pages/home');
+		$this->assertEquals($result, '/pages/home');
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'about'));
-		$this->assertEqual($result, '/pages/about');
+		$this->assertEquals($result, '/pages/about');
 
 
 		$route = new CakeRoute('/blog/:action', array('controller' => 'posts'));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view'));
-		$this->assertEqual($result, '/blog/view');
+		$this->assertEquals($result, '/blog/view');
 
 		$result = $route->match(array('controller' => 'nodes', 'action' => 'view'));
 		$this->assertFalse($result);
@@ -279,15 +279,15 @@ class CakeRouteTest extends CakeTestCase {
 
 		$route = new CakeRoute('/foo/:controller/:action', array('action' => 'index'));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view'));
-		$this->assertEqual($result, '/foo/posts/view');
+		$this->assertEquals($result, '/foo/posts/view');
 
 
 		$route = new CakeRoute('/:plugin/:id/*', array('controller' => 'posts', 'action' => 'view'));
 		$result = $route->match(array('plugin' => 'test', 'controller' => 'posts', 'action' => 'view', 'id' => '1'));
-		$this->assertEqual($result, '/test/1/');
+		$this->assertEquals($result, '/test/1/');
 
 		$result = $route->match(array('plugin' => 'fo', 'controller' => 'posts', 'action' => 'view', 'id' => '1', '0'));
-		$this->assertEqual($result, '/fo/1/0');
+		$this->assertEquals($result, '/fo/1/0');
 
 		$result = $route->match(array('plugin' => 'fo', 'controller' => 'nodes', 'action' => 'view', 'id' => 1));
 		$this->assertFalse($result);
@@ -303,7 +303,7 @@ class CakeRouteTest extends CakeTestCase {
 		$url = array('controller' => 'subscribe', 'admin' => true, 'action' => 'edit', 1);
 		$result = $route->match($url);
 		$expected = '/admin/subscriptions/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -342,7 +342,7 @@ class CakeRouteTest extends CakeTestCase {
 		$result = $route->match(array(
 			'controller' => 'posts', 'action' => 'index', 'plugin' => null, 'admin' => false
 		));
-		$this->assertEqual($result, '/posts/index/');
+		$this->assertEquals($result, '/posts/index/');
 	}
 
 /**
@@ -355,29 +355,29 @@ class CakeRouteTest extends CakeTestCase {
 
 		$route = new CakeRoute('/:controller/:action/*', array('plugin' => null));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'index', 'plugin' => null, 'page' => 1));
-		$this->assertEqual($result, '/posts/index/page:1');
+		$this->assertEquals($result, '/posts/index/page:1');
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 5));
-		$this->assertEqual($result, '/posts/view/5');
+		$this->assertEquals($result, '/posts/view/5');
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 0));
-		$this->assertEqual($result, '/posts/view/0');
+		$this->assertEquals($result, '/posts/view/0');
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, '0'));
-		$this->assertEqual($result, '/posts/view/0');
+		$this->assertEquals($result, '/posts/view/0');
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 5, 'page' => 1, 'limit' => 20, 'order' => 'title'));
-		$this->assertEqual($result, '/posts/view/5/page:1/limit:20/order:title');
+		$this->assertEquals($result, '/posts/view/5/page:1/limit:20/order:title');
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 'word space', 'order' => 'Θ'));
-		$this->assertEqual($result, '/posts/view/word%20space/order:%CE%98');
+		$this->assertEquals($result, '/posts/view/word%20space/order:%CE%98');
 
 		$route = new CakeRoute('/test2/*', array('controller' => 'pages', 'action' => 'display', 2));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 1));
 		$this->assertFalse($result);
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 2, 'something'));
-		$this->assertEqual($result, '/test2/something');
+		$this->assertEquals($result, '/test2/something');
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 5, 'something'));
 		$this->assertFalse($result);
@@ -425,10 +425,10 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '9'));
-		$this->assertEqual($result, '/posts/view/9');
+		$this->assertEquals($result, '/posts/view/9');
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '922'));
-		$this->assertEqual($result, '/posts/view/922');
+		$this->assertEquals($result, '/posts/view/922');
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 'a99'));
 		$this->assertFalse($result);
@@ -448,14 +448,14 @@ class CakeRouteTest extends CakeTestCase {
 		$url = array('controller' => 'posts', 'action' => 'index');
 		$params = array('lang' => 'en', 'color' => 'blue');
 		$result = $route->persistParams($url, $params);
-		$this->assertEqual($result['lang'], 'en');
-		$this->assertEqual($result['color'], 'blue');
+		$this->assertEquals($result['lang'], 'en');
+		$this->assertEquals($result['color'], 'blue');
 
 		$url = array('controller' => 'posts', 'action' => 'index', 'color' => 'red');
 		$params = array('lang' => 'en', 'color' => 'blue');
 		$result = $route->persistParams($url, $params);
-		$this->assertEqual($result['lang'], 'en');
-		$this->assertEqual($result['color'], 'red');
+		$this->assertEquals($result['lang'], 'en');
+		$this->assertEquals($result['color'], 'red');
 	}
 
 /**
@@ -471,9 +471,9 @@ class CakeRouteTest extends CakeTestCase {
 		);
 		$route->compile();
 		$result = $route->parse('/posts/view/1');
-		$this->assertEqual($result['controller'], 'posts');
-		$this->assertEqual($result['action'], 'view');
-		$this->assertEqual($result['id'], '1');
+		$this->assertEquals($result['controller'], 'posts');
+		$this->assertEquals($result['action'], 'view');
+		$this->assertEquals($result['id'], '1');
 
 		$route = new Cakeroute(
 			'/admin/:controller',
@@ -484,8 +484,8 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->parse('/admin/posts');
-		$this->assertEqual($result['controller'], 'posts');
-		$this->assertEqual($result['action'], 'index');
+		$this->assertEquals($result['controller'], 'posts');
+		$this->assertEquals($result['action'], 'index');
 	}
 
 /**
@@ -536,7 +536,7 @@ class CakeRouteTest extends CakeTestCase {
 
 		$result = $route->parse('/blog/other');
 		$expected = array('controller' => 'blog_posts', 'action' => 'other', 'pass' => array(), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $route->parse('/blog/foobar');
 		$this->assertFalse($result);
@@ -684,7 +684,7 @@ class CakeRouteTest extends CakeTestCase {
 			),
 			'pass' => array(),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $route->parse('/tests/action/theanswer[is]:42/var[]:val2/var[]:val3');
 		$expected = array(
@@ -701,7 +701,7 @@ class CakeRouteTest extends CakeTestCase {
 			),
 			'pass' => array(),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $route->parse('/tests/action/theanswer[is][not]:42/theanswer[]:5/theanswer[is]:6');
 		$expected = array(
@@ -718,7 +718,7 @@ class CakeRouteTest extends CakeTestCase {
 			),
 			'pass' => array(),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
@@ -45,9 +45,9 @@ class PluginShortRouteTestCase extends  CakeTestCase {
 		$route = new PluginShortRoute('/:plugin', array('action' => 'index'), array('plugin' => 'foo|bar'));
 
 		$result = $route->parse('/foo');
-		$this->assertEqual($result['plugin'], 'foo');
-		$this->assertEqual($result['controller'], 'foo');
-		$this->assertEqual($result['action'], 'index');
+		$this->assertEquals($result['plugin'], 'foo');
+		$this->assertEquals($result['controller'], 'foo');
+		$this->assertEquals($result['action'], 'index');
 
 		$result = $route->parse('/wrong');
 		$this->assertFalse($result, 'Wrong plugin name matched %s');
@@ -65,6 +65,6 @@ class PluginShortRouteTestCase extends  CakeTestCase {
 		$this->assertFalse($result, 'plugin controller mismatch was converted. %s');
 
 		$result = $route->match(array('plugin' => 'foo', 'controller' => 'foo', 'action' => 'index'));
-		$this->assertEqual($result, '/foo');
+		$this->assertEquals($result, '/foo');
 	}
 }

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -48,51 +48,51 @@ class RedirectRouteTestCase extends  CakeTestCase {
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/home');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/posts', true)));
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/posts', true)));
 
 		$route = new RedirectRoute('/home', array('controller' => 'posts', 'action' => 'index'));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/home');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/posts', true)));
-		$this->assertEqual($route->response->statusCode(), 301);
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/posts', true)));
+		$this->assertEquals($route->response->statusCode(), 301);
 
 		$route = new RedirectRoute('/google', 'http://google.com');
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/google');
-		$this->assertEqual($route->response->header(), array('Location' => 'http://google.com'));
+		$this->assertEquals($route->response->header(), array('Location' => 'http://google.com'));
 
 		$route = new RedirectRoute('/posts/*', array('controller' => 'posts', 'action' => 'view'), array('status' => 302));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/posts/view', true)));
-		$this->assertEqual($route->response->statusCode(), 302);
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/posts/view', true)));
+		$this->assertEquals($route->response->statusCode(), 302);
 
 		$route = new RedirectRoute('/posts/*', array('controller' => 'posts', 'action' => 'view'), array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/posts/view/2', true)));
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/posts/view/2', true)));
 
 		$route = new RedirectRoute('/posts/*', '/test', array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/test', true)));
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/test', true)));
 
 		$route = new RedirectRoute('/my_controllers/:action/*', array('controller' => 'tags', 'action' => 'add'), array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/tags/add/passme/named:param', true)));
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/tags/add/passme/named:param', true)));
 
 		$route = new RedirectRoute('/my_controllers/:action/*', array('controller' => 'tags', 'action' => 'add'));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
-		$this->assertEqual($route->response->header(), array('Location' => Router::url('/tags/add', true)));
+		$this->assertEquals($route->response->header(), array('Location' => Router::url('/tags/add', true)));
 	}
 
 }

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -61,10 +61,10 @@ class RouterTest extends CakeTestCase {
 		if ($skip) {
 			$this->markTestSkipped('Cannot validate base urls in CLI');
 		}
-		$this->assertPattern('/^http(s)?:\/\//', Router::url('/', true));
-		$this->assertPattern('/^http(s)?:\/\//', Router::url(null, true));
-		$this->assertPattern('/^http(s)?:\/\//', Router::url(array('full_base' => true)));
-		$this->assertIdentical(FULL_BASE_URL . '/', Router::url(array('full_base' => true)));
+		$this->assertRegExp('/^http(s)?:\/\//', Router::url('/', true));
+		$this->assertRegExp('/^http(s)?:\/\//', Router::url(null, true));
+		$this->assertRegExp('/^http(s)?:\/\//', Router::url(array('full_base' => true)));
+		$this->assertSame(FULL_BASE_URL . '/', Router::url(array('full_base' => true)));
 	}
 
 /**
@@ -74,7 +74,7 @@ class RouterTest extends CakeTestCase {
  */
 	public function testRouteDefaultParams() {
 		Router::connect('/:controller', array('controller' => 'posts'));
-		$this->assertEqual(Router::url(array('action' => 'index')), '/');
+		$this->assertEquals(Router::url(array('action' => 'index')), '/');
 	}
 
 /**
@@ -87,27 +87,27 @@ class RouterTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
-		$this->assertEqual($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
-		$this->assertEqual($resources, array('posts'));
+		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
+		$this->assertEquals($resources, array('posts'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/13');
-		$this->assertEqual($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => '13', '[method]' => 'GET'));
+		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => '13', '[method]' => 'GET'));
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
-		$this->assertEqual($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
+		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/13');
-		$this->assertEqual($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '13', '[method]' => 'PUT'));
+		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '13', '[method]' => 'PUT'));
 
 		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
-		$this->assertEqual($result, array('pass' => array('475acc39-a328-44d3-95fb-015000000000'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '475acc39-a328-44d3-95fb-015000000000', '[method]' => 'PUT'));
+		$this->assertEquals($result, array('pass' => array('475acc39-a328-44d3-95fb-015000000000'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '475acc39-a328-44d3-95fb-015000000000', '[method]' => 'PUT'));
 
 		$_SERVER['REQUEST_METHOD'] = 'DELETE';
 		$result = Router::parse('/posts/13');
-		$this->assertEqual($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'delete', 'id' => '13', '[method]' => 'DELETE'));
+		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'delete', 'id' => '13', '[method]' => 'DELETE'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/add');
@@ -115,15 +115,15 @@ class RouterTest extends CakeTestCase {
 
 		Router::reload();
 		$resources = Router::mapResources('Posts', array('id' => '[a-z0-9_]+'));
-		$this->assertEqual($resources, array('posts'));
+		$this->assertEquals($resources, array('posts'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/add');
-		$this->assertEqual($result, array('pass' => array('add'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => 'add', '[method]' => 'GET'));
+		$this->assertEquals($result, array('pass' => array('add'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => 'add', '[method]' => 'GET'));
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/name');
-		$this->assertEqual($result, array('pass' => array('name'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'));
+		$this->assertEquals($result, array('pass' => array('name'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'));
 	}
 
 /**
@@ -149,8 +149,8 @@ class RouterTest extends CakeTestCase {
 			'action' => 'index',
 			'[method]' => 'GET'
 		);
-		$this->assertEqual($result, $expected);
-		$this->assertEqual($resources, array('test_plugin'));
+		$this->assertEquals($result, $expected);
+		$this->assertEquals($resources, array('test_plugin'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/test_plugin/test_plugin/13');
@@ -163,7 +163,7 @@ class RouterTest extends CakeTestCase {
 			'id' => '13',
 			'[method]' => 'GET'
 		);
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 	}
 
 /**
@@ -189,8 +189,8 @@ class RouterTest extends CakeTestCase {
 			'action' => 'index',
 			'[method]' => 'GET'
 		);
-		$this->assertEqual($result, $expected);
-		$this->assertEqual($resources, array('test_plugin'));
+		$this->assertEquals($result, $expected);
+		$this->assertEquals($resources, array('test_plugin'));
 	}
 
 /**
@@ -203,11 +203,11 @@ class RouterTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
-		$this->assertEqual($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
+		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
-		$this->assertEqual($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
+		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
 	}
 
 /**
@@ -220,27 +220,27 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
 		$expected = '/posts';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', '[method]' => 'GET', 'id' => 10));
 		$expected = '/posts/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
 		$expected = '/posts';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', '[method]' => 'PUT', 'id' => 10));
 		$expected = '/posts/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'delete', '[method]' => 'DELETE', 'id' => 10));
 		$expected = '/posts/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', '[method]' => 'POST', 'id' => 10));
 		$expected = '/posts/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -252,37 +252,37 @@ class RouterTest extends CakeTestCase {
 		$expected = '/users/logout';
 
 		$result = Router::normalize('/users/logout/');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::normalize('//users//logout//');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::normalize('users/logout');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::normalize(array('controller' => 'users', 'action' => 'logout'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::normalize('/');
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$result = Router::normalize('http://google.com/');
-		$this->assertEqual($result, 'http://google.com/');
+		$this->assertEquals($result, 'http://google.com/');
 
 		$result = Router::normalize('http://google.com//');
-		$this->assertEqual($result, 'http://google.com//');
+		$this->assertEquals($result, 'http://google.com//');
 
 		$result = Router::normalize('/users/login/scope://foo');
-		$this->assertEqual($result, '/users/login/scope:/foo');
+		$this->assertEquals($result, '/users/login/scope:/foo');
 
 		$result = Router::normalize('/recipe/recipes/add');
-		$this->assertEqual($result, '/recipe/recipes/add');
+		$this->assertEquals($result, '/recipe/recipes/add');
 
 		$request = new CakeRequest();
 		$request->base = '/us';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('/us/users/logout/');
-		$this->assertEqual($result, '/users/logout');
+		$this->assertEquals($result, '/users/logout');
 
 		Router::reload();
 
@@ -290,7 +290,7 @@ class RouterTest extends CakeTestCase {
 		$request->base = '/cake_12';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('/cake_12/users/logout/');
-		$this->assertEqual($result, '/users/logout');
+		$this->assertEquals($result, '/users/logout');
 
 		Router::reload();
 		$_back = Configure::read('App.baseUrl');
@@ -300,7 +300,7 @@ class RouterTest extends CakeTestCase {
 		$request->base = '/';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('users/login');
-		$this->assertEqual($result, '/users/login');
+		$this->assertEquals($result, '/users/login');
 		Configure::write('App.baseUrl', $_back);
 
 		Router::reload();
@@ -308,10 +308,10 @@ class RouterTest extends CakeTestCase {
 		$request->base = 'beer';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('beer/admin/beers_tags/add');
-		$this->assertEqual($result, '/admin/beers_tags/add');
+		$this->assertEquals($result, '/admin/beers_tags/add');
 
 		$result = Router::normalize('/admin/beers_tags/add');
-		$this->assertEqual($result, '/admin/beers_tags/add');
+		$this->assertEquals($result, '/admin/beers_tags/add');
 	}
 
 /**
@@ -332,18 +332,18 @@ class RouterTest extends CakeTestCase {
 		Router::setRequestInfo($request);
 
 		$result = Router::url();
-		$this->assertEqual('/magazine', $result);
+		$this->assertEquals('/magazine', $result);
 
 		Router::reload();
 
 		Router::connect('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		$out = Router::url(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEqual($out, '/');
+		$this->assertEquals($out, '/');
 
 		Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 'about'));
 		$expected = '/pages/about';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:plugin/:id/*', array('controller' => 'posts', 'action' => 'view'), array('id' => $ID));
@@ -351,11 +351,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => 'cake_plugin', 'controller' => 'posts', 'action' => 'view', 'id' => '1'));
 		$expected = '/cake_plugin/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => 'cake_plugin', 'controller' => 'posts', 'action' => 'view', 'id' => '1', '0'));
 		$expected = '/cake_plugin/1/0';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:controller/:action/:id', array(), array('id' => $ID));
@@ -363,7 +363,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 'id' => '1'));
 		$expected = '/posts/view/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:controller/:id', array('action' => 'view'));
@@ -371,17 +371,17 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 'id' => '1'));
 		$expected = '/posts/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index', '0'));
 		$expected = '/posts/index/0';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::connect('/view/*', array('controller' => 'posts', 'action' => 'view'));
 		Router::promote();
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', '1'));
 		$expected = '/view/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		$request = new CakeRequest();
@@ -398,11 +398,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'real_controller_name', 'page' => '1'));
 		$expected = '/short_controller_name/index/page:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'add'));
 		$expected = '/short_controller_name/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::parse('/');
@@ -417,7 +417,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('action' => 'login'));
 		$expected = '/users/login';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/page/*', array('plugin' => null, 'controller' => 'pages', 'action' => 'view'));
@@ -425,7 +425,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => 'my_plugin', 'controller' => 'pages', 'action' => 'view', 'my-page'));
 		$expected = '/my_plugin/pages/view/my-page';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/contact/:action', array('plugin' => 'contact', 'controller' => 'contact'));
@@ -434,7 +434,7 @@ class RouterTest extends CakeTestCase {
 		$result = Router::url(array('plugin' => 'contact', 'controller' => 'contact', 'action' => 'me'));
 
 		$expected = '/contact/me';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		$request = new CakeRequest();
@@ -448,7 +448,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'myothercontroller'));
 		$expected = '/myothercontroller';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -461,7 +461,7 @@ class RouterTest extends CakeTestCase {
 			1, 2, 3
 		)));
 		$expected = '/tests/index/pages[0]:1/pages[1]:2/pages[2]:3';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'tests',
 			'pages' => array(
@@ -473,7 +473,7 @@ class RouterTest extends CakeTestCase {
 			)
 		));
 		$expected = '/tests/index/pages[param1][0]:one/pages[param1][1]:two/pages[0]:three';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'tests',
 			'pages' => array(
@@ -485,7 +485,7 @@ class RouterTest extends CakeTestCase {
 			)
 		));
 		$expected = '/tests/index/pages[param1][one]:1/pages[param1][two]:2/pages[0]:three';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'tests',
 			'super' => array(
@@ -497,14 +497,14 @@ class RouterTest extends CakeTestCase {
 			)
 		));
 		$expected = '/tests/index/super[nested][array]:awesome/super[nested][something]:else/super[0]:cool';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'tests', 'namedParam' => array(
 			'keyed' => 'is an array',
 			'test'
 		)));
 		$expected = '/tests/index/namedParam[keyed]:is an array/namedParam[0]:test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -515,20 +515,20 @@ class RouterTest extends CakeTestCase {
 	public function testUrlGenerationWithQueryStrings() {
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => 'var=test&var2=test2'));
 		$expected = '/posts/index/0?var=test&var2=test2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => 'var=test&var2=test2'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => array('var' => 'test', 'var2' => 'test2')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => array('var' => null)));
-		$this->assertEqual($result, '/posts/index/0');
+		$this->assertEquals($result, '/posts/index/0');
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => 'var=test&var2=test2', '#' => 'unencoded string %'));
 		$expected = '/posts/index/0?var=test&var2=test2#unencoded+string+%25';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -556,11 +556,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('admin' => false, 'language' => 'dan', 'action' => 'index', 'controller' => 'galleries'));
 		$expected = '/dan/galleries';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('admin' => false, 'language' => 'eng', 'action' => 'index', 'controller' => 'galleries'));
 		$expected = '/eng/galleries';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:language/pages',
@@ -571,14 +571,14 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('language' => 'eng', 'action' => 'index', 'controller' => 'pages'));
 		$expected = '/eng/pages';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('language' => 'eng', 'controller' => 'pages'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('language' => 'eng', 'controller' => 'pages', 'action' => 'add'));
 		$expected = '/eng/pages/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/forestillinger/:month/:year/*',
@@ -589,7 +589,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'month' => 10, 'year' => 2007, 'min-forestilling'));
 		$expected = '/forestillinger/10/2007/min-forestilling';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/kalender/:month/:year/*',
@@ -601,11 +601,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'min-forestilling'));
 		$expected = '/kalender/min-forestilling';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'year' => 2007, 'month' => 10, 'min-forestilling'));
 		$expected = '/kalender/10/2007/min-forestilling';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:controller/:action/*', array(), array(
@@ -644,7 +644,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('page' => 2));
 		$expected = '/admin/registrations/index/page:2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		$request = new CakeRequest();
@@ -680,11 +680,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('action' => 'edit', 1));
 		$expected = '/magazine/admin/subscriptions/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('admin' => true, 'controller' => 'users', 'action' => 'login'));
 		$expected = '/magazine/admin/users/login';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		Router::reload();
@@ -703,7 +703,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('admin' => true, 'controller' => 'pages', 'action' => 'view', 'my-page'));
 		$expected = '/page/my-page';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 
@@ -720,7 +720,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false));
 		$expected = '/admin/pages/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		Router::reload();
@@ -737,7 +737,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false));
 		$expected = '/admin/pages/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/admin/:controller/:action/:id', array('admin' => true), array('id' => '[0-9]+'));
@@ -755,7 +755,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'edit', 'id' => '284'));
 		$expected = '/admin/pages/edit/284';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		Router::reload();
@@ -773,7 +773,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false));
 		$expected = '/admin/pages/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		Router::reload();
@@ -791,7 +791,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'edit', 284));
 		$expected = '/admin/pages/edit/284';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		Router::reload();
@@ -808,7 +808,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('all'));
 		$expected = '/admin/posts/all';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -820,19 +820,19 @@ class RouterTest extends CakeTestCase {
 		Router::parse('/');
 		$result = Router::url(array('plugin' => null, 'controller' => 'articles', 'action' => 'add', 'id' => null, 'ext' => 'json'));
 		$expected = '/articles/add.json';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'articles', 'action' => 'add', 'ext' => 'json'));
 		$expected = '/articles/add.json';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'articles', 'action' => 'index', 'id' => null, 'ext' => 'json'));
 		$expected = '/articles.json';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'articles', 'action' => 'index', 'ext' => 'json'));
 		$expected = '/articles.json';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -850,7 +850,7 @@ class RouterTest extends CakeTestCase {
 			))
 		);
 
-		$this->assertEqual(Router::url('read/1'), '/base/test/controller/read/1');
+		$this->assertEquals(Router::url('read/1'), '/base/test/controller/read/1');
 
 		Router::reload();
 		Router::connect('/:lang/:plugin/:controller/*', array('action' => 'index'));
@@ -873,7 +873,7 @@ class RouterTest extends CakeTestCase {
 			'controller' => 'shows', 'action' => 'index', 'page' => '1',
 		));
 		$expected = '/en/shows/shows/page:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -908,13 +908,13 @@ class RouterTest extends CakeTestCase {
 			))
 		);
 		$result = Router::url(array('plugin' => null, 'controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, '/admin/posts');
+		$this->assertEquals($result, '/admin/posts');
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, '/admin/this/posts');
+		$this->assertEquals($result, '/admin/this/posts');
 
 		$result = Router::url(array('plugin' => 'aliased', 'controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, '/admin/other/posts/index');
+		$this->assertEquals($result, '/admin/other/posts/index');
 	}
 
 /**
@@ -928,43 +928,43 @@ class RouterTest extends CakeTestCase {
 		Router::connect('/posts/:value/:somevalue/:othervalue/*', array('controller' => 'posts', 'action' => 'view'), array('value','somevalue', 'othervalue'));
 		$result = Router::parse('/posts/2007/08/01/title-of-post-here');
 		$expected = array('value' => '2007', 'somevalue' => '08', 'othervalue' => '01', 'controller' => 'posts', 'action' => 'view', 'plugin' =>'', 'pass' => array('0' => 'title-of-post-here'), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:year/:month/:day/*', array('controller' => 'posts', 'action' => 'view'), array('year' => $Year, 'month' => $Month, 'day' => $Day));
 		$result = Router::parse('/posts/2007/08/01/title-of-post-here');
 		$expected = array('year' => '2007', 'month' => '08', 'day' => '01', 'controller' => 'posts', 'action' => 'view', 'plugin' =>'', 'pass' => array('0' => 'title-of-post-here'), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:day/:year/:month/*', array('controller' => 'posts', 'action' => 'view'), array('year' => $Year, 'month' => $Month, 'day' => $Day));
 		$result = Router::parse('/posts/01/2007/08/title-of-post-here');
 		$expected = array('day' => '01', 'year' => '2007', 'month' => '08', 'controller' => 'posts', 'action' => 'view', 'plugin' =>'', 'pass' => array('0' => 'title-of-post-here'), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:month/:day/:year/*', array('controller' => 'posts', 'action' => 'view'), array('year' => $Year, 'month' => $Month, 'day' => $Day));
 		$result = Router::parse('/posts/08/01/2007/title-of-post-here');
 		$expected = array('month' => '08', 'day' => '01', 'year' => '2007', 'controller' => 'posts', 'action' => 'view', 'plugin' =>'', 'pass' => array('0' => 'title-of-post-here'), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:year/:month/:day/*', array('controller' => 'posts', 'action' => 'view'));
 		$result = Router::parse('/posts/2007/08/01/title-of-post-here');
 		$expected = array('year' => '2007', 'month' => '08', 'day' => '01', 'controller' => 'posts', 'action' => 'view', 'plugin' =>'', 'pass' => array('0' => 'title-of-post-here'), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::parse('/pages/display/home');
 		$expected = array('plugin' => null, 'pass' => array('home'), 'controller' => 'pages', 'action' => 'display', 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('pages/display/home/');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('pages/display/home');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/page/*', array('controller' => 'test'));
@@ -975,7 +975,7 @@ class RouterTest extends CakeTestCase {
 		Router::connect('/:language/contact', array('language' => 'eng', 'plugin' => 'contact', 'controller' => 'contact', 'action' => 'index'), array('language' => '[a-z]{3}'));
 		$result = Router::parse('/eng/contact');
 		$expected = array('pass' => array(), 'named' => array(), 'language' => 'eng', 'plugin' => 'contact', 'controller' => 'contact', 'action' => 'index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/forestillinger/:month/:year/*',
@@ -985,54 +985,54 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/forestillinger/10/2007/min-forestilling');
 		$expected = array('pass' => array('min-forestilling'), 'plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'year' => 2007, 'month' => 10, 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:controller/:action/*');
 		Router::connect('/', array('plugin' => 'pages', 'controller' => 'pages', 'action' => 'display'));
 		$result = Router::parse('/');
 		$expected = array('pass' => array(), 'named' => array(), 'controller' => 'pages', 'action' => 'display', 'plugin' => 'pages');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/edit/0');
 		$expected = array('pass' => array(0), 'named' => array(), 'controller' => 'posts', 'action' => 'edit', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:id::url_title', array('controller' => 'posts', 'action' => 'view'), array('pass' => array('id', 'url_title'), 'id' => '[\d]+'));
 		$result = Router::parse('/posts/5:sample-post-title');
 		$expected = array('pass' => array('5', 'sample-post-title'), 'named' => array(), 'id' => 5, 'url_title' => 'sample-post-title', 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:id::url_title/*', array('controller' => 'posts', 'action' => 'view'), array('pass' => array('id', 'url_title'), 'id' => '[\d]+'));
 		$result = Router::parse('/posts/5:sample-post-title/other/params/4');
 		$expected = array('pass' => array('5', 'sample-post-title', 'other', 'params', '4'), 'named' => array(), 'id' => 5, 'url_title' => 'sample-post-title', 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/:url_title-(uuid::id)', array('controller' => 'posts', 'action' => 'view'), array('pass' => array('id', 'url_title'), 'id' => $UUID));
 		$result = Router::parse('/posts/sample-post-title-(uuid:47fc97a9-019c-41d1-a058-1fa3cbdd56cb)');
 		$expected = array('pass' => array('47fc97a9-019c-41d1-a058-1fa3cbdd56cb', 'sample-post-title'), 'named' => array(), 'id' => '47fc97a9-019c-41d1-a058-1fa3cbdd56cb', 'url_title' => 'sample-post-title', 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/view/*', array('controller' => 'posts', 'action' => 'view'), array('named' => false));
 		$result = Router::parse('/posts/view/foo:bar/routing:fun');
 		$expected = array('pass' => array('foo:bar', 'routing:fun'), 'named' => array(), 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/view/*', array('controller' => 'posts', 'action' => 'view'), array('named' => array('foo', 'answer')));
 		$result = Router::parse('/posts/view/foo:bar/routing:fun/answer:42');
 		$expected = array('pass' => array('routing:fun'), 'named' => array('foo' => 'bar', 'answer' => '42'), 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/posts/view/*', array('controller' => 'posts', 'action' => 'view'), array('named' => array('foo', 'answer'), 'greedyNamed' => true));
 		$result = Router::parse('/posts/view/foo:bar/routing:fun/answer:42');
 		$expected = array('pass' => array(), 'named' => array('foo' => 'bar', 'routing' => 'fun', 'answer' => '42'), 'plugin' => null, 'controller' => 'posts', 'action' => 'view');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1074,27 +1074,27 @@ class RouterTest extends CakeTestCase {
 		);
 		$expected = '/en/red/posts/view/6';
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 6));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '/en/blue/posts/index';
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index', 'color' => 'blue'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '/posts/edit/6';
 		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', 6, 'color' => null, 'lang' => null));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '/posts';
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '/posts/edit/7';
 		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', 7));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '/about';
 		$result = Router::url(array('controller' => 'pages', 'action' => 'view', 'about'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1110,7 +1110,7 @@ class RouterTest extends CakeTestCase {
 		);
 		$result = Router::parse('/subjects/add/4795d601-19c8-49a6-930e-06a8b01d17b7');
 		$expected = array('pass' => array(), 'named' => array(), 'category_id' => '4795d601-19c8-49a6-930e-06a8b01d17b7', 'plugin' => null, 'controller' => 'subjects', 'action' => 'add');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1127,11 +1127,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/some_extra/page/this_is_the_slug');
 		$expected = array('pass' => array(), 'named' => array(), 'plugin' => null, 'controller' => 'pages', 'action' => 'view', 'slug' => 'this_is_the_slug', 'extra' => 'some_extra');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/page/this_is_the_slug');
 		$expected = array('pass' => array(), 'named' => array(), 'plugin' => null, 'controller' => 'pages', 'action' => 'view', 'slug' => 'this_is_the_slug', 'extra' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect(
@@ -1143,11 +1143,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('admin' => null, 'plugin' => null, 'controller' => 'pages', 'action' => 'view', 'slug' => 'this_is_the_slug', 'extra' => null));
 		$expected = '/page/this_is_the_slug';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('admin' => null, 'plugin' => null, 'controller' => 'pages', 'action' => 'view', 'slug' => 'this_is_the_slug', 'extra' => 'some_extra'));
 		$expected = '/some_extra/page/this_is_the_slug';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1163,13 +1163,13 @@ class RouterTest extends CakeTestCase {
 		Router::reload();
 		$result = Router::prefixes();
 		$expected = array('admin', 'member', 'super_user');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing.prefixes', array('admin', 'member'));
 		Router::reload();
 		$result = Router::prefixes();
 		$expected = array('admin', 'member');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing', $restore);
 	}
@@ -1206,7 +1206,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('plugin' => 'test_plugin', 'controller' => 'test_plugin', 'action' => 'index'));
 		$expected = '/admin/test_plugin';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
@@ -1228,13 +1228,13 @@ class RouterTest extends CakeTestCase {
 			'admin' => true, 'prefix' => 'admin'
 		));
 		$expected = '/admin/test_plugin/show_tickets/edit/6';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array(
 			'plugin' => 'test_plugin', 'controller' => 'show_tickets', 'action' => 'index', 'admin' => true
 		));
 		$expected = '/admin/test_plugin/show_tickets';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		App::build(array('plugins' => $paths));
 	}
@@ -1248,7 +1248,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals(array(), Router::extensions());
 
 		Router::parseExtensions('rss');
-		$this->assertEqual(Router::extensions(), array('rss'));
+		$this->assertEquals(Router::extensions(), array('rss'));
 	}
 
 /**
@@ -1262,18 +1262,18 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/posts.rss');
 		$expected = array('plugin' => null, 'controller' => 'posts', 'action' => 'index', 'ext' => 'rss', 'pass'=> array(), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/view/1.rss');
 		$expected = array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'pass' => array('1'), 'named' => array(), 'ext' => 'rss', 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/view/1.rss?query=test');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/view/1.atom');
 		$expected['ext'] = 'atom';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
@@ -1282,24 +1282,24 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/posts.xml');
 		$expected = array('plugin' => null, 'controller' => 'posts', 'action' => 'index', 'ext' => 'xml', 'pass'=> array(), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts.atom?hello=goodbye');
 		$expected = array('plugin' => null, 'controller' => 'posts.atom', 'action' => 'index', 'pass' => array(), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => 'rss'));
 		$result = Router::parse('/controller/action');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::parseExtensions('rss');
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', 'ext' => 'rss'));
 		$result = Router::parse('/controller/action');
 		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, 'ext' => 'rss', 'named' => array(), 'pass' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1310,25 +1310,25 @@ class RouterTest extends CakeTestCase {
 	public function testQuerystringGeneration() {
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => 'var=test&var2=test2'));
 		$expected = '/posts/index/0?var=test&var2=test2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => array('var' => 'test', 'var2' => 'test2')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected .= '&more=test+data';
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => array('var' => 'test', 'var2' => 'test2', 'more' => 'test data')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 // Test bug #4614
 		$restore = ini_get('arg_separator.output');
 		ini_set('arg_separator.output', '&amp;');
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => array('var' => 'test', 'var2' => 'test2', 'more' => 'test data')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		ini_set('arg_separator.output', $restore);
 
 		$result = Router::url(array('controller' => 'posts', 'action'=>'index', '0', '?' => array('var' => 'test', 'var2' => 'test2')), array('escape' => true));
 		$expected = '/posts/index/0?var=test&amp;var2=test2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1339,21 +1339,21 @@ class RouterTest extends CakeTestCase {
 	public function testConnectNamed() {
 		$named = Router::connectNamed(false, array('default' => true));
 		$this->assertFalse($named['greedyNamed']);
-		$this->assertEqual(array_keys($named['rules']), $named['default']);
+		$this->assertEquals(array_keys($named['rules']), $named['default']);
 
 		Router::reload();
 		Router::connect('/foo/*', array('controller' => 'bar', 'action' => 'fubar'));
 		Router::connectNamed(array(), array('separator' => '='));
 		$result = Router::parse('/foo/param1=value1/param2=value2');
 		$expected = array('pass' => array(), 'named' => array('param1' => 'value1', 'param2' => 'value2'), 'controller' => 'bar', 'action' => 'fubar', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/controller/action/*', array('controller' => 'controller', 'action' => 'action'), array('named' => array('param1' => 'value[\d]')));
 		Router::connectNamed(array(), array('greedy' => false, 'separator' => '='));
 		$result = Router::parse('/controller/action/param1=value1/param2=value2');
 		$expected = array('pass' => array('param2=value2'), 'named' => array('param1' => 'value1'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/:controller/:action/*');
@@ -1370,11 +1370,11 @@ class RouterTest extends CakeTestCase {
 	public function testNamedArgsUrlGeneration() {
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index', 'published' => 1, 'deleted' => 1));
 		$expected = '/posts/index/published:1/deleted:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index', 'published' => 0, 'deleted' => 0));
 		$expected = '/posts/index/published:0/deleted:0';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		extract(Router::getNamedExpressions());
@@ -1384,11 +1384,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'graphs', 'action' => 'view', 'id' => 12, 'file' => 'asdf.png'));
 		$expected = '/12/file:asdf.png';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'graphs', 'action' => 'view', 12, 'file' => 'asdf.foo'));
 		$expected = '/graphs/view/12/file:asdf.foo';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing.prefixes', array('admin'));
 
@@ -1407,7 +1407,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('page' => 1, 0 => null, 'sort' => 'controller', 'direction' => 'asc', 'order' => null));
 		$expected = "/admin/controller/index/page:1/sort:controller/direction:asc";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		$request = new CakeRequest('admin/controller/index');
@@ -1420,7 +1420,7 @@ class RouterTest extends CakeTestCase {
 		$result = Router::parse('/admin/controller/index/type:whatever');
 		$result = Router::url(array('type'=> 'new'));
 		$expected = "/admin/controller/index/type:new";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1433,22 +1433,22 @@ class RouterTest extends CakeTestCase {
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::parse('/controller/action/param1:value1:1/param2:value2:3/param:value');
 		$expected = array('pass' => array(), 'named' => array('param1' => 'value1:1', 'param2' => 'value2:3', 'param' => 'value'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::connectNamed(false);
-		$this->assertEqual(array_keys($result['rules']), array());
+		$this->assertEquals(array_keys($result['rules']), array());
 		$this->assertFalse($result['greedyNamed']);
 		$result = Router::parse('/controller/action/param1:value1:1/param2:value2:3/param:value');
 		$expected = array('pass' => array('param1:value1:1', 'param2:value2:3', 'param:value'), 'named' => array(), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::connectNamed(true);
 		$named = Router::namedConfig();
-		$this->assertEqual(array_keys($result['rules']), $named['default']);
+		$this->assertEquals(array_keys($result['rules']), $named['default']);
 		$this->assertTrue($result['greedyNamed']);
 
 		Router::reload();
@@ -1456,32 +1456,32 @@ class RouterTest extends CakeTestCase {
 		Router::connectNamed(array('param1' => 'not-matching'));
 		$result = Router::parse('/controller/action/param1:value1:1/param2:value2:3/param:value');
 		$expected = array('pass' => array('param1:value1:1'), 'named' => array('param2' => 'value2:3', 'param' => 'value'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/foo/view/param1:value1:1/param2:value2:3/param:value');
 		$expected = array('pass' => array('param1:value1:1'), 'named' => array('param2' => 'value2:3', 'param' => 'value'), 'controller' => 'foo', 'action' => 'view', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		Router::connectNamed(array('param1' => '[\d]', 'param2' => '[a-z]', 'param3' => '[\d]'));
 		$result = Router::parse('/controller/action/param1:1/param2:2/param3:3');
 		$expected = array('pass' => array('param2:2'), 'named' => array('param1' => '1', 'param3' => '3'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		Router::connectNamed(array('param1' => '[\d]', 'param2' => true, 'param3' => '[\d]'));
 		$result = Router::parse('/controller/action/param1:1/param2:2/param3:3');
 		$expected = array('pass' => array(), 'named' => array('param1' => '1', 'param2' => '2', 'param3' => '3'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		Router::connectNamed(array('param1' => 'value[\d]+:[\d]+'), array('greedy' => false));
 		$result = Router::parse('/controller/action/param1:value1:1/param2:value2:3/param3:value');
 		$expected = array('pass' => array('param2:value2:3', 'param3:value'), 'named' => array('param1' => 'value1:1'), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1513,7 +1513,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('protected' => true));
 		$expected = '/protected/images/index';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add'));
 		$expected = '/images/add';
@@ -1521,40 +1521,40 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add', 'protected' => true));
 		$expected = '/protected/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1));
 		$expected = '/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'protected_edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1));
 		$expected = '/others/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/others/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true, 'page' => 1));
 		$expected = '/protected/others/edit/1/page:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::connectNamed(array('random'));
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true, 'random' => 'my-value'));
 		$expected = '/protected/others/edit/1/random:my-value';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1581,48 +1581,48 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add'));
 		$expected = '/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add', 'protected' => true));
 		$expected = '/protected/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1));
 		$expected = '/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'protected_edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'protectededit', 1, 'protected' => true));
 		$expected = '/protected/images/protectededit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/images/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1));
 		$expected = '/others/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true));
 		$expected = '/protected/others/edit/1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true, 'page' => 1));
 		$expected = '/protected/others/edit/1/page:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::connectNamed(array('random'));
 		$result = Router::url(array('controller' => 'others', 'action' => 'edit', 1, 'protected' => true, 'random' => 'my-value'));
 		$expected = '/protected/others/edit/1/random:my-value';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1649,11 +1649,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add'));
 		$expected = '/protected/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add', 'protected' => false));
 		$expected = '/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1680,7 +1680,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'images', 'action' => 'add', 'admin' => true));
 		$expected = '/admin/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$request = new CakeRequest();
 		Router::setRequestInfo(
@@ -1695,7 +1695,7 @@ class RouterTest extends CakeTestCase {
 		);
 		$result = Router::url(array('controller' => 'images', 'action' => 'add', 'protected' => true));
 		$expected = '/protected/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1718,15 +1718,15 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'my_controller', 'action' => 'my_action'));
 		$expected = '/base/my_controller/my_action';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'my_controller', 'action' => 'my_action', 'base' => false));
 		$expected = '/my_controller/my_action';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'my_controller', 'action' => 'my_action', 'base' => true));
 		$expected = '/base/my_controller/my_action/base:1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1740,11 +1740,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/');
 		$expected = array('pass'=> array('home'), 'named' => array(), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/home/');
 		$expected = array('pass' => array('home'), 'named' => array(), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
@@ -1752,19 +1752,19 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/');
 		$expected = array('pass' => array('home'), 'named' => array(), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/display/home/event:value');
 		$expected = array('pass' => array('home'), 'named' => array('event' => 'value'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/display/home/event:Val_u2');
 		$expected = array('pass' => array('home'), 'named' => array('event' => 'Val_u2'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/pages/display/home/event:val-ue');
 		$expected = array('pass' => array('home'), 'named' => array('event' => 'val-ue'), 'plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 		Router::connect('/', array('controller' => 'posts', 'action' => 'index'));
@@ -1772,7 +1772,7 @@ class RouterTest extends CakeTestCase {
 		$result = Router::parse('/pages/contact/');
 
 		$expected = array('pass'=>array('contact'), 'named' => array(), 'plugin'=> null, 'controller'=>'pages', 'action'=>'display');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1784,10 +1784,10 @@ class RouterTest extends CakeTestCase {
 		Router::reload();
 		Router::connect('/:controller/:action/*');
 		$result = Router::parse('/posts/view/something.');
-		$this->assertEqual($result['pass'][0], 'something.', 'Period was chopped off %s');
+		$this->assertEquals($result['pass'][0], 'something.', 'Period was chopped off %s');
 
 		$result = Router::parse('/posts/view/something. . .');
-		$this->assertEqual($result['pass'][0], 'something. . .', 'Period was chopped off %s');
+		$this->assertEquals($result['pass'][0], 'something. . .', 'Period was chopped off %s');
 	}
 
 /**
@@ -1801,10 +1801,10 @@ class RouterTest extends CakeTestCase {
 		Router::parseExtensions('json');
 
 		$result = Router::parse('/posts/view/something.');
-		$this->assertEqual($result['pass'][0], 'something.', 'Period was chopped off %s');
+		$this->assertEquals($result['pass'][0], 'something.', 'Period was chopped off %s');
 
 		$result = Router::parse('/posts/view/something. . .');
-		$this->assertEqual($result['pass'][0], 'something. . .', 'Period was chopped off %s');
+		$this->assertEquals($result['pass'][0], 'something. . .', 'Period was chopped off %s');
 	}
 
 /**
@@ -1827,7 +1827,7 @@ class RouterTest extends CakeTestCase {
 			'pass' => array(),
 			'named' => array()
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/blog/foobar');
 		$this->assertEquals(array(), $result);
@@ -1863,18 +1863,18 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/admin/posts/');
 		$expected = array('pass' => array(), 'named' => array(), 'prefix' => 'admin', 'plugin' => null, 'controller' => 'posts', 'action' => 'admin_index', 'admin' => true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/admin/posts');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('admin' => true, 'controller' => 'posts'));
 		$expected = '/base/admin/posts';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::prefixes();
 		$expected = array('admin');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Router::reload();
 
@@ -1897,15 +1897,15 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/members/posts/index');
 		$expected = array('pass' => array(), 'named' => array(), 'prefix' => 'members', 'plugin' => null, 'controller' => 'posts', 'action' => 'members_index', 'members' => true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('members' => true, 'controller' => 'posts', 'action' =>'index', 'page' => 2));
 		$expected = '/base/members/posts/index/page:2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('members' => true, 'controller' => 'users', 'action' => 'add'));
 		$expected = '/base/members/users/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1919,11 +1919,11 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'company' => true));
 		$expected = '/company/users/login';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'company_login', 'company' => true));
 		$expected = '/company/users/login';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$request = new CakeRequest();
 		Router::setRequestInfo(
@@ -1939,7 +1939,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'company' => false));
 		$expected = '/login';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1964,13 +1964,13 @@ class RouterTest extends CakeTestCase {
 			))
 		);
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'admin' => true));
-		$this->assertEqual($result, '/admin/login');
+		$this->assertEquals($result, '/admin/login');
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'login'));
-		$this->assertEqual($result, '/admin/login');
+		$this->assertEquals($result, '/admin/login');
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'admin_login'));
-		$this->assertEqual($result, '/admin/login');
+		$this->assertEquals($result, '/admin/login');
 	}
 
 /**
@@ -1986,15 +1986,15 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 1, 'whatever'));
 		$expected = '/test/whatever';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 2, 'whatever'));
 		$expected = '/test2/whatever';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 'home', 'whatever'));
 		$expected = '/test-passed/whatever';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
@@ -2020,11 +2020,11 @@ class RouterTest extends CakeTestCase {
 		Router::parse('/');
 		$result = Router::url(array('controller' => 'images', 'action' => 'add'));
 		$expected = '/protected/images/add';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::prefixes();
 		$expected = array('admin', 'protected');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2037,7 +2037,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::parse('/eng/test/test_action');
 		$expected = array('pass' => array(), 'named' => array(), 'locale' => 'eng', 'controller' => 'test', 'action' => 'test_action', 'plugin' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/badness/test/test_action');
 		$this->assertEquals(array(), $result);
@@ -2059,15 +2059,15 @@ class RouterTest extends CakeTestCase {
 
 		$result = Router::url(array('action' => 'test_another_action'));
 		$expected = '/test/test_another_action';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'test_another_action', 'locale' => 'eng'));
 		$expected = '/eng/test/test_another_action';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('action' => 'test_another_action', 'locale' => 'badness'));
 		$expected = '/test/test_another_action/locale:badness';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2080,9 +2080,9 @@ class RouterTest extends CakeTestCase {
 		$url = 'example.com/' . $pluginName . '/';
 		$expected = 'example.com';
 
-		$this->assertEqual(Router::stripPlugin($url, $pluginName), $expected);
-		$this->assertEqual(Router::stripPlugin($url), $url);
-		$this->assertEqual(Router::stripPlugin($url, null), $url);
+		$this->assertEquals(Router::stripPlugin($url, $pluginName), $expected);
+		$this->assertEquals(Router::stripPlugin($url), $url);
+		$this->assertEquals(Router::stripPlugin($url, null), $url);
 	}
 /**
  * testCurentRoute
@@ -2096,7 +2096,7 @@ class RouterTest extends CakeTestCase {
 		Router::connect('/government', $url);
 		Router::parse('/government');
 		$route = Router::currentRoute();
-		$this->assertEqual(array_merge($url, array('plugin' => null)), $route->defaults);
+		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 	}
 /**
  * testRequestRoute
@@ -2108,21 +2108,21 @@ class RouterTest extends CakeTestCase {
 		Router::connect('/government', $url);
 		Router::parse('/government');
 		$route = Router::requestRoute();
-		$this->assertEqual(array_merge($url, array('plugin' => null)), $route->defaults);
+		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 
 		// test that the first route is matched
 		$newUrl = array('controller' => 'products', 'action' => 'display', 6);
 		Router::connect('/government', $url);
 		Router::parse('/government');
 		$route = Router::requestRoute();
-		$this->assertEqual(array_merge($url, array('plugin' => null)), $route->defaults);
+		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 
 		// test that an unmatched route does not change the current route
 		$newUrl = array('controller' => 'products', 'action' => 'display', 6);
 		Router::connect('/actor', $url);
 		Router::parse('/government');
 		$route = Router::requestRoute();
-		$this->assertEqual(array_merge($url, array('plugin' => null)), $route->defaults);
+		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 	}
 /**
  * testGetParams
@@ -2138,18 +2138,18 @@ class RouterTest extends CakeTestCase {
 			'plugin' => null, 'controller' => false, 'action' => false,
 			'param1' => '1', 'param2' => '2'
 		);
-		$this->assertEqual(Router::getParams(), $expected);
-		$this->assertEqual(Router::getParam('controller'), false);
-		$this->assertEqual(Router::getParam('param1'), '1');
-		$this->assertEqual(Router::getParam('param2'), '2');
+		$this->assertEquals(Router::getParams(), $expected);
+		$this->assertEquals(Router::getParam('controller'), false);
+		$this->assertEquals(Router::getParam('param1'), '1');
+		$this->assertEquals(Router::getParam('param2'), '2');
 
 		Router::reload();
 
 		$params = array('controller' => 'pages', 'action' => 'display');
 		Router::setRequestInfo(array($params, $paths));
 		$expected = array('plugin' => null, 'controller' => 'pages', 'action' => 'display');
-		$this->assertEqual(Router::getParams(), $expected);
-		$this->assertEqual(Router::getParams(true), $expected);
+		$this->assertEquals(Router::getParams(), $expected);
+		$this->assertEquals(Router::getParams(true), $expected);
 	}
 
 /**
@@ -2180,17 +2180,17 @@ class RouterTest extends CakeTestCase {
 		require CAKE . 'Config' . DS . 'routes.php';
 
 		$result = Router::url(array('plugin' => 'plugin_js', 'controller' => 'js_file', 'action' => 'index'));
-		$this->assertEqual($result, '/plugin_js/js_file');
+		$this->assertEquals($result, '/plugin_js/js_file');
 
 		$result = Router::parse('/plugin_js/js_file');
 		$expected = array(
 			'plugin' => 'plugin_js', 'controller' => 'js_file', 'action' => 'index',
 			'named' => array(), 'pass' => array()
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => 'test_plugin', 'controller' => 'test_plugin', 'action' => 'index'));
-		$this->assertEqual($result, '/test_plugin');
+		$this->assertEquals($result, '/test_plugin');
 
 		$result = Router::parse('/test_plugin');
 		$expected = array(
@@ -2198,7 +2198,7 @@ class RouterTest extends CakeTestCase {
 			'named' => array(), 'pass' => array()
 		);
 
-		$this->assertEqual($expected, $result, 'Plugin shortcut route broken. %s');
+		$this->assertEquals($expected, $result, 'Plugin shortcut route broken. %s');
 	}
 
 /**
@@ -2219,7 +2219,7 @@ class RouterTest extends CakeTestCase {
 			->method('parse')
 			->will($this->returnValue($expected));
 		$result = Router::parse('/test');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2251,7 +2251,7 @@ class RouterTest extends CakeTestCase {
 			'_Token' => array('key' => 'sekret')
 		);
 		$result = Router::reverse($params);
-		$this->assertEqual($result, '/posts/view/1');
+		$this->assertEquals($result, '/posts/view/1');
 
 		$params = array(
 			'controller' => 'posts',
@@ -2261,7 +2261,7 @@ class RouterTest extends CakeTestCase {
 			'url' => array()
 		);
 		$result = Router::reverse($params);
-		$this->assertEqual($result, '/posts/index/1/page:1/sort:Article.title/direction:desc');
+		$this->assertEquals($result, '/posts/index/1/page:1/sort:Article.title/direction:desc');
 
 		Router::connect('/:lang/:controller/:action/*', array(), array('lang' => '[a-z]{3}'));
 		$params = array(
@@ -2273,7 +2273,7 @@ class RouterTest extends CakeTestCase {
 			'url' => array('url' => 'eng/posts/view/1')
 		);
 		$result = Router::reverse($params);
-		$this->assertEqual($result, '/eng/posts/view/1');
+		$this->assertEquals($result, '/eng/posts/view/1');
 
 		$params = array(
 			'lang' => 'eng',
@@ -2286,7 +2286,7 @@ class RouterTest extends CakeTestCase {
 			'models' => array()
 		);
 		$result = Router::reverse($params);
-		$this->assertEqual($result, '/eng/posts/view/1?foo=bar&baz=quu');
+		$this->assertEquals($result, '/eng/posts/view/1?foo=bar&baz=quu');
 
 		$request = new CakeRequest('/eng/posts/view/1');
 		$request->addParams(array(
@@ -2310,7 +2310,7 @@ class RouterTest extends CakeTestCase {
 			'url' => array('url' => 'eng/posts/view/1')
 		);
 		$result = Router::reverse($params, true);
-		$this->assertPattern('/^http(s)?:\/\//', $result);
+		$this->assertRegExp('/^http(s)?:\/\//', $result);
 	}
 
 /**
@@ -2353,11 +2353,11 @@ class RouterTest extends CakeTestCase {
 			)
 		));
 		$result = Router::getRequest();
-		$this->assertEqual($result->controller, 'images');
-		$this->assertEqual($result->action, 'index');
-		$this->assertEqual($result->base, '');
-		$this->assertEqual($result->here, '/protected/images/index');
-		$this->assertEqual($result->webroot, '/');
+		$this->assertEquals($result->controller, 'images');
+		$this->assertEquals($result->action, 'index');
+		$this->assertEquals($result->base, '');
+		$this->assertEquals($result->here, '/protected/images/index');
+		$this->assertEquals($result->webroot, '/');
 	}
 
 /**
@@ -2413,16 +2413,16 @@ class RouterTest extends CakeTestCase {
  */
 	public function testUrlProtocol() {
 		$url = 'http://example.com';
-		$this->assertEqual($url, Router::url($url));
+		$this->assertEquals($url, Router::url($url));
 
 		$url = 'ed2k://example.com';
-		$this->assertEqual($url, Router::url($url));
+		$this->assertEquals($url, Router::url($url));
 
 		$url = 'svn+ssh://example.com';
-		$this->assertEqual($url, Router::url($url));
+		$this->assertEquals($url, Router::url($url));
 
 		$url = '://example.com';
-		$this->assertEqual($url, Router::url($url));
+		$this->assertEquals($url, Router::url($url));
 	}
 
 /**
@@ -2444,7 +2444,7 @@ class RouterTest extends CakeTestCase {
 
 		$result = $route->parse('/blog/other');
 		$expected = array('controller' => 'blog_posts', 'action' => 'other', 'pass' => array(), 'named' => array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $route->parse('/blog/foobar');
 		$this->assertFalse($result);
@@ -2457,18 +2457,18 @@ class RouterTest extends CakeTestCase {
  */
 	public function testRouteRedirection() {
 		Router::redirect('/blog', array('controller' => 'posts'), array('status' => 302));
-		$this->assertEqual(count(Router::$routes), 1);
+		$this->assertEquals(count(Router::$routes), 1);
 		Router::$routes[0]->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		Router::$routes[0]->stop = false;
-		$this->assertEqual(Router::$routes[0]->options['status'], 302);
+		$this->assertEquals(Router::$routes[0]->options['status'], 302);
 
 		Router::parse('/blog');
-		$this->assertEqual(Router::$routes[0]->response->header(), array('Location' => Router::url('/posts', true)));
-		$this->assertEqual(Router::$routes[0]->response->statusCode(), 302);
+		$this->assertEquals(Router::$routes[0]->response->header(), array('Location' => Router::url('/posts', true)));
+		$this->assertEquals(Router::$routes[0]->response->statusCode(), 302);
 
 		Router::$routes[0]->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		Router::parse('/not-a-match');
-		$this->assertEqual(Router::$routes[0]->response->header(), array());
+		$this->assertEquals(Router::$routes[0]->response->header(), array());
 	}
 
 }

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -209,13 +209,13 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture = new CakeTestFixtureTestFixture();
 		unset($Fixture->table);
 		$Fixture->init();
-		$this->assertEqual($Fixture->table, 'fixture_tests');
-		$this->assertEqual($Fixture->primaryKey, 'id');
+		$this->assertEquals($Fixture->table, 'fixture_tests');
+		$this->assertEquals($Fixture->primaryKey, 'id');
 
 		$Fixture = new CakeTestFixtureTestFixture();
 		$Fixture->primaryKey = 'my_random_key';
 		$Fixture->init();
-		$this->assertEqual($Fixture->primaryKey, 'my_random_key');
+		$this->assertEquals($Fixture->primaryKey, 'my_random_key');
 	}
 
 
@@ -234,7 +234,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 
 		$Fixture = new CakeTestFixtureTestFixture();
 		$expected = array('id', 'name', 'created');
-		$this->assertEqual(array_keys($Fixture->fields), $expected);
+		$this->assertEquals(array_keys($Fixture->fields), $expected);
 
 		$config = $db->config;
 		$config['prefix'] = 'fixture_test_suite_';
@@ -243,15 +243,15 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = null;
 		$Fixture->import = array('table' => 'fixture_tests', 'connection' => 'test', 'records' => true);
 		$Fixture->init();
-		$this->assertEqual(count($Fixture->records), count($Source->records));
+		$this->assertEquals(count($Fixture->records), count($Source->records));
 		$Fixture->create(ConnectionManager::getDataSource('fixture_test_suite'));
 
 		$Fixture = new CakeTestFixtureImportFixture();
 		$Fixture->fields = $Fixture->records = $Fixture->table = null;
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'test');
 		$Fixture->init();
-		$this->assertEqual(array_keys($Fixture->fields), array('id', 'name', 'created'));
-		$this->assertEqual($Fixture->table, 'fixture_tests');
+		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals($Fixture->table, 'fixture_tests');
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -283,8 +283,8 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'test');
 
 		$Fixture->init();
-		$this->assertEqual(array_keys($Fixture->fields), array('id', 'name', 'created'));
-		$this->assertEqual($Fixture->table, 'fixture_tests');
+		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals($Fixture->table, 'fixture_tests');
 
 		$Source->drop($db);
 		$db->config['prefix'] = $backPrefix;
@@ -308,7 +308,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = null;
 		$Fixture->import = array('model' => 'FixturePrefixTest', 'connection' => 'test', 'records' => false);
 		$Fixture->init();
-		$this->assertEqual($Fixture->table, 'fixture_tests');
+		$this->assertEquals($Fixture->table, 'fixture_tests');
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -335,7 +335,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = null;
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'new_test_suite');
 		$Fixture->init();
-		$this->assertEqual(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -366,7 +366,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 			'model' => 'FixtureImportTestModel', 'connection' => 'new_test_suite', 'records' => true
 		);
 		$Fixture->init();
-		$this->assertEqual(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
 		$this->assertFalse(empty($Fixture->records[0]), 'No records loaded on importing fixture.');
 		$this->assertTrue(isset($Fixture->records[0]['name']), 'No name loaded for first record');
 
@@ -406,14 +406,14 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$this->assertTrue(!empty($this->insertMulti));
 		$this->assertTrue($this->criticDb->fullDebug);
 		$this->assertTrue($return);
-		$this->assertEqual('fixture_tests', $this->insertMulti['table']);
-		$this->assertEqual(array('name', 'created'), $this->insertMulti['fields']);
+		$this->assertEquals('fixture_tests', $this->insertMulti['table']);
+		$this->assertEquals(array('name', 'created'), $this->insertMulti['fields']);
 		$expected = array(
 			array('Gandalf', '2009-04-28 19:20:00'),
 			array('Captain Picard', '2009-04-28 19:20:00'),
 			array('Chewbacca', '2009-04-28 19:20:00')
 		);
-		$this->assertEqual($expected, $this->insertMulti['values']);
+		$this->assertEquals($expected, $this->insertMulti['values']);
 	}
 
 /**
@@ -445,14 +445,14 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$return = $Fixture->insert($this->criticDb);
 		$this->assertTrue($this->criticDb->fullDebug);
 		$this->assertTrue($return);
-		$this->assertEqual('strings', $this->insertMulti['table']);
-		$this->assertEqual(array('email', 'name', 'age'), $this->insertMulti['fields']);
+		$this->assertEquals('strings', $this->insertMulti['table']);
+		$this->assertEquals(array('email', 'name', 'age'), $this->insertMulti['fields']);
 		$expected = array(
 			array('Mark Doe', 'mark.doe@email.com', null),
 			array('John Doe', 'john.doe@email.com', 20),
 			array('Jane Doe', 'jane.doe@email.com', 30),
 		);
-		$this->assertEqual($expected, $this->insertMulti['values']);
+		$this->assertEquals($expected, $this->insertMulti['values']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -257,7 +257,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$this->assertEquals($expected, $results);
 
 		$result = $this->Case->controller->response->body();
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
+		$this->assertRegExp('/This is the TestsAppsController index view/', $result);
 
 		$Controller = $this->Case->generate('TestsApps');
 		$this->Case->testAction('/tests_apps/redirect_to');
@@ -337,9 +337,9 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'contents'
 		));
-		$this->assertPattern('/<html/', $result);
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
-		$this->assertPattern('/<\/html>/', $result);
+		$this->assertRegExp('/<html/', $result);
+		$this->assertRegExp('/This is the TestsAppsController index view/', $result);
+		$this->assertRegExp('/<\/html>/', $result);
 	}
 
 /**
@@ -365,7 +365,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$expected = array(
 			'named' => 'param'
 		);
-		$this->assertEqual($this->Case->controller->request->named, $expected);
+		$this->assertEquals($this->Case->controller->request->named, $expected);
 		$this->assertEquals($this->Case->controller->data, $data);
 
 		$result = $this->Case->testAction('/tests_apps_posts/post_var', array(
@@ -376,11 +376,11 @@ class ControllerTestCaseTest extends CakeTestCase {
 				'pork' => 'and beans',
 			)
 		));
-		$this->assertEqual(array_keys($result['data']), array('name', 'pork'));
+		$this->assertEquals(array_keys($result['data']), array('name', 'pork'));
 
 		$result = $this->Case->testAction('/tests_apps_posts/add', array('return' => 'vars'));
 		$this->assertTrue(array_key_exists('posts', $result));
-		$this->assertEqual(count($result['posts']), 4);
+		$this->assertEquals(count($result['posts']), 4);
 		$this->assertTrue($this->Case->controller->request->is('post'));
 	}
 
@@ -404,13 +404,13 @@ class ControllerTestCaseTest extends CakeTestCase {
 			'return' => 'vars',
 			'method' => 'get',
 		));
-		$this->assertEqual(array_keys($result['params']['named']), array('var1', 'var2'));
+		$this->assertEquals(array_keys($result['params']['named']), array('var1', 'var2'));
 
 		$result = $this->Case->testAction('/tests_apps_posts/url_var/gogo/val2', array(
 			'return' => 'vars',
 			'method' => 'get',
 		));
-		$this->assertEqual($result['params']['pass'], array('gogo', 'val2'));
+		$this->assertEquals($result['params']['pass'], array('gogo', 'val2'));
 
 		$result = $this->Case->testAction('/tests_apps_posts/url_var', array(
 			'return' => 'vars',
@@ -475,9 +475,9 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'contents'
 		));
-		$this->assertPattern('/<html/', $result);
-		$this->assertPattern('/This is the TestsAppsController index view/', $result);
-		$this->assertPattern('/<\/html>/', $result);
+		$this->assertRegExp('/<html/', $result);
+		$this->assertRegExp('/This is the TestsAppsController index view/', $result);
+		$this->assertRegExp('/<\/html>/', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -182,9 +182,9 @@ class ClassRegistryTest extends CakeTestCase {
 		$this->assertTrue(is_a($ParentCategory, 'RegisterCategory'));
 		$this->assertNotSame($Category, $ParentCategory);
 
-		$this->assertNotEqual($Category->alias, $ParentCategory->alias);
-		$this->assertEqual('RegisterCategory', $Category->alias);
-		$this->assertEqual('ParentCategory', $ParentCategory->alias);
+		$this->assertNotEquals($Category->alias, $ParentCategory->alias);
+		$this->assertEquals('RegisterCategory', $Category->alias);
+		$this->assertEquals('ParentCategory', $ParentCategory->alias);
 	}
 
 /**
@@ -259,7 +259,7 @@ class ClassRegistryTest extends CakeTestCase {
 		$TestRegistryPluginModel = ClassRegistry::init('RegistryPlugin.TestRegistryPluginModel');
 		$this->assertTrue(is_a($TestRegistryPluginModel, 'TestRegistryPluginModel'));
 
-		$this->assertEqual($TestRegistryPluginModel->tablePrefix, 'something_');
+		$this->assertEquals($TestRegistryPluginModel->tablePrefix, 'something_');
 
 		$PluginUser = ClassRegistry::init(array('class' => 'RegistryPlugin.RegisterUser', 'alias' => 'RegistryPluginUser', 'table' => false));
 		$this->assertTrue(is_a($PluginUser, 'RegistryPluginAppModel'));

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -383,16 +383,16 @@ class DebuggerTest extends CakeTestCase {
  */
 	public function testGetInstance() {
 		$result = Debugger::getInstance();
-		$this->assertIsA($result, 'Debugger');
+		$this->assertInstanceOf('Debugger', $result);
 
 		$result = Debugger::getInstance('DebuggerTestCaseDebugger');
-		$this->assertIsA($result, 'DebuggerTestCaseDebugger');
+		$this->assertInstanceOf('DebuggerTestCaseDebugger', $result);
 
 		$result = Debugger::getInstance();
-		$this->assertIsA($result, 'DebuggerTestCaseDebugger');
+		$this->assertInstanceOf('DebuggerTestCaseDebugger', $result);
 
 		$result = Debugger::getInstance('Debugger');
-		$this->assertIsA($result, 'Debugger');
+		$this->assertInstanceOf('Debugger', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -69,9 +69,9 @@ class DebuggerTest extends CakeTestCase {
  */
 	public function testDocRef() {
 		ini_set('docref_root', '');
-		$this->assertEqual(ini_get('docref_root'), '');
+		$this->assertEquals(ini_get('docref_root'), '');
 		$debugger = new Debugger();
-		$this->assertEqual(ini_get('docref_root'), 'http://php.net/');
+		$this->assertEquals(ini_get('docref_root'), 'http://php.net/');
 	}
 
 /**
@@ -82,12 +82,12 @@ class DebuggerTest extends CakeTestCase {
 	public function testExcerpt() {
 		$result = Debugger::excerpt(__FILE__, __LINE__, 2);
 		$this->assertTrue(is_array($result));
-		$this->assertEqual(count($result), 5);
-		$this->assertPattern('/function(.+)testExcerpt/', $result[1]);
+		$this->assertEquals(count($result), 5);
+		$this->assertRegExp('/function(.+)testExcerpt/', $result[1]);
 
 		$result = Debugger::excerpt(__FILE__, 2, 2);
 		$this->assertTrue(is_array($result));
-		$this->assertEqual(count($result), 4);
+		$this->assertEquals(count($result), 4);
 
 		$pattern = '/<code><span style\="color\: \#\d+">.*?&lt;\?php/';
 		$this->assertRegExp($pattern, $result[0]);
@@ -106,30 +106,30 @@ class DebuggerTest extends CakeTestCase {
 		$this->_restoreError = true;
 
 		$result = Debugger::output(false);
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 		$out .= '';
 		$result = Debugger::output(true);
 
-		$this->assertEqual($result[0]['error'], 'Notice');
-		$this->assertPattern('/Undefined variable\:\s+out/', $result[0]['description']);
-		$this->assertPattern('/DebuggerTest::testOutput/i', $result[0]['trace']);
+		$this->assertEquals($result[0]['error'], 'Notice');
+		$this->assertRegExp('/Undefined variable\:\s+out/', $result[0]['description']);
+		$this->assertRegExp('/DebuggerTest::testOutput/i', $result[0]['trace']);
 
 		ob_start();
 		Debugger::output('txt');
 		$other .= '';
 		$result = ob_get_clean();
 
-		$this->assertPattern('/Undefined variable:\s+other/', $result);
-		$this->assertPattern('/Context:/', $result);
-		$this->assertPattern('/DebuggerTest::testOutput/i', $result);
+		$this->assertRegExp('/Undefined variable:\s+other/', $result);
+		$this->assertRegExp('/Context:/', $result);
+		$this->assertRegExp('/DebuggerTest::testOutput/i', $result);
 
 		ob_start();
 		Debugger::output('html');
 		$wrong .= '';
 		$result = ob_get_clean();
-		$this->assertPattern('/<pre class="cake-error">.+<\/pre>/', $result);
-		$this->assertPattern('/<b>Notice<\/b>/', $result);
-		$this->assertPattern('/variable:\s+wrong/', $result);
+		$this->assertRegExp('/<pre class="cake-error">.+<\/pre>/', $result);
+		$this->assertRegExp('/<b>Notice<\/b>/', $result);
+		$this->assertRegExp('/variable:\s+wrong/', $result);
 
 		ob_start();
 		Debugger::output('js');
@@ -146,9 +146,9 @@ class DebuggerTest extends CakeTestCase {
 			'b' => array(), 'Notice', '/b', ' (8)',
 		));
 
-		$this->assertPattern('/Undefined variable:\s+buzz/', $result[1]);
-		$this->assertPattern('/<a[^>]+>Code/', $result[1]);
-		$this->assertPattern('/<a[^>]+>Context/', $result[2]);
+		$this->assertRegExp('/Undefined variable:\s+buzz/', $result[1]);
+		$this->assertRegExp('/<a[^>]+>Code/', $result[1]);
+		$this->assertRegExp('/<a[^>]+>Context/', $result[2]);
 	}
 
 /**
@@ -165,7 +165,7 @@ class DebuggerTest extends CakeTestCase {
 			               '&line={:line}">{:path}</a>, line {:line}'
 		));
 		$result = Debugger::trace();
-		$this->assertPattern('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
+		$this->assertRegExp('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
 
 		Debugger::output('xml', array(
 			'error' => '<error><code>{:code}</code><file>{:file}</file><line>{:line}</line>' .
@@ -226,7 +226,7 @@ class DebuggerTest extends CakeTestCase {
 		Debugger::outputAs('js');
 
 		$result = Debugger::trace();
-		$this->assertPattern('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
+		$this->assertRegExp('/' . preg_quote('txmt://open?url=file://', '/') . '(\/|[A-Z]:\\\\)' . '/', $result);
 
 		Debugger::addFormat('xml', array(
 			'error' => '<error><code>{:code}</code><file>{:file}</file><line>{:line}</line>' .
@@ -281,8 +281,8 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function testTrimPath() {
-		$this->assertEqual(Debugger::trimPath(APP), 'APP' . DS);
-		$this->assertEqual(Debugger::trimPath(CAKE_CORE_INCLUDE_PATH), 'CORE');
+		$this->assertEquals(Debugger::trimPath(APP), 'APP' . DS);
+		$this->assertEquals(Debugger::trimPath(CAKE_CORE_INCLUDE_PATH), 'CORE');
 	}
 
 /**
@@ -321,7 +321,7 @@ class DebuggerTest extends CakeTestCase {
 
 		$result = str_replace(array("\t", "\r\n", "\n"), "", $result);
 		$expected =  str_replace(array("\t", "\r\n", "\n"), "", $expected);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -336,18 +336,18 @@ class DebuggerTest extends CakeTestCase {
 
 		Debugger::log('cool');
 		$result = file_get_contents(LOGS . 'debug.log');
-		$this->assertPattern('/DebuggerTest\:\:testLog/i', $result);
-		$this->assertPattern('/"cool"/', $result);
+		$this->assertRegExp('/DebuggerTest\:\:testLog/i', $result);
+		$this->assertRegExp('/"cool"/', $result);
 
 		unlink(TMP . 'logs' . DS . 'debug.log');
 
 		Debugger::log(array('whatever', 'here'));
 		$result = file_get_contents(TMP . 'logs' . DS . 'debug.log');
-		$this->assertPattern('/DebuggerTest\:\:testLog/i', $result);
-		$this->assertPattern('/\[main\]/', $result);
-		$this->assertPattern('/array/', $result);
-		$this->assertPattern('/"whatever",/', $result);
-		$this->assertPattern('/"here"/', $result);
+		$this->assertRegExp('/DebuggerTest\:\:testLog/i', $result);
+		$this->assertRegExp('/\[main\]/', $result);
+		$this->assertRegExp('/array/', $result);
+		$this->assertRegExp('/"whatever",/', $result);
+		$this->assertRegExp('/"here"/', $result);
 	}
 
 /**
@@ -373,7 +373,7 @@ class DebuggerTest extends CakeTestCase {
 		Debugger::dump($var);
 		$result = ob_get_clean();
 		$expected = "<pre>array(\n\t\"People\" => array()\n)</pre>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -427,7 +427,7 @@ class DebuggerTest extends CakeTestCase {
 		);
 		$expected = Debugger::exportVar($expectedArray);
 
-		$this->assertEqual($expected, $output);
+		$this->assertEquals($expected, $output);
 	}
 
 /**
@@ -437,11 +437,11 @@ class DebuggerTest extends CakeTestCase {
  */
 	public function testTraceExclude() {
 		$result = Debugger::trace();
-		$this->assertPattern('/^DebuggerTest::testTraceExclude/', $result);
+		$this->assertRegExp('/^DebuggerTest::testTraceExclude/', $result);
 
 		$result = Debugger::trace(array(
 			'exclude' => array('DebuggerTest::testTraceExclude')
 		));
-		$this->assertNoPattern('/^DebuggerTest::testTraceExclude/', $result);
+		$this->assertNotRegExp('/^DebuggerTest::testTraceExclude/', $result);
 	}
 }

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -133,7 +133,7 @@ class FileTest extends CakeTestCase {
 		$this->File->lock = true;
 		$result = $this->File->read();
 		$expecting = file_get_contents(__FILE__);
-		$this->assertEqual($result, trim($expecting));
+		$this->assertEquals($result, trim($expecting));
 		$this->File->lock = null;
 
 		$data = $expecting;
@@ -165,7 +165,7 @@ class FileTest extends CakeTestCase {
 
 		$result = $this->File->offset();
 		$expecting = 0;
-		$this->assertIdentical($result, $expecting);
+		$this->assertSame($result, $expecting);
 
 		$data = file_get_contents(__FILE__);
 		$success = $this->File->offset(5);
@@ -176,7 +176,7 @@ class FileTest extends CakeTestCase {
 
 		$result = $this->File->offset();
 		$expecting = 5+3;
-		$this->assertIdentical($result, $expecting);
+		$this->assertSame($result, $expecting);
 	}
 
 /**
@@ -257,11 +257,11 @@ class FileTest extends CakeTestCase {
 		} else {
 			$expected = "some\nvery\ncool\nteststring here\n\n\nfor\n\n\n\n\nhere";
 		}
-		$this->assertIdentical(File::prepare($string), $expected);
+		$this->assertSame(File::prepare($string), $expected);
 
 		$expected = "some\r\nvery\r\ncool\r\nteststring here\r\n\r\n\r\n";
 		$expected .= "for\r\n\r\n\r\n\r\n\r\nhere";
-		$this->assertIdentical(File::prepare($string, true), $expected);
+		$this->assertSame(File::prepare($string, true), $expected);
 	}
 
 /**
@@ -312,7 +312,7 @@ class FileTest extends CakeTestCase {
 		$someFile = new File(TMP . 'some_file.txt', false);
 		$this->assertFalse($someFile->lastAccess());
 		$this->assertTrue($someFile->open());
-		$this->assertEqual($someFile->lastAccess(), time());
+		$this->assertEquals($someFile->lastAccess(), time());
 		$someFile->close();
 		$someFile->delete();
 	}
@@ -326,9 +326,9 @@ class FileTest extends CakeTestCase {
 		$someFile = new File(TMP . 'some_file.txt', false);
 		$this->assertFalse($someFile->lastChange());
 		$this->assertTrue($someFile->open('r+'));
-		$this->assertEqual($someFile->lastChange(), time());
+		$this->assertEquals($someFile->lastChange(), time());
 		$someFile->write('something');
-		$this->assertEqual($someFile->lastChange(), time());
+		$this->assertEquals($someFile->lastChange(), time());
 		$someFile->close();
 		$someFile->delete();
 	}
@@ -355,7 +355,7 @@ class FileTest extends CakeTestCase {
 			$r = $TmpFile->write($data);
 			$this->assertTrue($r);
 			$this->assertTrue(file_exists($tmpFile));
-			$this->assertEqual($data, file_get_contents($tmpFile));
+			$this->assertEquals($data, file_get_contents($tmpFile));
 			$this->assertTrue(is_resource($TmpFile->handle));
 			$TmpFile->close();
 
@@ -386,7 +386,7 @@ class FileTest extends CakeTestCase {
 			$this->assertTrue($r);
 			$this->assertTrue(file_exists($tmpFile));
 			$data = $data.$fragment;
-			$this->assertEqual($data, file_get_contents($tmpFile));
+			$this->assertEquals($data, file_get_contents($tmpFile));
 			$TmpFile->close();
 		}
 	}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -107,7 +107,7 @@ class FileTest extends CakeTestCase {
 		$this->assertEquals($expecting, $result);
 
 		$result = $this->File->Folder();
-		$this->assertIsA($result, 'Folder');
+		$this->assertInstanceOf('Folder', $result);
 
 		$this->skipIf(DIRECTORY_SEPARATOR === '\\', 'File permissions tests not supported on Windows.');
 

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -75,15 +75,15 @@ class FolderTest extends CakeTestCase {
 		$Folder = new Folder($path);
 
 		$result = $Folder->pwd();
-		$this->assertEqual($result, $path);
+		$this->assertEquals($result, $path);
 
 		$result = Folder::addPathElement($path, 'test');
 		$expected = $path . DS . 'test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Folder->cd(ROOT);
 		$expected = ROOT;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $Folder->cd(ROOT . DS . 'non-existent');
 		$this->assertFalse($result);
@@ -101,13 +101,13 @@ class FolderTest extends CakeTestCase {
 		$Folder = new Folder($path);
 
 		$result = $Folder->pwd();
-		$this->assertEqual($result, $path);
+		$this->assertEquals($result, $path);
 
 		$result = Folder::isSlashTerm($inside);
 		$this->assertTrue($result);
 
 		$result = $Folder->realpath('Test/');
-		$this->assertEqual($result, $path . DS .'Test' . DS);
+		$this->assertEquals($result, $path . DS .'Test' . DS);
 
 		$result = $Folder->inPath('Test' . DS);
 		$this->assertTrue($result);
@@ -230,7 +230,7 @@ class FolderTest extends CakeTestCase {
 
 		$expected = $new . ' is a file';
 		$result = $Folder->errors();
-		$this->assertEqual($result[0], $expected);
+		$this->assertEquals($result[0], $expected);
 
 		$new = TMP . 'test_folder_new';
 		$result = $Folder->create($new);
@@ -277,16 +277,16 @@ class FolderTest extends CakeTestCase {
 		$this->assertTrue($Folder->chmod($new, 0777, true, array('skip_me.php', 'test2')));
 		
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test1')), -4);
-		$this->assertEqual($perms, '0777');
+		$this->assertEquals($perms, '0777');
 		
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
-		$this->assertEqual($perms, '0755');
+		$this->assertEquals($perms, '0755');
 		
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test1.php')), -4);
-		$this->assertEqual($perms, '0777');
+		$this->assertEquals($perms, '0777');
 		
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'skip_me.php')), -4);
-		$this->assertEqual($perms, '0755');
+		$this->assertEquals($perms, '0755');
 		
 		$Folder->delete($new);
 	}
@@ -298,7 +298,7 @@ class FolderTest extends CakeTestCase {
  */
 	public function testRealPathForWebroot() {
 		$Folder = new Folder('files/');
-		$this->assertEqual(realpath('files/'), $Folder->path);
+		$this->assertEquals(realpath('files/'), $Folder->path);
 	}
 
 /**
@@ -313,11 +313,11 @@ class FolderTest extends CakeTestCase {
 
 		$result = $Folder->read(true, true);
 		$expected = array('0', 'cache', 'logs', 'sessions', 'tests');
-		$this->assertEqual($expected, $result[0]);
+		$this->assertEquals($expected, $result[0]);
 
 		$result = $Folder->read(true, array('logs'));
 		$expected = array('0', 'cache', 'sessions', 'tests');
-		$this->assertEqual($expected, $result[0]);
+		$this->assertEquals($expected, $result[0]);
 
 		$result = $Folder->delete($new);
 		$this->assertTrue($result);
@@ -330,10 +330,10 @@ class FolderTest extends CakeTestCase {
  */
 	public function testAddPathElement() {
 		$result = Folder::addPathElement(DS . 'some' . DS . 'dir', 'another_path');
-		$this->assertEqual($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
+		$this->assertEquals($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
 
 		$result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, 'another_path');
-		$this->assertEqual($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
+		$this->assertEquals($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
 	}
 /**
  * testFolderRead method
@@ -345,12 +345,12 @@ class FolderTest extends CakeTestCase {
 
 		$expected = array('cache', 'logs', 'sessions', 'tests');
 		$result = $Folder->read(true, true);
-		$this->assertEqual($result[0], $expected);
+		$this->assertEquals($result[0], $expected);
 
 		$Folder->path = TMP . 'non-existent';
 		$expected = array(array(), array());
 		$result = $Folder->read(true, true);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -453,7 +453,7 @@ class FolderTest extends CakeTestCase {
  */
 	public function testSlashTerm() {
 		$result = Folder::slashTerm('/path/to/file');
-		$this->assertEqual($result, '/path/to/file/');
+		$this->assertEquals($result, '/path/to/file/');
 	}
 
 /**
@@ -464,15 +464,15 @@ class FolderTest extends CakeTestCase {
 	public function testNormalizePath() {
 		$path = '/path/to/file';
 		$result = Folder::normalizePath($path);
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$path = '\\path\\\to\\\file';
 		$result = Folder::normalizePath($path);
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$path = 'C:\\path\\to\\file';
 		$result = Folder::normalizePath($path);
-		$this->assertEqual($result, '\\');
+		$this->assertEquals($result, '\\');
 	}
 
 /**
@@ -483,15 +483,15 @@ class FolderTest extends CakeTestCase {
 	public function testCorrectSlashFor() {
 		$path = '/path/to/file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$path = '\\path\\to\\file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEqual($result, '/');
+		$this->assertEquals($result, '/');
 
 		$path = 'C:\\path\to\\file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEqual($result, '\\');
+		$this->assertEquals($result, '\\');
 	}
 
 /**
@@ -645,13 +645,13 @@ class FolderTest extends CakeTestCase {
  */
 	public function testDirSize() {
 		$Folder = new Folder(TMP . 'config_non_existant', true);
-		$this->assertEqual($Folder->dirSize(), 0);
+		$this->assertEquals($Folder->dirSize(), 0);
 
 		$File = new File($Folder->pwd() . DS . 'my.php', true, 0777);
 		$File->create();
 		$File->write('something here');
 		$File->close();
-		$this->assertEqual($Folder->dirSize(), 14);
+		$this->assertEquals($Folder->dirSize(), 14);
 
 		$Folder->cd(TMP);
 		$Folder->delete($Folder->pwd() . 'config_non_existant');
@@ -681,7 +681,7 @@ class FolderTest extends CakeTestCase {
 			$path . DS . 'file2 removed',
 			$path . ' removed'
 		);
-		$this->assertEqual($expected, $messages);
+		$this->assertEquals($expected, $messages);
 	}
 
 /**
@@ -735,7 +735,7 @@ class FolderTest extends CakeTestCase {
 		$result = $Folder->copy($folder3);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folder3 . DS . 'file1.php'));
-		$this->assertEqual(file_get_contents($folder3 . DS . 'folder2' . DS . 'file2.php'), 'untouched');
+		$this->assertEquals(file_get_contents($folder3 . DS . 'folder2' . DS . 'file2.php'), 'untouched');
 
 		$Folder = new Folder($path);
 		$Folder->delete();
@@ -809,7 +809,7 @@ class FolderTest extends CakeTestCase {
 		$result = $Folder->move($folder3);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folder3 . DS . 'file1.php'));
-		$this->assertEqual(file_get_contents($folder3 . DS . 'folder2' . DS . 'file2.php'), 'untouched');
+		$this->assertEquals(file_get_contents($folder3 . DS . 'folder2' . DS . 'file2.php'), 'untouched');
 		$this->assertFalse(file_exists($file1));
 		$this->assertFalse(file_exists($folder2));
 		$this->assertFalse(file_exists($file2));

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -268,11 +268,26 @@ class FolderTest extends CakeTestCase {
 		$filePath = $new . DS . 'test1.php';
 		$File = new File($filePath);
 		$this->assertTrue($File->create());
-		$copy = TMP . 'test_folder_copy';
+		
+		$filePath = $new . DS . 'skip_me.php';
+		$File = new File($filePath);
+		$this->assertTrue($File->create());
 
-		$this->assertTrue($Folder->chmod($new, 0777, true));
-		$this->assertEqual($File->perms(), '0777');
-
+		$this->assertTrue($Folder->chmod($new, 0755, true));
+		$this->assertTrue($Folder->chmod($new, 0777, true, array('skip_me.php', 'test2')));
+		
+		$perms = substr(sprintf('%o', fileperms($new . DS . 'test1')), -4);
+		$this->assertEqual($perms, '0777');
+		
+		$perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
+		$this->assertEqual($perms, '0755');
+		
+		$perms = substr(sprintf('%o', fileperms($new . DS . 'test1.php')), -4);
+		$this->assertEqual($perms, '0777');
+		
+		$perms = substr(sprintf('%o', fileperms($new . DS . 'skip_me.php')), -4);
+		$this->assertEqual($perms, '0755');
+		
 		$Folder->delete($new);
 	}
 

--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -49,67 +49,67 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testInflectingSingulars() {
-		$this->assertEqual(Inflector::singularize('categorias'), 'categoria');
-		$this->assertEqual(Inflector::singularize('menus'), 'menu');
-		$this->assertEqual(Inflector::singularize('news'), 'news');
-		$this->assertEqual(Inflector::singularize('food_menus'), 'food_menu');
-		$this->assertEqual(Inflector::singularize('Menus'), 'Menu');
-		$this->assertEqual(Inflector::singularize('FoodMenus'), 'FoodMenu');
-		$this->assertEqual(Inflector::singularize('houses'), 'house');
-		$this->assertEqual(Inflector::singularize('powerhouses'), 'powerhouse');
-		$this->assertEqual(Inflector::singularize('quizzes'), 'quiz');
-		$this->assertEqual(Inflector::singularize('Buses'), 'Bus');
-		$this->assertEqual(Inflector::singularize('buses'), 'bus');
-		$this->assertEqual(Inflector::singularize('matrix_rows'), 'matrix_row');
-		$this->assertEqual(Inflector::singularize('matrices'), 'matrix');
-		$this->assertEqual(Inflector::singularize('vertices'), 'vertex');
-		$this->assertEqual(Inflector::singularize('indices'), 'index');
-		$this->assertEqual(Inflector::singularize('Aliases'), 'Alias');
-		$this->assertEqual(Inflector::singularize('Alias'), 'Alias');
-		$this->assertEqual(Inflector::singularize('Media'), 'Media');
-		$this->assertEqual(Inflector::singularize('NodeMedia'), 'NodeMedia');
-		$this->assertEqual(Inflector::singularize('alumni'), 'alumnus');
-		$this->assertEqual(Inflector::singularize('bacilli'), 'bacillus');
-		$this->assertEqual(Inflector::singularize('cacti'), 'cactus');
-		$this->assertEqual(Inflector::singularize('foci'), 'focus');
-		$this->assertEqual(Inflector::singularize('fungi'), 'fungus');
-		$this->assertEqual(Inflector::singularize('nuclei'), 'nucleus');
-		$this->assertEqual(Inflector::singularize('octopuses'), 'octopus');
-		$this->assertEqual(Inflector::singularize('radii'), 'radius');
-		$this->assertEqual(Inflector::singularize('stimuli'), 'stimulus');
-		$this->assertEqual(Inflector::singularize('syllabi'), 'syllabus');
-		$this->assertEqual(Inflector::singularize('termini'), 'terminus');
-		$this->assertEqual(Inflector::singularize('viri'), 'virus');
-		$this->assertEqual(Inflector::singularize('people'), 'person');
-		$this->assertEqual(Inflector::singularize('gloves'), 'glove');
-		$this->assertEqual(Inflector::singularize('doves'), 'dove');
-		$this->assertEqual(Inflector::singularize('lives'), 'life');
-		$this->assertEqual(Inflector::singularize('knives'), 'knife');
-		$this->assertEqual(Inflector::singularize('wolves'), 'wolf');
-		$this->assertEqual(Inflector::singularize('slaves'), 'slave');
-		$this->assertEqual(Inflector::singularize('shelves'), 'shelf');
-		$this->assertEqual(Inflector::singularize('taxis'), 'taxi');
-		$this->assertEqual(Inflector::singularize('taxes'), 'tax');
-		$this->assertEqual(Inflector::singularize('Taxes'), 'Tax');
-		$this->assertEqual(Inflector::singularize('AwesomeTaxes'), 'AwesomeTax');
-		$this->assertEqual(Inflector::singularize('faxes'), 'fax');
-		$this->assertEqual(Inflector::singularize('waxes'), 'wax');
-		$this->assertEqual(Inflector::singularize('niches'), 'niche');
-		$this->assertEqual(Inflector::singularize('waves'), 'wave');
-		$this->assertEqual(Inflector::singularize('bureaus'), 'bureau');
-		$this->assertEqual(Inflector::singularize('genetic_analyses'), 'genetic_analysis');
-		$this->assertEqual(Inflector::singularize('doctor_diagnoses'), 'doctor_diagnosis');
-		$this->assertEqual(Inflector::singularize('parantheses'), 'paranthesis');
-		$this->assertEqual(Inflector::singularize('Causes'), 'Cause');
-		$this->assertEqual(Inflector::singularize('colossuses'), 'colossus');
-		$this->assertEqual(Inflector::singularize('diagnoses'), 'diagnosis');
-		$this->assertEqual(Inflector::singularize('bases'), 'basis');
-		$this->assertEqual(Inflector::singularize('analyses'), 'analysis');
-		$this->assertEqual(Inflector::singularize('curves'), 'curve');
-		$this->assertEqual(Inflector::singularize('cafes'), 'cafe');
-		$this->assertEqual(Inflector::singularize('roofs'), 'roof');
+		$this->assertEquals(Inflector::singularize('categorias'), 'categoria');
+		$this->assertEquals(Inflector::singularize('menus'), 'menu');
+		$this->assertEquals(Inflector::singularize('news'), 'news');
+		$this->assertEquals(Inflector::singularize('food_menus'), 'food_menu');
+		$this->assertEquals(Inflector::singularize('Menus'), 'Menu');
+		$this->assertEquals(Inflector::singularize('FoodMenus'), 'FoodMenu');
+		$this->assertEquals(Inflector::singularize('houses'), 'house');
+		$this->assertEquals(Inflector::singularize('powerhouses'), 'powerhouse');
+		$this->assertEquals(Inflector::singularize('quizzes'), 'quiz');
+		$this->assertEquals(Inflector::singularize('Buses'), 'Bus');
+		$this->assertEquals(Inflector::singularize('buses'), 'bus');
+		$this->assertEquals(Inflector::singularize('matrix_rows'), 'matrix_row');
+		$this->assertEquals(Inflector::singularize('matrices'), 'matrix');
+		$this->assertEquals(Inflector::singularize('vertices'), 'vertex');
+		$this->assertEquals(Inflector::singularize('indices'), 'index');
+		$this->assertEquals(Inflector::singularize('Aliases'), 'Alias');
+		$this->assertEquals(Inflector::singularize('Alias'), 'Alias');
+		$this->assertEquals(Inflector::singularize('Media'), 'Media');
+		$this->assertEquals(Inflector::singularize('NodeMedia'), 'NodeMedia');
+		$this->assertEquals(Inflector::singularize('alumni'), 'alumnus');
+		$this->assertEquals(Inflector::singularize('bacilli'), 'bacillus');
+		$this->assertEquals(Inflector::singularize('cacti'), 'cactus');
+		$this->assertEquals(Inflector::singularize('foci'), 'focus');
+		$this->assertEquals(Inflector::singularize('fungi'), 'fungus');
+		$this->assertEquals(Inflector::singularize('nuclei'), 'nucleus');
+		$this->assertEquals(Inflector::singularize('octopuses'), 'octopus');
+		$this->assertEquals(Inflector::singularize('radii'), 'radius');
+		$this->assertEquals(Inflector::singularize('stimuli'), 'stimulus');
+		$this->assertEquals(Inflector::singularize('syllabi'), 'syllabus');
+		$this->assertEquals(Inflector::singularize('termini'), 'terminus');
+		$this->assertEquals(Inflector::singularize('viri'), 'virus');
+		$this->assertEquals(Inflector::singularize('people'), 'person');
+		$this->assertEquals(Inflector::singularize('gloves'), 'glove');
+		$this->assertEquals(Inflector::singularize('doves'), 'dove');
+		$this->assertEquals(Inflector::singularize('lives'), 'life');
+		$this->assertEquals(Inflector::singularize('knives'), 'knife');
+		$this->assertEquals(Inflector::singularize('wolves'), 'wolf');
+		$this->assertEquals(Inflector::singularize('slaves'), 'slave');
+		$this->assertEquals(Inflector::singularize('shelves'), 'shelf');
+		$this->assertEquals(Inflector::singularize('taxis'), 'taxi');
+		$this->assertEquals(Inflector::singularize('taxes'), 'tax');
+		$this->assertEquals(Inflector::singularize('Taxes'), 'Tax');
+		$this->assertEquals(Inflector::singularize('AwesomeTaxes'), 'AwesomeTax');
+		$this->assertEquals(Inflector::singularize('faxes'), 'fax');
+		$this->assertEquals(Inflector::singularize('waxes'), 'wax');
+		$this->assertEquals(Inflector::singularize('niches'), 'niche');
+		$this->assertEquals(Inflector::singularize('waves'), 'wave');
+		$this->assertEquals(Inflector::singularize('bureaus'), 'bureau');
+		$this->assertEquals(Inflector::singularize('genetic_analyses'), 'genetic_analysis');
+		$this->assertEquals(Inflector::singularize('doctor_diagnoses'), 'doctor_diagnosis');
+		$this->assertEquals(Inflector::singularize('parantheses'), 'paranthesis');
+		$this->assertEquals(Inflector::singularize('Causes'), 'Cause');
+		$this->assertEquals(Inflector::singularize('colossuses'), 'colossus');
+		$this->assertEquals(Inflector::singularize('diagnoses'), 'diagnosis');
+		$this->assertEquals(Inflector::singularize('bases'), 'basis');
+		$this->assertEquals(Inflector::singularize('analyses'), 'analysis');
+		$this->assertEquals(Inflector::singularize('curves'), 'curve');
+		$this->assertEquals(Inflector::singularize('cafes'), 'cafe');
+		$this->assertEquals(Inflector::singularize('roofs'), 'roof');
 
-		$this->assertEqual(Inflector::singularize(''), '');
+		$this->assertEquals(Inflector::singularize(''), '');
 	}
 
 /**
@@ -118,47 +118,47 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testInflectingPlurals() {
-		$this->assertEqual(Inflector::pluralize('categoria'), 'categorias');
-		$this->assertEqual(Inflector::pluralize('house'), 'houses');
-		$this->assertEqual(Inflector::pluralize('powerhouse'), 'powerhouses');
-		$this->assertEqual(Inflector::pluralize('Bus'), 'Buses');
-		$this->assertEqual(Inflector::pluralize('bus'), 'buses');
-		$this->assertEqual(Inflector::pluralize('menu'), 'menus');
-		$this->assertEqual(Inflector::pluralize('news'), 'news');
-		$this->assertEqual(Inflector::pluralize('food_menu'), 'food_menus');
-		$this->assertEqual(Inflector::pluralize('Menu'), 'Menus');
-		$this->assertEqual(Inflector::pluralize('FoodMenu'), 'FoodMenus');
-		$this->assertEqual(Inflector::pluralize('quiz'), 'quizzes');
-		$this->assertEqual(Inflector::pluralize('matrix_row'), 'matrix_rows');
-		$this->assertEqual(Inflector::pluralize('matrix'), 'matrices');
-		$this->assertEqual(Inflector::pluralize('vertex'), 'vertices');
-		$this->assertEqual(Inflector::pluralize('index'), 'indices');
-		$this->assertEqual(Inflector::pluralize('Alias'), 'Aliases');
-		$this->assertEqual(Inflector::pluralize('Aliases'), 'Aliases');
-		$this->assertEqual(Inflector::pluralize('Media'), 'Media');
-		$this->assertEqual(Inflector::pluralize('NodeMedia'), 'NodeMedia');
-		$this->assertEqual(Inflector::pluralize('alumnus'), 'alumni');
-		$this->assertEqual(Inflector::pluralize('bacillus'), 'bacilli');
-		$this->assertEqual(Inflector::pluralize('cactus'), 'cacti');
-		$this->assertEqual(Inflector::pluralize('focus'), 'foci');
-		$this->assertEqual(Inflector::pluralize('fungus'), 'fungi');
-		$this->assertEqual(Inflector::pluralize('nucleus'), 'nuclei');
-		$this->assertEqual(Inflector::pluralize('octopus'), 'octopuses');
-		$this->assertEqual(Inflector::pluralize('radius'), 'radii');
-		$this->assertEqual(Inflector::pluralize('stimulus'), 'stimuli');
-		$this->assertEqual(Inflector::pluralize('syllabus'), 'syllabi');
-		$this->assertEqual(Inflector::pluralize('terminus'), 'termini');
-		$this->assertEqual(Inflector::pluralize('virus'), 'viri');
-		$this->assertEqual(Inflector::pluralize('person'), 'people');
-		$this->assertEqual(Inflector::pluralize('people'), 'people');
-		$this->assertEqual(Inflector::pluralize('glove'), 'gloves');
-		$this->assertEqual(Inflector::pluralize('crisis'), 'crises');
-		$this->assertEqual(Inflector::pluralize('tax'), 'taxes');
-		$this->assertEqual(Inflector::pluralize('wave'), 'waves');
-		$this->assertEqual(Inflector::pluralize('bureau'), 'bureaus');
-		$this->assertEqual(Inflector::pluralize('cafe'), 'cafes');
-		$this->assertEqual(Inflector::pluralize('roof'), 'roofs');
-		$this->assertEqual(Inflector::pluralize(''), '');
+		$this->assertEquals(Inflector::pluralize('categoria'), 'categorias');
+		$this->assertEquals(Inflector::pluralize('house'), 'houses');
+		$this->assertEquals(Inflector::pluralize('powerhouse'), 'powerhouses');
+		$this->assertEquals(Inflector::pluralize('Bus'), 'Buses');
+		$this->assertEquals(Inflector::pluralize('bus'), 'buses');
+		$this->assertEquals(Inflector::pluralize('menu'), 'menus');
+		$this->assertEquals(Inflector::pluralize('news'), 'news');
+		$this->assertEquals(Inflector::pluralize('food_menu'), 'food_menus');
+		$this->assertEquals(Inflector::pluralize('Menu'), 'Menus');
+		$this->assertEquals(Inflector::pluralize('FoodMenu'), 'FoodMenus');
+		$this->assertEquals(Inflector::pluralize('quiz'), 'quizzes');
+		$this->assertEquals(Inflector::pluralize('matrix_row'), 'matrix_rows');
+		$this->assertEquals(Inflector::pluralize('matrix'), 'matrices');
+		$this->assertEquals(Inflector::pluralize('vertex'), 'vertices');
+		$this->assertEquals(Inflector::pluralize('index'), 'indices');
+		$this->assertEquals(Inflector::pluralize('Alias'), 'Aliases');
+		$this->assertEquals(Inflector::pluralize('Aliases'), 'Aliases');
+		$this->assertEquals(Inflector::pluralize('Media'), 'Media');
+		$this->assertEquals(Inflector::pluralize('NodeMedia'), 'NodeMedia');
+		$this->assertEquals(Inflector::pluralize('alumnus'), 'alumni');
+		$this->assertEquals(Inflector::pluralize('bacillus'), 'bacilli');
+		$this->assertEquals(Inflector::pluralize('cactus'), 'cacti');
+		$this->assertEquals(Inflector::pluralize('focus'), 'foci');
+		$this->assertEquals(Inflector::pluralize('fungus'), 'fungi');
+		$this->assertEquals(Inflector::pluralize('nucleus'), 'nuclei');
+		$this->assertEquals(Inflector::pluralize('octopus'), 'octopuses');
+		$this->assertEquals(Inflector::pluralize('radius'), 'radii');
+		$this->assertEquals(Inflector::pluralize('stimulus'), 'stimuli');
+		$this->assertEquals(Inflector::pluralize('syllabus'), 'syllabi');
+		$this->assertEquals(Inflector::pluralize('terminus'), 'termini');
+		$this->assertEquals(Inflector::pluralize('virus'), 'viri');
+		$this->assertEquals(Inflector::pluralize('person'), 'people');
+		$this->assertEquals(Inflector::pluralize('people'), 'people');
+		$this->assertEquals(Inflector::pluralize('glove'), 'gloves');
+		$this->assertEquals(Inflector::pluralize('crisis'), 'crises');
+		$this->assertEquals(Inflector::pluralize('tax'), 'taxes');
+		$this->assertEquals(Inflector::pluralize('wave'), 'waves');
+		$this->assertEquals(Inflector::pluralize('bureau'), 'bureaus');
+		$this->assertEquals(Inflector::pluralize('cafe'), 'cafes');
+		$this->assertEquals(Inflector::pluralize('roof'), 'roofs');
+		$this->assertEquals(Inflector::pluralize(''), '');
 	}
 
 /**
@@ -169,59 +169,59 @@ class InflectorTest extends CakeTestCase {
 	public function testInflectorSlug() {
 		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more');
 		$expected = 'Foo_Bar_Not_just_for_breakfast_any_more';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('this/is/a/path');
 		$expected = 'this_is_a_path';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', "-");
 		$expected = 'Foo-Bar-Not-just-for-breakfast-any-more';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('Foo Bar: Not just for breakfast any-more', "+");
 		$expected = 'Foo+Bar+Not+just+for+breakfast+any+more';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('Äpfel Über Öl grün ärgert groß öko', '-');
 		$expected = 'Aepfel-Ueber-Oel-gruen-aergert-gross-oeko';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('The truth - and- more- news', '-');
 		$expected = 'The-truth-and-more-news';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('The truth: and more news', '-');
 		$expected = 'The-truth-and-more-news';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('La langue française est un attribut de souveraineté en France', '-');
 		$expected = 'La-langue-francaise-est-un-attribut-de-souverainete-en-France';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('!@$#exciting stuff! - what !@-# was that?', '-');
 		$expected = 'exciting-stuff-what-was-that';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('20% of profits went to me!', '-');
 		$expected = '20-of-profits-went-to-me';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('#this melts your face1#2#3', '-');
 		$expected = 'this-melts-your-face1-2-3';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('controller/action/りんご/1');
 		$expected = 'controller_action_りんご_1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('の話が出たので大丈夫かなあと');
 		$expected = 'の話が出たので大丈夫かなあと';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('posts/view/한국어/page:1/sort:asc');
 		$expected = 'posts_view_한국어_page_1_sort_asc';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -233,11 +233,11 @@ class InflectorTest extends CakeTestCase {
 	    Inflector::rules('transliteration', array('/r/' => '1'));
 		$result = Inflector::slug('replace every r');
 		$expected = '1eplace_eve1y_1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Inflector::slug('replace every r', '_');
 		$expected = '1eplace_eve1y_1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -249,7 +249,7 @@ class InflectorTest extends CakeTestCase {
 	    Inflector::rules('transliteration', array('/å/' => 'aa', '/ø/' => 'oe'));
 		$result = Inflector::slug('Testing æ ø å', '-');
 		$expected = 'Testing-ae-oe-aa';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -258,21 +258,21 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testInflectorUnderscore() {
-		$this->assertIdentical(Inflector::underscore('TestThing'), 'test_thing');
-		$this->assertIdentical(Inflector::underscore('testThing'), 'test_thing');
-		$this->assertIdentical(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
-		$this->assertIdentical(Inflector::underscore('testThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('TestThing'), 'test_thing');
+		$this->assertSame(Inflector::underscore('testThing'), 'test_thing');
+		$this->assertSame(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('testThingExtra'), 'test_thing_extra');
 
 		// Identical checks test the cache code path.
-		$this->assertIdentical(Inflector::underscore('TestThing'), 'test_thing');
-		$this->assertIdentical(Inflector::underscore('testThing'), 'test_thing');
-		$this->assertIdentical(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
-		$this->assertIdentical(Inflector::underscore('testThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('TestThing'), 'test_thing');
+		$this->assertSame(Inflector::underscore('testThing'), 'test_thing');
+		$this->assertSame(Inflector::underscore('TestThingExtra'), 'test_thing_extra');
+		$this->assertSame(Inflector::underscore('testThingExtra'), 'test_thing_extra');
 
 		// Test stupid values
-		$this->assertIdentical(Inflector::underscore(''), '');
-		$this->assertIdentical(Inflector::underscore(0), '0');
-		$this->assertIdentical(Inflector::underscore(false), '');
+		$this->assertSame(Inflector::underscore(''), '');
+		$this->assertSame(Inflector::underscore(0), '0');
+		$this->assertSame(Inflector::underscore(false), '');
 	}
 
 /**
@@ -281,10 +281,10 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testVariableNaming() {
-		$this->assertEqual(Inflector::variable('test_field'), 'testField');
-		$this->assertEqual(Inflector::variable('test_fieLd'), 'testFieLd');
-		$this->assertEqual(Inflector::variable('test field'), 'testField');
-		$this->assertEqual(Inflector::variable('Test_field'), 'testField');
+		$this->assertEquals(Inflector::variable('test_field'), 'testField');
+		$this->assertEquals(Inflector::variable('test_fieLd'), 'testFieLd');
+		$this->assertEquals(Inflector::variable('test field'), 'testField');
+		$this->assertEquals(Inflector::variable('Test_field'), 'testField');
 	}
 
 /**
@@ -293,10 +293,10 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testClassNaming() {
-		$this->assertEqual(Inflector::classify('artists_genres'), 'ArtistsGenre');
-		$this->assertEqual(Inflector::classify('file_systems'), 'FileSystem');
-		$this->assertEqual(Inflector::classify('news'), 'News');
-		$this->assertEqual(Inflector::classify('bureaus'), 'Bureau');
+		$this->assertEquals(Inflector::classify('artists_genres'), 'ArtistsGenre');
+		$this->assertEquals(Inflector::classify('file_systems'), 'FileSystem');
+		$this->assertEquals(Inflector::classify('news'), 'News');
+		$this->assertEquals(Inflector::classify('bureaus'), 'Bureau');
 	}
 
 /**
@@ -305,10 +305,10 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testTableNaming() {
-		$this->assertEqual(Inflector::tableize('ArtistsGenre'), 'artists_genres');
-		$this->assertEqual(Inflector::tableize('FileSystem'), 'file_systems');
-		$this->assertEqual(Inflector::tableize('News'), 'news');
-		$this->assertEqual(Inflector::tableize('Bureau'), 'bureaus');
+		$this->assertEquals(Inflector::tableize('ArtistsGenre'), 'artists_genres');
+		$this->assertEquals(Inflector::tableize('FileSystem'), 'file_systems');
+		$this->assertEquals(Inflector::tableize('News'), 'news');
+		$this->assertEquals(Inflector::tableize('Bureau'), 'bureaus');
 	}
 
 /**
@@ -317,9 +317,9 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testHumanization() {
-		$this->assertEqual(Inflector::humanize('posts'), 'Posts');
-		$this->assertEqual(Inflector::humanize('posts_tags'), 'Posts Tags');
-		$this->assertEqual(Inflector::humanize('file_systems'), 'File Systems');
+		$this->assertEquals(Inflector::humanize('posts'), 'Posts');
+		$this->assertEquals(Inflector::humanize('posts_tags'), 'Posts Tags');
+		$this->assertEquals(Inflector::humanize('file_systems'), 'File Systems');
 	}
 
 /**
@@ -329,21 +329,21 @@ class InflectorTest extends CakeTestCase {
  */
 	public function testCustomPluralRule() {
 		Inflector::rules('plural', array('/^(custom)$/i' => '\1izables'));
-		$this->assertEqual(Inflector::pluralize('custom'), 'customizables');
+		$this->assertEquals(Inflector::pluralize('custom'), 'customizables');
 
 		Inflector::rules('plural', array('uninflected' => array('uninflectable')));
-		$this->assertEqual(Inflector::pluralize('uninflectable'), 'uninflectable');
+		$this->assertEquals(Inflector::pluralize('uninflectable'), 'uninflectable');
 
 		Inflector::rules('plural', array(
 			'rules' => array('/^(alert)$/i' => '\1ables'),
 			'uninflected' => array('noflect', 'abtuse'),
 			'irregular' => array('amaze' => 'amazable', 'phone' => 'phonezes')
 		));
-		$this->assertEqual(Inflector::pluralize('noflect'), 'noflect');
-		$this->assertEqual(Inflector::pluralize('abtuse'), 'abtuse');
-		$this->assertEqual(Inflector::pluralize('alert'), 'alertables');
-		$this->assertEqual(Inflector::pluralize('amaze'), 'amazable');
-		$this->assertEqual(Inflector::pluralize('phone'), 'phonezes');
+		$this->assertEquals(Inflector::pluralize('noflect'), 'noflect');
+		$this->assertEquals(Inflector::pluralize('abtuse'), 'abtuse');
+		$this->assertEquals(Inflector::pluralize('alert'), 'alertables');
+		$this->assertEquals(Inflector::pluralize('amaze'), 'amazable');
+		$this->assertEquals(Inflector::pluralize('phone'), 'phonezes');
 	}
 
 /**
@@ -354,8 +354,8 @@ class InflectorTest extends CakeTestCase {
 	public function testCustomSingularRule() {
 		Inflector::rules('singular', array('/(eple)r$/i' => '\1', '/(jente)r$/i' => '\1'));
 
-		$this->assertEqual(Inflector::singularize('epler'), 'eple');
-		$this->assertEqual(Inflector::singularize('jenter'), 'jente');
+		$this->assertEquals(Inflector::singularize('epler'), 'eple');
+		$this->assertEquals(Inflector::singularize('jenter'), 'jente');
 
 		Inflector::rules('singular', array(
 			'rules' => array('/^(bil)er$/i' => '\1', '/^(inflec|contribu)tors$/i' => '\1ta'),
@@ -363,10 +363,10 @@ class InflectorTest extends CakeTestCase {
 			'irregular' => array('spins' => 'spinor')
 		));
 
-		$this->assertEqual(Inflector::singularize('inflectors'), 'inflecta');
-		$this->assertEqual(Inflector::singularize('contributors'), 'contributa');
-		$this->assertEqual(Inflector::singularize('spins'), 'spinor');
-		$this->assertEqual(Inflector::singularize('singulars'), 'singulars');
+		$this->assertEquals(Inflector::singularize('inflectors'), 'inflecta');
+		$this->assertEquals(Inflector::singularize('contributors'), 'contributa');
+		$this->assertEquals(Inflector::singularize('spins'), 'spinor');
+		$this->assertEquals(Inflector::singularize('singulars'), 'singulars');
 	}
 
 /**
@@ -375,13 +375,13 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testCustomTransliterationRule() {
-		$this->assertEqual(Inflector::slug('Testing æ ø å'), 'Testing_ae_o_a');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_o_a');
 
 		Inflector::rules('transliteration', array('/å/' => 'aa', '/ø/' => 'oe'));
-		$this->assertEqual(Inflector::slug('Testing æ ø å'), 'Testing_ae_oe_aa');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_oe_aa');
 
 		Inflector::rules('transliteration', array('/ä|æ/' => 'ae', '/å/' => 'aa'), true);
-		$this->assertEqual(Inflector::slug('Testing æ ø å'), 'Testing_ae_ø_aa');
+		$this->assertEquals(Inflector::slug('Testing æ ø å'), 'Testing_ae_ø_aa');
 	}
 
 /**
@@ -390,9 +390,9 @@ class InflectorTest extends CakeTestCase {
  * @return void
  */
 	public function testRulesClearsCaches() {
-		$this->assertEqual(Inflector::singularize('Bananas'), 'Banana');
-		$this->assertEqual(Inflector::tableize('Banana'), 'bananas');
-		$this->assertEqual(Inflector::pluralize('Banana'), 'Bananas');
+		$this->assertEquals(Inflector::singularize('Bananas'), 'Banana');
+		$this->assertEquals(Inflector::tableize('Banana'), 'bananas');
+		$this->assertEquals(Inflector::pluralize('Banana'), 'Bananas');
 
 		Inflector::rules('singular', array(
 			'rules' => array('/(.*)nas$/i' => '\1zzz')
@@ -403,8 +403,8 @@ class InflectorTest extends CakeTestCase {
 			'rules' => array('/(.*)na$/i' => '\1zzz'),
 			'irregular' => array('corpus' => 'corpora')
 		));
-		$this->assertEqual(Inflector::pluralize('Banana'), 'Banazzz', 'Was inflected with old rules.');
-		$this->assertEqual(Inflector::pluralize('corpus'), 'corpora', 'Was inflected with old irregular form.');
+		$this->assertEquals(Inflector::pluralize('Banana'), 'Banazzz', 'Was inflected with old rules.');
+		$this->assertEquals(Inflector::pluralize('corpus'), 'corpora', 'Was inflected with old irregular form.');
 	}
 
 /**
@@ -429,10 +429,10 @@ class InflectorTest extends CakeTestCase {
 			'irregular' => $pluralIrregular
 		), true);
 
-		$this->assertEqual(Inflector::pluralize('Alcool'), 'Alcoois');
-		$this->assertEqual(Inflector::pluralize('Atlas'), 'Atlas');
-		$this->assertEqual(Inflector::singularize('Alcoois'), 'Alcool');
-		$this->assertEqual(Inflector::singularize('Atlas'), 'Atlas');
+		$this->assertEquals(Inflector::pluralize('Alcool'), 'Alcoois');
+		$this->assertEquals(Inflector::pluralize('Atlas'), 'Atlas');
+		$this->assertEquals(Inflector::singularize('Alcoois'), 'Alcool');
+		$this->assertEquals(Inflector::singularize('Atlas'), 'Atlas');
 	}
 
 }

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -144,10 +144,10 @@ class ObjectCollectionTest extends CakeTestCase {
 		$this->assertEquals(array('First'), $result, 'loaded objects are wrong');
 
 		$result = $this->Objects->set('First', new SecondGenericObject());
-		$this->assertIsA($result['First'], 'SecondGenericObject', 'set failed');
+		$this->assertInstanceOf('SecondGenericObject', $result['First'], 'set failed');
 
 		$result = $this->Objects->set('Second', new SecondGenericObject());
-		$this->assertIsA($result['Second'], 'SecondGenericObject', 'set failed');
+		$this->assertInstanceOf('SecondGenericObject', $result['Second'], 'set failed');
 
 		$this->assertEquals(count($result), 2);
 	}

--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -90,28 +90,28 @@ class SanitizeTest extends CakeTestCase {
  */
 	public function testEscapeAlphaNumeric() {
 		$resultAlpha = Sanitize::escape('abc', 'test');
-		$this->assertEqual($resultAlpha, 'abc');
+		$this->assertEquals($resultAlpha, 'abc');
 
 		$resultNumeric = Sanitize::escape('123', 'test');
-		$this->assertEqual($resultNumeric, '123');
+		$this->assertEquals($resultNumeric, '123');
 
 		$resultNumeric = Sanitize::escape(1234, 'test');
-		$this->assertEqual($resultNumeric, 1234);
+		$this->assertEquals($resultNumeric, 1234);
 
 		$resultNumeric = Sanitize::escape(1234.23, 'test');
-		$this->assertEqual($resultNumeric, 1234.23);
+		$this->assertEquals($resultNumeric, 1234.23);
 
 		$resultNumeric = Sanitize::escape('#1234.23', 'test');
-		$this->assertEqual($resultNumeric, '#1234.23');
+		$this->assertEquals($resultNumeric, '#1234.23');
 
 		$resultNull = Sanitize::escape(null, 'test');
-		$this->assertEqual($resultNull, null);
+		$this->assertEquals($resultNull, null);
 
 		$resultNull = Sanitize::escape(false, 'test');
-		$this->assertEqual($resultNull, false);
+		$this->assertEquals($resultNull, false);
 
 		$resultNull = Sanitize::escape(true, 'test');
-		$this->assertEqual($resultNull, true);
+		$this->assertEquals($resultNull, true);
 	}
 
 /**
@@ -123,52 +123,52 @@ class SanitizeTest extends CakeTestCase {
 		$string = 'test & "quote" \'other\' ;.$ symbol.' . "\r" . 'another line';
 		$expected = 'test &amp; &quot;quote&quot; &#039;other&#039; ;.$ symbol.another line';
 		$result = Sanitize::clean($string, array('connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'test & "quote" \'other\' ;.$ symbol.' . "\r" . 'another line';
 		$expected = 'test & ' . Sanitize::escape('"quote"', 'test') . ' ' . Sanitize::escape('\'other\'', 'test') . ' ;.$ symbol.another line';
 		$result = Sanitize::clean($string, array('encode' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'test & "quote" \'other\' ;.$ \\$ symbol.' . "\r" . 'another line';
 		$expected = 'test & "quote" \'other\' ;.$ $ symbol.another line';
 		$result = Sanitize::clean($string, array('encode' => false, 'escape' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'test & "quote" \'other\' ;.$ \\$ symbol.' . "\r" . 'another line';
 		$expected = 'test & "quote" \'other\' ;.$ \\$ symbol.another line';
 		$result = Sanitize::clean($string, array('encode' => false, 'escape' => false, 'dollar' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'test & "quote" \'other\' ;.$ symbol.' . "\r" . 'another line';
 		$expected = 'test & "quote" \'other\' ;.$ symbol.' . "\r" . 'another line';
 		$result = Sanitize::clean($string, array('encode' => false, 'escape' => false, 'carriage' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$array = array(array('test & "quote" \'other\' ;.$ symbol.' . "\r" . 'another line'));
 		$expected = array(array('test &amp; &quot;quote&quot; &#039;other&#039; ;.$ symbol.another line'));
 		$result = Sanitize::clean($array, array('connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$array = array(array('test & "quote" \'other\' ;.$ \\$ symbol.' . "\r" . 'another line'));
 		$expected = array(array('test & "quote" \'other\' ;.$ $ symbol.another line'));
 		$result = Sanitize::clean($array, array('encode' => false, 'escape' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$array = array(array('test odd Ä spacesé'));
 		$expected = array(array('test odd &Auml; spaces&eacute;'));
 		$result = Sanitize::clean($array, array('odd_spaces' => false, 'escape' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$array = array(array('\\$', array('key' => 'test & "quote" \'other\' ;.$ \\$ symbol.' . "\r" . 'another line')));
 		$expected = array(array('$', array('key' => 'test & "quote" \'other\' ;.$ $ symbol.another line')));
 		$result = Sanitize::clean($array, array('encode' => false, 'escape' => false, 'connection' => 'test'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '';
 		$expected = '';
 		$result = Sanitize::clean($string, array('connection' => 'test'));
-		$this->assertEqual($string, $expected);
+		$this->assertEquals($string, $expected);
 
 		$data = array(
 			'Grant' => array(
@@ -191,7 +191,7 @@ class SanitizeTest extends CakeTestCase {
 			)
 		);
 		$result = Sanitize::clean($data, array('connection' => 'test'));
-		$this->assertEqual($result, $data);
+		$this->assertEquals($result, $data);
 	}
 
 /**
@@ -203,36 +203,36 @@ class SanitizeTest extends CakeTestCase {
 		$string = '<p>This is a <em>test string</em> & so is this</p>';
 		$expected = 'This is a test string &amp; so is this';
 		$result = Sanitize::html($string, array('remove' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'The "lazy" dog \'jumped\' & flew over the moon. If (1+1) = 2 <em>is</em> true, (2-1) = 1 is also true';
 		$expected = 'The &quot;lazy&quot; dog &#039;jumped&#039; &amp; flew over the moon. If (1+1) = 2 &lt;em&gt;is&lt;/em&gt; true, (2-1) = 1 is also true';
 		$result = Sanitize::html($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'The "lazy" dog \'jumped\'';
 		$expected = 'The &quot;lazy&quot; dog \'jumped\'';
 		$result = Sanitize::html($string, array('quotes' => ENT_COMPAT));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'The "lazy" dog \'jumped\'';
 		$result = Sanitize::html($string, array('quotes' => ENT_NOQUOTES));
-		$this->assertEqual($result, $string);
+		$this->assertEquals($result, $string);
 
 		$string = 'The "lazy" dog \'jumped\' & flew over the moon. If (1+1) = 2 <em>is</em> true, (2-1) = 1 is also true';
 		$expected = 'The &quot;lazy&quot; dog &#039;jumped&#039; &amp; flew over the moon. If (1+1) = 2 &lt;em&gt;is&lt;/em&gt; true, (2-1) = 1 is also true';
 		$result = Sanitize::html($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'The "lazy" dog & his friend Apple&reg; conquered the world';
 		$expected = 'The &quot;lazy&quot; dog &amp; his friend Apple&amp;reg; conquered the world';
 		$result = Sanitize::html($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'The "lazy" dog & his friend Apple&reg; conquered the world';
 		$expected = 'The &quot;lazy&quot; dog &amp; his friend Apple&reg; conquered the world';
 		$result = Sanitize::html($string, array('double' => false));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -249,7 +249,7 @@ class SanitizeTest extends CakeTestCase {
 		$text = 'I    love  ßá†ö√    letters.';
 		$result = Sanitize::stripWhitespace($text);
 		$expected = 'I love ßá†ö√ letters.';
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($result, $expected);
 	}
 
 /**
@@ -261,7 +261,7 @@ class SanitizeTest extends CakeTestCase {
 		$string = 'I would like to !%@#% & dance & sing ^$&*()-+';
 		$expected = 'Iwouldliketodancesing';
 		$result = Sanitize::paranoid($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = array('This |s th% s0ng that never ends it g*es',
 						'on and on my friends, b^ca#use it is the',
@@ -270,27 +270,27 @@ class SanitizeTest extends CakeTestCase {
 						'on and on my friends bcause it is the',
 						'sog tht never ends.');
 		$result = Sanitize::paranoid($string, array('%', '*', '.', ' '));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = "anything' OR 1 = 1";
 		$expected = 'anythingOR11';
 		$result = Sanitize::paranoid($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = "x' AND email IS NULL; --";
 		$expected = 'xANDemailISNULL';
 		$result = Sanitize::paranoid($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = "x' AND 1=(SELECT COUNT(*) FROM users); --";
 		$expected = "xAND1SELECTCOUNTFROMusers";
 		$result = Sanitize::paranoid($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = "x'; DROP TABLE members; --";
 		$expected = "xDROPTABLEmembers";
 		$result = Sanitize::paranoid($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -302,22 +302,22 @@ class SanitizeTest extends CakeTestCase {
 		$string = '<img src="/img/test.jpg" alt="my image" />';
 		$expected = 'my image<br />';
 		$result = Sanitize::stripImages($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<img src="javascript:alert(\'XSS\');" />';
 		$expected = '';
 		$result = Sanitize::stripImages($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<a href="http://www.badsite.com/phising"><img src="/img/test.jpg" alt="test image alt" title="test image title" id="myImage" class="image-left"/></a>';
 		$expected = '<a href="http://www.badsite.com/phising">test image alt</a><br />';
 		$result = Sanitize::stripImages($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<a onclick="medium()" href="http://example.com"><img src="foobar.png" onclick="evilFunction(); return false;"/></a>';
 		$expected = '<a onclick="medium()" href="http://example.com"></a>';
 		$result = Sanitize::stripImages($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -329,32 +329,32 @@ class SanitizeTest extends CakeTestCase {
 		$string = '<link href="/css/styles.css" media="screen" rel="stylesheet" />';
 		$expected = '';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<link href="/css/styles.css" media="screen" rel="stylesheet" />' . "\n" . '<link rel="icon" href="/favicon.ico" type="image/x-icon" />' . "\n" . '<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />' . "\n" . '<link rel="alternate" href="/feed.xml" title="RSS Feed" type="application/rss+xml" />';
 		$expected = "\n" . '<link rel="icon" href="/favicon.ico" type="image/x-icon" />' . "\n" . '<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />'."\n".'<link rel="alternate" href="/feed.xml" title="RSS Feed" type="application/rss+xml" />';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<script type="text/javascript"> alert("hacked!");</script>';
 		$expected = '';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<script> alert("hacked!");</script>';
 		$expected = '';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<style>#content { display:none; }</style>';
 		$expected = '';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<style type="text/css"><!-- #content { display:none; } --></style>';
 		$expected = '';
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = <<<HTML
 text
@@ -367,7 +367,7 @@ text
 HTML;
 		$expected = "text\n\ntext";
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = <<<HTML
 text
@@ -380,7 +380,7 @@ text
 HTML;
 		$expected = "text\n\ntext";
 		$result = Sanitize::stripScripts($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -392,17 +392,17 @@ HTML;
 		$string = '<img """><script>alert("xss")</script>"/>';
 		$expected ='"/>';
 		$result = Sanitize::stripAll($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<IMG SRC=&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041>';
 		$expected = '';
 		$result = Sanitize::stripAll($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<<script>alert("XSS");//<</script>';
 		$expected = '<';
 		$result = Sanitize::stripAll($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<img src="http://google.com/images/logo.gif" onload="window.location=\'http://sam.com/\'" />'."\n".
 					"<p>This is ok      \t\n   text</p>\n".
@@ -410,7 +410,7 @@ HTML;
 					'<script src="xss.js" type="text/javascript" charset="utf-8"></script>';
 		$expected = '<p>This is ok text</p>';
 		$result = Sanitize::stripAll($string);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -423,36 +423,36 @@ HTML;
 		$string = '<h2>Headline</h2><p><a href="http://example.com">My Link</a> could go to a bad site</p>';
 		$expected = 'Headline<p>My Link could go to a bad site</p>';
 		$result = Sanitize::stripTags($string, 'h2', 'a');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<script type="text/javascript" src="http://evildomain.com"> </script>';
 		$expected = ' ';
 		$result = Sanitize::stripTags($string, 'script');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<h2>Important</h2><p>Additional information here <a href="/about"><img src="/img/test.png" /></a>. Read even more here</p>';
 		$expected = 'Important<p>Additional information here <img src="/img/test.png" />. Read even more here</p>';
 		$result = Sanitize::stripTags($string, 'h2', 'a');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<h2>Important</h2><p>Additional information here <a href="/about"><img src="/img/test.png" /></a>. Read even more here</p>';
 		$expected = 'Important<p>Additional information here . Read even more here</p>';
 		$result = Sanitize::stripTags($string, 'h2', 'a', 'img');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<b>Important message!</b><br>This message will self destruct!';
 		$expected = 'Important message!<br>This message will self destruct!';
 		$result = Sanitize::stripTags($string, 'b');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<b>Important message!</b><br />This message will self destruct!';
 		$expected = 'Important message!<br />This message will self destruct!';
 		$result = Sanitize::stripTags($string, 'b');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<h2 onclick="alert(\'evil\'); onmouseover="badness()">Important</h2><p>Additional information here <a href="/about"><img src="/img/test.png" /></a>. Read even more here</p>';
 		$expected = 'Important<p>Additional information here . Read even more here</p>';
 		$result = Sanitize::stripTags($string, 'h2', 'a', 'img');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -39,13 +39,13 @@ class SecurityTest extends CakeTestCase {
  */
 	public function testInactiveMins() {
 		Configure::write('Security.level', 'high');
-		$this->assertEqual(10, Security::inactiveMins());
+		$this->assertEquals(10, Security::inactiveMins());
 
 		Configure::write('Security.level', 'medium');
-		$this->assertEqual(100, Security::inactiveMins());
+		$this->assertEquals(100, Security::inactiveMins());
 
 		Configure::write('Security.level', 'low');
-		$this->assertEqual(300, Security::inactiveMins());
+		$this->assertEquals(300, Security::inactiveMins());
 	}
 
 /**
@@ -54,7 +54,7 @@ class SecurityTest extends CakeTestCase {
  * @return void
  */
 	public function testGenerateAuthkey() {
-		$this->assertEqual(strlen(Security::generateAuthKey()), 40);
+		$this->assertEquals(strlen(Security::generateAuthKey()), 40);
 	}
 
 /**
@@ -78,38 +78,38 @@ class SecurityTest extends CakeTestCase {
 		$key = 'someKey';
 		$hash = 'someHash';
 
-		$this->assertIdentical(strlen(Security::hash($key, null, false)), 40);
-		$this->assertIdentical(strlen(Security::hash($key, 'sha1', false)), 40);
-		$this->assertIdentical(strlen(Security::hash($key, null, true)), 40);
-		$this->assertIdentical(strlen(Security::hash($key, 'sha1', true)), 40);
+		$this->assertSame(strlen(Security::hash($key, null, false)), 40);
+		$this->assertSame(strlen(Security::hash($key, 'sha1', false)), 40);
+		$this->assertSame(strlen(Security::hash($key, null, true)), 40);
+		$this->assertSame(strlen(Security::hash($key, 'sha1', true)), 40);
 
 		$result = Security::hash($key, null, $hash);
-		$this->assertIdentical($result, 'e38fcb877dccb6a94729a81523851c931a46efb1');
+		$this->assertSame($result, 'e38fcb877dccb6a94729a81523851c931a46efb1');
 
 		$result = Security::hash($key, 'sha1', $hash);
-		$this->assertIdentical($result, 'e38fcb877dccb6a94729a81523851c931a46efb1');
+		$this->assertSame($result, 'e38fcb877dccb6a94729a81523851c931a46efb1');
 
 		$hashType = 'sha1';
 		Security::setHash($hashType);
-		$this->assertIdentical(Security::$hashType, $hashType);
-		$this->assertIdentical(strlen(Security::hash($key, null, true)), 40);
-		$this->assertIdentical(strlen(Security::hash($key, null, false)), 40);
+		$this->assertSame(Security::$hashType, $hashType);
+		$this->assertSame(strlen(Security::hash($key, null, true)), 40);
+		$this->assertSame(strlen(Security::hash($key, null, false)), 40);
 
-		$this->assertIdentical(strlen(Security::hash($key, 'md5', false)), 32);
-		$this->assertIdentical(strlen(Security::hash($key, 'md5', true)), 32);
+		$this->assertSame(strlen(Security::hash($key, 'md5', false)), 32);
+		$this->assertSame(strlen(Security::hash($key, 'md5', true)), 32);
 
 		$hashType = 'md5';
 		Security::setHash($hashType);
-		$this->assertIdentical(Security::$hashType, $hashType);
-		$this->assertIdentical(strlen(Security::hash($key, null, false)), 32);
-		$this->assertIdentical(strlen(Security::hash($key, null, true)), 32);
+		$this->assertSame(Security::$hashType, $hashType);
+		$this->assertSame(strlen(Security::hash($key, null, false)), 32);
+		$this->assertSame(strlen(Security::hash($key, null, true)), 32);
 
 		if (!function_exists('hash') && !function_exists('mhash')) {
-			$this->assertIdentical(strlen(Security::hash($key, 'sha256', false)), 32);
-			$this->assertIdentical(strlen(Security::hash($key, 'sha256', true)), 32);
+			$this->assertSame(strlen(Security::hash($key, 'sha256', false)), 32);
+			$this->assertSame(strlen(Security::hash($key, 'sha256', true)), 32);
 		} else {
-			$this->assertIdentical(strlen(Security::hash($key, 'sha256', false)), 64);
-			$this->assertIdentical(strlen(Security::hash($key, 'sha256', true)), 64);
+			$this->assertSame(strlen(Security::hash($key, 'sha256', false)), 64);
+			$this->assertSame(strlen(Security::hash($key, 'sha256', true)), 64);
 		}
 
 		Security::setHash($_hashType);
@@ -128,22 +128,22 @@ class SecurityTest extends CakeTestCase {
 		}
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEqual(Security::cipher($result, $key), $txt);
+		$this->assertEquals(Security::cipher($result, $key), $txt);
 
 		$txt = '';
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEqual(Security::cipher($result, $key), $txt);
+		$this->assertEquals(Security::cipher($result, $key), $txt);
 
 		$txt = 123456;
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEqual(Security::cipher($result, $key), $txt);
+		$this->assertEquals(Security::cipher($result, $key), $txt);
 
 		$txt = '123456';
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEqual(Security::cipher($result, $key), $txt);
+		$this->assertEquals(Security::cipher($result, $key), $txt);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SetTest.php
+++ b/lib/Cake/Test/Case/Utility/SetTest.php
@@ -89,19 +89,19 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::filter(array(1, array(false)));
 		$expected = array(1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::filter(array(1, array(false, false)));
 		$expected = array(1);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::filter(array(1, array('empty', false)));
 		$expected = array(1, array('empty'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::filter(array(1, array('2', false, array(3, null))));
 		$expected = array(1, array('2', 2 => array(3)));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertSame(array(), Set::filter(array()));
 	}
@@ -362,7 +362,7 @@ class SetTest extends CakeTestCase {
 			array('employees' => array(array('name' => array()))),
 			array('employees' => array(array('name' => array())))
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -386,10 +386,10 @@ class SetTest extends CakeTestCase {
 			array('class' => 625, 'test2' => 4),
 		);
 		$result = Set::sort($data, '{n}.class', 'asc');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::sort($data, '{n}.test2', 'asc');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -459,52 +459,52 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(array('a' => $c[2]['a']));
 		$r = Set::extract('/a/II[a=3]/..', $c);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEqual(Set::extract('/User/id', $a), $expected);
+		$this->assertEquals(Set::extract('/User/id', $a), $expected);
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEqual(Set::extract('/User/id', $a), $expected);
+		$this->assertEquals(Set::extract('/User/id', $a), $expected);
 
 		$expected = array(
 			array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5)
 		);
 
 		$r = Set::extract('/User/id', $a, array('flatten' => false));
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
-		$this->assertEqual(Set::extract('/Deep/Nesting/test', $a), $expected);
-		$this->assertEqual(Set::extract('/Deep/Nesting/test', $b), $expected);
+		$this->assertEquals(Set::extract('/Deep/Nesting/test', $a), $expected);
+		$this->assertEquals(Set::extract('/Deep/Nesting/test', $b), $expected);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/1/..', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/2/and/../..', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/2/../../../Nesting/test/2/..', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(2);
 		$r = Set::extract('/User[2]/id', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(4, 5);
 		$r = Set::extract('/User[id>3]/id', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(2, 3);
 		$r = Set::extract('/User[id>1][id<=3]/id', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('I'), array('II'));
 		$r = Set::extract('/a/@*', $c);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$single = array(
 			'User' => array(
@@ -539,27 +539,27 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(1, 2, 3, 4);
 		$r = Set::extract('/User/id', $tricky);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(4);
 		$r = Set::extract('/User/id', $single);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(1, 3);
 		$r = Set::extract('/User[name=/n/]/id', $tricky);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(4);
 		$r = Set::extract('/User[name=/N/]/id', $tricky);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(1, 3, 4);
 		$r = Set::extract('/User[name=/N/i]/id', $tricky);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('id', 'name'), array('id', 'name'), array('id', 'name'), array('id', 'name'));
 		$r = Set::extract('/User/@*', $tricky);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$common = array(
 			array(
@@ -621,50 +621,50 @@ class SetTest extends CakeTestCase {
 
 		$r = Set::extract('/Comment/id', $common);
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(1, 2, 4, 5);
 		$r = Set::extract('/Comment[id!=3]/id', $common);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$r = Set::extract('/', $common);
-		$this->assertEqual($r, $common);
+		$this->assertEquals($r, $common);
 
 		$expected = array(1, 2, 4, 5);
 		$r = Set::extract($common, '/Comment[id!=3]/id');
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array($common[0]['Comment'][2]);
 		$r = Set::extract($common, '/Comment/2');
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array($common[0]['Comment'][0]);
 		$r = Set::extract($common, '/Comment[1]/.[id=1]');
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array($common[1]['Comment'][1]);
 		$r = Set::extract($common, '/1/Comment/.[2]');
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array();
 		$r = Set::extract('/User/id', array());
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(5);
 		$r = Set::extract('/Comment/id[:last]', $common);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(1);
 		$r = Set::extract('/Comment/id[:first]', $common);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(3);
 		$r = Set::extract('/Article[:last]/id', $common);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('Comment' => $common[1]['Comment'][0]));
 		$r = Set::extract('/Comment[addition=]', $common);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$habtm = array(
 			array(
@@ -718,15 +718,15 @@ class SetTest extends CakeTestCase {
 		);
 
 		$r = Set::extract('/Comment/User[name=/bob|dan/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'dan');
-		$this->assertEqual(count($r), 2);
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'dan');
+		$this->assertEquals(count($r), 2);
 
 		$r = Set::extract('/Comment/User[name=/bob|tod/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
 
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEqual(count($r), 2);
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
+		$this->assertEquals(count($r), 2);
 
 		$tree = array(
 			array(
@@ -748,20 +748,20 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(array('Category' => $tree[1]['Category']));
 		$r = Set::extract('/Category[name=Category 2]', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(
 			array('Category' => $tree[1]['Category'], 'children' => $tree[1]['children'])
 		);
 		$r = Set::extract('/Category[name=Category 2]/..', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(
 			array('children' => $tree[1]['children'][0]),
 			array('children' => $tree[1]['children'][1])
 		);
 		$r = Set::extract('/Category[name=Category 2]/../children', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$habtm = array(
 			array(
@@ -815,28 +815,28 @@ class SetTest extends CakeTestCase {
 		);
 
 		$r = Set::extract('/Comment/User[name=/\w+/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEqual($r[2]['Comment']['User']['name'], 'dan');
-		$this->assertEqual($r[3]['Comment']['User']['name'], 'dan');
-		$this->assertEqual(count($r), 4);
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
+		$this->assertEquals($r[2]['Comment']['User']['name'], 'dan');
+		$this->assertEquals($r[3]['Comment']['User']['name'], 'dan');
+		$this->assertEquals(count($r), 4);
 
 		$r = Set::extract('/Comment/User[name=/[a-z]+/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEqual($r[2]['Comment']['User']['name'], 'dan');
-		$this->assertEqual($r[3]['Comment']['User']['name'], 'dan');
-		$this->assertEqual(count($r), 4);
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
+		$this->assertEquals($r[2]['Comment']['User']['name'], 'dan');
+		$this->assertEquals($r[3]['Comment']['User']['name'], 'dan');
+		$this->assertEquals(count($r), 4);
 
 		$r = Set::extract('/Comment/User[name=/bob|dan/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'dan');
-		$this->assertEqual(count($r), 2);
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'dan');
+		$this->assertEquals(count($r), 2);
 
 		$r = Set::extract('/Comment/User[name=/bob|tod/]/..', $habtm);
-		$this->assertEqual($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEqual($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEqual(count($r), 2);
+		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
+		$this->assertEquals(count($r), 2);
 
 		$mixedKeys = array(
 			'User' => array(
@@ -853,7 +853,7 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array('Neo', 'Morpheus');
 		$r = Set::extract('/User/name', $mixedKeys);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$f = array(
 			array(
@@ -886,11 +886,11 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('name' => 'zipfile2.zip','type' => 'application/x-zip-compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784'));
 		$r = Set::extract('/file/.[type=application/x-zip-compressed]', $f);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('name' => 'zipfile.zip','type' => 'application/zip','tmp_name' => '/tmp/php178.tmp','error' => 0,'size' => '564647'));
 		$r = Set::extract('/file/.[type=application/zip]', $f);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$f = array(
 			array(
@@ -923,14 +923,14 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('name' => 'zipfile2.zip','type' => 'application/x zip compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784'));
 		$r = Set::extract('/file/.[type=application/x zip compressed]', $f);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(
 			array('name' => 'zipfile.zip','type' => 'application/zip','tmp_name' => '/tmp/php178.tmp','error' => 0,'size' => '564647'),
 			array('name' => 'zipfile2.zip','type' => 'application/x zip compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784')
 		);
 		$r = Set::extract('/file/.[tmp_name=/tmp\/php17/]', $f);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$hasMany = array(
 			'Node' => array(
@@ -1062,15 +1062,15 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('Category' => $tree[1]['Category']));
 		$r = Set::extract('/Category[name=Category 2]', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('Category' => $tree[1]['Category'], 'children' => $tree[1]['children']));
 		$r = Set::extract('/Category[name=Category 2]/..', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(array('children' => $tree[1]['children'][0]), array('children' => $tree[1]['children'][1]));
 		$r = Set::extract('/Category[name=Category 2]/../children', $tree);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$single = array(
 			array(
@@ -1085,7 +1085,7 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(7);
 		$r = Set::extract('/CallType[name=Internal Voice]/../x/hour', $single);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$multiple = array(
 			array(
@@ -1116,7 +1116,7 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(7,2,1);
 		$r = Set::extract('/CallType[name=Internal Voice]/../x/hour', $multiple);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$a = array(
 			'Model' => array(
@@ -1184,7 +1184,7 @@ class SetTest extends CakeTestCase {
 			)
 		);
 		$r = Set::extract('/Model/SubModelsModel[type=2]/..', $a);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 	}
 
 /**
@@ -1215,7 +1215,7 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(1, 2, 3);
 		$r = Set::extract('/User/id', $nonZero);
-		$this->assertEqual($r, $expected);
+		$this->assertEquals($r, $expected);
 
 		$expected = array(
 			array('User' => array('id' => 1, 'name' => 'John')),
@@ -1223,7 +1223,7 @@ class SetTest extends CakeTestCase {
 			array('User' => array('id' => 3, 'name' => 'Tony')),
 		);
 		$result = Set::extract('/User', $nonZero);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$nonSequential = array(
 			'User' => array(
@@ -1246,16 +1246,16 @@ class SetTest extends CakeTestCase {
 		);
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEqual(Set::extract('/User/id', $nonSequential), $expected);
+		$this->assertEquals(Set::extract('/User/id', $nonSequential), $expected);
 
 		$result = Set::extract('/User/id', $nonZero);
-		$this->assertEqual($expected, $result, 'Failed non zero array key extract');
+		$this->assertEquals($expected, $result, 'Failed non zero array key extract');
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEqual(Set::extract('/User/id', $nonSequential), $expected);
+		$this->assertEquals(Set::extract('/User/id', $nonSequential), $expected);
 
 		$result = Set::extract('/User/id', $nonZero);
-		$this->assertEqual($expected, $result, 'Failed non zero array key extract');
+		$this->assertEquals($expected, $result, 'Failed non zero array key extract');
 
 		$startingAtOne = array(
 			'Article' => array(
@@ -1268,7 +1268,7 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(0 => array('Article' => array('id' => 1, 'approved' => 1)));
 		$result = Set::extract('/Article[approved=1]', $startingAtOne);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$items = array(
 			240 => array(
@@ -1288,8 +1288,8 @@ class SetTest extends CakeTestCase {
 		);
 
 		$result = Set::extract('/B/field1', $items);
-		$this->assertIdentical($expected, $result);
-		$this->assertIdentical($result, Set::extract('{n}.B.field1', $items));
+		$this->assertSame($expected, $result);
+		$this->assertSame($result, Set::extract('{n}.B.field1', $items));
 	}
 /**
  * testExtractWithArrays method
@@ -1303,8 +1303,8 @@ class SetTest extends CakeTestCase {
 				'Level2bis' => array('test3', 'test4')
 			)
 		);
-		$this->assertEqual(Set::extract('/Level1/Level2', $data), array(array('Level2' => array('test1', 'test2'))));
-		$this->assertEqual(Set::extract('/Level1/Level2bis', $data), array(array('Level2bis' => array('test3', 'test4'))));
+		$this->assertEquals(Set::extract('/Level1/Level2', $data), array(array('Level2' => array('test1', 'test2'))));
+		$this->assertEquals(Set::extract('/Level1/Level2bis', $data), array(array('Level2bis' => array('test3', 'test4'))));
 	}
 
 /**
@@ -1324,7 +1324,7 @@ class SetTest extends CakeTestCase {
 			array('node' => array('foo')),
 			'bar'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'node' => array(
@@ -1337,7 +1337,7 @@ class SetTest extends CakeTestCase {
 			array('foo' => array('bar')),
 			array('bar' => array('foo')),
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$data = array(
 			'node' => array(
@@ -1352,7 +1352,7 @@ class SetTest extends CakeTestCase {
 			array('foo' => array('bar')),
 			'foo'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1421,8 +1421,8 @@ class SetTest extends CakeTestCase {
 		);
 
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
-		$this->assertEqual(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
-		$this->assertEqual(Set::extract('/Article/keep/User/fields', $r), array('user'));
+		$this->assertEquals(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
+		$this->assertEquals(Set::extract('/Article/keep/User/fields', $r), array('user'));
 
 
 	}
@@ -1739,7 +1739,7 @@ class SetTest extends CakeTestCase {
  */
 	public function testWritingWithFunkyKeys() {
 		$set = Set::insert(array(), 'Session Test', "test");
-		$this->assertEqual(Set::extract($set, 'Session Test'), 'test');
+		$this->assertEquals(Set::extract($set, 'Session Test'), 'test');
 
 		$set = Set::remove($set, 'Session Test');
 		$this->assertFalse(Set::check($set, 'Session Test'));
@@ -1986,7 +1986,7 @@ class SetTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Set::combine($a, 'fail', 'fail');
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 	}
 
 /**
@@ -1996,10 +1996,10 @@ class SetTest extends CakeTestCase {
  */
 	public function testMapReverse() {
 		$result = Set::reverse(null);
-		$this->assertEqual($result, null);
+		$this->assertEquals($result, null);
 
 		$result = Set::reverse(false);
-		$this->assertEqual($result, false);
+		$this->assertEquals($result, false);
 
 		$expected = array(
 		'Array1' => array(
@@ -2017,8 +2017,8 @@ class SetTest extends CakeTestCase {
 				3 => array('Array3Data1' => 4, 'Array3Data2' => 'Array3Data2 value 2', 'Array3Data3' => 'Array3Data3 value 2', 'Array3Data4' => 'Array3Data4 value 4'),
 				4 => array('Array3Data1' => 5, 'Array3Data2' => 'Array3Data2 value 2', 'Array3Data3' => 'Array3Data3 value 2', 'Array3Data4' => 'Array3Data4 value 4')));
 		$map = Set::map($expected, true);
-		$this->assertEqual($map->Array1->Array1Data1, $expected['Array1']['Array1Data1']);
-		$this->assertEqual($map->Array2[0]->Array2Data1, $expected['Array2'][0]['Array2Data1']);
+		$this->assertEquals($map->Array1->Array1Data1, $expected['Array1']['Array1Data1']);
+		$this->assertEquals($map->Array2[0]->Array2Data1, $expected['Array2'][0]['Array2Data1']);
 
 		$result = Set::reverse($map);
 		$this->assertEquals($expected, $result);
@@ -2201,7 +2201,7 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::reverse($class);
 		$expected = array('User' => array('id' => '100'), 'someString'=> 'this is some string', 'Profile' => array('name' => 'Joe Mamma'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$class = new stdClass;
 		$class->User = new stdClass;
@@ -2213,7 +2213,7 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::reverse($class);
 		$expected = array('User' => array('id' => '100'), 'Profile' => array('name' => 'Joe Mamma'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2229,38 +2229,38 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::format($data, '{1}, {0}', array('{n}.Person.first_name', '{n}.Person.last_name'));
 		$expected = array('Abele, Nate', 'Masters, Larry', 'Woodworth, Garrett');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{0}, {1}', array('{n}.Person.last_name', '{n}.Person.first_name'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{0}, {1}', array('{n}.Person.city', '{n}.Person.state'));
 		$expected = array('Boston, MA', 'Boondock, TN', 'Venice Beach, CA');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{{0}, {1}}', array('{n}.Person.city', '{n}.Person.state'));
 		$expected = array('{Boston, MA}', '{Boondock, TN}', '{Venice Beach, CA}');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{{0}, {1}}', array('{n}.Person.something', '{n}.Person.something'));
 		$expected = array('{42, 42}', '{{0}, {0}}', '{{1}, {1}}');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{%2$d, %1$s}', array('{n}.Person.something', '{n}.Person.something'));
 		$expected = array('{42, 42}', '{0, {0}}', '{0, {1}}');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{%1$s, %1$s}', array('{n}.Person.something', '{n}.Person.something'));
 		$expected = array('{42, 42}', '{{0}, {0}}', '{{1}, {1}}');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '%2$d, %1$s', array('{n}.Person.first_name', '{n}.Person.something'));
 		$expected = array('42, Nate', '0, Larry', '0, Garrett');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '%1$s, %2$d', array('{n}.Person.first_name', '{n}.Person.something'));
 		$expected = array('Nate, 42', 'Larry, 0', 'Garrett, 0');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2276,11 +2276,11 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::format($data, '%s', array('{n}.Person.something'));
 		$expected = array('42', '', '');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::format($data, '{0}, {1}', array('{n}.Person.city', '{n}.Person.something'));
 		$expected = array('Boston, 42', 'Boondock, ', 'Venice Beach, ');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2291,50 +2291,50 @@ class SetTest extends CakeTestCase {
 	public function testCountDim() {
 		$data = array('one', '2', 'three');
 		$result = Set::countDim($data);
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 
 		$data = array('1' => '1.1', '2', '3');
 		$result = Set::countDim($data);
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data);
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$data = array('1' => '1.1', '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data);
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 
 		$data = array('1' => '1.1', '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data, true);
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data);
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEqual($result, 3);
+		$this->assertEquals($result, 3);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => '2.1.1.1'))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEqual($result, 5);
+		$this->assertEquals($result, 5);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1' => '2.1.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEqual($result, 5);
+		$this->assertEquals($result, 5);
 
 		$set = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1' => '2.1.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($set, false, 0);
-		$this->assertEqual($result, 2);
+		$this->assertEquals($result, 2);
 
 		$result = Set::countDim($set, true);
-		$this->assertEqual($result, 5);
+		$this->assertEquals($result, 5);
 	}
 
 /**
@@ -2406,8 +2406,8 @@ class SetTest extends CakeTestCase {
 		foreach($mapped as $object)	 {
 			$ids[] = $object->id;
 		}
-		$this->assertEqual($ids, array(1, 2));
-		$this->assertEqual(get_object_vars($mapped[0]->headers), $expected[0]['IndexedPage']['headers']);
+		$this->assertEquals($ids, array(1, 2));
+		$this->assertEquals(get_object_vars($mapped[0]->headers), $expected[0]['IndexedPage']['headers']);
 
 		$result = Set::reverse($mapped);
 		$this->assertEquals($expected, $result);
@@ -2454,11 +2454,11 @@ class SetTest extends CakeTestCase {
 		foreach($mapped as $object)	 {
 			$ids[] = $object->id;
 		}
-		$this->assertEqual($ids, array(1, 2));
+		$this->assertEquals($ids, array(1, 2));
 
 		$result = Set::map(null);
 		$expected = null;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2769,28 +2769,28 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::apply('/Movie/rating', $data, 'array_sum');
 		$expected = 9;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 
 		$result = Set::apply('/Movie/rating', $data, 'array_product');
 		$expected = 15;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::apply('/Movie/title', $data, 'ucfirst', array('type' => 'map'));
 		$expected = array('Movie 3', 'Movie 1', 'Movie 2');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::apply('/Movie/title', $data, 'strtoupper', array('type' => 'map'));
 		$expected = array('MOVIE 3', 'MOVIE 1', 'MOVIE 2');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::apply('/Movie/rating', $data, array('SetTest', '_method'), array('type' => 'reduce'));
 		$expected = 9;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::apply('/Movie/rating', $data, 'strtoupper', array('type' => 'non existing type'));
 		$expected = null;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -2866,13 +2866,13 @@ class SetTest extends CakeTestCase {
 				)
 			)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$string ='<data><post title="Title of this post" description="cool"/></data>';
 
 		$xml = Xml::build($string);
 		$result = Set::reverse($xml);
 		$expected = array('data' => array('post' => array('@title' => 'Title of this post', '@description' => 'cool')));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$xml = Xml::build('<example><item><title>An example of a correctly reversed SimpleXMLElement</title><desc/></item></example>');
 		$result = Set::reverse($xml);
@@ -2980,7 +2980,7 @@ class SetTest extends CakeTestCase {
 				)
 			)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = '<?xml version="1.0" encoding="UTF-8"?>
 		<XRDS xmlns="xri://$xrds">
@@ -3043,7 +3043,7 @@ class SetTest extends CakeTestCase {
 				)
 			)
 		));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3064,11 +3064,11 @@ class SetTest extends CakeTestCase {
 	public function testFlatten() {
 		$data = array('Larry', 'Curly', 'Moe');
 		$result = Set::flatten($data);
-		$this->assertEqual($result, $data);
+		$this->assertEquals($result, $data);
 
 		$data[9] = 'Shemp';
 		$result = Set::flatten($data);
-		$this->assertEqual($result, $data);
+		$this->assertEquals($result, $data);
 
 		$data = array(
 			array(
@@ -3088,7 +3088,7 @@ class SetTest extends CakeTestCase {
 			'1.Post.title' => 'Second Post', '1.Post.body' => 'Second Post Body', '1.Author.id' => '3',
 			'1.Author.user' => 'larry', '1.Author.password' => null
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3099,15 +3099,15 @@ class SetTest extends CakeTestCase {
 	public function testNormalizeStrings() {
 		$result = Set::normalize('one,two,three');
 		$expected = array('one' => null, 'two' => null, 'three' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize('one two three', true, ' ');
 		$expected = array('one' => null, 'two' => null, 'three' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize('one  ,  two   ,  three   ', true, ',', true);
 		$expected = array('one' => null, 'two' => null, 'three' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3118,22 +3118,22 @@ class SetTest extends CakeTestCase {
 	public function testNormalizeArrays() {
 		$result = Set::normalize(array('one', 'two', 'three'));
 		$expected = array('one' => null, 'two' => null, 'three' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize(array('one', 'two', 'three'), false);
 		$expected = array('one', 'two', 'three');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize(array('one' => 1, 'two' => 2, 'three' => 3, 'four'), false);
 		$expected = array('one' => 1, 'two' => 2, 'three' => 3, 'four' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize(array('one' => 1, 'two' => 2, 'three' => 3, 'four'));
 		$expected = array('one' => 1, 'two' => 2, 'three' => 3, 'four' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = Set::normalize(array('one' => array('a', 'b', 'c' => 'cee'), 'two' => 2, 'three'));
 		$expected = array('one' => array('a', 'b', 'c' => 'cee'), 'two' => 2, 'three' => null);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -65,124 +65,124 @@ class StringTest extends CakeTestCase {
 		$string = 'some string';
 		$expected = 'some string';
 		$result = String::insert($string, array());
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = :sum. Cake is :adjective.';
 		$expected = '2 + 2 = 4. Cake is yummy.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = %sum. Cake is %adjective.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('before' => '%'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = 2sum2. Cake is 9adjective9.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('format' => '/([\d])%s\\1/'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = 12sum21. Cake is 23adjective45.';
 		$expected = '2 + 2 = 4. Cake is 23adjective45.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('format' => '/([\d])([\d])%s\\2\\1/'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':web :web_site';
 		$expected = 'www http';
 		$result = String::insert($string, array('web' => 'www', 'web_site' => 'http'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = <sum. Cake is <adjective>.';
 		$expected = '2 + 2 = <sum. Cake is yummy.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('before' => '<', 'after' => '>'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = \:sum. Cake is :adjective.';
 		$expected = '2 + 2 = :sum. Cake is yummy.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = !:sum. Cake is :adjective.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('escape' => '!'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '2 + 2 = \%sum. Cake is %adjective.';
 		$expected = '2 + 2 = %sum. Cake is yummy.';
 		$result = String::insert($string, array('sum' => '4', 'adjective' => 'yummy'), array('before' => '%'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':a :b \:a :a';
 		$expected = '1 2 :a 1';
 		$result = String::insert($string, array('a' => 1, 'b' => 2));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':a :b :c';
 		$expected = '2 3';
 		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':a :b :c';
 		$expected = '1 3';
 		$result = String::insert($string, array('a' => 1, 'c' => 3), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':a :b :c';
 		$expected = '2 3';
 		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = ':a, :b and :c';
 		$expected = '2 and 3';
 		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '":a, :b and :c"';
 		$expected = '"1, 2"';
 		$result = String::insert($string, array('a' => 1, 'b' => 2), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '"${a}, ${b} and ${c}"';
 		$expected = '"1, 2"';
 		$result = String::insert($string, array('a' => 1, 'b' => 2), array('before' => '${', 'after' => '}', 'clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<img src=":src" alt=":alt" class="foo :extra bar"/>';
 		$expected = '<img src="foo" class="foo bar"/>';
 		$result = String::insert($string, array('src' => 'foo'), array('clean' => 'html'));
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<img src=":src" class=":no :extra"/>';
 		$expected = '<img src="foo"/>';
 		$result = String::insert($string, array('src' => 'foo'), array('clean' => 'html'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = '<img src=":src" class=":no :extra"/>';
 		$expected = '<img src="foo" class="bar"/>';
 		$result = String::insert($string, array('src' => 'foo', 'extra' => 'bar'), array('clean' => 'html'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert("this is a ? string", "test");
 		$expected = "this is a test string";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert("this is a ? string with a ? ? ?", array('long', 'few?', 'params', 'you know'));
 		$expected = "this is a long string with a few? params you know";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert('update saved_urls set url = :url where id = :id', array('url' => 'http://www.testurl.com/param1:url/param2:id','id' => 1));
 		$expected = "update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert('update saved_urls set url = :url where id = :id', array('id' => 1, 'url' => 'http://www.testurl.com/param1:url/param2:id'));
 		$expected = "update saved_urls set url = http://www.testurl.com/param1:url/param2:id where id = 1";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert(':me cake. :subject :verb fantastic.', array('me' => 'I :verb', 'subject' => 'cake', 'verb' => 'is'));
 		$expected = "I :verb cake. cake is fantastic.";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert(':I.am: :not.yet: passing.', array('I.am' => 'We are'), array('before' => ':', 'after' => ':', 'clean' => array('replacement' => ' of course', 'method' => 'text')));
 		$expected = "We are of course passing.";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert(
 			':I.am: :not.yet: passing.',
@@ -190,31 +190,31 @@ class StringTest extends CakeTestCase {
 			array('before' => ':', 'after' => ':', 'clean' => true)
 		);
 		$expected = "We are passing.";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::insert('?-pended result', array('Pre'));
 		$expected = "Pre-pended result";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'switching :timeout / :timeout_count';
 		$expected = 'switching 5 / 10';
 		$result = String::insert($string, array('timeout' => 5, 'timeout_count' => 10));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'switching :timeout / :timeout_count';
 		$expected = 'switching 5 / 10';
 		$result = String::insert($string, array('timeout_count' => 10, 'timeout' => 5));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'switching :timeout_count by :timeout';
 		$expected = 'switching 10 by 5';
 		$result = String::insert($string, array('timeout' => 5, 'timeout_count' => 10));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$string = 'switching :timeout_count by :timeout';
 		$expected = 'switching 10 by 5';
 		$result = String::insert($string, array('timeout_count' => 10, 'timeout' => 5));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -226,34 +226,34 @@ class StringTest extends CakeTestCase {
 		$result = String::cleanInsert(':incomplete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$result = String::cleanInsert(':incomplete', array(
 			'clean' => array('method' => 'text', 'replacement' => 'complete'),
 			'before' => ':', 'after' => '')
 		);
-		$this->assertEqual($result, 'complete');
+		$this->assertEquals($result, 'complete');
 
 		$result = String::cleanInsert(':in.complete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$result = String::cleanInsert(':in.complete and', array(
 			'clean' => true, 'before' => ':', 'after' => '')
 		);
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$result = String::cleanInsert(':in.complete or stuff', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEqual($result, 'stuff');
+		$this->assertEquals($result, 'stuff');
 
 		$result = String::cleanInsert(
 			'<p class=":missing" id=":missing">Text here</p>',
 			array('clean' => 'html', 'before' => ':', 'after' => '')
 		);
-		$this->assertEqual($result, '<p>Text here</p>');
+		$this->assertEquals($result, '<p>Text here</p>');
 	}
 
 /**
@@ -265,7 +265,7 @@ class StringTest extends CakeTestCase {
 	public function testAutoIgnoreBadInsertData() {
 		$data = array('foo' => 'alpha', 'bar' => 'beta', 'fale' => array());
 		$result = String::insert('(:foo > :bar || :fale!)', $data, array('clean' => 'text'));
-		$this->assertEqual($result, '(alpha > beta || !)');
+		$this->assertEquals($result, '(alpha > beta || !)');
 	}
 
 /**
@@ -276,30 +276,30 @@ class StringTest extends CakeTestCase {
 	public function testTokenize() {
 		$result = String::tokenize('A,(short,boring test)');
 		$expected = array('A', '(short,boring test)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::tokenize('A,(short,more interesting( test)');
 		$expected = array('A', '(short,more interesting( test)');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::tokenize('A,(short,very interesting( test))');
 		$expected = array('A', '(short,very interesting( test))');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::tokenize('"single tag"', ' ', '"', '"');
 		$expected = array('"single tag"');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = String::tokenize('tagA "single tag" tagB', ' ', '"', '"');
 		$expected = array('tagA', '"single tag"', 'tagB');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testReplaceWithQuestionMarkInString() {
 		$string = ':a, :b and :c?';
 		$expected = '2 and 3?';
 		$result = String::insert($string, array('b' => 2, 'c' => 3), array('clean' => true));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -120,41 +120,41 @@ class XmlTest extends CakeTestCase {
 		$xml = '<tag>value</tag>';
 		$obj = Xml::build($xml);
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEqual((string)$obj->getName(), 'tag');
-		$this->assertEqual((string)$obj, 'value');
+		$this->assertEquals((string)$obj->getName(), 'tag');
+		$this->assertEquals((string)$obj, 'value');
 
 		$xml = '<?xml version="1.0" encoding="UTF-8"?><tag>value</tag>';
-		$this->assertEqual($obj, Xml::build($xml));
+		$this->assertEquals($obj, Xml::build($xml));
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
 		$this->assertTrue($obj instanceof DOMDocument);
-		$this->assertEqual($obj->firstChild->nodeName, 'tag');
-		$this->assertEqual($obj->firstChild->nodeValue, 'value');
+		$this->assertEquals($obj->firstChild->nodeName, 'tag');
+		$this->assertEquals($obj->firstChild->nodeValue, 'value');
 
 		$xml = CAKE . 'Test' . DS . 'Fixture' . DS . 'sample.xml';
 		$obj = Xml::build($xml);
-		$this->assertEqual($obj->getName(), 'tags');
-		$this->assertEqual(count($obj), 2);
+		$this->assertEquals($obj->getName(), 'tags');
+		$this->assertEquals(count($obj), 2);
 
-		$this->assertEqual(Xml::build($xml), Xml::build(file_get_contents($xml)));
+		$this->assertEquals(Xml::build($xml), Xml::build(file_get_contents($xml)));
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
-		$this->assertEqual($obj->firstChild->nodeName, 'tags');
+		$this->assertEquals($obj->firstChild->nodeName, 'tags');
 
-		$this->assertEqual(Xml::build($xml, array('return' => 'domdocument')), Xml::build(file_get_contents($xml), array('return' => 'domdocument')));
-		$this->assertEqual(Xml::build($xml, array('return' => 'simplexml')), Xml::build($xml, 'simplexml'));
+		$this->assertEquals(Xml::build($xml, array('return' => 'domdocument')), Xml::build(file_get_contents($xml), array('return' => 'domdocument')));
+		$this->assertEquals(Xml::build($xml, array('return' => 'simplexml')), Xml::build($xml, 'simplexml'));
 
 		$xml = array('tag' => 'value');
 		$obj = Xml::build($xml);
-		$this->assertEqual($obj->getName(), 'tag');
-		$this->assertEqual((string)$obj, 'value');
+		$this->assertEquals($obj->getName(), 'tag');
+		$this->assertEquals((string)$obj, 'value');
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
-		$this->assertEqual($obj->firstChild->nodeName, 'tag');
-		$this->assertEqual($obj->firstChild->nodeValue, 'value');
+		$this->assertEquals($obj->firstChild->nodeName, 'tag');
+		$this->assertEquals($obj->firstChild->nodeValue, 'value');
 
 		$obj = Xml::build($xml, array('return' => 'domdocument', 'encoding' => null));
-		$this->assertNoPattern('/encoding/', $obj->saveXML());
+		$this->assertNotRegExp('/encoding/', $obj->saveXML());
 	}
 
 /**
@@ -203,18 +203,18 @@ class XmlTest extends CakeTestCase {
 	public function testFromArray() {
 		$xml = array('tag' => 'value');
 		$obj = Xml::fromArray($xml);
-		$this->assertEqual($obj->getName(), 'tag');
-		$this->assertEqual((string)$obj, 'value');
+		$this->assertEquals($obj->getName(), 'tag');
+		$this->assertEquals((string)$obj, 'value');
 
 		$xml = array('tag' => null);
 		$obj = Xml::fromArray($xml);
-		$this->assertEqual($obj->getName(), 'tag');
-		$this->assertEqual((string)$obj, '');
+		$this->assertEquals($obj->getName(), 'tag');
+		$this->assertEquals((string)$obj, '');
 
 		$xml = array('tag' => array('@' => 'value'));
 		$obj = Xml::fromArray($xml);
-		$this->assertEqual($obj->getName(), 'tag');
-		$this->assertEqual((string)$obj, 'value');
+		$this->assertEquals($obj->getName(), 'tag');
+		$this->assertEquals((string)$obj, 'value');
 
 		$xml = array(
 			'tags' => array(
@@ -232,25 +232,25 @@ class XmlTest extends CakeTestCase {
 		);
 		$obj = Xml::fromArray($xml, 'attributes');
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEqual($obj->getName(), 'tags');
-		$this->assertEqual(count($obj), 2);
+		$this->assertEquals($obj->getName(), 'tags');
+		$this->assertEquals(count($obj), 2);
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag id="1" name="defect"/><tag id="2" name="enhancement"/></tags>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
 		$obj = Xml::fromArray($xml);
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEqual($obj->getName(), 'tags');
-		$this->assertEqual(count($obj), 2);
+		$this->assertEquals($obj->getName(), 'tags');
+		$this->assertEquals(count($obj), 2);
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag><id>1</id><name>defect</name></tag><tag><id>2</id><name>enhancement</name></tag></tags>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
 		$xml = array(
 			'tags' => array(
 			)
 		);
 		$obj = Xml::fromArray($xml);
-		$this->assertEqual($obj->getName(), 'tags');
-		$this->assertEqual((string)$obj, '');
+		$this->assertEquals($obj->getName(), 'tags');
+		$this->assertEquals((string)$obj, '');
 
 		$xml = array(
 			'tags' => array(
@@ -263,13 +263,13 @@ class XmlTest extends CakeTestCase {
 			)
 		);
 		$obj = Xml::fromArray($xml, 'tags');
-		$this->assertEqual(count($obj), 6);
-		$this->assertIdentical((string)$obj->bool, '1');
-		$this->assertIdentical((string)$obj->int, '1');
-		$this->assertIdentical((string)$obj->float, '10.2');
-		$this->assertIdentical((string)$obj->string, 'ok');
-		$this->assertIdentical((string)$obj->null, '');
-		$this->assertIdentical((string)$obj->array, '');
+		$this->assertEquals(count($obj), 6);
+		$this->assertSame((string)$obj->bool, '1');
+		$this->assertSame((string)$obj->int, '1');
+		$this->assertSame((string)$obj->float, '10.2');
+		$this->assertSame((string)$obj->string, 'ok');
+		$this->assertSame((string)$obj->null, '');
+		$this->assertSame((string)$obj->array, '');
 
 		$xml = array(
 			'tags' => array(
@@ -287,7 +287,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$obj = Xml::fromArray($xml, 'tags');
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag id="1"><name>defect</name></tag><tag id="2"><name>enhancement</name></tag></tags>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
 		$xml = array(
 			'tags' => array(
@@ -307,7 +307,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$obj = Xml::fromArray($xml, 'tags');
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags>All tags<tag id="1">Tag 1<name>defect</name></tag><tag id="2"><name>enhancement</name></tag></tags>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
 		$xml = array(
 			'tags' => array(
@@ -319,7 +319,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$obj = Xml::fromArray($xml, 'attributes');
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag id="1">defect</tag></tags>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 	}
 
 /**
@@ -387,7 +387,7 @@ class XmlTest extends CakeTestCase {
 	public function testToArray() {
 		$xml = '<tag>name</tag>';
 		$obj = Xml::build($xml);
-		$this->assertEqual(Xml::toArray($obj), array('tag' => 'name'));
+		$this->assertEquals(Xml::toArray($obj), array('tag' => 'name'));
 
 		$xml = CAKE . 'Test' . DS . 'Fixture' . DS . 'sample.xml';
 		$obj = Xml::build($xml);
@@ -405,7 +405,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($obj), $expected);
+		$this->assertEquals(Xml::toArray($obj), $expected);
 
 		$array = array(
 			'tags' => array(
@@ -421,7 +421,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, 'tags')), $array);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, 'tags')), $array);
 
 		$expected = array(
 			'tags' => array(
@@ -437,10 +437,10 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument', 'format' => 'attributes'))), $expected);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array)), $array);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument'))), $array);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument', 'format' => 'attributes'))), $expected);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array)), $array);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument'))), $array);
 
 		$array = array(
 			'tags' => array(
@@ -474,8 +474,8 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
-		$this->assertEqual(Xml::toArray(Xml::fromArray($array, array('format' => 'attributes', 'return' => 'domdocument'))), $expected);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
+		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('format' => 'attributes', 'return' => 'domdocument'))), $expected);
 
 		$xml = '<root>';
 		$xml .= '<tag id="1">defect</tag>';
@@ -490,7 +490,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($obj), $expected);
+		$this->assertEquals(Xml::toArray($obj), $expected);
 
 		$xml = '<root>';
 		$xml .= '<table xmlns="http://www.w3.org/TR/html4/"><tr><td>Apples</td><td>Bananas</td></tr></table>';
@@ -508,7 +508,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($obj), $expected);
+		$this->assertEquals(Xml::toArray($obj), $expected);
 
 		$xml = '<root xmlns:cake="http://www.cakephp.org/">';
 		$xml .= '<tag>defect</tag>';
@@ -522,7 +522,7 @@ class XmlTest extends CakeTestCase {
 				'cake:bug' => 1
 			)
 		);
-		$this->assertEqual(Xml::toArray($obj), $expected);
+		$this->assertEquals(Xml::toArray($obj), $expected);
 	}
 
 /**
@@ -533,12 +533,12 @@ class XmlTest extends CakeTestCase {
 	public function testRss() {
 		$rss = file_get_contents(CAKE . 'Test' . DS . 'Fixture' . DS . 'rss.xml');
 		$rssAsArray = Xml::toArray(Xml::build($rss));
-		$this->assertEqual($rssAsArray['rss']['@version'], '2.0');
-		$this->assertEqual(count($rssAsArray['rss']['channel']['item']), 2);
+		$this->assertEquals($rssAsArray['rss']['@version'], '2.0');
+		$this->assertEquals(count($rssAsArray['rss']['channel']['item']), 2);
 
 		$atomLink = array('@href' => 'http://bakery.cakephp.org/articles/rss', '@rel' => 'self', '@type' => 'application/rss+xml');
-		$this->assertEqual($rssAsArray['rss']['channel']['atom:link'], $atomLink);
-		$this->assertEqual($rssAsArray['rss']['channel']['link'], 'http://bakery.cakephp.org/');
+		$this->assertEquals($rssAsArray['rss']['channel']['atom:link'], $atomLink);
+		$this->assertEquals($rssAsArray['rss']['channel']['link'], 'http://bakery.cakephp.org/');
 
 		$expected = array(
 			'title' => 'Alertpay automated sales via IPN',
@@ -547,7 +547,7 @@ class XmlTest extends CakeTestCase {
 			'pubDate' => 'Tue, 31 Aug 2010 01:42:00 -0500',
 			'guid' => 'http://bakery.cakephp.org/articles/view/alertpay-automated-sales-via-ipn'
 		);
-		$this->assertIdentical($rssAsArray['rss']['channel']['item'][1], $expected);
+		$this->assertSame($rssAsArray['rss']['channel']['item'][1], $expected);
 
 		$rss = array(
 			'rss' => array(
@@ -588,7 +588,7 @@ class XmlTest extends CakeTestCase {
 		$xmlText .= '<item><title>CakePHP 1.3.4 released</title><link>http://bakery.cakephp.org/articles/view/cakephp-1-3-4-released</link></item>';
 		$xmlText .= '<item><title>Wizard Component 1.2 Tutorial</title><link>http://bakery.cakephp.org/articles/view/wizard-component-1-2-tutorial</link></item>';
 		$xmlText .= '</channel></rss>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $rssAsSimpleXML->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $rssAsSimpleXML->asXML()), $xmlText);
 	}
 
 /**
@@ -604,7 +604,7 @@ class XmlTest extends CakeTestCase {
 				'params' => ''
 			)
 		);
-		$this->assertIdentical(Xml::toArray($xml), $expected);
+		$this->assertSame(Xml::toArray($xml), $expected);
 
 		$xml = Xml::build('<methodCall><methodName>test</methodName><params><param><value><array><data><value><int>12</int></value><value><string>Egypt</string></value><value><boolean>0</boolean></value><value><int>-31</int></value></data></array></value></param></params></methodCall>');
 		$expected = array(
@@ -628,7 +628,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertIdentical(Xml::toArray($xml), $expected);
+		$this->assertSame(Xml::toArray($xml), $expected);
 
 		$xmlText = '<?xml version="1.0" encoding="UTF-8"?><methodResponse><params><param><value><array><data><value><int>1</int></value><value><string>testing</string></value></data></array></value></param></params></methodResponse>';
 		$xml = Xml::build($xmlText);
@@ -650,10 +650,10 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertIdentical(Xml::toArray($xml), $expected);
+		$this->assertSame(Xml::toArray($xml), $expected);
 
 		$xml = Xml::fromArray($expected, 'tags');
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xml->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xml->asXML()), $xmlText);
 	}
 
 /**
@@ -673,7 +673,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($xmlRequest), $expected);
+		$this->assertEquals(Xml::toArray($xmlRequest), $expected);
 
 		$xmlResponse = Xml::build(CAKE . 'Test' . DS . 'Fixture' . DS . 'soap_response.xml');
 		$expected = array(
@@ -686,7 +686,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
 
 		$xml = array(
 			'soap:Envelope' => array(
@@ -706,7 +706,7 @@ class XmlTest extends CakeTestCase {
 		$xmlText .= '<soap:Body xmlns:m="http://www.example.org/stock">';
 		$xmlText .= '<m:GetStockPrice><m:StockName>IBM</m:StockName></m:GetStockPrice>';
 		$xmlText .= '</soap:Body></soap:Envelope>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlRequest->asXML()), $xmlText);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlRequest->asXML()), $xmlText);
 	}
 
 /**
@@ -726,7 +726,7 @@ class XmlTest extends CakeTestCase {
 				'tag' => 'Tag without ns'
 			)
 		);
-		$this->assertEqual(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
 
 		$xmlResponse = Xml::build('<root xmlns:ns="http://cakephp.org"><ns:tag id="1" /><tag><id>1</id></tag></root>');
 		$expected = array(
@@ -739,7 +739,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEqual(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
 
 		$xmlResponse = Xml::build('<root xmlns:ns="http://cakephp.org"><ns:attr>1</ns:attr></root>');
 		$expected = array(
@@ -747,10 +747,10 @@ class XmlTest extends CakeTestCase {
 				'ns:attr' => '1'
 			)
 		);
-		$this->assertEqual(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
 
 		$xmlResponse = Xml::build('<root><ns:attr xmlns:ns="http://cakephp.org">1</ns:attr></root>');
-		$this->assertEqual(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
 
 		$xml = array(
 			'root' => array(
@@ -762,7 +762,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root><ns:attr xmlns:ns="http://cakephp.org">1</ns:attr></root>';
 		$xmlResponse = Xml::fromArray($xml);
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
 
 		$xml = array(
 			'root' => array(
@@ -777,7 +777,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root><tag xmlns:pref="http://cakephp.org"><pref:item>item 1</pref:item><pref:item>item 2</pref:item></tag></root>';
 		$xmlResponse = Xml::fromArray($xml);
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
 
 		$xml = array(
 			'root' => array(
@@ -788,7 +788,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root><tag xmlns="http://cakephp.org"/></root>';
 		$xmlResponse = Xml::fromArray($xml);
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
 
 		$xml = array(
 			'root' => array(
@@ -797,7 +797,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root xmlns="http://cakephp.org"/>';
 		$xmlResponse = Xml::fromArray($xml);
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
 
 		$xml = array(
 			'root' => array(
@@ -806,7 +806,7 @@ class XmlTest extends CakeTestCase {
 		);
 		$expected = '<' . '?xml version="1.0" encoding="UTF-8"?><root xmlns:ns="http://cakephp.org"/>';
 		$xmlResponse = Xml::fromArray($xml);
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $xmlResponse->asXML()), $expected);
 	}
 
 /**
@@ -864,7 +864,7 @@ class XmlTest extends CakeTestCase {
 		$expected .= '<Article><id>3</id><user_id>1</user_id><title>Third Article</title><body>Third Article Body</body>';
 		$expected .= '<published>Y</published><created>2007-03-18 10:43:23</created><updated>2007-03-18 10:45:31</updated></Article>';
 		$expected .= '</data>';
-		$this->assertEqual(str_replace(array("\r", "\n"), '', $obj->asXML()), $expected);
+		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $expected);
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -116,16 +116,16 @@ class CacheHelperTest extends CakeTestCase {
 
 		$View = new View($this->Controller);
 		$result = $View->render('index');
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
 
 		$contents = file_get_contents($filename);
-		$this->assertPattern('/php echo \$variable/', $contents);
-		$this->assertPattern('/php echo microtime()/', $contents);
-		$this->assertPattern('/clark kent/', $result);
+		$this->assertRegExp('/php echo \$variable/', $contents);
+		$this->assertRegExp('/php echo microtime()/', $contents);
+		$this->assertRegExp('/clark kent/', $result);
 
 		@unlink($filename);
 	}
@@ -176,17 +176,17 @@ class CacheHelperTest extends CakeTestCase {
 
 		$View = new View($this->Controller);
 		$result = $View->render('test_nocache_tags');
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
 
 		$contents = file_get_contents($filename);
-		$this->assertPattern('/if \(is_writable\(TMP\)\)\:/', $contents);
-		$this->assertPattern('/php echo \$variable/', $contents);
-		$this->assertPattern('/php echo microtime()/', $contents);
-		$this->assertNoPattern('/cake:nocache/', $contents);
+		$this->assertRegExp('/if \(is_writable\(TMP\)\)\:/', $contents);
+		$this->assertRegExp('/php echo \$variable/', $contents);
+		$this->assertRegExp('/php echo microtime()/', $contents);
+		$this->assertNotRegExp('/cake:nocache/', $contents);
 
 		@unlink($filename);
 	}
@@ -212,14 +212,14 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('multiple_nocache');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
 
 		$contents = file_get_contents($filename);
-		$this->assertNoPattern('/cake:nocache/', $contents);
+		$this->assertNotRegExp('/cake:nocache/', $contents);
 		@unlink($filename);
 	}
 
@@ -246,42 +246,42 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('sequencial_nocache');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
-		$this->assertPattern('/A\. Layout Before Content/', $result);
-		$this->assertPattern('/B\. In Plain Element/', $result);
-		$this->assertPattern('/C\. Layout After Test Element/', $result);
-		$this->assertPattern('/D\. In View File/', $result);
-		$this->assertPattern('/E\. Layout After Content/', $result);
-		//$this->assertPattern('/F\. In Element With No Cache Tags/', $result);
-		$this->assertPattern('/G\. Layout After Content And After Element With No Cache Tags/', $result);
-		$this->assertNoPattern('/1\. layout before content/', $result);
-		$this->assertNoPattern('/2\. in plain element/', $result);
-		$this->assertNoPattern('/3\. layout after test element/', $result);
-		$this->assertNoPattern('/4\. in view file/', $result);
-		$this->assertNoPattern('/5\. layout after content/', $result);
-		//$this->assertNoPattern('/6\. in element with no cache tags/', $result);
-		$this->assertNoPattern('/7\. layout after content and after element with no cache tags/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
+		$this->assertRegExp('/A\. Layout Before Content/', $result);
+		$this->assertRegExp('/B\. In Plain Element/', $result);
+		$this->assertRegExp('/C\. Layout After Test Element/', $result);
+		$this->assertRegExp('/D\. In View File/', $result);
+		$this->assertRegExp('/E\. Layout After Content/', $result);
+		//$this->assertRegExp('/F\. In Element With No Cache Tags/', $result);
+		$this->assertRegExp('/G\. Layout After Content And After Element With No Cache Tags/', $result);
+		$this->assertNotRegExp('/1\. layout before content/', $result);
+		$this->assertNotRegExp('/2\. in plain element/', $result);
+		$this->assertNotRegExp('/3\. layout after test element/', $result);
+		$this->assertNotRegExp('/4\. in view file/', $result);
+		$this->assertNotRegExp('/5\. layout after content/', $result);
+		//$this->assertNotRegExp('/6\. in element with no cache tags/', $result);
+		$this->assertNotRegExp('/7\. layout after content and after element with no cache tags/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_complex.php';
 		$this->assertTrue(file_exists($filename));
 		$contents = file_get_contents($filename);
 		@unlink($filename);
 
-		$this->assertPattern('/A\. Layout Before Content/', $contents);
-		$this->assertNoPattern('/B\. In Plain Element/', $contents);
-		$this->assertPattern('/C\. Layout After Test Element/', $contents);
-		$this->assertPattern('/D\. In View File/', $contents);
-		$this->assertPattern('/E\. Layout After Content/', $contents);
-		//$this->assertPattern('/F\. In Element With No Cache Tags/', $contents);
-		$this->assertPattern('/G\. Layout After Content And After Element With No Cache Tags/', $contents);
-		$this->assertPattern('/1\. layout before content/', $contents);
-		$this->assertNoPattern('/2\. in plain element/', $contents);
-		$this->assertPattern('/3\. layout after test element/', $contents);
-		$this->assertPattern('/4\. in view file/', $contents);
-		$this->assertPattern('/5\. layout after content/', $contents);
-		//$this->assertPattern('/6\. in element with no cache tags/', $contents);
-		$this->assertPattern('/7\. layout after content and after element with no cache tags/', $contents);
+		$this->assertRegExp('/A\. Layout Before Content/', $contents);
+		$this->assertNotRegExp('/B\. In Plain Element/', $contents);
+		$this->assertRegExp('/C\. Layout After Test Element/', $contents);
+		$this->assertRegExp('/D\. In View File/', $contents);
+		$this->assertRegExp('/E\. Layout After Content/', $contents);
+		//$this->assertRegExp('/F\. In Element With No Cache Tags/', $contents);
+		$this->assertRegExp('/G\. Layout After Content And After Element With No Cache Tags/', $contents);
+		$this->assertRegExp('/1\. layout before content/', $contents);
+		$this->assertNotRegExp('/2\. in plain element/', $contents);
+		$this->assertRegExp('/3\. layout after test element/', $contents);
+		$this->assertRegExp('/4\. in view file/', $contents);
+		$this->assertRegExp('/5\. layout after content/', $contents);
+		//$this->assertRegExp('/6\. in element with no cache tags/', $contents);
+		$this->assertRegExp('/7\. layout after content and after element with no cache tags/', $contents);
 	}
 
 /**
@@ -304,16 +304,16 @@ class CacheHelperTest extends CakeTestCase {
 
 		$View = new View($this->Controller);
 		$result = $View->render('index');
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
 
 		$contents = file_get_contents($filename);
-		$this->assertPattern('/\$this\-\>viewVars/', $contents);
-		$this->assertPattern('/extract\(\$this\-\>viewVars, EXTR_SKIP\);/', $contents);
-		$this->assertPattern('/php echo \$variable/', $contents);
+		$this->assertRegExp('/\$this\-\>viewVars/', $contents);
+		$this->assertRegExp('/extract\(\$this\-\>viewVars, EXTR_SKIP\);/', $contents);
+		$this->assertRegExp('/php echo \$variable/', $contents);
 
 		@unlink($filename);
 	}
@@ -349,7 +349,7 @@ class CacheHelperTest extends CakeTestCase {
 
 		$contents = file_get_contents($filename);
 
-		$this->assertPattern('/\$controller->startupProcess\(\);/', $contents);
+		$this->assertRegExp('/\$controller->startupProcess\(\);/', $contents);
 
 		@unlink($filename);
 	}
@@ -377,8 +377,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cache_test_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
@@ -395,8 +395,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
@@ -420,8 +420,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_parsing.php';
 		$this->assertFalse(file_exists($filename));
@@ -454,8 +454,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cache_test_cache_parsing_1_2_name_mark_ice_cream.php';
 		$this->assertTrue(file_exists($filename));
@@ -489,8 +489,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'en_cache_test_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
@@ -525,8 +525,8 @@ class CacheHelperTest extends CakeTestCase {
 		$View = new View($this->Controller);
 		$result = $View->render('index');
 
-		$this->assertNoPattern('/cake:nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
 
 		$filename = CACHE . 'views' . DS . 'cache_cachetest_cache_name.php';
 		$this->assertTrue(file_exists($filename));
@@ -605,9 +605,9 @@ class CacheHelperTest extends CakeTestCase {
 
 		$View = new View($this->Controller);
 		$result = $View->render('cache_empty_sections');
-		$this->assertNoPattern('/nocache/', $result);
-		$this->assertNoPattern('/php echo/', $result);
-		$this->assertPattern(
+		$this->assertNotRegExp('/nocache/', $result);
+		$this->assertNotRegExp('/php echo/', $result);
+		$this->assertRegExp(
 			'@</title>\s*</head>\s*' .
 			'<body>\s*' .
 			'View Content\s*' .
@@ -617,8 +617,8 @@ class CacheHelperTest extends CakeTestCase {
 		$filename = CACHE . 'views' . DS . 'cachetest_cache_empty_sections.php';
 		$this->assertTrue(file_exists($filename));
 		$contents = file_get_contents($filename);
-		$this->assertNoPattern('/nocache/', $contents);
-		$this->assertPattern(
+		$this->assertNotRegExp('/nocache/', $contents);
+		$this->assertRegExp(
 			'@<head>\s*<title>Posts</title>\s*' .
 			'<\?php \$x \= 1; \?>\s*' .
 			'</head>\s*' .

--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -64,7 +64,9 @@ class CacheHelperTest extends CakeTestCase {
  * @return void
  */
 	public function skip() {
-		$this->skipUnless(is_writable(TMP . 'cache' . DS . 'views' . DS), 'TMP/views is not writable %s');
+		if (!is_writable(TMP . 'cache' . DS . 'views' . DS)) {
+			$this->markTestSkipped('TMP/views is not writable %s');
+		}
 	}
 /**
  * setUp method

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -712,7 +712,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testCreateClearingFields() {
 		$this->Form->fields = array('model_id');
 		$this->Form->create('Contact');
-		$this->assertEqual($this->Form->fields, array());
+		$this->assertEquals($this->Form->fields, array());
 	}
 
 /**
@@ -723,7 +723,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testValidateHashNoModel() {
 		$this->Form->request['_Token'] = array('key' => 'foo');
 		$result = $this->Form->secure(array('anything'));
-		$this->assertPattern('/540ac9c60d323c22bafe997b72c0790f39a8bdef/', $result);
+		$this->assertRegExp('/540ac9c60d323c22bafe997b72c0790f39a8bdef/', $result);
 	}
 
 /**
@@ -733,25 +733,25 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testDuplicateFieldNameResolution() {
 		$result = $this->Form->create('ValidateUser');
-		$this->assertEqual($this->Form->entity(), array('ValidateUser'));
+		$this->assertEquals($this->Form->entity(), array('ValidateUser'));
 
 		$result = $this->Form->input('ValidateItem.name');
-		$this->assertEqual($this->Form->entity(), array('ValidateItem', 'name'));
+		$this->assertEquals($this->Form->entity(), array('ValidateItem', 'name'));
 
 		$result = $this->Form->input('ValidateUser.name');
-		$this->assertEqual($this->Form->entity(), array('ValidateUser', 'name'));
-		$this->assertPattern('/name="data\[ValidateUser\]\[name\]"/', $result);
-		$this->assertPattern('/type="text"/', $result);
+		$this->assertEquals($this->Form->entity(), array('ValidateUser', 'name'));
+		$this->assertRegExp('/name="data\[ValidateUser\]\[name\]"/', $result);
+		$this->assertRegExp('/type="text"/', $result);
 
 		$result = $this->Form->input('ValidateItem.name');
-		$this->assertEqual($this->Form->entity(), array('ValidateItem', 'name'));
-		$this->assertPattern('/name="data\[ValidateItem\]\[name\]"/', $result);
-		$this->assertPattern('/<textarea/', $result);
+		$this->assertEquals($this->Form->entity(), array('ValidateItem', 'name'));
+		$this->assertRegExp('/name="data\[ValidateItem\]\[name\]"/', $result);
+		$this->assertRegExp('/<textarea/', $result);
 
 		$result = $this->Form->input('name');
-		$this->assertEqual($this->Form->entity(), array('ValidateUser', 'name'));
-		$this->assertPattern('/name="data\[ValidateUser\]\[name\]"/', $result);
-		$this->assertPattern('/type="text"/', $result);
+		$this->assertEquals($this->Form->entity(), array('ValidateUser', 'name'));
+		$this->assertRegExp('/name="data\[ValidateUser\]\[name\]"/', $result);
+		$this->assertRegExp('/type="text"/', $result);
 	}
 
 /**
@@ -761,10 +761,10 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testNoCheckboxLocking() {
 		$this->Form->request['_Token'] = array('key' => 'foo');
-		$this->assertIdentical($this->Form->fields, array());
+		$this->assertSame($this->Form->fields, array());
 
 		$this->Form->checkbox('check', array('value' => '1'));
-		$this->assertIdentical($this->Form->fields, array('check'));
+		$this->assertSame($this->Form->fields, array('check'));
 	}
 
 /**
@@ -1060,7 +1060,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request->params['_Token']['key'] = $key;
 		$this->Form->create('Address');
 		$this->Form->input('Address.primary.1');
-		$this->assertEqual('Address.primary', $this->Form->fields[0]);
+		$this->assertEquals('Address.primary', $this->Form->fields[0]);
 	}
 
 /**
@@ -1140,7 +1140,7 @@ class FormHelperTest extends CakeTestCase {
 			'Addresses.id' => '123456', 'Addresses.title', 'Addresses.last_name',
 			'Addresses.city', 'Addresses.phone'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Form->secure($expected);
 
@@ -1169,10 +1169,10 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request->params['_Token']['key'] = 'testKey';
 
 		$this->Form->text('UserForm.published', array('name' => 'data[User][custom]'));
-		$this->assertEqual('User.custom', $this->Form->fields[0]);
+		$this->assertEquals('User.custom', $this->Form->fields[0]);
 
 		$this->Form->text('UserForm.published', array('name' => 'data[User][custom][another][value]'));
-		$this->assertEqual('User.custom.another.value', $this->Form->fields[1]);
+		$this->assertEquals('User.custom.another.value', $this->Form->fields[1]);
 	}
 
 /**
@@ -1264,7 +1264,7 @@ class FormHelperTest extends CakeTestCase {
 			'UserForm.published', 'UserForm.other', 'UserForm.stuff' => '',
 			'UserForm.hidden' => '0', 'UserForm.something'
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$hash = 'bd7c4a654e5361f9a433a43f488ff9a1065d0aaf%3AUserForm.hidden%7CUserForm.stuff';
 
@@ -1291,14 +1291,14 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredFileInput() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEqual($this->Form->fields, array());
+		$this->assertEquals($this->Form->fields, array());
 
 		$result = $this->Form->file('Attachment.file');
 		$expected = array (
 			'Attachment.file.name', 'Attachment.file.type', 'Attachment.file.tmp_name',
 			'Attachment.file.error', 'Attachment.file.size'
 		);
-		$this->assertEqual($this->Form->fields, $expected);
+		$this->assertEquals($this->Form->fields, $expected);
 	}
 
 /**
@@ -1308,16 +1308,16 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredMultipleSelect() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEqual($this->Form->fields, array());
+		$this->assertEquals($this->Form->fields, array());
 		$options = array('1' => 'one', '2' => 'two');
 
 		$this->Form->select('Model.select', $options);
 		$expected = array('Model.select');
-		$this->assertEqual($this->Form->fields, $expected);
+		$this->assertEquals($this->Form->fields, $expected);
 
 		$this->Form->fields = array();
 		$this->Form->select('Model.select', $options, array('multiple' => true));
-		$this->assertEqual($this->Form->fields, $expected);
+		$this->assertEquals($this->Form->fields, $expected);
 	}
 
 /**
@@ -1327,12 +1327,12 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredRadio() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEqual($this->Form->fields, array());
+		$this->assertEquals($this->Form->fields, array());
 		$options = array('1' => 'option1', '2' => 'option2');
 
 		$this->Form->radio('Test.test', $options);
 		$expected = array('Test.test');
-		$this->assertEqual($this->Form->fields, $expected);
+		$this->assertEquals($this->Form->fields, $expected);
 	}
 
 /**
@@ -1359,7 +1359,7 @@ class FormHelperTest extends CakeTestCase {
 		$expected = array(
 			'Addresses.id' => '123456', 'Addresses.title',
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1523,7 +1523,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'OpenidUrl.openid_not_registered', 'Error, not registered', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Error, not registered');
+		$this->assertEquals($result, 'Error, not registered');
 
 		unset($this->UserForm->OpenidUrl, $this->UserForm);
 	}
@@ -1562,17 +1562,17 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateUser.email', 'Invalid email', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid email');
+		$this->assertEquals($result, 'Invalid email');
 
 		$result = $this->Form->error(
 			'ValidateProfile.full_name', 'Invalid name', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid name');
+		$this->assertEquals($result, 'Invalid name');
 
 		$result = $this->Form->error(
 			'ValidateProfile.city', 'Invalid city', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid city');
+		$this->assertEquals($result, 'Invalid city');
 
 		unset($this->ValidateUser->ValidateProfile);
 		unset($this->ValidateUser);
@@ -1615,12 +1615,12 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateUser.email', 'Invalid email', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid email');
+		$this->assertEquals($result, 'Invalid email');
 
 		$result = $this->Form->error(
 			'ValidateProfile.full_name', 'Invalid name', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid name');
+		$this->assertEquals($result, 'Invalid name');
 
 		$result = $this->Form->error(
 			'ValidateProfile.city', 'Invalid city', array('wrap' => false)
@@ -1629,7 +1629,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateItem.description', 'Invalid description', array('wrap' => false)
 		);
-		$this->assertEqual($result, 'Invalid description');
+		$this->assertEquals($result, 'Invalid description');
 
 		unset($this->ValidateUser->ValidateProfile->ValidateItem);
 		unset($this->ValidateUser->ValidateProfile);
@@ -2089,47 +2089,47 @@ class FormHelperTest extends CakeTestCase {
 		extract($this->dateRegex);
 		$result = $this->Form->input('Contact.created', array('type' => 'time', 'timeFormat' => 24));
 		$result = explode(':', $result);
-		$this->assertPattern('/option value="23"/', $result[0]);
-		$this->assertNoPattern('/option value="24"/', $result[0]);
+		$this->assertRegExp('/option value="23"/', $result[0]);
+		$this->assertNotRegExp('/option value="24"/', $result[0]);
 
 		$result = $this->Form->input('Contact.created', array('type' => 'time', 'timeFormat' => 24));
 		$result = explode(':', $result);
-		$this->assertPattern('/option value="23"/', $result[0]);
-		$this->assertNoPattern('/option value="24"/', $result[0]);
+		$this->assertRegExp('/option value="23"/', $result[0]);
+		$this->assertNotRegExp('/option value="24"/', $result[0]);
 
 		$result = $this->Form->input('Model.field', array(
 			'type' => 'time', 'timeFormat' => 24, 'interval' => 15
 		));
 		$result = explode(':', $result);
-		$this->assertNoPattern('#<option value="12"[^>]*>12</option>#', $result[1]);
-		$this->assertNoPattern('#<option value="50"[^>]*>50</option>#', $result[1]);
-		$this->assertPattern('#<option value="15"[^>]*>15</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="12"[^>]*>12</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="50"[^>]*>50</option>#', $result[1]);
+		$this->assertRegExp('#<option value="15"[^>]*>15</option>#', $result[1]);
 
 		$result = $this->Form->input('Model.field', array(
 			'type' => 'time', 'timeFormat' => 12, 'interval' => 15
 		));
 		$result = explode(':', $result);
-		$this->assertNoPattern('#<option value="12"[^>]*>12</option>#', $result[1]);
-		$this->assertNoPattern('#<option value="50"[^>]*>50</option>#', $result[1]);
-		$this->assertPattern('#<option value="15"[^>]*>15</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="12"[^>]*>12</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="50"[^>]*>50</option>#', $result[1]);
+		$this->assertRegExp('#<option value="15"[^>]*>15</option>#', $result[1]);
 
 		$result = $this->Form->input('prueba', array(
 			'type' => 'time', 'timeFormat'=> 24 , 'dateFormat'=>'DMY' , 'minYear' => 2008,
 			'maxYear' => date('Y') + 1 ,'interval' => 15
 		));
 		$result = explode(':', $result);
-		$this->assertNoPattern('#<option value="12"[^>]*>12</option>#', $result[1]);
-		$this->assertNoPattern('#<option value="50"[^>]*>50</option>#', $result[1]);
-		$this->assertPattern('#<option value="15"[^>]*>15</option>#', $result[1]);
-		$this->assertPattern('#<option value="30"[^>]*>30</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="12"[^>]*>12</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="50"[^>]*>50</option>#', $result[1]);
+		$this->assertRegExp('#<option value="15"[^>]*>15</option>#', $result[1]);
+		$this->assertRegExp('#<option value="30"[^>]*>30</option>#', $result[1]);
 
 		$result = $this->Form->input('Random.start_time', array(
 			'type' => 'time',
 			'selected' => '18:15'
 		));
-		$this->assertPattern('#<option value="06"[^>]*>6</option>#', $result);
-		$this->assertPattern('#<option value="15"[^>]*>15</option>#', $result);
-		$this->assertPattern('#<option value="pm"[^>]*>pm</option>#', $result);
+		$this->assertRegExp('#<option value="06"[^>]*>6</option>#', $result);
+		$this->assertRegExp('#<option value="15"[^>]*>15</option>#', $result);
+		$this->assertRegExp('#<option value="pm"[^>]*>pm</option>#', $result);
 	}
 
 /**
@@ -2144,42 +2144,42 @@ class FormHelperTest extends CakeTestCase {
 			'maxYear' => date('Y') + 1 ,'interval' => 15
 		));
 		$result = explode(':', $result);
-		$this->assertNoPattern('#<option value="12"[^>]*>12</option>#', $result[1]);
-		$this->assertNoPattern('#<option value="50"[^>]*>50</option>#', $result[1]);
-		$this->assertPattern('#<option value="15"[^>]*>15</option>#', $result[1]);
-		$this->assertPattern('#<option value="30"[^>]*>30</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="12"[^>]*>12</option>#', $result[1]);
+		$this->assertNotRegExp('#<option value="50"[^>]*>50</option>#', $result[1]);
+		$this->assertRegExp('#<option value="15"[^>]*>15</option>#', $result[1]);
+		$this->assertRegExp('#<option value="30"[^>]*>30</option>#', $result[1]);
 
 		//related to ticket #5013
 		$result = $this->Form->input('Contact.date', array(
 			'type' => 'date', 'class' => 'customClass', 'onChange' => 'function(){}'
 		));
-		$this->assertPattern('/class="customClass"/', $result);
-		$this->assertPattern('/onChange="function\(\)\{\}"/', $result);
+		$this->assertRegExp('/class="customClass"/', $result);
+		$this->assertRegExp('/onChange="function\(\)\{\}"/', $result);
 
 		$result = $this->Form->input('Contact.date', array(
 			'type' => 'date', 'id' => 'customId', 'onChange' => 'function(){}'
 		));
-		$this->assertPattern('/id="customIdDay"/', $result);
-		$this->assertPattern('/id="customIdMonth"/', $result);
-		$this->assertPattern('/onChange="function\(\)\{\}"/', $result);
+		$this->assertRegExp('/id="customIdDay"/', $result);
+		$this->assertRegExp('/id="customIdMonth"/', $result);
+		$this->assertRegExp('/onChange="function\(\)\{\}"/', $result);
 
 		$result = $this->Form->input('Model.field', array(
 			'type' => 'datetime', 'timeFormat' => 24, 'id' => 'customID'
 		));
-		$this->assertPattern('/id="customIDDay"/', $result);
-		$this->assertPattern('/id="customIDHour"/', $result);
+		$this->assertRegExp('/id="customIDDay"/', $result);
+		$this->assertRegExp('/id="customIDHour"/', $result);
 		$result = explode('</select><select', $result);
 		$result = explode(':', $result[1]);
-		$this->assertPattern('/option value="23"/', $result[0]);
-		$this->assertNoPattern('/option value="24"/', $result[0]);
+		$this->assertRegExp('/option value="23"/', $result[0]);
+		$this->assertNotRegExp('/option value="24"/', $result[0]);
 
 		$result = $this->Form->input('Model.field', array(
 			'type' => 'datetime', 'timeFormat' => 12
 		));
 		$result = explode('</select><select', $result);
 		$result = explode(':', $result[1]);
-		$this->assertPattern('/option value="12"/', $result[0]);
-		$this->assertNoPattern('/option value="13"/', $result[0]);
+		$this->assertRegExp('/option value="12"/', $result[0]);
+		$this->assertNotRegExp('/option value="13"/', $result[0]);
 
 		$this->Form->request->data = array('Contact' => array('created' => null));
 		$result = $this->Form->input('Contact.created', array('empty' => 'Date Unknown'));
@@ -2206,18 +2206,18 @@ class FormHelperTest extends CakeTestCase {
 
 		$this->Form->request->data = array('Contact' => array('created' => null));
 		$result = $this->Form->input('Contact.created', array('type' => 'datetime', 'dateFormat' => 'NONE'));
-		$this->assertPattern('/for\="ContactCreatedHour"/', $result);
+		$this->assertRegExp('/for\="ContactCreatedHour"/', $result);
 
 		$this->Form->request->data = array('Contact' => array('created' => null));
 		$result = $this->Form->input('Contact.created', array('type' => 'datetime', 'timeFormat' => 'NONE'));
-		$this->assertPattern('/for\="ContactCreatedMonth"/', $result);
+		$this->assertRegExp('/for\="ContactCreatedMonth"/', $result);
 
 		$result = $this->Form->input('Contact.created', array(
 			'type' => 'date',
 			'id' => array('day' => 'created-day', 'month' => 'created-month', 'year' => 'created-year'),
 			'timeFormat' => 'NONE'
 		));
-		$this->assertPattern('/for\="created-month"/', $result);
+		$this->assertRegExp('/for\="created-month"/', $result);
 	}
 
 /**
@@ -2489,7 +2489,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testInputMagicSelectChangeToRadio() {
 		$this->View->viewVars['users'] = array('value' => 'good', 'other' => 'bad');
 		$result = $this->Form->input('Model.user_id', array('type' => 'radio'));
-		$this->assertPattern('/input type="radio"/', $result);
+		$this->assertRegExp('/input type="radio"/', $result);
 	}
 
 /**
@@ -2895,11 +2895,11 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('div' => array('class' => 'error-message'), 'Error in field Field', '/div'));
 
 		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEqual($result, 'Error in field Field');
+		$this->assertEquals($result, 'Error in field Field');
 
 		$Contact->validationErrors['field'] = array("This field contains invalid input");
 		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEqual($result, 'This field contains invalid input');
+		$this->assertEquals($result, 'This field contains invalid input');
 
 		$Contact->validationErrors['field'] = array("This field contains invalid input");
 		$result = $this->Form->error('Contact.field', null, array('wrap' => 'span'));
@@ -2909,13 +2909,13 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('span' => array('class' => 'error-message'), 'There is an error fool!', '/span'));
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false));
-		$this->assertEqual($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
+		$this->assertEquals($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => true));
-		$this->assertEqual($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
+		$this->assertEquals($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => false));
-		$this->assertEqual($result, '<strong>Badness!</strong>');
+		$this->assertEquals($result, '<strong>Badness!</strong>');
 
 		$Contact->validationErrors['field'] = array("email");
 		$result = $this->Form->error('Contact.field', array('attributes' => array('class' => 'field-error'), 'email' => 'No good!'));
@@ -2996,10 +2996,10 @@ class FormHelperTest extends CakeTestCase {
 		$ValidateProfile = ClassRegistry::getObject('ValidateProfile');
 		$ValidateProfile->validationErrors['city'] = array('required<br>');
 		$result = $this->Form->input('city',array('error' => array('attributes' => array('escape' => true))));
-		$this->assertPattern('/required&lt;br&gt;/', $result);
+		$this->assertRegExp('/required&lt;br&gt;/', $result);
 
 		$result = $this->Form->input('city',array('error' => array('attributes' => array('escape' => false))));
-		$this->assertPattern('/required<br>/', $result);
+		$this->assertRegExp('/required<br>/', $result);
 	}
 
 /**
@@ -3994,17 +3994,17 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testSelectMultipleCheckboxSecurity() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEqual($this->Form->fields, array());
+		$this->assertEquals($this->Form->fields, array());
 
 		$result = $this->Form->select(
 			'Model.multi_field', array('1' => 'first', '2' => 'second', '3' => 'third'),
 			array('multiple' => 'checkbox')
 		);
-		$this->assertEqual($this->Form->fields, array('Model.multi_field'));
+		$this->assertEquals($this->Form->fields, array('Model.multi_field'));
 
 		$result = $this->Form->secure($this->Form->fields);
 		$key = 'f7d573650a295b94e0938d32b323fde775e5f32b%3A';
-		$this->assertPattern('/"' . $key . '"/', $result);
+		$this->assertRegExp('/"' . $key . '"/', $result);
 	}
 
 /**
@@ -4526,7 +4526,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('value' => false));
 		$expected = array(
@@ -4566,7 +4566,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('value' => ''));
 		$expected = array(
@@ -4606,7 +4606,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 5, 'value' => ''));
 		$expected = array(
@@ -4655,7 +4655,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('minuteInterval' => 5, 'value' => ''));
 		$expected = array(
@@ -4704,7 +4704,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$this->Form->request->data['Contact']['data'] = null;
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12');
@@ -4745,7 +4745,7 @@ class FormHelperTest extends CakeTestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNoPattern('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 
 		$this->Form->request->data['Model']['field'] = date('Y') . '-01-01 00:00:00';
 		$now = strtotime($this->Form->data['Model']['field']);
@@ -4796,12 +4796,12 @@ class FormHelperTest extends CakeTestCase {
 
 		$selected = strtotime('2008-10-26 12:33:00');
 		$result = $this->Form->dateTime('Model.field', 'DMY', '12', array('value' => $selected));
-		$this->assertPattern('/<option[^<>]+value="2008"[^<>]+selected="selected"[^>]*>2008<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="10"[^<>]+selected="selected"[^>]*>October<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="26"[^<>]+selected="selected"[^>]*>26<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="12"[^<>]+selected="selected"[^>]*>12<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="33"[^<>]+selected="selected"[^>]*>33<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="pm"[^<>]+selected="selected"[^>]*>pm<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="2008"[^<>]+selected="selected"[^>]*>2008<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="10"[^<>]+selected="selected"[^>]*>October<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="26"[^<>]+selected="selected"[^>]*>26<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="12"[^<>]+selected="selected"[^>]*>12<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="33"[^<>]+selected="selected"[^>]*>33<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="pm"[^<>]+selected="selected"[^>]*>pm<\/option>/', $result);
 
 		$this->Form->create('Contact');
 		$result = $this->Form->input('published');
@@ -4921,11 +4921,11 @@ class FormHelperTest extends CakeTestCase {
 			'selected' => strtotime('2009-09-03 13:37:00'),
 			'type' => 'datetime'
 		));
-		$this->assertPattern('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="09"[^<>]+selected="selected"[^>]*>September<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="03"[^<>]+selected="selected"[^>]*>3<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="13"[^<>]+selected="selected"[^>]*>13<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="35"[^<>]+selected="selected"[^>]*>35<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="09"[^<>]+selected="selected"[^>]*>September<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="03"[^<>]+selected="selected"[^>]*>3<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="13"[^<>]+selected="selected"[^>]*>13<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="35"[^<>]+selected="selected"[^>]*>35<\/option>/', $result);
 
 		$this->assertNoErrors();
 		$this->Form->request->data['Contact'] = array(
@@ -4948,16 +4948,16 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testDatetimeWithDefault() {
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
-		$this->assertPattern('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
 
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array(
 			'default' => '2009-06-01 11:15:30'
 		));
-		$this->assertPattern('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
-		$this->assertPattern('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
+		$this->assertRegExp('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
 	}
 
 /**
@@ -4967,7 +4967,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testDateTimeWithBogusData() {
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
-		$this->assertNoPattern('/selected="selected">\d/', $result);
+		$this->assertNotRegExp('/selected="selected">\d/', $result);
 	}
 
 /**
@@ -5400,7 +5400,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->hour('Model.field', true, array('value' => 'now'));
 		$thisHour = date('H');
 		$optValue = date('G');
-		$this->assertPattern('/<option value="' . $thisHour . '" selected="selected">'. $optValue .'<\/option>/', $result);
+		$this->assertRegExp('/<option value="' . $thisHour . '" selected="selected">'. $optValue .'<\/option>/', $result);
 	}
 
 /**
@@ -5726,7 +5726,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('button' => array('type' => 'reset'), '&lt;Clear Form&gt;', '/button'));
 
 		$result = $this->Form->button('Upload Text', array('onClick' => "$('#postAddForm').ajaxSubmit({target: '#postTextUpload', url: '/posts/text'});return false;'", 'escape' => false));
-		$this->assertNoPattern('/\&039/', $result);
+		$this->assertNotRegExp('/\&039/', $result);
 	}
 
 /**
@@ -6519,7 +6519,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('input' => array(
 			'name' => 'password', 'type' => 'password', 'id' => 'ContactPassword'
 		)));
-		$this->assertNoPattern('/<input[^<>]+[^id|name|type|value]=[^<>]*>$/', $result);
+		$this->assertNotRegExp('/<input[^<>]+[^id|name|type|value]=[^<>]*>$/', $result);
 
 		$result = $this->Form->text('user_form');
 		$this->assertTags($result, array('input' => array(
@@ -6560,12 +6560,12 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->create('Contact', array('type' => 'get'));
 		$result = $this->Form->datetime('created');
 
-		$this->assertPattern('/name="created\[year\]"/', $result, 'year name attribute is wrong.');
-		$this->assertPattern('/name="created\[month\]"/', $result, 'month name attribute is wrong.');
-		$this->assertPattern('/name="created\[day\]"/', $result, 'day name attribute is wrong.');
-		$this->assertPattern('/name="created\[hour\]"/', $result, 'hour name attribute is wrong.');
-		$this->assertPattern('/name="created\[min\]"/', $result, 'min name attribute is wrong.');
-		$this->assertPattern('/name="created\[meridian\]"/', $result, 'meridian name attribute is wrong.');
+		$this->assertRegExp('/name="created\[year\]"/', $result, 'year name attribute is wrong.');
+		$this->assertRegExp('/name="created\[month\]"/', $result, 'month name attribute is wrong.');
+		$this->assertRegExp('/name="created\[day\]"/', $result, 'day name attribute is wrong.');
+		$this->assertRegExp('/name="created\[hour\]"/', $result, 'hour name attribute is wrong.');
+		$this->assertRegExp('/name="created\[min\]"/', $result, 'min name attribute is wrong.');
+		$this->assertRegExp('/name="created\[meridian\]"/', $result, 'meridian name attribute is wrong.');
 	}
 /**
  * testEditFormWithData method
@@ -7099,7 +7099,7 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testFormEnd() {
-		$this->assertEqual($this->Form->end(), '</form>');
+		$this->assertEquals($this->Form->end(), '</form>');
 
 		$result = $this->Form->end('');
 		$expected = array(

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -170,11 +170,11 @@ class HtmlHelperTest extends CakeTestCase {
 	public function testDocType() {
 		$result = $this->Html->docType();
 		$expected = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Html->docType('html4-strict');
 		$expected = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->assertNull($this->Html->docType('non-existing-doctype'));
 	}
@@ -444,16 +444,16 @@ class HtmlHelperTest extends CakeTestCase {
  */
 	public function testStyle() {
 		$result = $this->Html->style('display: none;');
-		$this->assertEqual($result, 'display: none;');
+		$this->assertEquals($result, 'display: none;');
 
 		$result = $this->Html->style(array('display'=> 'none', 'margin'=>'10px'));
 		$expected = 'display:none; margin:10px;';
-		$this->assertPattern('/^display\s*:\s*none\s*;\s*margin\s*:\s*10px\s*;?$/', $expected);
+		$this->assertRegExp('/^display\s*:\s*none\s*;\s*margin\s*:\s*10px\s*;?$/', $expected);
 
 		$result = $this->Html->style(array('display'=> 'none', 'margin'=>'10px'), false);
 		$lines = explode("\n", $result);
-		$this->assertPattern('/^\s*display\s*:\s*none\s*;\s*$/', $lines[0]);
-		$this->assertPattern('/^\s*margin\s*:\s*10px\s*;?$/', $lines[1]);
+		$this->assertRegExp('/^\s*display\s*:\s*none\s*;\s*$/', $lines[0]);
+		$this->assertRegExp('/^\s*margin\s*:\s*10px\s*;?$/', $lines[1]);
 	}
 
 /**
@@ -497,7 +497,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertTags($result[0], $expected);
 		$expected['link']['href'] = 'preg:/.*css\/vendor\.generic\.css/';
 		$this->assertTags($result[1], $expected);
-		$this->assertEqual(count($result), 2);
+		$this->assertEquals(count($result), 2);
 
 		$this->View->expects($this->at(0))->method('addScript')
 			->with($this->matchesRegularExpression('/css_in_head.css/'));
@@ -568,12 +568,12 @@ class HtmlHelperTest extends CakeTestCase {
 		$timestamp = substr(strtotime('now'), 0, 8);
 
 		$result = $this->Html->script('__cake_js_test', array('inline' => true, 'once' => false));
-		$this->assertPattern('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
+		$this->assertRegExp('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
 
 		Configure::write('debug', 0);
 		Configure::write('Asset.timestamp', 'force');
 		$result = $this->Html->script('__cake_js_test', array('inline' => true, 'once' => false));
-		$this->assertPattern('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
+		$this->assertRegExp('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
 		unlink(WWW_ROOT . 'js' . DS. '__cake_js_test.js');
 		Configure::write('Asset.timestamp', false);
 	}
@@ -634,7 +634,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertNull($result, 'Script returned upon duplicate inclusion %s');
 
 		$result = $this->Html->script(array('foo', 'bar', 'baz'));
-		$this->assertNoPattern('/foo.js/', $result);
+		$this->assertNotRegExp('/foo.js/', $result);
 
 		$result = $this->Html->script('foo', array('inline' => true, 'once' => false));
 		$this->assertNotNull($result);
@@ -835,11 +835,11 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->assertPattern('/^<a[^<>]+>First<\/a> &gt; <a[^<>]+>Second<\/a> &gt; <a[^<>]+>Third<\/a>$/', $result);
-		$this->assertPattern('/<a\s+href=["\']+\#first["\']+[^<>]*>First<\/a>/', $result);
-		$this->assertPattern('/<a\s+href=["\']+\#second["\']+[^<>]*>Second<\/a>/', $result);
-		$this->assertPattern('/<a\s+href=["\']+\#third["\']+[^<>]*>Third<\/a>/', $result);
-		$this->assertNoPattern('/<a[^<>]+[^href]=[^<>]*>/', $result);
+		$this->assertRegExp('/^<a[^<>]+>First<\/a> &gt; <a[^<>]+>Second<\/a> &gt; <a[^<>]+>Third<\/a>$/', $result);
+		$this->assertRegExp('/<a\s+href=["\']+\#first["\']+[^<>]*>First<\/a>/', $result);
+		$this->assertRegExp('/<a\s+href=["\']+\#second["\']+[^<>]*>Second<\/a>/', $result);
+		$this->assertRegExp('/<a\s+href=["\']+\#third["\']+[^<>]*>Third<\/a>/', $result);
+		$this->assertNotRegExp('/<a[^<>]+[^href]=[^<>]*>/', $result);
 
 		$this->Html->addCrumb('Fourth', null);
 
@@ -1200,7 +1200,7 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->meta('keywords', 'these, are, some, meta, keywords');
 		$this->assertTags($result, array('meta' => array('name' => 'keywords', 'content' => 'these, are, some, meta, keywords')));
-		$this->assertPattern('/\s+\/>$/', $result);
+		$this->assertRegExp('/\s+\/>$/', $result);
 
 
 		$result = $this->Html->meta('description', 'this is the meta description');
@@ -1278,7 +1278,7 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$result = $this->Html->tableCells($tr, array('class' => 'odd'), array('class' => 'even'));
 		$expected = "<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$tr = array(
 			array('td content 1', 'td content 2', 'td content 3'),
@@ -1288,7 +1288,7 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$result = $this->Html->tableCells($tr, array('class' => 'odd'), array('class' => 'even'));
 		$expected = "<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$tr = array(
 			array('td content 1', 'td content 2', 'td content 3'),
@@ -1298,7 +1298,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->Html->tableCells($tr, array('class' => 'odd'), array('class' => 'even'));
 		$result = $this->Html->tableCells($tr, array('class' => 'odd'), array('class' => 'even'), false, false);
 		$expected = "<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"even\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>\n<tr class=\"odd\"><td>td content 1</td> <td>td content 2</td> <td>td content 3</td></tr>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1327,13 +1327,13 @@ class HtmlHelperTest extends CakeTestCase {
  */
 	public function testUseTag() {
 		$result = $this->Html->useTag('unknowntag');
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$result = $this->Html->useTag('formend');
 		$this->assertTags($result, '/form');
 
 		$result = $this->Html->useTag('form', 'url', ' test');
-		$this->assertEqual($result, '<form action="url" test>');
+		$this->assertEquals($result, '<form action="url" test>');
 
 		$result = $this->Html->useTag('form', 'example.com', array('test' => 'ok'));
 		$this->assertTags($result, array('form' => array('test' => 'ok', 'action' => 'example.com')));
@@ -1420,18 +1420,18 @@ class HtmlHelperTest extends CakeTestCase {
 				'formend' => 'finish form'
 			)
 		);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$tags = $this->Html->getAttribute('_tags');
-		$this->assertEqual($tags['form'], 'start form');
-		$this->assertEqual($tags['formend'], 'finish form');
-		$this->assertEqual($tags['selectend'], '</select>');
+		$this->assertEquals($tags['form'], 'start form');
+		$this->assertEquals($tags['formend'], 'finish form');
+		$this->assertEquals($tags['selectend'], '</select>');
 
 		$result = $this->Html->loadConfig(array('htmlhelper_minimized.ini', 'ini'), $path);
 		$expected = array(
 			'minimizedAttributeFormat' => 'format'
 		);
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($this->Html->getAttribute('_minimizedAttributeFormat'), 'format');
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($this->Html->getAttribute('_minimizedAttributeFormat'), 'format');
 	}
 
 /**
@@ -1469,16 +1469,16 @@ class HtmlHelperTest extends CakeTestCase {
 			foreach (array('true', true, 1, '1', $attribute) as $value) {
 				$attrs = array($attribute => $value);
 				$expected = ' ' . $attribute . '="' . $attribute . '"';
-				$this->assertEqual($helper->parseAttributes($attrs), $expected, '%s Failed on ' . $value);
+				$this->assertEquals($helper->parseAttributes($attrs), $expected, '%s Failed on ' . $value);
 			}
 		}
-		$this->assertEqual($helper->parseAttributes(array('compact')), ' compact="compact"');
+		$this->assertEquals($helper->parseAttributes(array('compact')), ' compact="compact"');
 
 		$helper = new Html5TestHelper($this->View);
 		$expected = ' require';
-		$this->assertEqual($helper->parseAttributes(array('require')), $expected);
-		$this->assertEqual($helper->parseAttributes(array('require' => true)), $expected);
-		$this->assertEqual($helper->parseAttributes(array('require' => false)), '');
+		$this->assertEquals($helper->parseAttributes(array('require')), $expected);
+		$this->assertEquals($helper->parseAttributes(array('require' => true)), $expected);
+		$this->assertEquals($helper->parseAttributes(array('require' => false)), '');
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
@@ -51,20 +51,20 @@ class JqueryEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Jquery->get('#content');
-		$this->assertEqual($result, $this->Jquery);
-		$this->assertEqual($this->Jquery->selection, '$("#content")');
+		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery->selection, '$("#content")');
 
 		$result = $this->Jquery->get('document');
-		$this->assertEqual($result, $this->Jquery);
-		$this->assertEqual($this->Jquery->selection, '$(document)');
+		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery->selection, '$(document)');
 
 		$result = $this->Jquery->get('window');
-		$this->assertEqual($result, $this->Jquery);
-		$this->assertEqual($this->Jquery->selection, '$(window)');
+		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery->selection, '$(window)');
 
 		$result = $this->Jquery->get('ul');
-		$this->assertEqual($result, $this->Jquery);
-		$this->assertEqual($this->Jquery->selection, '$("ul")');
+		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery->selection, '$("ul")');
 	}
 
 /**
@@ -76,15 +76,15 @@ class JqueryEngineHelperTest extends CakeTestCase {
 		$this->Jquery->get('#myLink');
 		$result = $this->Jquery->event('click', 'doClick', array('wrap' => false));
 		$expected = '$("#myLink").bind("click", doClick);';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->event('click', '$(this).show();', array('stop' => false));
 		$expected = '$("#myLink").bind("click", function (event) {$(this).show();});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->event('click', '$(this).hide();');
 		$expected = '$("#myLink").bind("click", function (event) {$(this).hide();'."\n".'return false;});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -95,7 +95,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 	public function testDomReady() {
 		$result = $this->Jquery->domReady('foo.name = "bar";');
 		$expected = '$(document).ready(function () {foo.name = "bar";});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -107,7 +107,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 		$this->Jquery->get('#foo');
 		$result = $this->Jquery->each('$(this).hide();');
 		$expected = '$("#foo").each(function () {$(this).hide();});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -119,39 +119,39 @@ class JqueryEngineHelperTest extends CakeTestCase {
 		$this->Jquery->get('#foo');
 		$result = $this->Jquery->effect('show');
 		$expected = '$("#foo").show();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('hide');
 		$expected = '$("#foo").hide();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('hide', array('speed' => 'fast'));
 		$expected = '$("#foo").hide("fast");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('fadeIn');
 		$expected = '$("#foo").fadeIn();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('fadeOut');
 		$expected = '$("#foo").fadeOut();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('slideIn');
 		$expected = '$("#foo").slideDown();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('slideOut');
 		$expected = '$("#foo").slideUp();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('slideDown');
 		$expected = '$("#foo").slideDown();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->effect('slideUp');
 		$expected = '$("#foo").slideUp();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -162,13 +162,13 @@ class JqueryEngineHelperTest extends CakeTestCase {
 	public function testRequest() {
 		$result = $this->Jquery->request(array('controller' => 'posts', 'action' => 'view', 1));
 		$expected = '$.ajax({url:"\\/posts\\/view\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->request(array('controller' => 'posts', 'action' => 'view', 1), array(
 			'update' => '#content'
 		));
 		$expected = '$.ajax({dataType:"html", success:function (data, textStatus) {$("#content").html(data);}, url:"\/posts\/view\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->request('/people/edit/1', array(
 			'method' => 'post',
@@ -181,7 +181,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$.ajax({beforeSend:doBefore, complete:doComplete, data:"name=jim&height=185cm", dataType:"json", error:handleError, success:doSuccess, type:"post", url:"\\/people\\/edit\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->request('/people/edit/1', array(
 			'update' => '#updated',
@@ -190,7 +190,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$.ajax({dataType:"html", success:function (data, textStatus) {doFoo$("#updated").html(data);}, type:"post", url:"\\/people\\/edit\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->request('/people/edit/1', array(
 			'update' => '#updated',
@@ -201,7 +201,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$.ajax({data:$("#someId").serialize(), dataType:"html", success:function (data, textStatus) {doFoo$("#updated").html(data);}, type:"post", url:"\\/people\\/edit\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->request('/people/edit/1', array(
 			'success' => 'doFoo',
@@ -211,7 +211,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'data' => '$("#someId").serialize()',
 		));
 		$expected = '$.ajax({beforeSend:function (XMLHttpRequest) {doBefore}, data:$("#someId").serialize(), success:function (data, textStatus) {doFoo}, type:"post", url:"\\/people\\/edit\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -231,7 +231,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$j.ajax({data:$j("#someId").serialize(), dataType:"html", success:function (data, textStatus) {doFoo$j("#updated").html(data);}, type:"post", url:"\\/people\\/edit\\/1"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -250,7 +250,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("#myList").sortable({containment:"parent", distance:5, sort:onSort, start:onStart, stop:onStop});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->sortable(array(
 			'distance' => 5,
@@ -260,7 +260,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'sort' => 'onSort',
 		));
 		$expected = '$("#myList").sortable({containment:"parent", distance:5, sort:function (event, ui) {onSort}, start:function (event, ui) {onStart}, stop:function (event, ui) {onStop}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -279,7 +279,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("#element").draggable({containment:"#content", drag:onDrag, grid:[10,10], start:onStart, stop:onStop});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->drag(array(
 			'container' => '#content',
@@ -289,7 +289,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'snapGrid' => array(10, 10),
 		));
 		$expected = '$("#element").draggable({containment:"#content", drag:function (event, ui) {onDrag}, grid:[10,10], start:function (event, ui) {onStart}, stop:function (event, ui) {onStop}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -307,7 +307,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("#element").droppable({accept:".items", drop:onDrop, out:onExit, over:onHover});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->drop(array(
 			'accept' => '.items',
@@ -316,7 +316,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'drop' => 'onDrop',
 		));
 		$expected = '$("#element").droppable({accept:".items", drop:function (event, ui) {onDrop}, out:function (event, ui) {onExit}, over:function (event, ui) {onHover}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -336,7 +336,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("#element").slider({change:onChange, max:10, min:0, orientation:"vertical", stop:onComplete, value:2});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->slider(array(
 			'complete' => 'onComplete',
@@ -347,7 +347,7 @@ class JqueryEngineHelperTest extends CakeTestCase {
 			'direction' => 'vertical',
 		));
 		$expected = '$("#element").slider({change:function (event, ui) {onChange}, max:10, min:0, orientation:"vertical", stop:function (event, ui) {onComplete}, value:2});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -359,14 +359,14 @@ class JqueryEngineHelperTest extends CakeTestCase {
 		$this->Jquery->get('#element');
 		$result = $this->Jquery->serializeForm(array('isForm' => false));
 		$expected = '$("#element").closest("form").serialize();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->serializeForm(array('isForm' => true));
 		$expected = '$("#element").serialize();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Jquery->serializeForm(array('isForm' => false, 'inline' => true));
 		$expected = '$("#element").closest("form").serialize()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -154,16 +154,16 @@ class JsHelperTest extends CakeTestCase {
  */
 	public function testConstruction() {
 		$js = new JsHelper($this->View);
-		$this->assertEqual($js->helpers, array('Html', 'Form', 'JqueryEngine'));
+		$this->assertEquals($js->helpers, array('Html', 'Form', 'JqueryEngine'));
 
 		$js = new JsHelper($this->View, array('mootools'));
-		$this->assertEqual($js->helpers, array('Html', 'Form', 'mootoolsEngine'));
+		$this->assertEquals($js->helpers, array('Html', 'Form', 'mootoolsEngine'));
 
 		$js = new JsHelper($this->View, 'prototype');
-		$this->assertEqual($js->helpers, array('Html', 'Form', 'prototypeEngine'));
+		$this->assertEquals($js->helpers, array('Html', 'Form', 'prototypeEngine'));
 
 		$js = new JsHelper($this->View, 'MyPlugin.Dojo');
-		$this->assertEqual($js->helpers, array('Html', 'Form', 'MyPlugin.DojoEngine'));
+		$this->assertEquals($js->helpers, array('Html', 'Form', 'MyPlugin.DojoEngine'));
 	}
 
 /**
@@ -201,18 +201,18 @@ class JsHelperTest extends CakeTestCase {
 
 		$this->Js->event('click', 'foo');
 		$result = $this->Js->getBuffer();
-		$this->assertEqual(count($result), 1);
-		$this->assertEqual($result[0], 'This is an event call');
+		$this->assertEquals(count($result), 1);
+		$this->assertEquals($result[0], 'This is an event call');
 
 		$result = $this->Js->event('click', 'foo', array('buffer' => false));
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEqual($result, 'This is an event call');
+		$this->assertEquals($result, 'This is an event call');
 
 		$result = $this->Js->event('click', 'foo', false);
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEqual($result, 'This is an event call');
+		$this->assertEquals($result, 'This is an event call');
 	}
 
 /**
@@ -229,25 +229,25 @@ class JsHelperTest extends CakeTestCase {
 		$result = $this->Js->effect('slideIn');
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEqual($result, 'I am not buffered.');
+		$this->assertEquals($result, 'I am not buffered.');
 
 		$result = $this->Js->effect('slideIn', true);
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEqual(count($buffer), 1);
-		$this->assertEqual($buffer[0], 'I am not buffered.');
+		$this->assertEquals(count($buffer), 1);
+		$this->assertEquals($buffer[0], 'I am not buffered.');
 
 		$result = $this->Js->effect('slideIn', array('speed' => 'slow'), true);
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEqual(count($buffer), 1);
-		$this->assertEqual($buffer[0], 'I am not buffered.');
+		$this->assertEquals(count($buffer), 1);
+		$this->assertEquals($buffer[0], 'I am not buffered.');
 
 		$result = $this->Js->effect('slideIn', array('speed' => 'slow', 'buffer' => true));
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEqual(count($buffer), 1);
-		$this->assertEqual($buffer[0], 'I am not buffered.');
+		$this->assertEquals(count($buffer), 1);
+		$this->assertEquals($buffer[0], 'I am not buffered.');
 	}
 
 /**
@@ -327,7 +327,7 @@ class JsHelperTest extends CakeTestCase {
 		preg_match('/src="(.*\.js)"/', $result, $filename);
 		$this->assertTrue(file_exists(WWW_ROOT . $filename[1]));
 		$contents = file_get_contents(WWW_ROOT . $filename[1]);
-		$this->assertPattern('/one\s=\s1;\ntwo\s=\s2;/', $contents);
+		$this->assertRegExp('/one\s=\s1;\ntwo\s=\s2;/', $contents);
 
 		@unlink(WWW_ROOT . $filename[1]);
 	}
@@ -620,7 +620,7 @@ class JsHelperTest extends CakeTestCase {
 	public function testObjectPassThrough() {
 		$result = $this->Js->object(array('one' => 'first', 'two' => 'second'));
 		$expected = '{"one":"first","two":"second"}';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -632,7 +632,7 @@ class JsHelperTest extends CakeTestCase {
 	public function testValuePassThrough() {
 		$result = $this->Js->value('string "quote"', true);
 		$expected = '"string \"quote\""';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -645,21 +645,21 @@ class JsHelperTest extends CakeTestCase {
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$result = $this->Js->getBuffer();
 		$expected = 'window.app = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEqual($result[0], $expected);
+		$this->assertEquals($result[0], $expected);
 
 		$this->Js->set('loggedIn', true);
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$this->Js->setVariable = 'WICKED';
 		$result = $this->Js->getBuffer();
 		$expected = 'window.WICKED = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEqual($result[0], $expected);
+		$this->assertEquals($result[0], $expected);
 
 		$this->Js->set('loggedIn', true);
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$this->Js->setVariable = 'Application.variables';
 		$result = $this->Js->getBuffer();
 		$expected = 'Application.variables = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEqual($result[0], $expected);
+		$this->assertEquals($result[0], $expected);
 	}
 
 /**
@@ -674,9 +674,9 @@ class JsHelperTest extends CakeTestCase {
 		$result = $this->Js->getBuffer(false);
 
 		$expected = 'window.app = {"height":"tall","color":"purple"};';
-		$this->assertEqual($result[0], $expected);
-		$this->assertEqual($result[1], 'alert("hey you!");');
-		$this->assertEqual($result[2], 'confirm("Are you sure?");');
+		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($result[1], 'alert("hey you!");');
+		$this->assertEquals($result[2], 'confirm("Are you sure?");');
 	}
 }
 
@@ -715,27 +715,27 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testEscaping() {
 		$result = $this->JsEngine->escape('');
 		$expected = '';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->escape('CakePHP' . "\n" . 'Rapid Development Framework');
 		$expected = 'CakePHP\\nRapid Development Framework';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->escape('CakePHP' . "\r\n" . 'Rapid Development Framework' . "\r" . 'For PHP');
 		$expected = 'CakePHP\\r\\nRapid Development Framework\\rFor PHP';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->escape('CakePHP: "Rapid Development Framework"');
 		$expected = 'CakePHP: \\"Rapid Development Framework\\"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->escape("CakePHP: 'Rapid Development Framework'");
 		$expected = "CakePHP: 'Rapid Development Framework'";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->escape('my \\"string\\"');
 		$expected = 'my \\\\\\"string\\\\\\"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -746,11 +746,11 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testPrompt() {
 		$result = $this->JsEngine->prompt('Hey, hey you', 'hi!');
 		$expected = 'prompt("Hey, hey you", "hi!");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->prompt('"Hey"', '"hi"');
 		$expected = 'prompt("\"Hey\"", "\"hi\"");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -761,11 +761,11 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testAlert() {
 		$result = $this->JsEngine->alert('Hey there');
 		$expected = 'alert("Hey there");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->alert('"Hey"');
 		$expected = 'alert("\"Hey\"");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -776,11 +776,11 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testConfirm() {
 		$result = $this->JsEngine->confirm('Are you sure?');
 		$expected = 'confirm("Are you sure?");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->confirm('"Are you sure?"');
 		$expected = 'confirm("\"Are you sure?\"");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -791,7 +791,7 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testRedirect() {
 		$result = $this->JsEngine->redirect(array('controller' => 'posts', 'action' => 'view', 1));
 		$expected = 'window.location = "/posts/view/1";';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -804,17 +804,17 @@ class JsBaseEngineTest extends CakeTestCase {
 		$object = array('title' => 'New thing', 'indexes' => array(5, 6, 7, 8));
 		$result = $this->JsEngine->object($object);
 		$expected = '{"title":"New thing","indexes":[5,6,7,8]}';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$object = new JsEncodingObject();
 		$object->title = 'New thing';
 		$object->indexes = array(5,6,7,8);
 		$result = $this->JsEngine->object($object);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->object(array('default' => 0));
 		$expected = '{"default":0}';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->JsEngine->object(array(
 			'2007' => array(
@@ -835,19 +835,19 @@ class JsBaseEngineTest extends CakeTestCase {
 			)
 		));
 		$expected = '{"2007":{"Spring":{"1":{"id":1,"name":"Josh"},"2":{"id":2,"name":"Becky"}},"Fall":{"1":{"id":1,"name":"Josh"},"2":{"id":2,"name":"Becky"}}},"2006":{"Spring":{"1":{"id":1,"name":"Josh"},"2":{"id":2,"name":"Becky"}},"Fall":{"1":{"id":1,"name":"Josh"},"2":{"id":2,"name":"Becky"}}}}';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		foreach (array('true' => true, 'false' => false, 'null' => null) as $expected => $data) {
 			$result = $this->JsEngine->object($data);
-			$this->assertEqual($expected, $result);
+			$this->assertEquals($expected, $result);
 		}
 
 		$object = array('title' => 'New thing', 'indexes' => array(5, 6, 7, 8), 'object' => array('inner' => array('value' => 1)));
 		$result = $this->JsEngine->object($object, array('prefix' => 'PREFIX', 'postfix' => 'POSTFIX'));
-		$this->assertPattern('/^PREFIX/', $result);
-		$this->assertPattern('/POSTFIX$/', $result);
-		$this->assertNoPattern('/.PREFIX./', $result);
-		$this->assertNoPattern('/.POSTFIX./', $result);
+		$this->assertRegExp('/^PREFIX/', $result);
+		$this->assertRegExp('/POSTFIX$/', $result);
+		$this->assertNotRegExp('/.PREFIX./', $result);
+		$this->assertNotRegExp('/.POSTFIX./', $result);
 	}
 
 /**
@@ -858,16 +858,16 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testOptionMapping() {
 		$JsEngine = new OptionEngineHelper($this->View);
 		$result = $JsEngine->testMap();
-		$this->assertEqual($result, array());
+		$this->assertEquals($result, array());
 
 		$result = $JsEngine->testMap(array('foo' => 'bar', 'baz' => 'sho'));
-		$this->assertEqual($result, array('foo' => 'bar', 'baz' => 'sho'));
+		$this->assertEquals($result, array('foo' => 'bar', 'baz' => 'sho'));
 
 		$result = $JsEngine->testMap(array('complete' => 'myFunc', 'type' => 'json', 'update' => '#element'));
-		$this->assertEqual($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
+		$this->assertEquals($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
 
 		$result = $JsEngine->testMap(array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
-		$this->assertEqual($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
+		$this->assertEquals($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
 	}
 
 /**
@@ -880,11 +880,11 @@ class JsBaseEngineTest extends CakeTestCase {
 
 		$result = $JsEngine->testParseOptions(array('url' => '/posts/view/1', 'key' => 1));
 		$expected = 'key:1, url:"\\/posts\\/view\\/1"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $JsEngine->testParseOptions(array('url' => '/posts/view/1', 'success' => 'doSuccess'), array('success'));
 		$expected = 'success:doSuccess, url:"\\/posts\\/view\\/1"';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
@@ -51,28 +51,28 @@ class MootoolsEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Moo->get('#content');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, '$("content")');
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, '$("content")');
 
 		$result = $this->Moo->get('a .remove');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, '$$("a .remove")');
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, '$$("a .remove")');
 
 		$result = $this->Moo->get('document');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, "$(document)");
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, "$(document)");
 
 		$result = $this->Moo->get('window');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, "$(window)");
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, "$(window)");
 
 		$result = $this->Moo->get('ul');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, '$$("ul")');
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, '$$("ul")');
 
 		$result = $this->Moo->get('#some_long-id.class');
-		$this->assertEqual($result, $this->Moo);
-		$this->assertEqual($this->Moo->selection, '$$("#some_long-id.class")');
+		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo->selection, '$$("#some_long-id.class")');
 	}
 /**
  * test event binding
@@ -83,15 +83,15 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$this->Moo->get('#myLink');
 		$result = $this->Moo->event('click', 'doClick', array('wrap' => false));
 		$expected = '$("myLink").addEvent("click", doClick);';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->event('click', 'this.setStyle("display", "");', array('stop' => false));
 		$expected = '$("myLink").addEvent("click", function (event) {this.setStyle("display", "");});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->event('click', 'this.setStyle("display", "none");');
 		$expected = "\$(\"myLink\").addEvent(\"click\", function (event) {event.stop();\nthis.setStyle(\"display\", \"none\");});";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test dom ready event creation
@@ -101,7 +101,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 	public function testDomReady() {
 		$result = $this->Moo->domReady('foo.name = "bar";');
 		$expected = 'window.addEvent("domready", function (event) {foo.name = "bar";});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test Each method
@@ -112,7 +112,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$this->Moo->get('#foo');
 		$result = $this->Moo->each('item.setStyle("display", "none");');
 		$expected = '$("foo").each(function (item, index) {item.setStyle("display", "none");});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test Effect generation
@@ -123,35 +123,35 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$this->Moo->get('#foo');
 		$result = $this->Moo->effect('show');
 		$expected = '$("foo").setStyle("display", "");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('hide');
 		$expected = '$("foo").setStyle("display", "none");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('fadeIn');
 		$expected = '$("foo").fade("in");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('fadeOut');
 		$expected = '$("foo").fade("out");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('slideIn');
 		$expected = '$("foo").slide("in");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('slideOut');
 		$expected = '$("foo").slide("out");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('slideOut', array('speed' => 'fast'));
 		$expected = '$("foo").set("slide", {duration:"short"}).slide("out");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->effect('slideOut', array('speed' => 'slow'));
 		$expected = '$("foo").set("slide", {duration:"long"}).slide("out");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * Test Request Generation
@@ -161,11 +161,11 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 	public function testRequest() {
 		$result = $this->Moo->request(array('controller' => 'posts', 'action' => 'view', 1));
 		$expected = 'var jsRequest = new Request({url:"\\/posts\\/view\\/1"}).send();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/posts/view/1', array('update' => 'content'));
 		$expected = 'var jsRequest = new Request.HTML({update:"content", url:"\\/posts\\/view\\/1"}).send();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/people/edit/1', array(
 			'method' => 'post',
@@ -176,7 +176,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Request.JSON({method:"post", onComplete:doSuccess, onFailure:handleError, url:"\\/people\\/edit\\/1"}).send({"name":"jim","height":"185cm"});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/people/edit/1', array(
 			'method' => 'post',
@@ -185,7 +185,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Request.HTML({method:"post", onComplete:doSuccess, update:"update-zone", url:"\\/people\\/edit\\/1"}).send();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/people/edit/1', array(
 			'method' => 'post',
@@ -197,7 +197,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Request.HTML({method:"post", onComplete:doComplete, onFailure:doFailure, onRequest:doBefore, onSuccess:doSuccess, update:"update-zone", url:"\\/people\\/edit\\/1"}).send();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/people/edit/1', array(
 			'method' => 'post',
@@ -211,7 +211,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Request.HTML({method:"post", onComplete:doComplete, onFailure:doFailure, onRequest:doBefore, onSuccess:doSuccess, update:"update-zone", url:"\\/people\\/edit\\/1"}).send($("foo").toQueryString());';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->request('/people/edit/1', array(
 			'method' => 'post',
@@ -221,7 +221,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'update' => '#update-zone',
 		));
 		$expected = 'var jsRequest = new Request.HTML({method:"post", onComplete:function () {doComplete}, onRequest:function () {doBefore}, onSuccess:function (responseText, responseXML) {doSuccess}, update:"update-zone", url:"\\/people\\/edit\\/1"}).send();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test sortable list generation
@@ -239,7 +239,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsSortable = new Sortables($("myList"), {constrain:"parent", onComplete:onStop, onSort:onSort, onStart:onStart, snap:5});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test drag() method
@@ -256,7 +256,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("drag-me").makeDraggable({onComplete:onStop, onDrag:onDrag, onStart:onStart, snap:[10,10]});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -288,8 +288,8 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$("my-drag").makeDraggable({droppables:$("drop-me"), onDrop:onDrop, onEnter:onHover, onLeave:onLeave});';
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($this->Moo->selection, '$("drop-me")');
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($this->Moo->selection, '$("drop-me")');
 
 		$result = $this->Moo->drop(array(
 			'drop' => 'onDrop',
@@ -298,7 +298,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'drag' => '#my-drag',
 		));
 		$expected = '$("my-drag").makeDraggable({droppables:$("drop-me"), onDrop:function (element, droppable, event) {onDrop}, onEnter:function (element, droppable) {onHover}, onLeave:function (element, droppable) {onLeave}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test slider generation
@@ -315,8 +315,8 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsSlider = new Slider($("slider"), $("my-handle"), {mode:"horizontal", onChange:onChange, onComplete:onComplete});';
-		$this->assertEqual($expected, $result);
-		$this->assertEqual($this->Moo->selection, '$("slider")');
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($this->Moo->selection, '$("slider")');
 
 		$this->Moo->get('#slider');
 		$result = $this->Moo->slider(array(
@@ -329,7 +329,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsSlider = new Slider($("slider"), $("my-handle"), {mode:"horizontal", onChange:onChange, onComplete:onComplete, range:[10,40]});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Moo->get('#slider');
 		$result = $this->Moo->slider(array(
@@ -339,7 +339,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'direction' => 'horizontal',
 		));
 		$expected = 'var jsSlider = new Slider($("slider"), $("my-handle"), {mode:"horizontal", onChange:function (step) {change;}, onComplete:function (event) {complete;}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 /**
  * test the serializeForm implementation.
@@ -350,18 +350,18 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$this->Moo->get('#element');
 		$result = $this->Moo->serializeForm(array('isForm' => true));
 		$expected = '$("element").toQueryString();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->serializeForm(array('isForm' => true, 'inline' => true));
 		$expected = '$("element").toQueryString()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->serializeForm(array('isForm' => false));
 		$expected = '$($("element").form).toQueryString();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Moo->serializeForm(array('isForm' => false, 'inline' => true));
 		$expected = '$($("element").form).toQueryString()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
@@ -65,19 +65,19 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->format($value, '#');
 		$expected = '#100,100,100';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->format($value, 3);
 		$expected = '100,100,100.000';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->format($value);
 		$expected = '100,100,100';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->format($value, '-');
 		$expected = '100-100-100';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -90,79 +90,79 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value);
 		$expected = '$100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, '#');
 		$expected = '#100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, false);
 		$expected = '100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'USD');
 		$expected = '$100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '&#8364;100.100.100,00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '&#163;100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, '', array('thousands' =>' ', 'wholeSymbol' => '€', 'wholePosition' => 'after', 'decimals' => ',', 'zero' => 'Gratuit'));
 		$expected = '100 100 100,00€';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(1000.45, NULL, array('after'=>'øre','before'=>'Kr. ','decimals'=>',','thousands'=>'.'));
 		$expected = 'Kr. 1.000,45';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 
 		$result = $this->Number->currency(0.5, 'USD');
 		$expected = '50c';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 
 		$result = $this->Number->currency(0.5, NULL, array('after'=>'øre'));
 		$expected = '50øre';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 
 		$result = $this->Number->currency(1, null, array('wholeSymbol' => '$ '));
 		$expected = '$ 1.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(1, null, array('wholeSymbol' => ' $', 'wholePosition' => 'after'));
 		$expected = '1.00 $';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(.2, null, array('wholeSymbol' => ' $', 'wholePosition' => 'after', 'fractionSymbol' => 'cents'));
 		$expected = '20cents';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(.2, null, array('wholeSymbol' => ' $', 'wholePosition' => 'after', 'fractionSymbol' => 'cents', 'fractionPosition' => 'before'));
 		$expected = 'cents20';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(311, 'USD', array('wholePosition' => 'after'));
 		$expected = '311.00$';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(.2, 'EUR');
 		$expected = '&#8364;0,20';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(12, null, array('wholeSymbol' => ' dollars', 'wholePosition' => 'after', 'fractionSymbol' => ' cents', 'fractionPosition' => 'after'));
 		$expected = '12.00 dollars';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(.12, null, array('wholeSymbol' => ' dollars', 'wholePosition' => 'after', 'fractionSymbol' => ' cents', 'fractionPosition' => 'after'));
 		$expected = '12 cents';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency(.5, null, array('fractionSymbol' => false, 'fractionPosition' => 'before', 'wholeSymbol' => '$'));
 		$expected = '$0.50';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -174,16 +174,16 @@ class NumberHelperTest extends CakeTestCase {
 		$this->Number->addFormat('NOK', array('before' => 'Kr. '));
 		$result = $this->Number->currency(1000, 'NOK');
 		$expected = 'Kr. 1,000.00';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 
 		$this->Number->addFormat('Other', array('before' => '$$ ', 'after' => 'c!'));
 		$result = $this->Number->currency(0.22, 'Other');
 		$expected = '22c!';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 
 		$result = $this->Number->currency(-10, 'Other');
 		$expected = '($$ 10.00)';
-		$this->assertEqual($expected,$result);
+		$this->assertEquals($expected,$result);
 	}
 
 /**
@@ -196,27 +196,27 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value);
 		$expected = '$100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'USD', array('before'=> '#'));
 		$expected = '#100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, false);
 		$expected = '100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'USD');
 		$expected = '$100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '&#8364;100.100.100,00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '&#163;100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -229,27 +229,27 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value);
 		$expected = '($100,100,100.00)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '(&#8364;100.100.100,00)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '(&#163;100,100,100.00)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'USD', array('negative'=>'-'));
 		$expected = '-$100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR', array('negative'=>'-'));
 		$expected = '-&#8364;100.100.100,00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('negative'=>'-'));
 		$expected = '-&#163;100,100,100.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -263,15 +263,15 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value, 'USD');
 		$expected = '99c';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '&#8364;0,99';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '99p';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -284,27 +284,27 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value, 'USD');
 		$expected = '(99c)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '(&#8364;0,99)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '(99p)';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'USD', array('negative'=>'-'));
 		$expected = '-99c';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR', array('negative'=>'-'));
 		$expected = '-&#8364;0,99';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('negative'=>'-'));
 		$expected = '-99p';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -317,19 +317,19 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value, 'USD');
 		$expected = '$0.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'EUR');
 		$expected = '&#8364;0,00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP');
 		$expected = '&#163;0.00';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('zero' => 'FREE!'));
 		$expected = 'FREE!';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -342,39 +342,39 @@ class NumberHelperTest extends CakeTestCase {
 
 		$result = $this->Number->currency($value, null, array('before' => 'GBP'));
 		$expected = 'GBP1,234,567.89';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('places' => 0));
 		$expected = '&#163;1,234,568';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('1234567.8912345', null, array('before' => 'GBP', 'places' => 3));
 		$expected = 'GBP1,234,567.891';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('650.120001', null, array('before' => 'GBP', 'places' => 4));
 		$expected = 'GBP650.1200';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency($value, 'GBP', array('escape' => true));
 		$expected = '&amp;#163;1,234,567.89';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('0.35', 'USD', array('after' => false));
 		$expected = '$0.35';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('0.35', 'GBP', array('after' => false));
 		$expected = '&#163;0.35';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('0.35', 'GBP');
 		$expected = '35p';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->currency('0.35', 'EUR');
 		$expected = '&#8364;0,35';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -385,59 +385,59 @@ class NumberHelperTest extends CakeTestCase {
 	public function testToReadableSize() {
 		$result = $this->Number->toReadableSize(0);
 		$expected = '0 Bytes';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1);
 		$expected = '1 Byte';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(45);
 		$expected = '45 Bytes';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1023);
 		$expected = '1023 Bytes';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024);
 		$expected = '1 KB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*512);
 		$expected = '512 KB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024-1);
 		$expected = '1.00 MB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*512);
 		$expected = '512.00 MB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024-1);
 		$expected = '1.00 GB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024*512);
 		$expected = '512.00 GB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024*1024-1);
 		$expected = '1.00 TB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024*1024*512);
 		$expected = '512.00 TB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024*1024*1024-1);
 		$expected = '1024.00 TB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toReadableSize(1024*1024*1024*1024*1024*1024);
 		$expected = (1024 * 1024) . '.00 TB';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -448,18 +448,18 @@ class NumberHelperTest extends CakeTestCase {
 	public function testToPercentage() {
 		$result = $this->Number->toPercentage(45, 0);
 		$expected = '45%';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toPercentage(45, 2);
 		$expected = '45.00%';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toPercentage(0, 0);
 		$expected = '0%';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Number->toPercentage(0, 4);
 		$expected = '0.0000%';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -82,9 +82,9 @@ class PaginatorHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testHasPrevious() {
-		$this->assertIdentical($this->Paginator->hasPrev(), false);
+		$this->assertSame($this->Paginator->hasPrev(), false);
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
-		$this->assertIdentical($this->Paginator->hasPrev(), true);
+		$this->assertSame($this->Paginator->hasPrev(), true);
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
 	}
 
@@ -94,9 +94,9 @@ class PaginatorHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testHasNext() {
-		$this->assertIdentical($this->Paginator->hasNext(), true);
+		$this->assertSame($this->Paginator->hasNext(), true);
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = false;
-		$this->assertIdentical($this->Paginator->hasNext(), false);
+		$this->assertSame($this->Paginator->hasNext(), false);
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = true;
 	}
 
@@ -110,7 +110,7 @@ class PaginatorHelperTest extends CakeTestCase {
 		$this->Paginator->request->params['paging']['Article']['page'] = 1;
 		$result = $this->Paginator->next('Next', array(), true);
 		$expected = '<span class="next">Next</span>';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
 		$result = $this->Paginator->prev('prev', array('update' => 'theList', 'indicator' => 'loading', 'url' => array('controller' => 'posts')), null, array('class' => 'disabled', 'tag' => 'span'));
@@ -193,39 +193,39 @@ class PaginatorHelperTest extends CakeTestCase {
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title');
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title');
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc'));
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:asc" class="desc">Title<\/a>$/', $result);
 
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
 
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc'));
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="asc">Title<\/a>$/', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
 		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc', 'class' => 'foo'));
-		$this->assertPattern('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="foo asc">Title<\/a>$/', $result);
+		$this->assertRegExp('/\/accounts\/index\/param\/page:1\/sort:title\/direction:desc" class="foo asc">Title<\/a>$/', $result);
 	}
 
 /**
@@ -357,16 +357,16 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->sortKey(null, array(
 			'order' => array('Article.title' => 'desc'
 		)));
-		$this->assertEqual('Article.title', $result);
+		$this->assertEquals('Article.title', $result);
 
 		$result = $this->Paginator->sortKey('Article', array('order' => 'Article.title'));
-		$this->assertEqual($result, 'Article.title');
+		$this->assertEquals($result, 'Article.title');
 
 		$result = $this->Paginator->sortKey('Article', array('sort' => 'Article.title'));
-		$this->assertEqual($result, 'Article.title');
+		$this->assertEquals($result, 'Article.title');
 
 		$result = $this->Paginator->sortKey('Article', array('sort' => 'Article'));
-		$this->assertEqual($result, 'Article');
+		$this->assertEquals($result, 'Article');
 	}
 
 /**
@@ -378,64 +378,64 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->sortDir();
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
 		$result = $this->Paginator->sortDir();
 		$expected = 'desc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
 		$result = $this->Paginator->sortDir();
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('title' => 'desc');
 		$result = $this->Paginator->sortDir();
 		$expected = 'desc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('title' => 'asc');
 		$result = $this->Paginator->sortDir();
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$this->Paginator->request->params['paging']['Article']['options']['direction'] = 'asc';
 		$result = $this->Paginator->sortDir();
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$this->Paginator->request->params['paging']['Article']['options']['direction'] = 'desc';
 		$result = $this->Paginator->sortDir();
 		$expected = 'desc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		unset($this->Paginator->request->params['paging']['Article']['options']);
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'asc'));
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'desc'));
 		$expected = 'desc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'asc'));
 		$expected = 'asc';
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -503,20 +503,20 @@ class PaginatorHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->url();
-		$this->assertEqual($result, '/index/page:1');
+		$this->assertEquals($result, '/index/page:1');
 
 		$this->Paginator->request->params['paging']['Article']['options']['page'] = 2;
 		$result = $this->Paginator->url();
-		$this->assertEqual($result, '/index/page:2');
+		$this->assertEquals($result, '/index/page:2');
 
 		$options = array('order' => array('Article' => 'desc'));
 		$result = $this->Paginator->url($options);
-		$this->assertEqual($result, '/index/page:2/sort:Article/direction:desc');
+		$this->assertEquals($result, '/index/page:2/sort:Article/direction:desc');
 
 		$this->Paginator->request->params['paging']['Article']['options']['page'] = 3;
 		$options = array('order' => array('Article.name' => 'desc'));
 		$result = $this->Paginator->url($options);
-		$this->assertEqual($result, '/index/page:3/sort:Article.name/direction:desc');
+		$this->assertEquals($result, '/index/page:3/sort:Article.name/direction:desc');
 	}
 
 /**
@@ -544,7 +544,7 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$result = $this->Paginator->url($options);
 		$expected = '/members/posts/index/page:2';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->sort('name', null, array('url' => $options));
 		$expected = array(
@@ -577,12 +577,12 @@ class PaginatorHelperTest extends CakeTestCase {
 		$options = array('members' => true, 'controller' => 'posts', 'order' => array('name' => 'desc'));
 		$result = $this->Paginator->url($options);
 		$expected = '/members/posts/index/page:2/sort:name/direction:desc';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$options = array('controller' => 'posts', 'order' => array('Article.name' => 'desc'));
 		$result = $this->Paginator->url($options);
 		$expected = '/posts/index/page:2/sort:Article.name/direction:desc';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing', $_back);
 	}
@@ -594,7 +594,7 @@ class PaginatorHelperTest extends CakeTestCase {
  */
 	public function testOptions() {
 		$this->Paginator->options('myDiv');
-		$this->assertEqual('myDiv', $this->Paginator->options['update']);
+		$this->assertEquals('myDiv', $this->Paginator->options['update']);
 
 		$this->Paginator->options = array();
 		$this->Paginator->request->params = array();
@@ -609,7 +609,7 @@ class PaginatorHelperTest extends CakeTestCase {
 			'order' => 'desc',
 			'sort' => 'title'
 		));
-		$this->assertEqual($expected, $this->Paginator->request->params['paging']);
+		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
 
 		$this->Paginator->options = array();
 		$this->Paginator->request->params = array();
@@ -619,7 +619,7 @@ class PaginatorHelperTest extends CakeTestCase {
 			'sort' => 'title'
 		));
 		$this->Paginator->options($options);
-		$this->assertEqual($expected, $this->Paginator->request->params['paging']);
+		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
 
 		$options = array('paging' => array('Article' => array(
 			'order' => 'desc',
@@ -631,7 +631,7 @@ class PaginatorHelperTest extends CakeTestCase {
 			'order' => 'desc',
 			'sort' => 'Article.title'
 		));
-		$this->assertEqual($expected, $this->Paginator->request->params['paging']);
+		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
 	}
 
 /**
@@ -1796,7 +1796,7 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$result = $this->Paginator->last();
 		$expected = '';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1809,7 +1809,7 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$result = $this->Paginator->first();
 		$expected = '';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2011,29 +2011,29 @@ class PaginatorHelperTest extends CakeTestCase {
 		$result = $this->Paginator->counter($input);
 		$expected = 'Page 1 of 5, showing 3 records out of 13 total, starting on record 1, ';
 		$expected .= 'ending on 3';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$input = 'Page {:page} of {:pages}, showing {:current} records out of {:count} total, ';
 		$input .= 'starting on record {:start}, ending on {:end}';
 		$result = $this->Paginator->counter($input);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$input = 'Page %page% of %pages%';
 		$result = $this->Paginator->counter($input);
 		$expected = 'Page 1 of 5';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->counter(array('format' => $input));
 		$expected = 'Page 1 of 5';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->counter(array('format' => 'pages'));
 		$expected = '1 of 5';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->counter(array('format' => 'range'));
 		$expected = '1 - 3 of 13';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->counter('Showing %page% of %pages% %model%');
 		$this->assertEquals('Showing 1 of 5 clients', $result);
@@ -2169,7 +2169,7 @@ class PaginatorHelperTest extends CakeTestCase {
 			->will($this->returnValue('I am a link'));
 
 		$result = $this->Paginator->link('test', array('controller' => 'posts'), array('update' => '#content'));
-		$this->assertEqual($result, 'I am a link');
+		$this->assertEquals($result, 'I am a link');
 	}
 
 /**
@@ -2336,6 +2336,6 @@ class PaginatorHelperTest extends CakeTestCase {
 
 		$result = $this->Paginator->counter(array('format' => 'pages'));
 		$expected = '0 of 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
@@ -51,28 +51,28 @@ class PrototypeEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Proto->get('#content');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, '$("content")');
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, '$("content")');
 
 		$result = $this->Proto->get('a .remove');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, '$$("a .remove")');
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, '$$("a .remove")');
 
 		$result = $this->Proto->get('document');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, "$(document)");
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, "$(document)");
 
 		$result = $this->Proto->get('window');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, "$(window)");
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, "$(window)");
 
 		$result = $this->Proto->get('ul');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, '$$("ul")');
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, '$$("ul")');
 
 		$result = $this->Proto->get('#some_long-id.class');
-		$this->assertEqual($result, $this->Proto);
-		$this->assertEqual($this->Proto->selection, '$$("#some_long-id.class")');
+		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto->selection, '$$("#some_long-id.class")');
 	}
 
 /**
@@ -84,15 +84,15 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 		$this->Proto->get('#myLink');
 		$result = $this->Proto->event('click', 'doClick', array('wrap' => false));
 		$expected = '$("myLink").observe("click", doClick);';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->event('click', 'Element.hide(this);', array('stop' => false));
 		$expected = '$("myLink").observe("click", function (event) {Element.hide(this);});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->event('click', 'Element.hide(this);');
 		$expected = "\$(\"myLink\").observe(\"click\", function (event) {event.stop();\nElement.hide(this);});";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -103,7 +103,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 	public function testDomReady() {
 		$result = $this->Proto->domReady('foo.name = "bar";');
 		$expected = 'document.observe("dom:loaded", function (event) {foo.name = "bar";});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -115,7 +115,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 		$this->Proto->get('#foo li');
 		$result = $this->Proto->each('item.hide();');
 		$expected = '$$("#foo li").each(function (item, index) {item.hide();});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -127,51 +127,51 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 		$this->Proto->get('#foo');
 		$result = $this->Proto->effect('show');
 		$expected = '$("foo").show();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('hide');
 		$expected = '$("foo").hide();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeIn');
 		$expected = '$("foo").appear();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeIn', array('speed' => 'fast'));
 		$expected = '$("foo").appear({duration:0.50000000000});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeIn', array('speed' => 'slow'));
 		$expected = '$("foo").appear({duration:2});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeOut');
 		$expected = '$("foo").fade();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeOut', array('speed' => 'fast'));
 		$expected = '$("foo").fade({duration:0.50000000000});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('fadeOut', array('speed' => 'slow'));
 		$expected = '$("foo").fade({duration:2});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('slideIn');
 		$expected = 'Effect.slideDown($("foo"));';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('slideOut');
 		$expected = 'Effect.slideUp($("foo"));';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('slideOut', array('speed' => 'fast'));
 		$expected = 'Effect.slideUp($("foo"), {duration:0.50000000000});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->effect('slideOut', array('speed' => 'slow'));
 		$expected = 'Effect.slideUp($("foo"), {duration:2});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -182,7 +182,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 	public function testRequest() {
 		$result = $this->Proto->request(array('controller' => 'posts', 'action' => 'view', 1));
 		$expected = 'var jsRequest = new Ajax.Request("/posts/view/1");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/posts/view/1', array(
 			'method' => 'post',
@@ -194,11 +194,11 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Ajax.Request("/posts/view/1", {method:"post", onComplete:doComplete, onCreate:doBefore, onFailure:doError, onSuccess:doSuccess, parameters:{"name":"jim","height":"185cm"}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/posts/view/1', array('update' => 'content'));
 		$expected = 'var jsRequest = new Ajax.Updater("content", "/posts/view/1");';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/people/edit/1', array(
 			'method' => 'post',
@@ -207,7 +207,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Ajax.Updater("update-zone", "/people/edit/1", {method:"post", onComplete:doSuccess});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/people/edit/1', array(
 			'method' => 'post',
@@ -218,7 +218,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Ajax.Request("/people/edit/1", {method:"post", onComplete:doSuccess, onFailure:handleError, parameters:{"name":"jim","height":"185cm"}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/people/edit/1', array(
 			'method' => 'post',
@@ -230,7 +230,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsRequest = new Ajax.Request("/people/edit/1", {method:"post", onComplete:doSuccess, onFailure:handleError, parameters:$("element").serialize()});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/people/edit/1', array(
 			'method' => 'post',
@@ -240,7 +240,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'error' => 'handleError();',
 		));
 		$expected = 'var jsRequest = new Ajax.Request("/people/edit/1", {method:"post", onComplete:function (transport) {doComplete();}, onCreate:function (transport) {doBefore();}, onFailure:function (response, jsonHeader) {handleError();}, onSuccess:function (response, jsonHeader) {doSuccess();}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->request('/people/edit/1', array(
 			'async' => false,
@@ -251,7 +251,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'error' => 'handleError();',
 		));
 		$expected = 'var jsRequest = new Ajax.Request("/people/edit/1", {asynchronous:false, method:"post", onComplete:function (transport) {doComplete();}, onCreate:function (transport) {doBefore();}, onFailure:function (response, jsonHeader) {handleError();}, onSuccess:function (response, jsonHeader) {doSuccess();}});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Proto->get('#submit');
 		$result = $this->Proto->request('/users/login', array(
@@ -278,7 +278,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsSortable = Sortable.create($("myList"), {onChange:onSort, onUpdate:onComplete});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -297,7 +297,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsDrag = new Draggable($("element"), {onDrag:onDrag, onEnd:onStop, onStart:onStart, snap:[10,10]});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Proto->get('div.dragger');
 		$result = $this->Proto->drag(array(
@@ -308,7 +308,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = '$$("div.dragger").each(function (item, index) {new Draggable(item, {onDrag:onDrag, onEnd:onStop, onStart:onStart, snap:[10,10]});});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -325,7 +325,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'Droppables.add($("element"), {accept:".drag-me", onDrop:onDrop, onHover:onHover});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -344,7 +344,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'wrapCallbacks' => false
 		));
 		$expected = 'var jsSlider = new Control.Slider($("handle"), $("element"), {axis:"horizontal", onChange:onComplete, onSlide:onChange, sliderValue:4});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Proto->get('#element');
 		$result = $this->Proto->slider(array(
@@ -356,7 +356,7 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 			'max' => 100
 		));
 		$expected = 'var jsSlider = new Control.Slider($("handle"), $("element"), {onChange:function (value) {complete();}, onSlide:function (value) {change();}, range:$R(10,100), sliderValue:4});';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -368,18 +368,18 @@ class PrototypeEngineHelperTest extends CakeTestCase {
 		$this->Proto->get('#element');
 		$result = $this->Proto->serializeForm(array('isForm' => true));
 		$expected = '$("element").serialize();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->serializeForm(array('isForm' => true, 'inline' => true));
 		$expected = '$("element").serialize()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->serializeForm(array('isForm' => false));
 		$expected = '$($("element").form).serialize();';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Proto->serializeForm(array('isForm' => false, 'inline' => true));
 		$expected = '$($("element").form).serialize()';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -293,7 +293,7 @@ class RssHelperTest extends CakeTestCase {
 
 		$result = $this->Rss->items(array());
 		$expected = '';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -91,10 +91,10 @@ class SessionHelperTest extends CakeTestCase {
  */
 	public function testRead() {
 		$result = $this->Session->read('Deeply.nested.key');
-		$this->assertEqual($result, 'value');
+		$this->assertEquals($result, 'value');
 
 		$result = $this->Session->read('test');
-		$this->assertEqual($result, 'info');
+		$this->assertEquals($result, 'info');
 	}
 
 /**
@@ -120,12 +120,12 @@ class SessionHelperTest extends CakeTestCase {
 	public function testFlash() {
 		$result = $this->Session->flash('flash');
 		$expected = '<div id="flashMessage" class="message">This is a calling</div>';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($this->Session->check('Message.flash'));
 
 		$expected = '<div id="classyMessage" class="positive">Recorded</div>';
 		$result = $this->Session->flash('classy');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		App::build(array(
 			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS)
@@ -133,12 +133,12 @@ class SessionHelperTest extends CakeTestCase {
 		$result = $this->Session->flash('notification');
 		$result = str_replace("\r\n", "\n", $result);
 		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($this->Session->check('Message.notification'));
 
 		$result = $this->Session->flash('bare');
 		$expected = 'Bare message';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($this->Session->check('Message.bare'));
 	}
 
@@ -150,7 +150,7 @@ class SessionHelperTest extends CakeTestCase {
 	public function testFlashAttributes() {
 		$result = $this->Session->flash('flash', array('params' => array('class' => 'test-message')));
 		$expected = '<div id="flashMessage" class="test-message">This is a calling</div>';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 		$this->assertFalse($this->Session->check('Message.flash'));
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -63,29 +63,29 @@ class TextHelperTest extends CakeTestCase {
         $text8 = 'Vive la R'.chr(195).chr(169).'publique de France';
 		$text9 = 'НОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыь';
 
-		$this->assertIdentical($this->Text->truncate($text1, 15), 'The quick br...');
-		$this->assertIdentical($this->Text->truncate($text1, 15, array('exact' => false)), 'The quick...');
-		$this->assertIdentical($this->Text->truncate($text1, 100), 'The quick brown fox jumps over the lazy dog');
-		$this->assertIdentical($this->Text->truncate($text2, 10), 'Heiz&ou...');
-		$this->assertIdentical($this->Text->truncate($text2, 10, array('exact' => false)), '...');
-		$this->assertIdentical($this->Text->truncate($text3, 20), '<b>&copy; 2005-20...');
-		$this->assertIdentical($this->Text->truncate($text4, 15), '<img src="my...');
-		$this->assertIdentical($this->Text->truncate($text5, 6, array('ending' => '')), '0<b>1<');
-		$this->assertIdentical($this->Text->truncate($text1, 15, array('html' => true)), 'The quick br...');
-		$this->assertIdentical($this->Text->truncate($text1, 15, array('exact' => false, 'html' => true)), 'The quick...');
-		$this->assertIdentical($this->Text->truncate($text2, 10, array('html' => true)), 'Heiz&ouml;lr...');
-		$this->assertIdentical($this->Text->truncate($text2, 10, array('exact' => false, 'html' => true)), '...');
-		$this->assertIdentical($this->Text->truncate($text3, 20, array('html' => true)), '<b>&copy; 2005-2007, Cake...</b>');
-		$this->assertIdentical($this->Text->truncate($text4, 15, array('html' => true)), '<img src="mypic.jpg"> This image ...');
-		$this->assertIdentical($this->Text->truncate($text4, 45, array('html' => true)), '<img src="mypic.jpg"> This image tag is not XHTML conform!<br><hr/><b>But t...</b>');
-		$this->assertIdentical($this->Text->truncate($text4, 90, array('html' => true)), '<img src="mypic.jpg"> This image tag is not XHTML conform!<br><hr/><b>But the following image tag should be conform <img src="mypic.jpg" alt="Me, myself and I" /></b><br />Grea...');
-		$this->assertIdentical($this->Text->truncate($text5, 6, array('ending' => '', 'html' => true)), '0<b>1<i>2<span class="myclass">3</span>4<u>5</u></i></b>');
-		$this->assertIdentical($this->Text->truncate($text5, 20, array('ending' => '', 'html' => true)), $text5);
-		$this->assertIdentical($this->Text->truncate($text6, 57, array('exact' => false, 'html' => true)), "<p><strong>Extra dates have been announced for this year's...</strong></p>");
-		$this->assertIdentical($this->Text->truncate($text7, 255), $text7);
-		$this->assertIdentical($this->Text->truncate($text7, 15), 'El moño está...');
-		$this->assertIdentical($this->Text->truncate($text8, 15), 'Vive la R'.chr(195).chr(169).'pu...');
-		$this->assertIdentical($this->Text->truncate($text9, 10), 'НОПРСТУ...');
+		$this->assertSame($this->Text->truncate($text1, 15), 'The quick br...');
+		$this->assertSame($this->Text->truncate($text1, 15, array('exact' => false)), 'The quick...');
+		$this->assertSame($this->Text->truncate($text1, 100), 'The quick brown fox jumps over the lazy dog');
+		$this->assertSame($this->Text->truncate($text2, 10), 'Heiz&ou...');
+		$this->assertSame($this->Text->truncate($text2, 10, array('exact' => false)), '...');
+		$this->assertSame($this->Text->truncate($text3, 20), '<b>&copy; 2005-20...');
+		$this->assertSame($this->Text->truncate($text4, 15), '<img src="my...');
+		$this->assertSame($this->Text->truncate($text5, 6, array('ending' => '')), '0<b>1<');
+		$this->assertSame($this->Text->truncate($text1, 15, array('html' => true)), 'The quick br...');
+		$this->assertSame($this->Text->truncate($text1, 15, array('exact' => false, 'html' => true)), 'The quick...');
+		$this->assertSame($this->Text->truncate($text2, 10, array('html' => true)), 'Heiz&ouml;lr...');
+		$this->assertSame($this->Text->truncate($text2, 10, array('exact' => false, 'html' => true)), '...');
+		$this->assertSame($this->Text->truncate($text3, 20, array('html' => true)), '<b>&copy; 2005-2007, Cake...</b>');
+		$this->assertSame($this->Text->truncate($text4, 15, array('html' => true)), '<img src="mypic.jpg"> This image ...');
+		$this->assertSame($this->Text->truncate($text4, 45, array('html' => true)), '<img src="mypic.jpg"> This image tag is not XHTML conform!<br><hr/><b>But t...</b>');
+		$this->assertSame($this->Text->truncate($text4, 90, array('html' => true)), '<img src="mypic.jpg"> This image tag is not XHTML conform!<br><hr/><b>But the following image tag should be conform <img src="mypic.jpg" alt="Me, myself and I" /></b><br />Grea...');
+		$this->assertSame($this->Text->truncate($text5, 6, array('ending' => '', 'html' => true)), '0<b>1<i>2<span class="myclass">3</span>4<u>5</u></i></b>');
+		$this->assertSame($this->Text->truncate($text5, 20, array('ending' => '', 'html' => true)), $text5);
+		$this->assertSame($this->Text->truncate($text6, 57, array('exact' => false, 'html' => true)), "<p><strong>Extra dates have been announced for this year's...</strong></p>");
+		$this->assertSame($this->Text->truncate($text7, 255), $text7);
+		$this->assertSame($this->Text->truncate($text7, 15), 'El moño está...');
+		$this->assertSame($this->Text->truncate($text8, 15), 'Vive la R'.chr(195).chr(169).'pu...');
+		$this->assertSame($this->Text->truncate($text9, 10), 'НОПРСТУ...');
 	}
 /**
  * testHighlight method
@@ -97,23 +97,23 @@ class TextHelperTest extends CakeTestCase {
 		$phrases = array('This', 'text');
 		$result = $this->Text->highlight($text, $phrases, array('format' => '<b>\1</b>'));
 		$expected = '<b>This</b> is a test <b>text</b>';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text';
 		$phrases = null;
 		$result = $this->Text->highlight($text, $phrases, array('format' => '<b>\1</b>'));
-		$this->assertEqual($result, $text);
+		$this->assertEquals($result, $text);
 
 		$text = 'This is a (test) text';
 		$phrases = '(test';
 		$result = $this->Text->highlight($text, $phrases, array('format' => '<b>\1</b>'));
-		$this->assertEqual('This is a <b>(test</b>) text', $result);
+		$this->assertEquals('This is a <b>(test</b>) text', $result);
 
 		$text = 'Ich saß in einem Café am Übergang';
 		$expected = 'Ich <b>saß</b> in einem <b>Café</b> am <b>Übergang</b>';
 		$phrases = array('saß', 'café', 'übergang');
 		$result = $this->Text->highlight($text, $phrases, array('format' => '<b>\1</b>'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -129,17 +129,17 @@ class TextHelperTest extends CakeTestCase {
 		$options = array('format' => '<b>\1</b>', 'html' => true);
 
 		$expected = '<p><b>strong</b>bow isn&rsquo;t real cider</p>';
-		$this->assertEqual($this->Text->highlight($text1, 'strong', $options), $expected);
+		$this->assertEquals($this->Text->highlight($text1, 'strong', $options), $expected);
 
 		$expected = '<p><b>strong</b>bow <strong>isn&rsquo;t</strong> real cider</p>';
-		$this->assertEqual($this->Text->highlight($text2, 'strong', $options), $expected);
+		$this->assertEquals($this->Text->highlight($text2, 'strong', $options), $expected);
 
-		$this->assertEqual($this->Text->highlight($text3, 'strong', $options), $text3);
+		$this->assertEquals($this->Text->highlight($text3, 'strong', $options), $text3);
 
-		$this->assertEqual($this->Text->highlight($text3, array('strong', 'what'), $options), $text3);
+		$this->assertEquals($this->Text->highlight($text3, array('strong', 'what'), $options), $text3);
 
 		$expected = '<b>What</b> a <b>strong</b> mouse: <img src="what-a-strong-mouse.png" alt="What a strong mouse!" />';
-		$this->assertEqual($this->Text->highlight($text4, array('strong', 'what'), $options), $expected);
+		$this->assertEquals($this->Text->highlight($text4, array('strong', 'what'), $options), $expected);
 	}
 
 /**
@@ -152,7 +152,7 @@ class TextHelperTest extends CakeTestCase {
 		$phrases = array('This', 'text');
 		$result = $this->Text->highlight($text, $phrases, array('format' => array('<b>\1</b>', '<em>\1</em>')));
 		$expected = '<b>This</b> is a test <em>text</em>';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -165,22 +165,22 @@ class TextHelperTest extends CakeTestCase {
 		$text = 'This is a test text';
 		$expected = 'This is a test text';
 		$result = $this->Text->stripLinks($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a <a href="#">test</a> text';
 		$expected = 'This is a test text';
 		$result = $this->Text->stripLinks($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This <strong>is</strong> a <a href="#">test</a> <a href="#">text</a>';
 		$expected = 'This <strong>is</strong> a test text';
 		$result = $this->Text->stripLinks($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This <strong>is</strong> a <a href="#">test</a> and <abbr>some</abbr> other <a href="#">text</a>';
 		$expected = 'This <strong>is</strong> a test and <abbr>some</abbr> other text';
 		$result = $this->Text->stripLinks($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -192,42 +192,42 @@ class TextHelperTest extends CakeTestCase {
 		$text = 'This is a test text';
 		$expected = 'This is a test text';
 		$result = $this->Text->autoLink($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a partial www.cakephp.org URL and test@cakephp.org email address';
 		$result = $this->Text->autoLink($text);
 		$expected = 'Text with a partial <a href="http://www.cakephp.org">www.cakephp.org</a> URL and <a href="mailto:test@cakephp\.org">test@cakephp\.org</a> email address';
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = 'This is a test text with URL http://www.cakephp.org';
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
 		$result = $this->Text->autoLink($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text with URL http://www.cakephp.org and some more text';
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a> and some more text';
 		$result = $this->Text->autoLink($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = "This is a test text with URL http://www.cakephp.org\tand some more text";
 		$expected = "This is a test text with URL <a href=\"http://www.cakephp.org\">http://www.cakephp.org</a>\tand some more text";
 		$result = $this->Text->autoLink($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text with URL http://www.cakephp.org(and some more text)';
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>(and some more text)';
 		$result = $this->Text->autoLink($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text with URL http://www.cakephp.org';
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link">http://www.cakephp.org</a>';
 		$result = $this->Text->autoLink($text, array('class'=>'link'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test text with URL http://www.cakephp.org';
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link" id="MyLink">http://www.cakephp.org</a>';
 		$result = $this->Text->autoLink($text, array('class'=>'link', 'id'=>'MyLink'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -239,57 +239,57 @@ class TextHelperTest extends CakeTestCase {
 		$text = 'This is a test text';
 		$expected = 'This is a test text';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'This is a test that includes (www.cakephp.org)';
 		$expected = 'This is a test that includes (<a href="http://www.cakephp.org">www.cakephp.org</a>)';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a partial www.cakephp.org URL';
 		$expected = 'Text with a partial <a href="http://www.cakephp.org"\s*>www.cakephp.org</a> URL';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = 'Text with a partial www.cakephp.org URL';
 		$expected = 'Text with a partial <a href="http://www.cakephp.org" \s*class="link">www.cakephp.org</a> URL';
 		$result = $this->Text->autoLinkUrls($text, array('class' => 'link'));
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = 'Text with a partial WWW.cakephp.org URL';
 		$expected = 'Text with a partial <a href="http://WWW.cakephp.org"\s*>WWW.cakephp.org</a> URL';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = 'Text with a partial WWW.cakephp.org &copy; URL';
 		$expected = 'Text with a partial <a href="http://WWW.cakephp.org"\s*>WWW.cakephp.org</a> &copy; URL';
 		$result = $this->Text->autoLinkUrls($text, array('escape' => false));
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = 'Text with a url www.cot.ag/cuIb2Q and more';
 		$expected = 'Text with a url <a href="http://www.cot.ag/cuIb2Q">www.cot.ag/cuIb2Q</a> and more';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a url http://www.does--not--work.com and more';
 		$expected = 'Text with a url <a href="http://www.does--not--work.com">http://www.does--not--work.com</a> and more';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a url http://www.not--work.com and more';
 		$expected = 'Text with a url <a href="http://www.not--work.com">http://www.not--work.com</a> and more';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a partial <a href="http://www.cakephp.org">link</a> link';
 		$expected = 'Text with a partial <a href="http://www.cakephp.org">link</a> link';
 		$result = $this->Text->autoLinkUrls($text, array('escape' => false));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
 		$expected = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
 		$result = $this->Text->autoLinkUrls($text, array('escape' => false));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -301,22 +301,22 @@ class TextHelperTest extends CakeTestCase {
 		$text = 'This is a test text';
 		$expected = 'This is a test text';
 		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with email@example.com address';
 		$expected = 'Text with <a href="mailto:email@example.com"\s*>email@example.com</a> address';
 		$result = $this->Text->autoLinkEmails($text);
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 
 		$text = "Text with o'hare._-bob@example.com address";
 		$expected = 'Text with <a href="mailto:o&#039;hare._-bob@example.com">o&#039;hare._-bob@example.com</a> address';
 		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$text = 'Text with email@example.com address';
 		$expected = 'Text with <a href="mailto:email@example.com" \s*class="link">email@example.com</a> address';
 		$result = $this->Text->autoLinkEmails($text, array('class' => 'link'));
-		$this->assertPattern('#^' . $expected . '$#', $result);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 	}
 
 /**
@@ -327,7 +327,7 @@ class TextHelperTest extends CakeTestCase {
 	public function testAutoLinkEmailInvalid() {
 		$result = $this->Text->autoLinkEmails('this is a myaddress@gmx-de test');
 		$expected = 'this is a myaddress@gmx-de test';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -340,10 +340,10 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'This is a <b>Test</b> text';
 
 		$result = $this->Text->highlight($text, 'test', array('format' => '<b>\1</b>'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Text->highlight($text, array('test'), array('format' => '<b>\1</b>'));
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -356,33 +356,33 @@ class TextHelperTest extends CakeTestCase {
 
 		$expected = '...with test text...';
 		$result = $this->Text->excerpt($text, 'test', 9, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 'This is a...';
 		$result = $this->Text->excerpt($text, 'not_found', 9, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 'This is a phras...';
 		$result = $this->Text->excerpt($text, null, 9, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = $text;
 		$result = $this->Text->excerpt($text, null, 200, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = '...phrase...';
 		$result = $this->Text->excerpt($text, 'phrase', 2, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$phrase = 'This is a phrase with test';
 		$expected = $text;
 		$result = $this->Text->excerpt($text, $phrase, strlen($phrase) + 3, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$phrase = 'This is a phrase with text';
 		$expected = $text;
 		$result = $this->Text->excerpt($text, $phrase, 10, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -395,11 +395,11 @@ class TextHelperTest extends CakeTestCase {
 
 		$expected = '...with test text...';
 		$result = $this->Text->excerpt($text, 'TEST', 9, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = 'This is a...';
 		$result = $this->Text->excerpt($text, 'NOT_FOUND', 9, '...');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -409,27 +409,27 @@ class TextHelperTest extends CakeTestCase {
  */
 	public function testListGeneration() {
 		$result = $this->Text->toList(array());
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$result = $this->Text->toList(array('One'));
-		$this->assertEqual($result, 'One');
+		$this->assertEquals($result, 'One');
 
 		$result = $this->Text->toList(array('Larry', 'Curly', 'Moe'));
-		$this->assertEqual($result, 'Larry, Curly and Moe');
+		$this->assertEquals($result, 'Larry, Curly and Moe');
 
 		$result = $this->Text->toList(array('Dusty', 'Lucky', 'Ned'), 'y');
-		$this->assertEqual($result, 'Dusty, Lucky y Ned');
+		$this->assertEquals($result, 'Dusty, Lucky y Ned');
 
 		$result = $this->Text->toList(array( 1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'), 'y');
-		$this->assertEqual($result, 'Dusty, Lucky y Ned');
+		$this->assertEquals($result, 'Dusty, Lucky y Ned');
 
 		$result = $this->Text->toList(array( 1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'), 'and', ' + ');
-		$this->assertEqual($result, 'Dusty + Lucky and Ned');
+		$this->assertEquals($result, 'Dusty + Lucky and Ned');
 
 		$result = $this->Text->toList(array( 'name1' => 'Dusty', 'name2' => 'Lucky'));
-		$this->assertEqual($result, 'Dusty and Lucky');
+		$this->assertEquals($result, 'Dusty and Lucky');
 
 		$result = $this->Text->toList(array( 'test_0' => 'banana', 'test_1' => 'apple', 'test_2' => 'lemon'));
-		$this->assertEqual($result, 'banana, apple and lemon');
+		$this->assertEquals($result, 'banana, apple and lemon');
 	}
 }

--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -53,25 +53,25 @@ class TimeHelperTest extends CakeTestCase {
  */
 	public function testToQuarter() {
 		$result = $this->Time->toQuarter('2007-12-25');
-		$this->assertEqual($result, 4);
+		$this->assertEquals($result, 4);
 
 		$result = $this->Time->toQuarter('2007-9-25');
-		$this->assertEqual($result, 3);
+		$this->assertEquals($result, 3);
 
 		$result = $this->Time->toQuarter('2007-3-25');
-		$this->assertEqual($result, 1);
+		$this->assertEquals($result, 1);
 
 		$result = $this->Time->toQuarter('2007-3-25', true);
-		$this->assertEqual($result, array('2007-01-01', '2007-03-31'));
+		$this->assertEquals($result, array('2007-01-01', '2007-03-31'));
 
 		$result = $this->Time->toQuarter('2007-5-25', true);
-		$this->assertEqual($result, array('2007-04-01', '2007-06-30'));
+		$this->assertEquals($result, array('2007-04-01', '2007-06-30'));
 
 		$result = $this->Time->toQuarter('2007-8-25', true);
-		$this->assertEqual($result, array('2007-07-01', '2007-09-30'));
+		$this->assertEquals($result, array('2007-07-01', '2007-09-30'));
 
 		$result = $this->Time->toQuarter('2007-12-25', true);
-		$this->assertEqual($result, array('2007-10-01', '2007-12-31'));
+		$this->assertEquals($result, array('2007-10-01', '2007-12-31'));
 	}
 
 /**
@@ -81,40 +81,40 @@ class TimeHelperTest extends CakeTestCase {
  */
 	public function testTimeAgoInWords() {
 		$result = $this->Time->timeAgoInWords('-1 week');
-		$this->assertEqual($result, '1 week ago');
+		$this->assertEquals($result, '1 week ago');
 
 		$result = $this->Time->timeAgoInWords('+1 week');
-		$this->assertEqual($result, '1 week');
+		$this->assertEquals($result, '1 week');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +3 days'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '4 months, 2 weeks, 3 days');
+		$this->assertEquals($result, '4 months, 2 weeks, 3 days');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +2 days'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '4 months, 2 weeks, 2 days');
+		$this->assertEquals($result, '4 months, 2 weeks, 2 days');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '4 months, 2 weeks, 1 day');
+		$this->assertEquals($result, '4 months, 2 weeks, 1 day');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '3 months, 2 weeks, 1 day');
+		$this->assertEquals($result, '3 months, 2 weeks, 1 day');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +2 weeks'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '3 months, 2 weeks');
+		$this->assertEquals($result, '3 months, 2 weeks');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '3 months, 1 week, 6 days');
+		$this->assertEquals($result, '3 months, 1 week, 6 days');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '2 months, 2 weeks, 1 day');
+		$this->assertEquals($result, '2 months, 2 weeks, 1 day');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 weeks'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '2 months, 2 weeks');
+		$this->assertEquals($result, '2 months, 2 weeks');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '2 months, 1 week, 6 days');
+		$this->assertEquals($result, '2 months, 1 week, 6 days');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+1 month +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEqual($result, '1 month, 1 week, 6 days');
+		$this->assertEquals($result, '1 month, 1 week, 6 days');
 
 		for($i = 0; $i < 200; $i ++) {
 			$years = mt_rand(0, 3);
@@ -164,7 +164,7 @@ class TimeHelperTest extends CakeTestCase {
 				}
 
 				$relative_date = str_replace('-', '', $relative_date) . ' ago';
-				$this->assertEqual($result, $relative_date);
+				$this->assertEquals($result, $relative_date);
 
 			}
 		}
@@ -218,78 +218,78 @@ class TimeHelperTest extends CakeTestCase {
 				}
 
 				$relative_date = str_replace('-', '', $relative_date) . '';
-				$this->assertEqual($result, $relative_date);
+				$this->assertEquals($result, $relative_date);
 			}
 		}
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 years -5 months -2 days'), array('end' => '3 years'), true);
-		$this->assertEqual($result, '2 years, 5 months, 2 days ago');
+		$this->assertEquals($result, '2 years, 5 months, 2 days ago');
 
 		$result = $this->Time->timeAgoInWords('2007-9-25');
-		$this->assertEqual($result, 'on 25/9/07');
+		$this->assertEquals($result, 'on 25/9/07');
 
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
-		$this->assertEqual($result, 'on 2007-09-25');
+		$this->assertEquals($result, 'on 2007-09-25');
 
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d', true);
-		$this->assertEqual($result, 'on 2007-09-25');
+		$this->assertEquals($result, 'on 2007-09-25');
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 weeks -2 days'), 'Y-m-d', false);
-		$this->assertEqual($result, '2 weeks, 2 days ago');
+		$this->assertEquals($result, '2 weeks, 2 days ago');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 weeks +2 days'), 'Y-m-d', true);
-		$this->assertPattern('/^2 weeks, [1|2] day(s)?$/', $result);
+		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '1 month'));
-		$this->assertEqual($result, 'on ' . date('j/n/y', strtotime('+2 months +2 days')));
+		$this->assertEquals($result, 'on ' . date('j/n/y', strtotime('+2 months +2 days')));
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '3 month'));
-		$this->assertPattern('/2 months/', $result);
+		$this->assertRegExp('/2 months/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +12 days'), array('end' => '3 month'));
-		$this->assertPattern('/2 months, 1 week/', $result);
+		$this->assertRegExp('/2 months, 1 week/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +5 days'), array('end' => '4 month'));
-		$this->assertEqual($result, '3 months, 5 days');
+		$this->assertEquals($result, '3 months, 5 days');
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '3 month'));
-		$this->assertEqual($result, '2 months, 2 days ago');
+		$this->assertEquals($result, '2 months, 2 days ago');
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '3 month'));
-		$this->assertEqual($result, '2 months, 2 days ago');
+		$this->assertEquals($result, '2 months, 2 days ago');
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '3 month'));
-		$this->assertPattern('/2 months/', $result);
+		$this->assertRegExp('/2 months/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '1 month', 'format' => 'Y-m-d'));
-		$this->assertEqual($result, 'on ' . date('Y-m-d', strtotime('+2 months +2 days')));
+		$this->assertEquals($result, 'on ' . date('Y-m-d', strtotime('+2 months +2 days')));
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '1 month', 'format' => 'Y-m-d'));
-		$this->assertEqual($result, 'on ' . date('Y-m-d', strtotime('-2 months -2 days')));
+		$this->assertEquals($result, 'on ' . date('Y-m-d', strtotime('-2 months -2 days')));
 
 		$result = $this->Time->timeAgoInWords(strtotime('-13 months -5 days'), array('end' => '2 years'));
-		$this->assertEqual($result, '1 year, 1 month, 5 days ago');
+		$this->assertEquals($result, '1 year, 1 month, 5 days ago');
 
 		$fourHours = $this->Time->timeAgoInWords(strtotime('-5 days -2 hours'), array('userOffset' => -4));
 		$result = $this->Time->timeAgoInWords(strtotime('-5 days -2 hours'), array('userOffset' => 4));
-		$this->assertEqual($fourHours, $result);
+		$this->assertEquals($fourHours, $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 hours'));
 		$expected = '2 hours ago';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-12 minutes'));
 		$expected = '12 minutes ago';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-12 seconds'));
 		$expected = '12 seconds ago';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$time = strtotime('-3 years -12 months');
 		$result = $this->Time->timeAgoInWords($time);
 		$expected = 'on ' . date('j/n/y', $time);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -299,26 +299,26 @@ class TimeHelperTest extends CakeTestCase {
  */
 	public function testNice() {
 		$time = time() + 2 * DAY;
-		$this->assertEqual(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
+		$this->assertEquals(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
 
 		$time = time() - 2 * DAY;
-		$this->assertEqual(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
+		$this->assertEquals(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
 
 		$time = time();
-		$this->assertEqual(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
+		$this->assertEquals(date('D, M jS Y, H:i', $time), $this->Time->nice($time));
 
 		$time = 0;
-		$this->assertEqual(date('D, M jS Y, H:i', time()), $this->Time->nice($time));
+		$this->assertEquals(date('D, M jS Y, H:i', time()), $this->Time->nice($time));
 
 		$time = null;
-		$this->assertEqual(date('D, M jS Y, H:i', time()), $this->Time->nice($time));
+		$this->assertEquals(date('D, M jS Y, H:i', time()), $this->Time->nice($time));
 
 		$time = time();
-		$this->assertEqual(date('D', $time), $this->Time->nice($time, null, '%a'));
-		$this->assertEqual(date('M d, Y', $time), $this->Time->nice($time, null, '%b %d, %Y'));
+		$this->assertEquals(date('D', $time), $this->Time->nice($time, null, '%a'));
+		$this->assertEquals(date('M d, Y', $time), $this->Time->nice($time, null, '%b %d, %Y'));
 
 		$this->Time->niceFormat = '%Y-%d-%m';
-		$this->assertEqual(date('Y-d-m', $time), $this->Time->nice($time));
+		$this->assertEquals(date('Y-d-m', $time), $this->Time->nice($time));
 	}
 
 /**
@@ -329,16 +329,16 @@ class TimeHelperTest extends CakeTestCase {
 	public function testNiceShort() {
 		$time = time() + 2 * DAY;
 		if (date('Y', $time) == date('Y')) {
-			$this->assertEqual(date('M jS, H:i', $time), $this->Time->niceShort($time));
+			$this->assertEquals(date('M jS, H:i', $time), $this->Time->niceShort($time));
 		} else {
-			$this->assertEqual(date('M jS Y, H:i', $time), $this->Time->niceShort($time));
+			$this->assertEquals(date('M jS Y, H:i', $time), $this->Time->niceShort($time));
 		}
 
 		$time = time();
-		$this->assertEqual('Today, ' . date('H:i', $time), $this->Time->niceShort($time));
+		$this->assertEquals('Today, ' . date('H:i', $time), $this->Time->niceShort($time));
 
 		$time = time() - DAY;
-		$this->assertEqual('Yesterday, ' . date('H:i', $time), $this->Time->niceShort($time));
+		$this->assertEquals('Yesterday, ' . date('H:i', $time), $this->Time->niceShort($time));
 	}
 
 /**
@@ -351,7 +351,7 @@ class TimeHelperTest extends CakeTestCase {
 		$end = time() + DAY;
 		$field = 'my_field';
 		$expected = '(my_field >= \''.date('Y-m-d', $begin).' 00:00:00\') AND (my_field <= \''.date('Y-m-d', $end).' 23:59:59\')';
-		$this->assertEqual($expected, $this->Time->daysAsSql($begin, $end, $field));
+		$this->assertEquals($expected, $this->Time->daysAsSql($begin, $end, $field));
 	}
 
 /**
@@ -363,7 +363,7 @@ class TimeHelperTest extends CakeTestCase {
 		$time = time();
 		$field = 'my_field';
 		$expected = '(my_field >= \''.date('Y-m-d', $time).' 00:00:00\') AND (my_field <= \''.date('Y-m-d', $time).' 23:59:59\')';
-		$this->assertEqual($expected, $this->Time->dayAsSql($time, $field));
+		$this->assertEquals($expected, $this->Time->dayAsSql($time, $field));
 	}
 
 /**
@@ -372,12 +372,12 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testToUnix() {
-		$this->assertEqual(time(), $this->Time->toUnix(time()));
-		$this->assertEqual(strtotime('+1 day'), $this->Time->toUnix('+1 day'));
-		$this->assertEqual(strtotime('+0 days'), $this->Time->toUnix('+0 days'));
-		$this->assertEqual(strtotime('-1 days'), $this->Time->toUnix('-1 days'));
-		$this->assertEqual(false, $this->Time->toUnix(''));
-		$this->assertEqual(false, $this->Time->toUnix(null));
+		$this->assertEquals(time(), $this->Time->toUnix(time()));
+		$this->assertEquals(strtotime('+1 day'), $this->Time->toUnix('+1 day'));
+		$this->assertEquals(strtotime('+0 days'), $this->Time->toUnix('+0 days'));
+		$this->assertEquals(strtotime('-1 days'), $this->Time->toUnix('-1 days'));
+		$this->assertEquals(false, $this->Time->toUnix(''));
+		$this->assertEquals(false, $this->Time->toUnix(null));
 	}
 
 /**
@@ -386,7 +386,7 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testToAtom() {
-		$this->assertEqual(date('Y-m-d\TH:i:s\Z'), $this->Time->toAtom(time()));
+		$this->assertEquals(date('Y-m-d\TH:i:s\Z'), $this->Time->toAtom(time()));
 	}
 
 /**
@@ -395,7 +395,7 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testToRss() {
-		$this->assertEqual(date('r'), $this->Time->toRss(time()));
+		$this->assertEquals(date('r'), $this->Time->toRss(time()));
 
 		if (!$this->skipIf(!class_exists('DateTimeZone'), '%s DateTimeZone class not available.')) {
 			$timezones = array('Europe/London', 'Europe/Brussels', 'UTC', 'America/Denver', 'America/Caracas', 'Asia/Kathmandu');
@@ -403,7 +403,7 @@ class TimeHelperTest extends CakeTestCase {
 				$yourTimezone = new DateTimeZone($timezone);
 				$yourTime = new DateTime('now', $yourTimezone);
 				$userOffset = $yourTimezone->getOffset($yourTime) / HOUR;
-				$this->assertEqual($yourTime->format('r'), $this->Time->toRss(time(), $userOffset));
+				$this->assertEquals($yourTime->format('r'), $this->Time->toRss(time(), $userOffset));
 			}
 		}
 	}
@@ -417,11 +417,11 @@ class TimeHelperTest extends CakeTestCase {
 		$format = 'D-M-Y';
 		$arr = array(time(), strtotime('+1 days'), strtotime('+1 days'), strtotime('+0 days'));
 		foreach ($arr as $val) {
-			$this->assertEqual(date($format, $val), $this->Time->format($format, $val));
+			$this->assertEquals(date($format, $val), $this->Time->format($format, $val));
 		}
 
 		$result = $this->Time->format('Y-m-d', null, 'never');
-		$this->assertEqual($result, 'never');
+		$this->assertEquals($result, 'never');
 	}
 
 /**
@@ -438,7 +438,7 @@ class TimeHelperTest extends CakeTestCase {
 		$year = 2007;
 		$time = mktime($hour, $min, $sec, $month, $day, $year);
 		$expected = gmmktime($hour, $min, $sec, $month, $day, $year);
-		$this->assertEqual($expected, $this->Time->gmt(date('Y-n-j G:i:s', $time)));
+		$this->assertEquals($expected, $this->Time->gmt(date('Y-n-j G:i:s', $time)));
 
 		$hour = date('H');
 		$min = date('i');
@@ -447,7 +447,7 @@ class TimeHelperTest extends CakeTestCase {
 		$day = date('d');
 		$year = date('Y');
 		$expected = gmmktime($hour, $min, $sec, $month, $day, $year);
-		$this->assertEqual($expected, $this->Time->gmt(null));
+		$this->assertEquals($expected, $this->Time->gmt(null));
 	}
 
 /**
@@ -609,7 +609,7 @@ class TimeHelperTest extends CakeTestCase {
 
 		$expected = time();
 		$result = $this->Time->fromString(time(), $yourTimezone);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -626,12 +626,12 @@ class TimeHelperTest extends CakeTestCase {
 
 		$result = $this->Time->fromString('+1 hour');
 		$expected = strtotime('+1 hour');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$timezone = date('Z', time());
 		$result = $this->Time->fromString('+1 hour', $timezone);
 		$expected = $this->Time->convert(strtotime('+1 hour'), $timezone);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -648,79 +648,79 @@ class TimeHelperTest extends CakeTestCase {
 
 		$result = $this->Time->convertSpecifiers('%a', $time);
 		$expected = 'jue';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%A', $time);
 		$expected = 'jueves';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%c', $time);
 		$expected = 'jue %d ene %Y %H:%M:%S %Z';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%C', $time);
 		$expected = '20';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%D', $time);
 		$expected = '%m/%d/%y';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%b', $time);
 		$expected = 'ene';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%h', $time);
 		$expected = 'ene';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%B', $time);
 		$expected = 'enero';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%n', $time);
 		$expected = "\n";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%n', $time);
 		$expected = "\n";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%p', $time);
 		$expected = 'AM';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%P', $time);
 		$expected = 'am';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%r', $time);
 		$expected = '%I:%M:%S AM';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%R', $time);
 		$expected = '11:43';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%t', $time);
 		$expected = "\t";
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%T', $time);
 		$expected = '%H:%M:%S';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%u', $time);
 		$expected = 4;
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%x', $time);
 		$expected = '%d/%m/%y';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%X', $time);
 		$expected = '%H:%M:%S';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -734,11 +734,11 @@ class TimeHelperTest extends CakeTestCase {
 		$time = strtotime('Thu Jan 14 11:43:39 2010');
 		$result = $this->Time->convertSpecifiers('%e', $time);
 		$expected = '14';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->convertSpecifiers('%e', strtotime('2011-01-01'));
 		$expected = ' 1';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -755,19 +755,19 @@ class TimeHelperTest extends CakeTestCase {
 
 		$result = $this->Time->i18nFormat($time);
 		$expected = '14/01/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, '%c');
 		$expected = 'jue 14 ene 2010 13:59:28 ' . strftime('%Z', $time);
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
 		$expected = 'Time is 01:59:28 PM, and date is 14/01/10';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat('invalid date', '%x', 'Date invalid');
 		$expected = 'Date invalid';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -777,7 +777,7 @@ class TimeHelperTest extends CakeTestCase {
  */
 	public function testFormatNewSyntax() {
 		$time = time();
-		$this->assertEqual($this->Time->format($time), $this->Time->i18nFormat($time));
-		$this->assertEqual($this->Time->format($time, '%c'), $this->Time->i18nFormat($time, '%c'));
+		$this->assertEquals($this->Time->format($time), $this->Time->i18nFormat($time));
+		$this->assertEquals($this->Time->format($time, '%c'), $this->Time->i18nFormat($time, '%c'));
 	}
 }

--- a/lib/Cake/Test/Case/View/HelperTest.php
+++ b/lib/Cake/Test/Case/View/HelperTest.php
@@ -416,21 +416,21 @@ class HelperTest extends CakeTestCase {
 		$this->Helper->request->data = array('fullname' => 'This is me');
 		$this->Helper->setEntity('fullname');
 		$result = $this->Helper->value('fullname');
-		$this->assertEqual($result, 'This is me');
+		$this->assertEquals($result, 'This is me');
 
 		$this->Helper->request->data = array(
 			'Post' => array('name' => 'First Post')
 		);
 		$this->Helper->setEntity('Post.name');
 		$result = $this->Helper->value('Post.name');
-		$this->assertEqual($result, 'First Post');
+		$this->assertEquals($result, 'First Post');
 
 		$this->Helper->request->data = array(
 			'Post' => array(2 => array('name' => 'First Post'))
 		);
 		$this->Helper->setEntity('Post.2.name');
 		$result = $this->Helper->value('Post.2.name');
-		$this->assertEqual($result, 'First Post');
+		$this->assertEquals($result, 'First Post');
 
 		$this->Helper->request->data = array(
 			'Post' => array(
@@ -439,7 +439,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('Post.2.created');
 		$result = $this->Helper->value('Post.2.created');
-		$this->assertEqual($result, array('year' => '2008'));
+		$this->assertEquals($result, array('year' => '2008'));
 
 		$this->Helper->request->data = array(
 			'Post' => array(
@@ -448,7 +448,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('Post.2.created.year');
 		$result = $this->Helper->value('Post.2.created.year');
-		$this->assertEqual($result, '2008');
+		$this->assertEquals($result, '2008');
 	}
 
 /**
@@ -460,15 +460,15 @@ class HelperTest extends CakeTestCase {
 		$this->Helper->request->data = array('zero' => 0);
 		$this->Helper->setEntity('zero');
 		$result = $this->Helper->value(array('default' => 'something'), 'zero');
-		$this->assertEqual($result, array('value' => 0));
+		$this->assertEquals($result, array('value' => 0));
 
 		$this->Helper->request->data = array('zero' => '0');
 		$result = $this->Helper->value(array('default' => 'something'), 'zero');
-		$this->assertEqual($result, array('value' => '0'));
+		$this->assertEquals($result, array('value' => '0'));
 
 		$this->Helper->setEntity('inexistent');
 		$result = $this->Helper->value(array('default' => 'something'), 'inexistent');
-		$this->assertEqual($result, array('value' => 'something'));
+		$this->assertEquals($result, array('value' => 'something'));
 	}
 
 /**
@@ -482,7 +482,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -491,7 +491,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEqual($result, array(2, 3, 4));
+		$this->assertEquals($result, array(2, 3, 4));
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -501,7 +501,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEqual($result, array(3 => 3, 5 => 5));
+		$this->assertEquals($result, array(3 => 3, 5 => 5));
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -511,7 +511,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.body');
 		$result = $this->Helper->value('HelperTestTag.body');
-		$this->assertEqual($result, '');
+		$this->assertEquals($result, '');
 	}
 
 /**
@@ -521,33 +521,33 @@ class HelperTest extends CakeTestCase {
  */
 	public function testUrlConversion() {
 		$result = $this->Helper->url('/controller/action/1');
-		$this->assertEqual($result, '/controller/action/1');
+		$this->assertEquals($result, '/controller/action/1');
 
 		$result = $this->Helper->url('/controller/action/1?one=1&two=2');
-		$this->assertEqual($result, '/controller/action/1?one=1&amp;two=2');
+		$this->assertEquals($result, '/controller/action/1?one=1&amp;two=2');
 
 		$result = $this->Helper->url(array('controller' => 'posts', 'action' => 'index', 'page' => '1" onclick="alert(\'XSS\');"'));
-		$this->assertEqual($result, "/posts/index/page:1&quot; onclick=&quot;alert(&#039;XSS&#039;);&quot;");
+		$this->assertEquals($result, "/posts/index/page:1&quot; onclick=&quot;alert(&#039;XSS&#039;);&quot;");
 
 		$result = $this->Helper->url('/controller/action/1/param:this+one+more');
-		$this->assertEqual($result, '/controller/action/1/param:this+one+more');
+		$this->assertEquals($result, '/controller/action/1/param:this+one+more');
 
 		$result = $this->Helper->url('/controller/action/1/param:this%20one%20more');
-		$this->assertEqual($result, '/controller/action/1/param:this%20one%20more');
+		$this->assertEquals($result, '/controller/action/1/param:this%20one%20more');
 
 		$result = $this->Helper->url('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
-		$this->assertEqual($result, '/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
+		$this->assertEquals($result, '/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
 
 		$result = $this->Helper->url(array(
 			'controller' => 'posts', 'action' => 'index', 'param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24'
 		));
-		$this->assertEqual($result, "/posts/index/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24");
+		$this->assertEquals($result, "/posts/index/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24");
 
 		$result = $this->Helper->url(array(
 			'controller' => 'posts', 'action' => 'index', 'page' => '1',
 			'?' => array('one' => 'value', 'two' => 'value', 'three' => 'purple')
 		));
-		$this->assertEqual($result, "/posts/index/page:1?one=value&amp;two=value&amp;three=purple");
+		$this->assertEquals($result, "/posts/index/page:1?one=value&amp;two=value&amp;three=purple");
 	}
 
 /**
@@ -561,29 +561,29 @@ class HelperTest extends CakeTestCase {
 
 		Configure::write('Asset.timestamp', false);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertEqual($result, CSS_URL . 'cake.generic.css');
+		$this->assertEquals($result, CSS_URL . 'cake.generic.css');
 
 		Configure::write('Asset.timestamp', true);
 		Configure::write('debug', 0);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertEqual($result, CSS_URL . 'cake.generic.css');
+		$this->assertEquals($result, CSS_URL . 'cake.generic.css');
 
 		Configure::write('Asset.timestamp', true);
 		Configure::write('debug', 2);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertPattern('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
+		$this->assertRegExp('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
 		Configure::write('Asset.timestamp', 'force');
 		Configure::write('debug', 0);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertPattern('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
+		$this->assertRegExp('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css?someparam');
-		$this->assertEqual($result, CSS_URL . 'cake.generic.css?someparam');
+		$this->assertEquals($result, CSS_URL . 'cake.generic.css?someparam');
 
 		$this->Helper->request->webroot = '/some/dir/';
 		$result = $this->Helper->assetTimestamp('/some/dir/' . CSS_URL . 'cake.generic.css');
-		$this->assertPattern('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
+		$this->assertRegExp('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
 		Configure::write('debug', $_debug);
 		Configure::write('Asset.timestamp', $_timestamp);
@@ -604,16 +604,16 @@ class HelperTest extends CakeTestCase {
 		CakePlugin::loadAll();
 
 		$result = $this->Helper->assetTimestamp('/test_plugin/css/test_plugin_asset.css');
-		$this->assertPattern('#/test_plugin/css/test_plugin_asset.css\?[0-9]+$#', $result, 'Missing timestamp plugin');
+		$this->assertRegExp('#/test_plugin/css/test_plugin_asset.css\?[0-9]+$#', $result, 'Missing timestamp plugin');
 
 		$result = $this->Helper->assetTimestamp('/test_plugin/css/i_dont_exist.css');
-		$this->assertPattern('#/test_plugin/css/i_dont_exist.css\?$#', $result, 'No error on missing file');
+		$this->assertRegExp('#/test_plugin/css/i_dont_exist.css\?$#', $result, 'No error on missing file');
 
 		$result = $this->Helper->assetTimestamp('/theme/test_theme/js/theme.js');
-		$this->assertPattern('#/theme/test_theme/js/theme.js\?[0-9]+$#', $result, 'Missing timestamp theme');
+		$this->assertRegExp('#/theme/test_theme/js/theme.js\?[0-9]+$#', $result, 'Missing timestamp theme');
 
 		$result = $this->Helper->assetTimestamp('/theme/test_theme/js/non_existant.js');
-		$this->assertPattern('#/theme/test_theme/js/non_existant.js\?$#', $result, 'No error on missing file');
+		$this->assertRegExp('#/theme/test_theme/js/non_existant.js\?$#', $result, 'No error on missing file');
 
 		App::build();
 		Configure::write('Asset.timestamp', $_timestamp);
@@ -691,20 +691,20 @@ class HelperTest extends CakeTestCase {
 			}
 		}
 		$expected = array('what', 'how', 'how', 'what', 'how', 'how');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Helper->request->data['HelperTestComment']['5']['id'] = 'ok';
 		$result = $this->Helper->value('HelperTestComment.5.id');
-		$this->assertEqual($result, 'ok');
+		$this->assertEquals($result, 'ok');
 
 		$this->Helper->setEntity('HelperTestPost', true);
 		$this->Helper->request->data['HelperTestPost']['5']['created']['month'] = '10';
 		$result = $this->Helper->value('5.created.month');
-		$this->assertEqual($result, 10);
+		$this->assertEquals($result, 10);
 
 		$this->Helper->request->data['HelperTestPost']['0']['id'] = 100;
 		$result = $this->Helper->value('HelperTestPost.0.id');
-		$this->assertEqual($result, 100);
+		$this->assertEquals($result, 100);
 	}
 
 /**
@@ -714,25 +714,25 @@ class HelperTest extends CakeTestCase {
  */
 	public function testClean() {
 		$result = $this->Helper->clean(array());
-		$this->assertEqual($result, null);
+		$this->assertEquals($result, null);
 
 		$result = $this->Helper->clean(array('<script>with something</script>', '<applet>something else</applet>'));
-		$this->assertEqual($result, array('with something', 'something else'));
+		$this->assertEquals($result, array('with something', 'something else'));
 
 		$result = $this->Helper->clean('<script>with something</script>');
-		$this->assertEqual($result, 'with something');
+		$this->assertEquals($result, 'with something');
 
 		$result = $this->Helper->clean('<script type="text/javascript">alert("ruined");</script>');
-		$this->assertNoPattern('#</*script#', $result);
+		$this->assertNotRegExp('#</*script#', $result);
 
 		$result = $this->Helper->clean("<script \ntype=\"text/javascript\">\n\talert('ruined');\n\n\t\t</script>");
-		$this->assertNoPattern('#</*script#', $result);
+		$this->assertNotRegExp('#</*script#', $result);
 
 		$result = $this->Helper->clean('<body/onload=do(/something/)>');
-		$this->assertEqual($result, '<body/>');
+		$this->assertEquals($result, '<body/>');
 
 		$result = $this->Helper->clean('&lt;script&gt;alert(document.cookie)&lt;/script&gt;');
-		$this->assertEqual($result, '&amp;lt;script&amp;gt;alert(document.cookie)&amp;lt;/script&amp;gt;');
+		$this->assertEquals($result, '&amp;lt;script&amp;gt;alert(document.cookie)&amp;lt;/script&amp;gt;');
 	}
 
 /**
@@ -786,14 +786,14 @@ class HelperTest extends CakeTestCase {
 
 		$this->Helper->request->data['My']['title'] = 'My Title';
 		$result = $this->Helper->value('My.title');
-		$this->assertEqual($result,'My Title');
+		$this->assertEquals($result,'My Title');
 	}
 
 	public function testWebrootPaths() {
 		$this->Helper->request->webroot = '/';
 		$result = $this->Helper->webroot('/img/cake.power.gif');
 		$expected = '/img/cake.power.gif';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$this->Helper->theme = 'test_theme';
 
@@ -803,30 +803,30 @@ class HelperTest extends CakeTestCase {
 
 		$result = $this->Helper->webroot('/img/cake.power.gif');
 		$expected = '/theme/test_theme/img/cake.power.gif';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Helper->webroot('/img/test.jpg');
 		$expected = '/theme/test_theme/img/test.jpg';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$webRoot = Configure::read('App.www_root');
 		Configure::write('App.www_root', CAKE . 'Test' . DS . 'test_app' . DS . 'webroot' . DS);
 
 		$result = $this->Helper->webroot('/img/cake.power.gif');
 		$expected = '/theme/test_theme/img/cake.power.gif';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Helper->webroot('/img/test.jpg');
 		$expected = '/theme/test_theme/img/test.jpg';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Helper->webroot('/img/cake.icon.gif');
 		$expected = '/img/cake.icon.gif';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Helper->webroot('/img/cake.icon.gif?some=param');
 		$expected = '/img/cake.icon.gif?some=param';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('App.www_root', $webRoot);
 	}

--- a/lib/Cake/Test/Case/View/MediaViewTest.php
+++ b/lib/Cake/Test/Case/View/MediaViewTest.php
@@ -105,7 +105,7 @@ class MediaViewTest extends CakeTestCase {
 		ob_start();
 		$result = $this->MediaView->render();
 		$output = ob_get_clean();
-		$this->assertEqual('this is the test asset css file', $output);
+		$this->assertEquals('this is the test asset css file', $output);
 		$this->assertTrue($result !== false);
 	}
 
@@ -161,7 +161,7 @@ class MediaViewTest extends CakeTestCase {
 		ob_start();
 		$result = $this->MediaView->render();
 		$output = ob_get_clean();
-		$this->assertEqual("some_key = some_value\nbool_key = 1\n", $output);
+		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
 		$this->assertTrue($result !== false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;
@@ -225,7 +225,7 @@ class MediaViewTest extends CakeTestCase {
 		ob_start();
 		$result = $this->MediaView->render();
 		$output = ob_get_clean();
-		$this->assertEqual("some_key = some_value\nbool_key = 1\n", $output);
+		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
 		$this->assertTrue($result !== false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;
@@ -289,7 +289,7 @@ class MediaViewTest extends CakeTestCase {
 		ob_start();
 		$result = $this->MediaView->render();
 		$output = ob_get_clean();
-		$this->assertEqual("some_key = some_value\nbool_key = 1\n", $output);
+		$this->assertEquals("some_key = some_value\nbool_key = 1\n", $output);
 		$this->assertTrue($result !== false);
 		if ($currentUserAgent !== null) {
 			$_SERVER['HTTP_USER_AGENT'] = $currentUserAgent;

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -118,39 +118,39 @@ class ScaffoldViewTest extends CakeTestCase {
 		$ScaffoldView = new TestScaffoldView($this->Controller);
 		$result = $ScaffoldView->testGetFilename('index');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'index.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('edit');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('add');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('view');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'view.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('admin_index');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'index.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('admin_view');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'view.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('admin_edit');
 		$expected =CAKE . 'View' . DS . 'Scaffolds' . DS . 'form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('admin_add');
 		$expected = CAKE . 'View' . DS . 'Scaffolds' . DS . 'form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('error');
 		$expected = CAKE . 'View' . DS . 'Errors' . DS . 'scaffold_error.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Controller = new ScaffoldViewMockController($this->request);
 		$Controller->scaffold = 'admin';
@@ -160,11 +160,11 @@ class ScaffoldViewTest extends CakeTestCase {
 		$ScaffoldView = new TestScaffoldView($Controller);
 		$result = $ScaffoldView->testGetFilename('admin_edit');
 		$expected = CAKE . 'Test' . DS . 'test_app' .DS . 'View' . DS . 'Posts' . DS . 'scaffold.form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('edit');
 		$expected = CAKE . 'Test' . DS . 'test_app' .DS . 'View' . DS . 'Posts' . DS . 'scaffold.form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$Controller = new ScaffoldViewMockController($this->request);
 		$Controller->scaffold = 'admin';
@@ -180,12 +180,12 @@ class ScaffoldViewTest extends CakeTestCase {
 		$result = $ScaffoldView->testGetFilename('admin_add');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin'
 			. DS .'TestPlugin' . DS . 'View' . DS . 'Tests' . DS . 'scaffold.form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $ScaffoldView->testGetFilename('add');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin'
 			. DS .'TestPlugin' . DS . 'View' . DS . 'Tests' . DS . 'scaffold.form.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		Configure::write('Routing.prefixes', $_admin);
 	}
@@ -204,7 +204,7 @@ class ScaffoldViewTest extends CakeTestCase {
 		$result = $ScaffoldView->testGetFilename('index');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS
 			. 'Themed' . DS . 'TestTheme' . DS . 'Posts' . DS . 'scaffold.index.ctp';
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -237,13 +237,13 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertPattern('#<h2>Scaffold Mock</h2>#', $result);
-		$this->assertPattern('#<table cellpadding="0" cellspacing="0">#', $result);
+		$this->assertRegExp('#<h2>Scaffold Mock</h2>#', $result);
+		$this->assertRegExp('#<table cellpadding="0" cellspacing="0">#', $result);
 
-		$this->assertPattern('#<a href="/scaffold_users/view/1">1</a>#', $result); //belongsTo links
-		$this->assertPattern('#<li><a href="/scaffold_mock/add">New Scaffold Mock</a></li>#', $result);
-		$this->assertPattern('#<li><a href="/scaffold_users">List Scaffold Users</a></li>#', $result);
-		$this->assertPattern('#<li><a href="/scaffold_comments/add">New Comment</a></li>#', $result);
+		$this->assertRegExp('#<a href="/scaffold_users/view/1">1</a>#', $result); //belongsTo links
+		$this->assertRegExp('#<li><a href="/scaffold_mock/add">New Scaffold Mock</a></li>#', $result);
+		$this->assertRegExp('#<li><a href="/scaffold_users">List Scaffold Users</a></li>#', $result);
+		$this->assertRegExp('#<li><a href="/scaffold_comments/add">New Comment</a></li>#', $result);
 	}
 
 /**
@@ -276,16 +276,16 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>View Scaffold Mock<\/h2>/', $result);
-		$this->assertPattern('/<dl>/', $result);
+		$this->assertRegExp('/<h2>View Scaffold Mock<\/h2>/', $result);
+		$this->assertRegExp('/<dl>/', $result);
 		//TODO: add specific tests for fields.
-		$this->assertPattern('/<a href="\/scaffold_users\/view\/1">1<\/a>/', $result); //belongsTo links
-		$this->assertPattern('/<li><a href="\/scaffold_mock\/edit\/1">Edit Scaffold Mock<\/a>\s<\/li>/', $result);
-		$this->assertPattern('/<li><a href="\/scaffold_mock\/delete\/1"[^>]*>Delete Scaffold Mock<\/a>\s*<\/li>/', $result);
+		$this->assertRegExp('/<a href="\/scaffold_users\/view\/1">1<\/a>/', $result); //belongsTo links
+		$this->assertRegExp('/<li><a href="\/scaffold_mock\/edit\/1">Edit Scaffold Mock<\/a>\s<\/li>/', $result);
+		$this->assertRegExp('/<li><a href="\/scaffold_mock\/delete\/1"[^>]*>Delete Scaffold Mock<\/a>\s*<\/li>/', $result);
 		//check related table
-		$this->assertPattern('/<div class="related">\s*<h3>Related Scaffold Comments<\/h3>\s*<table cellpadding="0" cellspacing="0">/', $result);
-		$this->assertPattern('/<li><a href="\/scaffold_comments\/add">New Comment<\/a><\/li>/', $result);
-		$this->assertNoPattern('/<th>JoinThing<\/th>/', $result);
+		$this->assertRegExp('/<div class="related">\s*<h3>Related Scaffold Comments<\/h3>\s*<table cellpadding="0" cellspacing="0">/', $result);
+		$this->assertRegExp('/<li><a href="\/scaffold_comments\/add">New Comment<\/a><\/li>/', $result);
+		$this->assertNotRegExp('/<th>JoinThing<\/th>/', $result);
 	}
 
 /**
@@ -327,7 +327,7 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->assertContains('input name="data[ScaffoldMock][title]" maxlength="255" type="text" value="First Article" id="ScaffoldMockTitle"', $result);
 		$this->assertContains('input name="data[ScaffoldMock][published]" maxlength="1" type="text" value="Y" id="ScaffoldMockPublished"', $result);
 		$this->assertContains('textarea name="data[ScaffoldMock][body]" cols="30" rows="6" id="ScaffoldMockBody"', $result);
-		$this->assertPattern('/<a href="\#" onclick="if[^>]*>Delete<\/a><\/li>/', $result);
+		$this->assertRegExp('/<a href="\#" onclick="if[^>]*>Delete<\/a><\/li>/', $result);
 	}
 
 /**
@@ -367,10 +367,10 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>Scaffold Mock<\/h2>/', $result);
-		$this->assertPattern('/<table cellpadding="0" cellspacing="0">/', $result);
+		$this->assertRegExp('/<h2>Scaffold Mock<\/h2>/', $result);
+		$this->assertRegExp('/<table cellpadding="0" cellspacing="0">/', $result);
 		//TODO: add testing for table generation
-		$this->assertPattern('/<li><a href="\/admin\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
+		$this->assertRegExp('/<li><a href="\/admin\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
 
 		Configure::write('Routing.prefixes', $_backAdmin);
 	}
@@ -410,8 +410,8 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertPattern('#admin/scaffold_mock/edit/1#', $result);
-		$this->assertPattern('#Scaffold Mock#', $result);
+		$this->assertRegExp('#admin/scaffold_mock/edit/1#', $result);
+		$this->assertRegExp('#Scaffold Mock#', $result);
 	}
 
 /**
@@ -451,10 +451,10 @@ class ScaffoldViewTest extends CakeTestCase {
 		$this->Controller->response->send();
 		$result = ob_get_clean();
 
-		$this->assertPattern('/<h2>Scaffold Mock<\/h2>/', $result);
-		$this->assertPattern('/<table cellpadding="0" cellspacing="0">/', $result);
+		$this->assertRegExp('/<h2>Scaffold Mock<\/h2>/', $result);
+		$this->assertRegExp('/<table cellpadding="0" cellspacing="0">/', $result);
 		//TODO: add testing for table generation
-		$this->assertPattern('/<li><a href="\/member\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
+		$this->assertRegExp('/<li><a href="\/member\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
 
 		Configure::write('Routing.prefixes', $_backAdmin);
 	}

--- a/lib/Cake/Test/Case/View/ThemeViewTest.php
+++ b/lib/Cake/Test/Case/View/ThemeViewTest.php
@@ -146,15 +146,15 @@ class ThemeViewTest extends CakeTestCase {
 		$ThemeView = new TestThemeView($this->Controller);
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Plugin' . DS . 'TestPlugin' . DS . 'Tests' . DS .'index.ctp';
 		$result = $ThemeView->getViewFileName('index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Plugin' . DS . 'TestPlugin' . DS . 'Layouts' . DS .'plugin_default.ctp';
 		$result = $ThemeView->getLayoutFileName('plugin_default');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Layouts' . DS .'default.ctp';
 		$result = $ThemeView->getLayoutFileName('default');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -173,25 +173,25 @@ class ThemeViewTest extends CakeTestCase {
 		$ThemeView->theme = 'TestTheme';
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS .'Pages' . DS .'home.ctp';
 		$result = $ThemeView->getViewFileName('home');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Posts' . DS .'index.ctp';
 		$result = $ThemeView->getViewFileName('/Posts/index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Layouts' . DS .'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$ThemeView->layoutPath = 'rss';
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Layouts' . DS . 'rss' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$ThemeView->layoutPath = 'Emails' . DS . 'html';
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Layouts' . DS . 'Emails' . DS . 'html' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -213,8 +213,8 @@ class ThemeViewTest extends CakeTestCase {
 		ob_start();
 		$result = $View->getViewFileName('does_not_exist');
 		$expected = str_replace(array("\t", "\r\n", "\n"), "", ob_get_clean());
-		$this->assertPattern("/PagesController::/", $expected);
-		$this->assertPattern("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)pages(\/|\\\)does_not_exist.ctp/", $expected);
+		$this->assertRegExp("/PagesController::/", $expected);
+		$this->assertRegExp("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)pages(\/|\\\)does_not_exist.ctp/", $expected);
 	}
 
 /**
@@ -234,8 +234,8 @@ class ThemeViewTest extends CakeTestCase {
 		ob_start();
 		$result = $View->getLayoutFileName();
 		$expected = str_replace(array("\t", "\r\n", "\n"), "", ob_get_clean());
-		$this->assertPattern("/Missing Layout/", $expected);
-		$this->assertPattern("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)layouts(\/|\\\)whatever.ctp/", $expected);
+		$this->assertRegExp("/Missing Layout/", $expected);
+		$this->assertRegExp("/views(\/|\\\)themed(\/|\\\)my_theme(\/|\\\)layouts(\/|\\\)whatever.ctp/", $expected);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -229,11 +229,11 @@ class ViewTest extends CakeTestCase {
 
 		$expected = CakePlugin::path('TestPlugin') . 'View' . DS .'Tests' . DS .'index.ctp';
 		$result = $View->getViewFileName('index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CakePlugin::path('TestPlugin') . 'View' . DS . 'Layouts' . DS .'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -250,7 +250,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->Controller);
 		$paths = $View->paths();
 		$expected = array_merge(App::path('View'), App::core('View'));
-		$this->assertEqual($paths, $expected);
+		$this->assertEquals($paths, $expected);
 
 		$paths = $View->paths('TestPlugin');
 		$pluginPath = CakePlugin::path('TestPlugin');
@@ -262,7 +262,7 @@ class ViewTest extends CakeTestCase {
 			CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS,
 			CAKE . 'View' . DS
 		);
-		$this->assertEqual($paths, $expected);
+		$this->assertEquals($paths, $expected);
 	}
 
 /**
@@ -285,11 +285,11 @@ class ViewTest extends CakeTestCase {
 		$pluginPath = CakePlugin::path('TestPlugin');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS .'TestPlugin' . DS . 'View' . DS .'Tests' . DS .'index.ctp';
 		$result = $View->getViewFileName('index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = $pluginPath. 'View' . DS . 'Layouts' . DS .'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -308,30 +308,30 @@ class ViewTest extends CakeTestCase {
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS .'Pages' . DS .'home.ctp';
 		$result = $View->getViewFileName('home');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS .'Posts' . DS .'index.ctp';
 		$result = $View->getViewFileName('/Posts/index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS .'Posts' . DS .'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Layouts' . DS .'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$View->layoutPath = 'rss';
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Layouts' . DS . 'rss' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 		$View->layoutPath = 'Emails' . DS . 'html';
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Layouts' . DS . 'Emails' . DS . 'html' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -376,7 +376,7 @@ class ViewTest extends CakeTestCase {
  * @return void
  */
 	public function testViewVars() {
-		$this->assertEqual($this->View->viewVars, array('testData' => 'Some test data', 'test2' => 'more data', 'test3' => 'even more data'));
+		$this->assertEquals($this->View->viewVars, array('testData' => 'Some test data', 'test2' => 'more data', 'test3' => 'even more data'));
 	}
 
 /**
@@ -386,11 +386,11 @@ class ViewTest extends CakeTestCase {
  */
 	public function testUUIDGeneration() {
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, 'form5988016017');
+		$this->assertEquals($result, 'form5988016017');
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, 'formc3dc6be854');
+		$this->assertEquals($result, 'formc3dc6be854');
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEqual($result, 'form28f92cc87f');
+		$this->assertEquals($result, 'form28f92cc87f');
 	}
 
 /**
@@ -402,10 +402,10 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->Controller);
 		$View->addScript('prototype.js');
 		$View->addScript('prototype.js');
-		$this->assertEqual($View->scripts(), array('prototype.js'));
+		$this->assertEquals($View->scripts(), array('prototype.js'));
 
 		$View->addScript('mainEvent', 'Event.observe(window, "load", function() { doSomething(); }, true);');
-		$this->assertEqual($View->scripts(), array('prototype.js', 'mainEvent' => 'Event.observe(window, "load", function() { doSomething(); }, true);'));
+		$this->assertEquals($View->scripts(), array('prototype.js', 'mainEvent' => 'Event.observe(window, "load", function() { doSomething(); }, true);'));
 	}
 
 /**
@@ -415,21 +415,21 @@ class ViewTest extends CakeTestCase {
  */
 	public function testElement() {
 		$result = $this->View->element('test_element');
-		$this->assertEqual($result, 'this is the test element');
+		$this->assertEquals($result, 'this is the test element');
 
 		$result = $this->View->element('plugin_element', array(), array('plugin' => 'TestPlugin'));
-		$this->assertEqual($result, 'this is the plugin element using params[plugin]');
+		$this->assertEquals($result, 'this is the plugin element using params[plugin]');
 
 		$result = $this->View->element('plugin_element', array(), array('plugin' => 'test_plugin'));
-		$this->assertEqual($result, 'this is the plugin element using params[plugin]');
+		$this->assertEquals($result, 'this is the plugin element using params[plugin]');
 
 		$this->View->plugin = 'TestPlugin';
 		$result = $this->View->element('test_plugin_element');
-		$this->assertEqual($result, 'this is the test set using View::$plugin plugin element');
+		$this->assertEquals($result, 'this is the test set using View::$plugin plugin element');
 
 		$result = $this->View->element('non_existant_element');
-		$this->assertPattern('/Not Found:/', $result);
-		$this->assertPattern('/non_existant_element/', $result);
+		$this->assertRegExp('/Not Found:/', $result);
+		$this->assertRegExp('/non_existant_element/', $result);
 	}
 
 /**
@@ -458,11 +458,11 @@ class ViewTest extends CakeTestCase {
 
 		$View = new View($Controller);
 		$result = $View->element('type_check', array('form' => 'string'), array('callbacks' => true));
-		$this->assertEqual('string', $result);
+		$this->assertEquals('string', $result);
 
 		$View->set('form', 'string');
 		$result = $View->element('type_check', array(), array('callbacks' => true));
-		$this->assertEqual('string', $result);
+		$this->assertEquals('string', $result);
 	}
 
 /**
@@ -475,7 +475,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($Controller);
 		$helpers = $View->loadHelpers();
 		$result = $View->element('test_element', array('ram' => 'val', 'test' => array('foo', 'bar')));
-		$this->assertEqual($result, 'this is the test element');
+		$this->assertEquals($result, 'this is the test element');
 	}
 
 /**
@@ -554,7 +554,7 @@ class ViewTest extends CakeTestCase {
 		$expected = 'this is the test element';
 		$result = $View->element($element);
 
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -604,7 +604,7 @@ class ViewTest extends CakeTestCase {
 		$this->PostsController->helpers = array('Session', 'TestAfter', 'Html');
 		$View = new View($this->PostsController);
 		$View->render('index');
-		$this->assertEqual($View->Helpers->TestAfter->property, 'Valuation');
+		$this->assertEquals($View->Helpers->TestAfter->property, 'Valuation');
 	}
 
 /**
@@ -621,8 +621,8 @@ class ViewTest extends CakeTestCase {
 
 		$content = 'This is my view output';
 		$result = $View->renderLayout($content, 'default');
-		$this->assertPattern('/modified in the afterlife/', $result);
-		$this->assertPattern('/This is my view output/', $result);
+		$this->assertRegExp('/modified in the afterlife/', $result);
+		$this->assertRegExp('/This is my view output/', $result);
 	}
 
 /**
@@ -635,7 +635,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 
 		$result = $View->render('index', false);
-		$this->assertEqual($result, 'posts index');
+		$this->assertEquals($result, 'posts index');
 
 		$attached = $View->Helpers->attached();
 		$this->assertEquals($attached, array('Session', 'Html', 'Form', 'Number'));
@@ -644,7 +644,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 
 		$result = $View->render('index', false);
-		$this->assertEqual($result, 'posts index');
+		$this->assertEquals($result, 'posts index');
 
 		$attached = $View->Helpers->attached();
 		$expected = array('Html', 'Form', 'Number', 'PluggedHelper');
@@ -660,9 +660,9 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 		$result = str_replace(array("\t", "\r\n", "\n"), "", $View->render('index'));
 
-		$this->assertPattern("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/><title>/", $result);
-		$this->assertPattern("/<div id=\"content\">posts index<\/div>/", $result);
-		$this->assertPattern("/<div id=\"content\">posts index<\/div>/", $result);
+		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/><title>/", $result);
+		$this->assertRegExp("/<div id=\"content\">posts index<\/div>/", $result);
+		$this->assertRegExp("/<div id=\"content\">posts index<\/div>/", $result);
 
 		$this->assertTrue(isset($View->viewVars['content_for_layout']), 'content_for_layout should be a view var');
 		$this->assertTrue(isset($View->viewVars['scripts_for_layout']), 'scripts_for_layout should be a view var');
@@ -675,8 +675,8 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 		$result = str_replace(array("\t", "\r\n", "\n"), "", $View->render(false, 'flash'));
 
-		$this->assertPattern("/<title>yo what up<\/title>/", $result);
-		$this->assertPattern("/<p><a href=\"flash\">yo what up<\/a><\/p>/", $result);
+		$this->assertRegExp("/<title>yo what up<\/title>/", $result);
+		$this->assertRegExp("/<p><a href=\"flash\">yo what up<\/a><\/p>/", $result);
 
 		$this->assertTrue($View->render(false, 'flash'));
 
@@ -689,9 +689,9 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 		$result = str_replace(array("\t", "\r\n", "\n"), "", $View->render('index'));
 
-		$this->assertPattern("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/><title>/", $result);
-		$this->assertPattern("/<div id=\"content\">posts index<\/div>/", $result);
-		$this->assertPattern("/<div id=\"content\">posts index<\/div>/", $result);
+		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/><title>/", $result);
+		$this->assertRegExp("/<div id=\"content\">posts index<\/div>/", $result);
+		$this->assertRegExp("/<div id=\"content\">posts index<\/div>/", $result);
 	}
 
 /**
@@ -721,8 +721,8 @@ class ViewTest extends CakeTestCase {
 		$View = new View($Controller);
 		$result = $View->render('helper_overwrite', false);
 
-		$this->assertPattern('/I am some test html/', $result);
-		$this->assertPattern('/Test link/', $result);
+		$this->assertRegExp('/I am some test html/', $result);
+		$this->assertRegExp('/Test link/', $result);
 	}
 
 /**
@@ -734,20 +734,20 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 
 		$result = $View->getViewFileName('index');
-		$this->assertPattern('/Posts(\/|\\\)index.ctp/', $result);
+		$this->assertRegExp('/Posts(\/|\\\)index.ctp/', $result);
 
 		$result = $View->getViewFileName('/Pages/home');
-		$this->assertPattern('/Pages(\/|\\\)home.ctp/', $result);
+		$this->assertRegExp('/Pages(\/|\\\)home.ctp/', $result);
 
 		$result = $View->getViewFileName('../Elements/test_element');
-		$this->assertPattern('/Elements(\/|\\\)test_element.ctp/', $result);
+		$this->assertRegExp('/Elements(\/|\\\)test_element.ctp/', $result);
 
 		$result = $View->getViewFileName('../Themed/TestTheme/Posts/index');
-		$this->assertPattern('/Themed(\/|\\\)TestTheme(\/|\\\)Posts(\/|\\\)index.ctp/', $result);
+		$this->assertRegExp('/Themed(\/|\\\)TestTheme(\/|\\\)Posts(\/|\\\)index.ctp/', $result);
 
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS .'Posts' . DS .'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
-		$this->assertEqual($expected, $result);
+		$this->assertEquals($expected, $result);
 
 	}
 
@@ -783,7 +783,7 @@ class ViewTest extends CakeTestCase {
 		$result = ob_get_clean();
 
 		$expected = 'some cacheText';
-		$this->assertPattern('/^some cacheText/', $result);
+		$this->assertRegExp('/^some cacheText/', $result);
 
 		@unlink($path);
 	}
@@ -800,7 +800,7 @@ class ViewTest extends CakeTestCase {
 		$View->helpers = array('Html', 'Form', 'Cache');
 		$View->layout = 'cache_layout';
 		$result = $View->render('index');
-		$this->assertNoPattern('/cake:nocache/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
 	}
 
 /**
@@ -815,7 +815,7 @@ class ViewTest extends CakeTestCase {
 		$View->helpers = array('Html', 'Form');
 		$View->layout = 'cache_layout';
 		$result = $View->render('index');
-		$this->assertNoPattern('/cake:nocache/', $result);
+		$this->assertNotRegExp('/cake:nocache/', $result);
 	}
 
 /**
@@ -845,14 +845,14 @@ class ViewTest extends CakeTestCase {
 		$result = ob_get_clean();
 		@unlink($filename);
 
-		$this->assertPattern('/php echo \$foo;/', $result);
-		$this->assertPattern('/php echo \$bar;/', $result);
-		$this->assertPattern('/php \$barfoo = \'in sub2\';/', $result);
-		$this->assertPattern('/php echo \$barfoo;/', $result);
-		$this->assertPattern('/printing: "in sub2"/', $result);
-		$this->assertPattern('/php \$foobar = \'in sub1\';/', $result);
-		$this->assertPattern('/php echo \$foobar;/', $result);
-		$this->assertPattern('/printing: "in sub1"/', $result);
+		$this->assertRegExp('/php echo \$foo;/', $result);
+		$this->assertRegExp('/php echo \$bar;/', $result);
+		$this->assertRegExp('/php \$barfoo = \'in sub2\';/', $result);
+		$this->assertRegExp('/php echo \$barfoo;/', $result);
+		$this->assertRegExp('/printing: "in sub2"/', $result);
+		$this->assertRegExp('/php \$foobar = \'in sub1\';/', $result);
+		$this->assertRegExp('/php echo \$foobar;/', $result);
+		$this->assertRegExp('/printing: "in sub1"/', $result);
 	}
 */
 
@@ -865,26 +865,26 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 		$View->viewVars = array();
 		$View->set('somekey', 'someValue');
-		$this->assertIdentical($View->viewVars, array('somekey' => 'someValue'));
-		$this->assertIdentical($View->getVars(), array('somekey'));
+		$this->assertSame($View->viewVars, array('somekey' => 'someValue'));
+		$this->assertSame($View->getVars(), array('somekey'));
 
 		$View->viewVars = array();
 		$keys = array('key1', 'key2');
 		$values = array('value1', 'value2');
 		$View->set($keys, $values);
-		$this->assertIdentical($View->viewVars, array('key1' => 'value1', 'key2' => 'value2'));
-		$this->assertIdentical($View->getVars(), array('key1', 'key2'));
-		$this->assertIdentical($View->getVar('key1'), 'value1');
+		$this->assertSame($View->viewVars, array('key1' => 'value1', 'key2' => 'value2'));
+		$this->assertSame($View->getVars(), array('key1', 'key2'));
+		$this->assertSame($View->getVar('key1'), 'value1');
 		$this->assertNull($View->getVar('key3'));
 
 		$View->set(array('key3' => 'value3'));
-		$this->assertIdentical($View->getVar('key3'), 'value3');
+		$this->assertSame($View->getVar('key3'), 'value3');
 
 		$View->viewVars = array();
 		$View->set(array(3 => 'three', 4 => 'four'));
 		$View->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEqual($View->viewVars, $expected);
+		$this->assertEquals($View->viewVars, $expected);
 	}
 
 /**
@@ -911,7 +911,7 @@ class ViewTest extends CakeTestCase {
 		$this->PostsController->ext = '.alt';
 		$View = new TestView($this->PostsController);
 		$result = $View->render('alt_ext', false);
-		$this->assertEqual($result, 'alt ext');
+		$this->assertEquals($result, 'alt ext');
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Model/Datasource/Test2OtherSource.php
+++ b/lib/Cake/Test/test_app/Model/Datasource/Test2OtherSource.php
@@ -5,23 +5,23 @@ class Test2OtherSource extends DataSource {
 		return compact('model');
 	}
 
-	public function listSources() {
+	public function listSources($data = null) {
 		return array('test_source');
 	}
 
-	public function create($model, $fields = array(), $values = array()) {
+	public function create(Model $model, $fields = null, $values = null) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function read($model, $queryData = array()) {
+	public function read(Model $model, $queryData = array()) {
 		return compact('model', 'queryData');
 	}
 
-	public function update($model, $fields = array(), $values = array()) {
+	public function update(Model $model, $fields = array(), $values = array()) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function delete($model, $id) {
+	public function delete(Model $model, $id = null) {
 		return compact('model', 'id');
 	}
 }

--- a/lib/Cake/Test/test_app/Model/Datasource/Test2Source.php
+++ b/lib/Cake/Test/test_app/Model/Datasource/Test2Source.php
@@ -5,23 +5,23 @@ class Test2Source extends DataSource {
 		return compact('model');
 	}
 
-	public function listSources() {
+	public function listSources($data = null) {
 		return array('test_source');
 	}
 
-	public function create($model, $fields = array(), $values = array()) {
+	public function create(Model $model, $fields = null, $values = null) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function read($model, $queryData = array()) {
+	public function read(Model $model, $queryData = array()) {
 		return compact('model', 'queryData');
 	}
 
-	public function update($model, $fields = array(), $values = array()) {
+	public function update(Model $model, $fields = array(), $values = array()) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function delete($model, $id) {
+	public function delete(Model $model, $id = null) {
 		return compact('model', 'id');
 	}
 }

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Datasource/test_other_source.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Datasource/test_other_source.php
@@ -5,23 +5,23 @@ class TestOtherSource extends DataSource {
 		return compact('model');
 	}
 
-	public function listSources() {
+	public function listSources($data = null) {
 		return array('test_source');
 	}
 
-	public function create($model, $fields = array(), $values = array()) {
+	public function create(Model $model, $fields = null, $values = array()) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function read($model, $queryData = array()) {
+	public function read(Model $model, $queryData = array()) {
 		return compact('model', 'queryData');
 	}
 
-	public function update($model, $fields = array(), $values = array()) {
+	public function update(Model $model, $fields = array(), $values = array()) {
 		return compact('model', 'fields', 'values');
 	}
 
-	public function delete($model, $id) {
+	public function delete(Model $model, $id = null) {
 		return compact('model', 'id');
 	}
 }

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -80,6 +80,7 @@ class File {
  * @param string $path Path to file
  * @param boolean $create Create file if it does not exist (if true)
  * @param integer $mode Mode to apply to the folder holding the file
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File
  */
 	public function __construct($path, $create = false, $mode = 0755) {
 		$this->Folder = new Folder(dirname($path), $create, $mode);
@@ -102,6 +103,7 @@ class File {
  * Creates the File.
  *
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::create
  */
 	public function create() {
 		$dir = $this->Folder->pwd();
@@ -121,6 +123,7 @@ class File {
  * @param string $mode A valid 'fopen' mode string (r|w|a ...)
  * @param boolean $force If true then the file will be re-opened even if its already opened, otherwise it won't
  * @return boolean True on success, false on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::open
  */
 	public function open($mode = 'r', $force = false) {
 		if (!$force && is_resource($this->handle)) {
@@ -147,6 +150,7 @@ class File {
  * @param string $mode A `fread` compatible mode.
  * @param boolean $force If true then the file will be re-opened even if its already opened, otherwise it won't
  * @return mixed string on success, false on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::read
  */
 	public function read($bytes = false, $mode = 'rb', $force = false) {
 		if ($bytes === false && $this->lock === null) {
@@ -182,6 +186,7 @@ class File {
  * @param mixed $offset The $offset in bytes to seek. If set to false then the current offset is returned.
  * @param integer $seek PHP Constant SEEK_SET | SEEK_CUR | SEEK_END determining what the $offset is relative to
  * @return mixed True on success, false on failure (set mode), false on failure or integer offset on success (get mode)
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::offset
  */
 	public function offset($offset = false, $seek = SEEK_SET) {
 		if ($offset === false) {
@@ -202,6 +207,7 @@ class File {
  * @param string $data Data to prepare for writing.
  * @param boolean $forceWindows
  * @return string The with converted line endings.
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::prepare
  */
 	public static function prepare($data, $forceWindows = false) {
 		$lineBreak = "\n";
@@ -218,6 +224,7 @@ class File {
  * @param string $mode Mode of writing. {@link http://php.net/fwrite See fwrite()}.
  * @param string $force force the file to open
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::write
  */
 	public function write($data, $mode = 'w', $force = false) {
 		$success = false;
@@ -244,6 +251,7 @@ class File {
  * @param string $data Data to write
  * @param string $force force the file to open
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::append
  */
 	public function append($data, $force = false) {
 		return $this->write($data, 'a', $force);
@@ -253,6 +261,7 @@ class File {
  * Closes the current file if it is opened.
  *
  * @return boolean True if closing was successful or file was already closed, otherwise false
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::close
  */
 	public function close() {
 		if (!is_resource($this->handle)) {
@@ -265,6 +274,7 @@ class File {
  * Deletes the File.
  *
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::delete
  */
 	public function delete() {
 		clearstatcache();
@@ -282,6 +292,7 @@ class File {
  * Returns the File info.
  *
  * @return string The File extension
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::info
  */
 	public function info() {
 		if ($this->info == null) {
@@ -297,6 +308,7 @@ class File {
  * Returns the File extension.
  *
  * @return string The File extension
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::ext
  */
 	public function ext() {
 		if ($this->info == null) {
@@ -312,6 +324,7 @@ class File {
  * Returns the File name without extension.
  *
  * @return string The File name without extension.
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::name
  */
 	public function name() {
 		if ($this->info == null) {
@@ -331,6 +344,7 @@ class File {
  * @param string $name The name of the file to make safe if different from $this->name
  * @param string $ext The name of the extension to make safe if different from $this->ext
  * @return string $ext the extension of the file
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::safe
  */
 	public function safe($name = null, $ext = null) {
 		if (!$name) {
@@ -347,6 +361,7 @@ class File {
  *
  * @param mixed $maxsize in MB or true to force
  * @return string md5 Checksum {@link http://php.net/md5_file See md5_file()}
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::md5
  */
 	public function md5($maxsize = 5) {
 		if ($maxsize === true) {
@@ -365,6 +380,7 @@ class File {
  * Returns the full path of the File.
  *
  * @return string Full path to file
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::pwd
  */
 	public function pwd() {
 		if (is_null($this->path)) {
@@ -377,6 +393,7 @@ class File {
  * Returns true if the File exists.
  *
  * @return boolean true if it exists, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::exists
  */
 	public function exists() {
 		return (file_exists($this->path) && is_file($this->path));
@@ -386,6 +403,7 @@ class File {
  * Returns the "chmod" (permissions) of the File.
  *
  * @return string Permissions for the file
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::perms
  */
 	public function perms() {
 		if ($this->exists()) {
@@ -398,6 +416,7 @@ class File {
  * Returns the Filesize
  *
  * @return integer size of the file in bytes, or false in case of an error
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::size
  */
 	public function size() {
 		if ($this->exists()) {
@@ -410,6 +429,7 @@ class File {
  * Returns true if the File is writable.
  *
  * @return boolean true if its writable, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::writable
  */
 	public function writable() {
 		return is_writable($this->path);
@@ -419,6 +439,7 @@ class File {
  * Returns true if the File is executable.
  *
  * @return boolean true if its executable, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::executable
  */
 	public function executable() {
 		return is_executable($this->path);
@@ -428,6 +449,7 @@ class File {
  * Returns true if the File is readable.
  *
  * @return boolean true if file is readable, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readable
  */
 	public function readable() {
 		return is_readable($this->path);
@@ -437,6 +459,7 @@ class File {
  * Returns the File's owner.
  *
  * @return integer the Fileowner
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::owner
  */
 	public function owner() {
 		if ($this->exists()) {
@@ -449,6 +472,7 @@ class File {
  * Returns the File's group.
  *
  * @return integer the Filegroup
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::group
  */
 	public function group() {
 		if ($this->exists()) {
@@ -461,6 +485,7 @@ class File {
  * Returns last access time.
  *
  * @return integer timestamp Timestamp of last access time
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::lastAccess
  */
 	public function lastAccess() {
 		if ($this->exists()) {
@@ -473,6 +498,7 @@ class File {
  * Returns last modified time.
  *
  * @return integer timestamp Timestamp of last modification
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::lastChange
  */
 	public function lastChange() {
 		if ($this->exists()) {
@@ -485,6 +511,7 @@ class File {
  * Returns the current folder.
  *
  * @return Folder Current folder
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::Folder
  */
 	public function &Folder() {
 		return $this->Folder;
@@ -495,7 +522,8 @@ class File {
  *
  * @param string $dest destination for the copy
  * @param boolean $overwrite Overwrite $dest if exists
- * @return boolean Succes
+ * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::copy
  */
 	public function copy($dest, $overwrite = true) {
 		if (!$this->exists() || is_file($dest) && !$overwrite) {

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -81,6 +81,7 @@ class Folder {
  * @param string $path Path to folder
  * @param boolean $create Create folder if not found
  * @param mixed $mode Mode (CHMOD) to apply to created folder, false to ignore
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder
  */
 	public function __construct($path = false, $create = false, $mode = false) {
 		if (empty($path)) {
@@ -105,6 +106,7 @@ class Folder {
  * Return current path.
  *
  * @return string Current path
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::pwd
  */
 	public function pwd() {
 		return $this->path;
@@ -115,6 +117,7 @@ class Folder {
  *
  * @param string $path Path to the directory to change to
  * @return string The new path. Returns false on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::cd
  */
 	public function cd($path) {
 		$path = $this->realpath($path);
@@ -133,6 +136,7 @@ class Folder {
  * @param mixed $exceptions Either an array or boolean true will not grab dot files
  * @param boolean $fullPath True returns the full path
  * @return mixed Contents of current directory as an array, an empty array on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::read
  */
 	public function read($sort = true, $exceptions = false, $fullPath = false) {
 		$dirs = $files = array();
@@ -181,6 +185,7 @@ class Folder {
  * @param string $regexpPattern Preg_match pattern (Defaults to: .*)
  * @param boolean $sort Whether results should be sorted.
  * @return array Files that match given pattern
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::find
  */
 	public function find($regexpPattern = '.*', $sort = false) {
 		list($dirs, $files) = $this->read($sort);
@@ -193,6 +198,7 @@ class Folder {
  * @param string $pattern Preg_match pattern (Defaults to: .*)
  * @param boolean $sort Whether results should be sorted.
  * @return array Files matching $pattern
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::findRecursive
  */
 	public function findRecursive($pattern = '.*', $sort = false) {
 		if (!$this->pwd()) {
@@ -234,6 +240,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return boolean true if windows path, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isWindowsPath
  */
 	public static function isWindowsPath($path) {
 		return (preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) == '\\\\');
@@ -244,6 +251,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return boolean true if path is absolute.
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isAbsolute
  */
 	public static function isAbsolute($path) {
 		return !empty($path) && ($path[0] === '/' || preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) == '\\\\');
@@ -254,6 +262,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return string Set of slashes ("\\" or "/")
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::normalizePath
  */
 	public static function normalizePath($path) {
 		return Folder::correctSlashFor($path);
@@ -264,6 +273,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return string Set of slashes ("\\" or "/")
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::correctSlashFor
  */
 	public static function correctSlashFor($path) {
 		return (Folder::isWindowsPath($path)) ? '\\' : '/';
@@ -274,6 +284,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return string Path with ending slash
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::slashTerm
  */
 	public static function slashTerm($path) {
 		if (Folder::isSlashTerm($path)) {
@@ -288,6 +299,7 @@ class Folder {
  * @param string $path Path
  * @param string $element Element to and at end of path
  * @return string Combined path
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::addPathElement
  */
 	public static function addPathElement($path, $element) {
 		return rtrim($path, DS) . DS . $element;
@@ -298,6 +310,7 @@ class Folder {
  *
  * @param string $path The path to check.
  * @return boolean
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::inCakePath
  */
 	public function inCakePath($path = '') {
 		$dir = substr(Folder::slashTerm(ROOT), 0, -1);
@@ -312,6 +325,7 @@ class Folder {
  * @param string $path The path to check that the current pwd() resides with in.
  * @param boolean $reverse
  * @return boolean
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::inPath
  */
 	public function inPath($path = '', $reverse = false) {
 		$dir = Folder::slashTerm($path);
@@ -333,6 +347,7 @@ class Folder {
  * @param boolean $recursive chmod recursively, set to false to only change the current directory.
  * @param array $exceptions array of files, directories to skip
  * @return boolean Returns TRUE on success, FALSE on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::chmod
  */
 	public function chmod($path, $mode = false, $recursive = true, $exceptions = array()) {
 		if (!$mode) {
@@ -383,6 +398,7 @@ class Folder {
  * @param mixed $exceptions Array of files to exclude, defaults to excluding hidden files.
  * @param string $type either file or dir. null returns both files and directories
  * @return mixed array of nested directories and files in each directory
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::tree
  */
 	public function tree($path = null, $exceptions = true, $type = null) {
 		if ($path == null) {
@@ -449,6 +465,7 @@ class Folder {
  * @param string $pathname The directory structure to create
  * @param integer $mode octal value 0755
  * @return boolean Returns TRUE on success, FALSE on failure
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::create
  */
 	public function create($pathname, $mode = false) {
 		if (is_dir($pathname) || empty($pathname)) {
@@ -487,6 +504,7 @@ class Folder {
  * Returns the size in bytes of this Folder and its contents.
  *
  * @return integer size in bytes of current folder
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::dirsize
  */
 	public function dirsize() {
 		$size = 0;
@@ -523,6 +541,7 @@ class Folder {
  *
  * @param string $path Path of directory to delete
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::delete
  */
 	public function delete($path = null) {
 		if (!$path) {
@@ -579,6 +598,7 @@ class Folder {
  *
  * @param mixed $options Either an array of options (see above) or a string of the destination directory.
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::copy
  */
 	public function copy($options = array()) {
 		if (!$this->pwd()) {
@@ -664,6 +684,7 @@ class Folder {
  *
  * @param array $options (to, from, chmod, skip)
  * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::move
  */
 	public function move($options) {
 		$to = null;
@@ -688,6 +709,7 @@ class Folder {
  * get messages from latest method
  *
  * @return array
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::messages
  */
 	public function messages() {
 		return $this->_messages;
@@ -697,6 +719,7 @@ class Folder {
  * get error from latest method
  *
  * @return array
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::errors
  */
 	public function errors() {
 		return $this->_errors;
@@ -707,6 +730,7 @@ class Folder {
  *
  * @param string $path Path to resolve
  * @return string The resolved path
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::realpath
  */
 	public function realpath($path) {
 		$path = str_replace('/', DS, trim($path));
@@ -747,6 +771,7 @@ class Folder {
  *
  * @param string $path Path to check
  * @return boolean true if path ends with slash, false otherwise
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isSlashTerm
  */
 	public static function isSlashTerm($path) {
 		$lastChar = $path[strlen($path) - 1];

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -569,6 +569,7 @@ class FormHelper extends AppHelper {
  *
  * @param string $name The dot separated name for the field.
  * @return mixed Either null, or the list of fields.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::unlockField
  */
 	public function unlockField($name = null) {
 		if ($name === null) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1303,7 +1303,7 @@ class FormHelper extends AppHelper {
 			if (isset($value) && $optValue == $value) {
 				$optionsHere['checked'] = 'checked';
 			}
-			if (!empty($disabled) && in_array($optValue, $disabled)) {
+			if (!empty($disabled) && (is_bool($disabled) || in_array($optValue, $disabled))) {
 				$optionsHere['disabled'] = true;
 			}
 			$tagName = Inflector::camelize(

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -181,6 +181,7 @@ class HtmlHelper extends AppHelper {
  * @param mixed $options Link attributes e.g. array('id'=>'selected')
  * @return void
  * @see HtmlHelper::link() for details on $options that can be used.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
 	public function addCrumb($name, $link = null, $options = null) {
 		$this->_crumbs[] = array($name, $link, $options);
@@ -615,6 +616,7 @@ class HtmlHelper extends AppHelper {
  * @param string $separator Text to separate crumbs.
  * @param string $startText This will be the first crumb, if false it defaults to first crumb in array
  * @return string Composed bread crumbs
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
 	public function getCrumbs($separator = '&raquo;', $startText = false) {
 		if (!empty($this->_crumbs)) {
@@ -645,6 +647,7 @@ class HtmlHelper extends AppHelper {
  *
  * @param array $options Array of html attributes to apply to the generated list elements.
  * @return string breadcrumbs html list
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
 	public function getCrumbList($options = array()) {
 		if (!empty($this->_crumbs)) {
@@ -975,6 +978,7 @@ class HtmlHelper extends AppHelper {
  * @param string $path Path with config file
  * @return mixed False to error or loaded configs
  * @throws ConfigureException
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#changing-the-tags-output-by-htmlhelper
  */
 	public function loadConfig($configFile, $path = null) {
 		if (!$path) {

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -159,6 +159,7 @@ class JsHelper extends AppHelper {
  * @param mixed $val A PHP variable to be converted to JSON
  * @param boolean $quoteString If false, leaves string values unquoted
  * @return string a JavaScript-safe/JSON representation of $val
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::value
  **/
 	public function value($val = array(), $quoteString = null, $key = 'value') {
 		if ($quoteString === null) {
@@ -185,6 +186,7 @@ class JsHelper extends AppHelper {
  * @param array $options options for the code block
  * @return mixed Completed javascript tag if there are scripts, if there are no buffered
  *   scripts null will be returned.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::writeBuffer
  */
 	public function writeBuffer($options = array()) {
 		$domReady = $this->request->is('ajax');
@@ -227,6 +229,7 @@ class JsHelper extends AppHelper {
  * @param boolean $top If true the script will be added to the top of the
  *   buffered scripts array.  If false the bottom.
  * @return void
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::buffer
  */
 	public function buffer($script, $top = false) {
 		if ($top) {
@@ -241,6 +244,7 @@ class JsHelper extends AppHelper {
  *
  * @param boolean $clear Whether or not to clear the script caches (default true)
  * @return array Array of scripts added to the request.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::getBuffer
  */
 	public function getBuffer($clear = true) {
 		$this->_createVars();
@@ -281,6 +285,7 @@ class JsHelper extends AppHelper {
  * @param mixed $url Mixed either a string URL or an cake url array.
  * @param array $options Options for both the HTML element and Js::request()
  * @return string Completed link. If buffering is disabled a script tag will be returned as well.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::link
  */
 	public function link($title, $url = null, $options = array()) {
 		if (!isset($options['id'])) {
@@ -355,6 +360,7 @@ class JsHelper extends AppHelper {
  * @param string $caption The display text of the submit button.
  * @param array $options Array of options to use. See the options for the above mentioned methods.
  * @return string Completed submit button.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::submit
  */
 	public function submit($caption = null, $options = array()) {
 		if (!isset($options['id'])) {

--- a/lib/Cake/View/Helper/NumberHelper.php
+++ b/lib/Cake/View/Helper/NumberHelper.php
@@ -247,6 +247,7 @@ class NumberHelper extends AppHelper {
  * @param array $options The array of options for this format.
  * @return void
  * @see NumberHelper::currency()
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::addFormat
  */
 	public function addFormat($formatName, $options) {
 		$this->_currencies[$formatName] = $options + $this->_currencyDefaults;

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -134,6 +134,7 @@ class PaginatorHelper extends AppHelper {
  * @param mixed $options Default options for pagination links. If a string is supplied - it
  *   is used as the DOM id element to update. See PaginatorHelper::$options for list of keys.
  * @return void
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::options
  */
 	public function options($options = array()) {
 		if (is_string($options)) {
@@ -245,6 +246,7 @@ class PaginatorHelper extends AppHelper {
  * @param string $disabledTitle Title when the link is disabled.
  * @param array $disabledOptions Options for the disabled pagination link. See #options for list of keys.
  * @return string A "previous" link or $disabledTitle text if the link is disabled.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::prev
  */
 	public function prev($title = '<< Previous', $options = array(), $disabledTitle = null, $disabledOptions = array()) {
 		$defaults = array(
@@ -268,6 +270,7 @@ class PaginatorHelper extends AppHelper {
  * @param string $disabledTitle Title when the link is disabled.
  * @param mixed $disabledOptions Options for the disabled pagination link. See above for list of keys.
  * @return string A "next" link or or $disabledTitle text if the link is disabled.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::next
  */
 	public function next($title = 'Next >>', $options = array(), $disabledTitle = null, $disabledOptions = array()) {
 		$defaults = array(
@@ -293,6 +296,7 @@ class PaginatorHelper extends AppHelper {
  * @param array $options Options for sorting link. See above for list of keys.
  * @return string A link sorting default by 'asc'. If the resultset is sorted 'asc' by the specified
  *  key the returned link will sort by 'desc'.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sort
  */
 	public function sort($key, $title = null, $options = array()) {
 		$options = array_merge(array('url' => array(), 'model' => null), $options);
@@ -345,6 +349,7 @@ class PaginatorHelper extends AppHelper {
  * @param mixed $url Url for the action. See Router::url()
  * @param array $options Options for the link. See #options for list of keys.
  * @return string A link with pagination parameters.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::link
  */
 	public function link($title, $url = array(), $options = array()) {
 		$options = array_merge(array('model' => null, 'escape' => true), $options);
@@ -373,6 +378,7 @@ class PaginatorHelper extends AppHelper {
  * @param boolean $asArray Return the url as an array, or a URI string
  * @param string $model Which model to paginate on
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
  */
 	public function url($options = array(), $asArray = false, $model = null) {
 		$paging = $this->params($model);
@@ -547,6 +553,7 @@ class PaginatorHelper extends AppHelper {
  * @param mixed $options Options for the counter string. See #options for list of keys.
  * @return string Counter string.
  * @deprecated The %page% style placeholders are deprecated.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
  */
 	public function counter($options = array()) {
 		if (is_string($options)) {
@@ -630,6 +637,7 @@ class PaginatorHelper extends AppHelper {
  *
  * @param mixed $options Options for the numbers, (before, after, model, modulus, separator)
  * @return string numbers string.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::numbers
  */
 	public function numbers($options = array()) {
 		if ($options === true) {
@@ -766,6 +774,7 @@ class PaginatorHelper extends AppHelper {
  *   you want at the beginning of the range.
  * @param mixed $options An array of options.
  * @return string numbers string.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::first
  */
 	public function first($first = '<< first', $options = array()) {
 		$options = array_merge(
@@ -831,6 +840,7 @@ class PaginatorHelper extends AppHelper {
  * @param mixed $last if string use as label for the link, if numeric print page numbers
  * @param mixed $options Array of options
  * @return string numbers string.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last
  */
 	public function last($last = 'last >>', $options = array()) {
 		$options = array_merge(

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -38,7 +38,7 @@ class SessionHelper extends AppHelper {
  *
  * @param string $name the name of the session key you want to read
  * @return mixed values from the session vars
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#displaying-notifcations-or-flash-messages
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::read
  */
 	public function read($name = null) {
 		return CakeSession::read($name);
@@ -51,7 +51,7 @@ class SessionHelper extends AppHelper {
  *
  * @param string $name
  * @return boolean
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#displaying-notifcations-or-flash-messages
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::check
  */
 	public function check($name) {
 		return CakeSession::check($name);
@@ -114,7 +114,6 @@ class SessionHelper extends AppHelper {
  * @param array $attrs Additional attributes to use for the creation of this flash message.
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#displaying-notifcations-or-flash-messages
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::flash
  */
 	public function flash($key = 'flash', $attrs = array()) {

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -91,12 +91,10 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 </div>
 HTML;
 		$text = <<<TEXT
-
 %s
 ########## DEBUG ##########
 %s
 ###########################
-
 TEXT;
 		$template = $html;
 		if (php_sapi_name() == 'cli' || $showHtml === false) {

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -76,6 +76,7 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 	if (Configure::read('debug') > 0) {
 		$file = '';
 		$line = '';
+		$lineInfo = '';
 		if ($showFrom) {
 			$calledFrom = debug_backtrace();
 			$file = substr(str_replace(ROOT, '', $calledFrom[0]['file']), 1);
@@ -83,32 +84,39 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 		}
 		$html = <<<HTML
 <div class="cake-debug-output">
-<span><strong>%s</strong> (line <strong>%s</strong>)</span>
+%s
 <pre class="cake-debug">
 %s
 </pre>
 </div>
 HTML;
-			$text = <<<TEXT
+		$text = <<<TEXT
 
-%s (line %s)
+%s
 ########## DEBUG ##########
 %s
 ###########################
 
 TEXT;
 		$template = $html;
-		if (php_sapi_name() == 'cli') {
+		if (php_sapi_name() == 'cli' || $showHtml === false) {
 			$template = $text;
+			if ($showFrom) {
+				$lineInfo = sprintf('%s (line %s)', $file, $line);
+			}
 		}
 		if ($showHtml === null && $template !== $text) {
 			$showHtml = true;
 		}
 		$var = print_r($var, true);
 		if ($showHtml) {
+			$template = $html;
 			$var = h($var);
+			if ($showFrom) {
+				$lineInfo = sprintf('<span><strong>%s</strong> (line <strong>%s</strong>)</span>', $file, $line);
+			}
 		}
-		printf($template, $file, $line, $var);
+		printf($template, $lineInfo, $var);
 	}
 }
 


### PR DESCRIPTION
To disable options in a radio button list you can set an array with keys, but it's not possible to set disabled => true to disable all values. In CakePHP 1.x this behavior was present.
