### PR TITLE
The first if-case in basics.php config() seemed useless

### DIFF
--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -44,9 +44,7 @@
 function config() {
 	$args = func_get_args();
 	foreach ($args as $arg) {
-		if ($arg === 'database' && file_exists(APP . 'Config' . DS . 'database.php')) {
-			include_once(APP . 'Config' . DS . $arg . '.php');
-		} elseif (file_exists(APP . 'Config' . DS . $arg . '.php')) {
+		if (file_exists(APP . 'Config' . DS . $arg . '.php')) {
 			include_once(APP . 'Config' . DS . $arg . '.php');
 
 			if (count($args) == 1) {


### PR DESCRIPTION
It looks like it's redundant to the `elseif` clause since the second case would check the same exact location
