### PR TITLE
Fix for when trying to use "Console/cake schema generate snapshot"

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -170,7 +170,7 @@ class SchemaShell extends Shell {
 			$count = 0;
 			if (!empty($result[1])) {
 				foreach ($result[1] as $file) {
-					if (preg_match('/'.$fileName.'(?:[_\d]*)?\.php$/', $file)) {
+					if (preg_match('/'.preg_quote($fileName).'(?:[_\d]*)?\.php$/', $file)) {
 						$count++;
 					}
 				}

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -64,7 +64,7 @@ class SchemaShell extends Shell {
 		$name = $path = $connection = $plugin = null;
 		if (!empty($this->params['name'])) {
 			$name = $this->params['name'];
-		} elseif (!empty($this->args[0])) {
+		} elseif (!empty($this->args[0]) && $this->args[0] !== 'snapshot') {
 			$name = $this->params['name'] = $this->args[0];
 		}
 
@@ -158,6 +158,7 @@ class SchemaShell extends Shell {
 		Configure::write('Cache.disable', $cacheDisable);
 
 		if ($snapshot === true) {
+			$fileName = rtrim($this->params['file'], '.php');
 			$Folder = new Folder($this->Schema->path);
 			$result = $Folder->read();
 
@@ -165,11 +166,11 @@ class SchemaShell extends Shell {
 			if (isset($this->params['snapshot'])) {
 				$numToUse = $this->params['snapshot'];
 			}
-
+			
 			$count = 0;
 			if (!empty($result[1])) {
 				foreach ($result[1] as $file) {
-					if (preg_match('/schema(?:[_\d]*)?\.php$/', $file)) {
+					if (preg_match('/'.$fileName.'(?:[_\d]*)?\.php$/', $file)) {
 						$count++;
 					}
 				}
@@ -180,8 +181,7 @@ class SchemaShell extends Shell {
 					$count = $numToUse;
 				}
 			}
-
-			$fileName = rtrim($this->params['file'], '.php');
+			
 			$content['file'] = $fileName . '_' . $count . '.php';
 		}
 


### PR DESCRIPTION
Fix for when trying to use "Console/cake schema generate snapshot" command, line 67 was making the name param snapshot, also fixed auto numbering in the case where the filename wasn't "schema"mmand, line 67 was making the name param snapshot, also fixed auto numbering in the case where the filename wasn't "schema"
