### PR TITLE
Enable short option for --plugin and --connection

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -444,9 +444,11 @@ class SchemaShell extends Shell {
  */
 	public function getOptionParser() {
 		$plugin = array(
+			'short' => 'p',
 			'help' => __d('cake_console', 'The plugin to use.'),
 		);
 		$connection = array(
+			'short' => 'c',
 			'help' => __d('cake_console', 'Set the db config to use.'),
 			'default' => 'default'
 		);


### PR DESCRIPTION
This is done to make things more consistent with the bake shell
