### PR TITLE
check presence of database.php before calling _init()

### DIFF
--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -184,7 +184,9 @@ class ConnectionManager {
  */
 	public static function enumConnectionObjects() {
 		if (empty(self::$_init)) {
-			self::_init();
+			if (file_exists(APP . 'Config' . DS . 'database.php')) {
+				self::_init();
+			}
 		}
 		return (array) self::$config;
 	}


### PR DESCRIPTION
Installers might need to know what datasources are available before
database.php has been configured.
