### PR TITLE
adding Context to CakeSocket

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -104,12 +104,17 @@ class CakeSocket {
 			$scheme = 'ssl://';
 		}
 
-		if ($this->config['persistent'] == true) {
-			$this->connection = @pfsockopen($scheme.$this->config['host'], $this->config['port'], $errNum, $errStr, $this->config['timeout']);
+		if (!empty($this->config['request']['context'])){
+			$mycontext = stream_context_create($this->config['request']['context']);
 		} else {
-			$this->connection = @fsockopen($scheme.$this->config['host'], $this->config['port'], $errNum, $errStr, $this->config['timeout']);
+			$mycontext = stream_context_create();
 		}
 
+		if ($this->config['persistent'] == true) {
+			$this->connection = @stream_socket_client($scheme.$this->config['host'].':'. $this->config['port'], &$errNum, &$errStr, $this->config['timeout'], STREAM_CLIENT_PERSISTENT, $mycontext);
+		} else {
+			$this->connection = @stream_socket_client($scheme.$this->config['host'].':'. $this->config['port'], &$errNum, &$errStr, $this->config['timeout'], STREAM_CLIENT_CONNECT, $mycontext);
+		}
 		if (!empty($errNum) || !empty($errStr)) {
 			$this->setLastError($errNum, $errStr);
 			throw new SocketException($errStr, $errNum);
@@ -228,6 +233,16 @@ class CakeSocket {
 		}
 		return false;
 	}
+/**
+ * get Connection Context.
+ *
+ * @return context Array
+ */
+	public function getContext(){
+		return stream_context_get_options($this->connection);
+	}
+
+
 
 /**
  * Disconnect the socket from the current connection.

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -427,7 +427,7 @@ class HttpResponse implements ArrayAccess {
 	}
 
 	public function setContext($context){
-		if (get_resource_type($context) === "OpenSSL X.509"){
+		if (get_resource_type($context) === "OpenSSL X.509" && function_exists(openssl_x509_export)){
 			if (!isset($context))
 				return false;
 			openssl_x509_export($context, &$certstring);

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -427,7 +427,7 @@ class HttpResponse implements ArrayAccess {
 	}
 
 	public function setContext($context){
-		if (get_resource_type($context) === "OpenSSL X.509" && function_exists(openssl_x509_export)){
+		if (get_resource_type($context) === "OpenSSL X.509"){
 			if (!isset($context))
 				return false;
 			openssl_x509_export($context, &$certstring);

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -53,6 +53,13 @@ class HttpResponse implements ArrayAccess {
 	public $httpVersion = 'HTTP/1.1';
 
 /**
+ * context
+ *
+ * @var array
+ */
+	public $context = array();
+
+/**
  * Response code
  *
  * @var integer
@@ -417,6 +424,21 @@ class HttpResponse implements ArrayAccess {
 				return $this->cookies;
 		}
 		return null;
+	}
+
+	public function setContext($context){
+		if (get_resource_type($context) === "OpenSSL X.509"){
+			if (!isset($context))
+				return false;
+			openssl_x509_export($context, &$certstring);
+			$certstring = str_replace('-----BEGIN CERTIFICATE-----', '', $certstring);
+			$certstring = str_replace('-----END CERTIFICATE-----', '', $certstring);
+			$this->context = openssl_x509_parse($context);
+			$this->context['fingerprint']['sha1'] = strtoupper(sha1($certstring));
+			$this->context['fingerprint']['md5'] = strtoupper(md5($certstring));
+		} else {
+			return false;
+		}
 	}
 
 /**

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -428,8 +428,9 @@ class HttpResponse implements ArrayAccess {
 
 	public function setContext($context){
 		if (get_resource_type($context) === "OpenSSL X.509" && function_exists(openssl_x509_export)){
-			if (!isset($context))
+			if (!isset($context)){
 				return false;
+			}
 			openssl_x509_export($context, &$certstring);
 			$certstring = str_replace('-----BEGIN CERTIFICATE-----', '', $certstring);
 			$certstring = str_replace('-----END CERTIFICATE-----', '', $certstring);

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -384,9 +384,9 @@ class HttpSocket extends CakeSocket {
 		$responseClass = $this->responseClass;
 		$this->response = new $responseClass($response);
 
-		if (!empty($context) && isset($context['ssl']['peer_certificate']))
+		if (!empty($context) && isset($context['ssl']['peer_certificate'])){
 			$this->response->setContext($context['ssl']['peer_certificate']);
-
+		}
 		if (!empty($this->response->cookies)) {
 			if (!isset($this->config['request']['cookies'][$Host])) {
 				$this->config['request']['cookies'][$Host] = array();
@@ -759,8 +759,9 @@ class HttpSocket extends CakeSocket {
 
 	
 	public function checkFingerprint($fingerprint){
-		if (!isset($this->request['context']['ssl']['peer_certificate']))
+		if (!isset($this->request['context']['ssl']['peer_certificate'])){
 			return false;
+		}
 		openssl_x509_export($this->request['context']['ssl']['peer_certificate'], &$certstring);
 		$certstring = str_replace('-----BEGIN CERTIFICATE-----', '', $certstring);
 		$certstring = str_replace('-----END CERTIFICATE-----', '', $certstring);


### PR DESCRIPTION
#2270 adding Context to CakeSocket and HTTP Socket. Changing CakeSocket

from fsockopen to stream_socket_client allows giving the connection an
context. the default behavior is: if the connection is secure we get
the certificate, parse it and deliver it with the http-response object.
