### PR TITLE
Removing timestamp lines from generated files

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -218,8 +218,7 @@ class SchemaShell extends Shell {
 			}
 		}
 		$db = ConnectionManager::getDataSource($this->Schema->connection);
-		$contents = "#" . $Schema->name . " sql generated on: " . date('Y-m-d H:i:s') . " : " . time() . "\n\n";
-		$contents .= $db->dropSchema($Schema) . "\n\n". $db->createSchema($Schema);
+		$contents = "\n\n" . $db->dropSchema($Schema) . "\n\n". $db->createSchema($Schema);
 
 		if ($write) {
 			if (strpos($write, '.sql') === false) {

--- a/lib/Cake/Console/Templates/default/classes/fixture.ctp
+++ b/lib/Cake/Console/Templates/default/classes/fixture.ctp
@@ -20,8 +20,6 @@
  */
 ?>
 <?php echo '<?php' . "\n"; ?>
-/* <?php echo $model; ?> Fixture generated on: <?php echo  date('Y-m-d H:i:s') . " : ". time(); ?> */
-
 /**
  * <?php echo $model; ?>Fixture
  *

--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -18,7 +18,6 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 echo "<?php\n";
-echo "/* ". $className ." Test cases generated on: " . date('Y-m-d H:i:s') . " : ". time() . "*/\n";
 ?>
 App::uses('<?php echo $fullClassName; ?>', '<?php echo $realType; ?>');
 

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -379,7 +379,7 @@ class CakeSchema extends Object {
 		$out .= "}\n";
 
 		$file = new SplFileObject($path . DS . $file, 'w+');
-		$content = "<?php \n/* {$name} schema generated on: " . date('Y-m-d H:i:s') . " : ". time() . "*/\n{$out}?>";
+		$content = "<?php\n{$out}";
 		if ($file->fwrite($content)) {
 			return $content;
 		}


### PR DESCRIPTION
This causes unnecessary diff chunks, and we should depend more on
the SCM instead of these values.
