### PR TITLE
Patch for view caching - Helper serialization

### DIFF
--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -279,7 +279,7 @@ class CacheHelper extends AppHelper {
 				$response = new CakeResponse(array("charset" => Configure::read("App.encoding")));
 				$controller = new ' . $this->_View->name . 'Controller($request, $response);
 				$controller->plugin = $this->plugin = \'' . $this->_View->plugin . '\';
-				$controller->helpers = $this->helpers = unserialize(\'' . serialize($this->_View->helpers) . '\');
+				$controller->helpers = $this->helpers = unserialize(\'' . str_replace("'", "\'", serialize($this->_View->helpers)) . '\');
 				$controller->layout = $this->layout = \'' . $this->_View->layout. '\';
 				$controller->theme = $this->theme = \'' . $this->_View->theme . '\';
 				$controller->viewVars = $this->viewVars = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->viewVars)) . '\'));

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -279,7 +279,7 @@ class CacheHelper extends AppHelper {
 				$response = new CakeResponse(array("charset" => Configure::read("App.encoding")));
 				$controller = new ' . $this->_View->name . 'Controller($request, $response);
 				$controller->plugin = $this->plugin = \'' . $this->_View->plugin . '\';
-				$controller->helpers = $this->helpers = unserialize(\'' . str_replace("'", "\'", serialize($this->_View->helpers)) . '\');
+				$controller->helpers = $this->helpers = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->helpers)) . '\'));
 				$controller->layout = $this->layout = \'' . $this->_View->layout. '\';
 				$controller->theme = $this->theme = \'' . $this->_View->theme . '\';
 				$controller->viewVars = $this->viewVars = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->viewVars)) . '\'));


### PR DESCRIPTION
In full page caching, if a helper's property contains a string with a single quote inside it, the cached view will produce a fatal error.
