### PR TITLE
Added "currentLink" and "currentClass" options to Paginator::numbers();

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -44,7 +44,8 @@ class TreeBehavior extends ModelBehavior {
  */
 	protected $_defaults = array(
 		'parent' => 'parent_id', 'left' => 'lft', 'right' => 'rght',
-		'scope' => '1 = 1', 'type' => 'nested', '__parentChange' => false, 'recursive' => -1
+		'scope' => '1 = 1', 'type' => 'nested', '__parentChange' => false, 'recursive' => -1,
+		'multiTree' => false, '__multiTreeKey' => null
 	);
 
 /**
@@ -66,6 +67,9 @@ class TreeBehavior extends ModelBehavior {
 			$parent = $Model->{$settings['scope']};
 			$settings['scope'] = $Model->alias . '.' . $data['foreignKey'] . ' = ' . $parent->alias . '.' . $parent->primaryKey;
 			$settings['recursive'] = 0;
+			if ($settings['multiTree']) {
+				$settings['__multiTreeKey'] = $data['foreignKey'];
+			}
 		}
 		$this->settings[$Model->alias] = $settings;
 	}
@@ -111,6 +115,9 @@ class TreeBehavior extends ModelBehavior {
 		}
 		$diff = $data[$right] - $data[$left] + 1;
 
+		if ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $data[$__multiTreeKey]);
+		}
 		if ($diff > 2) {
 			if (is_string($scope)) {
 				$scope = array($scope);
@@ -139,9 +146,14 @@ class TreeBehavior extends ModelBehavior {
 		$this->_addToWhitelist($Model, array($left, $right));
 		if (!$Model->id) {
 			if (array_key_exists($parent, $Model->data[$Model->alias]) && $Model->data[$Model->alias][$parent]) {
+				$parentFields = array($Model->primaryKey, $right);
+				if ($multiTree) {
+					$parentFields[] = $__multiTreeKey;
+					$scope = array();
+				}
 				$parentNode = $Model->find('first', array(
 					'conditions' => array($scope, $Model->escapeField() => $Model->data[$Model->alias][$parent]),
-					'fields' => array($Model->primaryKey, $right), 'recursive' => $recursive
+					'fields' => $parentFields, 'recursive' => $recursive
 				));
 				if (!$parentNode) {
 					return false;
@@ -149,7 +161,20 @@ class TreeBehavior extends ModelBehavior {
 				list($parentNode) = array_values($parentNode);
 				$Model->data[$Model->alias][$left] = 0; //$parentNode[$right];
 				$Model->data[$Model->alias][$right] = 0; //$parentNode[$right] + 1;
+				if ($multiTree) {
+					$this->_addToWhitelist($Model, $__multiTreeKey);
+					$Model->data[$Model->alias][$__multiTreeKey] = $parentNode[$__multiTreeKey];
+					$scope = $this->_multiTreeScope($Model, $parentNode[$__multiTreeKey]);
+				}
 			} else {
+				if ($multiTree) {
+					if (array_key_exists($__multiTreeKey, $Model->data[$Model->alias]) && $Model->data[$Model->alias][$__multiTreeKey]) { //no parent, must have tree_id
+						$scope = $this->_multiTreeScope($Model, $Model->data[$Model->alias][$__multiTreeKey]);
+						$this->_addToWhitelist($Model, $__multiTreeKey);
+					} else {
+						return false;
+					}
+				}
 				$edge = $this->_getMax($Model, $scope, $right, $recursive);
 				$Model->data[$Model->alias][$left] = $edge + 1;
 				$Model->data[$Model->alias][$right] = $edge + 2;
@@ -162,9 +187,19 @@ class TreeBehavior extends ModelBehavior {
 				$Model->data[$Model->alias][$parent] = null;
 				$this->_addToWhitelist($Model, $parent);
 			} else {
+				$fields = array($Model->primaryKey, $parent, $left, $right);
+				if ($multiTree) {
+					$fields[] = $__multiTreeKey;
+					$scope = array();
+				}
 				$values = $Model->find('first', array(
+<<<<<<< Updated upstream
 					'conditions' => array($scope,$Model->escapeField() => $Model->id),
 					'fields' => array($Model->primaryKey, $parent, $left, $right ), 'recursive' => $recursive)
+=======
+					'conditions' => array($scope, $Model->escapeField() => $Model->id),
+					'fields' => $fields, 'recursive' => $recursive)
+>>>>>>> Stashed changes
 				);
 
 				if ($values === false) {
@@ -172,9 +207,12 @@ class TreeBehavior extends ModelBehavior {
 				}
 				list($node) = array_values($values);
 
+				if ($multiTree) {
+					$scope = $this->_multiTreeScope($Model, $node[$__multiTreeKey]);
+				}
 				$parentNode = $Model->find('first', array(
 					'conditions' => array($scope, $Model->escapeField() => $Model->data[$Model->alias][$parent]),
-					'fields' => array($Model->primaryKey, $left, $right), 'recursive' => $recursive
+					'fields' => $fields, 'recursive' => $recursive
 				));
 				if (!$parentNode) {
 					return false;
@@ -214,6 +252,17 @@ class TreeBehavior extends ModelBehavior {
 		}
 		extract($this->settings[$Model->alias]);
 
+		if ($multiTree) {
+			if (isset($Model->data[$Model->alias][$__multiTreeKey]) && $Model->data[$Model->alias][$__multiTreeKey]) {
+				$scope = $Model->data[$Model->alias][$__multiTreeKey];
+			} else {
+				$node = $Model->find('first', array('conditions' => array($Model->escapeField() => $id), 'fields' => array($__multiTreeKey)));
+				if (!$node) {
+					return false;
+				}
+				$scope = $node[$Model->alias][$__multiTreeKey];
+			}
+		}
 		if ($direct) {
 			return $Model->find('count', array('conditions' => array($scope, $Model->escapeField($parent) => $id)));
 		}
@@ -269,17 +318,28 @@ class TreeBehavior extends ModelBehavior {
 		if (!$order) {
 			$order = $Model->alias . '.' . $left . ' asc';
 		}
+		if ($multiTree) {
+			$order = array($Model->alias . '.' . $__multiTreeKey . ' asc', $order);
+			$scope = array();
+		}
 		if ($direct) {
 			$conditions = array($scope, $Model->escapeField($parent) => $id);
 			return $Model->find('all', compact('conditions', 'fields', 'order', 'limit', 'page', 'recursive'));
 		}
 
 		if (!$id) {
+			if ($multiTree) {
+				return false;
+			}
 			$conditions = $scope;
 		} else {
+			$resultFields = array($left, $right);
+			if($multiTree){
+				$resultFields[] = $__multiTreeKey;
+			}
 			$result = array_values((array)$Model->find('first', array(
 				'conditions' => array($scope, $Model->escapeField() => $id),
-				'fields' => array($left, $right),
+				'fields' => $resultFields,
 				'recursive' => $recursive
 			)));
 
@@ -290,6 +350,10 @@ class TreeBehavior extends ModelBehavior {
 				$Model->escapeField($right) . ' <' => $result[0][$right],
 				$Model->escapeField($left) . ' >' => $result[0][$left]
 			);
+			if ($multiTree) {
+				$scope = $this->_multiTreeScope($Model, $result[0][$__multiTreeKey]);
+				$conditions = array_merge($scope, $conditions);
+			}
 		}
 		return $Model->find('all', compact('conditions', 'fields', 'order', 'limit', 'page', 'recursive'));
 	}
@@ -303,12 +367,30 @@ class TreeBehavior extends ModelBehavior {
  * @param string $valuePath A string path to the value, i.e. "{n}.Post.title"
  * @param string $spacer The character or characters which will be repeated
  * @param integer $recursive The number of levels deep to fetch associated records
+ * @param integer $treeScope id of the desired tree if using multiTree (returns all by default)
  * @return array An associative array of records, where the id is the key, and the display field is the value
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::generateTreeList
  */
-	public function generateTreeList($Model, $conditions = null, $keyPath = null, $valuePath = null, $spacer = '_', $recursive = null) {
+	public function generateTreeList($Model, $conditions = null, $keyPath = null, $valuePath = null, $spacer = '_', $recursive = null, $treeScope = null) {
 		$overrideRecursive = $recursive;
 		extract($this->settings[$Model->alias]);
+
+		if ($multiTree && !$treeScope) {
+			$trees = $Model->find('all', array('fields' => 'DISTINCT ' . $Model->escapeField($__multiTreeKey), 'recursive' => -1));
+			$conditions = (array)$conditions;
+
+			foreach($trees as $tree){
+				$treeId = $tree[$Model->alias][$__multiTreeKey];
+				$allTrees[$treeId] = $this->generateTreeList($Model, $conditions, $keyPath, $valuePath, $spacer, $recursive, $treeId);
+			}
+			if (empty($allTrees)) {
+				return array();
+			}
+			return $allTrees;
+
+		} elseif ($multiTree) {
+			$conditions[$Model->escapeField($__multiTreeKey)] = $treeScope;
+		}
 		if (!is_null($overrideRecursive)) {
 			$recursive = $overrideRecursive;
 		}
@@ -407,13 +489,20 @@ class TreeBehavior extends ModelBehavior {
 		if (!is_null($overrideRecursive)) {
 			$recursive = $overrideRecursive;
 		}
-		$result = $Model->find('first', array('conditions' => array($Model->escapeField() => $id), 'fields' => array($left, $right), 'recursive' => $recursive));
+		$resultFields = array($left, $right);
+		if ($multiTree) {
+			$resultFields[] = $__multiTreeKey;
+		}
+		$result = $Model->find('first', array('conditions' => array($Model->escapeField() => $id), 'fields' => $resultFields, 'recursive' => $recursive));
 		if ($result) {
 			$result = array_values($result);
 		} else {
 			return null;
 		}
 		$item = $result[0];
+		if ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $item[$__multiTreeKey]);
+		}
 		$results = $Model->find('all', array(
 			'conditions' => array($scope, $Model->escapeField($left) . ' <=' => $item[$left], $Model->escapeField($right) . ' >=' => $item[$right]),
 			'fields' => $fields, 'order' => array($Model->escapeField($left) => 'asc'), 'recursive' => $recursive
@@ -443,10 +532,18 @@ class TreeBehavior extends ModelBehavior {
 			$id = $Model->id;
 		}
 		extract($this->settings[$Model->alias]);
+		$nodeFields = array($Model->primaryKey, $left, $right, $parent);
+		if ($multiTree) {
+			$nodeFields[] = $__multiTreeKey;
+			$scope = array();
+		}
 		list($node) = array_values($Model->find('first', array(
 			'conditions' => array($scope, $Model->escapeField() => $id),
-			'fields' => array($Model->primaryKey, $left, $right, $parent), 'recursive' => $recursive
+			'fields' => $nodeFields, 'recursive' => $recursive
 		)));
+		if ($multiTree) {
+    		$scope = $this->_multiTreeScope($Model, $node[$__multiTreeKey]);
+		}
 		if ($node[$parent]) {
 			list($parentNode) = array_values($Model->find('first', array(
 				'conditions' => array($scope, $Model->escapeField() => $node[$parent]),
@@ -501,10 +598,22 @@ class TreeBehavior extends ModelBehavior {
 			$id = $Model->id;
 		}
 		extract($this->settings[$Model->alias]);
+		$nodeFields = array($Model->primaryKey, $left, $right, $parent);
+		if ($multiTree) {
+			$nodeFields[] = $__multiTreeKey;
+			$scope = array();
+		}
 		list($node) = array_values($Model->find('first', array(
 			'conditions' => array($scope, $Model->escapeField() => $id),
+<<<<<<< Updated upstream
 			'fields' => array($Model->primaryKey, $left, $right, $parent ), 'recursive' => $recursive
+=======
+			'fields' => $nodeFields, 'recursive' => $recursive
+>>>>>>> Stashed changes
 		)));
+		if ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $node[$__multiTreeKey]);
+		}
 		if ($node[$parent]) {
 			list($parentNode) = array_values($Model->find('first', array(
 				'conditions' => array($scope, $Model->escapeField() => $node[$parent]),
@@ -551,14 +660,27 @@ class TreeBehavior extends ModelBehavior {
  * @param string $mode parent or tree
  * @param mixed $missingParentAction 'return' to do nothing and return, 'delete' to
  * delete, or the id of the parent to set as the parent_id
+ * @param integer $treeScope id of the tree to be recovered if using multiTree (recovers all by default)
  * @return boolean true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::recover
  */
-	public function recover($Model, $mode = 'parent', $missingParentAction = null) {
+	public function recover($Model, $mode = 'parent', $missingParentAction = null, $treeScope = null) {
 		if (is_array($mode)) {
 			extract (array_merge(array('mode' => 'parent'), $mode));
 		}
 		extract($this->settings[$Model->alias]);
+		if ($multiTree && !$treeScope) {
+			$trees = $Model->find('all', array('fields' => 'DISTINCT ' . $Model->escapeField($__multiTreeKey), 'recursive' => -1));
+			foreach ($trees as $tree) {
+				$this->recover($Model, $mode, $missingParentAction, $tree[$Model->alias][$__multiTreeKey]);
+			}
+			if ($this->errors){
+				return false;
+			}
+			return true;
+		} elseif ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $treeScope);
+		}
 		$Model->recursive = $recursive;
 		if ($mode == 'parent') {
 			$Model->bindModel(array('belongsTo' => array('VerifyParent' => array(
@@ -587,20 +709,29 @@ class TreeBehavior extends ModelBehavior {
 				}
 			}
 			$count = 1;
+<<<<<<< Updated upstream
 			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey), 'order' => $left)) as $array) {
 				$Model->id = $array[$Model->alias][$Model->primaryKey];
+=======
+			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey), 'order' => $Model->escapeField($left))) as $array) {
+>>>>>>> Stashed changes
 				$lft = $count++;
 				$rght = $count++;
 				$Model->save(array($left => $lft, $right => $rght), array('callbacks' => false));
 			}
+<<<<<<< Updated upstream
 			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey, $parent), 'order' => $left)) as $array) {
 				$Model->create();
+=======
+			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey, $parent), 'order' => $Model->escapeField($left))) as $array) {
+				$Model->create(false);
+>>>>>>> Stashed changes
 				$Model->id = $array[$Model->alias][$Model->primaryKey];
 				$this->_setParent($Model, $array[$Model->alias][$parent]);
 			}
 		} else {
 			$db = ConnectionManager::getDataSource($Model->useDbConfig);
-			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey, $parent), 'order' => $left)) as $array) {
+			foreach ($Model->find('all', array('conditions' => $scope, 'fields' => array($Model->primaryKey, $parent), 'order' => $Model->escapeField($left))) as $array) {
 				$path = $this->getPath($Model, $array[$Model->alias][$Model->primaryKey]);
 				if ($path == null || count($path) < 2) {
 					$parentId = null;
@@ -677,13 +808,21 @@ class TreeBehavior extends ModelBehavior {
 			extract (array_merge(array('id' => null), $id));
 		}
 		extract($this->settings[$Model->alias]);
-
+		
+		$nodeFields = array($Model->primaryKey, $left, $right, $parent);
+		if ($multiTree) {
+			$nodeFields[] = $__multiTreeKey;
+			$scope = array();
+		}
 		list($node) = array_values($Model->find('first', array(
 			'conditions' => array($scope, $Model->escapeField() => $id),
-			'fields' => array($Model->primaryKey, $left, $right, $parent),
+			'fields' => $nodeFields,
 			'recursive' => $recursive
 		)));
-
+		
+		if ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $node[$__multiTreeKey]);
+		}
 		if ($node[$right] == $node[$left] + 1) {
 			if ($delete) {
 				return $Model->delete($id);
@@ -738,13 +877,30 @@ class TreeBehavior extends ModelBehavior {
  *
  * Returns true if the tree is valid otherwise an array of (type, incorrect left/right index, message)
  *
- * @param Model $Model Model instance
+ * @param $Model Model instance
+ * @param $treeScope id of tree to verify (verifies all by deafault)
  * @return mixed true if the tree is valid or empty, otherwise an array of (error type [index, node],
  *  [incorrect left/right index,node id], message)
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::verify
  */
-	public function verify($Model) {
+	public function verify($Model, $treeScope = null) {
 		extract($this->settings[$Model->alias]);
+		if ($multiTree && !$treeScope) {
+			$trees = $Model->find('all', array('fields' => 'DISTINCT ' . $Model->escapeField($__multiTreeKey), 'recursive' => -1));
+			$errors = array();
+			foreach ($trees as $tree) {
+				$verified = $this->verify($Model, $tree[$Model->alias][$__multiTreeKey]);
+				if ($verified !== true) {
+					$errors[$tree[$Model->alias][$__multiTreeKey]] = $verified;
+				}
+			}
+			if ($errors){
+				return $errors;
+			}
+			return true;
+		} elseif ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $treeScope);
+		}
 		if (!$Model->find('count', array('conditions' => $scope))) {
 			return true;
 		}
@@ -817,11 +973,19 @@ class TreeBehavior extends ModelBehavior {
  */
 	protected function _setParent($Model, $parentId = null, $created = false) {
 		extract($this->settings[$Model->alias]);
+		$nodeFields = array($Model->primaryKey, $parent, $left, $right);
+		if ($multiTree) {
+			$nodeFields[] = $__multiTreeKey;
+			$scope = array();
+		}
 		list($node) = array_values($Model->find('first', array(
 			'conditions' => array($scope, $Model->escapeField() => $Model->id),
-			'fields' => array($Model->primaryKey, $parent, $left, $right),
+			'fields' => $nodeFields,
 			'recursive' => $recursive
 		)));
+		if ($multiTree) {
+			$scope = $this->_multiTreeScope($Model, $node[$__multiTreeKey]);
+		}
 		$edge = $this->_getMax($Model, $scope, $right, $recursive, $created);
 
 		if (empty ($parentId)) {
@@ -936,17 +1100,18 @@ class TreeBehavior extends ModelBehavior {
  * @param integer $shift
  * @param string $dir
  * @param array $conditions
+ * @param integer $treeScope
  * @param boolean $created
  * @param string $field
  * @return void
  */
-	protected function _sync($Model, $shift, $dir = '+', $conditions = array(), $created = false, $field = 'both') {
+	protected function _sync($Model, $shift, $dir = '+', $conditions = array(), $treeScope = null, $created = false, $field = 'both') {
 		$ModelRecursive = $Model->recursive;
 		extract($this->settings[$Model->alias]);
 		$Model->recursive = $recursive;
 
 		if ($field == 'both') {
-			$this->_sync($Model, $shift, $dir, $conditions, $created, $left);
+			$this->_sync($Model, $shift, $dir, $conditions, $treeScope, $created, $left);
 			$field = $right;
 		}
 		if (is_string($conditions)) {
@@ -960,5 +1125,21 @@ class TreeBehavior extends ModelBehavior {
 		}
 		$Model->updateAll(array($Model->alias . '.' . $field => $Model->escapeField($field) . ' ' . $dir . ' ' . $shift), $conditions);
 		$Model->recursive = $ModelRecursive;
+	}
+
+/**
+ * Get scope condition for multiTree and store in current settings
+ *
+ * @param Model $Model
+ * @param integer $treeScope
+ * @return array
+ */
+	protected function _multiTreeScope($Model, $treeScope) {
+		if (!$this->settings[$Model->alias]['__multiTreeKey']) {
+			return $this->settings[$Model->alias]['scope'];
+		}
+		$scope = array($Model->escapeField($this->settings[$Model->alias]['__multiTreeKey']) => $treeScope);
+		$this->settings[$Model->alias]['scope'] = $scope;
+		return $scope;
 	}
 }

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberMultiTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberMultiTest.php
@@ -1,0 +1,1383 @@
+<?php
+/**
+ * TreeBehaviorNumberTest file
+ *
+ * This is the basic Tree behavior test
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Case.Model.Behavior
+ * @since         CakePHP(tm) v 1.2.0.5330
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('Model', 'Model');
+App::uses('AppModel', 'Model');
+require_once(dirname(dirname(__FILE__)) . DS . 'models.php');
+
+/**
+ * TreeBehaviorNumberTest class
+ *
+ * @package       Cake.Test.Case.Model.Behavior
+ */
+class TreeBehaviorNumberMultiTest extends CakeTestCase {
+
+/**
+ * Whether backup global state for each test method or not
+ *
+ * @var bool false
+ */
+	public $backupGlobals = false;
+
+/**
+ * settings property
+ *
+ * @var array
+ */
+	protected $settings = array(
+		'modelClass' => 'NumberMultiTree',
+		'leftField' => 'lft',
+		'rightField' => 'rght',
+		'parentField' => 'parent_id',
+		'treeField' => 'user_id',
+		'userClass' => 'User'
+	);
+
+/**
+ * fixtures property
+ *
+ * @var array
+ */
+	public $fixtures = array('core.number_multi_tree', 'core.user');
+
+/**
+ * testInitialize method
+ *
+ * @return void
+ */
+	public function testInitialize() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new $userClass();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->find('count');
+		$this->assertEquals($result, 28);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+/**
+ * testDetectInvalidLeft method
+ *
+ * @return void
+ */
+	public function testDetectInvalidLeft() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->findByName('1-1.1');
+
+		$save[$modelClass]['id'] = $result[$modelClass]['id'];
+		$save[$modelClass][$leftField] = 0;
+
+		$this->Tree->save($save);
+		$result = $this->Tree->findByName('1-1.1');
+		
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidRight method
+ *
+ * @return void
+ */
+	public function testDetectInvalidRight() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->findByName('1-1.1');
+
+		$save[$modelClass]['id'] = $result[$modelClass]['id'];
+		$save[$modelClass][$rightField] = 0;
+
+		$this->Tree->save($save);
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidParent method
+ *
+ * @return void
+ */
+	public function testDetectInvalidParent() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->findByName('1-1.1');
+
+		// Bypass behavior and any other logic
+		$this->Tree->updateAll(array($parentField => null), array($this->Tree->escapeField('id') => $result[$modelClass]['id']));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectNoneExistantParent method
+ *
+ * @return void
+ */
+	public function testDetectNoneExistantParent() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->findByName('1-1.1');
+		$this->Tree->updateAll(array($parentField => 999999), array($this->Tree->escapeField('id') => $result[$modelClass]['id']));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover('MPTT');
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testRecoverUsingParentMode method
+ *
+ * @return void
+ */
+	public function testRecoverUsingParentMode() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		
+		$this->Tree->Behaviors->disable('Tree');
+
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0, $treeField => 1));
+		$node1	= $this->Tree->id;
+
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0, $treeField => 1));
+		$node11	= $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0, $treeField => 1));
+		$node12	= $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0, $treeField => 1));
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0, $treeField => 1));
+
+		$this->Tree->Behaviors->enable('Tree');
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->verify();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->find('first', array(
+			'fields' => array('name', $parentField, $leftField, $rightField, $treeField),
+			'conditions' => array('name' => 'Main'),
+			'recursive' => -1
+		));
+		$expected = array(
+			$modelClass => array(
+				'name' => 'Main',
+				$parentField => null,
+				$leftField => 1,
+				$rightField => 10,
+				$treeField => 1
+			)
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testRecoverFromMissingParent method
+ *
+ * @return void
+ */
+	public function testRecoverFromMissingParent() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->findByName('1-1.1');
+		$this->Tree->updateAll(array($parentField => 999999), array($this->Tree->escapeField('id') => $result[$modelClass]['id']));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidParents method
+ *
+ * @return void
+ */
+	public function testDetectInvalidParents() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$this->Tree->updateAll(array($parentField => null), array($this->Tree->escapeField($treeField) => 1));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidLftsRghts method
+ *
+ * @return void
+ */
+	public function testDetectInvalidLftsRghts() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$this->Tree->updateAll(array($leftField => 0, $rightField => 0));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$this->Tree->recover();
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * Reproduces a situation where a single node has lft= rght, and all other lft and rght fields follow sequentially
+ *
+ * @return void
+ */
+	public function testDetectEqualLftsRghts() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 3);
+
+		$result = $this->Tree->findByName('1-1.1');
+		$this->Tree->updateAll(array($rightField => $result[$modelClass][$leftField]), array($this->Tree->escapeField('id') => $result[$modelClass]['id']));
+		$this->Tree->updateAll(array($leftField => $this->Tree->escapeField($leftField) . ' -1'),
+			array($leftField . ' >' => $result[$modelClass][$leftField], $this->Tree->escapeField($treeField) => 1));
+		$this->Tree->updateAll(array($rightField => $this->Tree->escapeField($rightField) . ' -1'),
+			array($rightField . ' >' => $result[$modelClass][$leftField], $this->Tree->escapeField($treeField) => 1));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->verify();
+		$this->assertTrue($result);
+	}
+
+/**
+ * testAddOrphan method
+ *
+ * @return void
+ */
+	public function testAddOrphan() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null, $treeField => 1)));
+		$result = $this->Tree->find('first', array('fields' => array('name', $parentField, $treeField), 'order' => $modelClass . '.' . $leftField . ' desc'));
+		$expected = array($modelClass => array('name' => 'testAddOrphan', $parentField => null, $treeField => 1));
+		$this->assertEquals($expected, $result);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+/**
+ * testAddMiddle method
+ *
+ * @return void
+ */
+	public function testAddMiddle() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1')));
+		$initialCount = $this->Tree->find('count');
+
+		$this->Tree->create();
+		$result = $this->Tree->save(array($modelClass => array('name' => 'testAddMiddle', $parentField => $data[$modelClass]['id'])));
+
+		$expected = array_merge(array($modelClass => array('name' => 'testAddMiddle', $parentField => '2')), $result);
+		$this->assertSame($expected, $result);
+
+		$laterCount = $this->Tree->find('count');
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount + 1, $laterCount);
+
+		$children = $this->Tree->children($data[$modelClass]['id'], true, array('name'));
+		$expects = array(array($modelClass => array('name' => '1-1.1.1')),
+			array($modelClass => array('name' => '1-1.1.2')),
+			array($modelClass => array('name' => 'testAddMiddle')));
+		$this->assertSame($children, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testAddInvalid method
+ *
+ * @return void
+ */
+	public function testAddInvalid() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$initialCount = $this->Tree->find('count');
+		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
+
+		$saveSuccess = $this->Tree->save(array($modelClass => array('name' => 'testAddInvalid', $parentField => 99999)));
+		$this->assertSame($saveSuccess, false);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertSame($initialCount, $laterCount);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testAddNoTree method
+ *
+ * @return void
+ */
+	public function testAddNoTree() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$initialCount = $this->Tree->find('count');
+		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
+
+		$saveSuccess = $this->Tree->save(array($modelClass => array('name' => 'testAddInvalid')));
+		$this->assertSame($saveSuccess, false);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertSame($initialCount, $laterCount);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testAddNotIndexedByModel method
+ *
+ * @return void
+ */
+	public function testAddNotIndexedByModel() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$this->Tree->save(array('name' => 'testAddNotIndexed', $parentField => null, $treeField => 1));
+		$result = $this->Tree->find('first', array('fields' => array('name', $parentField), 'order' => $modelClass . '.' . $leftField . ' desc',
+									'conditions' => array($treeField => 1)));
+		$expected = array($modelClass => array('name' => 'testAddNotIndexed', $parentField => null));
+		$this->assertEquals($expected, $result);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+}
+/**
+ * testMovePromote method
+ *
+ * @return void
+ */
+	public function testMovePromote() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$parent_id = $parent[$modelClass]['id'];
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1.1')));
+		$this->Tree->id= $data[$modelClass]['id'];
+		$this->Tree->saveField($parentField, $parent_id);
+		$direct = $this->Tree->children($parent_id, true, array('id', 'name', $parentField, $leftField, $rightField));
+		$expects = array(array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 5)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 6, $rightField => 11)),
+			array($modelClass => array('id' => 3, 'name' => '1-1.1.1', $parentField => 1, $leftField => 12, $rightField => 13)));
+		$this->assertEquals($direct, $expects);
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveWithWhitelist method
+ *
+ * @return void
+ */
+	public function testMoveWithWhitelist() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$parent_id = $parent[$modelClass]['id'];
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1.1')));
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->whitelist = array($parentField, 'name', 'description');
+		$this->Tree->saveField($parentField, $parent_id);
+
+		$result = $this->Tree->children($parent_id, true, array('id', 'name', $parentField, $leftField, $rightField));
+		$expected = array(array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 5)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 6, $rightField => 11)),
+			array($modelClass => array('id' => 3, 'name' => '1-1.1.1', $parentField => 1, $leftField => 12, $rightField => 13)));
+		$this->assertEquals($expected, $result);
+		$this->assertTrue($this->Tree->verify());
+	}
+
+/**
+ * testInsertWithWhitelist method
+ *
+ * @return void
+ */
+	public function testInsertWithWhitelist() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$this->Tree->whitelist = array('name', $parentField);
+		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null, $treeField => 1)));
+		$result = $this->Tree->findByName('testAddOrphan', array('name', $parentField, $leftField, $rightField));
+		$expected = array('name' => 'testAddOrphan', $parentField => null, $leftField => '15', $rightField => 16);
+		$this->assertEquals($result[$modelClass], $expected);
+		$this->assertSame($this->Tree->verify(), true);
+	}
+
+/**
+ * testMoveBefore method
+ *
+ * @return void
+ */
+	public function testMoveBefore() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.1')));
+		$parent_id = $parent[$modelClass]['id'];
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.2')));
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->saveField($parentField, $parent_id);
+
+		$result = $this->Tree->children($parent_id, true, array('name'));
+		$expects = array(array($modelClass => array('name' => '1-1.1.1')),
+			array($modelClass => array('name' => '1-1.1.2')),
+			array($modelClass => array('name' => '1-1.2')));
+		$this->assertEquals($result, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveAfter method
+ *
+ * @return void
+ */
+	public function testMoveAfter() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.2')));
+		$parent_id = $parent[$modelClass]['id'];
+
+		$data= $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1')));
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->saveField($parentField, $parent_id);
+
+		$result = $this->Tree->children($parent_id, true, array('name'));
+		$expects = array(array($modelClass => array('name' => '1-1.2.1')),
+			array($modelClass => array('name' => '1-1.2.2')),
+			array($modelClass => array('name' => '1-1.1')));
+		$this->assertEquals($result, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveDemoteInvalid method
+ *
+ * @return void
+ */
+	public function testMoveDemoteInvalid() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$parent = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$parent_id = $parent[$modelClass]['id'];
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1.1')));
+
+		$expects = $this->Tree->find('all');
+		$before = $this->Tree->read(null, $data[$modelClass]['id']);
+
+		$this->Tree->id = $parent_id;
+		//$this->expectError('Trying to save a node under itself in TreeBehavior::beforeSave');
+		$this->Tree->saveField($parentField, $data[$modelClass]['id']);
+
+		$results = $this->Tree->find('all');
+		$after = $this->Tree->read(null, $data[$modelClass]['id']);
+
+		$this->assertEquals($results, $expects);
+		$this->assertEquals($before, $after);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveInvalid method
+ *
+ * @return void
+ */
+	public function testMoveInvalid() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$initialCount = $this->Tree->find('count');
+		$data= $this->Tree->findByName('1-1.1');
+
+		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->saveField($parentField, 999999);
+
+		//$this->assertSame($saveSuccess, false);
+		$laterCount = $this->Tree->find('count');
+		$this->assertSame($initialCount, $laterCount);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveSelfInvalid method
+ *
+ * @return void
+ */
+	public function testMoveSelfInvalid() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$this->Tree->id = null;
+
+		$initialCount = $this->Tree->find('count');
+		$data= $this->Tree->findByName('1-1.1');
+
+		//$this->expectError('Trying to set a node to be the parent of itself in TreeBehavior::beforeSave');
+		$this->Tree->id = $data[$modelClass]['id'];
+		$saveSuccess = $this->Tree->saveField($parentField, $this->Tree->id);
+
+		$this->assertSame($saveSuccess, false);
+		$laterCount = $this->Tree->find('count');
+		$this->assertSame($initialCount, $laterCount);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testMoveUpSuccess method
+ *
+ * @return void
+ */
+	public function testMoveUpSuccess() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.2')));
+		$this->Tree->moveUp($data[$modelClass]['id']);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.1', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveUpFail method
+ *
+ * @return void
+ */
+	public function testMoveUpFail() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.1')));
+
+		$this->Tree->moveUp($data[$modelClass]['id']);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveUp2 method
+ *
+ * @return void
+ */
+	public function testMoveUp2() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 10);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.5')));
+		$this->Tree->moveUp($data[$modelClass]['id'], 2);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.5', )),
+			array($modelClass => array('name' => '1-1.3', )),
+			array($modelClass => array('name' => '1-1.4', )),
+			array($modelClass => array('name' => '1-1.6', )),
+			array($modelClass => array('name' => '1-1.7', )),
+			array($modelClass => array('name' => '1-1.8', )),
+			array($modelClass => array('name' => '1-1.9', )),
+			array($modelClass => array('name' => '1-1.10', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveUpFirst method
+ *
+ * @return void
+ */
+	public function testMoveUpFirst() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 10);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.5')));
+		$this->Tree->moveUp($data[$modelClass]['id'], true);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.5', )),
+			array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.3', )),
+			array($modelClass => array('name' => '1-1.4', )),
+			array($modelClass => array('name' => '1-1.6', )),
+			array($modelClass => array('name' => '1-1.7', )),
+			array($modelClass => array('name' => '1-1.8', )),
+			array($modelClass => array('name' => '1-1.9', )),
+			array($modelClass => array('name' => '1-1.10', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveDownSuccess method
+ *
+ * @return void
+ */
+	public function testMoveDownSuccess() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1')));
+		$this->Tree->moveDown($data[$modelClass]['id']);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.1', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveDownFail method
+ *
+ * @return void
+ */
+	public function testMoveDownFail() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.2')));
+		$this->Tree->moveDown($data[$modelClass]['id']);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveDownLast method
+ *
+ * @return void
+ */
+	public function testMoveDownLast() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 10);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.5')));
+		$this->Tree->moveDown($data[$modelClass]['id'], true);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.3', )),
+			array($modelClass => array('name' => '1-1.4', )),
+			array($modelClass => array('name' => '1-1.6', )),
+			array($modelClass => array('name' => '1-1.7', )),
+			array($modelClass => array('name' => '1-1.8', )),
+			array($modelClass => array('name' => '1-1.9', )),
+			array($modelClass => array('name' => '1-1.10', )),
+			array($modelClass => array('name' => '1-1.5', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveDown2 method
+ *
+ * @return void
+ */
+	public function testMoveDown2() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 10);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.5')));
+		$this->Tree->moveDown($data[$modelClass]['id'], 2);
+
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.3', )),
+			array($modelClass => array('name' => '1-1.4', )),
+			array($modelClass => array('name' => '1-1.6', )),
+			array($modelClass => array('name' => '1-1.7', )),
+			array($modelClass => array('name' => '1-1.5', )),
+			array($modelClass => array('name' => '1-1.8', )),
+			array($modelClass => array('name' => '1-1.9', )),
+			array($modelClass => array('name' => '1-1.10', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testSaveNoMove method
+ *
+ * @return void
+ */
+	public function testSaveNoMove() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 10);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.5')));
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->saveField('name', 'renamed');
+		$parent = $this->Tree->findByName('1-1. Root', array('id'));
+		$this->Tree->id = $parent[$modelClass]['id'];
+
+		$result = $this->Tree->children(null, true, array('name'));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.1', )),
+			array($modelClass => array('name' => '1-1.2', )),
+			array($modelClass => array('name' => '1-1.3', )),
+			array($modelClass => array('name' => '1-1.4', )),
+			array($modelClass => array('name' => 'renamed', )),
+			array($modelClass => array('name' => '1-1.6', )),
+			array($modelClass => array('name' => '1-1.7', )),
+			array($modelClass => array('name' => '1-1.8', )),
+			array($modelClass => array('name' => '1-1.9', )),
+			array($modelClass => array('name' => '1-1.10', )));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testMoveToRootAndMoveUp method
+ *
+ * @return void
+ */
+	public function testMoveToRootAndMoveUp() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 1, 1);
+
+		$data = $this->Tree->find('first', array('fields' => array('id', $treeField), 'conditions' => array($modelClass . '.name' => '1-1.1')));
+		$this->Tree->id = $data[$modelClass]['id'];
+		$this->Tree->save(array($parentField => null));
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+
+		$this->Tree->moveUp();
+
+		$result = $this->Tree->find('all', array('fields' => 'name', 'order' => $modelClass . '.' . $leftField . ' ASC',
+									'conditions' => array($treeField => $data[$modelClass][$treeField])));
+		$expected = array(
+			array($modelClass => array('name' => '1-1.1')),
+			array($modelClass => array('name' => '1-1. Root')));
+		$this->assertSame($expected, $result);
+	}
+/**
+ * testDelete method
+ *
+ * @return void
+ */
+	public function testDelete() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$initialCount = $this->Tree->find('count');
+		$result = $this->Tree->findByName('1-1.1.1');
+
+		$return = $this->Tree->delete($result[$modelClass]['id']);
+		$this->assertEquals($return, true);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount - 1, $laterCount);
+
+		$validTree= $this->Tree->verify();
+		$this->assertSame($validTree, true);
+
+		$initialCount = $this->Tree->find('count');
+		$result= $this->Tree->findByName('1-1.1');
+
+		$return = $this->Tree->delete($result[$modelClass]['id']);
+		$this->assertEquals($return, true);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount - 2, $laterCount);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testRemove method
+ *
+ * @return void
+ */
+	public function testRemove() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$initialCount = $this->Tree->find('count');
+		$result = $this->Tree->findByName('1-1.1');
+
+		$this->Tree->removeFromTree($result[$modelClass]['id']);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount, $laterCount);
+
+		$children = $this->Tree->children($result[$modelClass][$parentField], true, array('name'));
+		$expects = array(array($modelClass => array('name' => '1-1.1.1')),
+			array($modelClass => array('name' => '1-1.1.2')),
+			array($modelClass => array('name' => '1-1.2')));
+		$this->assertEquals($children, $expects);
+
+		$topNodes = $this->Tree->children(false, true,array('name'));
+		$expects = array(
+			array($modelClass => array('name' => '1-1. Root')),
+			array($modelClass => array('name' => '1-1.1')),
+			array($modelClass => array('name' => '2-1. Root')),
+			array($modelClass => array('name' => '3-1. Root')),
+			array($modelClass => array('name' => '4-1. Root')));
+		$this->assertEquals($topNodes, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testRemoveLastTopParent method
+ *
+ * @return void
+ */
+	public function testRemoveLastTopParent() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$initialCount = $this->Tree->find('count');
+		$initialTopNodes = $this->Tree->childCount(false);
+
+		$result = $this->Tree->findByName('1-1. Root');
+		$this->Tree->removeFromTree($result[$modelClass]['id']);
+
+		$laterCount = $this->Tree->find('count');
+		$laterTopNodes = $this->Tree->childCount(false);
+
+		$this->assertEquals($initialCount, $laterCount);
+		$this->assertEquals($initialTopNodes, $laterTopNodes);
+
+		$topNodes = $this->Tree->children(false, true, array('name'));
+		$expects = array(
+			array($modelClass => array('name' => '1-1.1')),
+			array($modelClass => array('name' => '1-1.2')),
+			array($modelClass => array('name' => '1-1. Root')),
+			array($modelClass => array('name' => '2-1. Root')),
+			array($modelClass => array('name' => '3-1. Root')),
+			array($modelClass => array('name' => '4-1. Root')));
+		$this->assertEquals($topNodes, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testRemoveNoChildren method
+ *
+ * @return void
+ */
+	public function testRemoveNoChildren() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$initialCount = $this->Tree->find('count');
+
+		$result = $this->Tree->findByName('1-1.1.1');
+		$this->Tree->removeFromTree($result[$modelClass]['id']);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount, $laterCount);
+
+		$nodes = $this->Tree->find('list', array('order' => $leftField, 'conditions' => array($treeField => $result[$modelClass][$treeField])));
+		$expects = array(
+			1 => '1-1. Root',
+			2 => '1-1.1',
+			4 => '1-1.1.2',
+			5 => '1-1.2',
+			6 => '1-1.2.1',
+			7 => '1-1.2.2',
+			3 => '1-1.1.1',
+		);
+
+		$this->assertEquals($nodes, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testRemoveAndDelete method
+ *
+ * @return void
+ */
+	public function testRemoveAndDelete() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$initialCount = $this->Tree->find('count');
+		$result = $this->Tree->findByName('1-1.1');
+
+		$this->Tree->removeFromTree($result[$modelClass]['id'], true);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount-1, $laterCount);
+
+		$children = $this->Tree->children($result[$modelClass][$parentField], true, array('name'), $leftField . ' asc');
+		$expects= array(
+			array($modelClass => array('name' => '1-1.1.1')),
+			array($modelClass => array('name' => '1-1.1.2')),
+			array($modelClass => array('name' => '1-1.2')));
+		$this->assertEquals($children, $expects);
+
+		$topNodes = $this->Tree->children(false, true,array('name'));
+		$expects = array(
+			array($modelClass => array('name' => '1-1. Root')),
+			array($modelClass => array('name' => '2-1. Root')),
+			array($modelClass => array('name' => '3-1. Root')),
+			array($modelClass => array('name' => '4-1. Root')));
+		$this->assertEquals($topNodes, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testRemoveAndDeleteNoChildren method
+ *
+ * @return void
+ */
+	public function testRemoveAndDeleteNoChildren() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+		$initialCount = $this->Tree->find('count');
+
+		$result = $this->Tree->findByName('1-1.1.1');
+		$this->Tree->removeFromTree($result[$modelClass]['id'], true);
+
+		$laterCount = $this->Tree->find('count');
+		$this->assertEquals($initialCount - 1, $laterCount);
+
+		$nodes = $this->Tree->find('list', array('order' => $leftField, 'conditions' => array($treeField => $result[$modelClass][$treeField])));
+		$expects = array(
+			1 => '1-1. Root',
+			2 => '1-1.1',
+			4 => '1-1.1.2',
+			5 => '1-1.2',
+			6 => '1-1.2.1',
+			7 => '1-1.2.2',
+		);
+		$this->assertEquals($nodes, $expects);
+
+		$validTree = $this->Tree->verify();
+		$this->assertSame($validTree, true);
+	}
+
+/**
+ * testChildren method
+ *
+ * @return void
+ */
+	public function testChildren() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$this->Tree->id= $data[$modelClass]['id'];
+
+		$direct = $this->Tree->children(null, true, array('id', 'name', $parentField, $leftField, $rightField));
+		$expects = array(array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 8, $rightField => 13)));
+		$this->assertEquals($direct, $expects);
+
+		$total = $this->Tree->children(null, null, array('id', 'name', $parentField, $leftField, $rightField));
+		$expects = array(array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
+			array($modelClass => array('id' => 3, 'name' => '1-1.1.1', $parentField => 2, $leftField => 3, $rightField => 4)),
+			array($modelClass => array('id' => 4, 'name' => '1-1.1.2', $parentField => 2, $leftField => 5, $rightField => 6)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 8, $rightField => 13)),
+			array($modelClass => array('id' => 6, 'name' => '1-1.2.1', $parentField => 5, $leftField => 9, $rightField => 10)),
+			array($modelClass => array('id' => 7, 'name' => '1-1.2.2', $parentField => 5, $leftField => 11, $rightField => 12)));
+		$this->assertEquals($total, $expects);
+
+		$this->assertEquals(array(), $this->Tree->children(10000));
+	}
+
+/**
+ * testCountChildren method
+ *
+ * @return void
+ */
+	public function testCountChildren() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$this->Tree->id = $data[$modelClass]['id'];
+
+		$direct = $this->Tree->childCount(null, true);
+		$this->assertEquals($direct, 2);
+
+		$total = $this->Tree->childCount();
+		$this->assertEquals($total, 6);
+
+		$this->Tree->read(null, $data[$modelClass]['id']);
+		$id = $this->Tree->field('id', array($modelClass . '.name' => '1-1.2'));
+		$total = $this->Tree->childCount($id);
+		$this->assertEquals($total, 2);
+	}
+/**
+ * testGetParentNode method
+ *
+ * @return void
+ */
+	public function testGetParentNode() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.2.2')));
+		$this->Tree->id= $data[$modelClass]['id'];
+
+		$result = $this->Tree->getParentNode(null, array('name'));
+		$expects = array($modelClass => array('name' => '1-1.2'));
+		$this->assertSame($result, $expects);
+	}
+
+/**
+ * testGetPath method
+ *
+ * @return void
+ */
+	public function testGetPath() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1.2.2')));
+		$this->Tree->id= $data[$modelClass]['id'];
+
+		$result = $this->Tree->getPath(null, array('name'));
+		$expects = array(array($modelClass => array('name' => '1-1. Root')),
+			array($modelClass => array('name' => '1-1.2')),
+			array($modelClass => array('name' => '1-1.2.2')));
+		$this->assertSame($result, $expects);
+	}
+
+/**
+ * testNoAmbiguousColumn method
+ *
+ * @return void
+ */
+	public function testNoAmbiguousColumn() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
+			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1-1. Root')));
+		$this->Tree->id= $data[$modelClass]['id'];
+
+		$direct = $this->Tree->children(null, true, array('id', 'name', $parentField, $leftField, $rightField));
+		$expects = array(array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 8, $rightField => 13)));
+		$this->assertEquals($direct, $expects);
+
+		$total = $this->Tree->children(null, null, array('id', 'name', $parentField, $leftField, $rightField));
+		$expects = array(
+			array($modelClass => array('id' => 2, 'name' => '1-1.1', $parentField => 1, $leftField => 2, $rightField => 7)),
+			array($modelClass => array('id' => 3, 'name' => '1-1.1.1', $parentField => 2, $leftField => 3, $rightField => 4)),
+			array($modelClass => array('id' => 4, 'name' => '1-1.1.2', $parentField => 2, $leftField => 5, $rightField => 6)),
+			array($modelClass => array('id' => 5, 'name' => '1-1.2', $parentField => 1, $leftField => 8, $rightField => 13)),
+			array($modelClass => array('id' => 6, 'name' => '1-1.2.1', $parentField => 5, $leftField => 9, $rightField => 10)),
+			array($modelClass => array('id' => 7, 'name' => '1-1.2.2', $parentField => 5, $leftField => 11, $rightField => 12))
+		);
+		$this->assertEquals($total, $expects);
+	}
+
+/**
+ * testReorderTree method
+ *
+ * @return void
+ */
+	public function testReorderTree() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 3, 3);
+		$nodes = $this->Tree->find('list', array('order' => $leftField));
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.1')));
+		$this->Tree->moveDown($data[$modelClass]['id']);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.2.1')));
+		$this->Tree->moveDown($data[$modelClass]['id']);
+
+		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1-1.3.2.2')));
+		$this->Tree->moveDown($data[$modelClass]['id']);
+
+		$unsortedNodes = $this->Tree->find('list', array('order' => $leftField));
+		$this->assertEquals($nodes, $unsortedNodes);
+		$this->assertNotEquals(array_keys($nodes), array_keys($unsortedNodes));
+
+		$this->Tree->reorder();
+		$sortedNodes = $this->Tree->find('list', array('order' => $leftField));
+		$this->assertSame($nodes, $sortedNodes);
+	}
+
+/**
+ * test reordering large-ish trees with cacheQueries = true.
+ * This caused infinite loops when moving down elements as stale data is returned
+ * from the memory cache
+ *
+ * @return void
+ */
+	public function testReorderBigTreeWithQueryCaching() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 2, 10);
+
+		$original = $this->Tree->cacheQueries;
+		$this->Tree->cacheQueries = true;
+		$this->Tree->reorder(array('field' => 'name', 'direction' => 'DESC'));
+		$this->assertTrue($this->Tree->cacheQueries, 'cacheQueries was not restored after reorder(). %s');
+		$this->Tree->cacheQueries = $original;
+	}
+
+/**
+ * testGenerateTreeListWithSelfJoin method
+ *
+ * @return void
+ */
+	public function testGenerateTreeListWithSelfJoin() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
+			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
+		$this->Tree->initialize($this->User->find('list'), 2, 2);
+
+		$result = $this->Tree->generateTreeList();
+		$expected = array(1 => array(1 => '1-1. Root', 2 => '_1-1.1', 3 => '__1-1.1.1', 4 => '__1-1.1.2', 5 => '_1-1.2', 6 => '__1-1.2.1', 7 => '__1-1.2.2'),
+			2 => array(8 => '2-1. Root', 9 => '_2-1.1', 10 => '__2-1.1.1', 11 => '__2-1.1.2', 12 => '_2-1.2', 13 => '__2-1.2.1', 14 => '__2-1.2.2'),
+			3 => array(15 => '3-1. Root', 16 => '_3-1.1', 17 => '__3-1.1.1', 18 => '__3-1.1.2', 19 => '_3-1.2', 20 => '__3-1.2.1', 21 => '__3-1.2.2'),
+			4 => array(22 => '4-1. Root', 23 => '_4-1.1', 24 => '__4-1.1.1', 25 => '__4-1.1.2', 26 => '_4-1.2', 27 => '__4-1.2.1', 28 => '__4-1.2.2'));
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testArraySyntax method
+ *
+ * @return void
+ */
+	public function testArraySyntax() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->User = new User();
+		$this->Tree->initialize($this->User->find('list'), 3, 3);
+		$this->assertSame($this->Tree->childCount(2), $this->Tree->childCount(array('id' => 2)));
+		$this->assertSame($this->Tree->getParentNode(2), $this->Tree->getParentNode(array('id' => 2)));
+		$this->assertSame($this->Tree->getPath(4), $this->Tree->getPath(array('id' => 4)));
+	}
+}

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorTest.php
@@ -38,6 +38,7 @@ class TreeBehaviorTest extends PHPUnit_Framework_TestSuite {
 		$suite->addTestFile(CORE_TEST_CASES . DS . 'Model' . DS . 'Behavior' . DS . 'TreeBehaviorScopedTest.php');
 		$suite->addTestFile(CORE_TEST_CASES . DS . 'Model' . DS . 'Behavior' . DS . 'TreeBehaviorAfterTest.php');
 		$suite->addTestFile(CORE_TEST_CASES . DS . 'Model' . DS . 'Behavior' . DS . 'TreeBehaviorUuidTest.php');
+		$suite->addTestFile(CORE_TEST_CASES . DS . 'Model' . DS . 'Behavior' . DS . 'TreeBehaviorNumberMultiTest.php');
 		return $suite;
 	}
 }

--- a/lib/Cake/Test/Fixture/NumberMultiTreeFixture.php
+++ b/lib/Cake/Test/Fixture/NumberMultiTreeFixture.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tree behavior class.
+ *
+ * Enables a model object to act as a node-based tree.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/view/1196/Testing CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 1.2.0.5331
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * Number Multi Tree Test Fixture
+ *
+ * Generates a tree of data for use testing the tree behavior
+ *
+ * @package       Cake.Test.Fixture
+ */
+class NumberMultiTreeFixture extends CakeTestFixture {
+
+/**
+ * name property
+ *
+ * @var string 'NumberMultiTree'
+ */
+	public $name = 'NumberMultiTree';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id'	=> array('type' => 'integer','key' => 'primary'),
+		'name'	=> 'string',
+		'parent_id' => 'integer',
+		'lft'	=> array('type' => 'integer','null' => false),
+		'rght'	=> array('type' => 'integer','null' => false),
+		'user_id'	=> 'integer'
+	);
+}

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -634,6 +634,8 @@ class PaginatorHelper extends AppHelper {
  * - `last` Whether you want last links generated, set to an integer to define the number of 'last'
  *    links to generate.
  * - `ellipsis` Ellipsis content, defaults to '...'
+ * - `currentLink` Whether you want the current page number to be also be a link, defaults to false
+ * - `currentClass` Class to be added to current page number, defaults to 'current'
  *
  * @param mixed $options Options for the numbers, (before, after, model, modulus, separator)
  * @return string numbers string.
@@ -649,6 +651,7 @@ class PaginatorHelper extends AppHelper {
 		$defaults = array(
 			'tag' => 'span', 'before' => null, 'after' => null, 'model' => $this->defaultModel(), 'class' => null,
 			'modulus' => '8', 'separator' => ' | ', 'first' => null, 'last' => null, 'ellipsis' => '...',
+			'currentLink' => false, 'currentClass' => 'current',
 		);
 		$options += $defaults;
 
@@ -662,7 +665,7 @@ class PaginatorHelper extends AppHelper {
 		extract($options);
 		unset($options['tag'], $options['before'], $options['after'], $options['model'],
 			$options['modulus'], $options['separator'], $options['first'], $options['last'],
-			$options['ellipsis'], $options['class']
+			$options['ellipsis'], $options['class'], $options['currentLink'], $options['currentClass']
 		);
 
 		$out = '';
@@ -696,11 +699,16 @@ class PaginatorHelper extends AppHelper {
 					. $separator;
 			}
 
-			$currentClass = 'current';
 			if ($class) {
 				$currentClass .= ' ' . $class;
 			}
-			$out .= $this->Html->tag($tag, $params['page'], array('class' => $currentClass));
+
+			if($currentLink) {
+				$out .= $this->Html->tag($tag, $this->link($params['page'], null, $options), array('class' => $currentClass));
+			} else {
+				$out .= $this->Html->tag($tag, $params['page'], array('class' => $currentClass));
+			}
+
 			if ($i != $params['pageCount']) {
 				$out .= $separator;
 			}
@@ -731,11 +739,17 @@ class PaginatorHelper extends AppHelper {
 
 			for ($i = 1; $i <= $params['pageCount']; $i++) {
 				if ($i == $params['page']) {
-					$currentClass = 'current';
+
 					if ($class) {
 						$currentClass .= ' ' . $class;
 					}
-					$out .= $this->Html->tag($tag, $i, array('class' => $currentClass));
+
+					if ($currentLink) {
+						$out .= $this->Html->tag($tag, $this->link($i, null, $options), array('class' => $currentClass));
+					} else {
+						$out .= $this->Html->tag($tag, $i, array('class' => $currentClass));
+					}
+
 				} else {
 					$out .= $this->Html->tag($tag, $this->link($i, array('page' => $i), $options), compact('class'));
 				}


### PR DESCRIPTION
`currentClass` => string, default: 'current'
This gives the option to override the $currentClass which was previously hard coded as 'current'

`currentLink` => boolean, default: 'false'
This gives the option to force the current page number to also be a link (as other page numbers), makes styling much easier as all elements can have consistent structure.

The defaults of both options are such that the behaviour of Paginator::numbers() will be the same as before.

(Have also added both to comment block)
