### PR TITLE
skipTables for ControllerTask and ViewTask

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -46,7 +46,7 @@ class ControllerTask extends BakeTask {
  *
  * @var array
  */
-	public $skipTables = array('cake_sesions', 'i18n');
+	public $skipTables = array('cake_sessions', 'i18n');
 
 /**
  * Override initialize

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -42,6 +42,13 @@ class ControllerTask extends BakeTask {
 	public $path = null;
 
 /**
+ * Tables to skip when running all()
+ *
+ * @var array
+ */
+	public $skipTables = array('i18n');
+
+/**
  * Override initialize
  *
  * @return void
@@ -106,6 +113,9 @@ class ControllerTask extends BakeTask {
 		ClassRegistry::config('Model', array('ds' => $this->connection));
 		$unitTestExists = $this->_checkUnitTest();
 		foreach ($this->__tables as $table) {
+			if (in_array($table, $this->skipTables)) {
+				continue;
+			}
 			$model = $this->_modelName($table);
 			$controller = $this->_controllerName($model);
 			App::uses($model, 'Model');

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -46,7 +46,7 @@ class ControllerTask extends BakeTask {
  *
  * @var array
  */
-	public $skipTables = array('i18n');
+	public $skipTables = array('cake_sesions', 'i18n');
 
 /**
  * Override initialize

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -48,7 +48,7 @@ class ModelTask extends BakeTask {
  *
  * @var array
  */
-	public $skipTables = array('i18n');
+	public $skipTables = array('cake_sessions', 'i18n');
 
 /**
  * Holds tables found on connection.

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -75,7 +75,7 @@ class ViewTask extends BakeTask {
  *
  * @var array
  */
-	public $skipTables = array('i18n');
+	public $skipTables = array('cake_sessions', 'i18n');
 
 /**
  * Override initialize

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -71,6 +71,13 @@ class ViewTask extends BakeTask {
 	public $noTemplateActions = array('delete');
 
 /**
+ * Tables to skip when running all()
+ *
+ * @var array
+ */
+	public $skipTables = array('i18n');
+
+/**
  * Override initialize
  *
  * @return void
@@ -174,6 +181,9 @@ class ViewTask extends BakeTask {
 		}
 		$this->interactive = false;
 		foreach ($tables as $table) {
+			if (in_array($table, $this->skipTables)) {
+				continue;
+			}
 			$model = $this->_modelName($table);
 			$this->controllerName = $this->_controllerName($model);
 			App::uses($model, 'Model');


### PR DESCRIPTION
Add skipTables from ModelTask to ControllerTask and ViewTask so that `cake bake controller all` and `cake bake view all` will not fail when i18n table exists
