### PR TITLE
Always set ControllerTestCase::testAction result variables

### DIFF
--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -263,12 +263,10 @@ abstract class ControllerTestCase extends CakeTestCase {
 		$Dispatch->response = $this->getMock('CakeResponse', array('send'));
 		$this->result = $Dispatch->dispatch($request, $Dispatch->response, $params);
 		$this->controller = $Dispatch->testController;
-		if ($options['return'] != 'result') {
-			if (isset($this->controller->View)) {
-				$this->vars = $this->controller->View->viewVars;
-				$this->view = $this->controller->View->_viewNoLayout;
-			}
-			$this->contents = $this->controller->response->body();
+		$this->vars = $this->controller->viewVars;
+		$this->contents = $this->controller->response->body();
+		if (isset($this->controller->View)) {
+			$this->view = $this->controller->View->_viewNoLayout;
 		}
 		$this->__dirtyController = true;
 		$this->headers = $Dispatch->response->header();


### PR DESCRIPTION
Is there any reason why `vars`, `contents` and `view` should not be set when the `return` type is `result`? This change doesn't break any of the existing tests but makes it more convenient when using testAction().

Also `$this->controller->viewVars` appears to be a more reliable way to get view vars than `$this->controller->View->viewVars`, which doesn't always appear to be set when testing.
