### PR TITLE
The patch for PHP5.4 and Built-in web server

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -73,6 +73,9 @@
 			define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 		}
 	}
+	if (php_sapi_name() == 'cli-server') {
+		$_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
+	}
 	if (!include(CORE_PATH . 'cake' . DS . 'bootstrap.php')) {
 		trigger_error("CakePHP core could not be found.  Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php.  It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
 	}

--- a/cake/bootstrap.php
+++ b/cake/bootstrap.php
@@ -25,7 +25,7 @@ if (!defined('PHP5')) {
 if (!defined('E_DEPRECATED')) {
 	define('E_DEPRECATED', 8192);
 }
-error_reporting(E_ALL & ~E_DEPRECATED);
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 require CORE_PATH . 'cake' . DS . 'basics.php';
 $TIME_START = getMicrotime();

--- a/cake/console/cake.php
+++ b/cake/console/cake.php
@@ -147,7 +147,7 @@ class ShellDispatcher {
 	function __initConstants() {
 		if (function_exists('ini_set')) {
 			ini_set('display_errors', '1');
-			ini_set('error_reporting', E_ALL & ~E_DEPRECATED);
+			ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_STRICT);
 			ini_set('html_errors', false);
 			ini_set('implicit_flush', true);
 			ini_set('max_execution_time', 0);

--- a/cake/console/templates/skel/webroot/index.php
+++ b/cake/console/templates/skel/webroot/index.php
@@ -73,6 +73,9 @@
 			define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 		}
 	}
+	if (php_sapi_name() == 'cli-server') {
+		$_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
+	}
 	if (!include(CORE_PATH . 'cake' . DS . 'bootstrap.php')) {
 		trigger_error("CakePHP core could not be found.  Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php.  It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
 	}

--- a/cake/tests/cases/libs/cake_log.test.php
+++ b/cake/tests/cases/libs/cake_log.test.php
@@ -166,7 +166,7 @@ class CakeLogTest extends CakeTestCase {
  */
 	function testLoggingWithErrorHandling() {
 		@unlink(LOGS . 'debug.log');
-		Configure::write('log', E_ALL & ~E_DEPRECATED);
+		Configure::write('log', E_ALL & ~E_DEPRECATED & ~E_STRICT);
 		Configure::write('debug', 0);
 
 		set_error_handler(array('CakeLog', 'handleError'));

--- a/cake/tests/cases/libs/configure.test.php
+++ b/cake/tests/cases/libs/configure.test.php
@@ -149,7 +149,7 @@ class ConfigureTest extends CakeTestCase {
 
 		Configure::write('debug', 2);
 		$result = ini_get('error_reporting');
-		$this->assertEqual($result, E_ALL & ~E_DEPRECATED);
+		$this->assertEqual($result, E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 		$result = ini_get('display_errors');
 		$this->assertEqual($result, 1);
@@ -177,7 +177,7 @@ class ConfigureTest extends CakeTestCase {
 		$this->assertEqual(ini_get('display_errors'), 0);
 
 		Configure::write('debug', 2);
-		$this->assertEqual(ini_get('error_reporting'), E_ALL & ~E_DEPRECATED);
+		$this->assertEqual(ini_get('error_reporting'), E_ALL & ~E_DEPRECATED & ~E_STRICT);
 		$this->assertEqual(ini_get('display_errors'), 1);
 
 		Configure::write('debug', 0);


### PR DESCRIPTION
- modify $_SERVER['PHP_SELF'] for runnning on built-in web server
- exclude E_STRICT from error_reporting(E_ALL)
