### PR TITLE
CakeSchemaTest: Skip testSchemaReadWithConfigPrefix test if an existing prefix has been set

### DIFF
--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -640,8 +640,11 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaReadWithConfigPrefix() {
 		$this->skipIf($this->db instanceof Sqlite, 'Cannot open 2 connections to Sqlite');
+		
 		$db = ConnectionManager::getDataSource('test');
 		$config = $db->config;
+		$this->skipIf(!empty($config['prefix']), 'This test can not be executed with datasource prefix set.');
+		
 		$config['prefix'] = 'schema_test_prefix_';
 		ConnectionManager::create('schema_prefix', $config);
 		$read = $this->Schema->read(array('connection' => 'schema_prefix', 'models' => false));


### PR DESCRIPTION
I get 1 fail on the CakeSchema test if I have an existing prefix set on my test datasource. This will skip the test as done on with the other tests on prefixes.
