### PR TITLE
Fix CakeSession test cases

### DIFF
--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -382,7 +382,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testCheckKeyWithSpaces() {
 		$this->assertTrue(TestCakeSession::write('Session Test', "test"));
-		$this->assertEquals('test', TestCakeSession::check('Session Test'));
+		$this->assertTrue(TestCakeSession::check('Session Test'));
 		TestCakeSession::delete('Session Test');
 
 		$this->assertTrue(TestCakeSession::write('Session Test.Test Case', "test"));
@@ -526,6 +526,7 @@ class CakeSessionTest extends CakeTestCase {
 		App::build(array(
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
 		), true);
+		CakePlugin::load('TestPlugin');
 
 		Configure::write('Session', array(
 			'defaults' => 'cake',


### PR DESCRIPTION
In `testCheckKeyWithSpaces()` the test attempts to assertEquals 'test' when the `CakeSession::check` method only returns a boolean.

In `testUsingPluginHandler()` the method `TestCakeSession::destroy()` throws an exception because the plugin `TestPlugin` is not loaded.
