### PR TITLE
Consistently setting setUp() and tearDown() on test cases

### DIFF
--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -45,7 +45,7 @@ class FileEngineTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Configure/IniReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/IniReaderTest.php
@@ -32,8 +32,8 @@ class IniReaderTest extends CakeTestCase {
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		$this->path = CAKE . 'Test' . DS . 'test_app' . DS . 'Config'. DS;
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -37,11 +37,12 @@ class AclShellTest extends CakeTestCase {
 	public $fixtures = array('core.aco', 'core.aro', 'core.aros_aco');
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		Configure::write('Acl.database', 'test');
 		Configure::write('Acl.classname', 'DbAcl');
 

--- a/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
@@ -59,7 +59,7 @@ class BakeShellTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -60,7 +60,7 @@ class CommandListShellTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -97,7 +97,7 @@ class SchemaShellTest extends CakeTestCase {
 	);
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -64,6 +64,7 @@ class ControllerTaskTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('ControllerTask',
@@ -86,14 +87,15 @@ class ControllerTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Task);
 		ClassRegistry::flush();
 		App::build();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
@@ -31,7 +31,7 @@ App::uses('DbConfigTask', 'Console/Command/Task');
 class DbConfigTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -95,7 +95,7 @@ class ModelTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -36,7 +36,7 @@ App::uses('File', 'Utility');
 class PluginTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -35,7 +35,7 @@ App::uses('File', 'Utility');
 class ProjectTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
@@ -52,7 +52,7 @@ class ProjectTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -33,11 +33,11 @@ App::uses('TemplateTask', 'Console/Command/Task');
 class TemplateTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
 		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
@@ -49,7 +49,7 @@ class TemplateTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -220,12 +220,12 @@ class TestTaskTest extends CakeTestCase {
 	public $fixtures = array('core.article', 'core.comment', 'core.articles_tag', 'core.tag');
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 

--- a/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
@@ -38,7 +38,7 @@ class ConsoleErrorHandlerTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/TaskCollectionTest.php
+++ b/lib/Cake/Test/Case/Console/TaskCollectionTest.php
@@ -22,23 +22,25 @@ App::uses('Shell', 'Console');
 
 class TaskCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$shell = $this->getMock('Shell', array(), array(), '', false);
 		$dispatcher = $this->getMock('ShellDispatcher', array(), array(), '', false);
 		$this->Tasks = new TaskCollection($shell, $dispatcher);
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Tasks);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
@@ -26,7 +26,7 @@ App::uses('CakeResponse', 'Network');
 class ActionsAuthorizeTest extends CakeTestCase {
 
 /**
- * setup
+ * setUp
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -57,7 +57,7 @@ class BasicAuthenticateTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -59,7 +59,7 @@ class DigestAuthenticateTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
@@ -29,21 +29,23 @@ class CookieAliasComponent extends CookieComponent {
 
 class ComponentCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->Components = new ComponentCollection();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Components);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -381,19 +381,21 @@ class ControllerTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::objects('plugin', null, false);
 		App::build();
 		Router::reload();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		CakePlugin::unload();
 		App::build();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -29,12 +29,14 @@ App::uses('Router', 'Routing');
 class ErrorHandlerTest extends CakeTestCase {
 
 	public $_restoreError = false;
+
 /**
  * setup create a request object to get out of router later.
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::build(array(
 			'View' => array(
 				CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS
@@ -51,17 +53,18 @@ class ErrorHandlerTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		Configure::write('debug', $this->_debug);
 		Configure::write('Error', $this->_error);
 		App::build();
 		if ($this->_restoreError) {
 			restore_error_handler();
 		}
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -142,12 +142,14 @@ class MissingWidgetThingException extends NotFoundException { }
 class ExceptionRendererTest extends CakeTestCase {
 
 	public $_restoreError = false;
+
 /**
  * setup create a request object to get out of router later.
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::build(array(
 			'views' => array(
 				CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS
@@ -164,17 +166,18 @@ class ExceptionRendererTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		Configure::write('debug', $this->_debug);
 		Configure::write('Error', $this->_error);
 		App::build();
 		if ($this->_restoreError) {
 			restore_error_handler();
 		}
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -71,8 +71,8 @@ class CakeSessionTest extends CakeTestCase {
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		Configure::write('Session', array(
 			'defaults' => 'php',
 			'cookie' => 'cakephp',

--- a/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
@@ -63,7 +63,7 @@ class CacheSessionTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -66,22 +66,24 @@ class DatabaseSessionTest extends CakeTestCase {
 	}
 
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->storage = new DatabaseSession();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->storage);
 		ClassRegistry::flush();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -131,7 +131,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/TestSuite/HtmlCoverageReportTest.php
+++ b/lib/Cake/Test/Case/TestSuite/HtmlCoverageReportTest.php
@@ -22,7 +22,7 @@ App::uses('CakeBaseReporter', 'TestSuite/Reporter');
 
 class HtmlCoverageReportTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
@@ -220,12 +220,13 @@ class HtmlCoverageReportTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
 	public function tearDown() {
 		CakePlugin::unload();
 		unset($this->Coverage);
+		parent::tearDown();
 	}
 }

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -44,7 +44,7 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		Configure::write('debug', 2);
 		Configure::write('log', false);
 	}
@@ -55,7 +55,7 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function tearDown() {
-		parent::teardown();
+		parent::tearDown();
 		Configure::write('log', true);
 		if ($this->_restoreError) {
 			restore_error_handler();

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -45,12 +45,12 @@ class FileTest extends CakeTestCase {
 	}
 
 /**
- * tear down for test.
+ * tearDown method
  *
  * @return void
  */
-	public function teardown() {
-		parent::teardown();
+	public function tearDown() {
+		parent::tearDown();
 		$this->File->close();
 		unset($this->File);
 	}

--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -34,7 +34,7 @@ App::uses('Inflector', 'Utility');
 class InflectorTest extends CakeTestCase {
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -73,21 +73,23 @@ class GenericObjectCollection extends ObjectCollection {
 
 class ObjectCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->Objects = new GenericObjectCollection();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Objects);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -90,12 +90,12 @@ class TestDeValidation {
 class ValidationTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		$this->_appEncoding = Configure::read('App.encoding');
 	}
 

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -91,12 +91,12 @@ class XmlTest extends CakeTestCase {
 	);
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		$this->_appEncoding = Configure::read('App.encoding');
 		Configure::write('App.encoding', 'UTF-8');
 	}

--- a/lib/Cake/Test/Case/View/HelperCollectionTest.php
+++ b/lib/Cake/Test/Case/View/HelperCollectionTest.php
@@ -29,23 +29,25 @@ class HtmlAliasHelper extends HtmlHelper {
 
 class HelperCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->View = $this->getMock('View', array(), array(null));
 		$this->Helpers = new HelperCollection($this->View);
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		CakePlugin::unload();
 		unset($this->Helpers, $this->View);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -96,7 +96,7 @@ class ScaffoldViewTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */


### PR DESCRIPTION
Making sure the casing on `setUp()` and `tearDown()` are consistent across the test cases. Also adding the calls to parents where they are missing.
