### PR TITLE
Solving the small defect in the array of behaviors(actsAs)

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -675,7 +675,7 @@ class Model extends Object {
 		}
 
 		if (is_subclass_of($this, 'AppModel')) {
-			$merge = array('actsAs','findMethods');
+			$merge = array('actsAs', 'findMethods');
 			$parentClass = get_parent_class($this);
 			if ($parentClass !== 'AppModel') {
 				$this->_mergeVars($merge, $parentClass);

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -676,7 +676,8 @@ class Model extends Object {
 
 		if (is_subclass_of($this, 'AppModel')) {
 			$merge = array('findMethods');
-			if ($this->actsAs !== null || $this->actsAs !== false) {
+			#if (!empty($this->actsAs)) { //Another possible solution
+			if ($this->actsAs !== null && $this->actsAs !== false) {
 				$merge[] = 'actsAs';
 			}
 			$parentClass = get_parent_class($this);

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -675,11 +675,7 @@ class Model extends Object {
 		}
 
 		if (is_subclass_of($this, 'AppModel')) {
-			$merge = array('findMethods');
-			#if (!empty($this->actsAs)) { //Another possible solution
-			if ($this->actsAs !== null && $this->actsAs !== false) {
-				$merge[] = 'actsAs';
-			}
+			$merge = array('actsAs','findMethods');
 			$parentClass = get_parent_class($this);
 			if ($parentClass !== 'AppModel') {
 				$this->_mergeVars($merge, $parentClass);


### PR DESCRIPTION
Reviewing the code I found a comparison that is always true:

``` php
<?php
    if ($this->actsAs !== null || $this->actsAs !== false)
```

I [commented](https://github.com/cakephp/cakephp/commit/15753ab6416bdc679aa48079cfd640819d61e668#commitcomment-732091) a few days , I thought some solutions pusibles:

The first is to change the logical comparator.

``` php
<?php
    if ($this->actsAs !== null && $this->actsAs !== false)
```

When thinking why does not generate any errors when testing, check the `Object::_mergeVars`, Another solution that comes to mind is to check that the element is not empty:

``` php
<?php
    if (!empty($this->actsAs))
```

Finally, if the condition is always true, we can avoid the `if` starting the array of `merge`:

``` php
<?php
    $merge = array('findMethods','actsAs');
    /*if ($this->actsAs !== null || $this->actsAs !== false) {
            $merge[] = 'actsAs';
    }*/
```

I honestly do not know which is the ideal solution.

> p.s. That makes a request while where I'm wrong, sorry.
