### PR TITLE
Removed 'type' => 'submit' by default for FormHelper::button()

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -5747,7 +5747,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testButton() {
 		$result = $this->Form->button('Hi');
-		$this->assertTags($result, array('button' => array('type' => 'submit'), 'Hi', '/button'));
+		$this->assertTags($result, array('button', 'Hi', '/button'));
 
 		$result = $this->Form->button('Clear Form >', array('type' => 'reset'));
 		$this->assertTags($result, array('button' => array('type' => 'reset'), 'Clear Form >', '/button'));

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1450,8 +1450,7 @@ class FormHelper extends AppHelper {
 	}
 
 /**
- * Creates a `<button>` tag.  The type attribute defaults to `type="submit"`
- * You can change it to a different value by using `$options['type']`.
+ * Creates a `<button>` tag.
  *
  * ### Options:
  *

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1491,6 +1491,7 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postButton
  */
 	public function postButton($title, $url, $options = array()) {
+		$options = array_merge(array('type' => 'submit'), $options);
 		$out = $this->create(false, array('id' => false, 'url' => $url, 'style' => 'display:none;'));
 		if (isset($options['data']) && is_array($options['data'])) {
 			foreach ($options['data'] as $key => $value) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1462,7 +1462,7 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::button
  */
 	public function button($title, $options = array()) {
-		$options += array('type' => 'submit', 'escape' => false, 'secure' => false);
+		$options += array('escape' => false, 'secure' => false);
 		if ($options['escape']) {
 			$title = h($title);
 		}


### PR DESCRIPTION
Why? Because:
- The type attribute is not required for buttons, so there's no real reason to include
- 'Submit' is a very unsafe default behavior. When people **don't** explicitly wish to use submit buttons, such as for cancel, expand, js-related, etc, submitting the form is not something people will want to override. Especially because of the first point.
- Follow the rule of design to expectation. The button should do what people expect it to. If no type is set, don't add one.
- **When calling `$this->Form->input('Call JS', array('type' => 'button'))` the type is always 'submit' and cannot be changed.** This is the main reason for this fix. Since type is already passed (to `input()`) it is impossible to correct this behavior.
