### PR TITLE
Removed 'type' => 'submit' by default for FormHelper::button()

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -200,6 +200,7 @@
  * timestamping regardless of debug value.
  */
 	//Configure::write('Asset.timestamp', true);
+
 /**
  * Compress CSS output by removing comments, whitespace, repeating tags, etc.
  * This requires a/var/cache directory to be writable by the web server for caching.

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -374,6 +374,7 @@ class Cache {
 		self::set(null, $config);
 		return $success;
 	}
+
 /**
  * Decrement a number under the key and return decremented value.
  *
@@ -401,6 +402,7 @@ class Cache {
 		self::set(null, $config);
 		return $success;
 	}
+
 /**
  * Delete a key from the cache.
  *

--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -110,6 +110,7 @@ class XcacheEngine extends CacheEngine {
 	public function decrement($key, $offset = 1) {
 		return xcache_dec($key, $offset);
 	}
+
 /**
  * Delete a key from the cache
  *

--- a/lib/Cake/Console/Command/ApiShell.php
+++ b/lib/Cake/Console/Command/ApiShell.php
@@ -151,6 +151,7 @@ class ApiShell extends AppShell {
 		))->description(__d('cake_console', 'Lookup doc block comments for classes in CakePHP.'));
 		return $parser;
 	}
+
 /**
  * Show help for this shell.
  *

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -101,10 +101,12 @@ class ModelTask extends BakeTask {
 				return $this->all();
 			}
 			$model = $this->_modelName($this->args[0]);
-			$object = $this->_getModelObject($model);
+			$this->listAll($this->connection);
+			$useTable = $this->getTable($model);
+			$object = $this->_getModelObject($model, $useTable);
 			if ($this->bake($object, false)) {
 				if ($this->_checkUnitTest()) {
-					$this->bakeFixture($model);
+					$this->bakeFixture($model, $useTable);
 					$this->bakeTest($model);
 				}
 			}
@@ -797,12 +799,14 @@ class ModelTask extends BakeTask {
 	public function listAll($useDbConfig = null) {
 		$this->_tables = $this->getAllTables($useDbConfig);
 
+		$this->_modelNames = array();
+		$count = count($this->_tables);
+		for ($i = 0; $i < $count; $i++) {
+			$this->_modelNames[] = $this->_modelName($this->_tables[$i]);
+		}
 		if ($this->interactive === true) {
 			$this->out(__d('cake_console', 'Possible Models based on your current database:'));
-			$this->_modelNames = array();
-			$count = count($this->_tables);
 			for ($i = 0; $i < $count; $i++) {
-				$this->_modelNames[] = $this->_modelName($this->_tables[$i]);
 				$this->out($i + 1 . ". " . $this->_modelNames[$i]);
 			}
 		}
@@ -817,26 +821,27 @@ class ModelTask extends BakeTask {
  * @return string Table name
  */
 	public function getTable($modelName, $useDbConfig = null) {
-		if (!isset($useDbConfig)) {
-			$useDbConfig = $this->connection;
-		}
-
-		$db = ConnectionManager::getDataSource($useDbConfig);
 		$useTable = Inflector::tableize($modelName);
 		if (in_array($modelName, $this->_modelNames)) {
 			$modelNames = array_flip($this->_modelNames);
 			$useTable = $this->_tables[$modelNames[$modelName]];
 		}
-		$fullTableName = $db->fullTableName($useTable, false);
-		$tableIsGood = false;
 
-		if (array_search($useTable, $this->_tables) === false) {
-			$this->out();
-			$this->out(__d('cake_console', "Given your model named '%s',\nCake would expect a database table named '%s'", $modelName, $fullTableName));
-			$tableIsGood = $this->in(__d('cake_console', 'Do you want to use this table?'), array('y', 'n'), 'y');
-		}
-		if (strtolower($tableIsGood) == 'n') {
-			$useTable = $this->in(__d('cake_console', 'What is the name of the table?'));
+		if ($this->interactive === true) {
+			if (!isset($useDbConfig)) {
+				$useDbConfig = $this->connection;
+			}
+			$db = ConnectionManager::getDataSource($useDbConfig);
+			$fullTableName = $db->fullTableName($useTable, false);
+			$tableIsGood = false;
+			if (array_search($useTable, $this->_tables) === false) {
+				$this->out();
+				$this->out(__d('cake_console', "Given your model named '%s',\nCake would expect a database table named '%s'", $modelName, $fullTableName));
+				$tableIsGood = $this->in(__d('cake_console', 'Do you want to use this table?'), array('y', 'n'), 'y');
+			}
+			if (strtolower($tableIsGood) == 'n') {
+				$useTable = $this->in(__d('cake_console', 'What is the name of the table?'));
+			}
 		}
 		return $useTable;
 	}

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -288,9 +288,7 @@ class ProjectTask extends AppShell {
 		$File = new File($path . 'Config' . DS . 'core.php');
 		$contents = $File->read();
 		if (preg_match('/([\s]*Configure::write\(\'Security.cipherSeed\',[\s\'A-z0-9]*\);)/', $contents, $match)) {
-			if (!class_exists('Security')) {
-				require CAKE . 'Utility' . DS . 'security.php';
-			}
+			App::uses('Security', 'Utility');
 			$string = substr(bin2hex(Security::generateAuthKey()), 0, 30);
 			$result = str_replace($match[0], "\t" . 'Configure::write(\'Security.cipherSeed\', \''.$string.'\');', $contents);
 			if ($File->write($result)) {

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -554,6 +554,7 @@ class UpgradeShell extends AppShell {
 		);
 		$this->_filesRegexpUpdate($patterns);
 	}
+
 /**
  * Move application views files to where they now should be
  *

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -716,10 +716,10 @@ class Shell extends Object {
 	}
 
 /**
- * Creates the proper controller camelized name (singularized) for the specified name
+ * Creates the proper model camelized name (singularized) for the specified name
  *
  * @param string $name Name
- * @return string Camelized and singularized controller name
+ * @return string Camelized and singularized model name
  */
 	protected function _modelName($name) {
 		return Inflector::camelize(Inflector::singularize($name));

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -200,6 +200,7 @@
  * timestamping regardless of debug value.
  */
 	//Configure::write('Asset.timestamp', true);
+
 /**
  * Compress CSS output by removing comments, whitespace, repeating tags, etc.
  * This requires a/var/cache directory to be writable by the web server for caching.

--- a/lib/Cake/Console/Templates/skel/webroot/css/cake.generic.css
+++ b/lib/Cake/Console/Templates/skel/webroot/css/cake.generic.css
@@ -365,6 +365,7 @@ form .submit input[type=submit] {
 form .submit input[type=submit]:hover {
 	background: #5BA150;
 }
+
 /* Form errors */
 form .error {
 	background: #FFDACC;
@@ -646,6 +647,7 @@ pre {
 	overflow: auto;
 	text-shadow: none;
 }
+
 /* excerpt */
 .cake-code-dump pre,
 .cake-code-dump pre code {

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -24,6 +24,7 @@
 	if (!defined('DS')) {
 		define('DS', DIRECTORY_SEPARATOR);
 	}
+
 /**
  * These defines should only be edited if you have cake installed in
  * a directory layout other than the way it is distributed.
@@ -37,6 +38,7 @@
 	if (!defined('ROOT')) {
 		define('ROOT', dirname(dirname(dirname(__FILE__))));
 	}
+
 /**
  * The actual directory name for the "app".
  *

--- a/lib/Cake/Console/Templates/skel/webroot/test.php
+++ b/lib/Cake/Console/Templates/skel/webroot/test.php
@@ -24,6 +24,7 @@ ini_set('display_errors', 1);
 	if (!defined('DS')) {
 		define('DS', DIRECTORY_SEPARATOR);
 	}
+
 /**
  * These defines should only be edited if you have cake installed in
  * a directory layout other than the way it is distributed.
@@ -37,6 +38,7 @@ ini_set('display_errors', 1);
 	if (!defined('ROOT')) {
 		define('ROOT', dirname(dirname(dirname(__FILE__))));
 	}
+
 /**
  * The actual directory name for the "app".
  *

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -100,6 +100,7 @@ class DigestAuthenticate extends BaseAuthenticate {
 			$this->settings['opaque'] = md5($this->settings['realm']);
 		}
 	}
+
 /**
  * Authenticate a user using Digest HTTP auth.  Will use the configured User model and attempt a
  * login using Digest HTTP auth.
@@ -142,6 +143,7 @@ class DigestAuthenticate extends BaseAuthenticate {
 		}
 		return false;
 	}
+
 /**
  * Find a user record using the standard options.
  *

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -152,9 +152,7 @@ class Object {
  * @return boolean Success of log write
  */
 	public function log($msg, $type = LOG_ERROR) {
-		if (!class_exists('CakeLog')) {
-			require CAKE . 'cake_log.php';
-		}
+		App::uses('CakeLog', 'Log');
 		if (!is_string($msg)) {
 			$msg = print_r($msg, true);
 		}

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -222,7 +222,7 @@ class ExceptionRenderer {
 	public function error500($error) {
 		$message = $error->getMessage();
 		if (Configure::read('debug') == 0) {
-			$message = __d('cake', 'An Internal Error Has Occurred');
+			$message = __d('cake', 'An Internal Error Has Occurred.');
 		}
 		$url = $this->controller->request->here();
 		$code = ($error->getCode() > 500 && $error->getCode() < 506) ? $error->getCode() : 500;

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -226,6 +226,7 @@ class MissingActionException extends CakeException {
 		parent::__construct($message, $code);
 	}
 }
+
 /**
  * Private Action exception - used when a controller action
  * starts with a  `_`.

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -247,7 +247,12 @@ class CakeSchema extends Object {
 					continue;
 				}
 
-				$Object = ClassRegistry::init(array('class' => $model, 'ds' => $connection));
+				try {
+					$Object = ClassRegistry::init(array('class' => $model, 'ds' => $connection));
+				} catch (CakeException $e) {
+					continue;
+				}
+
 				$db = $Object->getDataSource();
 				if (is_object($Object) && $Object->useTable !== false) {
 					$fulltable = $table = $db->fullTableName($Object, false);

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -585,6 +585,7 @@ class Sqlserver extends DboSource {
 				return parent::value($data, $column);
 		}
 	}
+
 /**
  * Returns an array of all result rows for a given SQL query.
  * Returns false if no rows matched.
@@ -742,6 +743,7 @@ class Sqlserver extends DboSource {
 		}
 		return $affected;
 	}
+
 /**
  * Executes given SQL statement.
  *

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1184,12 +1184,14 @@ class Model extends Object {
 				}
 			}
 
-			$format = $this->getDataSource()->columns[$type]['format'];
-			$day = empty($date['Y']) ? null : $date['Y'] . '-' . $date['m'] . '-' . $date['d'] . ' ';
-			$hour = empty($date['H']) ? null : $date['H'] . ':' . $date['i'] . ':' . $date['s'];
-			$date = new DateTime($day . $hour);
 			if ($useNewDate && !empty($date)) {
-				return $date->format($format);
+				$format = $this->getDataSource()->columns[$type]['format'];
+				foreach (array('m', 'd', 'H', 'i', 's') as $index) {
+					if (isset($date[$index])) {
+						$date[$index] = sprintf('%02d', $date[$index]);
+					}
+				}
+				return str_replace(array_keys($date), array_values($date), $format);
 			}
 		}
 		return $data;

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -701,6 +701,11 @@ class Model extends Object {
 		} elseif ($this->table === false) {
 			$this->table = Inflector::tableize($this->name);
 		}
+
+		if ($this->tablePrefix === null) {
+			unset($this->tablePrefix);
+		}
+
 		$this->_createLinks();
 		$this->Behaviors->init($this->alias, $this->actsAs);
 	}
@@ -799,6 +804,13 @@ class Model extends Object {
 	public function __get($name) {
 		if ($name === 'displayField') {
 			return $this->displayField = $this->hasField(array('title', 'name', $this->primaryKey));
+		}
+		if ($name === 'tablePrefix') {
+			$this->setDataSource();
+			if (property_exists($this, 'tablePrefix')) {
+				return $this->tablePrefix;
+			}
+			return $this->tablePrefix = null;
 		}
 		if (isset($this->{$name})) {
 			return $this->{$name};

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3075,6 +3075,7 @@ class Model extends Object {
 		}
 		return $valid;
 	}
+
 /**
  * Marks a field as invalid, optionally setting the name of validation
  * rule (in case of multiple validation for field) that was broken.

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -157,7 +157,30 @@ class HttpSocket extends CakeSocket {
 	}
 
 /**
- * Set authentication settings
+ * Set authentication settings.
+ *
+ * Accepts two forms of parameters.  If all you need is a username + password, as with
+ * Basic authentication you can do the following:
+ *
+ * {{{
+ * $http->configAuth('Basic', 'mark', 'secret');
+ * }}}
+ *
+ * If you are using an authentication strategy that requires more inputs, like Digest authentication
+ * you can call `configAuth()` with an array of user information.
+ *
+ * {{{
+ * $http->configAuth('Digest', array(
+ *		'user' => 'mark',
+ *		'pass' => 'secret',
+ *		'realm' => 'my-realm',
+ *		'nonce' => 1235
+ * ));
+ * }}}
+ *
+ * To remove any set authentication strategy, call `configAuth()` with no parameters:
+ *
+ * `$http->configAuth();`
  *
  * @param string $method Authentication method (ie. Basic, Digest). If empty, disable authentication
  * @param mixed $user Username for authentication. Can be an array with settings to authentication class

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -296,17 +296,17 @@ class HttpSocket extends CakeSocket {
 			if (!empty($this->request['cookies'])) {
 				$cookies = $this->buildCookies($this->request['cookies']);
 			}
-			$schema = '';
+			$scheme = '';
 			$port = 0;
-			if (isset($this->request['uri']['schema'])) {
-				$schema = $this->request['uri']['schema'];
+			if (isset($this->request['uri']['scheme'])) {
+				$scheme = $this->request['uri']['scheme'];
 			}
 			if (isset($this->request['uri']['port'])) {
 				$port = $this->request['uri']['port'];
 			}
 			if (
-				($schema === 'http' && $port != 80) ||
-				($schema === 'https' && $port != 443) ||
+				($scheme === 'http' && $port != 80) ||
+				($scheme === 'https' && $port != 443) ||
 				($port != 80 && $port != 443)
 			) {
 				$Host .= ':' . $port;

--- a/lib/Cake/Routing/Route/PluginShortRoute.php
+++ b/lib/Cake/Routing/Route/PluginShortRoute.php
@@ -1,5 +1,4 @@
 <?php
-App::uses('CakeRoute', 'Routing/Route');
 /**
  * Plugin short route, that copies the plugin param to the controller parameters
  * It is used for supporting /:plugin routes.
@@ -17,6 +16,13 @@ App::uses('CakeRoute', 'Routing/Route');
  * @package       Cake.Routing.Route
  * @since         CakePHP(tm) v 1.3
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+App::uses('CakeRoute', 'Routing/Route');
+
+/**
+ * Plugin Short Route class
+ * 
+ * @package Cake.Routing.Route
  */
 class PluginShortRoute extends CakeRoute {
 

--- a/lib/Cake/Routing/Route/PluginShortRoute.php
+++ b/lib/Cake/Routing/Route/PluginShortRoute.php
@@ -1,10 +1,5 @@
 <?php
 /**
- * Plugin short route, that copies the plugin param to the controller parameters
- * It is used for supporting /:plugin routes.
- *
- * PHP5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,21 +8,21 @@
  *
  * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Routing.Route
  * @since         CakePHP(tm) v 1.3
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 App::uses('CakeRoute', 'Routing/Route');
 
 /**
- * Plugin Short Route class
- * 
+ * Plugin short route, that copies the plugin param to the controller parameters
+ * It is used for supporting /:plugin routes.
+ *
  * @package Cake.Routing.Route
  */
 class PluginShortRoute extends CakeRoute {
 
 /**
- * Parses a string url into an array.  If a plugin key is found, it will be copied to the
+ * Parses a string url into an array. If a plugin key is found, it will be copied to the
  * controller parameter
  *
  * @param string $url The url to parse
@@ -43,7 +38,7 @@ class PluginShortRoute extends CakeRoute {
 	}
 
 /**
- * Reverse route plugin shortcut urls.  If the plugin and controller
+ * Reverse route plugin shortcut urls. If the plugin and controller
  * are not the same the match is an auto fail.
  *
  * @param array $url Array of parameters to convert to a string.

--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -1,7 +1,4 @@
 <?php
-App::uses('CakeResponse', 'Network');
-App::uses('CakeRoute', 'Routing/Route');
-
 /**
  * Redirect route will perform an immediate redirect.  Redirect routes
  * are useful when you want to have Routing layer redirects occur in your
@@ -20,6 +17,14 @@ App::uses('CakeRoute', 'Routing/Route');
  * @package       Cake.Routing.Route
  * @since         CakePHP(tm) v 2.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+App::uses('CakeResponse', 'Network');
+App::uses('CakeRoute', 'Routing/Route');
+
+/**
+ * Redirect Route class
+ *
+ * @package Cake.Routing.Route
  */
 class RedirectRoute extends CakeRoute {
 

--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -1,11 +1,5 @@
 <?php
 /**
- * Redirect route will perform an immediate redirect.  Redirect routes
- * are useful when you want to have Routing layer redirects occur in your
- * application, for when URLs move.
- *
- * PHP5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -22,7 +16,9 @@ App::uses('CakeResponse', 'Network');
 App::uses('CakeRoute', 'Routing/Route');
 
 /**
- * Redirect Route class
+ * Redirect route will perform an immediate redirect. Redirect routes
+ * are useful when you want to have Routing layer redirects occur in your
+ * application, for when URLs move.
  *
  * @package Cake.Routing.Route
  */
@@ -36,7 +32,7 @@ class RedirectRoute extends CakeRoute {
 	public $response = null;
 
 /**
- * The location to redirect to.  Either a string or a cake array url.
+ * The location to redirect to. Either a string or a cake array url.
  *
  * @var mixed
  */
@@ -105,7 +101,7 @@ class RedirectRoute extends CakeRoute {
 	}
 
 /**
- * Stop execution of the current script.  Wraps exit() making
+ * Stop execution of the current script. Wraps exit() making
  * testing easier.
  *
  * @param integer|string $status see http://php.net/exit for values

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -80,6 +80,7 @@ class BasicsTest extends CakeTestCase {
 		$this->assertEquals($result, array());
 
 	}
+
 /**
  * testHttpBase method
  *

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -45,7 +45,7 @@ class FileEngineTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -364,6 +364,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		Cache::clear(false, 'memcache2');
 	}
+
 /**
  * test that a 0 duration can succesfully write.
  *

--- a/lib/Cake/Test/Case/Configure/IniReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/IniReaderTest.php
@@ -32,8 +32,8 @@ class IniReaderTest extends CakeTestCase {
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		$this->path = CAKE . 'Test' . DS . 'test_app' . DS . 'Config'. DS;
 	}
 

--- a/lib/Cake/Test/Case/Configure/PhpReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/PhpReaderTest.php
@@ -28,6 +28,7 @@ class PhpReaderTest extends CakeTestCase {
 		parent::setUp();
 		$this->path = CAKE . 'Test' . DS . 'test_app' . DS . 'Config'. DS;
 	}
+
 /**
  * test reading files
  *

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -37,11 +37,12 @@ class AclShellTest extends CakeTestCase {
 	public $fixtures = array('core.aco', 'core.aro', 'core.aros_aco');
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		Configure::write('Acl.database', 'test');
 		Configure::write('Acl.classname', 'DbAcl');
 

--- a/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
@@ -59,7 +59,7 @@ class BakeShellTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -60,7 +60,7 @@ class CommandListShellTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -97,7 +97,7 @@ class SchemaShellTest extends CakeTestCase {
 	);
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -64,6 +64,7 @@ class ControllerTaskTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('ControllerTask',
@@ -86,14 +87,15 @@ class ControllerTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Task);
 		ClassRegistry::flush();
 		App::build();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
@@ -31,7 +31,7 @@ App::uses('DbConfigTask', 'Console/Command/Task');
 class DbConfigTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -95,7 +95,7 @@ class ModelTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -205,7 +205,7 @@ class ModelTaskTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testGetTableOddTable() {
+	public function testGetTableOddTableInteractive() {
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('ModelTask',
@@ -229,6 +229,34 @@ class ModelTaskTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Task->getTable($result);
+		$expected = 'bake_odd';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test getTable with non-conventional tablenames
+ *
+ * @return void
+ */
+	public function testGetTableOddTable() {
+		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
+		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
+		$this->Task = $this->getMock('ModelTask',
+			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables'),
+			array($out, $out, $in)
+		);
+		$this->_setupOtherMocks();
+
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->interactive = false;
+		$this->Task->args = array('BakeOdd');
+
+		$this->Task->expects($this->once())->method('getAllTables')->will($this->returnValue(array('articles', 'bake_odd')));
+
+		$this->Task->listAll();
+
+		$result = $this->Task->getTable('BakeOdd');
 		$expected = 'bake_odd';
 		$this->assertEquals($expected, $result);
 	}
@@ -954,6 +982,61 @@ STRINGEND;
 		$this->Task->args = array('all');
 		$this->Task->expects($this->once())->method('_checkUnitTest')->will($this->returnValue(true));
 		$this->Task->expects($this->once())->method('getAllTables')->will($this->returnValue(array('bake_odd')));
+		$object = new Model(array('name' => 'BakeOdd', 'table' => 'bake_odd', 'ds' => 'test'));
+		$this->Task->expects($this->once())->method('_getModelObject')->will($this->returnValue($object));
+		$this->Task->expects($this->once())->method('doAssociations')->will($this->returnValue(array()));
+		$this->Task->expects($this->once())->method('doValidation')->will($this->returnValue(array()));
+
+		$filename = '/my/path/BakeOdd.php';
+		$this->Task->expects($this->once())->method('createFile')
+			->with($filename, $this->stringContains('class BakeOdd'));
+
+		$filename = '/my/path/BakeOdd.php';
+		$this->Task->expects($this->once())->method('createFile')
+			->with($filename, $this->stringContains('public $useTable = \'bake_odd\''));
+
+		$this->Task->execute();
+	}
+
+/**
+ * test that odd tablenames arent inflected back from modelname
+ *
+ * @return void
+ */
+    public function testExecuteIntoBakeOddTables() {
+		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
+		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
+		$this->Task = $this->getMock('ModelTask',
+			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'bake', 'bakeFixture'),
+			array($out, $out, $in)
+		);
+		$this->_setupOtherMocks();
+
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->args = array('BakeOdd');
+		$this->Task->expects($this->once())->method('_checkUnitTest')->will($this->returnValue(true));
+		$this->Task->expects($this->once())->method('getAllTables')->will($this->returnValue(array('articles', 'bake_odd')));
+		$object = new Model(array('name' => 'BakeOdd', 'table' => 'bake_odd', 'ds' => 'test'));
+		$this->Task->expects($this->once())->method('_getModelObject')->with('BakeOdd', 'bake_odd')->will($this->returnValue($object));
+		$this->Task->expects($this->once())->method('bake')->with($object, false)->will($this->returnValue(true));
+		$this->Task->expects($this->once())->method('bakeFixture')->with('BakeOdd', 'bake_odd');
+
+		$this->Task->execute();
+
+		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
+		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
+		$this->Task = $this->getMock('ModelTask',
+			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'doAssociations', 'doValidation', 'createFile'),
+			array($out, $out, $in)
+		);
+		$this->_setupOtherMocks();
+
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->args = array('BakeOdd');
+		$this->Task->expects($this->once())->method('_checkUnitTest')->will($this->returnValue(true));
+		$this->Task->expects($this->once())->method('getAllTables')->will($this->returnValue(array('articles', 'bake_odd')));
 		$object = new Model(array('name' => 'BakeOdd', 'table' => 'bake_odd', 'ds' => 'test'));
 		$this->Task->expects($this->once())->method('_getModelObject')->will($this->returnValue($object));
 		$this->Task->expects($this->once())->method('doAssociations')->will($this->returnValue(array()));

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -36,7 +36,7 @@ App::uses('File', 'Utility');
 class PluginTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -35,7 +35,7 @@ App::uses('File', 'Utility');
 class ProjectTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
@@ -52,7 +52,7 @@ class ProjectTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -33,11 +33,11 @@ App::uses('TemplateTask', 'Console/Command/Task');
 class TemplateTaskTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
 		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
@@ -49,7 +49,7 @@ class TemplateTaskTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -19,12 +19,12 @@
  * @since         CakePHP(tm) v 1.3
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-
 App::uses('ShellDispatcher', 'Console');
 App::uses('ConsoleOutput', 'Console');
 App::uses('ConsoleInput', 'Console');
 App::uses('Shell', 'Console');
 App::uses('TemplateTask', 'Console/Command/Task');
+
 /**
  * TemplateTaskTest class
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -220,12 +220,12 @@ class TestTaskTest extends CakeTestCase {
 	public $fixtures = array('core.article', 'core.comment', 'core.articles_tag', 'core.tag');
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 

--- a/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
@@ -38,7 +38,7 @@ class ConsoleErrorHandlerTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/TaskCollectionTest.php
+++ b/lib/Cake/Test/Case/Console/TaskCollectionTest.php
@@ -71,6 +71,7 @@ class TaskCollectionTest extends CakeTestCase {
 
 		$this->assertFalse($this->Tasks->enabled('DbConfig'), 'DbConfigTask should be disabled');
 	}
+
 /**
  * test missingtask exception
  *

--- a/lib/Cake/Test/Case/Console/TaskCollectionTest.php
+++ b/lib/Cake/Test/Case/Console/TaskCollectionTest.php
@@ -22,23 +22,25 @@ App::uses('Shell', 'Console');
 
 class TaskCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$shell = $this->getMock('Shell', array(), array(), '', false);
 		$dispatcher = $this->getMock('ShellDispatcher', array(), array(), '', false);
 		$this->Tasks = new TaskCollection($shell, $dispatcher);
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Tasks);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
@@ -26,7 +26,7 @@ App::uses('CakeResponse', 'Network');
 class ActionsAuthorizeTest extends CakeTestCase {
 
 /**
- * setup
+ * setUp
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -57,7 +57,7 @@ class BasicAuthenticateTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -163,6 +163,7 @@ class BasicAuthenticateTest extends CakeTestCase {
 		$result = $this->auth->authenticate($request, $this->response);
 		$this->assertFalse($result);
 	}
+
 /**
  * test authenticate sucesss
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -59,7 +59,7 @@ class DigestAuthenticateTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -499,6 +499,7 @@ class CookieComponentTest extends CakeTestCase {
 		$this->assertNull($this->Cookie->read('User.email'));
 		$this->Cookie->destroy();
 	}
+
 /**
  * Test deleting recursively with keys that don't exist.
  *

--- a/lib/Cake/Test/Case/Controller/Component/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/DbAclTest.php
@@ -470,6 +470,7 @@ class DbAclTest extends CakeTestCase {
 
 		$this->Acl->deny('Bobs', 'ROOT/printers/DoesNotExist', 'create');
 	}
+
 /**
  * debug function - to help editing/creating test cases for the ACL component
  *

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -45,6 +45,7 @@ class RequestHandlerTestController extends Controller {
 		$this->viewPath = 'Posts';
 		$this->render('index');
 	}
+
 /**
  * test method for ajax redirection + parameter parsing
  *

--- a/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
@@ -29,21 +29,23 @@ class CookieAliasComponent extends CookieComponent {
 
 class ComponentCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->Components = new ComponentCollection();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Components);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
@@ -110,6 +110,7 @@ class ComponentCollectionTest extends CakeTestCase {
 
 		$this->assertFalse($this->Components->enabled('Cookie'), 'Cookie should be disabled');
 	}
+
 /**
  * test missingcomponent exception
  *

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -34,6 +34,7 @@ class MergeVarsAppController extends Controller {
  * @var array
  */
 	public $components = array('MergeVar' => array('flag', 'otherFlag', 'redirect' => false));
+
 /**
  * helpers
  *
@@ -41,7 +42,6 @@ class MergeVarsAppController extends Controller {
  */
 	public $helpers = array('MergeVar' => array('format' => 'html', 'terse'));
 }
-
 
 /**
  * MergeVar Component

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -35,12 +35,14 @@ class ControllerTestAppController extends Controller {
  * @var array
  */
 	public $helpers = array('Html');
+
 /**
  * uses property
  *
  * @var array
  */
 	public $uses = array('ControllerPost');
+
 /**
  * components property
  *
@@ -305,6 +307,7 @@ class TestComponent extends Object {
  */
 	public function beforeRedirect() {
 	}
+
 /**
  * initialize method
  *
@@ -320,6 +323,7 @@ class TestComponent extends Object {
  */
 	public function startup(&$controller) {
 	}
+
 /**
  * shutdown method
  *
@@ -327,6 +331,7 @@ class TestComponent extends Object {
  */
 	public function shutdown(&$controller) {
 	}
+
 /**
  * beforeRender callback
  *
@@ -351,6 +356,7 @@ class AnotherTestController extends ControllerTestAppController {
  * @var string 'Name'
  */
 	public $name = 'AnotherTest';
+
 /**
  * uses property
  *
@@ -358,6 +364,11 @@ class AnotherTestController extends ControllerTestAppController {
  */
 	public $uses = null;
 
+/**
+ * merge parent
+ * 
+ * @var string
+ */
 	protected $_mergeParent = 'ControllerTestAppController';
 }
 
@@ -1114,6 +1125,7 @@ class ControllerTest extends CakeTestCase {
 
 		$Controller->startupProcess();
 	}
+
 /**
  * Tests that the shutdown process calls the correct functions
  *

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -381,19 +381,21 @@ class ControllerTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::objects('plugin', null, false);
 		App::build();
 		Router::reload();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		CakePlugin::unload();
 		App::build();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -16,7 +16,6 @@
  * @since         CakePHP(tm) v 1.2.0.5436
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-
 App::uses('Router', 'Routing');
 App::uses('Controller', 'Controller');
 App::uses('Scaffold', 'Controller');
@@ -105,8 +104,6 @@ class TestScaffoldMock extends Scaffold {
     }
 }
 
-
-
 /**
  * Scaffold Test class
  *
@@ -127,6 +124,7 @@ class ScaffoldTest extends CakeTestCase {
  * @var array
  */
 	public $fixtures = array('core.article', 'core.user', 'core.comment', 'core.join_thing', 'core.tag');
+
 /**
  * setUp method
  *
@@ -273,6 +271,7 @@ class ScaffoldTest extends CakeTestCase {
 		$result = ob_get_clean();
 		$this->assertRegExp('/Scaffold Mock has been updated/', $result);
 	}
+
 /**
  * test that habtm relationship keys get added to scaffoldFields.
  *
@@ -308,6 +307,7 @@ class ScaffoldTest extends CakeTestCase {
 		$result = $Scaffold->controller->viewVars;
 		$this->assertEquals($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'));
 	}
+
 /**
  * test that the proper names and variable values are set by Scaffold
  *

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -29,12 +29,14 @@ App::uses('Router', 'Routing');
 class ErrorHandlerTest extends CakeTestCase {
 
 	public $_restoreError = false;
+
 /**
  * setup create a request object to get out of router later.
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::build(array(
 			'View' => array(
 				CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS
@@ -51,17 +53,18 @@ class ErrorHandlerTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		Configure::write('debug', $this->_debug);
 		Configure::write('Error', $this->_error);
 		App::build();
 		if ($this->_restoreError) {
 			restore_error_handler();
 		}
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -142,12 +142,14 @@ class MissingWidgetThingException extends NotFoundException { }
 class ExceptionRendererTest extends CakeTestCase {
 
 	public $_restoreError = false;
+
 /**
  * setup create a request object to get out of router later.
  *
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		App::build(array(
 			'views' => array(
 				CAKE . 'Test' . DS . 'test_app' . DS . 'View'. DS
@@ -164,17 +166,18 @@ class ExceptionRendererTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		Configure::write('debug', $this->_debug);
 		Configure::write('Error', $this->_error);
 		App::build();
 		if ($this->_restoreError) {
 			restore_error_handler();
 		}
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -126,6 +126,7 @@ class MyCustomExceptionRenderer extends ExceptionRenderer {
 		echo 'widget thing is missing';
 	}
 }
+
 /**
  * Exception class for testing app error handlers and custom errors.
  *
@@ -409,6 +410,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$result = ob_get_clean();
 		$this->assertContains('Not Found', $result);
 	}
+
 /**
  * test that error400 doesn't expose XSS
  *

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -2989,6 +2989,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertFalse(isset($result[0]['Comment']['published']), 'published found %s');
 		$this->assertFalse(isset($result[0]['User']['password']), 'password found %s');
 	}
+
 /**
  * testFindConditionalBinding method
  *
@@ -3568,6 +3569,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertTrue(isset($result[0]['Article']));
 		$this->assertTrue(isset($result[0]['User']));
 	}
+
 /**
  * test that autoFields doesn't splice in columns that aren't part of the join.
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -829,6 +829,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * testTranslateTableWithPrefix method
  * Tests that is possible to have a translation model with a custom tablePrefix

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -1202,6 +1202,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertTrue($this->Tree->cacheQueries, 'cacheQueries was not restored after reorder(). %s');
 		$this->Tree->cacheQueries = $original;
 	}
+
 /**
  * testGenerateTreeListWithSelfJoin method
  *

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -254,6 +254,7 @@ class TestBehavior extends ModelBehavior {
 		}
 		echo "onError trigger success";
 	}
+
 /**
  * beforeTest method
  *

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -440,12 +440,14 @@ class SchemaPrefixAuthUser extends CakeTestModel {
  * @var string
  */
 	public $name = 'SchemaPrefixAuthUser';
+
 /**
  * table prefix
  *
  * @var string
  */
 	public $tablePrefix = 'auth_';
+
 /**
  * useTable
  *
@@ -746,6 +748,7 @@ class CakeSchemaTest extends CakeTestCase {
 		$result = $this->Schema->generateTable('posts', $posts);
 		$this->assertRegExp('/public \$posts/', $result);
 	}
+
 /**
  * testSchemaWrite method
  *

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -640,8 +640,11 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaReadWithConfigPrefix() {
 		$this->skipIf($this->db instanceof Sqlite, 'Cannot open 2 connections to Sqlite');
+		
 		$db = ConnectionManager::getDataSource('test');
 		$config = $db->config;
+		$this->skipIf(!empty($config['prefix']), 'This test can not be executed with datasource prefix set.');
+		
 		$config['prefix'] = 'schema_test_prefix_';
 		ConnectionManager::create('schema_prefix', $config);
 		$read = $this->Schema->read(array('connection' => 'schema_prefix', 'models' => false));

--- a/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
+++ b/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
@@ -24,7 +24,6 @@ App::uses('ConnectionManager', 'Model');
  */
 class ConnectionManagerTest extends CakeTestCase {
 
-
 /**
  * tearDown method
  *
@@ -34,6 +33,7 @@ class ConnectionManagerTest extends CakeTestCase {
 		parent::tearDown();
 		CakePlugin::unload();
 	}
+
 /**
  * testEnumConnectionObjects method
  *

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -71,8 +71,8 @@ class CakeSessionTest extends CakeTestCase {
  *
  * @return void
  */
-	public function setup() {
-		parent::setup();
+	public function setUp() {
+		parent::setUp();
 		Configure::write('Session', array(
 			'defaults' => 'php',
 			'cookie' => 'cakephp',

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -382,7 +382,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testCheckKeyWithSpaces() {
 		$this->assertTrue(TestCakeSession::write('Session Test', "test"));
-		$this->assertEquals('test', TestCakeSession::check('Session Test'));
+		$this->assertTrue(TestCakeSession::check('Session Test'));
 		TestCakeSession::delete('Session Test');
 
 		$this->assertTrue(TestCakeSession::write('Session Test.Test Case', "test"));
@@ -526,6 +526,7 @@ class CakeSessionTest extends CakeTestCase {
 		App::build(array(
 			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
 		), true);
+		CakePlugin::load('TestPlugin');
 
 		Configure::write('Session', array(
 			'defaults' => 'cake',

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -225,6 +225,7 @@ class MysqlTest extends CakeTestCase {
 
 		$this->Dbo->rawQuery('DROP TABLE ' . $this->Dbo->fullTableName($tableName));
 	}
+
 /**
  * testLastAffected method
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -206,6 +206,7 @@ class PostgresTest extends CakeTestCase {
 		'core.tag', 'core.articles_tag', 'core.attachment', 'core.person', 'core.post', 'core.author',
 		'core.datatype',
 	);
+
 /**
  * Actual DB connection used in testing
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -163,6 +163,7 @@ class SqlserverTestModel extends Model {
 			'foreignKey' => 'client_id'
 		)
 	);
+
 /**
  * find method
  *
@@ -302,6 +303,7 @@ class SqlserverTest extends CakeTestCase {
 		$result = $this->db->value('', 'binary');
 		$this->assertSame($expected, $result);
 	}
+
 /**
  * testFields method
  *
@@ -459,6 +461,7 @@ class SqlserverTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * testBuildColumn
  *
@@ -521,6 +524,7 @@ class SqlserverTest extends CakeTestCase {
 		$expected = '[body] nvarchar(MAX)';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * testBuildIndex method
  *
@@ -547,6 +551,7 @@ class SqlserverTest extends CakeTestCase {
 		$expected = array('ALTER TABLE items ADD CONSTRAINT client_id UNIQUE([client_id], [period_id]);');
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * testUpdateAllSyntax method
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
@@ -63,7 +63,7 @@ class CacheSessionTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -169,11 +169,14 @@ class DatabaseSessionTest extends CakeTestCase {
  * @return void
  */
 	public function testGc() {
+		ClassRegistry::flush();
 		Configure::write('Session.timeout', 0);
-		$this->storage->write('foo', 'Some value');
+
+		$storage = new DatabaseSession();
+		$storage->write('foo', 'Some value');
 
 		sleep(1);
-		$this->storage->gc();
-		$this->assertFalse($this->storage->read('foo'));
+		$storage->gc();
+		$this->assertFalse($storage->read('foo'));
 	}
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -137,6 +137,7 @@ class DatabaseSessionTest extends CakeTestCase {
 		$result = $this->storage->write('', 'This is a Test');
 		$this->assertFalse($result);
 	}
+
 /**
  * test read()
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -66,22 +66,24 @@ class DatabaseSessionTest extends CakeTestCase {
 	}
 
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->storage = new DatabaseSession();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->storage);
 		ClassRegistry::flush();
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/DbAclTest.php
+++ b/lib/Cake/Test/Case/Model/DbAclTest.php
@@ -186,6 +186,7 @@ class DbAroUserTest extends CakeTestModel {
  * @var string 'auth_users'
  */
 	public $useTable = 'auth_users';
+
 /**
  * bindNode method
  *

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2049,6 +2049,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$result = $TestModel->escapeField('DomainHandle', 'Domain');
 		$expected = $db->name('Domain.DomainHandle');
 		$this->assertEquals($expected, $result);
+		ConnectionManager::drop('mock');
 	}
 
 /**
@@ -2073,4 +2074,21 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertTrue($Article->hasMethod('pass'));
 		$this->assertFalse($Article->hasMethod('fail'));
 	}
+
+/**
+ * Tests that tablePrefix is taken from the datasource if none is defined in the model
+ *
+ * @return void
+ * @see http://cakephp.lighthouseapp.com/projects/42648/tickets/2277-caketestmodels-in-test-cases-do-not-set-model-tableprefix
+ */
+	public function testModelPrefixFromDatasource() {
+		ConnectionManager::create('mock', array(
+			'datasource' => 'DboMock',
+			'prefix' => 'custom_prefix_'
+		));
+		$Article = new Article(false, null, 'mock');
+		$this->assertEquals('custom_prefix_', $Article->tablePrefix);
+		ConnectionManager::drop('mock');
+	}
+
 }

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -32,6 +32,7 @@ class DboMock extends DboSource {
 	public function name($field) {
 		return $field;
 	}
+
 /**
 * Returns true to fake a database connection
 */

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7447,6 +7447,7 @@ class ModelReadTest extends BaseModelTest {
 		);
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * Testing availability of $this->findQueryType in Model callbacks
  *

--- a/lib/Cake/Test/Case/Model/ModelTestBase.php
+++ b/lib/Cake/Test/Case/Model/ModelTestBase.php
@@ -41,6 +41,7 @@ abstract class BaseModelTest extends CakeTestCase {
  * @var bool false
  */
 	public $backupGlobals = false;
+
 /**
  * fixtures property
  *

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -539,6 +539,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $Model->save($data);
 		$this->assertFalse($result);
 	}
+
 /**
  * test that beforeSave returning false can abort saves.
  *
@@ -1795,6 +1796,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals(count($result['NotDoomedSomethingElse']), 2);
 		$this->assertEquals(count($result['DoomedSomethingElse']), 1);
 	}
+
 /**
  * testHabtmSaveKeyResolution method
  *

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -1894,6 +1894,7 @@ class AssociationTest2 extends CakeTestModel {
 class Callback extends CakeTestModel {
 
 }
+
 /**
  * CallbackPostTestModel class
  *

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -676,6 +676,7 @@ class CakeEmailTest extends CakeTestCase {
 		$result = $this->CakeEmail->transportClass();
 		$this->assertInstanceOf('DebugTransport', $result);
 	}
+
 /**
  * testSendWithContent method
  *
@@ -1213,6 +1214,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertTrue((bool)strpos($result['headers'], 'Message-ID: '));
 		$this->assertTrue((bool)strpos($result['headers'], 'To: '));
 	}
+
 /**
  * testViewRender method
  *

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -549,6 +549,26 @@ class HttpSocketTest extends CakeTestCase {
 	}
 
 /**
+ * Test the scheme + port keys
+ * 
+ * @return void
+ */
+	public function testGetWithSchemeAndPort() {
+		$this->Socket->reset();
+		$request = array(
+			'uri' => array(
+				'scheme' => 'http',
+				'host' => 'cakephp.org',
+				'port' => 8080,
+				'path' => '/',
+			),
+			'method' => 'GET'
+		);
+		$response = $this->Socket->request($request);
+		$this->assertContains('Host: cakephp.org:8080', $this->Socket->request['header']);
+	}
+
+/**
  * The "*" asterisk character is only allowed for the following methods: OPTIONS.
  *
  * @expectedException SocketException

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -291,6 +291,7 @@ class ArticlesTestController extends ArticlesTestAppController {
 	public function admin_index() {
 		return true;
 	}
+
 /**
  * fake index method.
  *
@@ -441,6 +442,7 @@ class TestCachedPagesController extends Controller {
 	public function view($id = null) {
 		$this->render('index');
 	}
+
 /**
  * test cached forms / tests view object being registered
  *
@@ -723,6 +725,7 @@ class DispatcherTest extends CakeTestCase {
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 	}
+
 /**
  * testDispatch method
  *

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2084,6 +2084,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals(Router::stripPlugin($url), $url);
 		$this->assertEquals(Router::stripPlugin($url, null), $url);
 	}
+
 /**
  * testCurentRoute
  *
@@ -2098,6 +2099,7 @@ class RouterTest extends CakeTestCase {
 		$route = Router::currentRoute();
 		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 	}
+
 /**
  * testRequestRoute
  *
@@ -2124,6 +2126,7 @@ class RouterTest extends CakeTestCase {
 		$route = Router::requestRoute();
 		$this->assertEquals(array_merge($url, array('plugin' => null)), $route->defaults);
 	}
+
 /**
  * testGetParams
  *
@@ -2389,6 +2392,7 @@ class RouterTest extends CakeTestCase {
 		$result = Router::url(array('base' => false));
 		$this->assertEquals('/posts', $result, 'with second requests, the last should win.');
 	}
+
 /**
  * test that a route object returning a full url is not modified.
  *

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -214,8 +214,8 @@ class CakeTestCaseTest extends CakeTestCase {
 		$manager->expects($this->once())->method('unload');
 		$result = $test->run();
 		$this->assertEquals(1, $result->errorCount());
-
 	}
+
 /**
  * testSkipIf
  *

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -131,7 +131,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/TestSuite/HtmlCoverageReportTest.php
+++ b/lib/Cake/Test/Case/TestSuite/HtmlCoverageReportTest.php
@@ -22,7 +22,7 @@ App::uses('CakeBaseReporter', 'TestSuite/Reporter');
 
 class HtmlCoverageReportTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
@@ -220,12 +220,13 @@ class HtmlCoverageReportTest extends CakeTestCase {
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
 	public function tearDown() {
 		CakePlugin::unload();
 		unset($this->Coverage);
+		parent::tearDown();
 	}
 }

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -124,6 +124,22 @@ class RegisterCategory extends ClassRegisterModel {
 }
 
 /**
+ * Abstract class for testing ClassRegistry.
+ */
+abstract class ClassRegistryAbstractModel extends ClassRegisterModel {
+
+	abstract function doSomething();
+}
+
+/**
+ * Interface for testing ClassRegistry
+ */
+interface ClassRegistryInterfaceTest {
+
+	function doSomething();
+}
+
+/**
  * ClassRegistryTest class
  *
  * @package       Cake.Test.Case.Utility
@@ -276,5 +292,25 @@ class ClassRegistryTest extends CakeTestCase {
  */
 	public function testInitStrict() {
 		$this->assertFalse(ClassRegistry::init('NonExistent', true));
+	}
+
+/**
+ * Test that you cannot init() an abstract class. An exception will be raised.
+ *
+ * @expectedException CakeException
+ * @return void
+ */
+	public function testInitAbstractClass() {
+		ClassRegistry::init('ClassRegistryAbstractModel');
+	}
+	
+/**
+ * Test that you cannot init() an abstract class. A exception will be raised.
+ *
+ * @expectedException CakeException
+ * @return void
+ */
+	public function testInitInterface() {
+		ClassRegistry::init('ClassRegistryInterfaceTest');
 	}
 }

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -44,7 +44,7 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		Configure::write('debug', 2);
 		Configure::write('log', false);
 	}
@@ -55,7 +55,7 @@ class DebuggerTest extends CakeTestCase {
  * @return void
  */
 	public function tearDown() {
-		parent::teardown();
+		parent::tearDown();
 		Configure::write('log', true);
 		if ($this->_restoreError) {
 			restore_error_handler();

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -309,10 +309,11 @@ class FileTest extends CakeTestCase {
  * @return void
  */
 	public function testLastAccess() {
+		$ts = time();
 		$someFile = new File(TMP . 'some_file.txt', false);
 		$this->assertFalse($someFile->lastAccess());
 		$this->assertTrue($someFile->open());
-		$this->assertEquals($someFile->lastAccess(), time());
+		$this->assertTrue($someFile->lastAccess() >= $ts);
 		$someFile->close();
 		$someFile->delete();
 	}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -45,12 +45,12 @@ class FileTest extends CakeTestCase {
 	}
 
 /**
- * tear down for test.
+ * tearDown method
  *
  * @return void
  */
-	public function teardown() {
-		parent::teardown();
+	public function tearDown() {
+		parent::tearDown();
 		$this->File->close();
 		unset($this->File);
 	}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -324,12 +324,13 @@ class FileTest extends CakeTestCase {
  * @return void
  */
 	public function testLastChange() {
+		$ts = time();
 		$someFile = new File(TMP . 'some_file.txt', false);
 		$this->assertFalse($someFile->lastChange());
 		$this->assertTrue($someFile->open('r+'));
-		$this->assertEquals($someFile->lastChange(), time());
+		$this->assertTrue($someFile->lastChange() >= $ts);
 		$someFile->write('something');
-		$this->assertEquals($someFile->lastChange(), time());
+		$this->assertTrue($someFile->lastChange() >= $ts);
 		$someFile->close();
 		$someFile->delete();
 	}

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -184,6 +184,7 @@ class FolderTest extends CakeTestCase {
 		chmod($path, '0777');
 		rmdir($path);
 	}
+
 /**
  * testOperations method
  *
@@ -343,6 +344,7 @@ class FolderTest extends CakeTestCase {
 		$result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, 'another_path');
 		$this->assertEquals($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
 	}
+
 /**
  * testFolderRead method
  *

--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -34,7 +34,7 @@ App::uses('Inflector', 'Utility');
 class InflectorTest extends CakeTestCase {
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -73,21 +73,23 @@ class GenericObjectCollection extends ObjectCollection {
 
 class ObjectCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->Objects = new GenericObjectCollection();
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		unset($this->Objects);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SetTest.php
+++ b/lib/Cake/Test/Case/Utility/SetTest.php
@@ -1291,6 +1291,7 @@ class SetTest extends CakeTestCase {
 		$this->assertSame($expected, $result);
 		$this->assertSame($result, Set::extract('{n}.B.field1', $items));
 	}
+
 /**
  * testExtractWithArrays method
  *

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -90,12 +90,12 @@ class TestDeValidation {
 class ValidationTest extends CakeTestCase {
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		$this->_appEncoding = Configure::read('App.encoding');
 	}
 

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -53,6 +53,7 @@ class TestNlValidation {
 	static function postal($check) {
 		return true;
 	}
+
 /**
  * ssn function for testing ssn pass through
  *

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -91,12 +91,12 @@ class XmlTest extends CakeTestCase {
 	);
 
 /**
- * setup method
+ * setUp method
  *
  * @return void
  */
 	public function setUp() {
-		parent::setup();
+		parent::setUp();
 		$this->_appEncoding = Configure::read('App.encoding');
 		Configure::write('App.encoding', 'UTF-8');
 	}

--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -68,6 +68,7 @@ class CacheHelperTest extends CakeTestCase {
 			$this->markTestSkipped('TMP/views is not writable %s');
 		}
 	}
+
 /**
  * setUp method
  *
@@ -158,6 +159,7 @@ class CacheHelperTest extends CakeTestCase {
 
 		@unlink($filename);
 	}
+
 /**
  * Test cache parsing with cake:nocache tags in view file.
  *

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -990,6 +990,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->unlockField();
 		$this->assertEquals(array('Address.button'), $result);
 	}
+
 /**
  * Test that the correct fields are unlocked for image submits with no names.
  *
@@ -1029,6 +1030,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 		$this->assertEquals(array('test', 'test_x', 'test_y'), $this->Form->unlockField());
 	}
+
 /**
  * testFormSecurityMultipleInputFields method
  *
@@ -4143,6 +4145,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
 /**
  * testSelectHiddenFieldOmission method
  *
@@ -5824,6 +5827,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
 /**
  * testPostLink method
  *
@@ -6597,6 +6601,7 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertRegExp('/name="created\[min\]"/', $result, 'min name attribute is wrong.');
 		$this->assertRegExp('/name="created\[meridian\]"/', $result, 'meridian name attribute is wrong.');
 	}
+
 /**
  * testEditFormWithData method
  *

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -5747,7 +5747,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testButton() {
 		$result = $this->Form->button('Hi');
-		$this->assertTags($result, array('button' => array('type' => 'submit'), 'Hi', '/button'));
+		$this->assertTags($result, array('button', 'Hi', '/button'));
 
 		$result = $this->Form->button('Clear Form >', array('type' => 'reset'));
 		$this->assertTags($result, array('button' => array('type' => 'reset'), 'Clear Form >', '/button'));

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -373,7 +373,8 @@ class HtmlHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testImageTagWithTheme() {
-		$this->skipIf(!is_writable(WWW_ROOT . 'theme'), 'Cannot write to webroot/theme.');
+		$this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
+		$themeExists = is_dir(WWW_ROOT . 'theme');
 
 		App::uses('File', 'Utility');
 
@@ -406,6 +407,10 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$dir = new Folder(WWW_ROOT . 'theme' . DS . 'test_theme');
 		$dir->delete();
+		if (!$themeExists) {
+			$dir = new Folder(WWW_ROOT . 'theme');
+			$dir->delete();
+		}
 	}
 
 /**
@@ -682,7 +687,8 @@ class HtmlHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testScriptInTheme() {
-		$this->skipIf(!is_writable(WWW_ROOT . 'theme'), 'Cannot write to webroot/theme.');
+		$this->skipIf(!is_writable(WWW_ROOT), 'Cannot write to webroot.');
+		$themeExists = is_dir(WWW_ROOT . 'theme');
 
 		App::uses('File', 'Utility');
 
@@ -703,7 +709,11 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$Folder = new Folder(WWW_ROOT . 'theme' . DS . 'test_theme');
 		$Folder->delete();
-		App::build();
+
+		if (!$themeExists) {
+			$dir = new Folder(WWW_ROOT . 'theme');
+			$dir->delete();
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -48,6 +48,7 @@ class OptionEngineHelper extends JsBaseEngineHelper {
 	public function testMap($options = array()) {
 		return $this->_mapOptions('request', $options);
 	}
+
 /**
  * test method for option parsing
  *
@@ -697,6 +698,7 @@ class JsBaseEngineTest extends CakeTestCase {
 		$this->View = $this->getMock('View', array('addScript'), array(&$controller));
 		$this->JsEngine = new OptionEngineHelper($this->View);
 	}
+
 /**
  * tearDown method
  *

--- a/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
@@ -74,6 +74,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$this->assertEquals($result, $this->Moo);
 		$this->assertEquals($this->Moo->selection, '$$("#some_long-id.class")');
 	}
+
 /**
  * test event binding
  *
@@ -93,6 +94,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = "\$(\"myLink\").addEvent(\"click\", function (event) {event.stop();\nthis.setStyle(\"display\", \"none\");});";
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test dom ready event creation
  *
@@ -103,6 +105,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = 'window.addEvent("domready", function (event) {foo.name = "bar";});';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test Each method
  *
@@ -114,6 +117,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = '$("foo").each(function (item, index) {item.setStyle("display", "none");});';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test Effect generation
  *
@@ -153,6 +157,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = '$("foo").set("slide", {duration:"long"}).slide("out");';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * Test Request Generation
  *
@@ -223,6 +228,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = 'var jsRequest = new Request.HTML({method:"post", onComplete:function () {doComplete}, onRequest:function () {doBefore}, onSuccess:function (responseText, responseXML) {doSuccess}, update:"update-zone", url:"\\/people\\/edit\\/1"}).send();';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test sortable list generation
  *
@@ -241,6 +247,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = 'var jsSortable = new Sortables($("myList"), {constrain:"parent", onComplete:onStop, onSort:onSort, onStart:onStart, snap:5});';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test drag() method
  *
@@ -273,6 +280,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 			'hover' => 'onHover',
 		));
 	}
+
 /**
  * test drop() method
  *
@@ -300,6 +308,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = '$("my-drag").makeDraggable({droppables:$("drop-me"), onDrop:function (element, droppable, event) {onDrop}, onEnter:function (element, droppable) {onHover}, onLeave:function (element, droppable) {onLeave}});';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test slider generation
  *
@@ -341,6 +350,7 @@ class MootoolsEngineHelperTest extends CakeTestCase {
 		$expected = 'var jsSlider = new Slider($("slider"), $("my-handle"), {mode:"horizontal", onChange:function (step) {change;}, onComplete:function (event) {complete;}});';
 		$this->assertEquals($expected, $result);
 	}
+
 /**
  * test the serializeForm implementation.
  *

--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -567,13 +567,14 @@ class RssHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testItemEnclosureLength() {
-		$tmpFile = $this->_getWwwTmpFile();
-
-		if (file_exists($tmpFile)) {
-			unlink($tmpFile);
+		if (!is_writable(WWW_ROOT)) {
+			$this->markTestSkipped(__d('cake_dev', 'Webroot is not writable.'));
 		}
+		$testExists = is_dir(WWW_ROOT . 'tests');
 
-		$File = new File($tmpFile, true, '0777');
+		$tmpFile = WWW_ROOT . 'tests' . DS . 'cakephp.file.test.tmp';
+		$File = new File($tmpFile, true);
+
 		$this->assertTrue($File->write('123'), 'Could not write to ' . $tmpFile);
 		clearstatcache(true, $tmpFile);
 
@@ -637,15 +638,12 @@ class RssHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		unlink($tmpFile);
-	}
+		$File->delete();
 
-/**
- * testTime method
- *
- * @return void
- */
-	public function testTime() {
+		if (!$testExists) {
+			$Folder = new Folder(WWW_ROOT . 'tests');
+			$Folder->delete();
+		}
 	}
 
 /**
@@ -676,21 +674,4 @@ class RssHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 	}
 
-/**
- * getWwwTmpFile method
- *
- * @param bool $paintSkip
- * @return void
- */
-	function _getWwwTmpFile() {
-		$path = WWW_ROOT . 'tests' . DS;
-		$tmpFile = $path. 'cakephp.file.test.tmp';
-		if (is_writable(dirname($tmpFile)) && (!file_exists($tmpFile) || is_writable($tmpFile))) {
-			return $tmpFile;
-		};
-
-		$message = __d('cake_dev', '%s is not writeable', $path );
-		$this->markTestSkipped($message);
-		return false;
-	}
 }

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -87,6 +87,7 @@ class TextHelperTest extends CakeTestCase {
 		$this->assertSame($this->Text->truncate($text8, 15), 'Vive la R'.chr(195).chr(169).'pu...');
 		$this->assertSame($this->Text->truncate($text9, 10), 'НОПРСТУ...');
 	}
+
 /**
  * testHighlight method
  *

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -354,7 +354,7 @@ class TextHelperTest extends CakeTestCase {
 	public function testExcerpt() {
 		$text = 'This is a phrase with test text to play with';
 
-		$expected = '...with test text...';
+		$expected = '...ase with test text to ...';
 		$result = $this->Text->excerpt($text, 'test', 9, '...');
 		$this->assertEquals($expected, $result);
 
@@ -370,18 +370,19 @@ class TextHelperTest extends CakeTestCase {
 		$result = $this->Text->excerpt($text, null, 200, '...');
 		$this->assertEquals($expected, $result);
 
-		$expected = '...phrase...';
+		$expected = '...a phrase w...';
 		$result = $this->Text->excerpt($text, 'phrase', 2, '...');
 		$this->assertEquals($expected, $result);
 
-		$phrase = 'This is a phrase with test';
+		$phrase = 'This is a phrase with test text';
 		$expected = $text;
-		$result = $this->Text->excerpt($text, $phrase, strlen($phrase) + 3, '...');
+		$result = $this->Text->excerpt($text, $phrase, 13, '...');
 		$this->assertEquals($expected, $result);
-
-		$phrase = 'This is a phrase with text';
-		$expected = $text;
-		$result = $this->Text->excerpt($text, $phrase, 10, '...');
+		
+		$text = 'aaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaa';
+		$phrase = 'bbbbbbbb';
+		$result = $this->Text->excerpt($text, $phrase, 10);
+		$expected = '...aaaaaaaaaabbbbbbbbaaaaaaaaaa...';
 		$this->assertEquals($expected, $result);
 	}
 
@@ -393,7 +394,7 @@ class TextHelperTest extends CakeTestCase {
 	public function testExcerptCaseInsensitivity() {
 		$text = 'This is a phrase with test text to play with';
 
-		$expected = '...with test text...';
+		$expected = '...ase with test text to ...';
 		$result = $this->Text->excerpt($text, 'TEST', 9, '...');
 		$this->assertEquals($expected, $result);
 

--- a/lib/Cake/Test/Case/View/HelperCollectionTest.php
+++ b/lib/Cake/Test/Case/View/HelperCollectionTest.php
@@ -29,23 +29,25 @@ class HtmlAliasHelper extends HtmlHelper {
 
 class HelperCollectionTest extends CakeTestCase {
 /**
- * setup
+ * setUp
  *
  * @return void
  */
-	public function setup() {
+	public function setUp() {
+		parent::setUp();
 		$this->View = $this->getMock('View', array(), array(null));
 		$this->Helpers = new HelperCollection($this->View);
 	}
 
 /**
- * teardown
+ * tearDown
  *
  * @return void
  */
-	public function teardown() {
+	public function tearDown() {
 		CakePlugin::unload();
 		unset($this->Helpers, $this->View);
+		parent::tearDown();
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -96,7 +96,7 @@ class ScaffoldViewTest extends CakeTestCase {
 	}
 
 /**
- * teardown method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -447,6 +447,7 @@ class ViewTest extends CakeTestCase {
 		$this->View->element('test_element', array(), array('callbacks' => true));
 		$this->mockObjects[] = $this->View->ElementCallbackMockHtml;
 	}
+
 /**
  * test that additional element viewVars don't get overwritten with helpers.
  *

--- a/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
@@ -34,12 +34,14 @@ class TranslateWithPrefixFixture extends CakeTestFixture {
  * @var string 'Translate'
  */
 	public $name = 'TranslateWithPrefix';
+
 /**
  * table property
  *
  * @var string 'i18n'
  */
 	public $table = 'i18n_translate_with_prefixes';
+
 /**
  * fields property
  *
@@ -53,6 +55,7 @@ class TranslateWithPrefixFixture extends CakeTestFixture {
 		'field' => array('type' => 'string', 'null' => false),
 		'content' => array('type' => 'text')
 	);
+
 /**
  * records property
  *

--- a/lib/Cake/Test/test_app/View/Posts/test_nocache_tags.ctp
+++ b/lib/Cake/Test/test_app/View/Posts/test_nocache_tags.ctp
@@ -75,9 +75,7 @@
 </p>
 <?php
 if (!empty($filePresent)):
-	if (!class_exists('ConnectionManager')) {
-		require CAKE . 'model' . DS . 'connection_manager.php';
-	}
+	App::uses('ConnectionManager', 'Model');
  	$connected = ConnectionManager::getDataSource('default');
 ?>
 <p>

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -45,6 +45,7 @@ class CakeTestSuiteDispatcher {
 		'filter' => false,
 		'fixture' => null
 	);
+
 /**
  * Baseurl for the request
  *

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -88,7 +88,8 @@ class ClassRegistry {
  *  stored in the registry and returned.
  * @param boolean $strict if set to true it will return false if the class was not found instead
  *	of trying to create an AppModel
- * @return object instance of ClassName
+ * @return object instance of ClassName.
+ * @throws CakeException when you try to construct an interface or abstract class.
  */
 	public static function init($class, $strict = false) {
 		$_this = ClassRegistry::getInstance();
@@ -132,8 +133,12 @@ class ClassRegistry {
 				App::uses($plugin . 'AppModel', $pluginPath . 'Model');
 				App::uses($class, $pluginPath . 'Model');
 
-				if (class_exists($class)) {
-					$instance = new $class($settings);
+				if (class_exists($class) || interface_exists($class)) {
+					$reflection = new ReflectionClass($class);
+					if ($reflection->isAbstract() || $reflection->isInterface()) {
+						throw new CakeException(__d('cake_dev', 'Cannot create instance of %s, as it is abstract or is an interface', $class));
+					}
+					$instance = $reflection->newInstance($settings);
 					if ($strict) {
 						$instance = ($instance instanceof Model) ? $instance : null;
 					}

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -1,5 +1,4 @@
 <?php
-App::import('Model', 'ConnectionManager');
 /**
  * Washes strings from unwanted noise.
  *
@@ -19,6 +18,7 @@ App::import('Model', 'ConnectionManager');
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+App::import('Model', 'ConnectionManager');
 
 /**
  * Data Sanitization.

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -283,7 +283,7 @@ class CacheHelper extends AppHelper {
 				$controller->helpers = $this->helpers = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->helpers)) . '\'));
 				$controller->layout = $this->layout = \'' . $this->_View->layout. '\';
 				$controller->theme = $this->theme = \'' . $this->_View->theme . '\';
-				$controller->viewVars = $this->viewVars = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->viewVars)) . '\'));
+				$controller->viewVars = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->viewVars)) . '\'));
 				Router::setRequestInfo($controller->request);
 				$this->request = $request;';
 
@@ -294,6 +294,7 @@ class CacheHelper extends AppHelper {
 		}
 
 		$file .= '
+				$this->viewVars = $controller->viewVars;
 				$this->loadHelpers();
 				extract($this->viewVars, EXTR_SKIP);
 		?>';

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1450,8 +1450,7 @@ class FormHelper extends AppHelper {
 	}
 
 /**
- * Creates a `<button>` tag.  The type attribute defaults to `type="submit"`
- * You can change it to a different value by using `$options['type']`.
+ * Creates a `<button>` tag.
  *
  * ### Options:
  *

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1491,6 +1491,7 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postButton
  */
 	public function postButton($title, $url, $options = array()) {
+		$options = array_merge(array('type' => 'submit'), $options);
 		$out = $this->create(false, array('id' => false, 'url' => $url, 'style' => 'display:none;'));
 		if (isset($options['data']) && is_array($options['data'])) {
 			foreach ($options['data'] as $key => $value) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1462,7 +1462,7 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::button
  */
 	public function button($title, $options = array()) {
-		$options += array('type' => 'submit', 'escape' => false, 'secure' => false);
+		$options += array('escape' => false, 'secure' => false);
 		if ($options['escape']) {
 			$title = h($title);
 		}

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -472,6 +472,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
  * @return string Completed slider script
  */
 	abstract public function slider($options = array());
+
 /**
  * Serialize the form attached to $selector.
  * Pass `true` for $isForm if the current selection is a form element.

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -321,34 +321,31 @@ class TextHelper extends AppHelper {
 			return $this->truncate($text, $radius * 2, array('ending' => $ending));
 		}
 
+		$append = $prepend = $ending;
+
 		$phraseLen = mb_strlen($phrase);
-		if ($radius < $phraseLen) {
-			$radius = $phraseLen;
-		}
+		$textLen = mb_strlen($text);
 
 		$pos = mb_strpos(mb_strtolower($text), mb_strtolower($phrase));
-
-		$startPos = 0;
-		if ($pos > $radius) {
-			$startPos = $pos - $radius;
+		if ($pos === false) {
+			return mb_substr($text, 0, $radius) . $ending;
 		}
 
-		$textLen = mb_strlen($text);
+		$startPos = $pos - $radius;
+		if ($startPos <= 0) {
+			$startPos = 0;
+			$prepend = '';
+		}
 
 		$endPos = $pos + $phraseLen + $radius;
 		if ($endPos >= $textLen) {
 			$endPos = $textLen;
+			$append = '';
 		}
 
 		$excerpt = mb_substr($text, $startPos, $endPos - $startPos);
-		if ($startPos != 0) {
-			$excerpt = substr_replace($excerpt, $ending, 0, $phraseLen);
-		}
-
-		if ($endPos != $textLen) {
-			$excerpt = substr_replace($excerpt, $ending, -$phraseLen);
-		}
-
+		$excerpt = $prepend . $excerpt . $append;
+		
 		return $excerpt;
 	}
 


### PR DESCRIPTION
Why? Because:
- The type attribute is not required for buttons, so there's no real reason to include
- 'Submit' is a very unsafe default behavior. When people **don't** explicitly wish to use submit buttons, such as for cancel, expand, js-related, etc, submitting the form is not something people will want to override. Especially because of the first point.
- Follow the rule of design to expectation. The button should do what people expect it to. If no type is set, don't add one.
- **When calling `$this->Form->input('Call JS', array('type' => 'button'))` the type is always 'submit' and cannot be changed.** This is the main reason for this fix. Since type is already passed (to `input()`) it is impossible to correct this behavior.
