### PR TITLE
Add tests for CakeTestSuite and dont include hidden folders when recursively addTestFile

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * CakePHP : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc.
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc.
+ * @link          http://cakephp.org CakePHP Project
+ * @package       Cake.Test.Case.TestSuite
+ * @since         CakePHP v 1.2.0.4487
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * CakeTestSuiteTest
+ *
+ * @package       Cake.Test.Case.TestSuite
+ */
+class CakeTestSuiteTest extends CakeTestCase {
+
+/**
+ * setUp
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+	}
+
+/**
+ * tearDown
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+/**
+ * testAddTestDirectory
+ * 
+ * @return void
+ */
+	public function testAddTestDirectory() {
+		$testFolder = CORE_TEST_CASES . DS . 'TestSuite';
+		$count = count(glob($testFolder . DS . '*Test.php'));
+
+		$suite = $this->getMock('CakeTestSuite', array('addTestFile'));
+		$suite
+			->expects($this->exactly($count))
+			->method('addTestFile');
+
+		$suite->addTestDirectory($testFolder);
+	}
+
+/**
+ * testAddTestDirectoryRecursive
+ * 
+ * @return void
+ */
+	public function testAddTestDirectoryRecursive() {return;
+		$testFolder = CORE_TEST_CASES . DS . 'Cache';
+		$count = count(glob($testFolder . DS . '*Test.php'));
+		$count += count(glob($testFolder . DS . 'Engine' . DS . '*Test.php'));
+
+		$suite = $this->getMock('CakeTestSuite', array('addTestFile'));
+		$suite
+			->expects($this->exactly($count))
+			->method('addTestFile');
+
+		$suite->addTestDirectoryRecursive($testFolder);
+	}
+
+/**
+ * testAddTestDirectoryRecursiveWithHidden
+ * 
+ * @return void
+ */
+	public function testAddTestDirectoryRecursiveWithHidden() {
+		$this->skipIf(!is_writeable(TMP), 'Cant addTestDirectoryRecursiveWithHidden unless the tmp folder is writable.');
+
+		$Folder = new Folder(TMP . 'MyTestFolder', true, 0777);
+		mkdir($Folder->path . DS . '.svn', 0777, true);
+		touch($Folder->path . DS . '.svn' . DS . 'InHiddenFolderTest.php');
+		touch($Folder->path . DS . 'NotHiddenTest.php');
+		touch($Folder->path . DS . '.HiddenTest.php');
+
+		$suite = $this->getMock('CakeTestSuite', array('addTestFile'));
+		$suite
+			->expects($this->exactly(1))
+			->method('addTestFile');
+
+		$suite->addTestDirectoryRecursive($Folder->pwd());
+
+		$Folder->delete();
+	}
+}

--- a/lib/Cake/TestSuite/CakeTestSuite.php
+++ b/lib/Cake/TestSuite/CakeTestSuite.php
@@ -52,7 +52,7 @@ class CakeTestSuite extends PHPUnit_Framework_TestSuite {
 		$files = $Folder->tree(null, false, 'files');
 
 		foreach ($files as $file) {
-			if (strpos($file, DS.'.') !== false) {
+			if (strpos($file, DS . '.') !== false) {
 				continue;
 			}
 			$this->addTestFile($file);

--- a/lib/Cake/TestSuite/CakeTestSuite.php
+++ b/lib/Cake/TestSuite/CakeTestSuite.php
@@ -52,6 +52,9 @@ class CakeTestSuite extends PHPUnit_Framework_TestSuite {
 		$files = $Folder->tree(null, false, 'files');
 
 		foreach ($files as $file) {
+			if (strpos($file, DS.'.') !== false) {
+				continue;
+			}
 			$this->addTestFile($file);
 		}
 	}


### PR DESCRIPTION
Adding tests for CakeTestSuite.

Also when trying to build a test suite while using svn it crashes when using `addTestDirectoryRecursive()`. Because it also adds the duplicated `*Test.php` files in the `.svn` folders.

The real issue is likely with `Folder::tree()` as even when you set it to skip hidden files it still will include visible files in hidden folders (as pull https://github.com/cakephp/cakephp/pull/370 demonstrates). I imagine that is not the desired behavior but 'fixing' that could likely cause more issues for others then just doing this simple fix in CakeTestSuite.
