### PR TITLE
Fix overreaching Inflector when ControllerTestCase autoMocks

### DIFF
--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -251,7 +251,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 
 		$plugin = empty($request->params['plugin']) ? '' : Inflector::camelize($request->params['plugin']) . '.';
 		if ($this->controller === null && $this->autoMock) {
-			$this->generate(Inflector::camelize($plugin . $request->params['controller']));
+			$this->generate($plugin . Inflector::camelize($request->params['controller']));
 		}
 		$params = array();
 		if ($options['return'] == 'result') {


### PR DESCRIPTION
`Inflector::camelize()` can't do its job properly when the plugin is included and the plugin is already being inflected above.
