### PR TITLE
Correcting assertEquals parameter order

### DIFF
--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -361,7 +361,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0664';
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -369,7 +369,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0666';
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -377,7 +377,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0644';
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
@@ -385,7 +385,7 @@ class FileEngineTest extends CakeTestCase {
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o',fileperms(TMP . 'tests' . DS .'cake_masking_test')), -4);
 		$expected = '0640';
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 	}

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -890,7 +890,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Sample->create();
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'modify', 'afterSave' => 'modify'));
 		$expected = Set::merge($record, array('Sample' => array('name' => 'sample99 modified before modified after on create')));

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -1932,7 +1932,7 @@ class MysqlTest extends CakeTestCase {
 		$conditions = array('Company.name similar to ' => 'a word');
 		$result = $this->Dbo->conditions($conditions);
 		$expected = " WHERE `Company`.`name` similar to 'a word'";
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2104,7 +2104,7 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->conditions(array('lower(Article.title)' =>  'secrets'));
 		$expected = " WHERE lower(`Article`.`title`) = 'secrets'";
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('title LIKE' => '%hello'));
 		$expected = " WHERE `title` LIKE '%hello'";
@@ -2279,7 +2279,7 @@ class MysqlTest extends CakeTestCase {
 		$conditions = array('MysqlModel.id' => '');
 		$result = $this->Dbo->conditions($conditions, true, true, $this->model);
 		$expected = " WHERE `MysqlModel`.`id` IS NULL";
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->conditions(array('Listing.beds >=' => 0));
 		$expected = " WHERE `Listing`.`beds` >= 0";

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -272,7 +272,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			array('User' => array('user' => 'mariano'), 'Article' => array('published' => 'Y')),
 			array('User' => array('user' => 'nate'), 'Article' => array('published' => ''))
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7561,7 +7561,7 @@ class ModelReadTest extends BaseModelTest {
 			'2' => 'Second Post',
 			'1' => 'First Post'
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$result = $Post->find('list', array('order' => array('Post.other_field' => 'DESC')));
 		$expected = array(
@@ -7569,23 +7569,23 @@ class ModelReadTest extends BaseModelTest {
 			'2' => 'Second Post',
 			'3' => 'Third Post'
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$Post->Author->virtualFields = array('joined' => 'Post.id * Author.id');
 		$result = $Post->find('all');
 		$result = Set::extract('{n}.Author.joined', $result);
 		$expected = array(1, 6, 3);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$result = $Post->find('all', array('order' => array('Author.joined' => 'ASC')));
 		$result = Set::extract('{n}.Author.joined', $result);
 		$expected = array(1, 3, 6);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$result = $Post->find('all', array('order' => array('Author.joined' => 'DESC')));
 		$result = Set::extract('{n}.Author.joined', $result);
 		$expected = array(6, 3, 1);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -149,7 +149,7 @@ class RouterTest extends CakeTestCase {
 			'action' => 'index',
 			'[method]' => 'GET'
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		$this->assertEquals($resources, array('test_plugin'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -163,7 +163,7 @@ class RouterTest extends CakeTestCase {
 			'id' => '13',
 			'[method]' => 'GET'
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -189,7 +189,7 @@ class RouterTest extends CakeTestCase {
 			'action' => 'index',
 			'[method]' => 'GET'
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 		$this->assertEquals($resources, array('test_plugin'));
 	}
 


### PR DESCRIPTION
Changed the order to `assertEquals($expected, $result)` where obvious.
