### PR TITLE
Add test for Model::getID(), simplify return and remove dated @see link

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3164,11 +3164,7 @@ class Model extends Object {
 			return false;
 		}
 
-		foreach ($this->id as $id) {
-			return $id;
-		}
-
-		return false;
+		return current($this->id);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2022,7 +2022,6 @@ class ModelIntegrationTest extends BaseModelTest {
 
 /**
  * testEscapeField to prove it escapes the field well even when it has part of the alias on it
- * @see ttp://cakephp.lighthouseapp.com/projects/42648-cakephp-1x/tickets/473-escapefield-doesnt-consistently-prepend-modelname
  *
  * @return void
  */
@@ -2050,6 +2049,30 @@ class ModelIntegrationTest extends BaseModelTest {
 		$expected = $db->name('Domain.DomainHandle');
 		$this->assertEquals($expected, $result);
 		ConnectionManager::drop('mock');
+	}
+
+/**
+ * testGetID
+ *
+ * @return void
+ */
+	public function testGetID() {
+		$TestModel = new Test();
+
+		$result = $TestModel->getID();
+		$this->assertFalse($result);
+
+		$TestModel->id = 9;
+		$result = $TestModel->getID();
+		$this->assertEquals(9, $result);
+
+		$TestModel->id = array(10, 9, 8, 7);
+		$result = $TestModel->getID(2);
+		$this->assertEquals(8, $result);
+
+		$TestModel->id = array(array(), 1, 2, 3);
+		$result = $TestModel->getID();
+		$this->assertFalse($result);
 	}
 
 /**


### PR DESCRIPTION
`Model::getID()` was missing a test case. The @see link on the escapeField test case was no longer relevant as well.
