### PR TITLE
Add debug flag to flush output

### DIFF
--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -147,6 +147,9 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 			ClassRegistry::flush();
 		}
 		Configure::write($this->_configure);
+		if (isset($_GET['debug']) && $_GET['debug']) {
+			ob_flush();
+		}
 	}
 
 /**


### PR DESCRIPTION
Add ability to add debug=1 to trigger output flushing when testing with PHPUnit 3.6's output swallowing.
Thanks for the idea @lorenzo!
