### PR TITLE
Remove extra space in HtmlHelper radio tag

### DIFF
--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -281,7 +281,7 @@ class CacheHelper extends AppHelper {
 				$controller = new ' . $this->_View->name . 'Controller($request, $response);
 				$controller->plugin = $this->plugin = \'' . $this->_View->plugin . '\';
 				$controller->helpers = $this->helpers = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->helpers)) . '\'));
-				$controller->layout = $this->layout = \'' . $this->_View->layout. '\';
+				$controller->layout = $this->layout = \'' . $this->_View->layout . '\';
 				$controller->theme = $this->theme = \'' . $this->_View->theme . '\';
 				$controller->viewVars = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->viewVars)) . '\'));
 				Router::setRequestInfo($controller->request);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -46,7 +46,7 @@ class HtmlHelper extends AppHelper {
 		'hidden' => '<input type="hidden" name="%s"%s/>',
 		'checkbox' => '<input type="checkbox" name="%s" %s/>',
 		'checkboxmultiple' => '<input type="checkbox" name="%s[]"%s />',
-		'radio' => '<input type="radio" name="%s" id="%s" %s />%s',
+		'radio' => '<input type="radio" name="%s" id="%s"%s />%s',
 		'selectstart' => '<select name="%s"%s>',
 		'selectmultiplestart' => '<select name="%s[]"%s>',
 		'selectempty' => '<option value=""%s>&nbsp;</option>',
@@ -235,9 +235,9 @@ class HtmlHelper extends AppHelper {
 
 		if (!is_array($type)) {
 			$types = array(
-				'rss'	=> array('type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $url),
-				'atom'	=> array('type' => 'application/atom+xml', 'title' => $type, 'link' => $url),
-				'icon'	=> array('type' => 'image/x-icon', 'rel' => 'icon', 'link' => $url),
+				'rss' => array('type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $url),
+				'atom' => array('type' => 'application/atom+xml', 'title' => $type, 'link' => $url),
+				'icon' => array('type' => 'image/x-icon', 'rel' => 'icon', 'link' => $url),
 				'keywords' => array('name' => 'keywords', 'content' => $url),
 				'description' => array('name' => 'description', 'content' => $url),
 			);


### PR DESCRIPTION
There is an extra space added between attributes when using the `radio` tag.
