### PR TITLE
Resource map

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -175,6 +175,20 @@ class Router {
 	}
 
 /**
+ * Resource map getter & setter.
+ *
+ * @param array $resourceMap Resource map
+ * @return mixed
+ * @see Router::$_resourceMap
+ */
+	public static function resourceMap($resourceMap = null) {
+		if ($resourceMap === null) {
+			return self::$_resourceMap;
+		}
+		self::$_resourceMap = $resourceMap;
+	}
+
+/**
  * Connects a new Route in the router.
  *
  * Routes are a way of connecting request urls to objects in your application.  At their core routes

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2455,6 +2455,37 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * Tests resourceMap as getter and setter.
+ *
+ * @return void
+ */
+	public function testResourceMap() {
+		$default = Router::resourceMap();
+		$exepcted = array(
+			array('action' => 'index',	'method' => 'GET',		'id' => false),
+			array('action' => 'view',	'method' => 'GET',		'id' => true),
+			array('action' => 'add',	'method' => 'POST',		'id' => false),
+			array('action' => 'edit',	'method' => 'PUT', 		'id' => true),
+			array('action' => 'delete',	'method' => 'DELETE',	'id' => true),
+			array('action' => 'edit',	'method' => 'POST', 	'id' => true)
+		);
+		$this->assertEquals($default, $exepcted);
+		
+		$custom = array(
+			array('action' => 'index',	'method' => 'GET',		'id' => false),
+			array('action' => 'view',	'method' => 'GET',		'id' => true),
+			array('action' => 'add',	'method' => 'POST',		'id' => false),
+			array('action' => 'edit',	'method' => 'PUT', 		'id' => true),
+			array('action' => 'delete',	'method' => 'DELETE',	'id' => true),
+			array('action' => 'update',	'method' => 'POST', 	'id' => true)
+		);
+		Router::resourceMap($custom);
+		$this->assertEquals($custom, Router::resourceMap());
+		
+		Router::resourceMap($default);
+	}
+
+/**
  * test setting redirect routes
  *
  * @return void


### PR DESCRIPTION
https://github.com/cakephp/cakephp/pull/391

Edit: My older pull request was against master and not against the development branch. Thank you @ceeram.

At this point there is no way to set custom resourceMap, without extending the Router. So, for example if you want the PUT /my-controller/:id to be pointed to MyController::update there is no easy way to do it. That's why I think that resourceMap accessor will be pretty useful.
