### PR TITLE
1.3 - Form helper to allow for html5 "number" type of text input

### DIFF
--- a/cake/libs/view/helpers/form.php
+++ b/cake/libs/view/helpers/form.php
@@ -746,7 +746,8 @@ class FormHelper extends AppHelper {
 					'string'  => 'text',     'datetime'  => 'datetime',
 					'boolean' => 'checkbox', 'timestamp' => 'datetime',
 					'text'    => 'textarea', 'time'      => 'time',
-					'date'    => 'date',     'float'     => 'text'
+					'date'    => 'date',     'float'     => 'text',
+					'integer' => 'number'
 				);
 
 				if (isset($this->map[$type])) {
@@ -883,6 +884,7 @@ class FormHelper extends AppHelper {
 			case 'text':
 			case 'password':
 			case 'file':
+			case 'number':
 				$input = $this->{$type}($fieldName, $options);
 			break;
 			case 'select':
@@ -1151,6 +1153,12 @@ class FormHelper extends AppHelper {
 			$this->Html->tags['input'],
 			$options['name'],
 			$this->_parseAttributes($options, array('name'), null, ' ')
+		);
+	}
+
+	function number($fieldName, $options = array()) {
+		return $this->text($fieldName, array_merge(
+			array('type' => 'number'), $options)
 		);
 	}
 

--- a/cake/tests/cases/libs/view/helpers/form.test.php
+++ b/cake/tests/cases/libs/view/helpers/form.test.php
@@ -873,6 +873,38 @@ class FormHelperTest extends CakeTestCase {
 			)),
 			'/div'
 		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Tests correct generation of text fields for integers fields
+ *
+ * @access public
+ * @return void
+ */
+	function testTextFieldGenerationForIntegers() {
+		$model = ClassRegistry::getObject('Contact');
+		$model->setSchema(array('foo' => array(
+			'type' => 'integer',
+			'null' => false,
+			'default' => null,
+			'length' => null
+		)));
+
+		$this->Form->create('Contact');
+		$result = $this->Form->input('foo');
+		$expected = array(
+			'div' => array('class' => 'input number'),
+			'label' => array('for' => 'ContactFoo'),
+			'Foo',
+			'/label',
+			array('input' => array(
+				'type' => 'number', 'name' => 'data[Contact][foo]',
+				'id' => 'ContactFoo'
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**


### PR DESCRIPTION
The html5 input type of "number" was not available with the form helper.  This is problematic when creating forms for mobile devices.  The only way to notify mobile device browsers that the keyboard should be a numeric keyboard is by the input type.

I've updated the `FormHelper::input` method to allow for type of "number" and associated the mapping of "integer" for field types to this new input method.

Also, while I was writing the test case for this change, I noticed the `testTextFieldGenerationForFloats()` was missing the assert call (essentially this method was never being called in the test case), so I added the assert for this test.
