### PR TITLE
buildCookies() function throws a notice when dealing with host's cookies

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -877,7 +877,9 @@ class HttpSocket extends CakeSocket {
 	public function buildCookies($cookies) {
 		$header = array();
 		foreach ($cookies as $name => $cookie) {
-			$header[] = $name . '=' . $this->_escapeToken($cookie['value'], array(';'));
+            if (isset($cookie['value'])){
+                $header[] = $name . '=' . $this->_escapeToken($cookie['value'], array(';'));
+            }
 		}
 		return $this->_buildHeader(array('Cookie' => implode('; ', $header)), 'pragmatic');
 	}


### PR DESCRIPTION
Sometimes, the "cookies" array inside the request object contains hosts names as keys to group cookies by hosts. The buildCookies functions wasn't considering it and the execution causes a notice:

```
Notice (8): Undefined index: value [CORE/Cake/Network/Http/HttpSocket.php, line 881]
```

This failed because on line 274, for example, the function was called passing the array in question, after it was the result of a merge between whatever there was in the array and the host cookies on the config object on line 261.

<pre>261: $this->request['cookies'] = array_merge($this->request['cookies'], $this->config['request']['cookies'][$Host], $request['cookies']);
…
274: $cookies = $this->buildCookies($this->request['cookies']);</pre>


To reproduce this error, make a request to a host which response comes with cookies. You can use bandcamp's api, for example. HttpSocket will put these cookies inside `$this->request->cookies['api.bandcamp.com']`. Then, make another request right away, it could be to the same host.
The cookies array will still be the same and cause the warning explained above.
