### PR TITLE
Fixed wrong boundary marker for inline-files

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1288,7 +1288,7 @@ class CakeEmail {
 			}
 			$data = $this->_readFile($fileInfo['file']);
 
-			$msg[] = '--' . $this->_boundary;
+			$msg[] = '--rel-' . $this->_boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];
 			$msg[] = 'Content-Transfer-Encoding: base64';
 			$msg[] = 'Content-ID: <' . $fileInfo['contentId'] . '>';


### PR DESCRIPTION
Inline-files should start new rel-boundaries, not (outer-)mixed-boundaries.

Amavis spits out this error:
X-Amavis-Alert: BAD HEADER MIME error: error: unexpected end of parts before epilogue
