### PR TITLE
2.0 2467

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -206,6 +206,8 @@ class Postgres extends DboSource {
 					if ($c->type == 'character varying') {
 						$length = null;
 						$type = 'text';
+					} else if ($c->type == 'uuid') {
+						$length = 36;
 					} else {
 						$length = intval($c->oct_length);
 					}


### PR DESCRIPTION
Return length 36 for uuid columns in Postgres.describe()

When describing a Postgres native "uuid" column, the length 36 should be
returned so that Model.save() will be able to correctly set $isUUID as
"true" on that column.

Fixes #2467
