### PR TITLE
$action in AclShell::_getParams() should default to '*', not NULL

### DIFF
--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -576,7 +576,7 @@ class AclShell extends AppShell {
 		if (is_string($aco)) {
 			$aco = $this->parseIdentifier($aco);
 		}
-		$action = null;
+		$action = '*';
 		if (isset($this->args[2])) {
 			$action = $this->args[2];
 			if ($action == '' || $action == 'all') {


### PR DESCRIPTION
When called as in the following example, `$action` is passed to AclComponent as `null`, which AclComponent then complains about, as it is expecting a value. Example:

```
> cake2 acl check warriors Weapons
```

This produces the following result:

```
---------------------------------------------------------------
App : app
Path: /home/rintaun/app/
---------------------------------------------------------------
Notice Error: ACO permissions key %s does not exist in DbAcl::check() in
[/usr/local/share/cakephp2/lib/Cake/Controller/Component/AclComponent.php,
line 313]

warriors is not allowed.
```

It may also be prudent to modify AclComponent, line 312, to include the case of `empty($action)`.
