### PR TITLE
Properly set the current action on CakeRequest when invoking Controller::setAction()

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -804,7 +804,7 @@ class Controller extends Object {
  * @return mixed Returns the return value of the called action
  */
 	public function setAction($action) {
-		$this->request->action = $action;
+		$this->request->params['action'] = $action;
 		$this->view = $action;
 		$args = func_get_args();
 		unset($args[0]);


### PR DESCRIPTION
Currently we just set a new instance variable, `CakeRequest->action`, which is not referenced anywhere in the application. I might be misunderstanding how this should work, but otherwise we have to do a check for that property in order to know setAction was invoked, and $this->request->params['action'] will be incorrect.
