### PR TITLE
Form model validation

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -114,6 +114,8 @@ class Contact extends CakeTestModel {
 			'between' => array('rule' => array('between', 5, 30)),
 		),
 		'imnotrequiredeither' => array('required' => true, 'rule' => array('between', 5, 30), 'allowEmpty' => true),
+		'imrequiredoncreate' => array('rule' => 'notEmpty', 'on' => 'create'),
+		'imrequiredonupdate' => array('rule' => 'notEmpty', 'on' => 'update')
 	);
 
 /**
@@ -7755,4 +7757,100 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error('Thing.field', null, array('wrap' => false));
 		$this->assertEquals('Badness!', $result);
 	}
+
+/**
+ * Tests for on create is required when no model ID is present
+ * FormHelper will look for `on create` key
+ * @return void
+ */
+
+    public function testOnCreateNoIdValidation() {
+		$result = $this->Form->input('Contact.imrequiredoncreate');
+		
+		$expected = array(
+			'div' => array('class' => 'input text required'),
+			'label' => array('for' => 'ContactImrequiredoncreate'),
+			'Imrequiredoncreate',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][imrequiredoncreate]',
+				'id' => 'ContactImrequiredoncreate'
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+    }
+
+/**
+ * Tests for on create is NOT required when model ID is present
+ * FormHelper will look for `on create` key
+ * @return void
+ */    
+    
+    public function testOnCreateWithIdValidation() {
+    	$this->Form->request->data = array('Contact' => array('id' => 1));
+    
+		$result = $this->Form->input('Contact.imrequiredoncreate');
+		
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'ContactImrequiredoncreate'),
+			'Imrequiredoncreate',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][imrequiredoncreate]',
+				'id' => 'ContactImrequiredoncreate'
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+    }
+
+/**
+ * Tests for on update is NOT required when model ID is not present
+ * FormHelper will look for `on update` key
+ * @return void
+ */    
+    
+    public function testOnUpdateNoIdValidation() {
+     	$result = $this->Form->input('Contact.imrequiredonupdate');
+		
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'ContactImrequiredonupdate'),
+			'Imrequiredonupdate',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][imrequiredonupdate]',
+				'id' => 'ContactImrequiredonupdate'
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+    }
+
+/**
+ * Tests for on update is required when model ID is present
+ * FormHelper will look for `on update` key
+ * @return void
+ */    
+    
+    public function testOnUpdateWithIdValidation() {
+     	$this->Form->request->data = array('Contact' => array('id' => 1));
+     
+		$result = $this->Form->input('Contact.imrequiredonupdate');
+		
+		$expected = array(
+			'div' => array('class' => 'input text required'),
+			'label' => array('for' => 'ContactImrequiredonupdate'),
+			'Imrequiredonupdate',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][imrequiredonupdate]',
+				'id' => 'ContactImrequiredonupdate'
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+    }
 }

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -243,7 +243,7 @@ class FormHelper extends AppHelper {
  * @param array $validateProperties
  * @return boolean true if field is required to be filled, false otherwise
  */
-	protected function _isRequiredField($validateProperties, $model = null) {
+	protected function _isRequiredField($validateProperties, $Model = null) {
 		$required = false;
 		if (is_string($validateProperties)) {
 			return true;
@@ -255,10 +255,10 @@ class FormHelper extends AppHelper {
 			}
 
 			foreach ($validateProperties as $rule => $validateProp) {
-				if(isset($validateProp['on']) && !empty($model) &&
+				if(isset($validateProp['on']) && !empty($Model) &&
 					(
-						!($validateProp['on'] == 'create' && empty($this->request->data[$model->name][$model->primaryKey])) &&
-					 	!($validateProp['on'] == 'update' && !empty($this->request->data[$model->name][$model->primaryKey]))
+						!($validateProp['on'] == 'create' && empty($this->request->data[$Model->alias][$Model->primaryKey])) &&
+					 	!($validateProp['on'] == 'update' && !empty($this->request->data[$Model->alias][$Model->primaryKey]))
 					)
 				){
 					return false;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -219,7 +219,7 @@ class FormHelper extends AppHelper {
 				$validates = array();
 				if (!empty($object->validate)) {
 					foreach ($object->validate as $validateField => $validateProperties) {
-						if ($this->_isRequiredField($validateProperties)) {
+						if ($this->_isRequiredField($validateProperties, $object)) {
 							$validates[$validateField] = true;
 						}
 					}
@@ -243,7 +243,7 @@ class FormHelper extends AppHelper {
  * @param array $validateProperties
  * @return boolean true if field is required to be filled, false otherwise
  */
-	protected function _isRequiredField($validateProperties) {
+	protected function _isRequiredField($validateProperties, $model = null) {
 		$required = false;
 		if (is_string($validateProperties)) {
 			return true;
@@ -255,6 +255,15 @@ class FormHelper extends AppHelper {
 			}
 
 			foreach ($validateProperties as $rule => $validateProp) {
+				if(isset($validateProp['on']) && !empty($model) &&
+					(
+						!($validateProp['on'] == 'create' && empty($this->request->data[$model->name][$model->primaryKey])) &&
+					 	!($validateProp['on'] == 'update' && !empty($this->request->data[$model->name][$model->primaryKey]))
+					)
+				){
+					return false;
+				}
+			
 				if (isset($validateProp['allowEmpty']) && $validateProp['allowEmpty'] === true) {
 					return false;
 				}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -241,6 +241,7 @@ class FormHelper extends AppHelper {
  * Returns if a field is required to be filled based on validation properties from the validating object.
  *
  * @param array $validateProperties
+ * @param object $Model model used to check existance of primary key for on create/update check
  * @return boolean true if field is required to be filled, false otherwise
  */
 	protected function _isRequiredField($validateProperties, $Model = null) {


### PR DESCRIPTION
Per ticket #2169, I developed logic in the form helper to use the `on` key as part of the validation.  The logic requires that the model structure be passed to the _isRequiredField function.  When the function loops through validateProperties, the new logic looks for the `on` key.  If it is set, and the model structure is passed, then it checks to see if the current request has an id.  It uses the `on` key and the request model id to determine if the rule is valid or not.

In my testing, this worked.  I cannot think of a circumstance where the action would be update and there would be no primary key in the request data.  Conversely, if there is no primary key in the request data, then the action would always be create, correct?  So, I think that this should cover all situations.
