### PR TITLE
Check the logic in the Shell::in($prompt, $options = null, $default = null)

### DIFF
--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -87,7 +87,7 @@ class DbConfigTask extends AppShell {
  */
 	protected function _interactive() {
 		$this->hr();
-		$this->out('Database Configuration:');
+		$this->out(__d('cake_console', 'Database Configuration:'));
 		$this->hr();
 		$done = false;
 		$dbConfigs = array();

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -456,7 +456,7 @@ class Shell extends Object {
 			}
 		}
 		if (is_array($options)) {
-			while ($in === '' || ($in !== '' && (!in_array(strtolower($in), $options) && !in_array(strtoupper($in), $options)) && !in_array($in, $options))) {
+			while ($in === '' || !(in_array(strtolower($in), $options) || in_array(strtoupper($in), $options) || in_array($in, $options))) {
 				$in = $this->_getInput($prompt, $options, $default);
 			}
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -675,7 +675,7 @@ class Model extends Object {
 		}
 
 		if (is_subclass_of($this, 'AppModel')) {
-			$merge = array('actsAs','findMethods');
+			$merge = array('actsAs', 'findMethods');
 			$parentClass = get_parent_class($this);
 			if ($parentClass !== 'AppModel') {
 				$this->_mergeVars($merge, $parentClass);

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -676,7 +676,8 @@ class Model extends Object {
 
 		if (is_subclass_of($this, 'AppModel')) {
 			$merge = array('findMethods');
-			if ($this->actsAs !== null || $this->actsAs !== false) {
+			#if (!empty($this->actsAs)) { //Another possible solution
+			if ($this->actsAs !== null && $this->actsAs !== false) {
 				$merge[] = 'actsAs';
 			}
 			$parentClass = get_parent_class($this);

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -675,11 +675,7 @@ class Model extends Object {
 		}
 
 		if (is_subclass_of($this, 'AppModel')) {
-			$merge = array('findMethods');
-			#if (!empty($this->actsAs)) { //Another possible solution
-			if ($this->actsAs !== null && $this->actsAs !== false) {
-				$merge[] = 'actsAs';
-			}
+			$merge = array('actsAs','findMethods');
 			$parentClass = get_parent_class($this);
 			if ($parentClass !== 'AppModel') {
 				$this->_mergeVars($merge, $parentClass);


### PR DESCRIPTION
Reviewing the code of the Shell I found a logic statement in particular that made ​​me confuzed, to which we apply a simple reduction:

If we review the logic of the following code:

``` php
<?php
     while ($in === '' || ($in !== '' && (!in_array(strtolower($in), $options) && !in_array(strtoupper($in), $options)) && !in_array($in, $options))) 

```

We will realize that $in must be different of '', which indicates that the code is equivalent to

``` php
<?php
     while ($in === '' || (!in_array(strtolower($in), $options) && !in_array(strtoupper($in), $options) && !in_array($in, $options)) 
```

Finally, the logic is: `(!a && !b && !c)` may take the form: `!(a || b || c)`:

``` php
<?php
      while ($in === '' || !(in_array(strtolower($in), $options) || in_array(strtoupper($in), $options) || in_array($in, $options))) {

```

Saludos!.
