### PR TITLE
Update lib/Cake/Network/Email/CakeEmail.php

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1365,7 +1365,10 @@ class CakeEmail {
 		}
 
 		if ($hasInlineAttachments) {
+    			$boundary = $this->_boundary;
+    			$this->_boundary = $relBoundary;
 			$attachments = $this->_attachInlineFiles();
+	    		$this->_boundary = $boundary;
 			$msg = array_merge($msg, $attachments);
 			$msg[] = '';
 			$msg[] = '--' . $relBoundary . '--';


### PR DESCRIPTION
In-line attachments were still treated as non in-line by Thunderbird. The problem lay in the wrong boundary. Here is a fix.
