### PR TITLE
Bake test plurals

### DIFF
--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -84,15 +84,21 @@ class <?php echo $fullClassName; ?>TestCase extends CakeTestCase {
 		parent::tearDown();
 	}
 
+<?php $methodKeys = array();?>
 <?php foreach ($methods as $method): ?>
+<?php 
+	$classifyMethodName = Inflector::classify($method);
+	if(!in_array($classifyMethodName, $methodKeys)):	
+		$methodKeys[] = $classifyMethodName;
+?>
 /**
- * test<?php echo Inflector::classify($method); ?> method
+ * test<?php echo $classifyMethodName; ?> method
  *
  * @return void
  */
-	public function test<?php echo Inflector::classify($method); ?>() {
+	public function test<?php echo $classifyMethodName; ?>() {
 
 	}
-
+	<?php endif; ?>
 <?php endforeach;?>
 }

--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -84,21 +84,14 @@ class <?php echo $fullClassName; ?>TestCase extends CakeTestCase {
 		parent::tearDown();
 	}
 
-<?php $methodKeys = array();?>
 <?php foreach ($methods as $method): ?>
-<?php 
-	$classifyMethodName = Inflector::classify($method);
-	if(!in_array($classifyMethodName, $methodKeys)):	
-		$methodKeys[] = $classifyMethodName;
-?>
 /**
- * test<?php echo $classifyMethodName; ?> method
+ * test<?php echo Inflector::camelize($method); ?> method
  *
  * @return void
  */
-	public function test<?php echo $classifyMethodName; ?>() {
+	public function test<?php echo Inflector::camelize($method); ?>() {
 
 	}
-	<?php endif; ?>
 <?php endforeach;?>
 }


### PR DESCRIPTION
In working with my previous pull request, I found a bug in test file generation when using FormHelper -- outlined in case #2478. The current implementation of the test file allows for duplicate function names to be created, therefor causing a fatal php error when the test is run. This fix creates an array of function names that is checked before each function is created. If it exists, then the duplicate is omitted.

This could be extended so that duplicate function names are given an alternative name. However, I wasn't sure if omission or alternative name creation would be the best path for the framework.
