### PR TITLE
Fix HtmlHelper::link test and extend HtmlHelper::image (issue #2476)

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -351,6 +351,10 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->image('/test/view/1.gif');
 		$this->assertTags($result, array('img' => array('src' => '/test/view/1.gif', 'alt' => '')));
+		
+		$result = $this->Html->image('test.gif', array('fullPath' => true));
+		$here = $this->Html->url('/', true);
+		$this->assertTags($result, array('img' => array('src' => $here . 'img/test.gif', 'alt' => '')));
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -353,7 +353,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$result = $this->Html->image('/test/view/1.gif');
 		$this->assertTags($result, array('img' => array('src' => '/test/view/1.gif', 'alt' => '')));
 		
-		$result = $this->Html->image('test.gif', array('fullPath' => true));
+		$result = $this->Html->image('test.gif', array('fullBase' => true));
 		$here = $this->Html->url('/', true);
 		$this->assertTags($result, array('img' => array('src' => $here . 'img/test.gif', 'alt' => '')));
 	}

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -315,18 +315,19 @@ class HtmlHelperTest extends CakeTestCase {
 
 		Configure::write('Asset.timestamp', 'force');
 
- 		$result = $this->Html->link($this->Html->image('../favicon.ico'), '#', array('escape' => false));
+		$result = $this->Html->link($this->Html->image('../favicon.ico'), '#', array('escape' => false));
  		$expected = array(
  			'a' => array('href' => '#'),
-			'img' => array('src' => 'preg:/img\/..\/favicon\.ico\?\d*/', 'alt' => ''),
+			'img' => array('src' => 'img/../favicon.ico', 'alt' => ''),
 			'/a'
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Html->image('../favicon.ico', array('url' => '#'));
+
 		$expected = array(
 			'a' => array('href' => '#'),
-			'img' => array('src' => 'preg:/img\/..\/favicon\.ico\?\d*/', 'alt' => ''),
+			'img' => array('src' => 'img/../favicon.ico', 'alt' => ''),
 			'/a'
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -706,6 +706,11 @@ class HtmlHelper extends AppHelper {
 			}
 			$path = $this->assetTimestamp($this->webroot($path));
 		}
+		
+		if(!empty($options['fullPath'])) {
+			$path = $this->url('/', true) . $path;
+			unset($options['fullPath']);
+		}
 
 		if (!isset($options['alt'])) {
 			$options['alt'] = '';

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -739,8 +739,9 @@ class HtmlHelper extends AppHelper {
 
 /**
  * Creates a formatted IMG element. If `$options['url']` is provided, an image link will be
- * generated with the link pointed at `$options['url']`.  This method will set an empty
- * alt attribute if one is not supplied.
+ * generated with the link pointed at `$options['url']`. If `$options['fullBase']` is provided,
+ * the src attribute will receive full address (non-relative url) of the image file.
+ * This method will set an empty alt attribute if one is not supplied.
  *
  * ### Usage
  *
@@ -767,9 +768,9 @@ class HtmlHelper extends AppHelper {
 			$path = $this->assetTimestamp($this->webroot($path));
 		}
 		
-		if(!empty($options['fullPath'])) {
+		if (!empty($options['fullBase'])) {
 			$path = $this->url('/', true) . $path;
-			unset($options['fullPath']);
+			unset($options['fullBase']);
 		}
 
 		if (!isset($options['alt'])) {


### PR DESCRIPTION
Include option 'fullPath' in HtmlHelper::image reconized paramters to allow img tags were src attribute receive full path of file. That's useful in formating mail and fix #2476 issue.

Fixed two test case of HtmlHelper::link
