### PR TITLE
Error Using NOT IN () with Arrays for Conditions (Issues #796 & #821)

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2368,7 +2368,7 @@ class DboSource extends DataSource {
 					$keys = array_keys($value);
 					if ($keys === array_values($keys)) {
 						$count = count($value);
-						if ($count === 1) {
+						if ($count === 1 && !preg_match("/\s+NOT$/", $key)) {
 							$data = $this->_quoteFields($key) . ' = (';
 						} else {
 							$data = $this->_quoteFields($key) . ' IN (';


### PR DESCRIPTION
I think that this issue could be solved with the check I added in this commit.  It extends the check for and array with 1 value and a string key, and looks for `NOT` at the end of the key.  It passed all of the core unit tests.  I will also add a unit test to case #796 since I can't attach them here.  I can't think of any other times where this could fail, so I am submitting for integration.
