### PR TITLE
Prevent blackhole auth error where are present multi fields

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -430,8 +430,8 @@ class SecurityComponent extends Component {
 		$multi = array();
 
 		foreach ($fieldList as $i => $key) {
-			if (preg_match('/\.\d+$/', $key)) {
-				$multi[$i] = preg_replace('/\.\d+$/', '', $key);
+			if (preg_match('/(\.\d+)+$/', $key)) {
+				$multi[$i] = preg_replace('/(\.\d+)+$/', '', $key);
 				unset($fieldList[$i]);
 			}
 		}


### PR DESCRIPTION
Prevent blackhole auth error where are present multi fields like TaxonomyData.1.0 (ex. Croogo).

Without this patch it became TaxonomyData.1 that differs from TaxonomyData in fields token.
