### PR TITLE
Prevent blackhole auth error where are present multi fields

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -430,8 +430,8 @@ class SecurityComponent extends Component {
 		$multi = array();
 
 		foreach ($fieldList as $i => $key) {
-			if (preg_match('/\.\d+$/', $key)) {
-				$multi[$i] = preg_replace('/\.\d+$/', '', $key);
+			if (preg_match('/(\.\d+)+$/', $key)) {
+				$multi[$i] = preg_replace('/(\.\d+)+$/', '', $key);
 				unset($fieldList[$i]);
 			}
 		}


### PR DESCRIPTION
You can reproduce the problem in Croogo CMS 1.4
In Nodes admin_add view ( https://github.com/croogo/croogo/blob/1.4/View/Nodes/admin_add.ctp )
it adds > 1 TaxonomyData inputs like this:

``` php
<?php
    foreach ($taxonomy AS $vocabularyId => $taxonomyTree) {
        echo $this->Form->input('TaxonomyData.'.$vocabularyId, array(
            'label' => $vocabularies[$vocabularyId]['title'],
            'type' => 'select',
            'multiple' => true,
            'options' => $taxonomyTree,
        ));
    }
?>
```

If I select one option of these input, when post data is submitted it gave me security error.
In _validatePost() method of the security component, these fields are flatted that way:

```
Array
(
    ...
    [TaxonomyData.1.0] => 2
    [TaxonomyData.2.0] => 3
    ...
)
```

That, after $multi preg_replace and array_unique, became:

```
Array
(
    ...
    [16] => TaxonomyData.1
    [17] => TaxonomyData.2
)
```

So, the check token is calculated with these two item instead of simply:

```
Array
(
    ...
    [16] => TaxonomyData
)
```

like it did on form creating, causing false _validatePost() return and blackhole auth error.
