### PR TITLE
Check that $namedValue is not an array in _writeUrl

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -480,7 +480,9 @@ class CakeRoute {
 				if (is_array($value)) {
 					$flat = Set::flatten($value, '][');
 					foreach ($flat as $namedKey => $namedValue) {
-						$named[] = $key . "[$namedKey]" . $separator . rawurlencode($namedValue);
+						if(!is_array($namedValue)) {
+							$named[] = $key . "[$namedKey]" . $separator . rawurlencode($namedValue);
+						}
 					}
 				} else {
 					$named[] = $key . $separator . rawurlencode($value);


### PR DESCRIPTION
We had a condition where we needed a url to have the format 

```
/users/index/conditions[User][group_id]:5
```

This needed to pass through to the $this->request->params['named'], it worked correctly but was throwing errors saying

```
rawurlencode() expects parameter 1 to be string, array given
```

The output in $this->request->params['named'] was

```
[named] => Array
        (
            [conditions] => Array
                (
                    [User] => Array
                        (
                            [group_id] => 5
                        )

                )

        )
```

Checking that the input isn't an array works however I was also playing with checking for is_string but didn't know if it would break the passing of anything else through.
