### PR TITLE
ViewCache uses Cache prefixes

### DIFF
--- a/cake/dispatcher.php
+++ b/cake/dispatcher.php
@@ -526,7 +526,7 @@ class Dispatcher extends Object {
 			if ($this->here == '/') {
 				$path = 'home';
 			}
-			$path = strtolower(Inflector::slug($path));
+			$path = strtolower(Inflector::slug(Configure::read('Cache.prefix') . '_' . $path));
 
 			$filename = CACHE . 'views' . DS . $path . '.php';
 

--- a/cake/libs/view/helpers/cache.php
+++ b/cake/libs/view/helpers/cache.php
@@ -240,7 +240,7 @@ class CacheHelper extends AppHelper {
 		if ($this->here == '/') {
 			$path = 'home';
 		}
-		$cache = strtolower(Inflector::slug($path));
+		$cache = strtolower(Inflector::slug(Configure::read('Cache.prefix') . '_' . $path));
 
 		if (empty($cache)) {
 			return;


### PR DESCRIPTION
Caching in Cake is awesome. We like how we can change the cache prefix for different configurations (e.g. language). The ViewCache however, does not follow in this: the cache prefix has no influence on where the cached views are stored. We feel this breaks expected behavior, hence this pull.

If a `Configure::read('Cache.prefix')` is present, it is appended to the filename of the cached view in `TMP/cache/views`.

So, if I set

``` php
Configure::write('Cache.prefix', 'us')
```

My cached homepage will end up in:

`tmp/views/us_home.php`

If I set a different cache prefix (e.g. for another language):

``` php
Configure::write('Cache.prefix', 'fr')
```

My cached homepage for French visitors will end up in:

`tmp/views/fr_home.php`

If no cache prefix is set, it will end up in the default location:

`tmp/views/home.php`
