### PR TITLE
Cookie 2.0 compatibility

### DIFF
--- a/cake/libs/controller/components/cookie.php
+++ b/cake/libs/controller/components/cookie.php
@@ -464,11 +464,11 @@ class CookieComponent extends Object {
  * Explode method to return array from string set in CookieComponent::__implode()
  *
  * @param string $string String in the form key1|value1,key2|value2
- * @return array Map of key and values
+ * @return mixed If array, map of key and values. If string, value.
  * @access private
  */
 	function __explode($string) {
-		if (($string[0] === '{' || $string[0] === '[') && function_exists('json_decode')) {
+		if (!empty($string[0]) && ($string[0] === '{' || $string[0] === '[') && function_exists('json_decode')) {
 			$ret = json_decode($string, true);
 			return ($ret != null) ? $ret : $string;
 		}

--- a/cake/libs/model/behaviors/translate.php
+++ b/cake/libs/model/behaviors/translate.php
@@ -110,7 +110,7 @@ class TranslateBehavior extends ModelBehavior {
 		}
 		$db =& ConnectionManager::getDataSource($model->useDbConfig);
 		$RuntimeModel =& $this->translateModel($model);
-	
+
 		if (!empty($RuntimeModel->tablePrefix)) {
 			$tablePrefix = $RuntimeModel->tablePrefix;
 		} else {

--- a/cake/tests/cases/libs/controller/components/cookie.test.php
+++ b/cake/tests/cases/libs/controller/components/cookie.test.php
@@ -487,9 +487,16 @@ class CookieComponentTest extends CakeTestCase {
 		if ($this->skipIf(!function_exists('json_decode'), 'no json_decode, skipping.')) {
 			return;
 		}
-		$_COOKIE['CakeTestCookie'] = array('Test' => '{"name":"value"}');
+		$_COOKIE['CakeTestCookie'] = array(
+			'JSON' => '{"name":"value"}',
+			'Empty' => '',
+			'String' => '{"somewhat:"broken"}'
+		);
 		$this->Controller->Cookie->startup($this->Controller);
-		$this->assertEqual('value', $this->Controller->Cookie->read('Test.name'));
+		$this->assertEqual(array('name' => 'value'), $this->Controller->Cookie->read('JSON'));
+		$this->assertEqual('value', $this->Controller->Cookie->read('JSON.name'));
+		$this->assertEqual('', $this->Controller->Cookie->read('Empty'));
+		$this->assertEqual('{"somewhat:"broken"}', $this->Controller->Cookie->read('String'));
 	}
 
 /**


### PR DESCRIPTION
Fix a bug introduced when generating partial compatibility between 1.3 and 2.0 Cookies, where an empty valued key caused a PHP notice. Also, harden tests. Completes the fix for #2131.
