### PR TITLE
set encoding declear.

### DIFF
--- a/app/webroot/css/cake.generic.css
+++ b/app/webroot/css/cake.generic.css
@@ -1,3 +1,4 @@
+@charset "utf-8";
 /**
  *
  * Generic CSS for CakePHP


### PR DESCRIPTION
cake.generic.css is containing multibyte symbol for th a.asc:after and th a.desc:after .
Even chrome misunderstand proper encoding of this css file.
To make work correct, charset should be specified at first line of css file.

this is just one line fix.
