### PR TITLE
Use Object for database results

### DIFF
--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -22,6 +22,7 @@
  *
  * @package       Cake.Model.Datasource
  */
+ App::uses('Record', 'Model');
 class DataSource extends Object {
 
 /**

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -239,12 +239,13 @@ class Mysql extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = array();
+			$resultRow = new Record($this);
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
-				$resultRow[$table][$column] = $row[$col];
+				$resultRow->setModelName($table);
+				$resultRow->{$column} = $row[$col];
 				if ($type === 'boolean' && $row[$col] !== null) {
-					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
+					$resultRow->{$column} = $row[$col];
 				}
 			}
 			return $resultRow;

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -239,7 +239,7 @@ class Mysql extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = new Record($this);
+			$resultRow = new Record;
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
 				$resultRow->setModelName($table);

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -708,7 +708,7 @@ class Postgres extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = new Record($this);
+			$resultRow = new Record;
 
 			foreach ($this->map as $index => $meta) {
 				list($table, $column, $type) = $meta;

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -708,21 +708,21 @@ class Postgres extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = array();
+			$resultRow = new Record($this);
 
 			foreach ($this->map as $index => $meta) {
 				list($table, $column, $type) = $meta;
-
+				$resultRow->setModelName($table);
 				switch ($type) {
 					case 'bool':
-						$resultRow[$table][$column] = is_null($row[$index]) ? null : $this->boolean($row[$index]);
+						$resultRow->{$column} = is_null($row[$index]) ? null : $this->boolean($row[$index]);
 					break;
 					case 'binary':
 					case 'bytea':
-						$resultRow[$table][$column] = stream_get_contents($row[$index]);
+						$resultRow->{$column} = stream_get_contents($row[$index]);
 					break;
 					default:
-						$resultRow[$table][$column] = $row[$index];
+						$resultRow->{$column} = $row[$index];
 					break;
 				}
 			}

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -331,7 +331,7 @@ class Sqlite extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = new Record($this);
+			$resultRow = new Record;
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
 				$resultRow->setModelName($table);

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -331,12 +331,13 @@ class Sqlite extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = array();
+			$resultRow = new Record($this);
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
-				$resultRow[$table][$column] = $row[$col];
+				$resultRow->setModelName($table);
+				$resultRow->{$column} = $row[$col];
 				if ($type == 'boolean' && !is_null($row[$col])) {
-					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
+					$resultRow->{$column} = $this->boolean($resultRow[$table][$column]);
 				}
 			}
 			return $resultRow;

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -608,15 +608,16 @@ class Sqlserver extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = array();
+			$resultRow = new Record($this);
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
+				$resultRow->setModelName($table);
 				if ($table === 0 && $column === self::ROW_COUNTER) {
 					continue;
 				}
-				$resultRow[$table][$column] = $row[$col];
+				$resultRow->{$column} = $row[$col];
 				if ($type === 'boolean' && !is_null($row[$col])) {
-					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
+					$resultRow->{$column} = $this->boolean($resultRow[$table][$column]);
 				}
 			}
 			return $resultRow;

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -608,7 +608,7 @@ class Sqlserver extends DboSource {
  */
 	public function fetchResult() {
 		if ($row = $this->_result->fetch(PDO::FETCH_NUM)) {
-			$resultRow = new Record($this);
+			$resultRow = new Record;
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
 				$resultRow->setModelName($table);

--- a/lib/Cake/Model/Record.php
+++ b/lib/Cake/Model/Record.php
@@ -72,8 +72,7 @@ class Record implements ArrayAccess
 
 		if(!$this->offsetExists($key))
 		{
-			// this is most likely an association that is beinh loaded
-			// TODO : query model association
+			// TODO : fetch model associations
 			throw new CakeException(__d('cake_dev', 'No association found - %s', $key));
 		} else {
 			return $this->_data[$key];

--- a/lib/Cake/Model/Record.php
+++ b/lib/Cake/Model/Record.php
@@ -1,0 +1,102 @@
+<?php
+
+class Record implements ArrayAccess
+{
+	protected $_data;
+
+	protected $_db_source;
+
+	protected $_model_name;
+
+	public function __construct(DataSource $source)
+	{
+		$this->setDbSource($source);
+	}
+
+	public function setModelName($model)
+	{
+		$this->_model_name = $model;
+	}
+
+	public function getModelName()
+	{
+		return $this->_model_name;
+	}
+
+	public function setDbSource(DataSource $source)
+	{
+		$this->_db_source = $source;
+	}
+
+	public function getDbSource()
+	{
+		return $this->_db_source;
+	}
+
+	public function __call($method, $args)
+	{
+		$type = substr($method, 0, 3);
+		$field = strtolower(substr($method, 3));
+
+		if($type == 'get')
+		{
+			if($this->offsetExists($field))
+			{
+				return $this->offsetGet($field);
+			}
+		} elseif($type == 'set')
+		{
+			if(isset($args[0]))
+			{
+				$this->offsetSet($field, $args[0]);
+			}
+		}
+	}
+
+	public function __set($key, $value)
+	{
+		return $this->offsetSet($key, $value);
+	}
+
+	public function __get($key)
+	{
+		return $this->offsetGet($key);
+	}
+
+	public function offsetGet($key)
+	{
+		if($key == $this->getModelName())
+		{
+			return $this;
+		}
+
+		if(!$this->offsetExists($key))
+		{
+			// this is most likely an association that is beinh loaded
+			// TODO : query model association
+			throw new CakeException(__d('cake_dev', 'No association found - %s', $key));
+		} else {
+			return $this->_data[$key];
+		}
+	}
+
+	public function offsetSet($key, $value)
+	{
+		$this->_data[$key] = $value;
+	}
+
+	public function offsetUnset($key)
+	{
+		unset($this->_data[$key]);
+	}
+	
+	public function offsetExists($key)
+	{
+		if($key == $this->getModelName())
+		{
+			return !empty($this->_data);
+		}
+
+		return isset($this->_data[$key]);
+	}
+}


### PR DESCRIPTION
I implemented an object for database results, instead of returning just an array.
The object implements ArrayAccess, so it is fulle backwards compatible.
The associations are loaded dynamically when you need them, so you don't have to select all related records at once.

E.G
The following query

``` php
$posts = $this->Post->find('all');
```

will return a Record instance.
Then you can do the following:

``` php
foreach($posts as $post)
{
    // the following will return the content field
    echo $post->content;
    echo $post->getContent();
    echo $post['content']
    echo $post['Post']['content'];

   // The following will return the associated data. As soon as calling any of the following, the db will be queried to get the associated data
    echo $post->User->name;
    echo $post['User']['name'];

    // easily save records
    // the following will all save the record with the changed data
    $post->content = 'new content';
    $post->save(); // will save the new content

    $post->setContent('new content');
    $post->save();

    $post['content'] = 'new content';
    $post->save();


    $post['Post']['content'] = 'new content';
    $post->save();

    $post->User->name = 'new user';
    $post->User->save();

    // or you can delete any record
    $post->delete(); // will delete the selected post
}
```

It still needs some work, but can maybe be used as a building block
