### PR TITLE
2.1 fix shell 

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -453,7 +453,8 @@ class Shell extends Object {
 		if (!$this->interactive) {
 			return $default;
 		}
-		$in = $this->_getInput($prompt, $options, $default);
+		$original_options = $options;
+		$in = $this->_getInput($prompt, $original_options, $default);
 
 		if ($options && is_string($options)) {
 			if (strpos($options, ',')) {
@@ -471,7 +472,7 @@ class Shell extends Object {
 				$options
 			);
 			while ($in === '' || !in_array($in, $options)) {
-				$in = $this->_getInput($prompt, $options, $default);
+				$in = $this->_getInput($prompt, $original_options, $default);
 			}
 		}
 		return $in;


### PR DESCRIPTION
this changes fix console help if user incorrect input data in bake

example:
## Interactive Bake Shell

[D]atabase Configuration
[M]odel
[V]iew
[C]ontroller
[P]roject
[F]ixture
[T]est case
[Q]uit
What would you like to Bake? (D/M/V/C/P/F/T/Q) 

> b
> What would you like to Bake? (d/m/v/c/p/f/t/q/D/M/V/C/P/F/T/Q/D/M/V/C/P/F/T/Q)

fixed:
## Interactive Bake Shell

[D]atabase Configuration
[M]odel
[V]iew
[C]ontroller
[P]roject
[F]ixture
[T]est case
[Q]uit
What would you like to Bake? (D/M/V/C/P/F/T/Q) 

> b
> What would you like to Bake? (D/M/V/C/P/F/T/Q)
