### PR TITLE
allow registering new packages using App::build(), fixes #2517

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -296,23 +296,24 @@ class App {
 			return;
 		}
 
-		foreach ($defaults as $type => $default) {
+		foreach ($paths as $type => $newPaths) {
 			if (!empty(self::$_packages[$type])) {
 				$path = self::$_packages[$type];
+			} else {
+				// new type
+				$path = array();
+				self::objects($type, null, false);
 			}
 
-			if (!empty($paths[$type])) {
-				$newPath = (array)$paths[$type];
+			$newPaths = (array) $newPaths;
 
-				if ($mode === App::PREPEND) {
-					$path = array_merge($newPath, $path);
-				} else {
-					$path = array_merge($path, $newPath);
-				}
-
-				$path = array_values(array_unique($path));
+			if ($mode === App::PREPEND) {
+				$path = array_merge($newPaths, $path);
+			} else {
+				$path = array_merge($path, $newPaths);
 			}
 
+			$path = array_values(array_unique($path));
 			self::$_packages[$type] = $path;
 		}
 	}

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -94,6 +94,21 @@ class AppTest extends CakeTestCase {
 			'/path/to/controllers/'
 		);
 		$this->assertEquals($expected, $new);
+		App::build(); //reset defaults
+
+		App::build(array(
+			'Foo/Bar' => array(APP.'Foo'.DS.'Bar'.DS),
+			'Model/Baz' => array(APP.'Model'.DS.'Baz'.DS),
+		));
+
+		$this->assertEquals(array(APP.'Foo'.DS.'Bar'.DS), App::path('Foo/Bar'));
+		$this->assertEquals(array(APP.'Model'.DS.'Baz'.DS), App::path('Model/Baz'));
+
+		App::build(array(
+			'Foo/Bar' => array(APP.'Foo'.DS.'Baz'.DS),
+		));
+
+		$this->assertEquals(array(APP.'Foo'.DS.'Baz'.DS, APP.'Foo'.DS.'Bar'.DS), App::path('Foo/Bar'));
 
 		App::build(); //reset defaults
 		$defaults = App::path('Model');


### PR DESCRIPTION
When registering packages App::build() should rather iterate over the new packages than the defaults.
