### PR TITLE
Named bug

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -275,6 +275,7 @@ class CakeRoute {
 			$separatorIsPresent = strpos($param, $namedConfig['separator']) !== false;
 			if ((!isset($this->options['named']) || !empty($this->options['named'])) && $separatorIsPresent) {
 				list($key, $val) = explode($namedConfig['separator'], $param, 2);
+				$key = rawurldecode($key);
 				$val = rawurldecode($val);
 				$hasRule = isset($rules[$key]);
 				$passIt = (!$hasRule && !$greedy) || ($hasRule && !$this->_matchNamed($val, $rules[$key], $context));

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -404,6 +404,26 @@ class CakeRouteTest extends CakeTestCase {
 	}
 
 /**
+ * Ensure that keys at named parameters are urldecoded
+ *
+ * @return void
+ */
+	public function testParseNamedKeyUrlDecode() {
+		Router::connectNamed(true);
+		$route = new CakeRoute('/:controller/:action/*', array('plugin' => null));
+
+		// checking /post/index/user[0]:a/user[1]:b
+		$result = $route->parse('/posts/index/user%5B0%5D:a/user%5B1%5D:b');
+		$this->assertArrayHasKey('user', $result['named']);
+		$this->assertEquals(array('a', 'b'), $result['named']['user']);
+
+		// checking /post/index/user[]:a/user[]:b
+		$result = $route->parse('/posts/index/user%5B%5D:a/user%5B%5D:b');
+		$this->assertArrayHasKey('user', $result['named']);
+		$this->assertEquals(array('a', 'b'), $result['named']['user']);
+	}
+
+/**
  * test that named params with null/false are excluded
  *
  * @return void


### PR DESCRIPTION
Keys at named parameters not decoded.

e.g.
On request `/posts/user[0]:a/user[1]:b`
instead `array( 'user' => array( 'a', 'b' ))` at `$this->request->params['named']` we have
`array('user%5B0%5D' => 'a', 'user%5B0%5D' => 'b')`
