### PR TITLE
Add APP/Package base path to check in App::load(). Fixes issue #2482

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -538,6 +538,7 @@ class App {
 		if (empty($plugin)) {
 			$appLibs = empty(self::$_packages['Lib']) ? APPLIBS : current(self::$_packages['Lib']);
 			$paths[] =  $appLibs . $package . DS;
+			$paths[] = APP . $package . DS;
 			$paths[] = CAKE . $package . DS;
 		}
 


### PR DESCRIPTION
In summary: `App::uses()` works counterintuitively; this is easily solved by the addition of APP/Package/ as another base path for testing `file_exists()` when `App::load()` is called.
