### PR TITLE
Fix a bug when extending plugin's view

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -942,7 +942,7 @@ class View extends Object {
 				$name = trim($name, DS);
 			} else if ($name[0] === '.') {
 				$name = substr($name, 3);
-			} else {
+			} else if (!$plugin) {
 				$name = $this->viewPath . DS . $subDir . $name;
 			}
 		}


### PR DESCRIPTION
Hi,

I'll try to explain the bug I found.

I have two plugin: Blog plugin and Content plugin.

In my Blog plugin, I tried to extend the view I have in the Content plugin like this:

File in Plugin/Blog/View/Blog/admin_index.ctp

``` php
$this->extend('Content.Contents/admin_index');
```

And I got missing view Exception:

```
Error: The view for BlogController::admin_index() was not found.

Error: Confirm you have created the file: .......\app\Plugin\Content\View\Blog\Contents\admin_index.ctp
```

Not sure if this is the best solution, but with this fix it works again.
