### PR TITLE
Make Ajax HTTP unauthorized response code customizable

### DIFF
--- a/cake/libs/controller/components/auth.php
+++ b/cake/libs/controller/components/auth.php
@@ -255,6 +255,14 @@ class AuthComponent extends Object {
 	var $params = array();
 
 /**
+ * HTTP Status code to send if user is unauthorized
+ *
+ * @var int
+ * @access public
+ */
+        var $httpUnauthorizedCode = 403;
+
+/**
  * Method list for bound controller
  *
  * @var array
@@ -400,7 +408,7 @@ class AuthComponent extends Object {
 					$this->_stop();
 					return false;
 				} else {
-					$controller->redirect(null, 403);
+					$controller->redirect(null, $this->httpUnauthorizedCode);
 				}
 			}
 		}
@@ -923,7 +931,7 @@ class AuthComponent extends Object {
 
 		if (is_array($data)) {
 			$model =& $this->getModel();
-			
+
 			if(isset($data[$model->alias])) {
 				if (isset($data[$model->alias][$this->fields['username']]) && isset($data[$model->alias][$this->fields['password']])) {
 					$data[$model->alias][$this->fields['password']] = $this->password($data[$model->alias][$this->fields['password']]);


### PR DESCRIPTION
Cake currently returns 403 Forbidden when a user is unauthorized. This is the wrong response and should be changed to 401 Unauthorized (Request requires user authentication). 403 should be used when access is denied for a resource. Since such a change probably breaks loads of things a better solution would be to make it customizable.
