### PR TITLE
Show bind params of prepared statement on sql debug element

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -405,7 +405,7 @@ class DboSource extends DataSource {
 		if ($options['log']) {
 			$this->took = round((microtime(true) - $t) * 1000, 0);
 			$this->numRows = $this->affected = $this->lastAffected();
-			$this->logQuery($sql);
+			$this->logQuery($sql, $params);
 		}
 
 		return $this->_result;
@@ -894,11 +894,12 @@ class DboSource extends DataSource {
  * @param string $sql SQL statement
  * @return void
  */
-	public function logQuery($sql) {
+	public function logQuery($sql, $params = array()) {
 		$this->_queriesCnt++;
 		$this->_queriesTime += $this->took;
 		$this->_queriesLog[] = array(
 			'query'		=> $sql,
+			'params'	=> $params,
 			'affected'	=> $this->affected,
 			'numRows'	=> $this->numRows,
 			'took'		=> $this->took

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -645,12 +645,31 @@ class DboSourceTest extends CakeTestCase {
 		$this->testDb->logQuery('Query 2');
 
 		$log = $this->testDb->getLog();
-		$expected = array('query' => 'Query 1', 'affected' => '', 'numRows' => '', 'took' => '');
+		$expected = array('query' => 'Query 1', 'params' => array(), 'affected' => '', 'numRows' => '', 'took' => '');
+
 		$this->assertEquals($log['log'][0], $expected);
-		$expected = array('query' => 'Query 2', 'affected' => '', 'numRows' => '', 'took' => '');
+		$expected = array('query' => 'Query 2', 'params' => array(), 'affected' => '', 'numRows' => '', 'took' => '');
 		$this->assertEquals($log['log'][1], $expected);
 		$expected = array('query' => 'Error 1', 'affected' => '', 'numRows' => '', 'took' => '');
 	}
+
+
+/**
+ * test getting the query log as an array, setting bind params.
+ *
+ * @return void
+ */
+	public function testGetLogParams() {
+		$this->testDb->logQuery('Query 1', array(1,2,'abc'));
+		$this->testDb->logQuery('Query 2', array('field1' => 1, 'field2' => 'abc'));
+
+		$log = $this->testDb->getLog();
+		$expected = array('query' => 'Query 1', 'params' => array(1,2,'abc'), 'affected' => '', 'numRows' => '', 'took' => '');
+		$this->assertEquals($log['log'][0], $expected);
+		$expected = array('query' => 'Query 2', 'params' => array('field1' => 1, 'field2' => 'abc'), 'affected' => '', 'numRows' => '', 'took' => '');
+		$this->assertEquals($log['log'][1], $expected);
+	}
+
 
 /**
  * test that query() returns boolean values from operations like CREATE TABLE

--- a/lib/Cake/View/Elements/sql_dump.ctp
+++ b/lib/Cake/View/Elements/sql_dump.ctp
@@ -49,6 +49,20 @@ if ($noLogs || isset($_forced_from_dbo_)):
 	<?php
 		foreach ($logInfo['log'] as $k => $i) :
 			$i += array('error' => '');
+			if(!empty($i['params']) && is_array($i['params'])) {
+				$bindParam = $bindType = null;
+				if(preg_match('/.+ :.+/', $i['query'])) {
+					$bindType = true;
+				}
+				foreach($i['params'] as $bindKey => $bindVal) {
+					if($bindType === true) {
+						$bindParam .= h($bindKey) ." => " . h($bindVal) . ", ";
+					} else {
+						$bindParam .= h($bindVal) . ", ";
+					}
+				}
+				$i['query'] .= " , params[ " . rtrim($bindParam, ', ') . " ]";
+			}
 			echo "<tr><td>" . ($k + 1) . "</td><td>" . h($i['query']) . "</td><td>{$i['error']}</td><td style = \"text-align: right\">{$i['affected']}</td><td style = \"text-align: right\">{$i['numRows']}</td><td style = \"text-align: right\">{$i['took']}</td></tr>\n";
 		endforeach;
 	?>


### PR DESCRIPTION
I'm using DboSource::fetchAll() for prepared statement.
It shows only sql statement log on the sql debug element.
This patch shows bind value as follows.

select \* from posts as Post where Post.id = ? or Post.id = ? , params[ 1, abc ]
select \* from posts as Post where Post.id = :id or Post.id = :id2 , params[ id => 1, id2 => 2 ]
