### PR TITLE
Added handling of E_USER_DEPRECATED to ErrorHandler and Debugger.

### DIFF
--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -217,6 +217,7 @@ class ErrorHandler {
 				$log = LOG_NOTICE;
 			break;
 			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
 				$error = 'Deprecated';
 				$log = LOG_NOTICE;
 			break;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -241,6 +241,11 @@ class Debugger {
 				$error = 'Notice';
 				$level = LOG_NOTICE;
 			break;
+			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
+				$error = 'Deprecated';
+				$level = LOG_NOTICE;
+			break;
 			default:
 				return;
 			break;
@@ -716,5 +721,4 @@ class Debugger {
 			trigger_error(__d('cake_dev', 'Please change the value of \'Security.cipherSeed\' in app/Config/core.php to a numeric (digits only) seed value specific to your application'), E_USER_NOTICE);
 		}
 	}
-
 }

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -23,6 +23,10 @@ define('TIME_START', microtime(true));
 if (!defined('E_DEPRECATED')) {
 	define('E_DEPRECATED', 8192);
 }
+
+if (!defined('E_USER_DEPRECATED')) {
+	define('E_USER_DEPRECATED', E_USER_NOTICE);
+}
 error_reporting(E_ALL & ~E_DEPRECATED);
 
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {


### PR DESCRIPTION
I added a definition of E_USER_DEPRECATED to bootstrap.php to handle E_USER_DEPRECATED error levels. For PHP 5.2.x E_USER_DEPRECATED is set to E_USER_NOTICE to maintain backwards compatibility.

See https://github.com/cakephp/cakephp/pull/459 for more information.
