### PR TITLE
Duplicate in i18n extract Ticket #2538

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -75,6 +75,13 @@ class ExtractTask extends Shell {
 	protected $_strings = array();
 
 /**
+ * Extracted sigular strings
+ *
+ * @var array
+ */
+	protected $_singulars = array();
+
+/**
  * Destination path
  *
  * @var string
@@ -322,6 +329,12 @@ class ExtractTask extends Shell {
 				if ($mapCount == count($strings)) {
 					extract(array_combine($map, $strings));
 					$domain = isset($domain) ? $domain : 'default';
+					if (isset($plural)) {
+					    if (!isset($_this->_singulars)) {
+					        $this->_singulars[$domain] = array();
+					    }
+					    array_push($this->_singulars[$domain], $singular);
+					}
 					$string = isset($plural) ? $singular . "\0" . $plural : $singular;
 					$this->_strings[$domain][$string][$this->_file][] = $line;
 				} else {
@@ -422,7 +435,10 @@ class ExtractTask extends Shell {
 				$header = '#: ' . str_replace($this->_paths, '', $occurrences) . "\n";
 
 				if (strpos($string, "\0") === false) {
-					$sentence = "msgid \"{$string}\"\n";
+				    if (isset($this->_singulars[$domain]) && in_array($string, $this->_singulars[$domain])) {
+                        continue;
+				    }
+				    $sentence = "msgid \"{$string}\"\n";
 					$sentence .= "msgstr \"\"\n\n";
 				} else {
 					list($singular, $plural) = explode("\0", $string);


### PR DESCRIPTION
I have added one attribute that store the singular text when the text was extract from a plural function this way it's possible avoid the duplication of msgid when the same string is used in a normal form __()...

http://cakephp.lighthouseapp.com/projects/42648/tickets/2538-duplicate-in-i18n-extract
