### PR TITLE
Duplicate in i18n extract

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -75,6 +75,13 @@ class ExtractTask extends Shell {
 	protected $_strings = array();
 
 /**
+ * Extracted sigular strings
+ *
+ * @var array
+ */
+	protected $_singulars = array();
+
+/**
  * Destination path
  *
  * @var string
@@ -322,6 +329,12 @@ class ExtractTask extends Shell {
 				if ($mapCount == count($strings)) {
 					extract(array_combine($map, $strings));
 					$domain = isset($domain) ? $domain : 'default';
+					if (isset($plural)) {
+					    if (!isset($_this->_singulars)) {
+					        $this->_singulars[$domain] = array();
+					    }
+					    array_push($this->_singulars[$domain], $singular);
+					}
 					$string = isset($plural) ? $singular . "\0" . $plural : $singular;
 					$this->_strings[$domain][$string][$this->_file][] = $line;
 				} else {
@@ -422,7 +435,10 @@ class ExtractTask extends Shell {
 				$header = '#: ' . str_replace($this->_paths, '', $occurrences) . "\n";
 
 				if (strpos($string, "\0") === false) {
-					$sentence = "msgid \"{$string}\"\n";
+				    if (isset($this->_singulars[$domain]) && in_array($string, $this->_singulars[$domain])) {
+                        continue;
+				    }
+				    $sentence = "msgid \"{$string}\"\n";
 					$sentence .= "msgstr \"\"\n\n";
 				} else {
 					list($singular, $plural) = explode("\0", $string);

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -330,7 +330,7 @@ class ExtractTask extends Shell {
 					extract(array_combine($map, $strings));
 					$domain = isset($domain) ? $domain : 'default';
 					if (isset($plural)) {
-					    if (!isset($_this->_singulars)) {
+					    if (!isset($_this->_singulars[$domain])) {
 					        $this->_singulars[$domain] = array();
 					    }
 					    array_push($this->_singulars[$domain], $singular);


### PR DESCRIPTION
when one string is used in plural __n('Number', 'Numbers'), and also used __('Number'), the extract was adding twice the same msgid inside de po file.

With this commit when the user uses the plural function the code store the singular one in one array to compare afterwards if the string is been called in anywhere else...

http://cakephp.lighthouseapp.com/projects/42648/tickets/2538-duplicate-in-i18n-extract
