### PR TITLE
Allow callbacks in Model->exists() method.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2483,12 +2483,12 @@ class Model extends Object implements CakeEventListener {
  *
  * @return boolean True if such a record exists
  */
-	public function exists() {
+	public function exists($callbacks = true) {
 		if ($this->getID() === false) {
 			return false;
 		}
 		$conditions = array($this->alias . '.' . $this->primaryKey => $this->getID());
-		$query = array('conditions' => $conditions, 'recursive' => -1, 'callbacks' => false);
+		$query = array('conditions' => $conditions, 'recursive' => -1, 'callbacks' => $callbacks);
 		return ($this->find('count', $query) > 0);
 	}
 


### PR DESCRIPTION
Hi,

in my Models I add some condition in beforeFind() callback to filter the results.

If in Model->exists() I can't choose to call the callbacks or not, I can have wrong response.

In this patch I set the default argument to true, I don't know if it is correct to you.

Thank you
