### PR TITLE
Fix Cache::clear() calls in tests.

### DIFF
--- a/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
@@ -46,7 +46,7 @@ class CacheSessionTest extends CakeTestCase {
  * @return void
  */
 	public static function teardownAfterClass() {
-		Cache::clear('session_test');
+		Cache::clear(false, 'session_test');
 		Cache::drop('session_test');
 
 		Configure::write('Session', self::$_sessionBackup);

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -726,7 +726,7 @@ class ViewTest extends CakeTestCase {
 			'path' => CACHE . 'views' . DS,
 			'prefix' => ''
 		));
-		Cache::clear('test_view');
+		Cache::clear(false, 'test_view');
 
 		$View = new TestView($this->PostsController);
 		$View->elementCache = 'test_view';
@@ -763,6 +763,7 @@ class ViewTest extends CakeTestCase {
 		$result = Cache::read('element__test_element_cache_param_foo', 'test_view');
 		$this->assertEquals($expected, $result);
 
+		Cache::clear(false, 'test_view');
 		Cache::drop('test_view');
 	}
 


### PR DESCRIPTION
It's  `Cache::clear($check = false, $config = 'default')` not `Cache::clear($config)`
