### PR TITLE
Static methods for CakeTime, CakeNumber, and String

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -328,6 +328,11 @@ class CakeTimeTest extends CakeTestCase {
 
 		$this->Time->niceFormat = '%Y-%d-%m';
 		$this->assertEquals(date('Y-d-m', $time), $this->Time->nice($time));
+		$this->assertEquals('%Y-%d-%m', $this->Time->niceFormat);
+
+		CakeTime::$niceFormat = '%Y-%d-%m %H:%M:%S';
+		$this->assertEquals(date('Y-d-m H:i:s', $time), $this->Time->nice($time));
+		$this->assertEquals('%Y-%d-%m %H:%M:%S', $this->Time->niceFormat);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
@@ -25,10 +25,16 @@ App::uses('NumberHelper', 'View/Helper');
  */
 class NumberHelperTestObject extends NumberHelper {
 
-	public function attach(CakeNumber $cakeNumber) {
+	public function attach(CakeNumberMock $cakeNumber) {
 		$this->_CakeNumber = $cakeNumber;
 	}
 
+}
+
+/**
+ * CakeNumberMock class
+ */
+class CakeNumberMock {
 }
 
 /**
@@ -45,10 +51,7 @@ class NumberHelperTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$view = $this->getMock('View', array(), array(), '', false);
-		$this->CakeNumber = $this->getMock('CakeNumber');
-		$this->Number = new NumberHelperTestObject($view);
-		$this->Number->attach($this->CakeNumber);
+		$this->View = new View(null);
 	}
 
 /**
@@ -58,7 +61,7 @@ class NumberHelperTest extends CakeTestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		unset($this->Number);
+		unset($this->View);
 	}
 
 
@@ -70,9 +73,12 @@ class NumberHelperTest extends CakeTestCase {
 			'precision', 'toReadableSize', 'toPercentage', 'format',
 			'currency', 'addFormat',
 			);
+		$CakeNumber = $this->getMock('CakeNumberMock', $methods);
+		$Number = new NumberHelperTestObject($this->View, array('engine' => 'CakeNumberMock'));
+		$Number->attach($CakeNumber);
 		foreach ($methods as $method) {
-			$this->CakeNumber->expects($this->at(0))->method($method);
-			$this->Number->{$method}('who', 'what', 'when', 'where', 'how');
+			$CakeNumber->expects($this->at(0))->method($method);
+			$Number->{$method}('who', 'what', 'when', 'where', 'how');
 		}
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -22,10 +22,16 @@ App::uses('TextHelper', 'View/Helper');
 
 class TextHelperTestObject extends TextHelper {
 
-	public function attach(String $string) {
+	public function attach(StringMock $string) {
 		$this->_String = $string;
 	}
 
+}
+
+/**
+ * StringMock class
+ */
+class StringMock {
 }
 
 /**
@@ -41,8 +47,8 @@ class TextHelperTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
-		$controller = null;
-		$this->View = new View($controller);
+		parent::setUp();
+		$this->View = new View(null);
 		$this->Text = new TextHelper($this->View);
 	}
 
@@ -52,23 +58,23 @@ class TextHelperTest extends CakeTestCase {
  * @return void
  */
 	public function tearDown() {
-		unset($this->View, $this->Text);
+		unset($this->View);
+		parent::tearDown();
 	}
 
 /**
  * test String class methods are called correctly
  */
 	public function testTextHelperProxyMethodCalls() {
-		$this->String = $this->getMock('String');
-		unset($this->Text);
-		$this->Text = new TextHelperTestObject($this->View);
-		$this->Text->attach($this->String);
 		$methods = array(
 			'highlight', 'stripLinks', 'truncate', 'excerpt', 'toList',
 			);
+		$String = $this->getMock('StringMock', $methods);
+		$Text = new TextHelperTestObject($this->View, array('engine' => 'StringMock'));
+		$Text->attach($String);
 		foreach ($methods as $method) {
-			$this->String->expects($this->at(0))->method($method);
-			$this->Text->{$method}('who', 'what', 'when', 'where', 'how');
+			$String->expects($this->at(0))->method($method);
+			$Text->{$method}('who', 'what', 'when', 'where', 'how');
 		}
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -25,10 +25,16 @@ App::uses('CakeTime', 'Utility');
  */
 class TimeHelperTestObject extends TimeHelper {
 
-	public function attach(CakeTime $cakeTime) {
+	public function attach(CakeTimeMock $cakeTime) {
 		$this->_CakeTime = $cakeTime;
 	}
 
+}
+
+/**
+ * CakeTimeMock class
+ */
+class CakeTimeMock {
 }
 
 /**
@@ -48,10 +54,8 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
-		$View = new View(null);
-		$this->CakeTime = $this->getMock('CakeTime');
-		$this->Time = new TimeHelperTestObject($View);
-		$this->Time->attach($this->CakeTime);
+		parent::setUp();
+		$this->View = new View(null);
 	}
 
 /**
@@ -60,8 +64,8 @@ class TimeHelperTest extends CakeTestCase {
  * @return void
  */
 	public function tearDown() {
-		unset($this->Time);
-		unset($this->CakeTime);
+		unset($this->View);
+		parent::tearDown();
 	}
 
 /**
@@ -75,9 +79,12 @@ class TimeHelperTest extends CakeTestCase {
 			'isTomorrow', 'toQuarter', 'toUnix', 'toAtom', 'toRSS',
 			'timeAgoInWords', 'wasWithinLast', 'gmt', 'format', 'i18nFormat',
 			);
+		$CakeTime = $this->getMock('CakeTimeMock', $methods);
+		$Time = new TimeHelperTestObject($this->View, array('engine' => 'CakeTimeMock'));
+		$Time->attach($CakeTime);
 		foreach ($methods as $method) {
-			$this->CakeTime->expects($this->at(0))->method($method);
-			$this->Time->{$method}('who', 'what', 'when', 'where', 'how');
+			$CakeTime->expects($this->at(0))->method($method);
+			$Time->{$method}('who', 'what', 'when', 'where', 'how');
 		}
 	}
 

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -68,7 +68,7 @@ class CakeNumber {
  * @return float Formatted float.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
  */
-	public function precision($number, $precision = 3) {
+	public static function precision($number, $precision = 3) {
 		return sprintf("%01.{$precision}f", $number);
 	}
 
@@ -79,18 +79,18 @@ class CakeNumber {
  * @return string Human readable size
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toReadableSize
  */
-	public function toReadableSize($size) {
+	public static function toReadableSize($size) {
 		switch (true) {
 			case $size < 1024:
 				return __dn('cake', '%d Byte', '%d Bytes', $size, $size);
 			case round($size / 1024) < 1024:
-				return __d('cake', '%d KB', $this->precision($size / 1024, 0));
+				return __d('cake', '%d KB', self::precision($size / 1024, 0));
 			case round($size / 1024 / 1024, 2) < 1024:
-				return __d('cake', '%.2f MB', $this->precision($size / 1024 / 1024, 2));
+				return __d('cake', '%.2f MB', self::precision($size / 1024 / 1024, 2));
 			case round($size / 1024 / 1024 / 1024, 2) < 1024:
-				return __d('cake', '%.2f GB', $this->precision($size / 1024 / 1024 / 1024, 2));
+				return __d('cake', '%.2f GB', self::precision($size / 1024 / 1024 / 1024, 2));
 			default:
-				return __d('cake', '%.2f TB', $this->precision($size / 1024 / 1024 / 1024 / 1024, 2));
+				return __d('cake', '%.2f TB', self::precision($size / 1024 / 1024 / 1024 / 1024, 2));
 		}
 	}
 
@@ -102,8 +102,8 @@ class CakeNumber {
  * @return string Percentage string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toPercentage
  */
-	public function toPercentage($number, $precision = 2) {
-		return $this->precision($number, $precision) . '%';
+	public static function toPercentage($number, $precision = 2) {
+		return self::precision($number, $precision) . '%';
 	}
 
 /**
@@ -115,7 +115,7 @@ class CakeNumber {
  * @return string formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
  */
-	public function format($number, $options = false) {
+	public static function format($number, $options = false) {
 		$places = 0;
 		if (is_int($options)) {
 			$places = $options;
@@ -172,7 +172,7 @@ class CakeNumber {
  * @return string Number formatted as a currency.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::currency
  */
-	public function currency($number, $currency = 'USD', $options = array()) {
+	public static function currency($number, $currency = 'USD', $options = array()) {
 		$default = self::$_currencyDefaults;
 
 		if (isset(self::$_currencies[$currency])) {
@@ -210,7 +210,7 @@ class CakeNumber {
 		$options[$position] = $options[$symbolKey.'Symbol'];
 
 		$abs = abs($number);
-		$result = $this->format($abs, $options);
+		$result = self::format($abs, $options);
 
 		if ($number < 0 ) {
 			if ($options['negative'] == '()') {
@@ -247,7 +247,7 @@ class CakeNumber {
  * @see NumberHelper::currency()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::addFormat
  */
-	public function addFormat($formatName, $options) {
+	public static function addFormat($formatName, $options) {
 		self::$_currencies[$formatName] = $options + self::$_currencyDefaults;
 	}
 

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -368,7 +368,7 @@ class String {
  * @return string The highlighted text
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::highlight
  */
-	public function highlight($text, $phrase, $options = array()) {
+	public static function highlight($text, $phrase, $options = array()) {
 		if (empty($phrase)) {
 			return $text;
 		}
@@ -412,7 +412,7 @@ class String {
  * @return string The text without links
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::stripLinks
  */
-	public function stripLinks($text) {
+	public static function stripLinks($text) {
 		return preg_replace('|<a\s+[^>]+>|im', '', preg_replace('|<\/a>|im', '', $text));
 	}
 
@@ -434,7 +434,7 @@ class String {
  * @return string Trimmed string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
  */
-	public function truncate($text, $length = 100, $options = array()) {
+	public static function truncate($text, $length = 100, $options = array()) {
 		$default = array(
 			'ending' => '...', 'exact' => true, 'html' => false
 		);
@@ -550,9 +550,9 @@ class String {
  * @return string Modified string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::excerpt
  */
-	public function excerpt($text, $phrase, $radius = 100, $ending = '...') {
+	public static function excerpt($text, $phrase, $radius = 100, $ending = '...') {
 		if (empty($text) or empty($phrase)) {
-			return $this->truncate($text, $radius * 2, array('ending' => $ending));
+			return self::truncate($text, $radius * 2, array('ending' => $ending));
 		}
 
 		$append = $prepend = $ending;
@@ -592,7 +592,7 @@ class String {
  * @return string The glued together string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::toList
  */
-	public function toList($list, $and = 'and', $separator = ', ') {
+	public static function toList($list, $and = 'and', $separator = ', ') {
 		if (count($list) > 1) {
 			return implode($separator, array_slice($list, null, -1)) . ' ' . $and . ' ' . array_pop($list);
 		} else {

--- a/lib/Cake/View/Helper/NumberHelper.php
+++ b/lib/Cake/View/Helper/NumberHelper.php
@@ -43,14 +43,21 @@ class NumberHelper extends AppHelper {
 	 * @param array $settings Configuration settings for the helper
 	 */
 	function __construct(View $View, $settings = array()) {
+		$settings = Set::merge(array('engine' => 'CakeNumber'), $settings);
 		parent::__construct($View, $settings);
-		$this->_CakeNumber = new CakeNumber();
+		$engineClass = $settings['engine'];
+		App::uses($engineClass, 'Utility');
+		if (class_exists($engineClass)) {
+			$this->_CakeNumber = new $engineClass($settings);
+		} else {
+			throw new CakeException(__d('cake_dev', '%s could not be found', $engineClass));
+		}
 	}
 
 	/**
 	 * Call methods from CakeNumber utility class
 	 */
-	function __call($method, $params) {
+	public function __call($method, $params) {
 		return call_user_func_array(array($this->_CakeNumber, $method), $params);
 	}
 

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -60,8 +60,15 @@ class TextHelper extends AppHelper {
  * @param array $settings Settings array Settings array
  */
 	public function __construct(View $View, $settings = array()) {
+		$settings = Set::merge(array('engine' => 'String'), $settings);
 		parent::__construct($View, $settings);
-		$this->_String = new String($settings);
+		$engineClass = $settings['engine'];
+		App::uses($engineClass, 'Utility');
+		if (class_exists($engineClass)) {
+			$this->_String = new $engineClass($settings);
+		} else {
+			throw new CakeException(__d('cake_dev', '%s could not be found', $engineClass));
+		}
 	}
 
 	/**

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -44,8 +44,15 @@ class TimeHelper extends AppHelper {
  * @param array $settings Settings array Settings array
  */
 	public function __construct(View $View, $settings = array()) {
+		$settings = Set::merge(array('engine' => 'CakeTime'), $settings);
 		parent::__construct($View, $settings);
-		$this->_CakeTime = new CakeTime($settings);
+		$engineClass = $settings['engine'];
+		App::uses($engineClass, 'Utility');
+		if (class_exists($engineClass)) {
+			$this->_CakeTime = new $engineClass($settings);
+		} else {
+			throw new CakeException(__d('cake_dev', '%s could not be found', $engineClass));
+		}
 	}
 
 /**
@@ -58,9 +65,11 @@ class TimeHelper extends AppHelper {
 	public function __set($name, $value) {
 		switch ($name) {
 			case 'niceFormat':
-				$this->_CakeTime->{$name} = $value; break;
+				$this->_CakeTime->{$name} = $value;
+			break;
 			default:
-				$this->{$name} = $value; break;
+				$this->{$name} = $value;
+			break;
 		}
 	}
 


### PR DESCRIPTION
When writing docs for the libifying of helpers, it occured to me that it would be awkward, primarily for `String` class, when using helper methods, eg:

``` php
    <?php
    class UsersController extends AppController {

        public $components = array('Auth');

        public function afterLogin() {
            App::uses('String', 'Utility');
            $String = new String();
            $message = $this->User->find('new_message');
            if (!empty($message)) {

                // truncate() is non-static, was moved from TextHelper
                $this->Session->setFlash(__('You have a new message: %s', $String->truncate($message['Message']['body'], 255, array('html' => true))));

                // wrap() is already static
                $this->log(String::wrap('Sent a new message notification to %s', $this->Auth->user('username'));
            }
        }
    }
```

This changeset makes all methods `CakeTime`, `CakeNumber` and `String` to static.

Thanks
