### PR TITLE
Bug fix in TextHelper autoLink

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -75,6 +75,13 @@ class ExtractTask extends Shell {
 	protected $_strings = array();
 
 /**
+ * Extracted sigular strings
+ *
+ * @var array
+ */
+	protected $_singulars = array();
+
+/**
  * Destination path
  *
  * @var string
@@ -322,6 +329,12 @@ class ExtractTask extends Shell {
 				if ($mapCount == count($strings)) {
 					extract(array_combine($map, $strings));
 					$domain = isset($domain) ? $domain : 'default';
+					if (isset($plural)) {
+					    if (!isset($_this->_singulars)) {
+					        $this->_singulars[$domain] = array();
+					    }
+					    array_push($this->_singulars[$domain], $singular);
+					}
 					$string = isset($plural) ? $singular . "\0" . $plural : $singular;
 					$this->_strings[$domain][$string][$this->_file][] = $line;
 				} else {
@@ -422,7 +435,10 @@ class ExtractTask extends Shell {
 				$header = '#: ' . str_replace($this->_paths, '', $occurrences) . "\n";
 
 				if (strpos($string, "\0") === false) {
-					$sentence = "msgid \"{$string}\"\n";
+				    if (isset($this->_singulars[$domain]) && in_array($string, $this->_singulars[$domain])) {
+                        continue;
+				    }
+				    $sentence = "msgid \"{$string}\"\n";
 					$sentence .= "msgstr \"\"\n\n";
 				} else {
 					list($singular, $plural) = explode("\0", $string);

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -330,7 +330,7 @@ class ExtractTask extends Shell {
 					extract(array_combine($map, $strings));
 					$domain = isset($domain) ? $domain : 'default';
 					if (isset($plural)) {
-					    if (!isset($_this->_singulars)) {
+					    if (!isset($_this->_singulars[$domain])) {
 					        $this->_singulars[$domain] = array();
 					    }
 					    array_push($this->_singulars[$domain], $singular);

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -290,6 +290,27 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
 		$result = $this->Text->autoLinkUrls($text, array('escape' => false));
 		$this->assertEqual($expected, $result);
+
+		$text = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url http://www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">http://www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url http://www.www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.www.not-working-www.com">http://www.www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -125,7 +125,7 @@ class TextHelper extends AppHelper {
 			$text
 		);
 		return preg_replace_callback(
-			'#(?<!href="|">)(?<!http://|https://|ftp://|nntp://)(www\.[^\n\%\ <]+[^<\n\%\,\.\ <])(?<!\))#i',
+			'#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www.[^\n\%\ <]+[^<\n\%\,\.\ <](?<!\))#i',
 			array(&$this, '_linkUrls'),
 			$text
 		);


### PR DESCRIPTION
When you put to autoLink texts, with www in the middle of url, the autoLink was adding the a tag twice... e.g: http://www.not-working-www.com

So I have changed the regex and also add some test to fix that.
