### PR TITLE
fixing regex of autoLinks to work with urls that have www

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -336,6 +336,26 @@ podeís adquirirla.</span></p>
 		$expected = 'Text with a partial <iframe src="http://www.cakephp.org" /> link';
 		$result = $this->Text->autoLinkUrls($text, array('escape' => false));
 		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url http://www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.not-working-www.com">http://www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
+
+		$text = 'Text with a url http://www.www.not-working-www.com and more';
+		$expected = 'Text with a url <a href="http://www.www.not-working-www.com">http://www.www.not-working-www.com</a> and more';
+		$result = $this->Text->autoLinkUrls($text);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -424,7 +444,7 @@ podeís adquirirla.</span></p>
 		$expected = $text;
 		$result = $this->Text->excerpt($text, $phrase, 13, '...');
 		$this->assertEquals($expected, $result);
-		
+
 		$text = 'aaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbaaaaaaaaaaaaaaaaaaaaaaaa';
 		$phrase = 'bbbbbbbb';
 		$result = $this->Text->excerpt($text, $phrase, 10);

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -121,7 +121,7 @@ class TextHelper extends AppHelper {
 			$text
 		);
 		return preg_replace_callback(
-			'#(?<!href="|">)(?<!http://|https://|ftp://|nntp://)(www\.[^\n\%\ <]+[^<\n\%\,\.\ <])(?<!\))#i',
+			'#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www.[^\n\%\ <]+[^<\n\%\,\.\ <](?<!\))#i',
 			array(&$this, '_linkUrls'),
 			$text
 		);
@@ -353,7 +353,7 @@ class TextHelper extends AppHelper {
 
 		$excerpt = mb_substr($text, $startPos, $endPos - $startPos);
 		$excerpt = $prepend . $excerpt . $append;
-		
+
 		return $excerpt;
 	}
 


### PR DESCRIPTION
When you put to autoLink texts, with www in the middle of url, the autoLink was adding the a tag twice... e.g: http://www.not-working-www.com

So I have changed the regex and also add some test to fix that.

http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2574
