### PR TITLE
Join issue

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1945,7 +1945,7 @@ class Model extends Object implements CakeEventListener {
 			return array();
 		}
 		$old = $this->find('first', array(
-			'conditions' => array($this->primaryKey => $this->id),
+			'conditions' => array($this->alias . '.' . $this->primaryKey => $this->id),
 			'fields' => array_values($included),
 			'recursive' => -1
 		));


### PR DESCRIPTION
I am adding some joins to my models in beforeFind() and using 'conditions' => array($this->primaryKey => $this->id) causes:

 "Uncaught exception 'PDOException' with message 'SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous'"

8   0.2530  10582488    Model->saveAll( )   ../AppController.php:712
9   0.2530  10583064    Model->saveAssociated( )    ../Model.php:1999
10  0.2607  10803296    Model->save( )  ../Model.php:2201
11  0.2718  10840712    Model->_prepareUpdateFields( )  ../Model.php:1687
12  0.2719  10843528    Model->find( )  ../Model.php:1951
13  0.2724  10854672    DboSource->read( )  ../Model.php:2631
14  0.2733  10858976    DboSource->fetchAll( )  ../DboSource.php:1057
15  0.2734  10860040    DboSource->execute( )   ../DboSource.php:647
16  0.2734  10860560    DboSource->_execute( )  ../DboSource.php:403
