### PR TITLE
Console help text

### DIFF
--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -223,7 +223,7 @@ class ConsoleOptionParser {
  */
 	public function command($text = null) {
 		if ($text !== null) {
-			$this->_command = Inflector::underscore($text);
+			$this->_command = Inflector::camelize($text);
 			return $this;
 		}
 		return $this->_command;


### PR DESCRIPTION
http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2588-console-help-text-not-consistent-with-rest-of-cake
