### PR TITLE
Added `startText` feature to HtmlHelper::getCrumbList()

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1786,6 +1786,50 @@ class HtmlHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Test getCrumbList startText
+ */
+    public function testCrumbListFirstLink() {
+        $this->Html->addCrumb('First', '#first');
+        $this->Html->addCrumb('Second', '#second');
+
+        $result = $this->Html->getCrumbList(null, 'Home');
+        $this->assertTags(
+            $result,
+            array(
+                '<ul',
+                array('li' => array('class' => 'first')),
+                array('a' => array('href' => '/')), 'Home', '/a',
+                '/li',
+                '<li',
+                array('a' => array('href' => '#first')), 'First', '/a',
+                '/li',
+                array('li' => array('class' => 'last')),
+                array('a' => array('href' => '#second')), 'Second', '/a',
+                '/li',
+                '/ul'
+            )
+        );
+
+        $result = $this->Html->getCrumbList(null, array('url' => '/home', 'text' => '<img src="/home.png" />', 'escape' => false));
+        $this->assertTags(
+            $result,
+            array(
+                '<ul',
+                array('li' => array('class' => 'first')),
+                array('a' => array('href' => '/home')), 'img' => array('src' => '/home.png'), '/a',
+                '/li',
+                '<li',
+                array('a' => array('href' => '#first')), 'First', '/a',
+                '/li',
+                array('li' => array('class' => 'last')),
+                array('a' => array('href' => '#second')), 'Second', '/a',
+                '/li',
+                '/ul'
+            )
+        );
+    }
+
+/**
  * testLoadConfig method
  *
  * @return void

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -719,15 +719,30 @@ class HtmlHelper extends AppHelper {
  * crumb was added with.
  *
  * @param array $options Array of html attributes to apply to the generated list elements.
+ * @param mixed $startText This will be the first crumb, if false it defaults to first crumb in array. Can
+ *   also be an array, see `HtmlHelper::getCrumbs` for details.
  * @return string breadcrumbs html list
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
-	public function getCrumbList($options = array()) {
+	public function getCrumbList($options = array(), $startText = false) {
 		if (!empty($this->_crumbs)) {
 			$result = '';
-			$crumbCount = count($this->_crumbs);
+			$crumbs = $this->_crumbs;
+			if ($startText) {
+				if (!is_array($startText)) {
+					$startText = array(
+						'url' => '/',
+						'text' => $startText
+					);
+				}
+				$startText += array('url' => '/', 'text' => __('Home'));
+				list($url, $text) = array($startText['url'], $startText['text']);
+				unset($startText['url'], $startText['text']);
+				array_unshift($crumbs, array($text, $url, $startText));
+			}
+			$crumbCount = count($crumbs);
 			$ulOptions = $options;
-			foreach ($this->_crumbs as $which => $crumb) {
+			foreach ($crumbs as $which => $crumb) {
 				$options = array();
 				if (empty($crumb[1])) {
 					$elementContent = $crumb[0];


### PR DESCRIPTION
This is for the following ticket I made a while back:

http://cakephp.lighthouseapp.com/projects/42648/tickets/2337-feature-request-add-starttext-option-of-getcrubs-to-getcrumblist

HtmlHelper::getCrumbs has this feature and I think getCrumbList should have it as well.

`getCrumbs(' - ', 'Home');` will create `<a href="/">Home</a> - <a href="rest">of crumbs</a>`

If a person wants it in a list format, they should be able to do it as well, IMO.
