### PR TITLE
added missing assertText methods to assert cross OS

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -256,4 +256,86 @@ class CakeTestCaseTest extends CakeTestCase {
 		$two = "\nOne\nTwo";
 		$this->assertTextEquals($one, $two);
 	}
+	
+/**
+ * test assertTextStartsWith()
+ *
+ * @return void
+ */
+	public function testAssertTextStartsWith() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertStringStartsWith("some\nstring", $stringDirty);
+		$this->assertStringStartsNotWith("some\r\nstring\r\nwith", $stringDirty);
+		$this->assertStringStartsNotWith("some\nstring\nwith", $stringDirty);
+
+		$this->assertTextStartsWith("some\nstring\nwith", $stringDirty);
+		$this->assertTextStartsWith("some\r\nstring\r\nwith", $stringDirty);
+	}
+
+/**
+ * test assertTextStartsNotWith()
+ *
+ * @return void
+ */
+	public function testAssertTextStartsNotWith() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertTextStartsNotWith("some\nstring\nwithout", $stringDirty);
+	}
+		
+/**
+ * test assertTextEndsWith()
+ *
+ * @return void
+ */	
+	public function testAssertTextEndsWith() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertTextEndsWith("string\nwith\r\ndifferent\rline endings!", $stringDirty);
+		$this->assertTextEndsWith("string\r\nwith\ndifferent\nline endings!", $stringDirty);
+	}
+
+/**
+ * test assertTextEndsNotWith()
+ *
+ * @return void
+ */	
+	public function testAssertTextEndsNotWith() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertStringEndsNotWith("different\nline endings", $stringDirty);
+		$this->assertTextEndsNotWith("different\rline endings", $stringDirty);
+	}
+	
+/**
+ * test assertTextContains()
+ *
+ * @return void
+ */	
+	public function testAssertTextContains() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertContains("different", $stringDirty);
+		$this->assertNotContains("different\rline", $stringDirty);
+		
+		$this->assertTextContains("different\rline", $stringDirty);	
+	}
+	
+/**
+ * test assertTextNotContains()
+ *
+ * @return void
+ */	
+	public function testAssertTextNotContains() {
+		$stringDirty = "some\nstring\r\nwith\rdifferent\nline endings!";
+		$stringClean = "some\nstring\nwith\ndifferent\nline endings!";
+		
+		$this->assertTextNotContains("different\rlines", $stringDirty);	
+	}
 }

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -199,6 +199,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $expected The expected value.
  * @param string $result The actual value.
  * @param message The message to use for failure.
+ * @return boolean
  */
 	public function assertTextNotEquals($expected, $result, $message = '') {
 		$expected = str_replace(array("\r\n", "\r"), "\n", $expected);
@@ -213,11 +214,104 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $expected The expected value.
  * @param string $result The actual value.
  * @param message The message to use for failure.
+ * @return boolean
  */
 	public function assertTextEquals($expected, $result, $message = '') {
 		$expected = str_replace(array("\r\n", "\r"), "\n", $expected);
 		$result = str_replace(array("\r\n", "\r"), "\n", $result);
 		return $this->assertEquals($expected, $result, $message);
+	}
+
+/**
+ * Asserts that a string starts with a given prefix, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $prefix
+ * @param string $string
+ * @param string $message
+ * @return boolean
+ */	
+	public function assertTextStartsWith($prefix, $string, $message = '') {
+		$prefix = str_replace(array("\r\n", "\r"), "\n", $prefix);
+		$string = str_replace(array("\r\n", "\r"), "\n", $string);
+		return $this->assertStringStartsWith($prefix, $string, $message);
+	}
+
+/**
+ * Asserts that a string starts not with a given prefix, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $prefix
+ * @param string $string
+ * @param string $message
+ * @return boolean
+ */	
+	public function assertTextStartsNotWith($prefix, $string, $message = '') {
+		$prefix = str_replace(array("\r\n", "\r"), "\n", $prefix);
+		$string = str_replace(array("\r\n", "\r"), "\n", $string);
+		return $this->assertStringStartsNotWith($prefix, $string, $message);
+	}
+
+/**
+ * Asserts that a string ends with a given prefix, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $suffix
+ * @param string $string
+ * @param string $message
+ * @return boolean
+ */	
+	public function assertTextEndsWith($suffix, $string, $message = '') {
+		$suffix = str_replace(array("\r\n", "\r"), "\n", $suffix);
+		$string = str_replace(array("\r\n", "\r"), "\n", $string);
+		return $this->assertStringEndsWith($suffix, $string, $message);
+	}
+
+/**
+ * Asserts that a string ends not with a given prefix, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $suffix
+ * @param string $string
+ * @param string $message
+ * @return boolean
+ */
+	public function assertTextEndsNotWith($suffix, $string, $message = '') {
+		$suffix = str_replace(array("\r\n", "\r"), "\n", $suffix);
+		$string = str_replace(array("\r\n", "\r"), "\n", $string);
+		return $this->assertStringEndsNotWith($suffix, $string, $message);
+	}	
+
+/**
+ * Assert that a string contains another string, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $needle
+ * @param string $haystack
+ * @param string $message
+ * @param boolean $ignoreCase
+ * @return boolean
+ */
+	public function assertTextContains($needle, $haystack, $message = '', $ignoreCase = false) {
+		$needle = str_replace(array("\r\n", "\r"), "\n", $needle);
+		$haystack = str_replace(array("\r\n", "\r"), "\n", $haystack);
+		return $this->assertContains($needle, $haystack, $message, $ignoreCase);
+	}
+
+/**
+ * Assert that a text doesn't contain another text, ignoring differences in newlines.
+ * Helpful for doing cross platform tests of blocks of text.
+ *
+ * @param string $needle
+ * @param string $haystack
+ * @param string $message
+ * @param boolean $ignoreCase
+ * @return boolean
+ */
+	public function assertTextNotContains($needle, $haystack, $message = '', $ignoreCase = false) {
+		$needle = str_replace(array("\r\n", "\r"), "\n", $needle);
+		$haystack = str_replace(array("\r\n", "\r"), "\n", $haystack);
+		return $this->assertNotContains($needle, $haystack, $message, $ignoreCase);
 	}
 
 /**


### PR DESCRIPTION
@see
http://cakephp.lighthouseapp.com/projects/42648/tickets/2148-test-cases-fail-on-windows#ticket-2148-29

I added those methods to assert text cross OS:
- assertTextStarts(Not)With
- assertTextEnds(Not)With
- assertText(Not)Contains
