### PR TITLE
Fix CakeRequest $_GET processing

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -185,7 +185,7 @@ class CakeRequest implements ArrayAccess {
 			$query = $_GET;
 		}
 
-		unset($query['/' . str_replace('.', '_', $this->url)]);
+		unset($query['/' . str_replace('.', '_', urldecode($this->url))]);
 		if (strpos($this->url, '?') !== false) {
 			list(, $querystr) = explode('?', $this->url);
 			parse_str($querystr, $queryArgs);


### PR DESCRIPTION
After copying $_GET into CakeRequest->query in CakeRequest::_processGet() we unset CakeRequest->url from it since it is included in $_GET but we don't want included in CakeRequest->query.

$_GET is URL-decoded and CakeRequest->url is not.  So if there is anything URL-encoded (such as utf-8 characters) in CakeRequest->url, it fails to be unset from CakeRequest->query therefore polluting CakeRequest->here() .

This patch fixes around 95% of the cases.  
It does not however fix the case where we have an ampersand (%26) as CakeRequest->url will be split into 2 separate keys in $_GET.  There is also the case where $_GET sometimes acts as a slug function and converts characters (such as space character:%20 ) into an underscore. 
