### PR TITLE
Added test for caching of SELECTS, but, not other statements which have ...

### DIFF
--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -420,7 +420,7 @@ class DboSource extends DataSource {
 			}
 
 			if ($cache) {
-				if (strpos(trim(strtolower($sql)), 'select') !== false) {
+				if (preg_match('/^\s*select/i', $sql)) {
 					$this->_queryCache[$sql] = $out;
 				}
 			}

--- a/cake/tests/cases/libs/model/datasources/dbo_source.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo_source.test.php
@@ -4251,6 +4251,25 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * test that query propery caches/doesn't cache selects
+ *
+ * @return void
+ * @author David Kullmann
+ */
+	function testFetchAllCaching() {
+		$query = "SELECT NOW() as TIME";
+		$result = $this->db->fetchAll($query);
+		
+		$this->assertTrue(is_array($this->db->_queryCache[$query]));
+		$this->assertEqual($this->db->_queryCache[$query][0][0]['TIME'], $result[0][0]['TIME']);
+
+		$query = "DROP TABLE IF EXISTS select_test";
+		$result = $this->db->fetchAll($query);
+		
+		$this->assertTrue(!isset($this->db->_queryCache[$query]));
+	}
+
+/**
  * test ShowQuery generation of regular and error messages
  *
  * @return void


### PR DESCRIPTION
...the word "select" somewhere in them

Examples include:

INSERT INTO … VALUES … ('Great selection!')
DROP TABLE IF EXISTS selection_table

Signed-off-by: David Kullmann kullmann.david@gmail.com
