### PR TITLE
2.1 folder merge

### DIFF
--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -691,7 +691,7 @@ class Folder {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);
 						}
 					} elseif (is_dir($from) && $options['scheme'] == Folder::MERGE) {
-						$options = array_merge($options, array('to'=> $to, 'from'=> $from));
+						$options = array_merge($options, array('to' => $to, 'from' => $from));
 						$this->copy($options);
 					}
 				}

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -26,6 +26,30 @@
 class Folder {
 
 /**
+ * Default scheme for Folder::copy
+ * Recursivly merges subfolders with the same name 
+ *
+ * @constant MERGE
+ */
+	const MERGE = 'merge';
+
+/**
+ * Overwrite scheme for Folder::copy
+ * subfolders with the same name will be replaced
+ *
+ * @constant OVERWRITE
+ */
+	const OVERWRITE = 'overwrite';
+
+/**
+ * Skip scheme for Folder::copy
+ * if a subfolder with the same name exists it will be skipped
+ *
+ * @constant SKIP
+ */
+	const SKIP = 'skip';
+	
+/**
  * Path to Folder.
  *
  * @var string
@@ -598,6 +622,7 @@ class Folder {
  * - `from` The directory to copy from, this will cause a cd() to occur, changing the results of pwd().
  * - `mode` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
+ * - `schema` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
  * @param mixed $options Either an array of options (see above) or a string of the destination directory.
  * @return boolean Success
@@ -612,7 +637,7 @@ class Folder {
 			$to = $options;
 			$options = array();
 		}
-		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array()), $options);
+		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme'=>Folder::MERGE), $options);
 
 		$fromDir = $options['from'];
 		$toDir = $options['to'];
@@ -634,10 +659,10 @@ class Folder {
 
 		$exceptions = array_merge(array('.', '..', '.svn'), $options['skip']);
 		if ($handle = @opendir($fromDir)) {
-			while (false !== ($item = readdir($handle))) {
-				if (!in_array($item, $exceptions)) {
-					$from = Folder::addPathElement($fromDir, $item);
-					$to = Folder::addPathElement($toDir, $item);
+			while (($item = readdir($handle)) !== false) {
+				$to = Folder::addPathElement($toDir, $item);
+				if (($options['scheme'] != Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions)) {
+					$from = Folder::addPathElement($fromDir, $item);				
 					if (is_file($from)) {
 						if (copy($from, $to)) {
 							chmod($to, intval($mode, 8));
@@ -646,6 +671,10 @@ class Folder {
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s NOT copied to %s', $from, $to);
 						}
+					}
+					
+					if (is_dir($from) && file_exists($to) && $options['scheme'] == Folder::OVERWRITE) {
+						$this->delete($to);
 					}
 
 					if (is_dir($from) && !file_exists($to)) {
@@ -656,11 +685,14 @@ class Folder {
 							chmod($to, $mode);
 							umask($old);
 							$this->_messages[] = __d('cake_dev', '%s created', $to);
-							$options = array_merge($options, array('to' => $to, 'from' => $from));
+							$options = array_merge($options, array('to'=> $to, 'from'=> $from));
 							$this->copy($options);
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);
 						}
+					} elseif (is_dir($from) && $options['scheme'] == Folder::MERGE) {
+						$options = array_merge($options, array('to'=> $to, 'from'=> $from));
+						$this->copy($options);
 					}
 				}
 			}

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -685,7 +685,7 @@ class Folder {
 							chmod($to, $mode);
 							umask($old);
 							$this->_messages[] = __d('cake_dev', '%s created', $to);
-							$options = array_merge($options, array('to'=> $to, 'from'=> $from));
+							$options = array_merge($options, array('to' => $to, 'from' => $from));
 							$this->copy($options);
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);


### PR DESCRIPTION
folder fix for merging by default to ensure the class works correctly in all cases, especially with multilevel folders. manual change to other merge schemes added. 
fix for default dirs added before starting the test. this ensures that if the tmp folder didnt contain all default dirs, that they are added.

@see ticket http://cakephp.lighthouseapp.com/projects/42648/tickets/2314-folder-class-should-merge-by-default
