### PR TITLE
Socket exception template

### DIFF
--- a/lib/Cake/View/Errors/socket.ctp
+++ b/lib/Cake/View/Errors/socket.ctp
@@ -1,0 +1,28 @@
+<?php
+/**
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       Cake.View.Errors
+ * @since         CakePHP(tm) v 2.1
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+?>
+<h2><?php echo __d('cake_dev', 'Socket Error'); ?></h2>
+<p class="error">
+	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
+	<?php echo __d('cake_dev', $error->getMessage()); ?>
+</p>
+<p class="notice">
+	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
+	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'socket.ctp'); ?>
+</p>
+<?php echo $this->element('exception_stack_trace'); ?>


### PR DESCRIPTION
I'm not sure about this one. Here's what happened. 

I was using CakeEmail to send a message. In my AppController I have a `Navigation` helper. When calling `$email->send()` I would just get View::Navigation undefined error instead of socket exception saying `Could not send email`.

The actual error isn't being displayed because of the missing template file for it. Again, I'm not sure about this - may just be my code.
