### PR TITLE
Shell input prompt fix

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -492,11 +492,16 @@ class Shell extends Object {
 		} else {
 			$printOptions = '(' . implode('/', $options) . ')';
 		}
-
-		if ($default === null) {
-			$this->stdout->write('<question>' . $prompt . '</question>' . " $printOptions \n" . '> ', 0);
+		if ($prompt!='') {
+			$question='<question>' . $prompt . '</question> ';
 		} else {
-			$this->stdout->write('<question>' . $prompt . '</question>' . " $printOptions \n" . "[$default] > ", 0);
+			$question='';	
+		}
+		
+		if ($default === null) {
+			$this->stdout->write($question . "$printOptions \n" . '> ', 0);
+		} else {
+			$this->stdout->write($question . "$printOptions \n" . "[$default] > ", 0);
 		}
 		$result = $this->stdin->read();
 


### PR DESCRIPTION
This removes the space character in front of the input prompt in shell when empty $prompt message is used.

Also added space after "if" as requested :)
