### PR TITLE
Fix class => file mapping for Plugins

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -501,12 +501,13 @@ class App {
 			return false;
 		}
 
-		if ($file = self::_mapped($className)) {
-			return include $file;
-		}
-
 		$parts = explode('.', self::$_classMap[$className], 2);
 		list($plugin, $package) = count($parts) > 1 ? $parts : array(null, current($parts));
+
+		if ($file = self::_mapped($className, $plugin)) {
+			return include $file;
+		}
+        
 		$paths = self::path($package, $plugin);
 
 		if (empty($plugin)) {
@@ -518,7 +519,7 @@ class App {
 		foreach ($paths as $path) {
 			$file = $path . $className . '.php';
 			if (file_exists($file)) {
-				self::_map($file, $className);
+				self::_map($file, $className, $plugin);
 				return include $file;
 			}
 		}
@@ -536,7 +537,7 @@ class App {
 			}
 			foreach ($tries as $file) {
 				if (file_exists($file)) {
-					self::_map($file, $className);
+					self::_map($file, $className, $plugin);
 					return include $file;
 				}
 			}


### PR DESCRIPTION
App::load() would potentially map a class which is in a Plugin folder to the app folder (or vice versa) if they have the same name.

A valid use case for having classes with similar names in both the plugin and the app folder would be an API. Eg. UsersController (/users) and Api.UsersController (/api/users).

Since the mapping is cached to cake_core_file_map, once a mapping happens incorrectly, it does not get rectified on subsequent dispatches.

The fix ensures that the $plugin variable is passed along so that classes map correctly.
