### PR TITLE
Fixed a testcase, support PostgreSQL 9.1

### DIFF
--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -852,23 +852,23 @@ class PostgresTest extends CakeTestCase {
 		$this->assertEquals(2, substr_count($result, 'field_two'), 'Too many fields');
 		$this->assertFalse(strpos(';ALTER', $result), 'Too many semi colons');
 	}
-	
+
 /**
  * test encoding setting.
  *
  * @return void
  */
 	public function testEncoding() {
-		$result = $this->Dbo->setEncoding('utf8');
+		$result = $this->Dbo->setEncoding('UTF8');
 		$this->assertTrue($result) ;
-		
+
 		$result = $this->Dbo->getEncoding();
-		$this->assertEquals('utf8', $result) ;
-		
-		$result = $this->Dbo->setEncoding('EUC-JP');
+		$this->assertEquals('UTF8', $result) ;
+
+		$result = $this->Dbo->setEncoding('EUC_JP'); /* 'EUC_JP' is right character code name in PostgreSQL */
 		$this->assertTrue($result) ;
-		
+
 		$result = $this->Dbo->getEncoding();
-		$this->assertEquals('EUC-JP', $result) ;
+		$this->assertEquals('EUC_JP', $result) ;
 	}
 }


### PR DESCRIPTION
This testcase failed in PostgreSQL 9.1.2.

The return value of 'SHOW client_encoding'  are different in PostgreSQL 8.4 and 9.1.2.
- SET NAMES 'utf8' ; SHOW client_encoding;
  - 8.4 : utf8
  - 9.1 : UTF8
- SET NAMES 'UTF8' ; SHOW client_encoding;
  - 8.4 : UTF8
  - 9.1 : UTF8
- SET NAMES 'EUC-JP'; SHOW client_encoding;
  - 8.4 : EUC-JP
  - 9.1 : EUC_JP
- SET NAMES 'EUC_JP'; SHOW client_encoding;
  - 8.4 : EUC_JP
  - 9.1 : EUC_JP
