### PR TITLE
Fix for Console/Task/TestTask::getRealClassName(). 

### DIFF
--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -274,7 +274,10 @@ class TestTask extends BakeTask {
 		if (strtolower($type) == 'model' || empty($this->classTypes[$type])) {
 			return $class;
 		}
-		if (strlen($class) - strpos($class, $type) == strlen($type)) {
+	
+		$position = strpos($class, $type);
+		 
+		if ($position !== false && strlen($class) - $position == strlen($type)) {
 			return $class;
 		}
 		return $class . $type;

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -403,6 +403,9 @@ class TestTaskTest extends CakeTestCase {
 
 		$result = $this->Task->getRealClassname('Controller', 'PostsController');
 		$this->assertEquals('PostsController', $result);
+		
+		$result = $this->Task->getRealClassname('Controller', 'AlertTypes');
+		$this->assertEquals('AlertTypesController', $result);
 
 		$result = $this->Task->getRealClassname('Helper', 'Form');
 		$this->assertEquals('FormHelper', $result);


### PR DESCRIPTION
Controller names of exactly 10 letters were being returned incorrectly, resulting in the controller test cases being written with missing model names.

![missing model names](http://dl.dropbox.com/u/12520837/Screen%20shot%202012-02-28%20at%2014.19.08.png)

Also added an assertion to the TestTaskTest (try and say that fast!) to check for a controller name of the same length of the word 'Controller'.

What do I win?
