### PR TITLE
Rename DboSource property fullDebug to log

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -70,11 +70,11 @@ class DboSource extends DataSource {
 	public $cacheMethods = true;
 
 /**
- * Print full query debug info?
+ * Enable full query log for debug or another application purpose
  *
  * @var boolean
  */
-	public $fullDebug = false;
+	public $log = false;
 
 /**
  * String to hold how many rows were affected by the last SQL operation.
@@ -234,7 +234,7 @@ class DboSource extends DataSource {
 			$config['prefix'] = '';
 		}
 		parent::__construct($config);
-		$this->fullDebug = Configure::read('debug') > 1;
+		$this->log = Configure::read('debug') > 1;
 		if (!$this->enabled()) {
 			throw new MissingConnectionException(array(
 				'class' => get_class($this)
@@ -397,7 +397,7 @@ class DboSource extends DataSource {
  * @return mixed Resource or object representing the result set, or false on failure
  */
 	public function execute($sql, $options = array(), $params = array()) {
-		$options += array('log' => $this->fullDebug);
+		$options += array('log' => $this->log);
 
 		$t = microtime(true);
 		$this->_result = $this->_execute($sql, $params);
@@ -2007,7 +2007,7 @@ class DboSource extends DataSource {
  */
 	public function begin() {
 		if ($this->_transactionStarted || $this->_connection->beginTransaction()) {
-			if ($this->fullDebug && empty($this->_transactionNesting)) {
+			if ($this->log && empty($this->_transactionNesting)) {
 				$this->logQuery('BEGIN');
 			}
 			$this->_transactionStarted = true;
@@ -2030,7 +2030,7 @@ class DboSource extends DataSource {
 			if ($this->_transactionNesting <= 0) {
 				$this->_transactionStarted = false;
 				$this->_transactionNesting = 0;
-				if ($this->fullDebug) {
+				if ($this->log) {
 					$this->logQuery('COMMIT');
 				}
 				return $this->_connection->commit();
@@ -2049,7 +2049,7 @@ class DboSource extends DataSource {
  */
 	public function rollback() {
 		if ($this->_transactionStarted && $this->_connection->rollBack()) {
-			if ($this->fullDebug) {
+			if ($this->log) {
 				$this->logQuery('ROLLBACK');
 			}
 			$this->_transactionStarted = false;

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -5831,8 +5831,8 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('CategoryThread');
 		$TestModel = new CategoryThread();
 
-		$fullDebug = $this->db->fullDebug;
-		$this->db->fullDebug = true;
+		$log = $this->db->log;
+		$this->db->log = true;
 		$TestModel->recursive = 6;
 		$TestModel->id = 7;
 		$result = $TestModel->read();
@@ -5882,7 +5882,7 @@ class ModelReadTest extends BaseModelTest {
 									'updated' => '2007-03-18 15:32:31'
 		)))))));
 
-		$this->db->fullDebug = $fullDebug;
+		$this->db->log = $log;
 		$this->assertEquals($expected, $result);
 	}
 
@@ -5895,8 +5895,8 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('CategoryThread');
 		$TestModel = new CategoryThread();
 
-		$fullDebug = $this->db->fullDebug;
-		$this->db->fullDebug = true;
+		$log = $this->db->log;
+		$this->db->log = true;
 		$TestModel->recursive = 6;
 		$result = $TestModel->find('first', array('conditions' => array('CategoryThread.id' => 7)));
 
@@ -5946,7 +5946,7 @@ class ModelReadTest extends BaseModelTest {
 									'updated' => '2007-03-18 15:32:31'
 		)))))));
 
-		$this->db->fullDebug = $fullDebug;
+		$this->db->log = $log;
 		$this->assertEquals($expected, $result);
 	}
 
@@ -5959,8 +5959,8 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('CategoryThread');
 		$TestModel = new CategoryThread();
 
-		$fullDebug = $this->db->fullDebug;
-		$this->db->fullDebug = true;
+		$log = $this->db->log;
+		$this->db->log = true;
 		$TestModel->recursive = 6;
 		$result = $TestModel->find('all', null, null, 'CategoryThread.id ASC');
 		$expected = array(
@@ -6166,7 +6166,7 @@ class ModelReadTest extends BaseModelTest {
 									'updated' => '2007-03-18 15:32:31'
 		))))))));
 
-		$this->db->fullDebug = $fullDebug;
+		$this->db->log = $log;
 		$this->assertEquals($expected, $result);
 	}
 
@@ -6783,11 +6783,11 @@ class ModelReadTest extends BaseModelTest {
 		$this->assertEquals($result, 4);
 
 		$this->db->getLog(false, true);
-		$fullDebug = $this->db->fullDebug;
-		$this->db->fullDebug = true;
+		$log = $this->db->log;
+		$this->db->log = true;
 		$TestModel->order = 'User.id';
 		$result = $TestModel->find('count');
-		$this->db->fullDebug = $fullDebug;
+		$this->db->log = $log;
 		$this->assertEquals($result, 4);
 
 		$log = $this->db->getLog();

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -185,7 +185,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$methods[] = 'connect';
 
 		$this->criticDb = $this->getMock('DboSource', $methods);
-		$this->criticDb->fullDebug = true;
+		$this->criticDb->log = true;
 		$this->db = ConnectionManager::getDataSource('test');
 		$this->_backupConfig = $this->db->config;
 	}
@@ -383,7 +383,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$this->criticDb->expects($this->atLeastOnce())->method('execute');
 		$this->criticDb->expects($this->atLeastOnce())->method('createSchema');
 		$return = $Fixture->create($this->criticDb);
-		$this->assertTrue($this->criticDb->fullDebug);
+		$this->assertTrue($this->criticDb->log);
 		$this->assertTrue($return);
 
 		unset($Fixture->fields);
@@ -404,7 +404,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 
 		$return = $Fixture->insert($this->criticDb);
 		$this->assertTrue(!empty($this->insertMulti));
-		$this->assertTrue($this->criticDb->fullDebug);
+		$this->assertTrue($this->criticDb->log);
 		$this->assertTrue($return);
 		$this->assertEquals('fixture_tests', $this->insertMulti['table']);
 		$this->assertEquals(array('name', 'created'), $this->insertMulti['fields']);
@@ -443,7 +443,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 			->will($this->returnCallback(array($this, 'insertCallback')));
 
 		$return = $Fixture->insert($this->criticDb);
-		$this->assertTrue($this->criticDb->fullDebug);
+		$this->assertTrue($this->criticDb->log);
 		$this->assertTrue($return);
 		$this->assertEquals('strings', $this->insertMulti['table']);
 		$this->assertEquals(array('email', 'name', 'age'), $this->insertMulti['fields']);
@@ -467,7 +467,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$this->criticDb->expects($this->exactly(2))->method('dropSchema');
 
 		$return = $Fixture->drop($this->criticDb);
-		$this->assertTrue($this->criticDb->fullDebug);
+		$this->assertTrue($this->criticDb->log);
 		$this->assertTrue($return);
 
 		$return = $Fixture->drop($this->criticDb);
@@ -487,6 +487,6 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture = new CakeTestFixtureTestFixture();
 		$this->criticDb->expects($this->atLeastOnce())->method('truncate');
 		$Fixture->truncate($this->criticDb);
-		$this->assertTrue($this->criticDb->fullDebug);
+		$this->assertTrue($this->criticDb->log);
 	}
 }

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -249,10 +249,10 @@ class CakeTestFixture {
  * @return boolean
  */
 	public function truncate($db) {
-		$fullDebug = $db->fullDebug;
-		$db->fullDebug = false;
+		$log = $db->log;
+		$db->log = false;
 		$return = $db->truncate($this->table);
-		$db->fullDebug = $fullDebug;
+		$db->log = $log;
 		return $return;
 	}
 }


### PR DESCRIPTION
Some people want to save Cake generated queries for your purpose and I think only renaming one property can make this more easy to understand.

DboSource have a property named fullDebug wich receive value from condition Configure::read('debug') > 1
But the property is public and can be used to enable query log without outputing it in sql_dump element.

What do you think of rename him to 'log', so everyone will see it like a configurable setting for different purposes?
