### PR TITLE
Make UpgradeShell recognize different code style

### DIFF
--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -191,7 +191,7 @@ class UpgradeShell extends AppShell {
 		$defaultOptions = array(
 			'recursive' => true,
 			'checkFolder' => true,
-			'regex' => '@class (\S*) .*{@i'
+			'regex' => '@class (\S*) .*(\s|\v)*{@i'
 		);
 		foreach ($sourceDirs as $dir => $options) {
 			if (is_numeric($dir)) {


### PR DESCRIPTION
I prefer write left brace at the next line after class name definition.
I'd extended the regex of file search to recognize this code style.
