### PR TITLE
Include database.php only if it exists

### DIFF
--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -65,9 +65,14 @@ class ConnectionManager {
  * @return void
  */
 	protected static function _init() {
-		include_once APP . 'Config' . DS . 'database.php';
+		$dbConfig = APP . 'Config' . DS . 'database.php';
+		if (file_exists($dbConfig)) {
+			include_once $dbConfig;
+		}
 		if (class_exists('DATABASE_CONFIG')) {
 			self::$config = new DATABASE_CONFIG();
+		} else {
+			self::$config = array();
 		}
 		self::$_init = true;
 	}


### PR DESCRIPTION
Adds an file check for the database configuration and includes
the file only if it exists.

The datasource configuration might not be always available e.g. for
application bootstrapping via a webfront. The patch inits an empty
configuration if no database.php file is present.
