### PR TITLE
Correct path in debug() method

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -692,7 +692,7 @@ $expectedText = <<<EXPECTED
 'this-is-a-test'
 ###########################
 EXPECTED;
-		$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT)), __LINE__ - 8);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -706,7 +706,7 @@ $expectedHtml = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT)), __LINE__ - 10);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -720,7 +720,7 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT)), __LINE__ - 10);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -734,7 +734,7 @@ $expected = <<<EXPECTED
 </pre>
 </div>
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 10);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT)), __LINE__ - 10);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -755,9 +755,9 @@ $expectedText = <<<EXPECTED
 ###########################
 EXPECTED;
 		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 17);
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT)), __LINE__ - 17);
 		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT)), __LINE__ - 19);
 		}
 		$this->assertEquals($expected, $result);
 
@@ -779,9 +779,9 @@ $expectedText = <<<EXPECTED
 ###########################
 EXPECTED;
 		if (php_sapi_name() == 'cli') {
-			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 17);
+			$expected = sprintf($expectedText, substr(__FILE__, strlen(ROOT)), __LINE__ - 17);
 		} else {
-			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 19);
+			$expected = sprintf($expectedHtml, substr(__FILE__, strlen(ROOT)), __LINE__ - 19);
 		}
 		$this->assertEquals($expected, $result);
 
@@ -794,7 +794,7 @@ $expected = <<<EXPECTED
 '<div>this-is-a-test</div>'
 ###########################
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT)), __LINE__ - 8);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -806,7 +806,7 @@ $expected = <<<EXPECTED
 '<div>this-is-a-test</div>'
 ###########################
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT)), __LINE__ - 8);
 		$this->assertEquals($expected, $result);
 
 		ob_start();
@@ -818,7 +818,7 @@ $expected = <<<EXPECTED
 '<div>this-is-a-test</div>'
 ###########################
 EXPECTED;
-		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT) + 1), __LINE__ - 8);
+		$expected = sprintf($expected, substr(__FILE__, strlen(ROOT)), __LINE__ - 8);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -77,7 +77,7 @@ function debug($var = false, $showHtml = null, $showFrom = true) {
 		$lineInfo = '';
 		if ($showFrom) {
 			$trace = Debugger::trace(array('start' => 1, 'depth' => 2, 'format' => 'array'));
-			$file = substr($trace[0]['file'], strlen(ROOT) + 1);
+			$file = substr($trace[0]['file'], strlen(ROOT));
 			$line = $trace[0]['line'];
 		}
 		$html = <<<HTML


### PR DESCRIPTION
When using debug() the path shown is `pp/Controller/CommentsController.php` when it should be app. This is because debug assumes the ROOT constant has a DS when it does not.
