### PR TITLE
Form helper url id

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -7839,4 +7839,36 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error('Thing.field', null, array('wrap' => false));
 		$this->assertEquals('Badness!', $result);
 	}
+	
+/**
+ * Tests that id is handled in url if passed through url array
+ *
+ * @return void
+ */
+	public function testUrlId() {
+		$encoding = strtolower(Configure::read('App.encoding'));
+		$this->Form->request->data['Contact']['id'] = 1;
+		$result = $this->Form->create('Contact', array(
+			'type' => 'post',
+			'escape' => false,
+			'url' => array(
+				'action' => 'edit',
+				'id' => null,
+			)
+		));
+		
+		$expected = array(
+			'form' => array(
+				'id' => 'ContactAddForm',
+				'method' => 'post',
+				'action' => '/contacts/edit',
+				'accept-charset' => $encoding
+			),
+			'div' => array('style' => 'display:none;'),
+			'input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST'),
+			'/div'
+		);
+		
+		$this->assertTags($result, $expected);
+	}
 }

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -372,6 +372,11 @@ class FormHelper extends AppHelper {
 					$options['url']['controller'] = Inflector::underscore($this->request->params['controller']);
 				}
 			}
+			
+			if(array_key_exists('id', $options['url'])){
+				$id = $options['url']['id'];
+			}
+			
 			if (empty($options['action'])) {
 				$options['action'] = $this->request->params['action'];
 			}


### PR DESCRIPTION
Currently, the form helper will auto set the `id` of the current item if the url contains an `id`.  I found myself wanting to prevent this in certain scenarios, such if I wanted to post to a route with a .json extension in order to use the ajax/iframe file post method.  

```
<?php 
    echo $this->Form->create(
        'User', 
        array(
            'url' => array(
                'plugin' => 'my_plugin', 
                'controller' => 'users', 
                'action' => 'edit.json', 
                'admin' => true, 
                'id' => null
        ), 
        'type' => 'file',
    );
?>
```

Without this fix, the form helper would create a url like below, which breaks the routing.

`/admin/my_plugin/users/edit.json/1`

I couldn't find any similar tickets on Lighthouse, so I created this update to the form helper in order for one to be able set the `id` parameter if they so choose.  Setting to null prevents the `id` from being part of the url resulting in the url below.

`/admin/my_plugin/users/edit.json`

Another possible solution could be to add an extension parameter to the url array to append the extension to the last passed variable.

`/admin/my_plugin/users/edit/1.json`
