### PR TITLE
Move inclusion of APP bootstrap after initialization of ErrorHandler

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -75,9 +75,6 @@ class Configure {
 			App::$bootstrapping = false;
 			App::init();
 			App::build();
-			if (!include APP . 'Config' . DS . 'bootstrap.php') {
-				trigger_error(__d('cake_dev', "Can't find application bootstrap file. Please create %sbootstrap.php, and make sure it is readable by PHP.", APP . 'Config' . DS), E_USER_ERROR);
-			}
 			$level = -1;
 			if (isset(self::$_values['Error']['level'])) {
 				error_reporting(self::$_values['Error']['level']);
@@ -88,6 +85,9 @@ class Configure {
 			}
 			if (!empty(self::$_values['Exception']['handler'])) {
 				set_exception_handler(self::$_values['Exception']['handler']);
+			}
+			if (!include APP . 'Config' . DS . 'bootstrap.php') {
+				trigger_error(__d('cake_dev', "Can't find application bootstrap file. Please create %sbootstrap.php, and make sure it is readable by PHP.", APP . 'Config' . DS), E_USER_ERROR);
 			}
 		}
 	}

--- a/lib/Cake/View/Elements/exception_stack_trace.ctp
+++ b/lib/Cake/View/Elements/exception_stack_trace.ctp
@@ -41,10 +41,12 @@ App::uses('Debugger', 'Utility');
 	echo ' &rarr; ';
 	if ($stack['function']):
 		$args = array();
-		foreach ($stack['args'] as $arg):
-			$args[] = Debugger::getType($arg);
-			$params[] = Debugger::exportVar($arg, 2);
-		endforeach;
+		if (!empty($stack['args'])):
+			foreach ((array)$stack['args'] as $arg):
+				$args[] = Debugger::getType($arg);
+				$params[] = Debugger::exportVar($arg, 2);
+			endforeach;
+		endif;
 
 		$called = isset($stack['class']) ? $stack['class'] . $stack['type'] . $stack['function'] : $stack['function'];
 	


### PR DESCRIPTION
I was trying to check dependencies of a plugin in plugin bootstrap (IMO the right place to do this), but since the ErrorHandler is not configured yet, triggering warnings or raising exceptions will break CakePHP's Error handling.

Moving the inclusion of APP bootstrap behind the ErrorHandler initialization would enable to do this kind of checking in plugin bootstrap files.
