### PR TITLE
1.3 fix error excerpt

### DIFF
--- a/cake/libs/debugger.php
+++ b/cake/libs/debugger.php
@@ -630,8 +630,8 @@ class Debugger extends Object {
 
 		$files = $this->trace(array('start' => 2, 'format' => 'points'));
 		$code = '';
-		if (isset($files[0]['file'])) {
-			$code = $this->excerpt($files[0]['file'], $files[0]['line'] - 1, 1);
+		if (isset($files[1]['file'])) {
+			$code = $this->excerpt($files[1]['file'], $files[1]['line'] - 1, 1);
 		}
 		$trace = $this->trace(array('start' => 2, 'depth' => '20'));
 		$insertOpts = array('before' => '{:', 'after' => '}');


### PR DESCRIPTION
The excerpted codes were always Debugger::_output(1.x)/output(2.x) on error triggered.
Also 2.x has same issue as far as I know.
