### PR TITLE
array_merge breaks CakeSchema column type change #2672

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -484,7 +484,7 @@ class CakeSchema extends Object {
 				if (!empty($old[$table][$field])) {
 					$diff = $this->_arrayDiffAssoc($value, $old[$table][$field]);
 					if (!empty($diff) && $field !== 'indexes' && $field !== 'tableParameters') {
-						$tables[$table]['change'][$field] = array_merge($old[$table][$field], $diff);
+						$tables[$table]['change'][$field] = $value;
 					}
 				}
 


### PR DESCRIPTION
Changing a column type from VARCHAR to DATETIME is not possible in CakeSchema.

The array_merge will add unnecessary properties and thus produce invalid SQL.

I'm not sure that skipping the array_merge all together and simply assigning the value is the best solution, but is does resolve the above problem.
