### PR TITLE
Prevent blackhole auth error where are present multi fields (part 2)

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -604,12 +604,8 @@ class FormHelper extends AppHelper {
 			}
 		}
 
-		$last = end($field);
-		if (is_numeric($last) || empty($last)) {
-			array_pop($field);
-		}
-
 		$field = implode('.', $field);
+		$field = preg_replace('/(\.\d+)+$/', '', $field);
 
 		if ($lock) {
 			if (!in_array($field, $this->fields)) {


### PR DESCRIPTION
I encountered a problem that is related to the one solved here:

https://github.com/cakephp/cakephp/pull/424

If I use Form Helper to do fields like this:

``` php
<?php
    echo $this->Form->input('Contact.others.0.0', array(
        'label'         => __('Voce'),
        'type'          => 'text',
        'div'           => 'control-group span4 input',
        'class'         => 'span4 input-others-key',
    ));
?>
<?php
    echo $this->Form->input('Contact.others.0.1', array(
        'label'         => __('Valore'),
        'type'          => 'text',
        'div'           => 'control-group span4 input',
        'class'         => 'span4 input-others-value',
    ));
?>
```

Then the secure method to determine form sign uses these fields:

``` php
Array
(
    ...
    [i] => Contact.others.0
    ....
)
```

And gave me auth error on form submit.

With this patch it correctly uses only input names:

``` php
Array
(
    ...
    [i] => Contact.others
    ....
)
```
