### PR TITLE
Fixed resetting of ErrorHandlers when custom error handlers are set in core.php

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -75,20 +75,19 @@ class Configure {
 			App::$bootstrapping = false;
 			App::init();
 			App::build();
-			$level = -1;
-			if (isset(self::$_values['Error']['level'])) {
-				error_reporting(self::$_values['Error']['level']);
-				$level = self::$_values['Error']['level'];
-			}
-			if (!empty(self::$_values['Error']['handler'])) {
-				set_error_handler(self::$_values['Error']['handler'], $level);
-			}
-			if (!empty(self::$_values['Exception']['handler'])) {
-				set_exception_handler(self::$_values['Exception']['handler']);
-			}
+
+			$error = self::$_values['Error'];
+			$exception = self::$_values['Exception'];
+			self::setErrorHandlers(true);
+
 			if (!include APP . 'Config' . DS . 'bootstrap.php') {
 				trigger_error(__d('cake_dev', "Can't find application bootstrap file. Please create %sbootstrap.php, and make sure it is readable by PHP.", APP . 'Config' . DS), E_USER_ERROR);
 			}
+
+			self::$_values['Error'] = $error;
+			self::$_values['Exception'] = $exception;
+			self::setErrorHandlers();
+			unset($error, $exception);
 		}
 	}
 
@@ -336,4 +335,38 @@ class Configure {
 		return false;
 	}
 
+/**
+ * Sets the configure error and exception handlers.
+ * If reset is true, sets the cake default error and exception handlers
+ * 
+ * @param boolean $reset True if the cake default error handlers should be set
+ * @return void
+ * @static
+ */
+	public static function setErrorHandlers($reset = false) {
+		if (true === $reset) {
+			self::$_values['Exception'] = array(
+				'handler' => 'ErrorHandler::handleException',
+				'renderer' => 'ExceptionRenderer',
+				'log' => true
+			);
+			self::$_values['Error'] = array(
+				'handler' => 'ErrorHandler::handleError',
+				'level' => E_ALL & ~E_DEPRECATED,
+				'trace' => true
+			);
+		}
+
+		$level = -1;
+		if (isset(self::$_values['Error']['level'])) {
+			error_reporting(self::$_values['Error']['level']);
+			$level = self::$_values['Error']['level'];
+		}
+		if (!empty(self::$_values['Error']['handler'])) {
+			set_error_handler(self::$_values['Error']['handler'], $level);
+		}
+		if (!empty(self::$_values['Exception']['handler'])) {
+			set_exception_handler(self::$_values['Exception']['handler']);
+		}
+	}
 }

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -353,5 +353,46 @@ class ConfigureTest extends CakeTestCase {
 		$reader = new StdClass();
 		Configure::config('test', $reader);
 	}
-}
 
+/**
+ * Tests that resetting the ErrorHandlers works as expected
+ * 
+ * @return void
+ */
+	public function testSetErrorHandlers() {
+		$error = array(
+			'handler' => 'ErrorHandler::handleError',
+			'level' => -2000,
+			'trace' => false
+		);
+		$exception = array(
+			'handler' => 'ErrorHandler::handleException',
+			'renderer' => 'MyExceptionRenderer',
+			'log' => false
+		);
+
+		Configure::write('Error', $error);
+		Configure::setErrorHandlers(true);
+
+		$expected = array(
+			'handler' => 'ErrorHandler::handleError',
+			'level' => E_ALL & ~E_DEPRECATED,
+			'trace' => true
+		);
+		$this->assertEqual(Configure::read('Error'), $expected);
+
+		$expected = array(
+			'handler' => 'ErrorHandler::handleException',
+			'renderer' => 'ExceptionRenderer',
+			'log' => true
+		);
+		$this->assertEqual(Configure::read('Exception'), $expected);
+
+		Configure::write('Error', $error);
+		Configure::write('Exception', $exception);
+		Configure::setErrorHandlers();
+		$this->assertEqual(Configure::read('Error'), $error);
+		$this->assertEqual(Configure::read('Exception'), $exception);
+	}
+
+}


### PR DESCRIPTION
Fixes warnings and errors when custom ErrorHandlers are defined in core.php.
Fixes changes introduced in https://github.com/cakephp/cakephp/pull/552
