### PR TITLE
Added MissingDriverException to use

### DIFF
--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -339,6 +339,17 @@ class MissingConnectionException extends CakeException {
 
 }
 
+ /**
+ * Used when a driver is missing
+ *
+ * @package       Cake.Error
+ */
+class MissingDriverException extends CakeException {
+
+       protected $_messageTemplate = 'Driver %s is missing, not loaded, or could not be found.';
+
+}
+
 /**
  * Used when a Task cannot be found.
  *


### PR DESCRIPTION
Added MissingDriverException for MySql to throw when it can't find the PDO driver. Otherwise DboSource throws "MissingConnectionException" and I spent 3 hours trying to figure out why I can login on the command line but CakePHP can't connect.
