### PR TITLE
Use a different exception for MissingConnection and MissingDriver

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -174,7 +174,10 @@ class Mysql extends DboSource {
  * @return boolean
  */
 	public function enabled() {
-		return in_array('mysql', PDO::getAvailableDrivers());
+		if(!in_array('mysql', PDO::getAvailableDrivers())) {
+			throw new MissingDriverException(array('class' => 'MySql PDO'));
+		}
+		return true;
 	}
 
 /**


### PR DESCRIPTION
See previous pull request from me. Utilizes a different error for MissingDriver when trying to load MySQL DB source
