### PR TITLE
Added Behaviorcollection::settings() for easier Behavior settings access

### DIFF
--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -275,6 +275,46 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
 	}
 
 /**
+ * Sets settings for a specific behavior for a specific Model alias.
+ *
+ * @param string $alias Model alais for which the behavior settings should be set
+ * @param string $behavior The Behavior name
+ * @param array $settings Configuration settings for $model
+ * @param boolean $mergeVars If true, merges the config with the existing settings. Defaults to TRUE.
+ * @return array The new settings array
+ * @access public
+ */
+	public function settings($alias, $behavior, $settings = array(), $mergeVars = true) {
+		if (!$alias || !is_string($alias)) {
+			return null;
+		}
+
+		try {
+			$behavior = $this->{$behavior};
+		} catch (Exception $e) {
+			return null;
+		}
+
+		if (null === $behavior) {
+			return null;
+		}
+		if (!isset($behavior->settings[$alias])) {
+			$behavior->settings[$alias] = array();
+		}
+		if (!empty($settings)) {
+			if (true === $mergeVars) {
+				$settings = array_merge(
+					$behavior->settings[$alias],
+					$settings
+				);
+			}
+			$behavior->settings[$alias] = $settings;
+			unset($settings);
+		}
+		return $behavior->settings[$alias];
+	}
+
+/**
  * Returns the implemented events that will get routed to the trigger function
  * in order to dispatch them separately on each behavior
  *

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -1138,4 +1138,50 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Tests that BehaviorCollection::settings() works as expected
+ * 
+ * @return void
+ * @access public
+ */
+	public function testBehaviorSettings() {
+		$model = new BehaviorTest();
+		$this->assertEqual(null, $model->Behaviors->settings('BehaviorTest', 'Dafuq?'));
+		$this->assertEqual(null, $model->Behaviors->settings(null, 'Dafuq?'));
+		$this->assertEqual(null, $model->Behaviors->settings(1234, 'Dafuq?'));
+
+		$expected = array(
+			'parent' => 'parent_id',
+			'left' => 'lft',
+			'right' => 'rght',
+			'scope' => '1 = 1',
+			'type' => 'nested',
+			'__parentChange' => false,
+			'recursive' => -1
+		);
+		$result = $model->Behaviors->settings('BehaviorTest', 'Tree');
+		$this->assertEqual($expected, $result);
+
+		$new = array(
+			'left' => 'right',
+			'right' => 'left',
+		);
+		$expected = array(
+			'parent' => 'parent_id',
+			'left' => 'right',
+			'right' => 'left',
+			'scope' => '1 = 1',
+			'type' => 'nested',
+			'__parentChange' => false,
+			'recursive' => -1
+		);
+		$this->assertEqual($expected, $model->Behaviors->settings('BehaviorTest', 'Tree', $new));
+		$new = array(
+			'left' => 'left',
+			'right' => 'right',
+		);
+		$this->assertEqual($new, $model->Behaviors->settings('BehaviorTest', 'Tree', $new, false));
+
+	}
+
 }

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -4921,3 +4921,26 @@ class CustomArticle extends AppModel {
 	}
 
 }
+
+/**
+ * BehaviorTestModel class
+ *
+ * @package       Cake.Test.Case.Model
+ */
+class BehaviorTest extends AppModel {
+
+/**
+ * useTable property
+ *
+ * @var string
+ */
+	public $useTable = false;
+
+/**
+ * actsAs property
+ *
+ * @var array
+ */
+	public $actsAs = array('Tree');
+
+}


### PR DESCRIPTION
I find myself either:

a) implementing a Behavior settings getter or
b) write `$this->MyModel->Behaviors->MyBehavior->settings['MyModel']['key'] = $value`

a lot of times.

This method will make setting and getting Behavior settings a lot easier IMO.
