### PR TITLE
Correct parameter order of assertEquals and assertNotEquals

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -77,7 +77,7 @@ class BasicsTest extends CakeTestCase {
 		$one = array('minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true);
 		$two = array('minYear' => null, 'maxYear' => null, 'separator' => '-', 'interval' => 1, 'monthNames' => true);
 		$result = array_diff_key($one, $two);
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**
@@ -282,7 +282,7 @@ class BasicsTest extends CakeTestCase {
 		$this->assertTrue(file_exists(CACHE . 'basics_test'));
 
 		$result = cache('basics_test');
-		$this->assertEquals($result, 'simple cache write');
+		$this->assertEquals('simple cache write', $result);
 		@unlink(CACHE . 'basics_test');
 
 		cache('basics_test', 'expired', '+1 second');
@@ -874,7 +874,7 @@ EXPECTED;
 				),
 			'g' => 'test'
 		);
-		$this->assertEquals(stripslashes_deep($nested), $expected);
+		$this->assertEquals($expected, stripslashes_deep($nested));
 	}
 
 /**
@@ -909,7 +909,7 @@ EXPECTED;
 				),
 			'g' => "te'''st"
 			);
-		$this->assertEquals(stripslashes_deep($nested), $expected);
+		$this->assertEquals($expected, stripslashes_deep($nested));
 	}
 
 /**
@@ -919,24 +919,24 @@ EXPECTED;
  */
 	public function testPluginSplit() {
 		$result = pluginSplit('Something.else');
-		$this->assertEquals($result, array('Something', 'else'));
+		$this->assertEquals(array('Something', 'else'), $result);
 
 		$result = pluginSplit('Something.else.more.dots');
-		$this->assertEquals($result, array('Something', 'else.more.dots'));
+		$this->assertEquals(array('Something', 'else.more.dots'), $result);
 
 		$result = pluginSplit('Somethingelse');
-		$this->assertEquals($result, array(null, 'Somethingelse'));
+		$this->assertEquals(array(null, 'Somethingelse'), $result);
 
 		$result = pluginSplit('Something.else', true);
-		$this->assertEquals($result, array('Something.', 'else'));
+		$this->assertEquals(array('Something.', 'else'), $result);
 
 		$result = pluginSplit('Something.else.more.dots', true);
-		$this->assertEquals($result, array('Something.', 'else.more.dots'));
+		$this->assertEquals(array('Something.', 'else.more.dots'), $result);
 
 		$result = pluginSplit('Post', false, 'Blog');
-		$this->assertEquals($result, array('Blog', 'Post'));
+		$this->assertEquals(array('Blog', 'Post'), $result);
 
 		$result = pluginSplit('Blog.Post', false, 'Ultimate');
-		$this->assertEquals($result, array('Blog', 'Post'));
+		$this->assertEquals(array('Blog', 'Post'), $result);
 	}
 }

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -57,7 +57,7 @@ class CacheTest extends CakeTestCase {
 	public function testConfig() {
 		$settings = array('engine' => 'File', 'path' => TMP . 'tests', 'prefix' => 'cake_test_');
 		$results = Cache::config('new', $settings);
-		$this->assertEquals($results, Cache::config('new'));
+		$this->assertEquals(Cache::config('new'), $results);
 		$this->assertTrue(isset($results['engine']));
 		$this->assertTrue(isset($results['settings']));
 	}
@@ -93,11 +93,11 @@ class CacheTest extends CakeTestCase {
 
 		$settings = array('engine' => 'TestAppCache', 'path' => TMP, 'prefix' => 'cake_test_');
 		$result = Cache::config('libEngine', $settings);
-		$this->assertEquals($result, Cache::config('libEngine'));
+		$this->assertEquals(Cache::config('libEngine'), $result);
 
 		$settings = array('engine' => 'TestPlugin.TestPluginCache', 'path' => TMP, 'prefix' => 'cake_test_');
 		$result = Cache::config('pluginLibEngine', $settings);
-		$this->assertEquals($result, Cache::config('pluginLibEngine'));
+		$this->assertEquals(Cache::config('pluginLibEngine'), $result);
 
 		Cache::drop('libEngine');
 		Cache::drop('pluginLibEngine');
@@ -161,10 +161,10 @@ class CacheTest extends CakeTestCase {
 		$_cacheConfigTests = Cache::config('tests');
 
 		$result = Cache::config('sessions', array('engine' => 'File', 'path' => TMP . 'sessions'));
-		$this->assertEquals($result['settings'], Cache::settings('sessions'));
+		$this->assertEquals(Cache::settings('sessions'), $result['settings']);
 
 		$result = Cache::config('tests', array('engine' => 'File', 'path' => TMP . 'tests'));
-		$this->assertEquals($result['settings'], Cache::settings('tests'));
+		$this->assertEquals(Cache::settings('tests'), $result['settings']);
 
 		Cache::config('sessions', $_cacheConfigSessions['settings']);
 		Cache::config('tests', $_cacheConfigTests['settings']);
@@ -180,17 +180,17 @@ class CacheTest extends CakeTestCase {
 
 		Cache::write('value_one', 'I am cached', 'test_name');
 		$result = Cache::read('value_one', 'test_name');
-		$this->assertEquals($result, 'I am cached');
+		$this->assertEquals('I am cached', $result);
 
 		$result = Cache::read('value_one');
-		$this->assertEquals($result, null);
+		$this->assertEquals(null, $result);
 
 		Cache::write('value_one', 'I am in default config!');
 		$result = Cache::read('value_one');
-		$this->assertEquals($result, 'I am in default config!');
+		$this->assertEquals('I am in default config!', $result);
 
 		$result = Cache::read('value_one', 'test_name');
-		$this->assertEquals($result, 'I am cached');
+		$this->assertEquals('I am cached', $result);
 
 		Cache::delete('value_one', 'test_name');
 		Cache::delete('value_one', 'default');
@@ -384,7 +384,7 @@ class CacheTest extends CakeTestCase {
 
 		Cache::set(array('duration' => '+1 year'));
 		$data = Cache::read('test_cache');
-		$this->assertEquals($data, 'this is just a simple test of the cache system');
+		$this->assertEquals('this is just a simple test of the cache system', $data);
 
 		Cache::delete('test_cache');
 

--- a/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
@@ -60,7 +60,7 @@ class ApcEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'apc');
 		$expecting = '';
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'apc');
@@ -68,7 +68,7 @@ class ApcEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'apc');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::delete('test', 'apc');
 	}

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -62,11 +62,11 @@ class FileEngineTest extends CakeTestCase {
  */
 	public function testCacheDirChange() {
 		$result = Cache::config('sessions', array('engine' => 'File', 'path' => TMP . 'sessions'));
-		$this->assertEquals($result['settings'], Cache::settings('sessions'));
+		$this->assertEquals(Cache::settings('sessions'), $result['settings']);
 
 		$result = Cache::config('sessions', array('engine' => 'File', 'path' => TMP . 'tests'));
-		$this->assertEquals($result['settings'], Cache::settings('sessions'));
-		$this->assertNotEquals($result['settings'], Cache::settings('default'));
+		$this->assertEquals(Cache::settings('sessions'), $result['settings']);
+		$this->assertNotEquals(Cache::settings('default'), $result['settings']);
 	}
 
 /**
@@ -84,7 +84,7 @@ class FileEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = '';
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'file_test');
@@ -92,7 +92,7 @@ class FileEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::delete('test', 'file_test');
 	}
@@ -243,11 +243,11 @@ class FileEngineTest extends CakeTestCase {
 		$FileOne->write('prefix_one_key_one', $data1, DAY);
 		$FileTwo->write('prefix_two_key_two', $data2, DAY);
 
-		$this->assertEquals($FileOne->read('prefix_one_key_one'), $expected);
-		$this->assertEquals($FileTwo->read('prefix_two_key_two'), $expected);
+		$this->assertEquals($expected, $FileOne->read('prefix_one_key_one'));
+		$this->assertEquals($expected, $FileTwo->read('prefix_two_key_two'));
 
 		$FileOne->clear(false);
-		$this->assertEquals($FileTwo->read('prefix_two_key_two'), $expected, 'secondary config was cleared by accident.');
+		$this->assertEquals($expected, $FileTwo->read('prefix_two_key_two'), 'secondary config was cleared by accident.');
 		$FileTwo->clear(false);
 	}
 
@@ -262,7 +262,7 @@ class FileEngineTest extends CakeTestCase {
 		$this->assertTrue(file_exists(CACHE . 'cake_views_countries_something'));
 
 		$result = Cache::read('views.countries.something', 'file_test');
-		$this->assertEquals($result, 'here');
+		$this->assertEquals('here', $result);
 
 		$result = Cache::clear(false, 'file_test');
 		$this->assertTrue($result);

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -91,7 +91,7 @@ class MemcacheEngineTest extends CakeTestCase {
 			'engine' => 'Memcache',
 			'persistent' => true,
 		);
-		$this->assertEquals($settings, $expecting);
+		$this->assertEquals($expecting, $settings);
 	}
 
 /**
@@ -118,7 +118,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$servers = array_keys($Memcache->__Memcache->getExtendedStats());
 		$settings = $Memcache->settings();
-		$this->assertEquals($servers, $settings['servers']);
+		$this->assertEquals($settings['servers'], $servers);
 		Cache::drop('dual_server');
 	}
 
@@ -160,10 +160,10 @@ class MemcacheEngineTest extends CakeTestCase {
 	public function testParseServerStringNonLatin() {
 		$Memcache = new TestMemcacheEngine();
 		$result = $Memcache->parseServerString('schülervz.net:13211');
-		$this->assertEquals($result, array('schülervz.net', '13211'));
+		$this->assertEquals(array('schülervz.net', '13211'), $result);
 
 		$result = $Memcache->parseServerString('sülül:1111');
-		$this->assertEquals($result, array('sülül', '1111'));
+		$this->assertEquals(array('sülül', '1111'), $result);
 	}
 
 /**
@@ -174,7 +174,7 @@ class MemcacheEngineTest extends CakeTestCase {
 	public function testParseServerStringUnix() {
 		$Memcache = new TestMemcacheEngine();
 		$result = $Memcache->parseServerString('unix:///path/to/memcached.sock');
-		$this->assertEquals($result, array('unix:///path/to/memcached.sock', 0));
+		$this->assertEquals(array('unix:///path/to/memcached.sock', 0), $result);
 	}
 
 /**
@@ -187,7 +187,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'memcache');
 		$expecting = '';
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'memcache');
@@ -195,7 +195,7 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'memcache');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::delete('test', 'memcache');
 	}
@@ -243,7 +243,7 @@ class MemcacheEngineTest extends CakeTestCase {
 		sleep(2);
 		$result = Cache::read('long_expiry_test', 'memcache');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::config('memcache', array('duration' => 3600));
 	}
@@ -327,11 +327,11 @@ class MemcacheEngineTest extends CakeTestCase {
 		$this->assertTrue(Cache::write('duration_test', 'yay', 'long_memcache'));
 		$this->assertTrue(Cache::write('short_duration_test', 'boo', 'short_memcache'));
 
-		$this->assertEquals(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
-		$this->assertEquals(Cache::read('short_duration_test', 'short_memcache'), 'boo', 'Value was not read %s');
+		$this->assertEquals('yay', Cache::read('duration_test', 'long_memcache'), 'Value was not read %s');
+		$this->assertEquals('boo', Cache::read('short_duration_test', 'short_memcache'), 'Value was not read %s');
 
 		sleep(1);
-		$this->assertEquals(Cache::read('duration_test', 'long_memcache'), 'yay', 'Value was not read %s');
+		$this->assertEquals('yay', Cache::read('duration_test', 'long_memcache'), 'Value was not read %s');
 
 		sleep(2);
 		$this->assertFalse(Cache::read('short_duration_test', 'short_memcache'), 'Cache was not invalidated %s');
@@ -376,9 +376,9 @@ class MemcacheEngineTest extends CakeTestCase {
 		Cache::config('memcache', array('duration' => 0));
 		$result = Cache::write('test_key', 'written!', 'memcache');
 
-		$this->assertTrue($result, 'Could not write with duration 0');
+		$this->assertTrue('Could not write with duration 0', $result);
 		$result = Cache::read('test_key', 'memcache');
-		$this->assertEquals($result, 'written!');
+		$this->assertEquals('written!', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
@@ -59,7 +59,7 @@ class WincacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'wincache');
 		$expecting = '';
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'wincache');
@@ -67,7 +67,7 @@ class WincacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test', 'wincache');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::delete('test', 'wincache');
 	}

--- a/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
@@ -80,7 +80,7 @@ class XcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test');
 		$expecting = '';
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data);
@@ -88,7 +88,7 @@ class XcacheEngineTest extends CakeTestCase {
 
 		$result = Cache::read('test');
 		$expecting = $data;
-		$this->assertEquals($result, $expecting);
+		$this->assertEquals($expecting, $result);
 
 		Cache::delete('test');
 	}

--- a/lib/Cake/Test/Case/Configure/IniReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/IniReaderTest.php
@@ -77,7 +77,7 @@ class IniReaderTest extends CakeTestCase {
 			'some_key' => 'some_value',
 			'bool_key' => true
 		);
-		$this->assertEquals($config, $expected);
+		$this->assertEquals($expected, $config);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -115,10 +115,10 @@ class AclShellTest extends CakeTestCase {
 		$expected = array('model' => 'Model', 'foreign_key' => 'foreignKey');
 
 		$result = $this->Task->parseIdentifier('mySuperUser');
-		$this->assertEquals($result, 'mySuperUser');
+		$this->assertEquals('mySuperUser', $result);
 
 		$result = $this->Task->parseIdentifier('111234');
-		$this->assertEquals($result, '111234');
+		$this->assertEquals('111234', $result);
 	}
 
 /**
@@ -137,9 +137,9 @@ class AclShellTest extends CakeTestCase {
 		$Aro = ClassRegistry::init('Aro');
 		$Aro->cacheQueries = false;
 		$result = $Aro->read();
-		$this->assertEquals($result['Aro']['model'], 'User');
-		$this->assertEquals($result['Aro']['foreign_key'], 1);
-		$this->assertEquals($result['Aro']['parent_id'], null);
+		$this->assertEquals('User', $result['Aro']['model']);
+		$this->assertEquals(1, $result['Aro']['foreign_key']);
+		$this->assertEquals(null, $result['Aro']['parent_id']);
 		$id = $result['Aro']['id'];
 
 		$this->Task->args = array('aro', 'User.1', 'User.3');
@@ -147,19 +147,19 @@ class AclShellTest extends CakeTestCase {
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read();
-		$this->assertEquals($result['Aro']['model'], 'User');
-		$this->assertEquals($result['Aro']['foreign_key'], 3);
-		$this->assertEquals($result['Aro']['parent_id'], $id);
+		$this->assertEquals('User', $result['Aro']['model']);
+		$this->assertEquals(3, $result['Aro']['foreign_key']);
+		$this->assertEquals($id, $result['Aro']['parent_id']);
 
 		$this->Task->args = array('aro', 'root', 'somealias');
 		$this->Task->create();
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read();
-		$this->assertEquals($result['Aro']['alias'], 'somealias');
-		$this->assertEquals($result['Aro']['model'], null);
-		$this->assertEquals($result['Aro']['foreign_key'], null);
-		$this->assertEquals($result['Aro']['parent_id'], null);
+		$this->assertEquals('somealias', $result['Aro']['alias']);
+		$this->assertEquals(null, $result['Aro']['model']);
+		$this->assertEquals(null, $result['Aro']['foreign_key']);
+		$this->assertEquals(null, $result['Aro']['parent_id']);
 	}
 
 /**
@@ -189,7 +189,7 @@ class AclShellTest extends CakeTestCase {
 
 		$Aro = ClassRegistry::init('Aro');
 		$result = $Aro->read(null, 4);
-		$this->assertEquals($result['Aro']['parent_id'], null);
+		$this->assertEquals(null, $result['Aro']['parent_id']);
 	}
 
 /**
@@ -206,7 +206,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEquals($node['Aco'][0]['Permission']['_create'], 1);
+		$this->assertEquals(1, $node['Aco'][0]['Permission']['_create']);
 	}
 
 /**
@@ -224,7 +224,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->node(array('model' => 'AuthUser', 'foreign_key' => 2));
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEquals($node['Aco'][0]['Permission']['_create'], -1);
+		$this->assertEquals(-1, $node['Aco'][0]['Permission']['_create']);
 	}
 
 /**
@@ -275,7 +275,7 @@ class AclShellTest extends CakeTestCase {
 		$node = $this->Task->Acl->Aro->node(array('model' => 'AuthUser', 'foreign_key' => 2));
 		$node = $this->Task->Acl->Aro->read(null, $node[0]['Aro']['id']);
 		$this->assertFalse(empty($node['Aco'][0]));
-		$this->assertEquals($node['Aco'][0]['Permission']['_create'], 0);
+		$this->assertEquals(0, $node['Aco'][0]['Permission']['_create']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -135,18 +135,18 @@ class SchemaShellTest extends CakeTestCase {
 		$this->Shell->startup();
 		$this->assertTrue(isset($this->Shell->Schema));
 		$this->assertTrue(is_a($this->Shell->Schema, 'CakeSchema'));
-		$this->assertEquals(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
-		$this->assertEquals($this->Shell->Schema->file, 'schema.php');
+		$this->assertEquals(strtolower(APP_DIR), strtolower($this->Shell->Schema->name));
+		$this->assertEquals('schema.php', $this->Shell->Schema->file);
 
 		$this->Shell->Schema = null;
 		$this->Shell->params = array(
 			'name' => 'TestSchema'
 		);
 		$this->Shell->startup();
-		$this->assertEquals($this->Shell->Schema->name, 'TestSchema');
-		$this->assertEquals($this->Shell->Schema->file, 'test_schema.php');
-		$this->assertEquals($this->Shell->Schema->connection, 'default');
-		$this->assertEquals($this->Shell->Schema->path, APP . 'Config' . DS . 'Schema');
+		$this->assertEquals('TestSchema', $this->Shell->Schema->name);
+		$this->assertEquals('test_schema.php', $this->Shell->Schema->file);
+		$this->assertEquals('default', $this->Shell->Schema->connection);
+		$this->assertEquals(APP . 'Config' . DS . 'Schema', $this->Shell->Schema->path);
 
 		$this->Shell->Schema = null;
 		$this->Shell->params = array(
@@ -155,10 +155,10 @@ class SchemaShellTest extends CakeTestCase {
 			'path' => '/test/path'
 		);
 		$this->Shell->startup();
-		$this->assertEquals(strtolower($this->Shell->Schema->name), strtolower(APP_DIR));
-		$this->assertEquals($this->Shell->Schema->file, 'other_file.php');
-		$this->assertEquals($this->Shell->Schema->connection, 'test');
-		$this->assertEquals($this->Shell->Schema->path, '/test/path');
+		$this->assertEquals(strtolower(APP_DIR), strtolower($this->Shell->Schema->name));
+		$this->assertEquals('other_file.php', $this->Shell->Schema->file);
+		$this->assertEquals('test', $this->Shell->Schema->connection);
+		$this->assertEquals('/test/path', $this->Shell->Schema->path);
 	}
 
 /**
@@ -459,7 +459,7 @@ class SchemaShellTest extends CakeTestCase {
 		);
 		$this->Shell->startup();
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPlugin' . DS . 'Config' . DS . 'Schema';
-		$this->assertEquals($this->Shell->Schema->path, $expected);
+		$this->assertEquals($expected, $this->Shell->Schema->path);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -179,7 +179,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoHelpersNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doHelpers();
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**
@@ -216,7 +216,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoComponentsNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doComponents();
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -90,7 +90,7 @@ class FixtureTaskTest extends CakeTestCase {
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 
 		$Task = new FixtureTask($out, $out, $in);
-		$this->assertEquals($Task->path, APP . 'Test' . DS . 'Fixture' . DS);
+		$this->assertEquals(APP . 'Test' . DS . 'Fixture' . DS, $Task->path);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -470,7 +470,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('y', 2));
 
 		$result = $this->Task->findDisplayField($fields);
-		$this->assertEquals($result, 'tagname');
+		$this->assertEquals('tagname', $result);
 	}
 
 /**
@@ -619,7 +619,7 @@ class ModelTaskTest extends CakeTestCase {
 				),
 			),
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -716,7 +716,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(6))->method('out')->with('3. three');
 		$this->Task->expects($this->at(7))->method('in')->will($this->returnValue(2));
 		$result = $this->Task->inOptions($options, 'Pick a number');
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -276,7 +276,7 @@ class ProjectTaskTest extends CakeTestCase {
 	public function testGetPrefix() {
 		Configure::write('Routing.prefixes', array('admin'));
 		$result = $this->Task->getPrefix();
-		$this->assertEquals($result, 'admin_');
+		$this->assertEquals('admin_', $result);
 
 		Configure::write('Routing.prefixes', null);
 		$this->_setupTestProject();
@@ -284,7 +284,7 @@ class ProjectTaskTest extends CakeTestCase {
 		$this->Task->expects($this->once())->method('in')->will($this->returnValue('super_duper_admin'));
 
 		$result = $this->Task->getPrefix();
-		$this->assertEquals($result, 'super_duper_admin_');
+		$this->assertEquals('super_duper_admin_', $result);
 
 		$File = new File($this->Task->configPath . 'core.php');
 		$File->delete();
@@ -322,7 +322,7 @@ class ProjectTaskTest extends CakeTestCase {
 		$this->Task->expects($this->once())->method('in')->will($this->returnValue(2));
 
 		$result = $this->Task->getPrefix();
-		$this->assertEquals($result, 'ninja_');
+		$this->assertEquals('ninja_', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -66,19 +66,19 @@ class TemplateTaskTest extends CakeTestCase {
 	public function testSet() {
 		$this->Task->set('one', 'two');
 		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEquals($this->Task->templateVars['one'], 'two');
+		$this->assertEquals('two', $this->Task->templateVars['one']);
 
 		$this->Task->set(array('one' => 'three', 'four' => 'five'));
 		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEquals($this->Task->templateVars['one'], 'three');
+		$this->assertEquals('three', $this->Task->templateVars['one']);
 		$this->assertTrue(isset($this->Task->templateVars['four']));
-		$this->assertEquals($this->Task->templateVars['four'], 'five');
+		$this->assertEquals('five', $this->Task->templateVars['four']);
 
 		$this->Task->templateVars = array();
 		$this->Task->set(array(3 => 'three', 4 => 'four'));
 		$this->Task->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($this->Task->templateVars, $expected);
+		$this->assertEquals($expected, $this->Task->templateVars);
 	}
 
 /**
@@ -105,17 +105,17 @@ class TemplateTaskTest extends CakeTestCase {
 		$this->Task->expects($this->exactly(1))->method('in')->will($this->returnValue('1'));
 
 		$result = $this->Task->getThemePath();
-		$this->assertEquals($result, $defaultTheme);
+		$this->assertEquals($defaultTheme, $result);
 
 		$this->Task->templatePaths = array('default' => $defaultTheme, 'other' => '/some/path');
 		$this->Task->params['theme'] = 'other';
 		$result = $this->Task->getThemePath();
-		$this->assertEquals($result, '/some/path');
+		$this->assertEquals('/some/path', $result);
 
 		$this->Task->params = array();
 		$result = $this->Task->getThemePath();
-		$this->assertEquals($result, $defaultTheme);
-		$this->assertEquals($this->Task->params['theme'], 'default');
+		$this->assertEquals($defaultTheme, $result);
+		$this->assertEquals('default', $this->Task->params['theme']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -312,7 +312,7 @@ class TestTaskTest extends CakeTestCase {
 		$expected = array('plugin.test_task.test_task_comment', 'app.articles_tags',
 			'app.test_task_article', 'app.test_task_tag');
 
-		$this->assertEquals(sort($result), sort($expected));
+		$this->assertEquals(sort($expected), sort($result));
 	}
 
 /**
@@ -368,7 +368,7 @@ class TestTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(1));
 
 		$result = $this->Task->getClassName('Model');
-		$this->assertEquals($result, 'MyCustomClass');
+		$this->assertEquals('MyCustomClass', $result);
 
 		$result = $this->Task->getClassName('Model');
 		$options = App::objects('model');

--- a/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
@@ -712,12 +712,12 @@ class ViewTaskTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $this->Task->getTemplate('add');
-		$this->assertEquals($result, 'form');
+		$this->assertEquals('form', $result);
 
 		Configure::write('Routing.prefixes', array('admin'));
 
 		$result = $this->Task->getTemplate('admin_add');
-		$this->assertEquals($result, 'form');
+		$this->assertEquals('form', $result);
 
 		$this->Task->Template->templatePaths = array(
 			'test' => CAKE . 'Test' . DS . 'test_app' . DS . 'Console' . DS . 'Templates' . DS . 'test' . DS
@@ -725,7 +725,7 @@ class ViewTaskTest extends CakeTestCase {
 		$this->Task->Template->params['theme'] = 'test';
 
 		$result = $this->Task->getTemplate('admin_edit');
-		$this->assertEquals($result, 'admin_edit');
+		$this->assertEquals('admin_edit', $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/Console/Command/TestShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/TestShellTest.php
@@ -310,7 +310,7 @@ class TestShellTest extends CakeTestCase {
 
 		$this->Shell->expects($this->once())->method('_run');
 		$this->Shell->available();
-		$this->assertEquals($this->Shell->args, array('core', 'AllBehaviors'));
+		$this->assertEquals(array('core', 'AllBehaviors'), $this->Shell->args);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -450,7 +450,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_with_main');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEquals($Dispatcher->args, array());
+		$this->assertEquals(array(), $Dispatcher->args);
 	}
 
 /**
@@ -498,7 +498,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_with_main_not_a');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEquals($Dispatcher->args, array());
+		$this->assertEquals(array(), $Dispatcher->args);
 
 		$Shell = new MockWithMainNotAShell($Dispatcher);
 		$this->mockObjects[] = $Shell;
@@ -531,7 +531,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher->args = array('mock_without_main_not_a');
 		$result = $Dispatcher->dispatch();
 		$this->assertTrue($result);
-		$this->assertEquals($Dispatcher->args, array());
+		$this->assertEquals(array(), $Dispatcher->args);
 
 		$Shell = new MockWithoutMainNotAShell($Dispatcher);
 		$this->mockObjects[] = $Shell;
@@ -553,24 +553,24 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 
 		$Dispatcher->args = array('a', 'b', 'c');
-		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertEquals('a', $Dispatcher->shiftArgs());
 		$this->assertSame($Dispatcher->args, array('b', 'c'));
 
 		$Dispatcher->args = array('a' => 'b', 'c', 'd');
-		$this->assertEquals($Dispatcher->shiftArgs(), 'b');
+		$this->assertEquals('b', $Dispatcher->shiftArgs());
 		$this->assertSame($Dispatcher->args, array('c', 'd'));
 
 		$Dispatcher->args = array('a', 'b' => 'c', 'd');
-		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertEquals('a', $Dispatcher->shiftArgs());
 		$this->assertSame($Dispatcher->args, array('b' => 'c', 'd'));
 
 		$Dispatcher->args = array(0 => 'a',  2 => 'b', 30 => 'c');
-		$this->assertEquals($Dispatcher->shiftArgs(), 'a');
+		$this->assertEquals('a', $Dispatcher->shiftArgs());
 		$this->assertSame($Dispatcher->args, array(0 => 'b', 1 => 'c'));
 
 		$Dispatcher->args = array();
 		$this->assertNull($Dispatcher->shiftArgs());
-		$this->assertSame($Dispatcher->args, array());
+		$this->assertSame(array(), $Dispatcher->args);
 	}
 
 }

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -140,7 +140,7 @@ class ShellTest extends CakeTestCase {
  * @return void
  */
 	public function testConstruct() {
-		$this->assertEquals($this->Shell->name, 'ShellTestShell');
+		$this->assertEquals('ShellTestShell', $this->Shell->name);
 		$this->assertInstanceOf('ConsoleInput', $this->Shell->stdin);
 		$this->assertInstanceOf('ConsoleOutput', $this->Shell->stdout);
 		$this->assertInstanceOf('ConsoleOutput', $this->Shell->stderr);
@@ -182,14 +182,14 @@ class ShellTest extends CakeTestCase {
 
 		$this->assertTrue(isset($this->Shell->TestPluginPost));
 		$this->assertInstanceOf('TestPluginPost', $this->Shell->TestPluginPost);
-		$this->assertEquals($this->Shell->modelClass, 'TestPluginPost');
+		$this->assertEquals('TestPluginPost', $this->Shell->modelClass);
 		CakePlugin::unload('TestPlugin');
 
 		$this->Shell->uses = array('Comment');
 		$this->Shell->initialize();
 		$this->assertTrue(isset($this->Shell->Comment));
 		$this->assertInstanceOf('Comment', $this->Shell->Comment);
-		$this->assertEquals($this->Shell->modelClass, 'Comment');
+		$this->assertEquals('Comment', $this->Shell->modelClass);
 
 		App::build();
 	}
@@ -225,22 +225,22 @@ class ShellTest extends CakeTestCase {
 			->will($this->returnValue('0'));
 
 		$result = $this->Shell->in('Just a test?', array('y', 'n'), 'n');
-		$this->assertEquals($result, 'n');
+		$this->assertEquals('n', $result);
 
 		$result = $this->Shell->in('Just a test?', array('y', 'n'), 'n');
-		$this->assertEquals($result, 'Y');
+		$this->assertEquals('Y', $result);
 
 		$result = $this->Shell->in('Just a test?', 'y,n', 'n');
-		$this->assertEquals($result, 'y');
+		$this->assertEquals('y', $result);
 
 		$result = $this->Shell->in('Just a test?', 'y/n', 'n');
-		$this->assertEquals($result, 'y');
+		$this->assertEquals('y', $result);
 
 		$result = $this->Shell->in('Just a test?', 'y', 'y');
-		$this->assertEquals($result, 'y');
+		$this->assertEquals('y', $result);
 
 		$result = $this->Shell->in('Just a test?', array(0, 1, 2), '0');
-		$this->assertEquals($result, '0');
+		$this->assertEquals('0', $result);
 	}
 
 /**
@@ -252,7 +252,7 @@ class ShellTest extends CakeTestCase {
 		$this->Shell->interactive = false;
 
 		$result = $this->Shell->in('Just a test?', 'y/n', 'n');
-		$this->assertEquals($result, 'n');
+		$this->assertEquals('n', $result);
 	}
 
 /**
@@ -367,7 +367,7 @@ class ShellTest extends CakeTestCase {
 		}
 		$this->assertEquals($this->Shell->nl(), $newLine);
 		$this->assertEquals($this->Shell->nl(true), $newLine);
-		$this->assertEquals($this->Shell->nl(false), "");
+		$this->assertEquals("", $this->Shell->nl(false));
 		$this->assertEquals($this->Shell->nl(2), $newLine . $newLine);
 		$this->assertEquals($this->Shell->nl(1), $newLine);
 	}
@@ -488,33 +488,33 @@ class ShellTest extends CakeTestCase {
  */
 	public function testShortPath() {
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'cd';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'cd' . DS;
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = $expected = DS . 'tmp' . DS . 'ab' . DS . 'index.php';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = DS . 'tmp' . DS . 'ab' . DS . DS . 'cd';
 		$expected = DS . 'tmp' . DS . 'ab' . DS . 'cd';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = 'tmp' . DS . 'ab';
 		$expected = 'tmp' . DS . 'ab';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = 'tmp' . DS . 'ab';
 		$expected = 'tmp' . DS . 'ab';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = APP;
 		$expected = DS . basename(APP) . DS;
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 
 		$path = APP . 'index.php';
 		$expected = DS . basename(APP) . DS . 'index.php';
-		$this->assertEquals($this->Shell->shortPath($path), $expected);
+		$this->assertEquals($expected, $this->Shell->shortPath($path));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -245,8 +245,8 @@ class DbAclTest extends CakeTestCase {
 			'parent_id' => $parent['AroTwoTest']['id']
 		));
 		$result = $this->Acl->Aro->findByAlias('Subordinate', null, null, -1);
-		$this->assertEquals($result['AroTwoTest']['lft'], 16);
-		$this->assertEquals($result['AroTwoTest']['rght'], 17);
+		$this->assertEquals(16, $result['AroTwoTest']['lft']);
+		$this->assertEquals(17, $result['AroTwoTest']['rght']);
 	}
 
 /**
@@ -387,7 +387,7 @@ class DbAclTest extends CakeTestCase {
 
 		$result = $this->Acl->Aro->Permission->find('all', array('conditions' => array('AroTwoTest.alias' => 'Samir')));
 		$expected = '-1';
-		$this->assertEquals($result[0]['PermissionTwoTest']['_delete'], $expected);
+		$this->assertEquals($expected, $result[0]['PermissionTwoTest']['_delete']);
 
 		$this->assertFalse($this->Acl->deny('Lumbergh', 'ROOT/tpsReports/DoesNotExist', 'create'));
 	}

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -573,7 +573,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 		$objects = $this->Controller->Auth->constructAuthorize();
 		$result = $objects[0];
-		$this->assertEquals($result->settings['actionPath'], 'controllers/');
+		$this->assertEquals('controllers/', $result->settings['actionPath']);
 	}
 
 /**
@@ -604,7 +604,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 		$objects = $this->Controller->Auth->constructAuthenticate();
 		$result = $objects[0];
-		$this->assertEquals($result->settings['userModel'], 'AuthUser');
+		$this->assertEquals('AuthUser', $result->settings['userModel']);
 	}
 
 /**
@@ -737,7 +737,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Controller->request->query['url'] = Router::normalize($url);
 		$this->Controller->Auth->initialize($this->Controller);
 		$this->Controller->Auth->allow('action_name', 'anotherAction');
-		$this->assertEquals($this->Controller->Auth->allowedActions, array('action_name', 'anotherAction'));
+		$this->assertEquals(array('action_name', 'anotherAction'), $this->Controller->Auth->allowedActions);
 	}
 
 /**
@@ -938,7 +938,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 
 		$this->Auth->startup($this->Controller);
-		$this->assertEquals($this->Controller->testUrl, '/admin/auth_test/login');
+		$this->assertEquals('/admin/auth_test/login', $this->Controller->testUrl);
 
 		Configure::write('Routing.prefixes', $pref);
 	}
@@ -1076,7 +1076,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->logoutRedirect = '/';
 		$result = $this->Auth->logout();
 
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 		$this->assertNull($this->Auth->Session->read('Auth.AuthUser'));
 		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
 	}

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -134,7 +134,7 @@ class CookieComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testCookieName() {
-		$this->assertEquals($this->Cookie->name, 'CakeTestCookie');
+		$this->assertEquals('CakeTestCookie', $this->Cookie->name);
 	}
 
 /**
@@ -146,11 +146,11 @@ class CookieComponentTest extends CakeTestCase {
 		$this->_setCookieData();
 		$data = $this->Cookie->read('Encrytped_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 	}
 
 /**
@@ -162,11 +162,11 @@ class CookieComponentTest extends CakeTestCase {
 		$this->_setCookieData();
 		$data = $this->Cookie->read('Plain_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 	}
 
 /**
@@ -219,7 +219,7 @@ class CookieComponentTest extends CakeTestCase {
 			'secure' => false,
 			'httpOnly' => true);
 		$result = $this->Controller->response->cookie($this->Cookie->name . '[Testing]');
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -240,7 +240,7 @@ class CookieComponentTest extends CakeTestCase {
 			'secure' => false,
 			'httpOnly' => true);
 		$result = $this->Controller->response->cookie($this->Cookie->name . '[Testing]');
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -251,9 +251,9 @@ class CookieComponentTest extends CakeTestCase {
 	public function testWritePlainCookieArray() {
 		$this->Cookie->write(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!'), null, false);
 
-		$this->assertEquals($this->Cookie->read('name'), 'CakePHP');
-		$this->assertEquals($this->Cookie->read('version'), '1.2.0.x');
-		$this->assertEquals($this->Cookie->read('tag'), 'CakePHP Rocks!');
+		$this->assertEquals('CakePHP', $this->Cookie->read('name'));
+		$this->assertEquals('1.2.0.x', $this->Cookie->read('version'));
+		$this->assertEquals('CakePHP Rocks!', $this->Cookie->read('tag'));
 
 		$this->Cookie->delete('name');
 		$this->Cookie->delete('version');
@@ -277,7 +277,7 @@ class CookieComponentTest extends CakeTestCase {
 			'secure' => false,
 			'httpOnly' => false);
 		$result = $this->Controller->response->cookie($this->Cookie->name . '[Testing]');
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -305,7 +305,7 @@ class CookieComponentTest extends CakeTestCase {
 				'name' => 'CakePHP',
 				'version' => '1.2.0.x',
 				'tag' => 'CakePHP Rocks!'));
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 	}
 
 /**
@@ -318,7 +318,7 @@ class CookieComponentTest extends CakeTestCase {
 		$this->Cookie->delete('Encrytped_multi_cookies.name');
 		$data = $this->Cookie->read('Encrytped_multi_cookies');
 		$expected = array('version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$this->Cookie->delete('Encrytped_array');
 		$data = $this->Cookie->read('Encrytped_array');
@@ -327,7 +327,7 @@ class CookieComponentTest extends CakeTestCase {
 		$this->Cookie->delete('Plain_multi_cookies.name');
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$this->Cookie->delete('Plain_array');
 		$data = $this->Cookie->read('Plain_array');
@@ -344,51 +344,51 @@ class CookieComponentTest extends CakeTestCase {
 
 		$data = $this->Cookie->read('Encrytped_array.name');
 		$expected = 'CakePHP';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_array.version');
 		$expected = '1.2.0.x';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_array.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.name');
 		$expected = 'CakePHP';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.version');
 		$expected = '1.2.0.x';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Encrytped_multi_cookies.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_array.name');
 		$expected = 'CakePHP';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_array.version');
 		$expected = '1.2.0.x';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_array.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.name');
 		$expected = 'CakePHP';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.version');
 		$expected = '1.2.0.x';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = $this->Cookie->read('Plain_multi_cookies.tag');
 		$expected = 'CakePHP Rocks!';
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -647,7 +647,7 @@ HTMLBLOC;
 		$this->assertEquals(trim($matches[1]), $subject);
 
 		$result = mb_internal_encoding();
-		$this->assertEquals($result, 'ISO-8859-1');
+		$this->assertEquals('ISO-8859-1', $result);
 
 		mb_internal_encoding($restore);
 	}

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -263,53 +263,53 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerComment'), '{n}.PaginatorControllerComment.id');
-		$this->assertEquals($results, array(1, 2, 3, 4, 5, 6));
+		$this->assertEquals(array(1, 2, 3, 4, 5, 6), $results);
 
 		$Controller->modelClass = null;
 
 		$Controller->uses[0] = 'Plugin.PaginatorControllerPost';
 		$results = Set::extract($Controller->Paginator->paginate(), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->request->params['named'] = array('page' => '-1');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->request->params['named'] = array('sort' => 'PaginatorControllerPost.id', 'direction' => 'asc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->request->params['named'] = array('sort' => 'PaginatorControllerPost.id', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals($results, array(3, 2, 1));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(3, 2, 1), $results);
 
 		$Controller->request->params['named'] = array('sort' => 'id', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals($results, array(3, 2, 1));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(3, 2, 1), $results);
 
 		$Controller->request->params['named'] = array('sort' => 'NotExisting.field', 'direction' => 'desc');
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1, 'Invalid field in query %s');
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page'], 'Invalid field in query %s');
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->request->params['named'] = array(
 			'sort' => 'PaginatorControllerPost.author_id', 'direction' => 'allYourBase'
 		);
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['order'][0], array('PaginatorControllerPost.author_id' => 'asc'));
-		$this->assertEquals($results, array(1, 3, 2));
+		$this->assertEquals(array('PaginatorControllerPost.author_id' => 'asc'), $Controller->PaginatorControllerPost->lastQueries[1]['order'][0]);
+		$this->assertEquals(array(1, 3, 2), $results);
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => 0, 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
@@ -317,7 +317,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => 'garbage!', 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
@@ -327,7 +327,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->Paginator->paginate('PaginatorControllerPost');
 
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['limit'], 1);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
+		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
@@ -378,8 +378,8 @@ class PaginatorComponentTest extends CakeTestCase {
 
 		$Controller->request->params['named'] = array('page' => '-1', 'contain' => array('PaginatorControllerComment'));
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(1, 2, 3), Set::extract($result, '{n}.PaginatorControllerPost.id'));
 		$this->assertTrue(!isset($Controller->PaginatorControllerPost->lastQueries[1]['contain']));
 
 		$Controller->request->params['named'] = array('page' => '-1');
@@ -391,8 +391,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			),
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['page'], 1);
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(1, 2, 3));
+		$this->assertEquals(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
+		$this->assertEquals(array(1, 2, 3), Set::extract($result, '{n}.PaginatorControllerPost.id'));
 		$this->assertTrue(isset($Controller->PaginatorControllerPost->lastQueries[1]['contain']));
 
 		$Controller->Paginator->settings = array(
@@ -401,16 +401,16 @@ class PaginatorComponentTest extends CakeTestCase {
 			),
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
-		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['conditions'], array('PaginatorControllerPost.id > ' => '1'));
+		$this->assertEquals(array(2, 3), Set::extract($result, '{n}.PaginatorControllerPost.id'));
+		$this->assertEquals(array('PaginatorControllerPost.id > ' => '1'), $Controller->PaginatorControllerPost->lastQueries[1]['conditions']);
 
 		$Controller->request->params['named'] = array('limit' => 12);
 		$Controller->Paginator->settings = array('limit' => 30, 'maxLimit' => 100, 'paramType' => 'named');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
 		$paging = $Controller->params['paging']['PaginatorControllerPost'];
 
-		$this->assertEquals($Controller->PaginatorControllerPost->lastQueries[1]['limit'], 12);
-		$this->assertEquals($paging['options']['limit'], 12);
+		$this->assertEquals(12, $Controller->PaginatorControllerPost->lastQueries[1]['limit']);
+		$this->assertEquals(12, $paging['options']['limit']);
 
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('ControllerPaginateModel');
@@ -431,8 +431,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'maxLimit' => 10,
 			'paramType' => 'named'
 		);
-		$this->assertEquals($Controller->ControllerPaginateModel->extra, $expected);
-		$this->assertEquals($Controller->ControllerPaginateModel->extraCount, $expected);
+		$this->assertEquals($expected, $Controller->ControllerPaginateModel->extra);
+		$this->assertEquals($expected, $Controller->ControllerPaginateModel->extraCount);
 
 		$Controller->Paginator->settings = array(
 			'ControllerPaginateModel' => array(
@@ -450,8 +450,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'maxLimit' => 10,
 			'paramType' => 'named'
 		);
-		$this->assertEquals($Controller->ControllerPaginateModel->extra, $expected);
-		$this->assertEquals($Controller->ControllerPaginateModel->extraCount, $expected);
+		$this->assertEquals($expected, $Controller->ControllerPaginateModel->extra);
+		$this->assertEquals($expected, $Controller->ControllerPaginateModel->extraCount);
 	}
 
 /**
@@ -476,7 +476,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
 
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.id'), array(2, 3));
+		$this->assertEquals(array(2, 3), Set::extract($result, '{n}.PaginatorControllerPost.id'));
 		$this->assertEquals(
 			$Controller->PaginatorControllerPost->lastQueries[1]['conditions'],
 			array('PaginatorControllerPost.id > ' => '1')
@@ -500,8 +500,8 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$results = Set::extract($Controller->Paginator->paginate('PaginatorControllerPost'), '{n}.PaginatorControllerPost.id');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['order'], 'PaginatorControllerPost.id DESC');
-		$this->assertEquals($results, array(3, 2, 1));
+		$this->assertEquals('PaginatorControllerPost.id DESC', $Controller->params['paging']['PaginatorControllerPost']['order']);
+		$this->assertEquals(array(3, 2, 1), $results);
 	}
 
 /**
@@ -525,11 +525,11 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(4, 3, 2));
+		$this->assertEquals(array(4, 3, 2), Set::extract($result, '{n}.PaginatorControllerPost.offset_test'));
 
 		$Controller->request->params['named'] = array('sort' => 'offset_test', 'direction' => 'asc');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerPost.offset_test'), array(2, 3, 4));
+		$this->assertEquals(array(2, 3, 4), Set::extract($result, '{n}.PaginatorControllerPost.offset_test'));
 	}
 
 /**
@@ -549,11 +549,11 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorAuthor.joined_offset'), array(4, 2, 2));
+		$this->assertEquals(array(4, 2, 2), Set::extract($result, '{n}.PaginatorAuthor.joined_offset'));
 
 		$Controller->request->params['named'] = array('sort' => 'PaginatorAuthor.joined_offset', 'direction' => 'asc');
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorAuthor.joined_offset'), array(2, 2, 4));
+		$this->assertEquals(array(2, 2, 4), Set::extract($result, '{n}.PaginatorAuthor.joined_offset'));
 	}
 
 /**
@@ -830,26 +830,26 @@ class PaginatorComponentTest extends CakeTestCase {
 			'contain' => array('ControllerComment'), 'limit' => '1000'
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
+		$this->assertEquals(100, $Controller->params['paging']['PaginatorControllerPost']['options']['limit']);
 
 		$Controller->request->params['named'] = array(
 			'contain' => array('ControllerComment'), 'limit' => '1000', 'maxLimit' => 1000
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 100);
+		$this->assertEquals(100, $Controller->params['paging']['PaginatorControllerPost']['options']['limit']);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '10');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 10);
+		$this->assertEquals(10, $Controller->params['paging']['PaginatorControllerPost']['options']['limit']);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '1000');
 		$Controller->paginate = array('maxLimit' => 2000, 'paramType' => 'named');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 1000);
+		$this->assertEquals(1000, $Controller->params['paging']['PaginatorControllerPost']['options']['limit']);
 
 		$Controller->request->params['named'] = array('contain' => array('ControllerComment'), 'limit' => '5000');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals($Controller->params['paging']['PaginatorControllerPost']['options']['limit'], 2000);
+		$this->assertEquals(2000, $Controller->params['paging']['PaginatorControllerPost']['options']['limit']);
 	}
 
 /**
@@ -878,7 +878,7 @@ class PaginatorComponentTest extends CakeTestCase {
 		);
 		$Controller->passedArgs = array('sort' => 'PaginatorControllerPost.title', 'dir' => 'asc');
 		$result = $Controller->paginate('PaginatorControllerComment');
-		$this->assertEquals(Set::extract($result, '{n}.PaginatorControllerComment.id'), array(1, 2, 3, 4, 5, 6));
+		$this->assertEquals(array(1, 2, 3, 4, 5, 6), Set::extract($result, '{n}.PaginatorControllerComment.id'));
 	}
 
 }

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -144,7 +144,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$Collection = new ComponentCollection();
 		$Collection->init($this->Controller);
 		$RequestHandler = new RequestHandlerComponent($Collection, $settings);
-		$this->assertEquals($RequestHandler->ajaxLayout, 'test_ajax');
+		$this->assertEquals('test_ajax', $RequestHandler->ajaxLayout);
 	}
 
 /**
@@ -156,7 +156,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->assertNull($this->RequestHandler->ext);
 		$this->Controller->request->params['ext'] = 'rss';
 		$this->RequestHandler->initialize($this->Controller);
-		$this->assertEquals($this->RequestHandler->ext, 'rss');
+		$this->assertEquals('rss', $this->RequestHandler->ext);
 	}
 
 /**
@@ -277,7 +277,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->RequestHandler->initialize($this->Controller);
 		$this->Controller->beforeFilter();
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEquals($this->Controller->params['isAjax'], true);
+		$this->assertEquals(true, $this->Controller->params['isAjax']);
 	}
 
 /**
@@ -290,7 +290,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->Controller->request->params['ext'] = 'rss';
 		$this->RequestHandler->initialize($this->Controller);
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEquals($this->Controller->ext, '.ctp');
+		$this->assertEquals('.ctp', $this->Controller->ext);
 	}
 
 /**
@@ -307,7 +307,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$this->Controller->request->params['ext'] = 'js';
 		$this->RequestHandler->initialize($this->Controller);
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertNotEquals($this->Controller->layout, 'ajax');
+		$this->assertNotEquals('ajax', $this->Controller->layout);
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
 	}
@@ -386,7 +386,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 
 		$this->Controller->viewPath = 'request_handler_test\\rss';
 		$this->RequestHandler->renderAs($this->Controller, 'js');
-		$this->assertEquals($this->Controller->viewPath, 'request_handler_test' . DS . 'js');
+		$this->assertEquals('request_handler_test' . DS . 'js', $this->Controller->viewPath);
 	}
 
 /**
@@ -485,7 +485,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
  */
 	public function testRequestClientTypes() {
 		$_SERVER['HTTP_X_PROTOTYPE_VERSION'] = '1.5';
-		$this->assertEquals($this->RequestHandler->getAjaxVersion(), '1.5');
+		$this->assertEquals('1.5', $this->RequestHandler->getAjaxVersion());
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH'], $_SERVER['HTTP_X_PROTOTYPE_VERSION']);
 		$this->assertFalse($this->RequestHandler->getAjaxVersion());
@@ -517,10 +517,10 @@ class RequestHandlerComponentTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['CONTENT_TYPE'] = 'application/json';
-		$this->assertEquals($this->RequestHandler->requestedWith(), 'json');
+		$this->assertEquals('json', $this->RequestHandler->requestedWith());
 
 		$result = $this->RequestHandler->requestedWith(array('json', 'xml'));
-		$this->assertEquals($result, 'json');
+		$this->assertEquals('json', $result);
 
 		$result = $this->RequestHandler->requestedWith(array('rss', 'atom'));
 		$this->assertFalse($result);
@@ -553,7 +553,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	public function testResponseContentType() {
 		$this->assertEquals('html', $this->RequestHandler->responseType());
 		$this->assertTrue($this->RequestHandler->respondAs('atom'));
-		$this->assertEquals($this->RequestHandler->responseType(), 'atom');
+		$this->assertEquals('atom', $this->RequestHandler->responseType());
 	}
 
 /**
@@ -657,22 +657,22 @@ class RequestHandlerComponentTest extends CakeTestCase {
  */
 	public function testPrefers() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*';
-		$this->assertNotEquals($this->RequestHandler->prefers(), 'rss');
+		$this->assertNotEquals('rss', $this->RequestHandler->prefers());
 		$this->RequestHandler->ext = 'rss';
-		$this->assertEquals($this->RequestHandler->prefers(), 'rss');
+		$this->assertEquals('rss', $this->RequestHandler->prefers());
 		$this->assertFalse($this->RequestHandler->prefers('xml'));
-		$this->assertEquals($this->RequestHandler->prefers(array('js', 'xml', 'xhtml')), 'xml');
+		$this->assertEquals('xml', $this->RequestHandler->prefers(array('js', 'xml', 'xhtml')));
 		$this->assertFalse($this->RequestHandler->prefers(array('red', 'blue')));
-		$this->assertEquals($this->RequestHandler->prefers(array('js', 'json', 'xhtml')), 'xhtml');
+		$this->assertEquals('xhtml', $this->RequestHandler->prefers(array('js', 'json', 'xhtml')));
 		$this->assertTrue($this->RequestHandler->prefers(array('rss')), 'Should return true if input matches ext.');
 		$this->assertFalse($this->RequestHandler->prefers(array('html')), 'No match with ext, return false.');
 
 		$_SERVER['HTTP_ACCEPT'] = 'text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
 		$this->_init();
-		$this->assertEquals($this->RequestHandler->prefers(), 'xml');
+		$this->assertEquals('xml', $this->RequestHandler->prefers());
 
 		$_SERVER['HTTP_ACCEPT'] = '*/*;q=0.5';
-		$this->assertEquals($this->RequestHandler->prefers(), 'html');
+		$this->assertEquals('html', $this->RequestHandler->prefers());
 		$this->assertFalse($this->RequestHandler->prefers('rss'));
 	}
 
@@ -685,7 +685,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/x-mobile,text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5';
 		$this->RequestHandler->setContent('mobile', 'text/x-mobile');
 		$this->RequestHandler->startup($this->Controller);
-		$this->assertEquals($this->RequestHandler->prefers(), 'mobile');
+		$this->assertEquals('mobile', $this->RequestHandler->prefers());
 	}
 
 /**
@@ -789,7 +789,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second')
 		);
 		$result = ob_get_clean();
-		$this->assertEquals($result, 'one: first two: second');
+		$this->assertEquals('one: first two: second', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -1105,7 +1105,7 @@ class SecurityComponentTest extends CakeTestCase {
 		$this->Security->startup($this->Controller);
 
 		$token = $this->Security->Session->read('_Token');
-		$this->assertEquals(count($token['csrfTokens']), 1, 'Missing the csrf token.');
+		$this->assertEquals(1, count($token['csrfTokens']), 'Missing the csrf token.');
 		$this->assertEquals(strtotime('+10 minutes'), current($token['csrfTokens']), 'Token expiry does not match');
 		$this->assertEquals(array('key', 'unlockedFields'), array_keys($this->Controller->request->params['_Token']), 'Keys don not match');
 	}
@@ -1124,7 +1124,7 @@ class SecurityComponentTest extends CakeTestCase {
 		$this->Security->startup($this->Controller);
 
 		$token = $this->Security->Session->read('_Token');
-		$this->assertEquals(count($token['csrfTokens']), 2, 'Missing the csrf token.');
+		$this->assertEquals(2, count($token['csrfTokens']), 'Missing the csrf token.');
 		foreach ($token['csrfTokens'] as $key => $expires) {
 			$diff = $csrfExpires - $expires;
 			$this->assertTrue($diff === 0 || $diff === 1, 'Token expiry does not match');

--- a/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
@@ -190,15 +190,15 @@ class SessionComponentTest extends CakeTestCase {
 		$this->assertNull($Session->read('Test'));
 
 		$this->assertTrue($Session->write('Test', 'some value'));
-		$this->assertEquals($Session->read('Test'), 'some value');
+		$this->assertEquals('some value', $Session->read('Test'));
 		$this->assertFalse($Session->write('Test.key', 'some value'));
 		$Session->delete('Test');
 
 		$this->assertTrue($Session->write('Test.key.path', 'some value'));
-		$this->assertEquals($Session->read('Test.key.path'), 'some value');
-		$this->assertEquals($Session->read('Test.key'), array('path' => 'some value'));
+		$this->assertEquals('some value', $Session->read('Test.key.path'));
+		$this->assertEquals(array('path' => 'some value'), $Session->read('Test.key'));
 		$this->assertTrue($Session->write('Test.key.path2', 'another value'));
-		$this->assertEquals($Session->read('Test.key'), array('path' => 'some value', 'path2' => 'another value'));
+		$this->assertEquals(array('path' => 'some value', 'path2' => 'another value'), $Session->read('Test.key'));
 		$Session->delete('Test');
 
 		$array = array('key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3');
@@ -208,7 +208,7 @@ class SessionComponentTest extends CakeTestCase {
 
 		$this->assertFalse($Session->write(array('Test'), 'some value'));
 		$this->assertTrue($Session->write(array('Test' => 'some value')));
-		$this->assertEquals($Session->read('Test'), 'some value');
+		$this->assertEquals('some value', $Session->read('Test'));
 		$Session->delete('Test');
 	}
 
@@ -252,16 +252,16 @@ class SessionComponentTest extends CakeTestCase {
 		$this->assertNull($Session->read('Message.flash'));
 
 		$Session->setFlash('This is a test message');
-		$this->assertEquals($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.flash'));
 
 		$Session->setFlash('This is a test message', 'test', array('name' => 'Joel Moss'));
-		$this->assertEquals($Session->read('Message.flash'), array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'test', 'params' => array('name' => 'Joel Moss')), $Session->read('Message.flash'));
 
 		$Session->setFlash('This is a test message', 'default', array(), 'myFlash');
-		$this->assertEquals($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.myFlash'));
 
 		$Session->setFlash('This is a test message', 'non_existing_layout');
-		$this->assertEquals($Session->read('Message.myFlash'), array('message' => 'This is a test message', 'element' => 'default', 'params' => array()));
+		$this->assertEquals(array('message' => 'This is a test message', 'element' => 'default', 'params' => array()), $Session->read('Message.myFlash'));
 
 		$Session->delete('Message');
 	}
@@ -287,7 +287,7 @@ class SessionComponentTest extends CakeTestCase {
 		$Session = new SessionComponent($this->ComponentCollection);
 
 		$Session->write('Test', 'some value');
-		$this->assertEquals($Session->read('Test'), 'some value');
+		$this->assertEquals('some value', $Session->read('Test'));
 		$Session->destroy('Test');
 		$this->assertNull($Session->read('Test'));
 	}

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -150,7 +150,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('flag', 'otherFlag', 'redirect' => false));
-		$this->assertEquals($Controller->components, $expected, 'Duplication of settings occurred. %s');
+		$this->assertEquals($expected, $Controller->components, 'Duplication of settings occurred. %s');
 	}
 
 /**
@@ -164,7 +164,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('flag', 'otherFlag', 'redirect' => true, 'remote'));
-		$this->assertEquals($Controller->components, $expected, 'Merging of settings is wrong. %s');
+		$this->assertEquals($expected, $Controller->components, 'Merging of settings is wrong. %s');
 	}
 
 /**
@@ -177,7 +177,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller->constructClasses();
 
 		$expected = array('MergeVar' => array('format' => 'html', 'terse'));
-		$this->assertEquals($Controller->helpers, $expected, 'Duplication of settings occurred. %s');
+		$this->assertEquals($expected, $Controller->helpers, 'Duplication of settings occurred. %s');
 	}
 
 /**
@@ -196,7 +196,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 			'Custom' => null,
 			'Foo' => array('something')
 		);
-		$this->assertSame($Controller->helpers, $expected, 'Order is incorrect.');
+		$this->assertSame($expected, $Controller->helpers, 'Order is incorrect.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -493,7 +493,7 @@ class ControllerTest extends CakeTestCase {
 		$this->assertTrue(is_a($Controller->ControllerPost, 'ControllerPost'));
 		$this->assertTrue(is_a($Controller->ControllerComment, 'ControllerComment'));
 
-		$this->assertEquals($Controller->ControllerComment->name, 'Comment');
+		$this->assertEquals('Comment', $Controller->ControllerComment->name);
 
 		unset($Controller);
 
@@ -519,8 +519,8 @@ class ControllerTest extends CakeTestCase {
 		$Controller->uses = array('NameTest');
 		$Controller->constructClasses();
 
-		$this->assertEquals($Controller->NameTest->name, 'Name');
-		$this->assertEquals($Controller->NameTest->alias, 'Name');
+		$this->assertEquals('Name', $Controller->NameTest->name);
+		$this->assertEquals('Name', $Controller->NameTest->alias);
 
 		unset($Controller);
 	}
@@ -602,13 +602,13 @@ class ControllerTest extends CakeTestCase {
 		$Controller->viewVars = array();
 		$expected = array('ModelName' => 'name', 'ModelName2' => 'name2');
 		$Controller->set(array('ModelName', 'ModelName2'), array('name', 'name2'));
-		$this->assertSame($Controller->viewVars, $expected);
+		$this->assertSame($expected, $Controller->viewVars);
 
 		$Controller->viewVars = array();
 		$Controller->set(array(3 => 'three', 4 => 'four'));
 		$Controller->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($Controller->viewVars, $expected);
+		$this->assertEquals($expected, $Controller->viewVars);
 	}
 
 /**
@@ -896,8 +896,8 @@ class ControllerTest extends CakeTestCase {
 					? array_merge($appVars['uses'], $testVars['uses'])
 					: $testVars['uses'];
 
-		$this->assertEquals(count(array_diff_key($TestController->helpers, array_flip($helpers))), 0);
-		$this->assertEquals(count(array_diff($TestController->uses, $uses)), 0);
+		$this->assertEquals(0, count(array_diff_key($TestController->helpers, array_flip($helpers))));
+		$this->assertEquals(0, count(array_diff($TestController->uses, $uses)));
 		$this->assertEquals(count(array_diff_assoc(Set::normalize($TestController->components), Set::normalize($components))), 0);
 
 		$expected = array('ControllerComment', 'ControllerAlias', 'ControllerPost');
@@ -940,7 +940,7 @@ class ControllerTest extends CakeTestCase {
 		$expected = array('foo');
 		$TestController->components = array('Cookie' => $expected);
 		$TestController->constructClasses();
-		$this->assertEquals($TestController->components['Cookie'], $expected);
+		$this->assertEquals($expected, $TestController->components['Cookie']);
 	}
 
 /**
@@ -974,12 +974,12 @@ class ControllerTest extends CakeTestCase {
 
 		$Controller = new Controller($request);
 		$result = $Controller->referer(null, true);
-		$this->assertEquals($result, '/posts/index');
+		$this->assertEquals('/posts/index', $result);
 
 		$Controller = new Controller($request);
 		$request->setReturnValue('referer', '/', array(true));
 		$result = $Controller->referer(array('controller' => 'posts', 'action' => 'index'), true);
-		$this->assertEquals($result, '/posts/index');
+		$this->assertEquals('/posts/index', $result);
 
 		$request = $this->getMock('CakeRequest');
 
@@ -989,11 +989,11 @@ class ControllerTest extends CakeTestCase {
 
 		$Controller = new Controller($request);
 		$result = $Controller->referer();
-		$this->assertEquals($result, 'http://localhost/posts/index');
+		$this->assertEquals('http://localhost/posts/index', $result);
 
 		$Controller = new Controller(null);
 		$result = $Controller->referer();
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 	}
 
 /**
@@ -1024,7 +1024,7 @@ class ControllerTest extends CakeTestCase {
 		$TestController = new TestController($request);
 		$TestController->constructClasses();
 		$this->assertFalse($TestController->validateErrors());
-		$this->assertEquals($TestController->validate(), 0);
+		$this->assertEquals(0, $TestController->validate());
 
 		$TestController->ControllerComment->invalidate('some_field', 'error_message');
 		$TestController->ControllerComment->invalidate('some_field2', 'error_message2');
@@ -1034,7 +1034,7 @@ class ControllerTest extends CakeTestCase {
 		$result = $TestController->validateErrors($comment);
 		$expected = array('some_field' => array('error_message'), 'some_field2' => array('error_message2'));
 		$this->assertSame($expected, $result);
-		$this->assertEquals($TestController->validate($comment), 2);
+		$this->assertEquals(2, $TestController->validate($comment));
 	}
 
 /**
@@ -1273,14 +1273,14 @@ class ControllerTest extends CakeTestCase {
 		$Controller->params['url'] = array();
 		$Controller->constructClasses();
 		$expected = array('page' => 1, 'limit' => 20, 'maxLimit' => 100, 'paramType' => 'named');
-		$this->assertEquals($Controller->paginate, $expected);
+		$this->assertEquals($expected, $Controller->paginate);
 
 		$results = Set::extract($Controller->paginate('ControllerPost'), '{n}.ControllerPost.id');
-		$this->assertEquals($results, array(1, 2, 3));
+		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->passedArgs = array();
 		$Controller->paginate = array('limit' => '-1');
-		$this->assertEquals($Controller->paginate, array('limit' => '-1'));
+		$this->assertEquals(array('limit' => '-1'), $Controller->paginate);
 		$Controller->paginate('ControllerPost');
 		$this->assertSame($Controller->params['paging']['ControllerPost']['page'], 1);
 		$this->assertSame($Controller->params['paging']['ControllerPost']['pageCount'], 3);

--- a/lib/Cake/Test/Case/Controller/PagesControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/PagesControllerTest.php
@@ -42,12 +42,12 @@ class PagesControllerTest extends CakeTestCase {
 		$Pages->viewPath = 'Posts';
 		$Pages->display('index');
 		$this->assertRegExp('/posts index/', $Pages->response->body());
-		$this->assertEquals($Pages->viewVars['page'], 'index');
+		$this->assertEquals('index', $Pages->viewVars['page']);
 
 		$Pages->viewPath = 'Themed';
 		$Pages->display('TestTheme', 'Posts', 'index');
 		$this->assertRegExp('/posts index themed view/', $Pages->response->body());
-		$this->assertEquals($Pages->viewVars['page'], 'TestTheme');
-		$this->assertEquals($Pages->viewVars['subpage'], 'Posts');
+		$this->assertEquals('TestTheme', $Pages->viewVars['page']);
+		$this->assertEquals('Posts', $Pages->viewVars['subpage']);
 	}
 }

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -177,7 +177,7 @@ class ScaffoldTest extends CakeTestCase {
 		$this->Controller->constructClasses();
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 		$result = $Scaffold->getParams();
-		$this->assertEquals($result['action'], 'admin_edit');
+		$this->assertEquals('admin_edit', $result['action']);
 	}
 
 /**
@@ -208,15 +208,15 @@ class ScaffoldTest extends CakeTestCase {
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 		$result = $Scaffold->controller->viewVars;
 
-		$this->assertEquals($result['title_for_layout'], 'Scaffold :: Admin Edit :: Scaffold Mock');
-		$this->assertEquals($result['singularHumanName'], 'Scaffold Mock');
-		$this->assertEquals($result['pluralHumanName'], 'Scaffold Mock');
-		$this->assertEquals($result['modelClass'], 'ScaffoldMock');
-		$this->assertEquals($result['primaryKey'], 'id');
-		$this->assertEquals($result['displayField'], 'title');
-		$this->assertEquals($result['singularVar'], 'scaffoldMock');
-		$this->assertEquals($result['pluralVar'], 'scaffoldMock');
-		$this->assertEquals($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated'));
+		$this->assertEquals('Scaffold :: Admin Edit :: Scaffold Mock', $result['title_for_layout']);
+		$this->assertEquals('Scaffold Mock', $result['singularHumanName']);
+		$this->assertEquals('Scaffold Mock', $result['pluralHumanName']);
+		$this->assertEquals('ScaffoldMock', $result['modelClass']);
+		$this->assertEquals('id', $result['primaryKey']);
+		$this->assertEquals('title', $result['displayField']);
+		$this->assertEquals('scaffoldMock', $result['singularVar']);
+		$this->assertEquals('scaffoldMock', $result['pluralVar']);
+		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated'), $result['scaffoldFields']);
 	}
 
 /**
@@ -231,7 +231,7 @@ class ScaffoldTest extends CakeTestCase {
 		$this->Controller->constructClasses();
 		$Scaffold = new TestScaffoldMock($this->Controller, $this->Controller->request);
 
-		$this->assertEquals($this->Controller->viewClass, 'Scaffold');
+		$this->assertEquals('Scaffold', $this->Controller->viewClass);
 	}
 
 /**
@@ -307,7 +307,7 @@ class ScaffoldTest extends CakeTestCase {
 		$this->assertRegExp('/name="data\[ScaffoldTag\]\[ScaffoldTag\]"/', $result);
 
 		$result = $Scaffold->controller->viewVars;
-		$this->assertEquals($result['scaffoldFields'], array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'));
+		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'), $result['scaffoldFields']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -346,7 +346,7 @@ class AppTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = App::objects('NonExistingType');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 
 		App::build(array(
 			'plugins' => array(
@@ -413,9 +413,9 @@ class AppTest extends CakeTestCase {
 		$this->assertTrue(in_array('OtherComponent', $result));
 
 		$result = App::objects('TestPluginTwo.behavior');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 		$result = App::objects('TestPluginTwo.Model/Behavior');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 
 		$result = App::objects('model', null, false);
 		$this->assertTrue(in_array('Comment', $result));
@@ -441,11 +441,11 @@ class AppTest extends CakeTestCase {
 
 		$path = App::pluginPath('TestPlugin');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPlugin' . DS;
-		$this->assertEquals($path, $expected);
+		$this->assertEquals($expected, $path);
 
 		$path = App::pluginPath('TestPluginTwo');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS;
-		$this->assertEquals($path, $expected);
+		$this->assertEquals($expected, $path);
 		App::build();
 	}
 
@@ -460,11 +460,11 @@ class AppTest extends CakeTestCase {
 		));
 		$path = App::themePath('test_theme');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEquals($path, $expected);
+		$this->assertEquals($expected, $path);
 
 		$path = App::themePath('TestTheme');
 		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEquals($path, $expected);
+		$this->assertEquals($expected, $path);
 
 		App::build();
 	}
@@ -748,7 +748,7 @@ class AppTest extends CakeTestCase {
 		$result = App::import('Vendor', 'css/TestAsset', array('ext' => 'css'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'this is the test asset css file');
+		$this->assertEquals('this is the test asset css file', $text);
 
 		$result = App::import('Vendor', 'TestPlugin.sample/SamplePlugin');
 		$this->assertTrue($result);
@@ -762,31 +762,31 @@ class AppTest extends CakeTestCase {
 		$result = App::import('Vendor', 'SomeNameInSubfolder', array('file' => 'somename/some.name.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'This is a file with dot in file name');
+		$this->assertEquals('This is a file with dot in file name', $text);
 
 		ob_start();
 		$result = App::import('Vendor', 'TestHello', array('file' => 'Test' . DS . 'hello.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'This is the hello.php file in Test directory');
+		$this->assertEquals('This is the hello.php file in Test directory', $text);
 
 		ob_start();
 		$result = App::import('Vendor', 'MyTest', array('file' => 'Test' . DS . 'MyTest.php'));
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'This is the MyTest.php file');
+		$this->assertEquals('This is the MyTest.php file', $text);
 
 		ob_start();
 		$result = App::import('Vendor', 'Welcome');
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'This is the welcome.php file in vendors directory');
+		$this->assertEquals('This is the welcome.php file in vendors directory', $text);
 
 		ob_start();
 		$result = App::import('Vendor', 'TestPlugin.Welcome');
 		$text = ob_get_clean();
 		$this->assertTrue($result);
-		$this->assertEquals($text, 'This is the welcome.php file in test_plugin/vendors directory');
+		$this->assertEquals('This is the welcome.php file in test_plugin/vendors directory', $text);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -83,7 +83,7 @@ class ConfigureTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Configure::read('level1.level2.level3_2');
-		$this->assertEquals($result, 'something_else');
+		$this->assertEquals('something_else', $result);
 
 		$result = Configure::read('debug');
 		$this->assertTrue($result >= 0);
@@ -106,12 +106,12 @@ class ConfigureTest extends CakeTestCase {
 		$writeResult = Configure::write('SomeName.someKey', 'myvalue');
 		$this->assertTrue($writeResult);
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEquals($result, 'myvalue');
+		$this->assertEquals('myvalue', $result);
 
 		$writeResult = Configure::write('SomeName.someKey', null);
 		$this->assertTrue($writeResult);
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEquals($result, null);
+		$this->assertEquals(null, $result);
 
 		$expected = array('One' => array('Two' => array('Three' => array('Four' => array('Five' => 'cool')))));
 		$writeResult = Configure::write('Key', $expected);
@@ -142,11 +142,11 @@ class ConfigureTest extends CakeTestCase {
 	public function testDebugSettingDisplayErrors() {
 		Configure::write('debug', 0);
 		$result = ini_get('display_errors');
-		$this->assertEquals($result, 0);
+		$this->assertEquals(0, $result);
 
 		Configure::write('debug', 2);
 		$result = ini_get('display_errors');
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 	}
 
 /**
@@ -157,7 +157,7 @@ class ConfigureTest extends CakeTestCase {
 	public function testDelete() {
 		Configure::write('SomeName.someKey', 'myvalue');
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEquals($result, 'myvalue');
+		$this->assertEquals('myvalue', $result);
 
 		Configure::delete('SomeName.someKey');
 		$result = Configure::read('SomeName.someKey');
@@ -166,10 +166,10 @@ class ConfigureTest extends CakeTestCase {
 		Configure::write('SomeName', array('someKey' => 'myvalue', 'otherKey' => 'otherValue'));
 
 		$result = Configure::read('SomeName.someKey');
-		$this->assertEquals($result, 'myvalue');
+		$this->assertEquals('myvalue', $result);
 
 		$result = Configure::read('SomeName.otherKey');
-		$this->assertEquals($result, 'otherValue');
+		$this->assertEquals('otherValue', $result);
 
 		Configure::delete('SomeName');
 
@@ -264,13 +264,13 @@ class ConfigureTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$expected = '/test_app/plugins/test_plugin/config/load.php';
 		$config = Configure::read('plugin_load');
-		$this->assertEquals($config, $expected);
+		$this->assertEquals($expected, $config);
 
 		$result = Configure::load('TestPlugin.more.load', 'test');
 		$this->assertTrue($result);
 		$expected = '/test_app/plugins/test_plugin/config/more.load.php';
 		$config = Configure::read('plugin_more_load');
-		$this->assertEquals($config, $expected);
+		$this->assertEquals($expected, $config);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Core/ObjectTest.php
+++ b/lib/Cake/Test/Case/Core/ObjectTest.php
@@ -356,17 +356,17 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testSet() {
 		$this->object->set('a string');
-		$this->assertEquals($this->object->firstName, 'Joel');
+		$this->assertEquals('Joel', $this->object->firstName);
 
 		$this->object->set(array('firstName'));
-		$this->assertEquals($this->object->firstName, 'Joel');
+		$this->assertEquals('Joel', $this->object->firstName);
 
 		$this->object->set(array('firstName' => 'Ashley'));
-		$this->assertEquals($this->object->firstName, 'Ashley');
+		$this->assertEquals('Ashley', $this->object->firstName);
 
 		$this->object->set(array('firstName' => 'Joel', 'lastName' => 'Moose'));
-		$this->assertEquals($this->object->firstName, 'Joel');
-		$this->assertEquals($this->object->lastName, 'Moose');
+		$this->assertEquals('Joel', $this->object->firstName);
+		$this->assertEquals('Moose', $this->object->lastName);
 	}
 
 /**
@@ -376,7 +376,7 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testToString() {
 		$result = strtolower($this->object->toString());
-		$this->assertEquals($result, 'testobject');
+		$this->assertEquals('testobject', $result);
 	}
 
 /**
@@ -598,20 +598,20 @@ class ObjectTest extends CakeTestCase {
  */
 	public function testRequestActionParamParseAndPass() {
 		$result = $this->object->requestAction('/request_action/params_pass');
-		$this->assertEquals($result->url, 'request_action/params_pass');
-		$this->assertEquals($result['controller'], 'request_action');
-		$this->assertEquals($result['action'], 'params_pass');
-		$this->assertEquals($result['plugin'], null);
+		$this->assertEquals('request_action/params_pass', $result->url);
+		$this->assertEquals('request_action', $result['controller']);
+		$this->assertEquals('params_pass', $result['action']);
+		$this->assertEquals(null, $result['plugin']);
 
 		$result = $this->object->requestAction('/request_action/params_pass/sort:desc/limit:5');
 		$expected = array('sort' => 'desc', 'limit' => 5,);
-		$this->assertEquals($result['named'], $expected);
+		$this->assertEquals($expected, $result['named']);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'params_pass'),
 			array('named' => array('sort' => 'desc', 'limit' => 5))
 		);
-		$this->assertEquals($result['named'], $expected);
+		$this->assertEquals($expected, $result['named']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -148,7 +148,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		$out .= '';
 
 		$result = file(LOGS . 'debug.log');
-		$this->assertEquals(count($result), 1);
+		$this->assertEquals(1, count($result));
 		$this->assertRegExp(
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (Notice|Debug): Notice \(8\): Undefined variable:\s+out in \[.+ line \d+\]$/',
 			$result[0]
@@ -239,7 +239,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		ob_start();
 		ErrorHandler::handleException($error);
 		$result = ob_get_clean();
-		$this->assertEquals($result, 'Rendered by test plugin');
+		$this->assertEquals('Rendered by test plugin', $result);
 		CakePlugin::unload();
 	}
 

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -211,7 +211,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertEquals($result, 'widget thing is missing');
+		$this->assertEquals('widget thing is missing', $result);
 	}
 
 /**
@@ -230,7 +230,7 @@ class ExceptionRendererTest extends CakeTestCase {
 		$ExceptionRenderer->render();
 		$result = ob_get_clean();
 
-		$this->assertEquals($result, 'widget thing is missing', 'Method declared in subclass converted to error400');
+		$this->assertEquals('widget thing is missing', $result, 'Method declared in subclass converted to error400');
 	}
 
 /**

--- a/lib/Cake/Test/Case/I18n/L10nTest.php
+++ b/lib/Cake/Test/Case/I18n/L10nTest.php
@@ -36,44 +36,44 @@ class L10nTest extends CakeTestCase {
 		// Catalog Entry
 		$localize->get('en');
 
-		$this->assertEquals($localize->language, 'English');
-		$this->assertEquals($localize->languagePath, array('eng', 'eng'));
-		$this->assertEquals($localize->locale, 'eng');
+		$this->assertEquals('English', $localize->language);
+		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals('eng', $localize->locale);
 
 		// Map Entry
 		$localize->get('eng');
 
-		$this->assertEquals($localize->language, 'English');
-		$this->assertEquals($localize->languagePath, array('eng', 'eng'));
-		$this->assertEquals($localize->locale, 'eng');
+		$this->assertEquals('English', $localize->language);
+		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals('eng', $localize->locale);
 
 		// Catalog Entry
 		$localize->get('en-ca');
 
-		$this->assertEquals($localize->language, 'English (Canadian)');
-		$this->assertEquals($localize->languagePath, array('en_ca', 'eng'));
-		$this->assertEquals($localize->locale, 'en_ca');
+		$this->assertEquals('English (Canadian)', $localize->language);
+		$this->assertEquals(array('en_ca', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_ca', $localize->locale);
 
 		// Default Entry
 		define('DEFAULT_LANGUAGE', 'en-us');
 
 		$localize->get('use_default');
 
-		$this->assertEquals($localize->language, 'English (United States)');
-		$this->assertEquals($localize->languagePath, array('en_us', 'eng'));
-		$this->assertEquals($localize->locale, 'en_us');
+		$this->assertEquals('English (United States)', $localize->language);
+		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_us', $localize->locale);
 
 		$localize->get('es');
 		$localize->get('');
-		$this->assertEquals($localize->lang, 'en-us');
+		$this->assertEquals('en-us', $localize->lang);
 
 		// Using $this->default
 		$localize = new L10n();
 
 		$localize->get('use_default');
-		$this->assertEquals($localize->language, 'English (United States)');
-		$this->assertEquals($localize->languagePath, array('en_us', 'eng', 'eng'));
-		$this->assertEquals($localize->locale, 'en_us');
+		$this->assertEquals('English (United States)', $localize->language);
+		$this->assertEquals(array('en_us', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_us', $localize->locale);
 	}
 
 /**
@@ -88,23 +88,23 @@ class L10nTest extends CakeTestCase {
 		$localize = new L10n();
 		$localize->get();
 
-		$this->assertEquals($localize->language, 'English (Canadian)');
-		$this->assertEquals($localize->languagePath, array('en_ca', 'eng', 'eng'));
-		$this->assertEquals($localize->locale, 'en_ca');
+		$this->assertEquals('English (Canadian)', $localize->language);
+		$this->assertEquals(array('en_ca', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_ca', $localize->locale);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es_mx';
 		$localize->get();
 
-		$this->assertEquals($localize->language, 'Spanish (Mexican)');
-		$this->assertEquals($localize->languagePath, array('es_mx', 'spa', 'eng'));
-		$this->assertEquals($localize->locale, 'es_mx');
+		$this->assertEquals('Spanish (Mexican)', $localize->language);
+		$this->assertEquals(array('es_mx', 'spa', 'eng'), $localize->languagePath);
+		$this->assertEquals('es_mx', $localize->locale);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en_xy,en_ca';
 		$localize->get();
 
-		$this->assertEquals($localize->language, 'English');
-		$this->assertEquals($localize->languagePath, array('eng', 'eng', 'eng'));
-		$this->assertEquals($localize->locale, 'eng');
+		$this->assertEquals('English', $localize->language);
+		$this->assertEquals(array('eng', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals('eng', $localize->locale);
 
 		$_SERVER = $serverBackup;
 	}

--- a/lib/Cake/Test/Case/I18n/MultibyteTest.php
+++ b/lib/Cake/Test/Case/I18n/MultibyteTest.php
@@ -9029,7 +9029,7 @@ class MultibyteTest extends CakeTestCase {
 	public function testMultibyteMimeEncode() {
 		$string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 		$result = Multibyte::mimeEncode($string);
-		$this->assertEquals($result, $string);
+		$this->assertEquals($string, $result);
 
 		$string = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ';
 		$result = Multibyte::mimeEncode($string);
@@ -9198,7 +9198,7 @@ class MultibyteTest extends CakeTestCase {
 
 		$string = 'Hello, World!';
 		$result = Multibyte::mimeEncode($string);
-		$this->assertEquals($result, $string);
+		$this->assertEquals($string, $result);
 
 		$string = 'čini';
 		$result = Multibyte::mimeEncode($string);

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -102,7 +102,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 
 		$result = CakeLog::configured();
-		$this->assertEquals($result, array('default'));
+		$this->assertEquals(array('default'), $result);
 		unlink(LOGS . 'error.log');
 	}
 
@@ -117,7 +117,7 @@ class CakeLogTest extends CakeTestCase {
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
-		$this->assertEquals($result, array('file'));
+		$this->assertEquals(array('file'), $result);
 
 		if (file_exists(LOGS . 'error.log')) {
 			@unlink(LOGS . 'error.log');
@@ -141,11 +141,11 @@ class CakeLogTest extends CakeTestCase {
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
-		$this->assertEquals($result, array('file'));
+		$this->assertEquals(array('file'), $result);
 
 		CakeLog::drop('file');
 		$result = CakeLog::configured();
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -285,7 +285,7 @@ class AclNodeTest extends CakeTestCase {
 		$this->assertNull($result);
 
 		$result = $Aco->node('');
-		$this->assertEquals($result, null);
+		$this->assertEquals(null, $result);
 	}
 
 /**
@@ -296,7 +296,7 @@ class AclNodeTest extends CakeTestCase {
 	public function testNodeWithDuplicatePathSegments() {
 		$Aco = new DbAcoTest();
 		$nodes = $Aco->node('ROOT/Users');
-		$this->assertEquals($nodes[0]['DbAcoTest']['parent_id'], 1, 'Parent id does not point at ROOT. %s');
+		$this->assertEquals(1, $nodes[0]['DbAcoTest']['parent_id'], 'Parent id does not point at ROOT. %s');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
@@ -235,12 +235,12 @@ class AclBehaviorTest extends CakeTestCase {
 	public function testSetup() {
 		$User = new AclUser();
 		$this->assertTrue(isset($User->Behaviors->Acl->settings['User']));
-		$this->assertEquals($User->Behaviors->Acl->settings['User']['type'], 'requester');
+		$this->assertEquals('requester', $User->Behaviors->Acl->settings['User']['type']);
 		$this->assertTrue(is_object($User->Aro));
 
 		$Post = new AclPost();
 		$this->assertTrue(isset($Post->Behaviors->Acl->settings['Post']));
-		$this->assertEquals($Post->Behaviors->Acl->settings['Post']['type'], 'controlled');
+		$this->assertEquals('controlled', $Post->Behaviors->Acl->settings['Post']['type']);
 		$this->assertTrue(is_object($Post->Aco));
 	}
 
@@ -252,7 +252,7 @@ class AclBehaviorTest extends CakeTestCase {
 	public function testSetupMulti() {
 		$User = new AclPerson();
 		$this->assertTrue(isset($User->Behaviors->Acl->settings['AclPerson']));
-		$this->assertEquals($User->Behaviors->Acl->settings['AclPerson']['type'], 'both');
+		$this->assertEquals('both', $User->Behaviors->Acl->settings['AclPerson']['type']);
 		$this->assertTrue(is_object($User->Aro));
 		$this->assertTrue(is_object($User->Aco));
 	}
@@ -277,8 +277,8 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aco.model' => 'Post', 'Aco.foreign_key' => $Post->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEquals($result['Aco']['model'], 'Post');
-		$this->assertEquals($result['Aco']['foreign_key'], $Post->id);
+		$this->assertEquals('Post', $result['Aco']['model']);
+		$this->assertEquals($Post->id, $result['Aco']['foreign_key']);
 
 		$aroData = array(
 			'Aro' => array(
@@ -311,12 +311,12 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEquals($result['Aro']['parent_id'], 5);
+		$this->assertEquals(5, $result['Aro']['parent_id']);
 
 		$node = $Person->node(array('model' => 'AclPerson', 'foreign_key' => 8), 'Aro');
-		$this->assertEquals(count($node), 2);
-		$this->assertEquals($node[0]['Aro']['parent_id'], 5);
-		$this->assertEquals($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(2, count($node));
+		$this->assertEquals(5, $node[0]['Aro']['parent_id']);
+		$this->assertEquals(null, $node[1]['Aro']['parent_id']);
 
 		$aroData = array(
 			'Aro' => array(
@@ -342,12 +342,12 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEquals($result['Aro']['parent_id'], 7);
+		$this->assertEquals(7, $result['Aro']['parent_id']);
 
 		$node = $Person->node(array('model' => 'AclPerson', 'foreign_key' => 8), 'Aro');
-		$this->assertEquals(count($node), 2);
-		$this->assertEquals($node[0]['Aro']['parent_id'], 7);
-		$this->assertEquals($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(2, count($node));
+		$this->assertEquals(7, $node[0]['Aro']['parent_id']);
+		$this->assertEquals(null, $node[1]['Aro']['parent_id']);
 	}
 
 /**
@@ -387,13 +387,13 @@ class AclBehaviorTest extends CakeTestCase {
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
 		$this->assertTrue(is_array($result));
-		$this->assertEquals($result['Aro']['parent_id'], 5);
+		$this->assertEquals(5, $result['Aro']['parent_id']);
 
 		$Person->save(array('id' => $Person->id, 'name' => 'Bruce'));
 		$result = $this->Aro->find('first', array(
 			'conditions' => array('Aro.model' => 'AclPerson', 'Aro.foreign_key' => $Person->id)
 		));
-		$this->assertEquals($result['Aro']['parent_id'], 5);
+		$this->assertEquals(5, $result['Aro']['parent_id']);
 	}
 
 /**
@@ -431,9 +431,9 @@ class AclBehaviorTest extends CakeTestCase {
 		$Person->save($data);
 		$id = $Person->id;
 		$node = $Person->node(null, 'Aro');
-		$this->assertEquals(count($node), 2);
-		$this->assertEquals($node[0]['Aro']['parent_id'], 5);
-		$this->assertEquals($node[1]['Aro']['parent_id'], null);
+		$this->assertEquals(2, count($node));
+		$this->assertEquals(5, $node[0]['Aro']['parent_id']);
+		$this->assertEquals(null, $node[1]['Aro']['parent_id']);
 
 		$Person->delete($id);
 		$result = $this->Aro->find('first', array(
@@ -485,6 +485,6 @@ class AclBehaviorTest extends CakeTestCase {
 		$Person->id = 2;
 		$result = $Person->node(null, 'Aro');
 		$this->assertTrue(is_array($result));
-		$this->assertEquals(count($result), 1);
+		$this->assertEquals(1, count($result));
 	}
 }

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -92,7 +92,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					'Category' => 'name'
 				)
 		)));
-		$this->assertEquals(Set::extract('/ArticleFeatured/keep/Featured/fields', $r), array('id'));
+		$this->assertEquals(array('id'), Set::extract('/ArticleFeatured/keep/Featured/fields', $r));
 
 		$r = $this->_containments($this->Article, array(
 			'Comment' => array(
@@ -109,37 +109,37 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertTrue(Set::matches('/User', $r));
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
 		$this->assertTrue(Set::matches('/Article/keep/User', $r));
-		$this->assertEquals(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
-		$this->assertEquals(Set::extract('/Article/keep/User/fields', $r), array('user'));
+		$this->assertEquals(array('comment', 'published'), Set::extract('/Article/keep/Comment/fields', $r));
+		$this->assertEquals(array('user'), Set::extract('/Article/keep/User/fields', $r));
 		$this->assertTrue(Set::matches('/Comment/keep/Attachment', $r));
-		$this->assertEquals(Set::extract('/Comment/keep/Attachment/fields', $r), array('attachment'));
+		$this->assertEquals(array('attachment'), Set::extract('/Comment/keep/Attachment/fields', $r));
 
 		$r = $this->_containments($this->Article, array('Comment' => array('limit' => 1)));
-		$this->assertEquals(array_keys($r), array('Comment', 'Article'));
+		$this->assertEquals(array('Comment', 'Article'), array_keys($r));
 		$result = Set::extract('/Comment/keep', $r);
-		$this->assertEquals(array_shift($result), array('keep' => array()));
+		$this->assertEquals(array('keep' => array()), array_shift($result));
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
 		$result = Set::extract('/Article/keep/Comment/.', $r);
-		$this->assertEquals(array_shift($result), array('limit' => 1));
+		$this->assertEquals(array('limit' => 1), array_shift($result));
 
 		$r = $this->_containments($this->Article, array('Comment.User'));
-		$this->assertEquals(array_keys($r), array('User', 'Comment', 'Article'));
+		$this->assertEquals(array('User', 'Comment', 'Article'), array_keys($r));
 
 		$result = Set::extract('/User/keep', $r);
-		$this->assertEquals(array_shift($result), array('keep' => array()));
+		$this->assertEquals(array('keep' => array()), array_shift($result));
 
 		$result = Set::extract('/Comment/keep', $r);
-		$this->assertEquals(array_shift($result), array('keep' => array('User' => array())));
+		$this->assertEquals(array('keep' => array('User' => array())), array_shift($result));
 
 		$result = Set::extract('/Article/keep', $r);
-		$this->assertEquals(array_shift($result), array('keep' => array('Comment' => array())));
+		$this->assertEquals(array('keep' => array('Comment' => array())), array_shift($result));
 
 		$r = $this->_containments($this->Tag, array('Article' => array('User' => array('Comment' => array(
 			'Attachment' => array('conditions' => array('Attachment.id >' => 1))
 		)))));
 		$this->assertTrue(Set::matches('/Attachment', $r));
 		$this->assertTrue(Set::matches('/Comment/keep/Attachment/conditions', $r));
-		$this->assertEquals($r['Comment']['keep']['Attachment']['conditions'], array('Attachment.id >' => 1));
+		$this->assertEquals(array('Attachment.id >' => 1), $r['Comment']['keep']['Attachment']['conditions']);
 		$this->assertTrue(Set::matches('/User/keep/Comment', $r));
 		$this->assertTrue(Set::matches('/Article/keep/User', $r));
 		$this->assertTrue(Set::matches('/Tag/keep/Article', $r));
@@ -3220,7 +3220,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		));
 
 		$result = $this->Article->Comment->find('all', $options);
-		$this->assertEquals($result, $firstResult);
+		$this->assertEquals($firstResult, $result);
 
 		$this->Article->unbindModel(array('hasMany' => array('Comment'), 'belongsTo' => array('User'), 'hasAndBelongsToMany' => array('Tag')), false);
 		$this->Article->bindModel(array('hasMany' => array('Comment'), 'belongsTo' => array('User')), false);
@@ -3354,7 +3354,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		);
 		$result = $this->Article->Comment->find('all', $findOptions);
 		$result = $this->Article->Comment->find('all', $initialOptions);
-		$this->assertEquals($result, $initialModels);
+		$this->assertEquals($initialModels, $result);
 	}
 
 /**
@@ -3581,7 +3581,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->Article->recursive = -1;
 		$result = $this->Article->field('title', array('Article.title' => 'First Article'));
 		$this->assertNoErrors();
-		$this->assertEquals($result, 'First Article', 'Field is wrong');
+		$this->assertEquals('First Article', $result, 'Field is wrong');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -87,24 +87,24 @@ class TranslateBehaviorTest extends CakeTestCase {
 		$TestModel->translateTable = 'another_i18n';
 		$TestModel->Behaviors->attach('Translate', array('title'));
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEquals($translateModel->name, 'I18nModel');
-		$this->assertEquals($translateModel->useTable, 'another_i18n');
+		$this->assertEquals('I18nModel', $translateModel->name);
+		$this->assertEquals('another_i18n', $translateModel->useTable);
 
 		$TestModel = new User();
 		$TestModel->Behaviors->attach('Translate', array('title'));
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEquals($translateModel->name, 'I18nModel');
-		$this->assertEquals($translateModel->useTable, 'i18n');
+		$this->assertEquals('I18nModel', $translateModel->name);
+		$this->assertEquals('i18n', $translateModel->useTable);
 
 		$TestModel = new TranslatedArticle();
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEquals($translateModel->name, 'TranslateArticleModel');
-		$this->assertEquals($translateModel->useTable, 'article_i18n');
+		$this->assertEquals('TranslateArticleModel', $translateModel->name);
+		$this->assertEquals('article_i18n', $translateModel->useTable);
 
 		$TestModel = new TranslatedItem();
 		$translateModel = $TestModel->Behaviors->Translate->translateModel($TestModel);
-		$this->assertEquals($translateModel->name, 'TranslateTestModel');
-		$this->assertEquals($translateModel->useTable, 'i18n');
+		$this->assertEquals('TranslateTestModel', $translateModel->name);
+		$this->assertEquals('i18n', $translateModel->useTable);
 	}
 
 /**
@@ -442,10 +442,10 @@ class TranslateBehaviorTest extends CakeTestCase {
 			Configure::write('debug', 0);
 
 			$result = $TestModel->find('list', array('recursive' => 1, 'callbacks' => false));
-			$this->assertEquals($result, array());
+			$this->assertEquals(array(), $result);
 
 			$result = $TestModel->find('list', array('recursive' => 1, 'callbacks' => 'after'));
-			$this->assertEquals($result, array());
+			$this->assertEquals(array(), $result);
 			Configure::write('debug', $debug);
 		}
 
@@ -668,7 +668,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		));
 		$TestModel->create();
 		$this->assertFalse($TestModel->save($data));
-		$this->assertEquals($TestModel->validationErrors['title'], array('This field cannot be left blank'));
+		$this->assertEquals(array('This field cannot be left blank'), $TestModel->validationErrors['title']);
 
 		$TestModel->locale = 'eng';
 		$TestModel->validate['title'] = '/Only this title/';

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
@@ -70,7 +70,7 @@ class TreeBehaviorAfterTest extends CakeTestCase {
 
 		$expected = array('AfterTree' => array('name' => 'Six and One Half', 'parent_id' => 6, 'lft' => 11, 'rght' => 12, 'id' => 8));
 		$result = $this->Tree->find('all');
-		$this->assertEquals($result[7], $expected);
+		$this->assertEquals($expected, $result[7]);
 	}
 }
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -67,7 +67,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->find('count');
-		$this->assertEquals($result, 7);
+		$this->assertEquals(7, $result);
 
 		$validTree = $this->Tree->verify();
 		$this->assertSame($validTree, true);
@@ -479,7 +479,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
 		$result = $this->Tree->findByName('testAddOrphan', array('name', $parentField, $leftField, $rightField));
 		$expected = array('name' => 'testAddOrphan', $parentField => null, $leftField => '15', $rightField => 16);
-		$this->assertEquals($result[$modelClass], $expected);
+		$this->assertEquals($expected, $result[$modelClass]);
 		$this->assertSame($this->Tree->verify(), true);
 	}
 
@@ -505,7 +505,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1.1.1')),
 			array($modelClass => array('name' => '1.1.2')),
 			array($modelClass => array('name' => '1.2')));
-		$this->assertEquals($result, $expects);
+		$this->assertEquals($expects, $result);
 
 		$validTree = $this->Tree->verify();
 		$this->assertSame($validTree, true);
@@ -533,7 +533,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1.2.1')),
 			array($modelClass => array('name' => '1.2.2')),
 			array($modelClass => array('name' => '1.1')));
-		$this->assertEquals($result, $expects);
+		$this->assertEquals($expects, $result);
 
 		$validTree = $this->Tree->verify();
 		$this->assertSame($validTree, true);
@@ -564,7 +564,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$results = $this->Tree->find('all');
 		$after = $this->Tree->read(null, $data[$modelClass]['id']);
 
-		$this->assertEquals($results, $expects);
+		$this->assertEquals($expects, $results);
 		$this->assertEquals($before, $after);
 
 		$validTree = $this->Tree->verify();
@@ -893,7 +893,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->findByName('1.1.1');
 
 		$return = $this->Tree->delete($result[$modelClass]['id']);
-		$this->assertEquals($return, true);
+		$this->assertEquals(true, $return);
 
 		$laterCount = $this->Tree->find('count');
 		$this->assertEquals($initialCount - 1, $laterCount);
@@ -905,7 +905,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->findByName('1.1');
 
 		$return = $this->Tree->delete($result[$modelClass]['id']);
-		$this->assertEquals($return, true);
+		$this->assertEquals(true, $return);
 
 		$laterCount = $this->Tree->find('count');
 		$this->assertEquals($initialCount - 2, $laterCount);
@@ -1123,15 +1123,15 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->id = $data[$modelClass]['id'];
 
 		$direct = $this->Tree->childCount(null, true);
-		$this->assertEquals($direct, 2);
+		$this->assertEquals(2, $direct);
 
 		$total = $this->Tree->childCount();
-		$this->assertEquals($total, 6);
+		$this->assertEquals(6, $total);
 
 		$this->Tree->read(null, $data[$modelClass]['id']);
 		$id = $this->Tree->field('id', array($modelClass . '.name' => '1.2'));
 		$total = $this->Tree->childCount($id);
-		$this->assertEquals($total, 2);
+		$this->assertEquals(2, $total);
 	}
 
 /**
@@ -1149,7 +1149,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$result = $this->Tree->getParentNode(null, array('name'));
 		$expects = array($modelClass => array('name' => '1.2'));
-		$this->assertSame($result, $expects);
+		$this->assertSame($expects, $result);
 	}
 
 /**
@@ -1169,7 +1169,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$expects = array(array($modelClass => array('name' => '1. Root')),
 			array($modelClass => array('name' => '1.2')),
 			array($modelClass => array('name' => '1.2.2')));
-		$this->assertSame($result, $expects);
+		$this->assertSame($expects, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -79,7 +79,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
-		$this->assertEquals($this->Tree->children(), array());
+		$this->assertEquals(array(), $this->Tree->children());
 
 		$this->Tree->id = 1;
 		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
@@ -89,7 +89,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->assertTrue($this->Tree->delete());
-		$this->assertEquals($this->Tree->find('count'), 11);
+		$this->assertEquals(11, $this->Tree->find('count'));
 	}
 
 /**
@@ -115,7 +115,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
-		$this->assertEquals($this->Tree->children(), array());
+		$this->assertEquals(array(), $this->Tree->children());
 
 		$this->Tree->id = 1;
 		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
@@ -125,7 +125,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$this->assertTrue($this->Tree->delete());
-		$this->assertEquals($this->Tree->find('count'), 11);
+		$this->assertEquals(11, $this->Tree->find('count'));
 	}
 
 /**
@@ -140,8 +140,8 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 
 		$this->Ad->id = 4;
 		$result = $this->Ad->children();
-		$this->assertEquals(Set::extract('/Ad/id', $result), array(6, 5));
-		$this->assertEquals(Set::extract('/Campaign/id', $result), array(2, 2));
+		$this->assertEquals(array(6, 5), Set::extract('/Ad/id', $result));
+		$this->assertEquals(array(2, 2), Set::extract('/Campaign/id', $result));
 	}
 
 /**
@@ -156,8 +156,8 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 
 		$this->Ad->id = 4;
 		$result = $this->Ad->children();
-		$this->assertEquals(Set::extract('/Ad/id', $result), array(5, 6));
-		$this->assertEquals(Set::extract('/Campaign/id', $result), array(2, 2));
+		$this->assertEquals(array(5, 6), Set::extract('/Ad/id', $result));
+		$this->assertEquals(array(2, 2), Set::extract('/Campaign/id', $result));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -437,7 +437,7 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testLoadDisabled() {
 		$Apple = new Apple();
-		$this->assertSame($Apple->Behaviors->attached(), array());
+		$this->assertSame(array(), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->load('Translate', array('enabled' => false));
 		$this->assertTrue($Apple->Behaviors->attached('Translate'));
@@ -449,16 +449,16 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testLoadAlias() {
 		$Apple = new Apple();
-		$this->assertSame($Apple->Behaviors->attached(), array());
+		$this->assertSame(array(), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->load('Test', array('className' => 'TestAlias', 'somesetting' => true));
-		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
+		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
 		$this->assertInstanceOf('TestAliasBehavior', $Apple->Behaviors->Test);
 		$this->assertTrue($Apple->Behaviors->Test->settings['Apple']['somesetting']);
 
-		$this->assertEquals($Apple->Behaviors->Test->testMethod($Apple, true), 'working');
-		$this->assertEquals($Apple->testMethod(true), 'working');
-		$this->assertEquals($Apple->Behaviors->dispatchMethod($Apple, 'testMethod'), 'working');
+		$this->assertEquals('working', $Apple->Behaviors->Test->testMethod($Apple, true));
+		$this->assertEquals('working', $Apple->testMethod(true));
+		$this->assertEquals('working', $Apple->Behaviors->dispatchMethod($Apple, 'testMethod'));
 
 		App::build(array('Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)));
 		CakePlugin::load('TestPlugin');
@@ -478,21 +478,21 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testBehaviorBinding() {
 		$Apple = new Apple();
-		$this->assertSame($Apple->Behaviors->attached(), array());
+		$this->assertSame(array(), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->attach('Test', array('key' => 'value'));
-		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
-		$this->assertEquals(strtolower(get_class($Apple->Behaviors->Test)), 'testbehavior');
+		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
+		$this->assertEquals('testbehavior', strtolower(get_class($Apple->Behaviors->Test)));
 		$expected = array('beforeFind' => 'on', 'afterFind' => 'off', 'key' => 'value');
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
-		$this->assertEquals(array_keys($Apple->Behaviors->Test->settings), array('Apple'));
+		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
+		$this->assertEquals(array('Apple'), array_keys($Apple->Behaviors->Test->settings));
 
 		$this->assertSame($Apple->Sample->Behaviors->attached(), array());
 		$Apple->Sample->Behaviors->attach('Test', array('key2' => 'value2'));
 		$this->assertSame($Apple->Sample->Behaviors->attached(), array('Test'));
-		$this->assertEquals($Apple->Sample->Behaviors->Test->settings['Sample'], array('beforeFind' => 'on', 'afterFind' => 'off', 'key2' => 'value2'));
+		$this->assertEquals(array('beforeFind' => 'on', 'afterFind' => 'off', 'key2' => 'value2'), $Apple->Sample->Behaviors->Test->settings['Sample']);
 
-		$this->assertEquals(array_keys($Apple->Behaviors->Test->settings), array('Apple', 'Sample'));
+		$this->assertEquals(array('Apple', 'Sample'), array_keys($Apple->Behaviors->Test->settings));
 		$this->assertSame(
 			$Apple->Sample->Behaviors->Test->settings,
 			$Apple->Behaviors->Test->settings
@@ -501,7 +501,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 
 		$Apple->Behaviors->attach('Test', array('key2' => 'value2', 'key3' => 'value3', 'beforeFind' => 'off'));
 		$Apple->Sample->Behaviors->attach('Test', array('key' => 'value', 'key3' => 'value3', 'beforeFind' => 'off'));
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], array('beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'value', 'key2' => 'value2', 'key3' => 'value3'));
+		$this->assertEquals(array('beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'value', 'key2' => 'value2', 'key3' => 'value3'), $Apple->Behaviors->Test->settings['Apple']);
 		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$this->assertFalse(isset($Apple->Child->Behaviors->Test));
@@ -520,20 +520,20 @@ class BehaviorCollectionTest extends CakeTestCase {
 			'beforeFind' => 'off', 'afterFind' => 'off', 'key' => 'new value',
 			'key2' => 'value2', 'key3' => 'value3'
 		);
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
 
 		$current = $Apple->Behaviors->Test->settings['Apple'];
 		$expected = array_merge($current, array('mangle' => 'trigger mangled'));
 		$Apple->Behaviors->attach('Test', array('mangle' => 'trigger'));
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
 
 		$Apple->Behaviors->attach('Test');
 		$expected = array_merge($current, array('mangle' => 'trigger mangled mangled'));
 
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
 		$Apple->Behaviors->attach('Test', array('mangle' => 'trigger'));
 		$expected = array_merge($current, array('mangle' => 'trigger mangled'));
-		$this->assertEquals($Apple->Behaviors->Test->settings['Apple'], $expected);
+		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
 	}
 
 /**
@@ -545,17 +545,17 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEquals($Apple->Behaviors->attached(), array('Test'));
+		$this->assertEquals(array('Test'), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->detach('Plugin.Test');
-		$this->assertEquals($Apple->Behaviors->attached(), array());
+		$this->assertEquals(array(), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEquals($Apple->Behaviors->attached(), array('Test'));
+		$this->assertEquals(array('Test'), $Apple->Behaviors->attached());
 
 		$Apple->Behaviors->detach('Test');
-		$this->assertEquals($Apple->Behaviors->attached(), array());
+		$this->assertEquals(array(), $Apple->Behaviors->attached());
 	}
 
 /**
@@ -583,7 +583,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');
-		$this->assertSame($Apple->Behaviors->attached(), array('Test'));
+		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
 		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Sample->Behaviors->attach('Test');
@@ -619,10 +619,10 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->find('all'), null);
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'test'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'modify'));
 		$expected2 = array(
@@ -641,13 +641,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->find('all'), array());
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'off'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'test'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'test2'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('afterFind' => 'modify'));
 		$expected = array(
@@ -659,7 +659,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 			array('id' => '6', 'apple_id' => '4', 'color' => 'My new appleOrange', 'name' => 'My new apple', 'created' => '2006-12-25 05:29:39', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:29:39', 'mytime' => '22:57:17'),
 			array('id' => '7', 'apple_id' => '6', 'color' => 'Some wierd color', 'name' => 'Some odd color', 'created' => '2006-12-25 05:34:21', 'date' => '2006-12-25', 'modified' => '2006-12-25 05:34:21', 'mytime' => '22:57:17')
 		);
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 	}
 
 /**
@@ -679,10 +679,10 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$expected2 = array(
 			array(
@@ -710,13 +710,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->Child->Behaviors->attach('Test', array('before' => 'off', 'after' => 'on'));
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Child->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 	}
 
 /**
@@ -736,23 +736,23 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Sample->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Sample->Behaviors->disable('Test');
 		$result = $Apple->find('all');
 		$this->assertEquals($expected, $result);
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Sample->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 	}
 
 /**
@@ -774,10 +774,10 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->find('all'), $wellBehaved);
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'off'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'test'));
-		$this->assertSame($Apple->find('all'), $expected);
+		$this->assertSame($expected, $Apple->find('all'));
 
 		$Apple->Parent->Behaviors->attach('Test', array('before' => 'modify'));
 		$expected2 = array(
@@ -802,13 +802,13 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'off'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'test'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 
 		$Apple->Parent->Behaviors->attach('Test', array('after' => 'test2'));
-		$this->assertEquals($Apple->find('all'), $expected);
+		$this->assertEquals($expected, $Apple->find('all'));
 	}
 
 /**
@@ -977,7 +977,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->validate['color'] = 'validateField';
 
 		$result = $Apple->save(array('name' => 'Genetically Modified Apple', 'color' => 'Orange'));
-		$this->assertEquals(array_keys($result['Apple']), array('name', 'color', 'modified', 'created', 'id'));
+		$this->assertEquals(array('name', 'color', 'modified', 'created', 'id'), array_keys($result['Apple']));
 
 		$Apple->create();
 		$result = $Apple->save(array('name' => 'Regular Apple', 'color' => 'Red'));
@@ -994,11 +994,11 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple->Behaviors->attach('Test');
 
 		$expected = 'working';
-		$this->assertEquals($Apple->testMethod(), $expected);
-		$this->assertEquals($Apple->Behaviors->dispatchMethod($Apple, 'testMethod'), $expected);
+		$this->assertEquals($expected, $Apple->testMethod());
+		$this->assertEquals($expected, $Apple->Behaviors->dispatchMethod($Apple, 'testMethod'));
 
 		$result = $Apple->Behaviors->dispatchMethod($Apple, 'wtf');
-		$this->assertEquals($result, array('unhandled'));
+		$this->assertEquals(array('unhandled'), $result);
 
 		$result = $Apple->{'look for the remote'}('in the couch');
 		$expected = "Item.name = 'the remote' AND Location.name = 'the couch'";

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -510,11 +510,11 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaName() {
 		$Schema = new CakeSchema();
-		$this->assertEquals(strtolower($Schema->name), strtolower(APP_DIR));
+		$this->assertEquals(strtolower(APP_DIR), strtolower($Schema->name));
 
 		Configure::write('App.dir', 'Some.name.with.dots');
 		$Schema = new CakeSchema();
-		$this->assertEquals($Schema->name, 'SomeNameWithDots');
+		$this->assertEquals('SomeNameWithDots', $Schema->name);
 
 		Configure::write('App.dir', 'app');
 	}
@@ -809,7 +809,7 @@ class CakeSchemaTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $compare);
 		$this->assertNull($New->getVar('comments'));
-		$this->assertEquals($New->getVar('_foo'), array('bar'));
+		$this->assertEquals(array('bar'), $New->getVar('_foo'));
 
 		$tables = array(
 			'missing' => array(
@@ -1026,7 +1026,7 @@ class CakeSchemaTest extends CakeTestCase {
  */
 	public function testSchemaLoading() {
 		$Other = $this->Schema->load(array('name' => 'MyOtherApp', 'path' => TMP . 'tests'));
-		$this->assertEquals($Other->name, 'MyOtherApp');
+		$this->assertEquals('MyOtherApp', $Other->name);
 		$this->assertEquals($Other->tables, $this->Schema->tables);
 	}
 
@@ -1041,8 +1041,8 @@ class CakeSchemaTest extends CakeTestCase {
 		));
 		CakePlugin::load('TestPlugin');
 		$Other = $this->Schema->load(array('name' => 'TestPluginApp', 'plugin' => 'TestPlugin'));
-		$this->assertEquals($Other->name, 'TestPluginApp');
-		$this->assertEquals(array_keys($Other->tables), array('test_plugin_acos'));
+		$this->assertEquals('TestPluginApp', $Other->name);
+		$this->assertEquals(array('test_plugin_acos'), array_keys($Other->tables));
 
 		App::build();
 	}

--- a/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
+++ b/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
@@ -253,14 +253,14 @@ class ConnectionManagerTest extends CakeTestCase {
 		$this->assertEquals($name, ConnectionManager::getSourceName($connection));
 
 		$source = ConnectionManager::create(null, array());
-		$this->assertEquals($source, null);
+		$this->assertEquals(null, $source);
 
 		$source = ConnectionManager::create('another_test', array());
-		$this->assertEquals($source, null);
+		$this->assertEquals(null, $source);
 
 		$config = array('classname' => 'DboMysql', 'filename' => 'dbo' . DS . 'dbo_mysql');
 		$source = ConnectionManager::create(null, $config);
-		$this->assertEquals($source, null);
+		$this->assertEquals(null, $source);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -128,10 +128,10 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testSessionPath() {
 		TestCakeSession::init('/index.php');
-		$this->assertEquals(TestCakeSession::$path, '/');
+		$this->assertEquals('/', TestCakeSession::$path);
 
 		TestCakeSession::init('/sub_dir/index.php');
-		$this->assertEquals(TestCakeSession::$path, '/sub_dir/');
+		$this->assertEquals('/sub_dir/', TestCakeSession::$path);
 	}
 
 /**
@@ -141,7 +141,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testCakeSessionPathEmpty() {
 		TestCakeSession::init('');
-		$this->assertEquals(TestCakeSession::$path, '/', 'Session path is empty, with "" as $base needs to be /');
+		$this->assertEquals('/', TestCakeSession::$path, 'Session path is empty, with "" as $base needs to be /');
 	}
 
 /**
@@ -151,7 +151,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testCakeSessionPathContainsQuestion() {
 		TestCakeSession::init('/index.php?');
-		$this->assertEquals(TestCakeSession::$path, '/');
+		$this->assertEquals('/', TestCakeSession::$path);
 	}
 
 /**
@@ -162,7 +162,7 @@ class CakeSessionTest extends CakeTestCase {
 	public function testSetHost() {
 		TestCakeSession::init();
 		TestCakeSession::setHost('cakephp.org');
-		$this->assertEquals(TestCakeSession::$host, 'cakephp.org');
+		$this->assertEquals('cakephp.org', TestCakeSession::$host);
 	}
 
 /**
@@ -173,7 +173,7 @@ class CakeSessionTest extends CakeTestCase {
 	public function testSetHostWithPort() {
 		TestCakeSession::init();
 		TestCakeSession::setHost('cakephp.org:443');
-		$this->assertEquals(TestCakeSession::$host, 'cakephp.org');
+		$this->assertEquals('cakephp.org', TestCakeSession::$host);
 	}
 
 /**
@@ -240,7 +240,7 @@ class CakeSessionTest extends CakeTestCase {
 
 		TestCakeSession::write('This.is.a.deep.array.my.friend', 'value');
 		$result = TestCakeSession::read('This.is.a.deep.array.my.friend');
-		$this->assertEquals($result, 'value');
+		$this->assertEquals('value', $result);
 	}
 
 /**
@@ -355,7 +355,7 @@ class CakeSessionTest extends CakeTestCase {
 		TestCakeSession::destroy();
 
 		$this->assertFalse(TestCakeSession::check('bulletProof'));
-		$this->assertNotEquals($id, TestCakeSession::id());
+		$this->assertNotEquals(TestCakeSession::id(), $id);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -203,8 +203,8 @@ class MysqlTest extends CakeTestCase {
 		));
 
 		$result = $this->model->schema();
-		$this->assertEquals($result['bool']['type'], 'boolean');
-		$this->assertEquals($result['small_int']['type'], 'integer');
+		$this->assertEquals('boolean', $result['bool']['type']);
+		$this->assertEquals('integer', $result['small_int']['type']);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 5, 'small_int' => 5)));
 		$result = $this->model->find('first');
@@ -529,7 +529,7 @@ class MysqlTest extends CakeTestCase {
 
 		//Test that the string is syntactically correct
 		$query = $this->Dbo->getConnection()->prepare($result);
-		$this->assertEquals($result, $query->queryString);
+		$this->assertEquals($query->queryString, $result);
 
 		$schemaB = new CakeSchema(array(
 			'name' => 'AlterTest2',
@@ -555,7 +555,7 @@ class MysqlTest extends CakeTestCase {
 
 		//Test that the string is syntactically correct
 		$query = $this->Dbo->getConnection()->prepare($result);
-		$this->assertEquals($result, $query->queryString);
+		$this->assertEquals($query->queryString, $result);
 
 		// Change three indexes, delete one and add another one
 		$schemaC = new CakeSchema(array(
@@ -585,10 +585,10 @@ class MysqlTest extends CakeTestCase {
 		$this->assertContains('ADD KEY compound_idx (`group2`, `group1`);', $result);
 
 		$query = $this->Dbo->getConnection()->prepare($result);
-		$this->assertEquals($result, $query->queryString);
+		$this->assertEquals($query->queryString, $result);
 
 		// Compare us to ourself.
-		$this->assertEquals($schemaC->compare($schemaC), array());
+		$this->assertEquals(array(), $schemaC->compare($schemaC));
 
 		// Drop the indexes
 		$result = $this->Dbo->alterSchema($schemaA->compare($schemaC));
@@ -600,7 +600,7 @@ class MysqlTest extends CakeTestCase {
 		$this->assertContains('DROP KEY id_name_idx;', $result);
 
 		$query = $this->Dbo->getConnection()->prepare($result);
-		$this->assertEquals($result, $query->queryString);
+		$this->assertEquals($query->queryString, $result);
 	}
 
 /**
@@ -617,7 +617,7 @@ class MysqlTest extends CakeTestCase {
 		$model->save(compact('data'));
 
 		$result = $model->find('first');
-		$this->assertEquals($result['BinaryTest']['data'], $data);
+		$this->assertEquals($data, $result['BinaryTest']['data']);
 	}
 
 /**
@@ -662,9 +662,9 @@ class MysqlTest extends CakeTestCase {
 
 		$this->Dbo->rawQuery($result);
 		$result = $this->Dbo->listDetailedSources($this->Dbo->fullTableName('altertest', false, false));
-		$this->assertEquals($result['Collation'], 'utf8_general_ci');
-		$this->assertEquals($result['Engine'], 'InnoDB');
-		$this->assertEquals($result['charset'], 'utf8');
+		$this->assertEquals('utf8_general_ci', $result['Collation']);
+		$this->assertEquals('InnoDB', $result['Engine']);
+		$this->assertEquals('utf8', $result['charset']);
 
 		$this->Dbo->rawQuery($this->Dbo->dropSchema($schemaA));
 	}
@@ -759,9 +759,9 @@ class MysqlTest extends CakeTestCase {
 	public function testGetCharsetName() {
 		$this->Dbo->cacheSources = $this->Dbo->testing = false;
 		$result = $this->Dbo->getCharsetName('utf8_unicode_ci');
-		$this->assertEquals($result, 'utf8');
+		$this->assertEquals('utf8', $result);
 		$result = $this->Dbo->getCharsetName('cp1250_general_ci');
-		$this->assertEquals($result, 'cp1250');
+		$this->assertEquals('cp1250', $result);
 	}
 
 /**
@@ -833,9 +833,9 @@ class MysqlTest extends CakeTestCase {
 		$result = $model->getDataSource()->describe($model);
 		$this->Dbo->execute($this->Dbo->dropSchema($schema));
 
-		$this->assertEquals($result['stringy']['collate'], 'cp1250_general_ci');
-		$this->assertEquals($result['stringy']['charset'], 'cp1250');
-		$this->assertEquals($result['other_col']['comment'], 'Test Comment');
+		$this->assertEquals('cp1250_general_ci', $result['stringy']['collate']);
+		$this->assertEquals('cp1250', $result['stringy']['charset']);
+		$this->assertEquals('Test Comment', $result['other_col']['comment']);
 	}
 
 /**
@@ -860,7 +860,7 @@ class MysqlTest extends CakeTestCase {
 			->will($this->returnValue(null));
 
 		$tables = $db->listSources();
-		$this->assertEquals($tables, array('cake_table', 'another_table'));
+		$this->assertEquals(array('cake_table', 'another_table'), $tables);
 	}
 
 /**
@@ -926,9 +926,9 @@ class MysqlTest extends CakeTestCase {
 			->method('getDataSource')
 			->will($this->returnValue($test));
 
-		$this->assertEquals($this->Model->escapeField(), '`Article`.`id`');
+		$this->assertEquals('`Article`.`id`', $this->Model->escapeField());
 		$result = $test->fields($this->Model, null, $this->Model->escapeField());
-		$this->assertEquals($result, array('`Article`.`id`'));
+		$this->assertEquals(array('`Article`.`id`'), $result);
 
 		$test->expects($this->at(0))->method('execute')
 			->with('SELECT `Article`.`id` FROM ' . $test->fullTableName('articles') . ' AS `Article`   WHERE 1 = 1');
@@ -941,10 +941,10 @@ class MysqlTest extends CakeTestCase {
 
 		$test->startQuote = '[';
 		$test->endQuote = ']';
-		$this->assertEquals($this->Model->escapeField(), '[Article].[id]');
+		$this->assertEquals('[Article].[id]', $this->Model->escapeField());
 
 		$result = $test->fields($this->Model, null, $this->Model->escapeField());
-		$this->assertEquals($result, array('[Article].[id]'));
+		$this->assertEquals(array('[Article].[id]'), $result);
 
 		$test->expects($this->at(0))->method('execute')
 			->with('SELECT [Article].[id] FROM ' . $test->fullTableName('articles') . ' AS [Article]   WHERE 1 = 1');
@@ -1033,7 +1033,7 @@ class MysqlTest extends CakeTestCase {
 			'callbacks' => null
 		);
 		$queryData['joins'][0]['table'] = $this->Dbo->fullTableName($queryData['joins'][0]['table']);
-		$this->assertEquals($queryData, $expected);
+		$this->assertEquals($expected, $queryData);
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel4Parent`\.`id`, `TestModel4Parent`\.`name`, `TestModel4Parent`\.`created`, `TestModel4Parent`\.`updated`\s+/', $result);
@@ -1045,7 +1045,7 @@ class MysqlTest extends CakeTestCase {
 		$this->Model->belongsTo['TestModel4Parent']['type'] = 'INNER';
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $params['linkModel'], $params['type'], $params['assoc'], $params['assocData'], $_queryData, $params['external'], $resultSet);
 		$this->assertTrue($result);
-		$this->assertEquals($_queryData['joins'][0]['type'], 'INNER');
+		$this->assertEquals('INNER', $_queryData['joins'][0]['type']);
 	}
 
 /**
@@ -1275,7 +1275,7 @@ class MysqlTest extends CakeTestCase {
 		$testModel5Table = $this->Dbo->fullTableName($this->Model->TestModel5);
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN ' . $testModel5Table . ' AS `TestModel5` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEquals(trim($result), trim($expected));
+		$this->assertEquals(trim($expected), trim($result));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertRegExp('/^SELECT\s+`TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`, `TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`\s+/', $result);
@@ -1336,7 +1336,7 @@ class MysqlTest extends CakeTestCase {
 		$testModel4Table = $this->Dbo->fullTableName($this->Model->TestModel4, true, true);
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN ' . $testModel4Table . ' AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEquals(trim($result), trim($expected));
+		$this->assertEquals(trim($expected), trim($result));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
@@ -1368,7 +1368,7 @@ class MysqlTest extends CakeTestCase {
 		$testModel4Table = $this->Dbo->fullTableName($this->Model->TestModel4, true, true);
 		$result = $this->Dbo->buildJoinStatement($queryData['joins'][0]);
 		$expected = ' LEFT JOIN ' . $testModel4Table . ' AS `TestModel4` ON (`TestModel5`.`test_model4_id` = `TestModel4`.`id`)';
-		$this->assertEquals(trim($result), trim($expected));
+		$this->assertEquals(trim($expected), trim($result));
 
 		$result = $this->Dbo->generateAssociationQuery($this->Model, $null, null, null, null, $queryData, false, $null);
 		$this->assertRegExp('/^SELECT\s+`TestModel5`\.`id`, `TestModel5`\.`test_model4_id`, `TestModel5`\.`name`, `TestModel5`\.`created`, `TestModel5`\.`updated`, `TestModel4`\.`id`, `TestModel4`\.`name`, `TestModel4`\.`created`, `TestModel4`\.`updated`\s+/', $result);
@@ -2431,13 +2431,13 @@ class MysqlTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'round( (3.55441 * fooField), 3 ) AS test');
-		$this->assertEquals($result, array('round( (3.55441 * fooField), 3 ) AS test'));
+		$this->assertEquals(array('round( (3.55441 * fooField), 3 ) AS test'), $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating');
-		$this->assertEquals($result, array('ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating'));
+		$this->assertEquals(array('ROUND(`Rating`.`rate_total` / `Rating`.`rate_count`,2) AS rating'), $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'ROUND(Rating.rate_total / Rating.rate_count,2) AS rating');
-		$this->assertEquals($result, array('ROUND(Rating.rate_total / Rating.rate_count,2) AS rating'));
+		$this->assertEquals(array('ROUND(Rating.rate_total / Rating.rate_count,2) AS rating'), $result);
 
 		$result = $this->Dbo->fields($this->Model, 'Post', "Node.created, CONCAT(REPEAT(' ', COUNT(Parent.name) - 1), Node.name) AS name");
 		$expected = array("`Node`.`created`", "CONCAT(REPEAT(' ', COUNT(`Parent`.`name`) - 1), Node.name) AS name");
@@ -2696,38 +2696,38 @@ class MysqlTest extends CakeTestCase {
 	public function testCalculations() {
 		$this->Model = new TestModel();
 		$result = $this->Dbo->calculate($this->Model, 'count');
-		$this->assertEquals($result, 'COUNT(*) AS `count`');
+		$this->assertEquals('COUNT(*) AS `count`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('id'));
-		$this->assertEquals($result, 'COUNT(`id`) AS `count`');
+		$this->assertEquals('COUNT(`id`) AS `count`', $result);
 
 		$result = $this->Dbo->calculate(
 			$this->Model,
 			'count',
 			array($this->Dbo->expression('DISTINCT id'))
 		);
-		$this->assertEquals($result, 'COUNT(DISTINCT id) AS `count`');
+		$this->assertEquals('COUNT(DISTINCT id) AS `count`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('id', 'id_count'));
-		$this->assertEquals($result, 'COUNT(`id`) AS `id_count`');
+		$this->assertEquals('COUNT(`id`) AS `id_count`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'count', array('Model.id', 'id_count'));
-		$this->assertEquals($result, 'COUNT(`Model`.`id`) AS `id_count`');
+		$this->assertEquals('COUNT(`Model`.`id`) AS `id_count`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('id'));
-		$this->assertEquals($result, 'MAX(`id`) AS `id`');
+		$this->assertEquals('MAX(`id`) AS `id`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('Model.id', 'id'));
-		$this->assertEquals($result, 'MAX(`Model`.`id`) AS `id`');
+		$this->assertEquals('MAX(`Model`.`id`) AS `id`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'max', array('`Model`.`id`', 'id'));
-		$this->assertEquals($result, 'MAX(`Model`.`id`) AS `id`');
+		$this->assertEquals('MAX(`Model`.`id`) AS `id`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'min', array('`Model`.`id`', 'id'));
-		$this->assertEquals($result, 'MIN(`Model`.`id`) AS `id`');
+		$this->assertEquals('MIN(`Model`.`id`) AS `id`', $result);
 
 		$result = $this->Dbo->calculate($this->Model, 'min', 'left');
-		$this->assertEquals($result, 'MIN(`left`) AS `left`');
+		$this->assertEquals('MIN(`left`) AS `left`', $result);
 	}
 
 /**
@@ -3160,7 +3160,7 @@ class MysqlTest extends CakeTestCase {
 		$qs = $this->Dbo->startQuote;
 		$qe = $this->Dbo->endQuote;
 
-		$this->assertEquals($result[0], "{$qs}Article{$qe}.{$qs}id{$qe}");
+		$this->assertEquals("{$qs}Article{$qe}.{$qs}id{$qe}", $result[0]);
 		$this->assertRegExp('/Article__distance/', $result[1]);
 		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]latitude[`\'"]/', $result[1]);
 		$this->assertRegExp('/[`\'"]Article[`\'"].[`\'"]longitude[`\'"]/', $result[1]);
@@ -3249,156 +3249,156 @@ class MysqlTest extends CakeTestCase {
  * @return void
  */
 	public function testIntrospectType() {
-		$this->assertEquals($this->Dbo->introspectType(0), 'integer');
-		$this->assertEquals($this->Dbo->introspectType(2), 'integer');
-		$this->assertEquals($this->Dbo->introspectType('2'), 'string');
-		$this->assertEquals($this->Dbo->introspectType('2.2'), 'string');
-		$this->assertEquals($this->Dbo->introspectType(2.2), 'float');
-		$this->assertEquals($this->Dbo->introspectType('stringme'), 'string');
-		$this->assertEquals($this->Dbo->introspectType('0stringme'), 'string');
+		$this->assertEquals('integer', $this->Dbo->introspectType(0));
+		$this->assertEquals('integer', $this->Dbo->introspectType(2));
+		$this->assertEquals('string', $this->Dbo->introspectType('2'));
+		$this->assertEquals('string', $this->Dbo->introspectType('2.2'));
+		$this->assertEquals('float', $this->Dbo->introspectType(2.2));
+		$this->assertEquals('string', $this->Dbo->introspectType('stringme'));
+		$this->assertEquals('string', $this->Dbo->introspectType('0stringme'));
 
 		$data = array(2.2);
-		$this->assertEquals($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals('float', $this->Dbo->introspectType($data));
 
 		$data = array('2.2');
-		$this->assertEquals($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals('float', $this->Dbo->introspectType($data));
 
 		$data = array(2);
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array('2');
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array('string');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array(2.2, '2.2');
-		$this->assertEquals($this->Dbo->introspectType($data), 'float');
+		$this->assertEquals('float', $this->Dbo->introspectType($data));
 
 		$data = array(2, '2');
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array('string one', 'string two');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array('2.2', 3);
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array('2.2', '0stringme');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array(2.2, 3);
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array(2.2, '0stringme');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array(2, 'stringme');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array(2, '2.2', 'stringgme');
-		$this->assertEquals($this->Dbo->introspectType($data), 'string');
+		$this->assertEquals('string', $this->Dbo->introspectType($data));
 
 		$data = array(2, '2.2');
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		$data = array(2, 2.2);
-		$this->assertEquals($this->Dbo->introspectType($data), 'integer');
+		$this->assertEquals('integer', $this->Dbo->introspectType($data));
 
 		// null
 		$result = $this->Dbo->value(null, 'boolean');
-		$this->assertEquals($result, 'NULL');
+		$this->assertEquals('NULL', $result);
 
 		// EMPTY STRING
 		$result = $this->Dbo->value('', 'boolean');
-		$this->assertEquals($result, "'0'");
+		$this->assertEquals("'0'", $result);
 
 		// BOOLEAN
 		$result = $this->Dbo->value('true', 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value('false', 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value(true, 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value(false, 'boolean');
-		$this->assertEquals($result, "'0'");
+		$this->assertEquals("'0'", $result);
 
 		$result = $this->Dbo->value(1, 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value(0, 'boolean');
-		$this->assertEquals($result, "'0'");
+		$this->assertEquals("'0'", $result);
 
 		$result = $this->Dbo->value('abc', 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value(1.234, 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		$result = $this->Dbo->value('1.234e05', 'boolean');
-		$this->assertEquals($result, "'1'");
+		$this->assertEquals("'1'", $result);
 
 		// NUMBERS
 		$result = $this->Dbo->value(123, 'integer');
-		$this->assertEquals($result, 123);
+		$this->assertEquals(123, $result);
 
 		$result = $this->Dbo->value('123', 'integer');
-		$this->assertEquals($result, '123');
+		$this->assertEquals('123', $result);
 
 		$result = $this->Dbo->value('0123', 'integer');
-		$this->assertEquals($result, "'0123'");
+		$this->assertEquals("'0123'", $result);
 
 		$result = $this->Dbo->value('0x123ABC', 'integer');
-		$this->assertEquals($result, "'0x123ABC'");
+		$this->assertEquals("'0x123ABC'", $result);
 
 		$result = $this->Dbo->value('0x123', 'integer');
-		$this->assertEquals($result, "'0x123'");
+		$this->assertEquals("'0x123'", $result);
 
 		$result = $this->Dbo->value(1.234, 'float');
-		$this->assertEquals($result, 1.234);
+		$this->assertEquals(1.234, $result);
 
 		$result = $this->Dbo->value('1.234', 'float');
-		$this->assertEquals($result, '1.234');
+		$this->assertEquals('1.234', $result);
 
 		$result = $this->Dbo->value(' 1.234 ', 'float');
-		$this->assertEquals($result, "' 1.234 '");
+		$this->assertEquals("' 1.234 '", $result);
 
 		$result = $this->Dbo->value('1.234e05', 'float');
-		$this->assertEquals($result, "'1.234e05'");
+		$this->assertEquals("'1.234e05'", $result);
 
 		$result = $this->Dbo->value('1.234e+5', 'float');
-		$this->assertEquals($result, "'1.234e+5'");
+		$this->assertEquals("'1.234e+5'", $result);
 
 		$result = $this->Dbo->value('1,234', 'float');
-		$this->assertEquals($result, "'1,234'");
+		$this->assertEquals("'1,234'", $result);
 
 		$result = $this->Dbo->value('FFF', 'integer');
-		$this->assertEquals($result, "'FFF'");
+		$this->assertEquals("'FFF'", $result);
 
 		$result = $this->Dbo->value('abc', 'integer');
-		$this->assertEquals($result, "'abc'");
+		$this->assertEquals("'abc'", $result);
 
 		// STRINGS
 		$result = $this->Dbo->value('123', 'string');
-		$this->assertEquals($result, "'123'");
+		$this->assertEquals("'123'", $result);
 
 		$result = $this->Dbo->value(123, 'string');
-		$this->assertEquals($result, "'123'");
+		$this->assertEquals("'123'", $result);
 
 		$result = $this->Dbo->value(1.234, 'string');
-		$this->assertEquals($result, "'1.234'");
+		$this->assertEquals("'1.234'", $result);
 
 		$result = $this->Dbo->value('abc', 'string');
-		$this->assertEquals($result, "'abc'");
+		$this->assertEquals("'abc'", $result);
 
 		$result = $this->Dbo->value(' abc ', 'string');
-		$this->assertEquals($result, "' abc '");
+		$this->assertEquals("' abc '", $result);
 
 		$result = $this->Dbo->value('a bc', 'string');
-		$this->assertEquals($result, "'a bc'");
+		$this->assertEquals("'a bc'", $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -301,12 +301,12 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testColumnParsing() {
-		$this->assertEquals($this->Dbo2->column('text'), 'text');
-		$this->assertEquals($this->Dbo2->column('date'), 'date');
-		$this->assertEquals($this->Dbo2->column('boolean'), 'boolean');
-		$this->assertEquals($this->Dbo2->column('character varying'), 'string');
-		$this->assertEquals($this->Dbo2->column('time without time zone'), 'time');
-		$this->assertEquals($this->Dbo2->column('timestamp without time zone'), 'datetime');
+		$this->assertEquals('text', $this->Dbo2->column('text'));
+		$this->assertEquals('date', $this->Dbo2->column('date'));
+		$this->assertEquals('boolean', $this->Dbo2->column('boolean'));
+		$this->assertEquals('string', $this->Dbo2->column('character varying'));
+		$this->assertEquals('time', $this->Dbo2->column('time without time zone'));
+		$this->assertEquals('datetime', $this->Dbo2->column('timestamp without time zone'));
 	}
 
 /**
@@ -315,30 +315,30 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testValueQuoting() {
-		$this->assertEquals($this->Dbo->value(1.2, 'float'), "1.200000");
-		$this->assertEquals($this->Dbo->value('1,2', 'float'), "'1,2'");
+		$this->assertEquals("1.200000", $this->Dbo->value(1.2, 'float'));
+		$this->assertEquals("'1,2'", $this->Dbo->value('1,2', 'float'));
 
-		$this->assertEquals($this->Dbo->value('0', 'integer'), "0");
-		$this->assertEquals($this->Dbo->value('', 'integer'), 'NULL');
-		$this->assertEquals($this->Dbo->value('', 'float'), 'NULL');
-		$this->assertEquals($this->Dbo->value('', 'integer', false), "NULL");
-		$this->assertEquals($this->Dbo->value('', 'float', false), "NULL");
-		$this->assertEquals($this->Dbo->value('0.0', 'float'), "'0.0'");
+		$this->assertEquals("0", $this->Dbo->value('0', 'integer'));
+		$this->assertEquals('NULL', $this->Dbo->value('', 'integer'));
+		$this->assertEquals('NULL', $this->Dbo->value('', 'float'));
+		$this->assertEquals("NULL", $this->Dbo->value('', 'integer', false));
+		$this->assertEquals("NULL", $this->Dbo->value('', 'float', false));
+		$this->assertEquals("'0.0'", $this->Dbo->value('0.0', 'float'));
 
-		$this->assertEquals($this->Dbo->value('t', 'boolean'), "'TRUE'");
-		$this->assertEquals($this->Dbo->value('f', 'boolean'), "'FALSE'");
-		$this->assertEquals($this->Dbo->value(true), "'TRUE'");
-		$this->assertEquals($this->Dbo->value(false), "'FALSE'");
-		$this->assertEquals($this->Dbo->value('t'), "'t'");
-		$this->assertEquals($this->Dbo->value('f'), "'f'");
-		$this->assertEquals($this->Dbo->value('true', 'boolean'), "'TRUE'");
-		$this->assertEquals($this->Dbo->value('false', 'boolean'), "'FALSE'");
-		$this->assertEquals($this->Dbo->value('', 'boolean'), "'FALSE'");
-		$this->assertEquals($this->Dbo->value(0, 'boolean'), "'FALSE'");
-		$this->assertEquals($this->Dbo->value(1, 'boolean'), "'TRUE'");
-		$this->assertEquals($this->Dbo->value('1', 'boolean'), "'TRUE'");
-		$this->assertEquals($this->Dbo->value(null, 'boolean'), "NULL");
-		$this->assertEquals($this->Dbo->value(array()), "NULL");
+		$this->assertEquals("'TRUE'", $this->Dbo->value('t', 'boolean'));
+		$this->assertEquals("'FALSE'", $this->Dbo->value('f', 'boolean'));
+		$this->assertEquals("'TRUE'", $this->Dbo->value(true));
+		$this->assertEquals("'FALSE'", $this->Dbo->value(false));
+		$this->assertEquals("'t'", $this->Dbo->value('t'));
+		$this->assertEquals("'f'", $this->Dbo->value('f'));
+		$this->assertEquals("'TRUE'", $this->Dbo->value('true', 'boolean'));
+		$this->assertEquals("'FALSE'", $this->Dbo->value('false', 'boolean'));
+		$this->assertEquals("'FALSE'", $this->Dbo->value('', 'boolean'));
+		$this->assertEquals("'FALSE'", $this->Dbo->value(0, 'boolean'));
+		$this->assertEquals("'TRUE'", $this->Dbo->value(1, 'boolean'));
+		$this->assertEquals("'TRUE'", $this->Dbo->value('1', 'boolean'));
+		$this->assertEquals("NULL", $this->Dbo->value(null, 'boolean'));
+		$this->assertEquals("NULL", $this->Dbo->value(array()));
 	}
 
 /**
@@ -351,10 +351,10 @@ class PostgresTest extends CakeTestCase {
 		setlocale(LC_ALL, 'de_DE');
 
 		$result = $this->db->value(3.141593, 'float');
-		$this->assertEquals($result, "3.141593");
+		$this->assertEquals("3.141593", $result);
 
 		$result = $this->db->value(3.14);
-		$this->assertEquals($result, "3.140000");
+		$this->assertEquals("3.140000", $result);
 
 		setlocale(LC_ALL, $restore);
 	}
@@ -365,17 +365,17 @@ class PostgresTest extends CakeTestCase {
  * @return void
  */
 	public function testDateAndTimeAsNull() {
-		$this->assertEquals($this->Dbo->value(null, 'date'), 'NULL');
-		$this->assertEquals($this->Dbo->value('', 'date'), 'NULL');
+		$this->assertEquals('NULL', $this->Dbo->value(null, 'date'));
+		$this->assertEquals('NULL', $this->Dbo->value('', 'date'));
 
-		$this->assertEquals($this->Dbo->value('', 'datetime'), 'NULL');
-		$this->assertEquals($this->Dbo->value(null, 'datetime'), 'NULL');
+		$this->assertEquals('NULL', $this->Dbo->value('', 'datetime'));
+		$this->assertEquals('NULL', $this->Dbo->value(null, 'datetime'));
 
-		$this->assertEquals($this->Dbo->value('', 'timestamp'), 'NULL');
-		$this->assertEquals($this->Dbo->value(null, 'timestamp'), 'NULL');
+		$this->assertEquals('NULL', $this->Dbo->value('', 'timestamp'));
+		$this->assertEquals('NULL', $this->Dbo->value(null, 'timestamp'));
 
-		$this->assertEquals($this->Dbo->value('', 'time'), 'NULL');
-		$this->assertEquals($this->Dbo->value(null, 'time'), 'NULL');
+		$this->assertEquals('NULL', $this->Dbo->value('', 'time'));
+		$this->assertEquals('NULL', $this->Dbo->value(null, 'time'));
 	}
 
 /**
@@ -427,10 +427,10 @@ class PostgresTest extends CakeTestCase {
 			"INSERT INTO {$table} (\"user\", password) VALUES ('mariano', '{$password}')"
 		);
 
-		$this->assertEquals($db1->lastInsertId($table), 5);
+		$this->assertEquals(5, $db1->lastInsertId($table));
 
 		$db1->execute("INSERT INTO {$table} (\"user\", password) VALUES ('hoge', '{$password}')");
-		$this->assertEquals($db1->lastInsertId($table), 6);
+		$this->assertEquals(6, $db1->lastInsertId($table));
 	}
 
 /**
@@ -442,11 +442,11 @@ class PostgresTest extends CakeTestCase {
 	public function testColumnUseLength() {
 		$result = array('name' => 'foo', 'type' => 'string', 'length' => 100, 'default' => 'FOO');
 		$expected = '"foo" varchar(100) DEFAULT \'FOO\'';
-		$this->assertEquals($this->Dbo->buildColumn($result), $expected);
+		$this->assertEquals($expected, $this->Dbo->buildColumn($result));
 
 		$result = array('name' => 'foo', 'type' => 'text', 'length' => 100, 'default' => 'FOO');
 		$expected = '"foo" text DEFAULT \'FOO\'';
-		$this->assertEquals($this->Dbo->buildColumn($result), $expected);
+		$this->assertEquals($expected, $this->Dbo->buildColumn($result));
 	}
 
 /**
@@ -479,7 +479,7 @@ class PostgresTest extends CakeTestCase {
 		$model->save(compact('data'));
 
 		$result = $model->find('first');
-		$this->assertEquals($result['BinaryTest']['data'], $data);
+		$this->assertEquals($data, $result['BinaryTest']['data']);
 	}
 
 /**
@@ -633,10 +633,10 @@ class PostgresTest extends CakeTestCase {
 		$result = $model->schema();
 		$this->assertTrue(isset($result['status']));
 		$this->assertFalse(isset($result['published']));
-		$this->assertEquals($result['body']['type'], 'string');
-		$this->assertEquals($result['status']['default'], 1);
-		$this->assertEquals($result['author_id']['null'], true);
-		$this->assertEquals($result['title']['null'], false);
+		$this->assertEquals('string', $result['body']['type']);
+		$this->assertEquals(1, $result['status']['default']);
+		$this->assertEquals(true, $result['author_id']['null']);
+		$this->assertEquals(false, $result['title']['null']);
 
 		$this->Dbo->query($this->Dbo->dropSchema($New));
 
@@ -721,7 +721,7 @@ class PostgresTest extends CakeTestCase {
 		$this->assertEquals($schema3->tables['altertest']['indexes'], $indexes);
 
 		// Compare us to ourself.
-		$this->assertEquals($schema3->compare($schema3), array());
+		$this->assertEquals(array(), $schema3->compare($schema3));
 
 		// Drop the indexes
 		$this->Dbo->query($this->Dbo->alterSchema($schema1->compare($schema3)));
@@ -747,10 +747,10 @@ class PostgresTest extends CakeTestCase {
 			'subquery' => 'SELECT count(*) FROM ' . $Article->Comment->table
 		);
 		$result = $Article->find('first');
-		$this->assertEquals($result['Article']['next_id'], 2);
+		$this->assertEquals(2, $result['Article']['next_id']);
 		$this->assertEquals($result['Article']['complex'], $result['Article']['title'] . $result['Article']['body']);
 		$this->assertEquals($result['Article']['functional'], $result['User']['user']);
-		$this->assertEquals($result['Article']['subquery'], 6);
+		$this->assertEquals(6, $result['Article']['subquery']);
 	}
 
 /**
@@ -819,7 +819,7 @@ class PostgresTest extends CakeTestCase {
 		$result = $Article->find('count', array(
 			'conditions' => array('Article.title' => 'Awesome')
 		));
-		$this->assertEquals($result, 1, 'Article count is wrong or fixture has changed.');
+		$this->assertEquals(1, $result, 'Article count is wrong or fixture has changed.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -171,13 +171,13 @@ class SqliteTest extends CakeTestCase {
 		$db->execute("CREATE TABLE test_list (id VARCHAR(255));");
 
 		$db->cacheSources = true;
-		$this->assertEquals($db->listSources(), array('test_list'));
+		$this->assertEquals(array('test_list'), $db->listSources());
 		$db->cacheSources = false;
 
 		$fileName = '_' . preg_replace('/[^A-Za-z0-9_\-+]/', '_', TMP . $dbName) . '_list';
 
 		$result = Cache::read($fileName, '_cake_model_');
-		$this->assertEquals($result, array('test_list'));
+		$this->assertEquals(array('test_list'), $result);
 
 		Cache::delete($fileName, '_cake_model_');
 		Configure::write('Cache.disable', true);
@@ -327,7 +327,7 @@ class SqliteTest extends CakeTestCase {
 			'default' => null,
 			'key' => 'primary',
 		);
-		$this->assertEquals($result['id'], $expected);
+		$this->assertEquals($expected, $result['id']);
 		$this->Dbo->query('DROP TABLE ' . $tableName);
 
 		$tableName = 'uuid_tests';
@@ -341,7 +341,7 @@ class SqliteTest extends CakeTestCase {
 			'default' => null,
 			'key' => 'primary',
 		);
-		$this->assertEquals($result['id'], $expected);
+		$this->assertEquals($expected, $result['id']);
 		$this->Dbo->query('DROP TABLE ' . $tableName);
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -564,7 +564,7 @@ class SqlserverTest extends CakeTestCase {
 
 		$indexes = array('client_id' => array('column' => 'client_id'));
 		$result = $this->db->buildIndex($indexes, 'items');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 
 		$indexes = array('client_id' => array('column' => array('client_id', 'period_id'), 'unique' => 1));
 		$result = $this->db->buildIndex($indexes, 'items');
@@ -598,7 +598,7 @@ class SqlserverTest extends CakeTestCase {
 
 		$this->db->describe = $schema;
 		$result = $this->db->getPrimaryKey($this->model);
-		$this->assertEquals($result, 'id');
+		$this->assertEquals('id', $result);
 
 		unset($schema['id']['key']);
 		$this->db->describe = $schema;

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -118,22 +118,22 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testBooleanNullConditionsParsing() {
 		$result = $this->testDb->conditions(true);
-		$this->assertEquals($result, ' WHERE 1 = 1', 'true conditions failed %s');
+		$this->assertEquals(' WHERE 1 = 1', $result, 'true conditions failed %s');
 
 		$result = $this->testDb->conditions(false);
-		$this->assertEquals($result, ' WHERE 0 = 1', 'false conditions failed %s');
+		$this->assertEquals(' WHERE 0 = 1', $result, 'false conditions failed %s');
 
 		$result = $this->testDb->conditions(null);
-		$this->assertEquals($result, ' WHERE 1 = 1', 'null conditions failed %s');
+		$this->assertEquals(' WHERE 1 = 1', $result, 'null conditions failed %s');
 
 		$result = $this->testDb->conditions(array());
-		$this->assertEquals($result, ' WHERE 1 = 1', 'array() conditions failed %s');
+		$this->assertEquals(' WHERE 1 = 1', $result, 'array() conditions failed %s');
 
 		$result = $this->testDb->conditions('');
-		$this->assertEquals($result, ' WHERE 1 = 1', '"" conditions failed %s');
+		$this->assertEquals(' WHERE 1 = 1', $result, '"" conditions failed %s');
 
 		$result = $this->testDb->conditions(' ', '"  " conditions failed %s');
-		$this->assertEquals($result, ' WHERE 1 = 1');
+		$this->assertEquals(' WHERE 1 = 1', $result);
 	}
 
 /**
@@ -175,7 +175,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Topic', 'hasOne');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array('Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
@@ -198,7 +198,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'User2', 'belongsTo');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article2' => array(
@@ -213,7 +213,7 @@ class DboSourceTest extends CakeTestCase {
 			'Comment' => array()
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article' => array(
@@ -246,7 +246,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article' => array(
@@ -291,7 +291,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article' => array(
@@ -346,7 +346,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Comment', 'hasMany');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article' => array(
@@ -387,7 +387,7 @@ class DboSourceTest extends CakeTestCase {
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Tag', 'hasAndBelongsToMany');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 
 		$data = array(
 			'Article' => array(
@@ -418,7 +418,7 @@ class DboSourceTest extends CakeTestCase {
 			'Tag' => array('id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31')
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Tag', 'hasOne');
-		$this->assertEquals($data, $expected);
+		$this->assertEquals($expected, $data);
 	}
 
 /**
@@ -502,7 +502,7 @@ class DboSourceTest extends CakeTestCase {
 			$this->markTestSkipped('Cannot run this test with SqlServer');
 		}
 		$result = $this->db->value('{$__cakeForeignKey__$}');
-		$this->assertEquals($result, '{$__cakeForeignKey__$}');
+		$this->assertEquals('{$__cakeForeignKey__$}', $result);
 
 		$result = $this->db->value(array('first', 2, 'third'));
 		$expected = array('\'first\'', 2, '\'third\'');
@@ -517,7 +517,7 @@ class DboSourceTest extends CakeTestCase {
 	public function testReconnect() {
 		$this->testDb->reconnect(array('prefix' => 'foo'));
 		$this->assertTrue($this->testDb->connected);
-		$this->assertEquals($this->testDb->config['prefix'], 'foo');
+		$this->assertEquals('foo', $this->testDb->config['prefix']);
 	}
 
 /**
@@ -587,10 +587,10 @@ class DboSourceTest extends CakeTestCase {
 	public function testCacheMethod() {
 		$this->testDb->cacheMethods = true;
 		$result = $this->testDb->cacheMethod('name', 'some-key', 'stuff');
-		$this->assertEquals($result, 'stuff');
+		$this->assertEquals('stuff', $result);
 
 		$result = $this->testDb->cacheMethod('name', 'some-key');
-		$this->assertEquals($result, 'stuff');
+		$this->assertEquals('stuff', $result);
 
 		$result = $this->testDb->cacheMethod('conditions', 'some-key');
 		$this->assertNull($result);
@@ -600,7 +600,7 @@ class DboSourceTest extends CakeTestCase {
 
 		$this->testDb->cacheMethods = false;
 		$result = $this->testDb->cacheMethod('name', 'some-key', 'stuff');
-		$this->assertEquals($result, 'stuff');
+		$this->assertEquals('stuff', $result);
 
 		$result = $this->testDb->cacheMethod('name', 'some-key');
 		$this->assertNull($result);
@@ -652,9 +652,9 @@ class DboSourceTest extends CakeTestCase {
 		$log = $this->testDb->getLog();
 		$expected = array('query' => 'Query 1', 'params' => array(), 'affected' => '', 'numRows' => '', 'took' => '');
 
-		$this->assertEquals($log['log'][0], $expected);
+		$this->assertEquals($expected, $log['log'][0]);
 		$expected = array('query' => 'Query 2', 'params' => array(), 'affected' => '', 'numRows' => '', 'took' => '');
-		$this->assertEquals($log['log'][1], $expected);
+		$this->assertEquals($expected, $log['log'][1]);
 		$expected = array('query' => 'Error 1', 'affected' => '', 'numRows' => '', 'took' => '');
 	}
 
@@ -669,9 +669,9 @@ class DboSourceTest extends CakeTestCase {
 
 		$log = $this->testDb->getLog();
 		$expected = array('query' => 'Query 1', 'params' => array(1,2,'abc'), 'affected' => '', 'numRows' => '', 'took' => '');
-		$this->assertEquals($log['log'][0], $expected);
+		$this->assertEquals($expected, $log['log'][0]);
 		$expected = array('query' => 'Query 2', 'params' => array('field1' => 1, 'field2' => 'abc'), 'affected' => '', 'numRows' => '', 'took' => '');
-		$this->assertEquals($log['log'][1], $expected);
+		$this->assertEquals($expected, $log['log'][1]);
 	}
 
 /**
@@ -720,16 +720,16 @@ class DboSourceTest extends CakeTestCase {
 	public function testFullTablePermutations() {
 		$Article = ClassRegistry::init('Article');
 		$result = $this->testDb->fullTableName($Article, false, false);
-		$this->assertEquals($result, 'articles');
+		$this->assertEquals('articles', $result);
 
 		$Article->tablePrefix = 'tbl_';
 		$result = $this->testDb->fullTableName($Article, false, false);
-		$this->assertEquals($result, 'tbl_articles');
+		$this->assertEquals('tbl_articles', $result);
 
 		$Article->useTable = $Article->table = 'with spaces';
 		$Article->tablePrefix = '';
 		$result = $this->testDb->fullTableName($Article, true, false);
-		$this->assertEquals($result, '`with spaces`');
+		$this->assertEquals('`with spaces`', $result);
 
 		$this->loadFixtures('Article');
 		$Article->useTable = $Article->table = 'articles';

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -70,7 +70,7 @@ class ModelDeleteTest extends BaseModelTest {
 					'item_id' => 5,
 					'portfolio_id' => 1
 		)));
-		$this->assertEquals($result['Item'], $expected);
+		$this->assertEquals($expected, $result['Item']);
 
 		$result = $Portfolio->ItemsPortfolio->find('all', array(
 			'conditions' => array('ItemsPortfolio.portfolio_id' => 1)
@@ -112,7 +112,7 @@ class ModelDeleteTest extends BaseModelTest {
 		$result = $Portfolio->ItemsPortfolio->find('all', array(
 			'conditions' => array('ItemsPortfolio.portfolio_id' => 1)
 		));
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**
@@ -271,10 +271,10 @@ class ModelDeleteTest extends BaseModelTest {
 
 		$User->Post->delete(3);
 		$result = $User->read(null, 301);
-		$this->assertEquals($result['User']['post_count'], 0);
+		$this->assertEquals(0, $result['User']['post_count']);
 
 		$result = $User->read(null, 66);
-		$this->assertEquals($result['User']['post_count'], 2);
+		$this->assertEquals(2, $result['User']['post_count']);
 	}
 
 /**
@@ -460,13 +460,13 @@ class ModelDeleteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $TestModel->find('count');
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$result = $TestModel->Comment->find('count');
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$result = $TestModel->Comment->Attachment->find('count');
-		$this->assertEquals($result, 0);
+		$this->assertEquals(0, $result);
 	}
 
 /**
@@ -479,12 +479,12 @@ class ModelDeleteTest extends BaseModelTest {
 		$TestModel = new Article10();
 
 		$result = $TestModel->find('all');
-		$this->assertEquals(count($result[0]['Comment']), 4);
-		$this->assertEquals(count($result[1]['Comment']), 2);
-		$this->assertEquals($TestModel->Comment->find('count'), 6);
+		$this->assertEquals(4, count($result[0]['Comment']));
+		$this->assertEquals(2, count($result[1]['Comment']));
+		$this->assertEquals(6, $TestModel->Comment->find('count'));
 
 		$TestModel->delete(1);
-		$this->assertEquals($TestModel->Comment->find('count'), 2);
+		$this->assertEquals(2, $TestModel->Comment->find('count'));
 	}
 
 /**
@@ -673,12 +673,12 @@ class ModelDeleteTest extends BaseModelTest {
 		$joinedBs = $JoinA->JoinAsJoinB->find('count', array(
 			'conditions' => array('JoinAsJoinB.join_a_id' => 1)
 		));
-		$this->assertEquals($joinedBs, 0, 'JoinA/JoinB link records left over. %s');
+		$this->assertEquals(0, $joinedBs, 'JoinA/JoinB link records left over. %s');
 
 		$joinedBs = $JoinA->JoinAsJoinC->find('count', array(
 			'conditions' => array('JoinAsJoinC.join_a_id' => 1)
 		));
-		$this->assertEquals($joinedBs, 0, 'JoinA/JoinC link records left over. %s');
+		$this->assertEquals(0, $joinedBs, 'JoinA/JoinC link records left over. %s');
 	}
 
 /**
@@ -706,7 +706,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 
 		$ThePaper = new ThePaper();
 		$ThePaper->id = 2;
@@ -726,7 +726,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 
 		$ThePaper->delete(1);
 		$result = $ThePaper->findById(2);
@@ -743,7 +743,7 @@ class ModelDeleteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 	}
 
 /**
@@ -787,7 +787,7 @@ class ModelDeleteTest extends BaseModelTest {
 		$before = $Article->find("all", array(
 			"conditions" => array("Article.id" => 1),
 		));
-		$this->assertEquals(count($before[0]['Tag']), 2, 'Tag count for Article.id = 1 is incorrect, should be 2 %s');
+		$this->assertEquals(2, count($before[0]['Tag']), 'Tag count for Article.id = 1 is incorrect, should be 2 %s');
 
 		// From now on, Tag #1 is only associated with Post #1
 		$submittedData = array(

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -81,8 +81,8 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$this->assertFalse(property_exists($Article, 'ArticleFeaturedsTag'));
 		$this->assertInstanceOf('AppModel', $Article->ArticleFeaturedsTag);
-		$this->assertEquals($Article->hasAndBelongsToMany['Tag']['joinTable'], 'article_featureds_tags');
-		$this->assertEquals($Article->hasAndBelongsToMany['Tag']['associationForeignKey'], 'tag_id');
+		$this->assertEquals('article_featureds_tags', $Article->hasAndBelongsToMany['Tag']['joinTable']);
+		$this->assertEquals('tag_id', $Article->hasAndBelongsToMany['Tag']['associationForeignKey']);
 	}
 
 /**
@@ -151,7 +151,7 @@ class ModelIntegrationTest extends BaseModelTest {
 	public function testPkInHabtmLinkModelArticleB() {
 		$this->loadFixtures('Article', 'Tag', 'ArticlesTag');
 		$TestModel = new ArticleB();
-		$this->assertEquals($TestModel->ArticlesTag->primaryKey, 'article_id');
+		$this->assertEquals('article_id', $TestModel->ArticlesTag->primaryKey);
 	}
 
 /**
@@ -183,21 +183,21 @@ class ModelIntegrationTest extends BaseModelTest {
 		//Test Nonconformant Models
 		$this->loadFixtures('Content', 'ContentAccount', 'Account', 'JoinC', 'JoinAC', 'ItemsPortfolio');
 		$TestModel = new Content();
-		$this->assertEquals($TestModel->ContentAccount->primaryKey, 'iContentAccountsId');
+		$this->assertEquals('iContentAccountsId', $TestModel->ContentAccount->primaryKey);
 
 		//test conformant models with no PK in the join table
 		$this->loadFixtures('Article', 'Tag');
 		$TestModel = new Article();
-		$this->assertEquals($TestModel->ArticlesTag->primaryKey, 'article_id');
+		$this->assertEquals('article_id', $TestModel->ArticlesTag->primaryKey);
 
 		//test conformant models with PK in join table
 		$TestModel = new Portfolio();
-		$this->assertEquals($TestModel->ItemsPortfolio->primaryKey, 'id');
+		$this->assertEquals('id', $TestModel->ItemsPortfolio->primaryKey);
 
 		//test conformant models with PK in join table - join table contains extra field
 		$this->loadFixtures('JoinA', 'JoinB', 'JoinAB');
 		$TestModel = new JoinA();
-		$this->assertEquals($TestModel->JoinAsJoinB->primaryKey, 'id');
+		$this->assertEquals('id', $TestModel->JoinAsJoinB->primaryKey);
 	}
 
 /**
@@ -428,12 +428,12 @@ class ModelIntegrationTest extends BaseModelTest {
 				'Comment' => array(),
 				'Tag' => array()
 		));
-		$this->assertEquals($TestModel->find('all'), $expected);
+		$this->assertEquals($expected, $TestModel->find('all'));
 
 		$db2 = ConnectionManager::getDataSource('test2');
 		$this->fixtureManager->loadSingle('User', $db2);
 		$this->fixtureManager->loadSingle('Comment', $db2);
-		$this->assertEquals($TestModel->find('count'), 3);
+		$this->assertEquals(3, $TestModel->find('count'));
 
 		$TestModel->User->setDataSource('test2');
 		$TestModel->Comment->setDataSource('test2');
@@ -457,8 +457,8 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertEquals($expected, $result);
 
 		$result = Set::extract($TestModel->User->find('all'), '{n}.User.id');
-		$this->assertEquals($result, array('1', '2', '3', '4'));
-		$this->assertEquals($TestModel->find('all'), $expected);
+		$this->assertEquals(array('1', '2', '3', '4'), $result);
+		$this->assertEquals($expected, $TestModel->find('all'));
 
 		$TestModel->Comment->unbindModel(array('hasOne' => array('Attachment')));
 		$expected = array(
@@ -618,7 +618,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'created' => '2007-03-18 10:41:23',
 					'updated' => '2007-03-18 10:43:31'
 		)));
-		$this->assertEquals($TestModel->Comment->find('all'), $expected);
+		$this->assertEquals($expected, $TestModel->Comment->find('all'));
 	}
 
 /**
@@ -632,7 +632,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Site = new Site();
 		$results = $Site->find('count');
 		$expected = 3;
-		$this->assertEquals($results, $expected);
+		$this->assertEquals($expected, $results);
 
 		$data = $Site->findById(1);
 
@@ -880,9 +880,9 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Comment = new Comment();
 		$Person = new Person();
 
-		$this->assertEquals($Post->displayField, 'title');
-		$this->assertEquals($Person->displayField, 'name');
-		$this->assertEquals($Comment->displayField, 'id');
+		$this->assertEquals('title', $Post->displayField);
+		$this->assertEquals('name', $Person->displayField);
+		$this->assertEquals('id', $Comment->displayField);
 	}
 
 /**
@@ -895,13 +895,13 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$result = $Post->schema();
 		$columns = array('id', 'author_id', 'title', 'body', 'published', 'created', 'updated');
-		$this->assertEquals(array_keys($result), $columns);
+		$this->assertEquals($columns, array_keys($result));
 
 		$types = array('integer', 'integer', 'string', 'text', 'string', 'datetime', 'datetime');
 		$this->assertEquals(Set::extract(array_values($result), '{n}.type'), $types);
 
 		$result = $Post->schema('body');
-		$this->assertEquals($result['type'], 'text');
+		$this->assertEquals('text', $result['type']);
 		$this->assertNull($Post->schema('foo'));
 
 		$this->assertEquals($Post->getColumnTypes(), array_combine($columns, $types));
@@ -986,7 +986,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('mytime' => $result));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 	}
 
 /**
@@ -1011,7 +1011,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['date']['year'] = '';
@@ -1021,7 +1021,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('date' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -1034,7 +1034,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => '2007-08-20 00:00:00'));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -1047,7 +1047,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => '2007-08-20 10:12:00'));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -1060,7 +1060,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '20';
@@ -1069,7 +1069,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '20';
@@ -1079,7 +1079,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['hour'] = '13';
@@ -1095,7 +1095,7 @@ class ModelIntegrationTest extends BaseModelTest {
 			'created' => '',
 			'date' => '2006-12-25'
 		));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -1115,7 +1115,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'created' => '2007-08-20 10:12:09',
 				'date' => '2006-12-25'
 		));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '--';
@@ -1131,7 +1131,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => '', 'date' => ''));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['created']['year'] = '2007';
@@ -1147,7 +1147,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => '', 'date' => '2006-12-25'));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$data = array();
 		$data['Apple']['date']['year'] = '2006';
@@ -1157,7 +1157,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('date' => '2006-12-25'));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 
 		$db = ConnectionManager::getDataSource('test');
 		$data = array();
@@ -1266,7 +1266,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Article->id = 2;
 		$Article->saveField('title', 'Staying alive');
 		$result = $Article->read(null, 2);
-		$this->assertEquals($result['Article']['title'], 'Staying alive');
+		$this->assertEquals('Staying alive', $result['Article']['title']);
 	}
 
 /**
@@ -1432,15 +1432,15 @@ class ModelIntegrationTest extends BaseModelTest {
 		}
 
 		$Article->bindModel(array('hasMany' => array('Category')));
-		$this->assertEquals($Article->getAssociated('hasMany'), array('Comment', 'Category'));
+		$this->assertEquals(array('Comment', 'Category'), $Article->getAssociated('hasMany'));
 
 		$results = $Article->getAssociated();
 		$results = array_keys($results);
 		sort($results);
-		$this->assertEquals($results, array('Category', 'Comment', 'Tag', 'User'));
+		$this->assertEquals(array('Category', 'Comment', 'Tag', 'User'), $results);
 
 		$Article->unbindModel(array('hasAndBelongsToMany' => array('Tag')));
-		$this->assertEquals($Article->getAssociated('hasAndBelongsToMany'), array());
+		$this->assertEquals(array(), $Article->getAssociated('hasAndBelongsToMany'));
 
 		$result = $Article->getAssociated('Category');
 		$expected = array(
@@ -1499,10 +1499,10 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertSame($TestModel->belongsTo, $expected);
 		$this->assertSame($TestFakeModel->belongsTo, $expected);
 
-		$this->assertEquals($TestModel->User->name, 'User');
-		$this->assertEquals($TestFakeModel->User->name, 'User');
-		$this->assertEquals($TestModel->Category->name, 'Category');
-		$this->assertEquals($TestFakeModel->Category->name, 'Category');
+		$this->assertEquals('User', $TestModel->User->name);
+		$this->assertEquals('User', $TestFakeModel->User->name);
+		$this->assertEquals('Category', $TestModel->Category->name);
+		$this->assertEquals('Category', $TestFakeModel->Category->name);
 
 		$expected = array(
 			'Featured' => array(
@@ -1517,8 +1517,8 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertSame($TestModel->hasOne, $expected);
 		$this->assertSame($TestFakeModel->hasOne, $expected);
 
-		$this->assertEquals($TestModel->Featured->name, 'Featured');
-		$this->assertEquals($TestFakeModel->Featured->name, 'Featured');
+		$this->assertEquals('Featured', $TestModel->Featured->name);
+		$this->assertEquals('Featured', $TestFakeModel->Featured->name);
 
 		$expected = array(
 			'Comment' => array(
@@ -1538,8 +1538,8 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertSame($TestModel->hasMany, $expected);
 		$this->assertSame($TestFakeModel->hasMany, $expected);
 
-		$this->assertEquals($TestModel->Comment->name, 'Comment');
-		$this->assertEquals($TestFakeModel->Comment->name, 'Comment');
+		$this->assertEquals('Comment', $TestModel->Comment->name);
+		$this->assertEquals('Comment', $TestFakeModel->Comment->name);
 
 		$expected = array(
 			'Tag' => array(
@@ -1563,8 +1563,8 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->assertSame($TestModel->hasAndBelongsToMany, $expected);
 		$this->assertSame($TestFakeModel->hasAndBelongsToMany, $expected);
 
-		$this->assertEquals($TestModel->Tag->name, 'Tag');
-		$this->assertEquals($TestFakeModel->Tag->name, 'Tag');
+		$this->assertEquals('Tag', $TestModel->Tag->name);
+		$this->assertEquals('Tag', $TestFakeModel->Tag->name);
 	}
 
 /**
@@ -1592,13 +1592,13 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->loadFixtures('Post');
 
 		$TestModel = ClassRegistry::init('MergeVarPluginPost');
-		$this->assertEquals($TestModel->actsAs, array('Containable' => null, 'Tree' => null));
+		$this->assertEquals(array('Containable' => null, 'Tree' => null), $TestModel->actsAs);
 		$this->assertTrue(isset($TestModel->Behaviors->Containable));
 		$this->assertTrue(isset($TestModel->Behaviors->Tree));
 
 		$TestModel = ClassRegistry::init('MergeVarPluginComment');
 		$expected = array('Containable' => array('some_settings'));
-		$this->assertEquals($TestModel->actsAs, $expected);
+		$this->assertEquals($expected, $TestModel->actsAs);
 		$this->assertTrue(isset($TestModel->Behaviors->Containable));
 	}
 
@@ -1627,15 +1627,15 @@ class ModelIntegrationTest extends BaseModelTest {
  */
 	public function testColumnTypeFetching() {
 		$model = new Test();
-		$this->assertEquals($model->getColumnType('id'), 'integer');
-		$this->assertEquals($model->getColumnType('notes'), 'text');
-		$this->assertEquals($model->getColumnType('updated'), 'datetime');
-		$this->assertEquals($model->getColumnType('unknown'), null);
+		$this->assertEquals('integer', $model->getColumnType('id'));
+		$this->assertEquals('text', $model->getColumnType('notes'));
+		$this->assertEquals('datetime', $model->getColumnType('updated'));
+		$this->assertEquals(null, $model->getColumnType('unknown'));
 
 		$model = new Article();
-		$this->assertEquals($model->getColumnType('User.created'), 'datetime');
-		$this->assertEquals($model->getColumnType('Tag.id'), 'integer');
-		$this->assertEquals($model->getColumnType('Article.id'), 'integer');
+		$this->assertEquals('datetime', $model->getColumnType('User.created'));
+		$this->assertEquals('integer', $model->getColumnType('Tag.id'));
+		$this->assertEquals('integer', $model->getColumnType('Article.id'));
 	}
 
 /**
@@ -2232,7 +2232,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'end_date' => '2008-06-20 00:00:00'
 		));
 
-		$this->assertEquals($FeaturedModel->create($data), $expected);
+		$this->assertEquals($expected, $FeaturedModel->create($data));
 
 		$data = array(
 			'published_date' => array(
@@ -2257,7 +2257,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'category_id' => 1
 		));
 
-		$this->assertEquals($FeaturedModel->create($data), $expected);
+		$this->assertEquals($expected, $FeaturedModel->create($data));
 	}
 
 /**
@@ -2353,10 +2353,10 @@ class ModelIntegrationTest extends BaseModelTest {
 		$this->loadFixtures('Player', 'Guild', 'GuildsPlayer');
 
 		$Player = ClassRegistry::init('Player');
-		$this->assertEquals($Player->useDbConfig, 'test');
-		$this->assertEquals($Player->Guild->useDbConfig, 'test');
-		$this->assertEquals($Player->Guild->GuildsPlayer->useDbConfig, 'test2');
-		$this->assertEquals($Player->GuildsPlayer->useDbConfig, 'test2');
+		$this->assertEquals('test', $Player->useDbConfig);
+		$this->assertEquals('test', $Player->Guild->useDbConfig);
+		$this->assertEquals('test2', $Player->Guild->GuildsPlayer->useDbConfig);
+		$this->assertEquals('test2', $Player->GuildsPlayer->useDbConfig);
 
 		$players = $Player->find('all', array('recursive' => -1));
 		$guilds = $Player->Guild->find('all', array('recursive' => -1));

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -73,12 +73,12 @@ class ModelReadTest extends BaseModelTest {
 
 		$result = $Something->JoinThing->find('all', array('conditions' => array('something_else_id' => 2)));
 
-		$this->assertEquals($result[0]['JoinThing']['doomed'], true);
-		$this->assertEquals($result[1]['JoinThing']['doomed'], false);
+		$this->assertEquals(true, $result[0]['JoinThing']['doomed']);
+		$this->assertEquals(false, $result[1]['JoinThing']['doomed']);
 
 		$result = $Something->find('first');
 
-		$this->assertEquals(count($result['SomethingElse']), 2);
+		$this->assertEquals(2, count($result['SomethingElse']));
 
 		$doomed = Set::extract('/JoinThing/doomed', $result['SomethingElse']);
 		$this->assertTrue(in_array(true, $doomed));
@@ -260,7 +260,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$results = $Article->query($query);
 		$this->assertTrue(is_array($results));
-		$this->assertEquals(count($results), 2);
+		$this->assertEquals(2, count($results));
 
 		$query  = 'SELECT title, body FROM ';
 		$query .= $this->db->fullTableName('articles');
@@ -3595,9 +3595,9 @@ class ModelReadTest extends BaseModelTest {
 		$result = $TestModel->find('neighbors', array('fields' => array('id')));
 
 		$this->assertNull($result['prev']);
-		$this->assertEquals($result['next']['Article'], array('id' => 2));
-		$this->assertEquals(count($result['next']['Comment']), 2);
-		$this->assertEquals(count($result['next']['Tag']), 2);
+		$this->assertEquals(array('id' => 2), $result['next']['Article']);
+		$this->assertEquals(2, count($result['next']['Comment']));
+		$this->assertEquals(2, count($result['next']['Tag']));
 
 		$TestModel->id = 2;
 		$TestModel->recursive = 0;
@@ -3621,9 +3621,9 @@ class ModelReadTest extends BaseModelTest {
 		$result = $TestModel->find('neighbors', array('fields' => array('id')));
 
 		$this->assertNull($result['next']);
-		$this->assertEquals($result['prev']['Article'], array('id' => 2));
-		$this->assertEquals(count($result['prev']['Comment']), 2);
-		$this->assertEquals(count($result['prev']['Tag']), 2);
+		$this->assertEquals(array('id' => 2), $result['prev']['Article']);
+		$this->assertEquals(2, count($result['prev']['Comment']));
+		$this->assertEquals(2, count($result['prev']['Tag']));
 
 		$TestModel->id = 1;
 		$result = $TestModel->find('neighbors', array('recursive' => -1));
@@ -4266,7 +4266,7 @@ class ModelReadTest extends BaseModelTest {
 
 		$TestModel->resetAssociations();
 		$result = $TestModel->hasMany;
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 
 		$result = $TestModel->bindModel(array('hasMany' => array('Comment')), false);
 		$this->assertTrue($result);
@@ -4583,7 +4583,7 @@ class ModelReadTest extends BaseModelTest {
 			'order' => '',
 			'counterCache' => ''
 		);
-		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($expected, $TestModel2->belongsTo['FeatureSet']);
 
 		$TestModel2->bindModel(array(
 			'belongsTo' => array(
@@ -4594,7 +4594,7 @@ class ModelReadTest extends BaseModelTest {
 			)
 		));
 		$expected['conditions'] = array('active' => true);
-		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($expected, $TestModel2->belongsTo['FeatureSet']);
 
 		$TestModel2->bindModel(array(
 			'belongsTo' => array(
@@ -4607,7 +4607,7 @@ class ModelReadTest extends BaseModelTest {
 		));
 		$expected['conditions'] = array('Feature.name' => 'DeviceType.name');
 		$expected['foreignKey'] = false;
-		$this->assertEquals($TestModel2->belongsTo['FeatureSet'], $expected);
+		$this->assertEquals($expected, $TestModel2->belongsTo['FeatureSet']);
 
 		$TestModel2->bindModel(array(
 			'hasMany' => array(
@@ -4631,7 +4631,7 @@ class ModelReadTest extends BaseModelTest {
 			'finderQuery' => '',
 			'counterQuery' => ''
 		);
-		$this->assertEquals($TestModel2->hasMany['NewFeatureSet'], $expected);
+		$this->assertEquals($expected, $TestModel2->hasMany['NewFeatureSet']);
 		$this->assertTrue(is_object($TestModel2->NewFeatureSet));
 	}
 
@@ -5016,7 +5016,7 @@ class ModelReadTest extends BaseModelTest {
 			'updated' => '2007-03-18 10:47:31',
 			'callback' => 'Fire'
 		);
-		$this->assertEquals($result[0]['Post'][0]['Comment'][0], $expected);
+		$this->assertEquals($expected, $result[0]['Post'][0]['Comment'][0]);
 	}
 
 /**
@@ -5131,7 +5131,7 @@ class ModelReadTest extends BaseModelTest {
 			'created' => '2007-03-18 10:45:23',
 			'updated' => '2007-03-18 10:47:31'
 		);
-		$this->assertEquals($result[0]['Post'][0]['Comment'][0], $expected);
+		$this->assertEquals($expected, $result[0]['Post'][0]['Comment'][0]);
 	}
 
 /**
@@ -5459,7 +5459,7 @@ class ModelReadTest extends BaseModelTest {
 				'tag' => 'tag2'
 		));
 
-		$this->assertEquals($result['Tag'], $expected);
+		$this->assertEquals($expected, $result['Tag']);
 	}
 
 /**
@@ -6598,8 +6598,8 @@ class ModelReadTest extends BaseModelTest {
 			7 => 'Some odd color'
 		);
 
-		$this->assertEquals($TestModel->find('list'), $expected);
-		$this->assertEquals($TestModel->Parent->find('list'), $expected);
+		$this->assertEquals($expected, $TestModel->find('list'));
+		$this->assertEquals($expected, $TestModel->Parent->find('list'));
 
 		$TestModel = new Post();
 		$result = $TestModel->find('list', array(
@@ -6730,22 +6730,22 @@ class ModelReadTest extends BaseModelTest {
 
 		$TestModel->id = 1;
 		$result = $TestModel->field('user');
-		$this->assertEquals($result, 'mariano');
+		$this->assertEquals('mariano', $result);
 
 		$result = $TestModel->field('User.user');
-		$this->assertEquals($result, 'mariano');
+		$this->assertEquals('mariano', $result);
 
 		$TestModel->id = false;
 		$result = $TestModel->field('user', array(
 			'user' => 'mariano'
 		));
-		$this->assertEquals($result, 'mariano');
+		$this->assertEquals('mariano', $result);
 
 		$result = $TestModel->field('COUNT(*) AS count', true);
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$result = $TestModel->field('COUNT(*)', true);
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 	}
 
 /**
@@ -6781,7 +6781,7 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel = new User();
 		$this->db->getLog(false, true);
 		$result = $TestModel->find('count');
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$this->db->getLog(false, true);
 		$fullDebug = $this->db->fullDebug;
@@ -6789,7 +6789,7 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel->order = 'User.id';
 		$result = $TestModel->find('count');
 		$this->db->fullDebug = $fullDebug;
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$log = $this->db->getLog();
 		$this->assertTrue(isset($log['log'][0]['query']));
@@ -6817,7 +6817,7 @@ class ModelReadTest extends BaseModelTest {
 		$Project->id = 3;
 		$result = $Project->find('first');
 
-		$this->assertEquals($result['Project']['name'], 'Project 1', 'Wrong record retrieved');
+		$this->assertEquals('Project 1', $result['Project']['name'], 'Wrong record retrieved');
 	}
 
 /**
@@ -6836,7 +6836,7 @@ class ModelReadTest extends BaseModelTest {
 		$TestModel->create(array('name' => 'project')) && $TestModel->save();
 
 		$result = $TestModel->find('count', array('fields' => 'DISTINCT name'));
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 	}
 
 /**
@@ -6854,12 +6854,12 @@ class ModelReadTest extends BaseModelTest {
 		$result = $TestModel->find('count', array('conditions' => array(
 			$db->expression('Project.name = \'Project 3\'')
 		)));
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 
 		$result = $TestModel->find('count', array('conditions' => array(
 			'Project.name' => $db->expression('\'Project 3\'')
 		)));
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 	}
 
 /**
@@ -7573,9 +7573,9 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('Comment');
 		$Comment = new AgainModifiedComment();
 		$comments = $Comment->find('all');
-		$this->assertEquals($comments[0]['Comment']['querytype'], 'all');
+		$this->assertEquals('all', $comments[0]['Comment']['querytype']);
 		$comments = $Comment->find('first');
-		$this->assertEquals($comments['Comment']['querytype'], 'first');
+		$this->assertEquals('first', $comments['Comment']['querytype']);
 	}
 
 /**
@@ -7591,13 +7591,13 @@ class ModelReadTest extends BaseModelTest {
 		$Post = ClassRegistry::init('Post');
 		$Post->virtualFields = array('two' => "1 + 1");
 		$result = $Post->find('first');
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 
 		// SQL Server does not support operators in expressions
 		if (!($this->db instanceof Sqlserver)) {
 			$Post->Author->virtualFields = array('false' => '1 = 2');
 			$result = $Post->find('first');
-			$this->assertEquals($result['Post']['two'], 2);
+			$this->assertEquals(2, $result['Post']['two']);
 			$this->assertFalse((bool)$result['Author']['false']);
 		}
 
@@ -7606,33 +7606,33 @@ class ModelReadTest extends BaseModelTest {
 		$this->assertFalse(isset($result['Author']['false']));
 
 		$result = $Post->find('first',array('fields' => array('author_id', 'two')));
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 		$this->assertFalse(isset($result['Author']['false']));
 
 		$result = $Post->find('first',array('fields' => array('two')));
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 
 		$Post->id = 1;
 		$result = $Post->field('two');
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('two' => 2),
 			'limit' => 1
 		));
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('two <' => 3),
 			'limit' => 1
 		));
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 
 		$result = $Post->find('first',array(
 			'conditions' => array('NOT' => array('two >' => 3)),
 			'limit' => 1
 		));
-		$this->assertEquals($result['Post']['two'], 2);
+		$this->assertEquals(2, $result['Post']['two']);
 
 		$dbo = $Post->getDataSource();
 		$Post->virtualFields = array('other_field' => 'Post.id + 1');
@@ -7640,24 +7640,24 @@ class ModelReadTest extends BaseModelTest {
 			'conditions' => array('other_field' => 3),
 			'limit' => 1
 		));
-		$this->assertEquals($result['Post']['id'], 2);
+		$this->assertEquals(2, $result['Post']['id']);
 
 		$Post->virtualFields = array('other_field' => 'Post.id + 1');
 		$result = $Post->find('all', array(
 			'fields' => array($dbo->calculate($Post, 'max', array('other_field')))
 		));
-		$this->assertEquals($result[0][0]['other_field'], 4);
+		$this->assertEquals(4, $result[0][0]['other_field']);
 
 		ClassRegistry::flush();
 		$Writing = ClassRegistry::init(array('class' => 'Post', 'alias' => 'Writing'), 'Model');
 		$Writing->virtualFields = array('two' => "1 + 1");
 		$result = $Writing->find('first');
-		$this->assertEquals($result['Writing']['two'], 2);
+		$this->assertEquals(2, $result['Writing']['two']);
 
 		$Post->create();
 		$Post->virtualFields = array('other_field' => 'COUNT(Post.id) + 1');
 		$result = $Post->field('other_field');
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 	}
 
 /**
@@ -7735,7 +7735,7 @@ class ModelReadTest extends BaseModelTest {
 			'group' => array('low_title')
 		));
 
-		$this->assertEquals($result, $expectation);
+		$this->assertEquals($expectation, $result);
 
 		$Author = ClassRegistry::init('Author');
 		$Author->virtualFields = array(

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -53,7 +53,7 @@ class ModelValidationTest extends BaseModelTest {
 			'or' => true,
 			'ignoreOnSame' => 'id'
 		);
-		$this->assertEquals($TestModel->validatorParams, $expected);
+		$this->assertEquals($expected, $TestModel->validatorParams);
 
 		$TestModel->validate['title'] = array(
 			'rule' => 'customValidatorWithMessage',
@@ -63,7 +63,7 @@ class ModelValidationTest extends BaseModelTest {
 			'title' => array('This field will *never* validate! Muhahaha!')
 		);
 
-		$this->assertEquals($TestModel->invalidFields(), $expected);
+		$this->assertEquals($expected, $TestModel->invalidFields());
 
 		$TestModel->validate['title'] = array(
 			'rule' => array('customValidatorWithSixParams', 'one', 'two', null, 'four'),
@@ -88,7 +88,7 @@ class ModelValidationTest extends BaseModelTest {
 			),
 			'six' => 6
 		);
-		$this->assertEquals($TestModel->validatorParams, $expected);
+		$this->assertEquals($expected, $TestModel->validatorParams);
 
 		$TestModel->validate['title'] = array(
 			'rule' => array('customValidatorWithSixParams', 'one', array('two'), null, 'four', array('five' => 5)),
@@ -113,7 +113,7 @@ class ModelValidationTest extends BaseModelTest {
 				'required' => true
 			)
 		);
-		$this->assertEquals($TestModel->validatorParams, $expected);
+		$this->assertEquals($expected, $TestModel->validatorParams);
 	}
 
 /**
@@ -137,14 +137,14 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'title' => array('This field cannot be left blank')
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name')));
 		$expected = array(
 			'name' => array('This field cannot be left blank')
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name', 'title')));
@@ -152,13 +152,13 @@ class ModelValidationTest extends BaseModelTest {
 			'name' => array('This field cannot be left blank'),
 			'title' => array('This field cannot be left blank')
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->whitelist = array('name');
 		$TestModel->invalidFields();
 		$expected = array('name' => array('This field cannot be left blank'));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$this->assertEquals($TestModel->validate, $validate);
 	}
@@ -184,7 +184,7 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel->save(array('name' => '#$$#', 'title' => '$$$$'));
 
 		$expected = array('name' => array('This field cannot be left blank'));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
 
 /**
@@ -207,7 +207,7 @@ class ModelValidationTest extends BaseModelTest {
 			'body' => 'body'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -225,7 +225,7 @@ class ModelValidationTest extends BaseModelTest {
 			'body' => 'body'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -235,7 +235,7 @@ class ModelValidationTest extends BaseModelTest {
 			'body' => 'body'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -248,7 +248,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => ''
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -259,7 +259,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => '2007-05-01'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -270,7 +270,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => 'invalid-date-here'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -281,7 +281,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => 0
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -292,7 +292,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => '0'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -300,19 +300,19 @@ class ModelValidationTest extends BaseModelTest {
 
 		$data = array('TestValidate' => array('modified' => null));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
 		$data = array('TestValidate' => array('modified' => false));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
 		$data = array('TestValidate' => array('modified' => ''));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -320,7 +320,7 @@ class ModelValidationTest extends BaseModelTest {
 			'modified' => '2007-05-01'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -333,7 +333,7 @@ class ModelValidationTest extends BaseModelTest {
 			'slug' => ''
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -344,7 +344,7 @@ class ModelValidationTest extends BaseModelTest {
 			'slug' => 'slug-right-here'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -355,7 +355,7 @@ class ModelValidationTest extends BaseModelTest {
 			'slug' => 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -375,7 +375,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => '0'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -384,7 +384,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => 0
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -393,7 +393,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => '3'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -402,7 +402,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => 3
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -422,7 +422,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => '3'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -431,7 +431,7 @@ class ModelValidationTest extends BaseModelTest {
 			'number' => 3
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -443,19 +443,19 @@ class ModelValidationTest extends BaseModelTest {
 
 		$data = array('TestValidate' => array('title' => ''));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
 		$data = array('TestValidate' => array('title' => 'new title'));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
 		$data = array('TestValidate' => array('title' => 'title-new'));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -465,7 +465,7 @@ class ModelValidationTest extends BaseModelTest {
 		));
 		$data = array('TestValidate' => array('title' => ''));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -477,7 +477,7 @@ class ModelValidationTest extends BaseModelTest {
 		)));
 		$data = array('TestValidate' => array('title' => ''));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -487,7 +487,7 @@ class ModelValidationTest extends BaseModelTest {
 		));
 		$data = array('TestValidate' => array('title' => 'My Article Title'));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertFalse($result);
 
@@ -495,7 +495,7 @@ class ModelValidationTest extends BaseModelTest {
 			'title' => 'My Article With a Different Title'
 		));
 		$result = $TestModel->create($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 		$result = $TestModel->validates();
 		$this->assertTrue($result);
 
@@ -569,7 +569,7 @@ class ModelValidationTest extends BaseModelTest {
 		$Something->create();
 		$result = $Something->save($data);
 		$this->assertFalse($result, 'Save occurred even when with models failed. %s');
-		$this->assertEquals($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($expectedError, $JoinThing->validationErrors);
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
 		$this->assertSame($count, 0);
 
@@ -592,7 +592,7 @@ class ModelValidationTest extends BaseModelTest {
 		$joinRecords = $JoinThing->find('count', array(
 			'conditions' => array('JoinThing.something_id' => $data['Something']['id'])
 		));
-		$this->assertEquals($joinRecords, 0, 'Records were saved on the join table. %s');
+		$this->assertEquals(0, $joinRecords, 'Records were saved on the join table. %s');
 	}
 
 /**
@@ -621,12 +621,12 @@ class ModelValidationTest extends BaseModelTest {
 		$Something->create();
 		$result = $Something->saveAll($data, array('validate' => 'only'));
 		$this->assertFalse($result);
-		$this->assertEquals($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($expectedError, $JoinThing->validationErrors);
 
 		$Something->create();
 		$result = $Something->saveAll($data, array('validate' => 'first'));
 		$this->assertFalse($result);
-		$this->assertEquals($JoinThing->validationErrors, $expectedError);
+		$this->assertEquals($expectedError, $JoinThing->validationErrors);
 
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
 		$this->assertSame($count, 0);
@@ -634,7 +634,7 @@ class ModelValidationTest extends BaseModelTest {
 		$joinRecords = $JoinThing->find('count', array(
 			'conditions' => array('JoinThing.something_id' => $data['Something']['id'])
 		));
-		$this->assertEquals($joinRecords, 0, 'Records were saved on the join table. %s');
+		$this->assertEquals(0, $joinRecords, 'Records were saved on the join table. %s');
 	}
 
 /**
@@ -716,7 +716,7 @@ class ModelValidationTest extends BaseModelTest {
 			)
 		);
 		$TestModel->invalidFields(array('fieldList' => array('title')));
-		$this->assertEquals($TestModel->validationErrors, array());
+		$this->assertEquals(array(), $TestModel->validationErrors);
 	}
 
 /**
@@ -748,7 +748,7 @@ class ModelValidationTest extends BaseModelTest {
 				'Minimum length allowed is 6 chars',
 			)
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$TestModel->create(array('title' => 'foo'));
 		$TestModel->invalidFields();
@@ -758,7 +758,7 @@ class ModelValidationTest extends BaseModelTest {
 				'You may enter up to 14 chars (minimum is 6 chars)'
 			)
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -57,7 +57,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->JoinAsJoinB->save($data);
 		$lastInsertId = $TestModel->JoinAsJoinB->getLastInsertID();
 		$data['id'] = $lastInsertId;
-		$this->assertEquals($result, array('JoinAsJoinB' => $data));
+		$this->assertEquals(array('JoinAsJoinB' => $data), $result);
 		$this->assertTrue($lastInsertId != null);
 
 		$result = $TestModel->JoinAsJoinB->findById(1);
@@ -78,7 +78,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $TestModel->JoinAsJoinB->findById(1);
-		$this->assertEquals($result['JoinAsJoinB']['other'], $updatedValue);
+		$this->assertEquals($updatedValue, $result['JoinAsJoinB']['other']);
 	}
 
 /**
@@ -108,7 +108,7 @@ class ModelWriteTest extends BaseModelTest {
 		$testResult = $Article->find('first', array('conditions' => array('Article.title' => 'Test Title')));
 
 		$this->assertEquals($testResult['Article']['title'], $data['Article']['title']);
-		$this->assertEquals($testResult['Article']['created'], '2008-01-01 00:00:00');
+		$this->assertEquals('2008-01-01 00:00:00', $testResult['Article']['created']);
 	}
 
 /**
@@ -121,7 +121,7 @@ class ModelWriteTest extends BaseModelTest {
 		$UnderscoreField = new UnderscoreField();
 
 		$currentCount = $UnderscoreField->find('count');
-		$this->assertEquals($currentCount, 3);
+		$this->assertEquals(3, $currentCount);
 		$data = array('UnderscoreField' => array(
 			'user_id' => '1',
 			'my_model_has_a_field' => 'Content here',
@@ -133,7 +133,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($ret));
 
 		$currentCount = $UnderscoreField->find('count');
-		$this->assertEquals($currentCount, 4);
+		$this->assertEquals(4, $currentCount);
 	}
 
 /**
@@ -154,7 +154,7 @@ class ModelWriteTest extends BaseModelTest {
 			array_keys($result['Uuid']),
 			array('id', 'title', 'count', 'created', 'updated')
 		);
-		$this->assertEquals(strlen($result['Uuid']['id']), 36);
+		$this->assertEquals(36, strlen($result['Uuid']['id']));
 	}
 
 /**
@@ -176,7 +176,7 @@ class ModelWriteTest extends BaseModelTest {
 			array_keys($result['Uuid']),
 			array('id', 'title', 'count', 'created', 'updated')
 		);
-		$this->assertEquals(strlen($result['Uuid']['id']), 36);
+		$this->assertEquals(36, strlen($result['Uuid']['id']));
 	}
 
 /**
@@ -193,8 +193,8 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->create(array());
 		$TestModel->save();
 		$result = $TestModel->findById($TestModel->id);
-		$this->assertEquals($result['DataTest']['count'], 0);
-		$this->assertEquals($result['DataTest']['float'], 0);
+		$this->assertEquals(0, $result['DataTest']['count']);
+		$this->assertEquals(0, $result['DataTest']['float']);
 	}
 
 /**
@@ -214,7 +214,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'foo',
 				'bar' => 'baz'
 		));
-		$this->assertEquals($TestModel->data, $expected);
+		$this->assertEquals($expected, $TestModel->data);
 	}
 
 /**
@@ -276,20 +276,20 @@ class ModelWriteTest extends BaseModelTest {
 		));
 
 		$result = $TestModel->findById(1);
-		$this->assertEquals($result['Syfile']['item_count'], 2);
+		$this->assertEquals(2, $result['Syfile']['item_count']);
 
 		$TestModel2->delete(1);
 		$result = $TestModel->findById(1);
-		$this->assertEquals($result['Syfile']['item_count'], 1);
+		$this->assertEquals(1, $result['Syfile']['item_count']);
 
 		$TestModel2->id = 2;
 		$TestModel2->saveField('syfile_id', 1);
 
 		$result = $TestModel->findById(1);
-		$this->assertEquals($result['Syfile']['item_count'], 2);
+		$this->assertEquals(2, $result['Syfile']['item_count']);
 
 		$result = $TestModel->findById(2);
-		$this->assertEquals($result['Syfile']['item_count'], 0);
+		$this->assertEquals(0, $result['Syfile']['item_count']);
 	}
 
 /**
@@ -357,8 +357,8 @@ class ModelWriteTest extends BaseModelTest {
 		$Post->save($data);
 
 		$users = $User->find('all',array('order' => 'User.id'));
-		$this->assertEquals($users[0]['User']['post_count'], 1);
-		$this->assertEquals($users[1]['User']['post_count'], 2);
+		$this->assertEquals(1, $users[0]['User']['post_count']);
+		$this->assertEquals(2, $users[1]['User']['post_count']);
 	}
 
 /**
@@ -384,8 +384,8 @@ class ModelWriteTest extends BaseModelTest {
 		$Post->save($data);
 
 		$users = $User->find('all',array('order' => 'User.uid'));
-		$this->assertEquals($users[0]['User']['post_count'], 1);
-		$this->assertEquals($users[1]['User']['post_count'], 2);
+		$this->assertEquals(1, $users[0]['User']['post_count']);
+		$this->assertEquals(2, $users[1]['User']['post_count']);
 	}
 
 /**
@@ -439,12 +439,12 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $TestModel->findById(1);
 
-		$this->assertEquals($result['Syfile']['item_count'], 1);
+		$this->assertEquals(1, $result['Syfile']['item_count']);
 
 		$TestModel2->id = 1;
 		$TestModel2->saveField('published', true);
 		$result = $TestModel->findById(1);
-		$this->assertEquals($result['Syfile']['item_count'], 2);
+		$this->assertEquals(2, $result['Syfile']['item_count']);
 
 		$TestModel2->save(array(
 			'id' => 1,
@@ -453,7 +453,7 @@ class ModelWriteTest extends BaseModelTest {
 		));
 
 		$result = $TestModel->findById(1);
-		$this->assertEquals($result['Syfile']['item_count'], 1);
+		$this->assertEquals(1, $result['Syfile']['item_count']);
 	}
 
 /**
@@ -632,11 +632,11 @@ class ModelWriteTest extends BaseModelTest {
 		$Node = new Node();
 		$Node->set('id', 1);
 		$result = $Node->read();
-		$this->assertEquals(Set::extract('/ParentNode/name', $result), array('Second'));
+		$this->assertEquals(array('Second'), Set::extract('/ParentNode/name', $result));
 
 		$Node->saveField('state', 10);
 		$result = $Node->read();
-		$this->assertEquals(Set::extract('/ParentNode/name', $result), array('Second'));
+		$this->assertEquals(array('Second'), Set::extract('/ParentNode/name', $result));
 	}
 
 /**
@@ -884,7 +884,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $User->save();
 		$this->assertFalse(empty($result));
 		$result = $User->read();
-		$this->assertEquals($User->data['User']['password'], 'something');
+		$this->assertEquals('something', $User->data['User']['password']);
 	}
 
 /**
@@ -1570,9 +1570,9 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save($data);
 		$result = $TestModel->read(null, 1);
 		$expected = array(4, 5);
-		$this->assertEquals(Set::extract('/JoinC/JoinAsJoinC/id', $result), $expected);
+		$this->assertEquals($expected, Set::extract('/JoinC/JoinAsJoinC/id', $result));
 		$expected = array('new record', 'new record');
-		$this->assertEquals(Set::extract('/JoinC/JoinAsJoinC/other', $result), $expected);
+		$this->assertEquals($expected, Set::extract('/JoinC/JoinAsJoinC/other', $result));
 	}
 
 /**
@@ -1794,7 +1794,7 @@ class ModelWriteTest extends BaseModelTest {
 		), false);
 		$result = $Something->read(null, 1);
 		$this->assertTrue(empty($result['NotDoomedSomethingElse']));
-		$this->assertEquals(count($result['DoomedSomethingElse']), 1);
+		$this->assertEquals(1, count($result['DoomedSomethingElse']));
 
 		$data = array(
 			'Something' => array('id' => 1),
@@ -1810,8 +1810,8 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Something->read(null, 1);
-		$this->assertEquals(count($result['NotDoomedSomethingElse']), 2);
-		$this->assertEquals(count($result['DoomedSomethingElse']), 1);
+		$this->assertEquals(2, count($result['NotDoomedSomethingElse']));
+		$this->assertEquals(1, count($result['DoomedSomethingElse']));
 	}
 
 /**
@@ -1840,7 +1840,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 
 		$ThePaper->id = 2;
 		$ThePaper->save(array('Monkey' => array(1, 2, 3)));
@@ -1865,7 +1865,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 
 		$ThePaper->id = 2;
 		$ThePaper->save(array('Monkey' => array(1, 3)));
@@ -1884,7 +1884,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 			));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 
 		$result = $ThePaper->findById(1);
 		$expected = array(
@@ -1900,7 +1900,7 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Device 3',
 				'typ' => '2'
 		));
-		$this->assertEquals($result['Monkey'], $expected);
+		$this->assertEquals($expected, $result['Monkey']);
 	}
 
 /**
@@ -1911,15 +1911,15 @@ class ModelWriteTest extends BaseModelTest {
 	public function testCreationOfEmptyRecord() {
 		$this->loadFixtures('Author');
 		$TestModel = new Author();
-		$this->assertEquals($TestModel->find('count'), 4);
+		$this->assertEquals(4, $TestModel->find('count'));
 
 		$TestModel->deleteAll(true, false, false);
-		$this->assertEquals($TestModel->find('count'), 0);
+		$this->assertEquals(0, $TestModel->find('count'));
 
 		$result = $TestModel->save();
 		$this->assertTrue(isset($result['Author']['created']));
 		$this->assertTrue(isset($result['Author']['updated']));
-		$this->assertEquals($TestModel->find('count'), 1);
+		$this->assertEquals(1, $TestModel->find('count'));
 	}
 
 /**
@@ -1947,7 +1947,7 @@ class ModelWriteTest extends BaseModelTest {
 		));
 
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($TestModel->id, 5);
+		$this->assertEquals(5, $TestModel->id);
 
 		$result = $TestModel->create($data, true);
 		$expected = array(
@@ -1998,7 +1998,7 @@ class ModelWriteTest extends BaseModelTest {
 				'modified' => '1970-01-01 12:00:00'
 		));
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($TestModel->id, 6);
+		$this->assertEquals(6, $TestModel->id);
 
 		$result = $TestModel->create(array(
 			'Article' => array_diff_key($data, array(
@@ -2226,7 +2226,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue(!empty($result));
 
 		$result = $Article->field('title', array('id' => 1));
-		$this->assertEquals($result, 'First Article');
+		$this->assertEquals('First Article', $result);
 
 		$articles = $Article->find('all', array(
 			'fields' => array('id','title'),
@@ -2350,8 +2350,8 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals($TestModel->id, $id);
 
 		$result = $TestModel->findById($id);
-		$this->assertEquals($result['User']['user'], 'updated user');
-		$this->assertEquals($result['User']['password'], 'some password');
+		$this->assertEquals('updated user', $result['User']['user']);
+		$this->assertEquals('some password', $result['User']['password']);
 
 		$Article = new Article();
 		$Comment = new Comment();
@@ -2442,7 +2442,7 @@ class ModelWriteTest extends BaseModelTest {
 		$id = $TestModel->id;
 		$result = $TestModel->read(null, $id);
 		$this->assertEquals(1, count($result['Uuiditem']));
-		$this->assertEquals(strlen($result['Uuiditem'][0]['UuiditemsUuidportfolio']['id']), 36);
+		$this->assertEquals(36, strlen($result['Uuiditem'][0]['UuiditemsUuidportfolio']['id']));
 	}
 
 /**
@@ -2641,7 +2641,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Post();
 
 		$result = $TestModel->find('all');
-		$this->assertEquals(count($result), 3);
+		$this->assertEquals(3, count($result));
 		$this->assertFalse(isset($result[3]));
 		$ts = date('Y-m-d H:i:s');
 
@@ -2676,11 +2676,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[3]['Author']['updated'] >= $ts);
 		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
 		unset($result[3]['Author']['created'], $result[3]['Author']['updated']);
-		$this->assertEquals($result[3], $expected);
-		$this->assertEquals(count($result), 4);
+		$this->assertEquals($expected, $result[3]);
+		$this->assertEquals(4, count($result));
 
 		$TestModel->deleteAll(true);
-		$this->assertEquals($TestModel->find('all'), array());
+		$this->assertEquals(array(), $TestModel->find('all'));
 
 		// SQLite seems to reset the PK counter when that happens, so we need this to make the tests pass
 		$this->db->truncate($TestModel);
@@ -2752,7 +2752,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Comment']['created'] >= $ts);
 		$this->assertTrue($result[6]['Comment']['updated'] >= $ts);
 		unset($result[6]['Comment']['created'], $result[6]['Comment']['updated']);
-		$this->assertEquals($result[6]['Comment'], $expected);
+		$this->assertEquals($expected, $result[6]['Comment']);
 
 		$expected = array(
 			'id' => '2',
@@ -2762,7 +2762,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Attachment']['created'] >= $ts);
 		$this->assertTrue($result[6]['Attachment']['updated'] >= $ts);
 		unset($result[6]['Attachment']['created'], $result[6]['Attachment']['updated']);
-		$this->assertEquals($result[6]['Attachment'], $expected);
+		$this->assertEquals($expected, $result[6]['Attachment']);
 	}
 
 /**
@@ -2790,10 +2790,10 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Article->read();
-		$this->assertEquals(count($result['Tag']), 2);
-		$this->assertEquals($result['Tag'][0]['tag'], 'tag1');
-		$this->assertEquals(count($result['Comment']), 1);
-		$this->assertEquals(count($result['Comment'][0]['comment']), 1);
+		$this->assertEquals(2, count($result['Tag']));
+		$this->assertEquals('tag1', $result['Tag'][0]['tag']);
+		$this->assertEquals(1, count($result['Comment']));
+		$this->assertEquals(1, count($result['Comment'][0]['comment']));
 	}
 
 /**
@@ -2823,7 +2823,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		$result = $Something->read();
 
-		$this->assertEquals(count($result['SomethingElse']), 3);
+		$this->assertEquals(3, count($result['SomethingElse']));
 		$this->assertTrue(Set::matches('/Something[id=4]', $result));
 
 		$this->assertTrue(Set::matches('/SomethingElse[id=1]', $result));
@@ -2847,10 +2847,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllHasOne() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEquals($model->Attachment->find('all'), array());
+		$this->assertEquals(array(), $model->Attachment->find('all'));
 
 		$this->assertTrue($model->saveAll(array(
 			'Comment' => array(
@@ -2898,10 +2898,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllBelongsTo() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Article->deleteAll(true);
-		$this->assertEquals($model->Article->find('all'), array());
+		$this->assertEquals(array(), $model->Article->find('all'));
 
 		$this->assertTrue($model->saveAll(array(
 			'Comment' => array(
@@ -2937,10 +2937,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllHasOneValidation() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEquals($model->Attachment->find('all'), array());
+		$this->assertEquals(array(), $model->Attachment->find('all'));
 
 		$model->validate = array('comment' => 'notEmpty');
 		$model->Attachment->validate = array('attachment' => 'notEmpty');
@@ -2961,8 +2961,8 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array('comment' => array('This field cannot be left blank')),
 			'Attachment' => array('attachment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($model->validationErrors, $expected['Comment']);
-		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($expected['Comment'], $model->validationErrors);
+		$this->assertEquals($expected['Attachment'], $model->Attachment->validationErrors);
 
 		$this->assertFalse($model->saveAll(
 			array(
@@ -2971,8 +2971,8 @@ class ModelWriteTest extends BaseModelTest {
 			),
 			array('validate' => 'only')
 		));
-		$this->assertEquals($model->validationErrors, $expected['Comment']);
-		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($expected['Comment'], $model->validationErrors);
+		$this->assertEquals($expected['Attachment'], $model->Attachment->validationErrors);
 	}
 
 /**
@@ -3030,7 +3030,7 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		), array('validate' => true, 'atomic' => false));
 
-		$this->assertSame($result, array(true, false));
+		$this->assertSame(array(true, false), $result);
 
 		$result = $TestModel->saveAll(array(
 			'Article' => array('id' => 2),
@@ -3154,7 +3154,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertEquals($expected['Attachment'], $result['Attachment']);
 
 		unset($result['Comment']['created'], $result['Comment']['updated']);
-		$this->assertEquals($result['Comment'], $expected['Comment']);
+		$this->assertEquals($expected['Comment'], $result['Comment']);
 
 		$result = $TestModel->findById($result['Comment']['article_id']);
 		$expected = array(
@@ -3185,7 +3185,7 @@ class ModelWriteTest extends BaseModelTest {
 			$result['User']['created'], $result['User']['updated'],
 			$result['Comment'][0]['created'], $result['Comment'][0]['updated']
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -3890,7 +3890,7 @@ class ModelWriteTest extends BaseModelTest {
 			))),
 			array('atomic' => false)
 		);
-		$this->assertEquals($result, array('Article' => false));
+		$this->assertEquals(array('Article' => false), $result);
 
 		$result = $TestModel->findById(2);
 		$expected = array(
@@ -3926,11 +3926,11 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array('Comment' => array(
 			array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 		$expected = array(
 			array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 
 		$result = $TestModel->saveAll(array(
 			'Article' => array('id' => 2),
@@ -4354,7 +4354,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Trying to get away with an empty title'
 		));
 		$result = $TestModel->saveAll($data, array('validate' => true, 'atomic' => false));
-		$this->assertEquals($result, array(true, false));
+		$this->assertEquals(array(true, false), $result);
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
 		$errors = array(1 => array('title' => array('This field cannot be left blank')));
 		$expected = array(
@@ -4470,7 +4470,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			0 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$result = $TestModel->saveAll(
 			array(
@@ -4484,7 +4484,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			1 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
 
 /**
@@ -4512,12 +4512,12 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $model->find('all');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 		$expected = array('Comment' => array(
 			1 => array('comment' => array('This field cannot be left blank'))
 		));
 
-		$this->assertEquals($model->Comment->validationErrors, $expected['Comment']);
+		$this->assertEquals($expected['Comment'], $model->Comment->validationErrors);
 
 		$this->assertSame($model->Comment->find('count'), 0);
 
@@ -4541,7 +4541,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $model->Comment->find('all');
 		$this->assertSame(count($result), 1);
 		$result = Set::extract('/Comment/article_id', $result);
-		$this->assertEquals($result[0], 4);
+		$this->assertEquals(4, $result[0]);
 
 		$model->deleteAll(true);
 		$data = array(
@@ -4562,7 +4562,7 @@ class ModelWriteTest extends BaseModelTest {
 			$result[0]['Article']['title'],
 			'Post with Author saveAlled from comment'
 		);
-		$this->assertEquals($result[0]['Comment'][0]['comment'], 'Only new comment');
+		$this->assertEquals('Only new comment', $result[0]['Comment'][0]['comment']);
 	}
 
 /**
@@ -4691,13 +4691,13 @@ class ModelWriteTest extends BaseModelTest {
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$expected = array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 	}
 
 /**
@@ -4729,7 +4729,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel = new Post();
 
 		$result = $TestModel->find('all');
-		$this->assertEquals(count($result), 3);
+		$this->assertEquals(3, count($result));
 		$this->assertFalse(isset($result[3]));
 		$ts = date('Y-m-d H:i:s');
 
@@ -4766,8 +4766,8 @@ class ModelWriteTest extends BaseModelTest {
 			$result[3]['Post']['updated'], $result[3]['Post']['created'],
 			$result[3]['Author']['updated'], $result[3]['Author']['created']
 		);
-		$this->assertEquals($result[3], $expected);
-		$this->assertEquals(count($result), 4);
+		$this->assertEquals($expected, $result[3]);
+		$this->assertEquals(4, count($result));
 
 		$ts = date('Y-m-d H:i:s');
 
@@ -4796,7 +4796,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Comment']['updated'] >= $ts);
 		$this->assertTrue($result[6]['Comment']['created'] >= $ts);
 		unset($result[6]['Comment']['updated'], $result[6]['Comment']['created']);
-		$this->assertEquals($result[6]['Comment'], $expected);
+		$this->assertEquals($expected, $result[6]['Comment']);
 
 		$expected = array(
 			'id' => '2',
@@ -4806,7 +4806,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertTrue($result[6]['Attachment']['updated'] >= $ts);
 		$this->assertTrue($result[6]['Attachment']['created'] >= $ts);
 		unset($result[6]['Attachment']['updated'], $result[6]['Attachment']['created']);
-		$this->assertEquals($result[6]['Attachment'], $expected);
+		$this->assertEquals($expected, $result[6]['Attachment']);
 	}
 
 /**
@@ -4818,7 +4818,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->loadFixtures('Post');
 		$TestModel = new Post();
 		$TestModel->deleteAll(true);
-		$this->assertEquals($TestModel->find('all'), array());
+		$this->assertEquals(array(), $TestModel->find('all'));
 
 		// SQLite seems to reset the PK counter when that happens, so we need this to make the tests pass
 		$this->db->truncate($TestModel);
@@ -4894,10 +4894,10 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = $Article->read();
-		$this->assertEquals(count($result['Tag']), 2);
-		$this->assertEquals($result['Tag'][0]['tag'], 'tag1');
-		$this->assertEquals(count($result['Comment']), 1);
-		$this->assertEquals(count($result['Comment'][0]['comment']), 1);
+		$this->assertEquals(2, count($result['Tag']));
+		$this->assertEquals('tag1', $result['Tag'][0]['tag']);
+		$this->assertEquals(1, count($result['Comment']));
+		$this->assertEquals(1, count($result['Comment'][0]['comment']));
 	}
 
 /**
@@ -4927,7 +4927,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		$result = $Something->read();
 
-		$this->assertEquals(count($result['SomethingElse']), 3);
+		$this->assertEquals(3, count($result['SomethingElse']));
 		$this->assertTrue(Set::matches('/Something[id=4]', $result));
 
 		$this->assertTrue(Set::matches('/SomethingElse[id=1]', $result));
@@ -4951,10 +4951,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedHasOne() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEquals($model->Attachment->find('all'), array());
+		$this->assertEquals(array(), $model->Attachment->find('all'));
 
 		$this->assertTrue($model->saveAssociated(array(
 			'Comment' => array(
@@ -5002,10 +5002,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedBelongsTo() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Article->deleteAll(true);
-		$this->assertEquals($model->Article->find('all'), array());
+		$this->assertEquals(array(), $model->Article->find('all'));
 
 		$this->assertTrue($model->saveAssociated(array(
 			'Comment' => array(
@@ -5041,10 +5041,10 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedHasOneValidation() {
 		$model = new Comment();
 		$model->deleteAll(true);
-		$this->assertEquals($model->find('all'), array());
+		$this->assertEquals(array(), $model->find('all'));
 
 		$model->Attachment->deleteAll(true);
-		$this->assertEquals($model->Attachment->find('all'), array());
+		$this->assertEquals(array(), $model->Attachment->find('all'));
 
 		$model->validate = array('comment' => 'notEmpty');
 		$model->Attachment->validate = array('attachment' => 'notEmpty');
@@ -5064,8 +5064,8 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array('comment' => array('This field cannot be left blank')),
 			'Attachment' => array('attachment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($model->validationErrors, $expected['Comment']);
-		$this->assertEquals($model->Attachment->validationErrors, $expected['Attachment']);
+		$this->assertEquals($expected['Comment'], $model->validationErrors);
+		$this->assertEquals($expected['Attachment'], $model->Attachment->validationErrors);
 	}
 
 /**
@@ -5149,7 +5149,7 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		), array('validate' => true, 'atomic' => false));
 
-		$this->assertSame($result, array(true, false));
+		$this->assertSame(array(true, false), $result);
 	}
 
 /**
@@ -5178,7 +5178,7 @@ class ModelWriteTest extends BaseModelTest {
 			'First new comment',
 			'Second new comment'
 		);
-		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals($expected, Set::extract($result['Comment'], '{n}.comment'));
 
 		$result = $TestModel->saveAssociated(
 			array(
@@ -5201,7 +5201,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals($expected, Set::extract($result['Comment'], '{n}.comment'));
 
 		$TestModel->beforeSaveReturn = false;
 		$result = $TestModel->saveAssociated(
@@ -5215,7 +5215,7 @@ class ModelWriteTest extends BaseModelTest {
 			))),
 			array('atomic' => false)
 		);
-		$this->assertEquals($result, array('Article' => false));
+		$this->assertEquals(array('Article' => false), $result);
 
 		$result = $TestModel->findById(2);
 		$expected = array(
@@ -5225,7 +5225,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Second new comment',
 			'Third new comment'
 		);
-		$this->assertEquals(Set::extract($result['Comment'], '{n}.comment'), $expected);
+		$this->assertEquals($expected, Set::extract($result['Comment'], '{n}.comment'));
 	}
 
 /**
@@ -5250,11 +5250,11 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array('Comment' => array(
 			array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 		$expected = array(
 			array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 
 		$result = $TestModel->saveAssociated(array(
 			'Article' => array('id' => 2),
@@ -5688,7 +5688,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Trying to get away with an empty title'
 		));
 		$result = $TestModel->saveMany($data, array('validate' => true, 'atomic' => false));
-		$this->assertEquals($result, array(true, false));
+		$this->assertEquals(array(true, false), $result);
 
 		$result = $TestModel->find('all', array(
 			'fields' => array('id', 'author_id', 'title', 'body', 'published'),
@@ -5773,7 +5773,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			0 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$result = $TestModel->validateMany(
 			array(
@@ -5785,7 +5785,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			1 => array('title' => array('This field cannot be left blank')),
 		);
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
 
 /**
@@ -5813,12 +5813,12 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $model->find('all');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 		$expected = array('Comment' => array(
 			1 => array('comment' => array('This field cannot be left blank'))
 		));
 
-		$this->assertEquals($model->Comment->validationErrors, $expected['Comment']);
+		$this->assertEquals($expected['Comment'], $model->Comment->validationErrors);
 
 		$this->assertSame($model->Comment->find('count'), 0);
 
@@ -5842,7 +5842,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $model->Comment->find('all');
 		$this->assertSame(count($result), 1);
 		$result = Set::extract('/Comment/article_id', $result);
-		$this->assertEquals($result[0], 4);
+		$this->assertEquals(4, $result[0]);
 
 		$model->deleteAll(true);
 		$data = array(
@@ -5863,7 +5863,7 @@ class ModelWriteTest extends BaseModelTest {
 			$result[0]['Article']['title'],
 			'Post with Author saveAlled from comment'
 		);
-		$this->assertEquals($result[0]['Comment'][0]['comment'], 'Only new comment');
+		$this->assertEquals('Only new comment', $result[0]['Comment'][0]['comment']);
 	}
 
 /**
@@ -6003,13 +6003,13 @@ class ModelWriteTest extends BaseModelTest {
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		));
-		$this->assertEquals($TestModel->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$expected = array(
 			0 => array('comment' => array('This field cannot be left blank')),
 			2 => array('comment' => array('This field cannot be left blank'))
 		);
-		$this->assertEquals($TestModel->Comment->validationErrors, $expected);
+		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 	}
 
 /**
@@ -6068,15 +6068,15 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEquals($result, array(5, 3, 4, 1));
+		$this->assertEquals(array(5, 3, 4, 1), $result);
 
 		$this->assertTrue($model->updateAll(array('count' => 'count + 2')));
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEquals($result, array(7, 5, 6, 3));
+		$this->assertEquals(array(7, 5, 6, 3), $result);
 
 		$this->assertTrue($model->updateAll(array('DataTest.count' => 'DataTest.count - 1')));
 		$result = Set::extract('/DataTest/count', $model->find('all', array('fields' => 'count')));
-		$this->assertEquals($result, array(6, 4, 5, 2));
+		$this->assertEquals(array(6, 4, 5, 2), $result);
 	}
 
 /**
@@ -6138,8 +6138,8 @@ class ModelWriteTest extends BaseModelTest {
 				)
 
 			);
-		$this->assertEquals($results, $expected);
-		$this->assertEquals($resultsFkFalse, $expected);
+		$this->assertEquals($expected, $results);
+		$this->assertEquals($expected, $resultsFkFalse);
 	}
 
 /**
@@ -6200,7 +6200,7 @@ class ModelWriteTest extends BaseModelTest {
 					'name' => 'group one',
 					'code' => 120)));
 
-		$this->assertEquals($results, $expected);
+		$this->assertEquals($expected, $results);
 	}
 
 /**
@@ -6252,7 +6252,7 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => 1,
 					'name' => 'group one',
 					'code' => 120)));
-		$this->assertEquals($resultsFkFalse, $expected);
+		$this->assertEquals($expected, $resultsFkFalse);
 	}
 
 /**
@@ -6392,7 +6392,7 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -93,7 +93,7 @@ class CakeRequestTest extends CakeTestCase {
 		);
 		$request = new CakeRequest('some/path');
 		$this->assertEquals($request->query, $_GET);
-		$this->assertEquals($request->url, 'some/path');
+		$this->assertEquals('some/path', $request->url);
 	}
 
 /**
@@ -136,9 +136,9 @@ class CakeRequestTest extends CakeTestCase {
 
 		$this->assertSame($result, $request, 'Method did not return itself. %s');
 
-		$this->assertEquals($request->controller, 'posts');
-		$this->assertEquals($request->action, 'index');
-		$this->assertEquals($request->plugin, null);
+		$this->assertEquals('posts', $request->controller);
+		$this->assertEquals('index', $request->action);
+		$this->assertEquals(null, $request->plugin);
 	}
 
 /**
@@ -155,9 +155,9 @@ class CakeRequestTest extends CakeTestCase {
 
 		$this->assertSame($result, $request, 'Method did not return itself. %s');
 
-		$this->assertEquals($request->webroot, '/');
-		$this->assertEquals($request->base, '/base_dir');
-		$this->assertEquals($request->here, '/');
+		$this->assertEquals('/', $request->webroot);
+		$this->assertEquals('/base_dir', $request->base);
+		$this->assertEquals('/', $request->here);
 		$this->assertFalse(isset($request->random));
 	}
 
@@ -306,7 +306,7 @@ class CakeRequestTest extends CakeTestCase {
 				'size' => 80469,
 			))
 		);
-		$this->assertEquals($request->data, $expected);
+		$this->assertEquals($expected, $request->data);
 
 		$_FILES = array(
 			'data' => array(
@@ -434,7 +434,7 @@ class CakeRequestTest extends CakeTestCase {
 				),
 			)
 		);
-		$this->assertEquals($request->data, $expected);
+		$this->assertEquals($expected, $request->data);
 
 		$_FILES = array(
 			'data' => array(
@@ -456,7 +456,7 @@ class CakeRequestTest extends CakeTestCase {
 				'size' => 123
 			)
 		);
-		$this->assertEquals($request->data, $expected);
+		$this->assertEquals($expected, $request->data);
 
 		$_FILES = array(
 			'something' => array(
@@ -500,17 +500,17 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['HTTP_CLIENT_IP'] = '192.168.1.2';
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.3';
 		$request = new CakeRequest('some/path');
-		$this->assertEquals($request->clientIp(false), '192.168.1.5');
-		$this->assertEquals($request->clientIp(), '192.168.1.2');
+		$this->assertEquals('192.168.1.5', $request->clientIp(false));
+		$this->assertEquals('192.168.1.2', $request->clientIp());
 
 		unset($_SERVER['HTTP_X_FORWARDED_FOR']);
-		$this->assertEquals($request->clientIp(), '192.168.1.2');
+		$this->assertEquals('192.168.1.2', $request->clientIp());
 
 		unset($_SERVER['HTTP_CLIENT_IP']);
-		$this->assertEquals($request->clientIp(), '192.168.1.3');
+		$this->assertEquals('192.168.1.3', $request->clientIp());
 
 		$_SERVER['HTTP_CLIENTADDRESS'] = '10.0.1.2, 10.0.1.1';
-		$this->assertEquals($request->clientIp(), '10.0.1.2');
+		$this->assertEquals('10.0.1.2', $request->clientIp());
 	}
 
 /**
@@ -726,9 +726,9 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest('some/path');
 		$request->params = array('controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs');
 
-		$this->assertEquals($request->controller, 'posts');
-		$this->assertEquals($request->action, 'view');
-		$this->assertEquals($request->plugin, 'blogs');
+		$this->assertEquals('posts', $request->controller);
+		$this->assertEquals('view', $request->action);
+		$this->assertEquals('blogs', $request->plugin);
 		$this->assertSame($request->banana, null);
 	}
 
@@ -761,11 +761,11 @@ class CakeRequestTest extends CakeTestCase {
 		$request = new CakeRequest('some/path');
 		$request->params = array('controller' => 'posts', 'action' => 'view', 'plugin' => 'blogs');
 
-		$this->assertEquals($request['controller'], 'posts');
+		$this->assertEquals('posts', $request['controller']);
 
 		$request['slug'] = 'speedy-slug';
-		$this->assertEquals($request->slug, 'speedy-slug');
-		$this->assertEquals($request['slug'], 'speedy-slug');
+		$this->assertEquals('speedy-slug', $request->slug);
+		$this->assertEquals('speedy-slug', $request['slug']);
 
 		$this->assertTrue(isset($request['action']));
 		$this->assertFalse(isset($request['wrong-param']));
@@ -780,7 +780,7 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertTrue(isset($request['url']['one']));
 
 		$request->data = array('Post' => array('title' => 'something'));
-		$this->assertEquals($request['data']['Post']['title'], 'something');
+		$this->assertEquals('something', $request['data']['Post']['title']);
 	}
 
 /**
@@ -938,18 +938,18 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PATH_INFO'] = '/posts/view/1';
 
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/1.2.x.x');
-		$this->assertEquals($request->webroot, '/1.2.x.x/');
-		$this->assertEquals($request->url, 'posts/view/1');
+		$this->assertEquals('/1.2.x.x', $request->base);
+		$this->assertEquals('/1.2.x.x/', $request->webroot);
+		$this->assertEquals('posts/view/1', $request->url);
 
 		$_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/app/webroot';
 		$_SERVER['PHP_SELF'] = '/index.php';
 		$_SERVER['PATH_INFO'] = '/posts/add';
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '');
-		$this->assertEquals($request->webroot, '/');
-		$this->assertEquals($request->url, 'posts/add');
+		$this->assertEquals('', $request->base);
+		$this->assertEquals('/', $request->webroot);
+		$this->assertEquals('posts/add', $request->url);
 
 		$_SERVER['DOCUMENT_ROOT'] = '/cake/repo/branches/1.2.x.x/test/';
 		$_SERVER['PHP_SELF'] = '/webroot/index.php';
@@ -962,8 +962,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PHP_SELF'] = '/app/webroot/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '');
-		$this->assertEquals($request->webroot, '/');
+		$this->assertEquals('', $request->base);
+		$this->assertEquals('/', $request->webroot);
 
 		Configure::write('App.dir', 'auth');
 
@@ -972,8 +972,8 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/demos/auth');
-		$this->assertEquals($request->webroot, '/demos/auth/');
+		$this->assertEquals('/demos/auth', $request->base);
+		$this->assertEquals('/demos/auth/', $request->webroot);
 
 		Configure::write('App.dir', 'code');
 
@@ -981,8 +981,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PHP_SELF'] = '/clients/PewterReport/code/webroot/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/clients/PewterReport/code');
-		$this->assertEquals($request->webroot, '/clients/PewterReport/code/');
+		$this->assertEquals('/clients/PewterReport/code', $request->base);
+		$this->assertEquals('/clients/PewterReport/code/', $request->webroot);
 	}
 
 /**
@@ -998,8 +998,8 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/control');
-		$this->assertEquals($request->webroot, '/control/');
+		$this->assertEquals('/control', $request->base);
+		$this->assertEquals('/control/', $request->webroot);
 
 		Configure::write('App.base', false);
 		Configure::write('App.dir', 'affiliate');
@@ -1009,8 +1009,8 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['PHP_SELF'] = '/newaffiliate/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/newaffiliate');
-		$this->assertEquals($request->webroot, '/newaffiliate/');
+		$this->assertEquals('/newaffiliate', $request->base);
+		$this->assertEquals('/newaffiliate/', $request->webroot);
 	}
 
 /**
@@ -1032,9 +1032,9 @@ class CakeRequestTest extends CakeTestCase {
 		));
 
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/cake/index.php');
-		$this->assertEquals($request->webroot, '/cake/app/webroot/');
-		$this->assertEquals($request->url, 'posts/index');
+		$this->assertEquals('/cake/index.php', $request->base);
+		$this->assertEquals('/cake/app/webroot/', $request->webroot);
+		$this->assertEquals('posts/index', $request->url);
 	}
 
 /**
@@ -1047,43 +1047,43 @@ class CakeRequestTest extends CakeTestCase {
 		Configure::write('App.baseUrl', '/app/webroot/index.php');
 
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/app/webroot/index.php');
-		$this->assertEquals($request->webroot, '/app/webroot/');
+		$this->assertEquals('/app/webroot/index.php', $request->base);
+		$this->assertEquals('/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/app/webroot/test.php');
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/app/webroot/test.php');
-		$this->assertEquals($request->webroot, '/app/webroot/');
+		$this->assertEquals('/app/webroot/test.php', $request->base);
+		$this->assertEquals('/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/app/index.php');
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/app/index.php');
-		$this->assertEquals($request->webroot, '/app/webroot/');
+		$this->assertEquals('/app/index.php', $request->base);
+		$this->assertEquals('/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/CakeBB/app/webroot/index.php');
 		$request = new CakeRequest();
-		$this->assertEquals($request->base, '/CakeBB/app/webroot/index.php');
-		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals('/CakeBB/app/webroot/index.php', $request->base);
+		$this->assertEquals('/CakeBB/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/CakeBB/app/index.php');
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/CakeBB/app/index.php');
-		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals('/CakeBB/app/index.php', $request->base);
+		$this->assertEquals('/CakeBB/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/CakeBB/index.php');
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/CakeBB/index.php');
-		$this->assertEquals($request->webroot, '/CakeBB/app/webroot/');
+		$this->assertEquals('/CakeBB/index.php', $request->base);
+		$this->assertEquals('/CakeBB/app/webroot/', $request->webroot);
 
 		Configure::write('App.baseUrl', '/dbhauser/index.php');
 		$_SERVER['DOCUMENT_ROOT'] = '/kunden/homepages/4/d181710652/htdocs/joomla';
 		$_SERVER['SCRIPT_FILENAME'] = '/kunden/homepages/4/d181710652/htdocs/joomla/dbhauser/index.php';
 		$request = new CakeRequest();
 
-		$this->assertEquals($request->base, '/dbhauser/index.php');
-		$this->assertEquals($request->webroot, '/dbhauser/app/webroot/');
+		$this->assertEquals('/dbhauser/index.php', $request->base);
+		$this->assertEquals('/dbhauser/app/webroot/', $request->webroot);
 	}
 
 /**
@@ -1535,7 +1535,7 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertEquals($expected['base'], $request->base, "base error");
 		$this->assertEquals($expected['webroot'], $request->webroot, "webroot error");
 		if (isset($expected['urlParams'])) {
-			$this->assertEquals($request->query, $expected['urlParams'], "GET param mismatch");
+			$this->assertEquals($expected['urlParams'], $request->query, "GET param mismatch");
 		}
 	}
 
@@ -1573,11 +1573,11 @@ class CakeRequestTest extends CakeTestCase {
 		$result = $request->data('Model.new_value', 'new value');
 		$this->assertSame($result, $request, 'Return was not $this');
 
-		$this->assertEquals($request->data['Model']['new_value'], 'new value');
+		$this->assertEquals('new value', $request->data['Model']['new_value']);
 
 		$request->data('Post.title', 'New post')->data('Comment.1.author', 'Mark');
-		$this->assertEquals($request->data['Post']['title'], 'New post');
-		$this->assertEquals($request->data['Comment']['1']['author'], 'Mark');
+		$this->assertEquals('New post', $request->data['Post']['title']);
+		$this->assertEquals('Mark', $request->data['Comment']['1']['author']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -46,9 +46,9 @@ class CakeResponseTest extends CakeTestCase {
 	public function testConstruct() {
 		$response = new CakeResponse();
 		$this->assertNull($response->body());
-		$this->assertEquals($response->charset(), 'UTF-8');
-		$this->assertEquals($response->type(), 'text/html');
-		$this->assertEquals($response->statusCode(), 200);
+		$this->assertEquals('UTF-8', $response->charset());
+		$this->assertEquals('text/html', $response->type());
+		$this->assertEquals(200, $response->statusCode());
 
 		$options = array(
 			'body' => 'This is the body',
@@ -57,10 +57,10 @@ class CakeResponseTest extends CakeTestCase {
 			'status' => '203'
 		);
 		$response = new CakeResponse($options);
-		$this->assertEquals($response->body(), 'This is the body');
-		$this->assertEquals($response->charset(), 'my-custom-charset');
-		$this->assertEquals($response->type(), 'audio/mpeg');
-		$this->assertEquals($response->statusCode(), 203);
+		$this->assertEquals('This is the body', $response->body());
+		$this->assertEquals('my-custom-charset', $response->charset());
+		$this->assertEquals('audio/mpeg', $response->type());
+		$this->assertEquals(203, $response->statusCode());
 	}
 
 /**
@@ -71,8 +71,8 @@ class CakeResponseTest extends CakeTestCase {
 		$response = new CakeResponse();
 		$this->assertNull($response->body());
 		$response->body('Response body');
-		$this->assertEquals($response->body(), 'Response body');
-		$this->assertEquals($response->body('Changed Body'), 'Changed Body');
+		$this->assertEquals('Response body', $response->body());
+		$this->assertEquals('Changed Body', $response->body('Changed Body'));
 	}
 
 /**
@@ -81,10 +81,10 @@ class CakeResponseTest extends CakeTestCase {
  */
 	public function testCharset() {
 		$response = new CakeResponse();
-		$this->assertEquals($response->charset(), 'UTF-8');
+		$this->assertEquals('UTF-8', $response->charset());
 		$response->charset('iso-8859-1');
-		$this->assertEquals($response->charset(), 'iso-8859-1');
-		$this->assertEquals($response->charset('UTF-16'), 'UTF-16');
+		$this->assertEquals('iso-8859-1', $response->charset());
+		$this->assertEquals('UTF-16', $response->charset('UTF-16'));
 	}
 
 /**
@@ -94,10 +94,10 @@ class CakeResponseTest extends CakeTestCase {
  */
 	public function testStatusCode() {
 		$response = new CakeResponse();
-		$this->assertEquals($response->statusCode(), 200);
+		$this->assertEquals(200, $response->statusCode());
 		$response->statusCode(404);
-		$this->assertEquals($response->statusCode(), 404);
-		$this->assertEquals($response->statusCode(500), 500);
+		$this->assertEquals(404, $response->statusCode());
+		$this->assertEquals(500, $response->statusCode(500));
 
 		//Throws exception
 		$response->statusCode(1001);
@@ -109,17 +109,17 @@ class CakeResponseTest extends CakeTestCase {
  */
 	public function testType() {
 		$response = new CakeResponse();
-		$this->assertEquals($response->type(), 'text/html');
+		$this->assertEquals('text/html', $response->type());
 		$response->type('pdf');
-		$this->assertEquals($response->type(), 'application/pdf');
-		$this->assertEquals($response->type('application/crazy-mime'), 'application/crazy-mime');
-		$this->assertEquals($response->type('json'), 'application/json');
-		$this->assertEquals($response->type('wap'), 'text/vnd.wap.wml');
-		$this->assertEquals($response->type('xhtml-mobile'), 'application/vnd.wap.xhtml+xml');
-		$this->assertEquals($response->type('csv'), 'text/csv');
+		$this->assertEquals('application/pdf', $response->type());
+		$this->assertEquals('application/crazy-mime', $response->type('application/crazy-mime'));
+		$this->assertEquals('application/json', $response->type('json'));
+		$this->assertEquals('text/vnd.wap.wml', $response->type('wap'));
+		$this->assertEquals('application/vnd.wap.xhtml+xml', $response->type('xhtml-mobile'));
+		$this->assertEquals('text/csv', $response->type('csv'));
 
 		$response->type(array('keynote' => 'application/keynote'));
-		$this->assertEquals($response->type('keynote'), 'application/keynote');
+		$this->assertEquals('application/keynote', $response->type('keynote'));
 
 		$this->assertFalse($response->type('wackytype'));
 	}
@@ -261,7 +261,7 @@ class CakeResponseTest extends CakeTestCase {
 			'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0'
 		);
 		$response->disableCache();
-		$this->assertEquals($response->header(), $expected);
+		$this->assertEquals($expected, $response->header());
 	}
 
 /**
@@ -280,7 +280,7 @@ class CakeResponseTest extends CakeTestCase {
 			'Cache-Control' => 'public, max-age=' . ($time->format('U') - time())
 		);
 		$response->cache($since);
-		$this->assertEquals($response->header(), $expected);
+		$this->assertEquals($expected, $response->header());
 
 		$response = new CakeResponse();
 		$since = time();
@@ -292,7 +292,7 @@ class CakeResponseTest extends CakeTestCase {
 			'Cache-Control' => 'public, max-age=' . (strtotime($time) - time())
 		);
 		$response->cache($since, $time);
-		$this->assertEquals($response->header(), $expected);
+		$this->assertEquals($expected, $response->header());
 
 		$response = new CakeResponse();
 		$since = time();
@@ -304,7 +304,7 @@ class CakeResponseTest extends CakeTestCase {
 			'Cache-Control' => 'public, max-age=0'
 		);
 		$response->cache($since, $time);
-		$this->assertEquals($response->header(), $expected);
+		$this->assertEquals($expected, $response->header());
 	}
 
 /**
@@ -342,7 +342,7 @@ class CakeResponseTest extends CakeTestCase {
 	public function testHttpCodes() {
 		$response = new CakeResponse();
 		$result = $response->httpCodes();
-		$this->assertEquals(count($result), 39);
+		$this->assertEquals(39, count($result));
 
 		$result = $response->httpCodes(100);
 		$expected = array(100 => 'Continue');
@@ -355,7 +355,7 @@ class CakeResponseTest extends CakeTestCase {
 
 		$result = $response->httpCodes($codes);
 		$this->assertTrue($result);
-		$this->assertEquals(count($response->httpCodes()), 41);
+		$this->assertEquals(41, count($response->httpCodes()));
 
 		$result = $response->httpCodes(1337);
 		$expected = array(1337 => 'Undefined Unicorn');
@@ -364,7 +364,7 @@ class CakeResponseTest extends CakeTestCase {
 		$codes = array(404 => 'Sorry Bro');
 		$result = $response->httpCodes($codes);
 		$this->assertTrue($result);
-		$this->assertEquals(count($response->httpCodes()), 41);
+		$this->assertEquals(41, count($response->httpCodes()));
 
 		$result = $response->httpCodes(404);
 		$expected = array(404 => 'Sorry Bro');
@@ -381,7 +381,7 @@ class CakeResponseTest extends CakeTestCase {
 			'Content-Disposition' => 'attachment; filename="myfile.mp3"'
 		);
 		$response->download('myfile.mp3');
-		$this->assertEquals($response->header(), $expected);
+		$this->assertEquals($expected, $response->header());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -130,16 +130,16 @@ class CakeSocketTest extends CakeTestCase {
 	public function testSocketHost() {
 		$this->Socket = new CakeSocket();
 		$this->Socket->connect();
-		$this->assertEquals($this->Socket->address(), '127.0.0.1');
+		$this->assertEquals('127.0.0.1', $this->Socket->address());
 		$this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
-		$this->assertEquals($this->Socket->lastError(), null);
+		$this->assertEquals(null, $this->Socket->lastError());
 		$this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
 
 		$this->Socket = new CakeSocket(array('host' => '127.0.0.1'));
 		$this->Socket->connect();
-		$this->assertEquals($this->Socket->address(), '127.0.0.1');
+		$this->assertEquals('127.0.0.1', $this->Socket->address());
 		$this->assertEquals(gethostbyaddr('127.0.0.1'), $this->Socket->host());
-		$this->assertEquals($this->Socket->lastError(), null);
+		$this->assertEquals(null, $this->Socket->lastError());
 		$this->assertTrue(in_array('127.0.0.1', $this->Socket->addresses()));
 	}
 
@@ -161,13 +161,13 @@ class CakeSocketTest extends CakeTestCase {
 	public function testSocketReading() {
 		$this->Socket = new CakeSocket(array('timeout' => 5));
 		$this->Socket->connect();
-		$this->assertEquals($this->Socket->read(26), null);
+		$this->assertEquals(null, $this->Socket->read(26));
 
 		$config = array('host' => 'google.com', 'port' => 80, 'timeout' => 1);
 		$this->Socket = new CakeSocket($config);
 		$this->assertTrue($this->Socket->connect());
-		$this->assertEquals($this->Socket->read(26), null);
-		$this->assertEquals($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
+		$this->assertEquals(null, $this->Socket->read(26));
+		$this->assertEquals('2: ' . __d('cake_dev', 'Connection timed out'), $this->Socket->lastError());
 	}
 
 /**
@@ -183,7 +183,7 @@ class CakeSocketTest extends CakeTestCase {
 		$config = array('host' => '127.0.0.1', 'timeout' => 0.00001);
 		$this->Socket = new CakeSocket($config);
 		$this->assertFalse($this->Socket->read(1024 * 1024));
-		$this->assertEquals($this->Socket->lastError(), '2: ' . __d('cake_dev', 'Connection timed out'));
+		$this->assertEquals('2: ' . __d('cake_dev', 'Connection timed out'), $this->Socket->lastError());
 	}
 
 /**
@@ -194,7 +194,7 @@ class CakeSocketTest extends CakeTestCase {
 	public function testLastError() {
 		$this->Socket = new CakeSocket();
 		$this->Socket->setLastError(4, 'some error here');
-		$this->assertEquals($this->Socket->lastError(), '4: some error here');
+		$this->assertEquals('4: some error here', $this->Socket->lastError());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1394,20 +1394,20 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testConfigCharset() {
 		$email = new CakeEmail();
-		$this->assertEquals($email->charset, Configure::read('App.encoding'));
-		$this->assertEquals($email->headerCharset, Configure::read('App.encoding'));
+		$this->assertEquals(Configure::read('App.encoding'), $email->charset);
+		$this->assertEquals(Configure::read('App.encoding'), $email->headerCharset);
 
 		$email = new CakeEmail(array('charset' => 'iso-2022-jp', 'headerCharset' => 'iso-2022-jp-ms'));
-		$this->assertEquals($email->charset, 'iso-2022-jp');
-		$this->assertEquals($email->headerCharset, 'iso-2022-jp-ms');
+		$this->assertEquals('iso-2022-jp', $email->charset);
+		$this->assertEquals('iso-2022-jp-ms', $email->headerCharset);
 
 		$email = new CakeEmail(array('charset' => 'iso-2022-jp'));
-		$this->assertEquals($email->charset, 'iso-2022-jp');
-		$this->assertEquals($email->headerCharset, 'iso-2022-jp');
+		$this->assertEquals('iso-2022-jp', $email->charset);
+		$this->assertEquals('iso-2022-jp', $email->headerCharset);
 
 		$email = new CakeEmail(array('headerCharset' => 'iso-2022-jp-ms'));
-		$this->assertEquals($email->charset, Configure::read('App.encoding'));
-		$this->assertEquals($email->headerCharset, 'iso-2022-jp-ms');
+		$this->assertEquals(Configure::read('App.encoding'), $email->charset);
+		$this->assertEquals('iso-2022-jp-ms', $email->headerCharset);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -41,7 +41,7 @@ class BasicAuthenticationTest extends CakeTestCase {
 		);
 
 		BasicAuthentication::authentication($http, $auth);
-		$this->assertEquals($http->request['header']['Authorization'], 'Basic bWFyazpzZWNyZXQ=');
+		$this->assertEquals('Basic bWFyazpzZWNyZXQ=', $http->request['header']['Authorization']);
 	}
 
 /**
@@ -58,7 +58,7 @@ class BasicAuthenticationTest extends CakeTestCase {
 		);
 
 		BasicAuthentication::proxyAuthentication($http, $proxy);
-		$this->assertEquals($http->request['header']['Proxy-Authorization'], 'Basic bWFyazpzZWNyZXQ=');
+		$this->assertEquals('Basic bWFyazpzZWNyZXQ=', $http->request['header']['Proxy-Authorization']);
 	}
 
 }

--- a/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
@@ -93,8 +93,8 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(isset($this->HttpSocket->request['header']['Authorization']));
-		$this->assertEquals($auth['realm'], 'The batcave');
-		$this->assertEquals($auth['nonce'], '4cded326c6c51');
+		$this->assertEquals('The batcave', $auth['realm']);
+		$this->assertEquals('4cded326c6c51', $auth['nonce']);
 	}
 
 /**
@@ -116,8 +116,8 @@ class DigestAuthenticationTest extends CakeTestCase {
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$expected = '@Digest username="admin", realm="The batcave", nonce="4cded326c6c51", uri="/", response="[a-z0-9]{32}", qop="auth", nc=00000001, cnonce="[a-z0-9]+"@';
 		$this->assertRegExp($expected, $this->HttpSocket->request['header']['Authorization']);
-		$this->assertEquals($auth['qop'], 'auth');
-		$this->assertEquals($auth['nc'], 2);
+		$this->assertEquals('auth', $auth['qop']);
+		$this->assertEquals(2, $auth['nc']);
 	}
 
 /**
@@ -147,18 +147,18 @@ class DigestAuthenticationTest extends CakeTestCase {
 		$auth = array('user' => 'admin', 'pass' => '1234');
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000001') > 0);
-		$this->assertEquals($auth['nc'], 2);
+		$this->assertEquals(2, $auth['nc']);
 
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000002') > 0);
-		$this->assertEquals($auth['nc'], 3);
+		$this->assertEquals(3, $auth['nc']);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$response = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
 
 		$this->HttpSocket->nextHeader = '';
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$this->assertTrue(strpos($this->HttpSocket->request['header']['Authorization'], 'nc=00000003') > 0);
-		$this->assertEquals($auth['nc'], 4);
+		$this->assertEquals(4, $auth['nc']);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$responseB = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
 		$this->assertNotEquals($response, $responseB);
@@ -176,7 +176,7 @@ class DigestAuthenticationTest extends CakeTestCase {
 		DigestAuthentication::authentication($this->HttpSocket, $auth);
 		$responsePos = strpos($this->HttpSocket->request['header']['Authorization'], 'response=');
 		$response = substr($this->HttpSocket->request['header']['Authorization'], $responsePos + 10, 32);
-		$this->assertNotEquals($response, 'da7e2a46b471d77f70a9bb3698c8902b');
+		$this->assertNotEquals('da7e2a46b471d77f70a9bb3698c8902b', $response);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -102,7 +102,7 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testBody() {
 		$this->HttpResponse->body = 'testing';
-		$this->assertEquals($this->HttpResponse->body(), 'testing');
+		$this->assertEquals('testing', $this->HttpResponse->body());
 
 		$this->HttpResponse->body = null;
 		$this->assertSame($this->HttpResponse->body(), '');
@@ -115,12 +115,12 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testToString() {
 		$this->HttpResponse->body = 'other test';
-		$this->assertEquals($this->HttpResponse->body(), 'other test');
-		$this->assertEquals((string)$this->HttpResponse, 'other test');
+		$this->assertEquals('other test', $this->HttpResponse->body());
+		$this->assertEquals('other test', (string)$this->HttpResponse);
 		$this->assertTrue(strpos($this->HttpResponse, 'test') > 0);
 
 		$this->HttpResponse->body = null;
-		$this->assertEquals((string)$this->HttpResponse, '');
+		$this->assertEquals('', (string)$this->HttpResponse);
 	}
 
 /**
@@ -136,15 +136,15 @@ class HttpResponseTest extends CakeTestCase {
 			'content-Type' => 'text/plain'
 		);
 
-		$this->assertEquals($this->HttpResponse->getHeader('foo'), 'Bar');
-		$this->assertEquals($this->HttpResponse->getHeader('Foo'), 'Bar');
-		$this->assertEquals($this->HttpResponse->getHeader('FOO'), 'Bar');
-		$this->assertEquals($this->HttpResponse->getHeader('header'), 'value');
-		$this->assertEquals($this->HttpResponse->getHeader('Content-Type'), 'text/plain');
+		$this->assertEquals('Bar', $this->HttpResponse->getHeader('foo'));
+		$this->assertEquals('Bar', $this->HttpResponse->getHeader('Foo'));
+		$this->assertEquals('Bar', $this->HttpResponse->getHeader('FOO'));
+		$this->assertEquals('value', $this->HttpResponse->getHeader('header'));
+		$this->assertEquals('text/plain', $this->HttpResponse->getHeader('Content-Type'));
 		$this->assertSame($this->HttpResponse->getHeader(0), null);
 
-		$this->assertEquals($this->HttpResponse->getHeader('foo', false), 'Bar');
-		$this->assertEquals($this->HttpResponse->getHeader('foo', array('foo' => 'not from class')), 'not from class');
+		$this->assertEquals('Bar', $this->HttpResponse->getHeader('foo', false));
+		$this->assertEquals('not from class', $this->HttpResponse->getHeader('foo', array('foo' => 'not from class')));
 	}
 
 /**
@@ -208,17 +208,17 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testParseHeader() {
 		$r = $this->HttpResponse->parseHeader(array('foo' => 'Bar', 'fOO-bAr' => 'quux'));
-		$this->assertEquals($r, array('foo' => 'Bar', 'fOO-bAr' => 'quux'));
+		$this->assertEquals(array('foo' => 'Bar', 'fOO-bAr' => 'quux'), $r);
 
 		$r = $this->HttpResponse->parseHeader(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$header = "Host: cakephp.org\t\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
 		$expected = array(
 			'Host' => 'cakephp.org'
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$header = "Date:Sat, 07 Apr 2007 10:10:25 GMT\r\nX-Powered-By: PHP/5.1.2\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
@@ -226,7 +226,7 @@ class HttpResponseTest extends CakeTestCase {
 			'Date' => 'Sat, 07 Apr 2007 10:10:25 GMT',
 			'X-Powered-By' => 'PHP/5.1.2'
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$header = "people: Jim,John\r\nfoo-LAND: Bar\r\ncAKe-PHP: rocks\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
@@ -235,14 +235,14 @@ class HttpResponseTest extends CakeTestCase {
 			'foo-LAND' => 'Bar',
 			'cAKe-PHP' => 'rocks'
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$header = "People: Jim,John,Tim\r\nPeople: Lisa,Tina,Chelsea\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
 		$expected = array(
 			'People' => array('Jim,John,Tim', 'Lisa,Tina,Chelsea')
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$header = "Multi-Line: I am a \r\nmulti line\t\r\nfield value.\r\nSingle-Line: I am not\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
@@ -250,14 +250,14 @@ class HttpResponseTest extends CakeTestCase {
 			'Multi-Line' => "I am a\r\nmulti line\r\nfield value.",
 			'Single-Line' => 'I am not'
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$header = "Esc\"@\"ped: value\r\n";
 		$r = $this->HttpResponse->parseHeader($header);
 		$expected = array(
 			'Esc@ped' => 'value'
 		);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 	}
 
 /**
@@ -303,7 +303,7 @@ class HttpResponseTest extends CakeTestCase {
 			$expectations = array_merge($expectations, $test['expectations']);
 
 			foreach ($expectations as $property => $expectedVal) {
-				$this->assertEquals($this->HttpResponse->{$property}, $expectedVal, 'Test "' . $name . '": response.' . $property . ' - %s');
+				$this->assertEquals($expectedVal, $this->HttpResponse->{$property}, 'Test "' . $name . '": response.' . $property . ' - %s');
 			}
 
 			foreach (array('status-line', 'header', 'body', 'response') as $field) {
@@ -344,10 +344,10 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testDecodeBody() {
 		$r = $this->HttpResponse->decodeBody(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->HttpResponse->decodeBody('Foobar', false);
-		$this->assertEquals($r, array('body' => 'Foobar', 'header' => false));
+		$this->assertEquals(array('body' => 'Foobar', 'header' => false), $r);
 
 		$encoding = 'chunked';
 		$sample = array(
@@ -375,10 +375,10 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testDecodeFooCoded() {
 		$r = $this->HttpResponse->decodeBody(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->HttpResponse->decodeBody('Foobar', false);
-		$this->assertEquals($r, array('body' => 'Foobar', 'header' => false));
+		$this->assertEquals(array('body' => 'Foobar', 'header' => false), $r);
 
 		$encoding = 'foo-bar';
 		$sample = array(
@@ -397,13 +397,13 @@ class HttpResponseTest extends CakeTestCase {
  */
 	public function testDecodeChunkedBody() {
 		$r = $this->HttpResponse->decodeChunkedBody(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$encoded = "19\r\nThis is a chunked message\r\n0\r\n";
 		$decoded = "This is a chunked message";
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
 		$this->assertEquals($r['body'], $decoded);
-		$this->assertEquals($r['header'], false);
+		$this->assertEquals(false, $r['header']);
 
 		$encoded = "19 \r\nThis is a chunked message\r\n0\r\n";
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
@@ -413,17 +413,17 @@ class HttpResponseTest extends CakeTestCase {
 		$decoded = "This is a chunked message\nThat is cool\n";
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
 		$this->assertEquals($r['body'], $decoded);
-		$this->assertEquals($r['header'], false);
+		$this->assertEquals(false, $r['header']);
 
 		$encoded = "19\r\nThis is a chunked message\r\nE;foo-chunk=5\r\n\nThat is cool\n\r\n0\r\n";
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
 		$this->assertEquals($r['body'], $decoded);
-		$this->assertEquals($r['header'], false);
+		$this->assertEquals(false, $r['header']);
 
 		$encoded = "19\r\nThis is a chunked message\r\nE\r\n\nThat is cool\n\r\n0\r\nfoo-header: bar\r\ncake: PHP\r\n\r\n";
 		$r = $this->HttpResponse->decodeChunkedBody($encoded);
 		$this->assertEquals($r['body'], $decoded);
-		$this->assertEquals($r['header'], array('foo-header' => 'bar', 'cake' => 'PHP'));
+		$this->assertEquals(array('foo-header' => 'bar', 'cake' => 'PHP'), $r['header']);
 	}
 
 /**
@@ -465,17 +465,17 @@ class HttpResponseTest extends CakeTestCase {
 				'value' => 'not=nice',
 			)
 		);
-		$this->assertEquals($cookies, $expected);
+		$this->assertEquals($expected, $cookies);
 
 		$header['Set-Cookie'][] = 'cakephp=great; Secure';
 		$expected['cakephp'] = array('value' => 'great', 'secure' => true);
 		$cookies = $this->HttpResponse->parseCookies($header);
-		$this->assertEquals($cookies, $expected);
+		$this->assertEquals($expected, $cookies);
 
 		$header['Set-Cookie'] = 'foo=bar';
 		unset($expected['people'], $expected['cakephp'], $expected['google']);
 		$cookies = $this->HttpResponse->parseCookies($header);
-		$this->assertEquals($cookies, $expected);
+		$this->assertEquals($expected, $cookies);
 	}
 
 /**
@@ -484,7 +484,7 @@ class HttpResponseTest extends CakeTestCase {
  * @return void
  */
 	public function testUnescapeToken() {
-		$this->assertEquals($this->HttpResponse->unescapeToken('Foo'), 'Foo');
+		$this->assertEquals('Foo', $this->HttpResponse->unescapeToken('Foo'));
 
 		$escape = $this->HttpResponse->tokenEscapeChars(false);
 		foreach ($escape as $char) {
@@ -492,7 +492,7 @@ class HttpResponseTest extends CakeTestCase {
 			$unescapedToken = $this->HttpResponse->unescapeToken($token);
 			$expectedToken = 'My-special-' . $char . '-Token';
 
-			$this->assertEquals($unescapedToken, $expectedToken, 'Test token unescaping for ASCII ' . ord($char));
+			$this->assertEquals($expectedToken, $unescapedToken, 'Test token unescaping for ASCII ' . ord($char));
 		}
 
 		$token = 'Extreme-":"Token-"	"-""""@"-test';
@@ -521,35 +521,35 @@ class HttpResponseTest extends CakeTestCase {
 		$this->HttpResponse->body = 'This is a test!';
 		$this->HttpResponse->raw = "HTTP/1.1 200 OK\r\nServer: CakePHP\r\nContEnt-Type: text/plain\r\n\r\nThis is a test!";
 		$expectedOne = "HTTP/1.1 200 OK\r\n";
-		$this->assertEquals($this->HttpResponse['raw']['status-line'], $expectedOne);
+		$this->assertEquals($expectedOne, $this->HttpResponse['raw']['status-line']);
 		$expectedTwo = "Server: CakePHP\r\nContEnt-Type: text/plain\r\n";
-		$this->assertEquals($this->HttpResponse['raw']['header'], $expectedTwo);
+		$this->assertEquals($expectedTwo, $this->HttpResponse['raw']['header']);
 		$expectedThree = 'This is a test!';
-		$this->assertEquals($this->HttpResponse['raw']['body'], $expectedThree);
+		$this->assertEquals($expectedThree, $this->HttpResponse['raw']['body']);
 		$expected = $expectedOne . $expectedTwo . "\r\n" . $expectedThree;
-		$this->assertEquals($this->HttpResponse['raw']['response'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['raw']['response']);
 
 		$expected = 'HTTP/1.1';
-		$this->assertEquals($this->HttpResponse['status']['http-version'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['status']['http-version']);
 		$expected = 200;
-		$this->assertEquals($this->HttpResponse['status']['code'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['status']['code']);
 		$expected = 'OK';
-		$this->assertEquals($this->HttpResponse['status']['reason-phrase'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['status']['reason-phrase']);
 
 		$expected = array(
 			'Server' => 'CakePHP',
 			'ContEnt-Type' => 'text/plain'
 		);
-		$this->assertEquals($this->HttpResponse['header'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['header']);
 
 		$expected = 'This is a test!';
-		$this->assertEquals($this->HttpResponse['body'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['body']);
 
 		$expected = array(
 			'foo' => array('value' => 'bar'),
 			'bar' => array('value' => 'foo')
 		);
-		$this->assertEquals($this->HttpResponse['cookies'], $expected);
+		$this->assertEquals($expected, $this->HttpResponse['cookies']);
 
 		$this->HttpResponse->raw = "HTTP/1.1 200 OK\r\n\r\nThis is a test!";
 		$this->assertSame($this->HttpResponse['raw']['header'], null);

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -263,12 +263,12 @@ class HttpSocketTest extends CakeTestCase {
 				'cookies' => array()
 			)
 		);
-		$this->assertEquals($this->Socket->config, $expected);
+		$this->assertEquals($expected, $this->Socket->config);
 		$this->assertTrue($r);
 		$r = $this->Socket->configUri(array('host' => 'www.foo-bar.org'));
 		$expected['host'] = 'www.foo-bar.org';
 		$expected['request']['uri']['host'] = 'www.foo-bar.org';
-		$this->assertEquals($this->Socket->config, $expected);
+		$this->assertEquals($expected, $this->Socket->config);
 		$this->assertTrue($r);
 
 		$r = $this->Socket->configUri('http://www.foo.com');
@@ -288,15 +288,15 @@ class HttpSocketTest extends CakeTestCase {
 				'cookies' => array()
 			)
 		);
-		$this->assertEquals($this->Socket->config, $expected);
+		$this->assertEquals($expected, $this->Socket->config);
 		$this->assertTrue($r);
 
 		$r = $this->Socket->configUri('/this-is-broken');
-		$this->assertEquals($this->Socket->config, $expected);
+		$this->assertEquals($expected, $this->Socket->config);
 		$this->assertFalse($r);
 
 		$r = $this->Socket->configUri(false);
-		$this->assertEquals($this->Socket->config, $expected);
+		$this->assertEquals($expected, $this->Socket->config);
 		$this->assertFalse($r);
 	}
 
@@ -552,7 +552,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 		$request = array('method' => 'POST', 'uri' => 'http://www.cakephp.org/posts/add', 'body' => array('name' => 'HttpSocket-is-released', 'date' => 'today'));
 		$response = $this->Socket->request($request);
-		$this->assertEquals($this->Socket->request['body'], "name=HttpSocket-is-released&date=today");
+		$this->assertEquals("name=HttpSocket-is-released&date=today", $this->Socket->request['body']);
 	}
 
 /**
@@ -643,7 +643,7 @@ class HttpSocketTest extends CakeTestCase {
 				'value' => 'bar'
 			)
 		);
-		$this->assertEquals($result, $expect);
+		$this->assertEquals($expect, $result);
 		$this->assertEquals($this->Socket->config['request']['cookies']['www.cakephp.org'], $expect);
 		$this->assertFalse($this->Socket->connected);
 	}
@@ -695,15 +695,15 @@ class HttpSocketTest extends CakeTestCase {
 
 		$this->Socket->setContentResource($f);
 		$result = (string)$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($result, '');
-		$this->assertEquals($this->Socket->response['header']['Server'], 'CakeHttp Server');
+		$this->assertEquals('', $result);
+		$this->assertEquals('CakeHttp Server', $this->Socket->response['header']['Server']);
 		fclose($f);
 		$this->assertEquals(file_get_contents(TMP . 'download.txt'), '<h1>This is a test!</h1>');
 		unlink(TMP . 'download.txt');
 
 		$this->Socket->setContentResource(false);
 		$result = (string)$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($result, '<h1>This is a test!</h1>');
+		$this->assertEquals('<h1>This is a test!</h1>', $result);
 	}
 
 /**
@@ -720,21 +720,21 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$expected = array('www.cakephp.org' => array('foo' => array('value' => 'bar')));
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($expected, $this->Socket->config['request']['cookies']);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: bar=foo\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$this->Socket->request('http://www.cakephp.org/other');
-		$this->assertEquals($this->Socket->request['cookies'], array('foo' => array('value' => 'bar')));
+		$this->assertEquals(array('foo' => array('value' => 'bar')), $this->Socket->request['cookies']);
 		$expected['www.cakephp.org'] += array('bar' => array('value' => 'foo'));
-		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($expected, $this->Socket->config['request']['cookies']);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$this->Socket->expects($this->at(2))->method('read')->will($this->returnValue(false));
 		$this->Socket->request('/other2');
-		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($expected, $this->Socket->config['request']['cookies']);
 
 		$serverResponse = "HTTP/1.x 200 OK\r\nSet-Cookie: foobar=ok\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>This is a test!</h1>";
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
@@ -742,7 +742,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->request('http://www.cake.com');
 		$this->assertTrue(empty($this->Socket->request['cookies']));
 		$expected['www.cake.com'] = array('foobar' => array('value' => 'ok'));
-		$this->assertEquals($this->Socket->config['request']['cookies'], $expected);
+		$this->assertEquals($expected, $this->Socket->config['request']['cookies']);
 	}
 
 /**
@@ -759,7 +759,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->responseClass = 'CustomResponse';
 		$response = $this->Socket->request('http://www.cakephp.org/');
 		$this->assertInstanceOf('CustomResponse', $response);
-		$this->assertEquals($response->first10, 'HTTP/1.x 2');
+		$this->assertEquals('HTTP/1.x 2', $response->first10);
 	}
 
 /**
@@ -824,9 +824,9 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->configProxy('proxy.server', 123);
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n";
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($this->Socket->request['raw'], $expected);
-		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
-		$this->assertEquals($this->Socket->config['port'], 123);
+		$this->assertEquals($expected, $this->Socket->request['raw']);
+		$this->assertEquals('proxy.server', $this->Socket->config['host']);
+		$this->assertEquals(123, $this->Socket->config['port']);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -834,13 +834,13 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => null,
 			'pass' => null
 		);
-		$this->assertEquals($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['proxy']);
 
 		$expected = "GET http://www.cakephp.org/bakery HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n";
 		$this->Socket->request('/bakery');
-		$this->assertEquals($this->Socket->request['raw'], $expected);
-		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
-		$this->assertEquals($this->Socket->config['port'], 123);
+		$this->assertEquals($expected, $this->Socket->request['raw']);
+		$this->assertEquals('proxy.server', $this->Socket->config['host']);
+		$this->assertEquals(123, $this->Socket->config['port']);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -848,14 +848,14 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => null,
 			'pass' => null
 		);
-		$this->assertEquals($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['proxy']);
 
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\nProxy-Authorization: Test mark.secret\r\n\r\n";
 		$this->Socket->configProxy('proxy.server', 123, 'Test', 'mark', 'secret');
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($this->Socket->request['raw'], $expected);
-		$this->assertEquals($this->Socket->config['host'], 'proxy.server');
-		$this->assertEquals($this->Socket->config['port'], 123);
+		$this->assertEquals($expected, $this->Socket->request['raw']);
+		$this->assertEquals('proxy.server', $this->Socket->config['host']);
+		$this->assertEquals(123, $this->Socket->config['port']);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -863,12 +863,12 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => 'mark',
 			'pass' => 'secret'
 		);
-		$this->assertEquals($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['proxy']);
 
 		$this->Socket->configAuth('Test', 'login', 'passwd');
 		$expected = "GET http://www.cakephp.org/ HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\nProxy-Authorization: Test mark.secret\r\nAuthorization: Test login.passwd\r\n\r\n";
 		$this->Socket->request('http://www.cakephp.org/');
-		$this->assertEquals($this->Socket->request['raw'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['raw']);
 		$expected = array(
 			'host' => 'proxy.server',
 			'port' => 123,
@@ -876,14 +876,14 @@ class HttpSocketTest extends CakeTestCase {
 			'user' => 'mark',
 			'pass' => 'secret'
 		);
-		$this->assertEquals($this->Socket->request['proxy'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['proxy']);
 		$expected = array(
 			'Test' => array(
 				'user' => 'login',
 				'pass' => 'passwd'
 			)
 		);
-		$this->assertEquals($this->Socket->request['auth'], $expected);
+		$this->assertEquals($expected, $this->Socket->request['auth']);
 	}
 
 /**
@@ -894,50 +894,50 @@ class HttpSocketTest extends CakeTestCase {
 	public function testUrl() {
 		$this->Socket->reset(true);
 
-		$this->assertEquals($this->Socket->url(true), false);
+		$this->assertEquals(false, $this->Socket->url(true));
 
 		$url = $this->Socket->url('www.cakephp.org');
-		$this->assertEquals($url, 'http://www.cakephp.org/');
+		$this->assertEquals('http://www.cakephp.org/', $url);
 
 		$url = $this->Socket->url('https://www.cakephp.org/posts/add');
-		$this->assertEquals($url, 'https://www.cakephp.org/posts/add');
+		$this->assertEquals('https://www.cakephp.org/posts/add', $url);
 		$url = $this->Socket->url('http://www.cakephp/search?q=socket', '/%path?%query');
-		$this->assertEquals($url, '/search?q=socket');
+		$this->assertEquals('/search?q=socket', $url);
 
 		$this->Socket->config['request']['uri']['host'] = 'bakery.cakephp.org';
 		$url = $this->Socket->url();
-		$this->assertEquals($url, 'http://bakery.cakephp.org/');
+		$this->assertEquals('http://bakery.cakephp.org/', $url);
 
 		$this->Socket->configUri('http://www.cakephp.org');
 		$url = $this->Socket->url('/search?q=bar');
-		$this->assertEquals($url, 'http://www.cakephp.org/search?q=bar');
+		$this->assertEquals('http://www.cakephp.org/search?q=bar', $url);
 
 		$url = $this->Socket->url(array('host' => 'www.foobar.org', 'query' => array('q' => 'bar')));
-		$this->assertEquals($url, 'http://www.foobar.org/?q=bar');
+		$this->assertEquals('http://www.foobar.org/?q=bar', $url);
 
 		$url = $this->Socket->url(array('path' => '/supersearch', 'query' => array('q' => 'bar')));
-		$this->assertEquals($url, 'http://www.cakephp.org/supersearch?q=bar');
+		$this->assertEquals('http://www.cakephp.org/supersearch?q=bar', $url);
 
 		$this->Socket->configUri('http://www.google.com');
 		$url = $this->Socket->url('/search?q=socket');
-		$this->assertEquals($url, 'http://www.google.com/search?q=socket');
+		$this->assertEquals('http://www.google.com/search?q=socket', $url);
 
 		$url = $this->Socket->url();
-		$this->assertEquals($url, 'http://www.google.com/');
+		$this->assertEquals('http://www.google.com/', $url);
 
 		$this->Socket->configUri('https://www.google.com');
 		$url = $this->Socket->url('/search?q=socket');
-		$this->assertEquals($url, 'https://www.google.com/search?q=socket');
+		$this->assertEquals('https://www.google.com/search?q=socket', $url);
 
 		$this->Socket->reset();
 		$this->Socket->configUri('www.google.com:443');
 		$url = $this->Socket->url('/search?q=socket');
-		$this->assertEquals($url, 'https://www.google.com/search?q=socket');
+		$this->assertEquals('https://www.google.com/search?q=socket', $url);
 
 		$this->Socket->reset();
 		$this->Socket->configUri('www.google.com:8080');
 		$url = $this->Socket->url('/search?q=socket');
-		$this->assertEquals($url, 'http://www.google.com:8080/search?q=socket');
+		$this->assertEquals('http://www.google.com:8080/search?q=socket', $url);
 	}
 
 /**
@@ -1007,8 +1007,8 @@ class HttpSocketTest extends CakeTestCase {
 	public function testConsecutiveGetResetsAuthCredentials() {
 		$socket = new MockHttpSocket();
 		$socket->get('http://mark:secret@example.com/test');
-		$this->assertEquals($socket->request['uri']['user'], 'mark');
-		$this->assertEquals($socket->request['uri']['pass'], 'secret');
+		$this->assertEquals('mark', $socket->request['uri']['user']);
+		$this->assertEquals('secret', $socket->request['uri']['pass']);
 		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
 		$socket->get('/test2');
@@ -1100,17 +1100,17 @@ class HttpSocketTest extends CakeTestCase {
 
 		$this->Socket->quirksMode = true;
 		$r = $this->Socket->buildRequestLine('Foo');
-		$this->assertEquals($r, 'Foo');
+		$this->assertEquals('Foo', $r);
 		$this->Socket->quirksMode = false;
 
 		$r = $this->Socket->buildRequestLine(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->Socket->buildRequestLine(array('foo' => 'bar', 'method' => 'foo'));
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->Socket->buildRequestLine(array('method' => 'GET', 'uri' => 'http://www.cakephp.org/search?q=socket'));
-		$this->assertEquals($r, "GET /search?q=socket HTTP/1.1\r\n");
+		$this->assertEquals("GET /search?q=socket HTTP/1.1\r\n", $r);
 
 		$request = array(
 			'method' => 'GET',
@@ -1120,26 +1120,26 @@ class HttpSocketTest extends CakeTestCase {
 			)
 		);
 		$r = $this->Socket->buildRequestLine($request);
-		$this->assertEquals($r, "GET /search?q=socket HTTP/1.1\r\n");
+		$this->assertEquals("GET /search?q=socket HTTP/1.1\r\n", $r);
 
 		unset($request['method']);
 		$r = $this->Socket->buildRequestLine($request);
-		$this->assertEquals($r, "GET /search?q=socket HTTP/1.1\r\n");
+		$this->assertEquals("GET /search?q=socket HTTP/1.1\r\n", $r);
 
 		$r = $this->Socket->buildRequestLine($request, 'CAKE-HTTP/0.1');
-		$this->assertEquals($r, "GET /search?q=socket CAKE-HTTP/0.1\r\n");
+		$this->assertEquals("GET /search?q=socket CAKE-HTTP/0.1\r\n", $r);
 
 		$request = array('method' => 'OPTIONS', 'uri' => '*');
 		$r = $this->Socket->buildRequestLine($request);
-		$this->assertEquals($r, "OPTIONS * HTTP/1.1\r\n");
+		$this->assertEquals("OPTIONS * HTTP/1.1\r\n", $r);
 
 		$request['method'] = 'GET';
 		$this->Socket->quirksMode = true;
 		$r = $this->Socket->buildRequestLine($request);
-		$this->assertEquals($r, "GET * HTTP/1.1\r\n");
+		$this->assertEquals("GET * HTTP/1.1\r\n", $r);
 
 		$r = $this->Socket->buildRequestLine("GET * HTTP/1.1\r\n");
-		$this->assertEquals($r, "GET * HTTP/1.1\r\n");
+		$this->assertEquals("GET * HTTP/1.1\r\n", $r);
 	}
 
 /**
@@ -1171,16 +1171,16 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 
 		$uri = $this->Socket->parseUri(array('invalid' => 'uri-string'));
-		$this->assertEquals($uri, false);
+		$this->assertEquals(false, $uri);
 
 		$uri = $this->Socket->parseUri(array('invalid' => 'uri-string'), array('host' => 'somehost'));
-		$this->assertEquals($uri, array('host' => 'somehost', 'invalid' => 'uri-string'));
+		$this->assertEquals(array('host' => 'somehost', 'invalid' => 'uri-string'), $uri);
 
 		$uri = $this->Socket->parseUri(false);
-		$this->assertEquals($uri, false);
+		$this->assertEquals(false, $uri);
 
 		$uri = $this->Socket->parseUri('/my-cool-path');
-		$this->assertEquals($uri, array('path' => '/my-cool-path'));
+		$this->assertEquals(array('path' => '/my-cool-path'), $uri);
 
 		$uri = $this->Socket->parseUri('http://bob:foo123@www.cakephp.org:40/search?q=dessert#results');
 		$this->assertEquals($uri, array(
@@ -1298,37 +1298,37 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 
 		$r = $this->Socket->buildUri(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->Socket->buildUri('foo.com');
-		$this->assertEquals($r, 'http://foo.com/');
+		$this->assertEquals('http://foo.com/', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org'));
-		$this->assertEquals($r, 'http://www.cakephp.org/');
+		$this->assertEquals('http://www.cakephp.org/', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'scheme' => 'https'));
-		$this->assertEquals($r, 'https://www.cakephp.org/');
+		$this->assertEquals('https://www.cakephp.org/', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'port' => 23));
-		$this->assertEquals($r, 'http://www.cakephp.org:23/');
+		$this->assertEquals('http://www.cakephp.org:23/', $r);
 
 		$r = $this->Socket->buildUri(array('path' => 'www.google.com/search', 'query' => 'q=cakephp'));
-		$this->assertEquals($r, 'http://www.google.com/search?q=cakephp');
+		$this->assertEquals('http://www.google.com/search?q=cakephp', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'scheme' => 'https', 'port' => 79));
-		$this->assertEquals($r, 'https://www.cakephp.org:79/');
+		$this->assertEquals('https://www.cakephp.org:79/', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'path' => 'foo'));
-		$this->assertEquals($r, 'http://www.cakephp.org/foo');
+		$this->assertEquals('http://www.cakephp.org/foo', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'path' => '/foo'));
-		$this->assertEquals($r, 'http://www.cakephp.org/foo');
+		$this->assertEquals('http://www.cakephp.org/foo', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'path' => '/search', 'query' => array('q' => 'HttpSocket')));
-		$this->assertEquals($r, 'http://www.cakephp.org/search?q=HttpSocket');
+		$this->assertEquals('http://www.cakephp.org/search?q=HttpSocket', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'fragment' => 'bar'));
-		$this->assertEquals($r, 'http://www.cakephp.org/#bar');
+		$this->assertEquals('http://www.cakephp.org/#bar', $r);
 
 		$r = $this->Socket->buildUri(array(
 			'scheme' => 'https',
@@ -1340,19 +1340,19 @@ class HttpSocketTest extends CakeTestCase {
 			'query' => array('foo' => 'bar'),
 			'fragment' => 'comment'
 		));
-		$this->assertEquals($r, 'https://bob:secret@www.cakephp.org:25/cool?foo=bar#comment');
+		$this->assertEquals('https://bob:secret@www.cakephp.org:25/cool?foo=bar#comment', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org', 'fragment' => 'bar'), '%fragment?%host');
-		$this->assertEquals($r, 'bar?www.cakephp.org');
+		$this->assertEquals('bar?www.cakephp.org', $r);
 
 		$r = $this->Socket->buildUri(array('host' => 'www.cakephp.org'), '%fragment???%host');
-		$this->assertEquals($r, '???www.cakephp.org');
+		$this->assertEquals('???www.cakephp.org', $r);
 
 		$r = $this->Socket->buildUri(array('path' => '*'), '/%path?%query');
-		$this->assertEquals($r, '*');
+		$this->assertEquals('*', $r);
 
 		$r = $this->Socket->buildUri(array('scheme' => 'foo', 'host' => 'www.cakephp.org'));
-		$this->assertEquals($r, 'foo://www.cakephp.org:80/');
+		$this->assertEquals('foo://www.cakephp.org:80/', $r);
 	}
 
 /**
@@ -1364,28 +1364,28 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 
 		$query = $this->Socket->parseQuery(array('framework' => 'cakephp'));
-		$this->assertEquals($query, array('framework' => 'cakephp'));
+		$this->assertEquals(array('framework' => 'cakephp'), $query);
 
 		$query = $this->Socket->parseQuery('');
-		$this->assertEquals($query, array());
+		$this->assertEquals(array(), $query);
 
 		$query = $this->Socket->parseQuery('framework=cakephp');
-		$this->assertEquals($query, array('framework' => 'cakephp'));
+		$this->assertEquals(array('framework' => 'cakephp'), $query);
 
 		$query = $this->Socket->parseQuery('?framework=cakephp');
-		$this->assertEquals($query, array('framework' => 'cakephp'));
+		$this->assertEquals(array('framework' => 'cakephp'), $query);
 
 		$query = $this->Socket->parseQuery('a&b&c');
-		$this->assertEquals($query, array('a' => '', 'b' => '', 'c' => ''));
+		$this->assertEquals(array('a' => '', 'b' => '', 'c' => ''), $query);
 
 		$query = $this->Socket->parseQuery('value=12345');
-		$this->assertEquals($query, array('value' => '12345'));
+		$this->assertEquals(array('value' => '12345'), $query);
 
 		$query = $this->Socket->parseQuery('a[0]=foo&a[1]=bar&a[2]=cake');
-		$this->assertEquals($query, array('a' => array(0 => 'foo', 1 => 'bar', 2 => 'cake')));
+		$this->assertEquals(array('a' => array(0 => 'foo', 1 => 'bar', 2 => 'cake')), $query);
 
 		$query = $this->Socket->parseQuery('a[]=foo&a[]=bar&a[]=cake');
-		$this->assertEquals($query, array('a' => array(0 => 'foo', 1 => 'bar', 2 => 'cake')));
+		$this->assertEquals(array('a' => array(0 => 'foo', 1 => 'bar', 2 => 'cake')), $query);
 
 		$query = $this->Socket->parseQuery('a[][]=foo&a[][]=bar&a[][]=cake');
 		$expectedQuery = array(
@@ -1401,7 +1401,7 @@ class HttpSocketTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals($query, $expectedQuery);
+		$this->assertEquals($expectedQuery, $query);
 
 		$query = $this->Socket->parseQuery('a[][]=foo&a[bar]=php&a[][]=bar&a[][]=cake');
 		$expectedQuery = array(
@@ -1412,7 +1412,7 @@ class HttpSocketTest extends CakeTestCase {
 				array('cake')
 			)
 		);
-		$this->assertEquals($query, $expectedQuery);
+		$this->assertEquals($expectedQuery, $query);
 
 		$query = $this->Socket->parseQuery('user[]=jim&user[3]=tom&user[]=bob');
 		$expectedQuery = array(
@@ -1422,7 +1422,7 @@ class HttpSocketTest extends CakeTestCase {
 				4 => 'bob'
 			)
 		);
-		$this->assertEquals($query, $expectedQuery);
+		$this->assertEquals($expectedQuery, $query);
 
 		$queryStr = 'user[0]=foo&user[0][items][]=foo&user[0][items][]=bar&user[][name]=jim&user[1][items][personal][]=book&user[1][items][personal][]=pen&user[1][items][]=ball&user[count]=2&empty';
 		$query = $this->Socket->parseQuery($queryStr);
@@ -1469,31 +1469,31 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 
 		$r = $this->Socket->buildHeader(true);
-		$this->assertEquals($r, false);
+		$this->assertEquals(false, $r);
 
 		$r = $this->Socket->buildHeader('My raw header');
-		$this->assertEquals($r, 'My raw header');
+		$this->assertEquals('My raw header', $r);
 
 		$r = $this->Socket->buildHeader(array('Host' => 'www.cakephp.org'));
-		$this->assertEquals($r, "Host: www.cakephp.org\r\n");
+		$this->assertEquals("Host: www.cakephp.org\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('Host' => 'www.cakephp.org', 'Connection' => 'Close'));
-		$this->assertEquals($r, "Host: www.cakephp.org\r\nConnection: Close\r\n");
+		$this->assertEquals("Host: www.cakephp.org\r\nConnection: Close\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('People' => array('Bob', 'Jim', 'John')));
-		$this->assertEquals($r, "People: Bob,Jim,John\r\n");
+		$this->assertEquals("People: Bob,Jim,John\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('Multi-Line-Field' => "This is my\r\nMulti Line field"));
-		$this->assertEquals($r, "Multi-Line-Field: This is my\r\n Multi Line field\r\n");
+		$this->assertEquals("Multi-Line-Field: This is my\r\n Multi Line field\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('Multi-Line-Field' => "This is my\r\n Multi Line field"));
-		$this->assertEquals($r, "Multi-Line-Field: This is my\r\n Multi Line field\r\n");
+		$this->assertEquals("Multi-Line-Field: This is my\r\n Multi Line field\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('Multi-Line-Field' => "This is my\r\n\tMulti Line field"));
-		$this->assertEquals($r, "Multi-Line-Field: This is my\r\n\tMulti Line field\r\n");
+		$this->assertEquals("Multi-Line-Field: This is my\r\n\tMulti Line field\r\n", $r);
 
 		$r = $this->Socket->buildHeader(array('Test@Field' => "My value"));
-		$this->assertEquals($r, "Test\"@\"Field: My value\r\n");
+		$this->assertEquals("Test\"@\"Field: My value\r\n", $r);
 	}
 
 /**
@@ -1514,7 +1514,7 @@ class HttpSocketTest extends CakeTestCase {
 		);
 		$expect = "Cookie: foo=bar; people=jim,jack,johnny\";\"\r\n";
 		$result = $this->Socket->buildCookies($cookies);
-		$this->assertEquals($result, $expect);
+		$this->assertEquals($expect, $result);
 	}
 
 /**
@@ -1532,14 +1532,14 @@ class HttpSocketTest extends CakeTestCase {
 			'\x1e','\x1f','\x7f'
 		);
 		$r = $this->Socket->tokenEscapeChars();
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		foreach ($expected as $key => $char) {
 			$expected[$key] = chr(hexdec(substr($char, 2)));
 		}
 
 		$r = $this->Socket->tokenEscapeChars(false);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 	}
 
 /**
@@ -1550,7 +1550,7 @@ class HttpSocketTest extends CakeTestCase {
 	public function testEscapeToken() {
 		$this->Socket->reset();
 
-		$this->assertEquals($this->Socket->escapeToken('Foo'), 'Foo');
+		$this->assertEquals('Foo', $this->Socket->escapeToken('Foo'));
 
 		$escape = $this->Socket->tokenEscapeChars(false);
 		foreach ($escape as $char) {
@@ -1558,7 +1558,7 @@ class HttpSocketTest extends CakeTestCase {
 			$escapedToken = $this->Socket->escapeToken($token);
 			$expectedToken = 'My-special-"' . $char . '"-Token';
 
-			$this->assertEquals($escapedToken, $expectedToken, 'Test token escaping for ASCII ' . ord($char));
+			$this->assertEquals($expectedToken, $escapedToken, 'Test token escaping for ASCII ' . ord($char));
 		}
 
 		$token = 'Extreme-:Token-	-"@-test';
@@ -1587,7 +1587,7 @@ class HttpSocketTest extends CakeTestCase {
 			$this->assertEquals($this->Socket->{$property}, $value);
 		}
 
-		$this->assertEquals($return, true);
+		$this->assertEquals(true, $return);
 	}
 
 /**
@@ -1612,9 +1612,9 @@ class HttpSocketTest extends CakeTestCase {
 			if (in_array($property, $partialResetProperties)) {
 				$this->assertEquals($this->Socket->{$property}, $originalValue);
 			} else {
-				$this->assertEquals($this->Socket->{$property}, 'Overwritten');
+				$this->assertEquals('Overwritten', $this->Socket->{$property});
 			}
 		}
-		$this->assertEquals($return, true);
+		$this->assertEquals(true, $return);
 	}
 }

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -585,7 +585,7 @@ class DispatcherTest extends CakeTestCase {
 		$Dispatcher = new Dispatcher();
 
 		$test = $Dispatcher->parseParams(new CakeRequest("/"));
-		$this->assertEquals($test['data']['testdata'], "My Posted Content");
+		$this->assertEquals("My Posted Content", $test['data']['testdata']);
 	}
 
 /**
@@ -682,7 +682,7 @@ class DispatcherTest extends CakeTestCase {
 		$this->assertRegExp('/display/', $result['action']);
 		$this->assertTrue(isset($result['url']['sleep']));
 		$this->assertTrue(isset($result['url']['coffee']));
-		$this->assertEquals($result['url']['coffee'], 'life');
+		$this->assertEquals('life', $result['url']['coffee']);
 	}
 
 /**
@@ -799,7 +799,7 @@ class DispatcherTest extends CakeTestCase {
 
 		$url = new CakeRequest('test_dispatch_pages/camelCased/something. .');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEquals($controller->params['pass'][0], 'something. .', 'Period was chopped off. %s');
+		$this->assertEquals('something. .', $controller->params['pass'][0], 'Period was chopped off. %s');
 	}
 
 /**
@@ -836,7 +836,7 @@ class DispatcherTest extends CakeTestCase {
 		Router::reload();
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertEquals($controller->name, 'TestDispatchPages');
+		$this->assertEquals('TestDispatchPages', $controller->name);
 
 		$this->assertSame($controller->passedArgs, array('param' => 'value', 'param2' => 'value2'));
 		$this->assertTrue($controller->params['admin']);
@@ -874,7 +874,7 @@ class DispatcherTest extends CakeTestCase {
 			'controller' => 'some_pages', 'action' => 'display'
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch ' . $key . ' %');
+			$this->assertEquals($value, $result[$key], 'Value mismatch ' . $key . ' %');
 		}
 
 		$this->assertSame($controller->plugin, 'MyPlugin');
@@ -941,7 +941,7 @@ class DispatcherTest extends CakeTestCase {
 		$this->assertSame($controller->plugin, 'MyPlugin');
 		$this->assertSame($controller->name, 'MyPlugin');
 		$this->assertSame($controller->action, 'add');
-		$this->assertEquals($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
+		$this->assertEquals(array('param' => 'value', 'param2' => 'value2'), $controller->params['named']);
 
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
@@ -961,7 +961,7 @@ class DispatcherTest extends CakeTestCase {
 		$this->assertSame($controller->action, 'index');
 
 		$expected = $pluginUrl;
-		$this->assertEquals($controller->params['controller'], $expected);
+		$this->assertEquals($expected, $controller->params['controller']);
 
 		Configure::write('Routing.prefixes', array('admin'));
 
@@ -974,17 +974,17 @@ class DispatcherTest extends CakeTestCase {
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
 
-		$this->assertEquals($controller->params['plugin'], 'my_plugin');
-		$this->assertEquals($controller->params['controller'], 'my_plugin');
-		$this->assertEquals($controller->params['action'], 'admin_add');
-		$this->assertEquals($controller->params['pass'], array(5));
-		$this->assertEquals($controller->params['named'], array('param' => 'value', 'param2' => 'value2'));
+		$this->assertEquals('my_plugin', $controller->params['plugin']);
+		$this->assertEquals('my_plugin', $controller->params['controller']);
+		$this->assertEquals('admin_add', $controller->params['action']);
+		$this->assertEquals(array(5), $controller->params['pass']);
+		$this->assertEquals(array('param' => 'value', 'param2' => 'value2'), $controller->params['named']);
 		$this->assertSame($controller->plugin, 'MyPlugin');
 		$this->assertSame($controller->name, 'MyPlugin');
 		$this->assertSame($controller->action, 'admin_add');
 
 		$expected = array(0 => 5, 'param' => 'value', 'param2' => 'value2');
-		$this->assertEquals($controller->passedArgs, $expected);
+		$this->assertEquals($expected, $controller->passedArgs);
 
 		Configure::write('Routing.prefixes', array('admin'));
 		CakePlugin::load('ArticlesTest', array('path' => '/fake/path'));
@@ -1009,7 +1009,7 @@ class DispatcherTest extends CakeTestCase {
 			'return' => 1
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($controller->request[$key], $expected[$key], 'Value mismatch ' . $key);
+			$this->assertEquals($expected[$key], $controller->request[$key], 'Value mismatch ' . $key);
 		}
 	}
 
@@ -1030,9 +1030,9 @@ class DispatcherTest extends CakeTestCase {
 		$response = $this->getMock('CakeResponse');
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEquals($controller->params['controller'], 'my_plugin');
-		$this->assertEquals($controller->params['plugin'], 'my_plugin');
-		$this->assertEquals($controller->params['action'], 'index');
+		$this->assertEquals('my_plugin', $controller->params['controller']);
+		$this->assertEquals('my_plugin', $controller->params['plugin']);
+		$this->assertEquals('index', $controller->params['action']);
 		$this->assertFalse(isset($controller->params['pass'][0]));
 	}
 
@@ -1059,24 +1059,24 @@ class DispatcherTest extends CakeTestCase {
 		$response = $this->getMock('CakeResponse');
 
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEquals($controller->params['controller'], 'test_plugin');
-		$this->assertEquals($controller->params['plugin'], 'test_plugin');
-		$this->assertEquals($controller->params['action'], 'index');
+		$this->assertEquals('test_plugin', $controller->params['controller']);
+		$this->assertEquals('test_plugin', $controller->params['plugin']);
+		$this->assertEquals('index', $controller->params['action']);
 		$this->assertFalse(isset($controller->params['pass'][0]));
 
 		$url = new CakeRequest('/test_plugin/tests/index');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEquals($controller->params['controller'], 'tests');
-		$this->assertEquals($controller->params['plugin'], 'test_plugin');
-		$this->assertEquals($controller->params['action'], 'index');
+		$this->assertEquals('tests', $controller->params['controller']);
+		$this->assertEquals('test_plugin', $controller->params['plugin']);
+		$this->assertEquals('index', $controller->params['action']);
 		$this->assertFalse(isset($controller->params['pass'][0]));
 
 		$url = new CakeRequest('/test_plugin/tests/index/some_param');
 		$controller = $Dispatcher->dispatch($url, $response, array('return' => 1));
-		$this->assertEquals($controller->params['controller'], 'tests');
-		$this->assertEquals($controller->params['plugin'], 'test_plugin');
-		$this->assertEquals($controller->params['action'], 'index');
-		$this->assertEquals($controller->params['pass'][0], 'some_param');
+		$this->assertEquals('tests', $controller->params['controller']);
+		$this->assertEquals('test_plugin', $controller->params['plugin']);
+		$this->assertEquals('index', $controller->params['action']);
+		$this->assertEquals('some_param', $controller->params['pass'][0]);
 
 		App::build();
 	}
@@ -1137,9 +1137,9 @@ class DispatcherTest extends CakeTestCase {
 		$this->assertTrue(class_exists('TestPluginAppController'));
 		$this->assertTrue(class_exists('PluginsComponent'));
 
-		$this->assertEquals($result->params['controller'], 'tests');
-		$this->assertEquals($result->params['plugin'], 'test_plugin');
-		$this->assertEquals($result->params['action'], 'index');
+		$this->assertEquals('tests', $result->params['controller']);
+		$this->assertEquals('test_plugin', $result->params['plugin']);
+		$this->assertEquals('index', $result->params['action']);
 
 		App::build();
 	}
@@ -1444,7 +1444,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts'));
 		$expected = array('pass' => array(), 'named' => array(), 'plugin' => null, 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST');
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($value, $result[$key], 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -1461,7 +1461,7 @@ class DispatcherTest extends CakeTestCase {
 			'[method]' => 'PUT'
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($value, $result[$key], 'Value mismatch for ' . $key . ' %s');
 		}
 
 		unset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
@@ -1470,7 +1470,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts/5'));
 		$expected = array('pass' => array('5'), 'named' => array(), 'id' => '5', 'plugin' => null, 'controller' => 'posts', 'action' => 'view', '[method]' => 'GET');
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($value, $result[$key], 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_POST['_method'] = 'PUT';
@@ -1478,7 +1478,7 @@ class DispatcherTest extends CakeTestCase {
 		$result = $dispatcher->parseParams(new CakeRequest('/posts/5'));
 		$expected = array('pass' => array('5'), 'named' => array(), 'id' => '5', 'plugin' => null, 'controller' => 'posts', 'action' => 'edit', '[method]' => 'PUT');
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($value, $result[$key], 'Value mismatch for ' . $key . ' %s');
 		}
 
 		$_POST['_method'] = 'POST';
@@ -1492,7 +1492,7 @@ class DispatcherTest extends CakeTestCase {
 			'[method]' => 'POST', 'data' => array('extra' => 'data', 'Post' => array('title' => 'New Post')),
 		);
 		foreach ($expected as $key => $value) {
-			$this->assertEquals($result[$key], $value, 'Value mismatch for ' . $key . ' %s');
+			$this->assertEquals($value, $result[$key], 'Value mismatch for ' . $key . ' %s');
 		}
 
 		unset($_POST['_method']);

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -45,9 +45,9 @@ class CakeRouteTest extends CakeTestCase {
 	public function testConstruction() {
 		$route = new CakeRoute('/:controller/:action/:id', array(), array('id' => '[0-9]+'));
 
-		$this->assertEquals($route->template, '/:controller/:action/:id');
-		$this->assertEquals($route->defaults, array());
-		$this->assertEquals($route->options, array('id' => '[0-9]+'));
+		$this->assertEquals('/:controller/:action/:id', $route->template);
+		$this->assertEquals(array(), $route->defaults);
+		$this->assertEquals(array('id' => '[0-9]+'), $route->options);
 		$this->assertFalse($route->compiled());
 	}
 
@@ -61,7 +61,7 @@ class CakeRouteTest extends CakeTestCase {
 		$result = $route->compile();
 		$expected = '#^/*$#';
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($route->keys, array());
+		$this->assertEquals(array(), $route->keys);
 
 		$route = new CakeRoute('/:controller/:action', array('controller' => 'posts'));
 		$result = $route->compile();
@@ -79,7 +79,7 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertNotRegExp($result, '/posts');
 		$this->assertNotRegExp($result, '/posts/');
 
-		$this->assertEquals($route->keys, array('id'));
+		$this->assertEquals(array('id'), $route->keys);
 
 		$route = new CakeRoute('/:plugin/:controller/:action/*', array('plugin' => 'test_plugin', 'action' => 'index'));
 		$result = $route->compile();
@@ -119,7 +119,7 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertRegExp($result, '/posts/view/518098');
 		$this->assertNotRegExp($result, '/posts/edit/name-of-post');
 		$this->assertNotRegExp($result, '/posts/edit/4/other:param');
-		$this->assertEquals($route->keys, array('controller', 'action', 'id'));
+		$this->assertEquals(array('controller', 'action', 'id'), $route->keys);
 
 		$route = new CakeRoute(
 			'/:lang/:controller/:action/:id',
@@ -131,7 +131,7 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertRegExp($result, '/cze/articles/view/1');
 		$this->assertNotRegExp($result, '/language/articles/view/2');
 		$this->assertNotRegExp($result, '/eng/articles/view/name-of-article');
-		$this->assertEquals($route->keys, array('lang', 'controller', 'action', 'id'));
+		$this->assertEquals(array('lang', 'controller', 'action', 'id'), $route->keys);
 
 		foreach (array(':', '@', ';', '$', '-') as $delim) {
 			$route = new CakeRoute('/posts/:id' . $delim . ':title');
@@ -142,7 +142,7 @@ class CakeRouteTest extends CakeTestCase {
 			$this->assertNotRegExp($result, '/posts/11!nameofarticle');
 			$this->assertNotRegExp($result, '/posts/11');
 
-			$this->assertEquals($route->keys, array('id', 'title'));
+			$this->assertEquals(array('id', 'title'), $route->keys);
 		}
 
 		$route = new CakeRoute(
@@ -156,7 +156,7 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertNotRegExp($result, '/posts/hey_now:nameofarticle');
 		$this->assertNotRegExp($result, '/posts/:nameofarticle/2009');
 		$this->assertNotRegExp($result, '/posts/:nameofarticle/01');
-		$this->assertEquals($route->keys, array('id', 'title', 'year'));
+		$this->assertEquals(array('id', 'title', 'year'), $route->keys);
 
 		$route = new CakeRoute(
 			'/posts/:url_title-(uuid::id)',
@@ -169,7 +169,7 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertNotRegExp($result, '/posts/');
 		$this->assertNotRegExp($result, '/posts/nameofarticle');
 		$this->assertNotRegExp($result, '/posts/nameofarticle-12347');
-		$this->assertEquals($route->keys, array('url_title', 'id'));
+		$this->assertEquals(array('url_title', 'id'), $route->keys);
 	}
 
 /**
@@ -188,13 +188,13 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertRegExp($result, '/posts/08/01/2007/title-of-post');
 		$result = $route->parse('/posts/08/01/2007/title-of-post');
 
-		$this->assertEquals(count($result), 7);
-		$this->assertEquals($result['controller'], 'posts');
-		$this->assertEquals($result['action'], 'view');
-		$this->assertEquals($result['year'], '2007');
-		$this->assertEquals($result['month'], '08');
-		$this->assertEquals($result['day'], '01');
-		$this->assertEquals($result['pass'][0], 'title-of-post');
+		$this->assertEquals(7, count($result));
+		$this->assertEquals('posts', $result['controller']);
+		$this->assertEquals('view', $result['action']);
+		$this->assertEquals('2007', $result['year']);
+		$this->assertEquals('08', $result['month']);
+		$this->assertEquals('01', $result['day']);
+		$this->assertEquals('title-of-post', $result['pass'][0]);
 
 		$route = new CakeRoute(
 			"/:extra/page/:slug/*",
@@ -205,13 +205,13 @@ class CakeRouteTest extends CakeTestCase {
 
 		$this->assertRegExp($result, '/some_extra/page/this_is_the_slug');
 		$this->assertRegExp($result, '/page/this_is_the_slug');
-		$this->assertEquals($route->keys, array('extra', 'slug'));
-		$this->assertEquals($route->options, array('extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'));
+		$this->assertEquals(array('extra', 'slug'), $route->keys);
+		$this->assertEquals(array('extra' => '[a-z1-9_]*', 'slug' => '[a-z1-9_]+', 'action' => 'view'), $route->options);
 		$expected = array(
 			'controller' => 'pages',
 			'action' => 'view'
 		);
-		$this->assertEquals($route->defaults, $expected);
+		$this->assertEquals($expected, $route->defaults);
 
 		$route = new CakeRoute(
 			'/:controller/:action/*',
@@ -245,25 +245,25 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 1));
-		$this->assertEquals($result, '/posts/view/1');
+		$this->assertEquals('/posts/view/1', $result);
 
 		$route = new CakeRoute('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'about'));
 		$this->assertFalse($result);
 
 		$route = new CakeRoute('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEquals($result, '/pages/home');
+		$this->assertEquals('/pages/home', $result);
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 'about'));
-		$this->assertEquals($result, '/pages/about');
+		$this->assertEquals('/pages/about', $result);
 
 		$route = new CakeRoute('/blog/:action', array('controller' => 'posts'));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view'));
-		$this->assertEquals($result, '/blog/view');
+		$this->assertEquals('/blog/view', $result);
 
 		$result = $route->match(array('controller' => 'nodes', 'action' => 'view'));
 		$this->assertFalse($result);
@@ -276,14 +276,14 @@ class CakeRouteTest extends CakeTestCase {
 
 		$route = new CakeRoute('/foo/:controller/:action', array('action' => 'index'));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view'));
-		$this->assertEquals($result, '/foo/posts/view');
+		$this->assertEquals('/foo/posts/view', $result);
 
 		$route = new CakeRoute('/:plugin/:id/*', array('controller' => 'posts', 'action' => 'view'));
 		$result = $route->match(array('plugin' => 'test', 'controller' => 'posts', 'action' => 'view', 'id' => '1'));
-		$this->assertEquals($result, '/test/1/');
+		$this->assertEquals('/test/1/', $result);
 
 		$result = $route->match(array('plugin' => 'fo', 'controller' => 'posts', 'action' => 'view', 'id' => '1', '0'));
-		$this->assertEquals($result, '/fo/1/0');
+		$this->assertEquals('/fo/1/0', $result);
 
 		$result = $route->match(array('plugin' => 'fo', 'controller' => 'nodes', 'action' => 'view', 'id' => 1));
 		$this->assertFalse($result);
@@ -337,7 +337,7 @@ class CakeRouteTest extends CakeTestCase {
 		$result = $route->match(array(
 			'controller' => 'posts', 'action' => 'index', 'plugin' => null, 'admin' => false
 		));
-		$this->assertEquals($result, '/posts/index/');
+		$this->assertEquals('/posts/index/', $result);
 	}
 
 /**
@@ -350,29 +350,29 @@ class CakeRouteTest extends CakeTestCase {
 
 		$route = new CakeRoute('/:controller/:action/*', array('plugin' => null));
 		$result = $route->match(array('controller' => 'posts', 'action' => 'index', 'plugin' => null, 'page' => 1));
-		$this->assertEquals($result, '/posts/index/page:1');
+		$this->assertEquals('/posts/index/page:1', $result);
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 5));
-		$this->assertEquals($result, '/posts/view/5');
+		$this->assertEquals('/posts/view/5', $result);
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 0));
-		$this->assertEquals($result, '/posts/view/0');
+		$this->assertEquals('/posts/view/0', $result);
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, '0'));
-		$this->assertEquals($result, '/posts/view/0');
+		$this->assertEquals('/posts/view/0', $result);
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 5, 'page' => 1, 'limit' => 20, 'order' => 'title'));
-		$this->assertEquals($result, '/posts/view/5/page:1/limit:20/order:title');
+		$this->assertEquals('/posts/view/5/page:1/limit:20/order:title', $result);
 
 		$result = $route->match(array('controller' => 'posts', 'action' => 'view', 'plugin' => null, 'word space', 'order' => 'Θ'));
-		$this->assertEquals($result, '/posts/view/word%20space/order:%CE%98');
+		$this->assertEquals('/posts/view/word%20space/order:%CE%98', $result);
 
 		$route = new CakeRoute('/test2/*', array('controller' => 'pages', 'action' => 'display', 2));
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 1));
 		$this->assertFalse($result);
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 2, 'something'));
-		$this->assertEquals($result, '/test2/something');
+		$this->assertEquals('/test2/something', $result);
 
 		$result = $route->match(array('controller' => 'pages', 'action' => 'display', 5, 'something'));
 		$this->assertFalse($result);
@@ -440,10 +440,10 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '9'));
-		$this->assertEquals($result, '/posts/view/9');
+		$this->assertEquals('/posts/view/9', $result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => '922'));
-		$this->assertEquals($result, '/posts/view/922');
+		$this->assertEquals('/posts/view/922', $result);
 
 		$result = $route->match(array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'id' => 'a99'));
 		$this->assertFalse($result);
@@ -463,14 +463,14 @@ class CakeRouteTest extends CakeTestCase {
 		$url = array('controller' => 'posts', 'action' => 'index');
 		$params = array('lang' => 'en', 'color' => 'blue');
 		$result = $route->persistParams($url, $params);
-		$this->assertEquals($result['lang'], 'en');
-		$this->assertEquals($result['color'], 'blue');
+		$this->assertEquals('en', $result['lang']);
+		$this->assertEquals('blue', $result['color']);
 
 		$url = array('controller' => 'posts', 'action' => 'index', 'color' => 'red');
 		$params = array('lang' => 'en', 'color' => 'blue');
 		$result = $route->persistParams($url, $params);
-		$this->assertEquals($result['lang'], 'en');
-		$this->assertEquals($result['color'], 'red');
+		$this->assertEquals('en', $result['lang']);
+		$this->assertEquals('red', $result['color']);
 	}
 
 /**
@@ -486,9 +486,9 @@ class CakeRouteTest extends CakeTestCase {
 		);
 		$route->compile();
 		$result = $route->parse('/posts/view/1');
-		$this->assertEquals($result['controller'], 'posts');
-		$this->assertEquals($result['action'], 'view');
-		$this->assertEquals($result['id'], '1');
+		$this->assertEquals('posts', $result['controller']);
+		$this->assertEquals('view', $result['action']);
+		$this->assertEquals('1', $result['id']);
 
 		$route = new Cakeroute(
 			'/admin/:controller',
@@ -499,8 +499,8 @@ class CakeRouteTest extends CakeTestCase {
 		$this->assertFalse($result);
 
 		$result = $route->parse('/admin/posts');
-		$this->assertEquals($result['controller'], 'posts');
-		$this->assertEquals($result['action'], 'index');
+		$this->assertEquals('posts', $result['controller']);
+		$this->assertEquals('index', $result['action']);
 	}
 
 /**
@@ -515,14 +515,14 @@ class CakeRouteTest extends CakeTestCase {
 		);
 		$route->compile();
 		$result = $route->parse('/posts/%E2%88%82%E2%88%82');
-		$this->assertEquals($result['controller'], 'posts');
-		$this->assertEquals($result['action'], 'view');
-		$this->assertEquals($result['slug'], '∂∂');
+		$this->assertEquals('posts', $result['controller']);
+		$this->assertEquals('view', $result['action']);
+		$this->assertEquals('∂∂', $result['slug']);
 
 		$result = $route->parse('/posts/∂∂');
-		$this->assertEquals($result['controller'], 'posts');
-		$this->assertEquals($result['action'], 'view');
-		$this->assertEquals($result['slug'], '∂∂');
+		$this->assertEquals('posts', $result['controller']);
+		$this->assertEquals('view', $result['action']);
+		$this->assertEquals('∂∂', $result['slug']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
@@ -47,9 +47,9 @@ class PluginShortRouteTestCase extends  CakeTestCase {
 		$route = new PluginShortRoute('/:plugin', array('action' => 'index'), array('plugin' => 'foo|bar'));
 
 		$result = $route->parse('/foo');
-		$this->assertEquals($result['plugin'], 'foo');
-		$this->assertEquals($result['controller'], 'foo');
-		$this->assertEquals($result['action'], 'index');
+		$this->assertEquals('foo', $result['plugin']);
+		$this->assertEquals('foo', $result['controller']);
+		$this->assertEquals('index', $result['action']);
 
 		$result = $route->parse('/wrong');
 		$this->assertFalse($result, 'Wrong plugin name matched %s');
@@ -67,6 +67,6 @@ class PluginShortRouteTestCase extends  CakeTestCase {
 		$this->assertFalse($result, 'plugin controller mismatch was converted. %s');
 
 		$result = $route->match(array('plugin' => 'foo', 'controller' => 'foo', 'action' => 'index'));
-		$this->assertEquals($result, '/foo');
+		$this->assertEquals('/foo', $result);
 	}
 }

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -50,58 +50,58 @@ class RedirectRouteTestCase extends  CakeTestCase {
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/home');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/posts', true));
+		$this->assertEquals(Router::url('/posts', true), $header['Location']);
 
 		$route = new RedirectRoute('/home', array('controller' => 'posts', 'action' => 'index'));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/home');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/posts', true));
-		$this->assertEquals($route->response->statusCode(), 301);
+		$this->assertEquals(Router::url('/posts', true), $header['Location']);
+		$this->assertEquals(301, $route->response->statusCode());
 
 		$route = new RedirectRoute('/google', 'http://google.com');
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/google');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], 'http://google.com');
+		$this->assertEquals('http://google.com', $header['Location']);
 
 		$route = new RedirectRoute('/posts/*', array('controller' => 'posts', 'action' => 'view'), array('status' => 302));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/posts/view', true));
-		$this->assertEquals($route->response->statusCode(), 302);
+		$this->assertEquals(Router::url('/posts/view', true), $header['Location']);
+		$this->assertEquals(302, $route->response->statusCode());
 
 		$route = new RedirectRoute('/posts/*', array('controller' => 'posts', 'action' => 'view'), array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/posts/view/2', true));
+		$this->assertEquals(Router::url('/posts/view/2', true), $header['Location']);
 
 		$route = new RedirectRoute('/posts/*', '/test', array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/posts/2');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/test', true));
+		$this->assertEquals(Router::url('/test', true), $header['Location']);
 
 		$route = new RedirectRoute('/my_controllers/:action/*', array('controller' => 'tags', 'action' => 'add'), array('persist' => true));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/tags/add/passme/named:param', true));
+		$this->assertEquals(Router::url('/tags/add/passme/named:param', true), $header['Location']);
 
 		$route = new RedirectRoute('/my_controllers/:action/*', array('controller' => 'tags', 'action' => 'add'));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
 		$header = $route->response->header();
-		$this->assertEquals($header['Location'], Router::url('/tags/add', true));
+		$this->assertEquals(Router::url('/tags/add', true), $header['Location']);
 	}
 
 }

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -87,27 +87,27 @@ class RouterTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
-		$this->assertEquals($resources, array('posts'));
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'), $result);
+		$this->assertEquals(array('posts'), $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/13');
-		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => '13', '[method]' => 'GET'));
+		$this->assertEquals(array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => '13', '[method]' => 'GET'), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/13');
-		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '13', '[method]' => 'PUT'));
+		$this->assertEquals(array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '13', '[method]' => 'PUT'), $result);
 
 		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
-		$this->assertEquals($result, array('pass' => array('475acc39-a328-44d3-95fb-015000000000'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '475acc39-a328-44d3-95fb-015000000000', '[method]' => 'PUT'));
+		$this->assertEquals(array('pass' => array('475acc39-a328-44d3-95fb-015000000000'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '475acc39-a328-44d3-95fb-015000000000', '[method]' => 'PUT'), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'DELETE';
 		$result = Router::parse('/posts/13');
-		$this->assertEquals($result, array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'delete', 'id' => '13', '[method]' => 'DELETE'));
+		$this->assertEquals(array('pass' => array('13'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'delete', 'id' => '13', '[method]' => 'DELETE'), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/add');
@@ -115,15 +115,15 @@ class RouterTest extends CakeTestCase {
 
 		Router::reload();
 		$resources = Router::mapResources('Posts', array('id' => '[a-z0-9_]+'));
-		$this->assertEquals($resources, array('posts'));
+		$this->assertEquals(array('posts'), $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/add');
-		$this->assertEquals($result, array('pass' => array('add'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => 'add', '[method]' => 'GET'));
+		$this->assertEquals(array('pass' => array('add'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => 'add', '[method]' => 'GET'), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/name');
-		$this->assertEquals($result, array('pass' => array('name'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'));
+		$this->assertEquals(array('pass' => array('name'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'), $result);
 	}
 
 /**
@@ -150,7 +150,7 @@ class RouterTest extends CakeTestCase {
 			'[method]' => 'GET'
 		);
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($resources, array('test_plugin'));
+		$this->assertEquals(array('test_plugin'), $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/test_plugin/test_plugin/13');
@@ -190,7 +190,7 @@ class RouterTest extends CakeTestCase {
 			'[method]' => 'GET'
 		);
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($resources, array('test_plugin'));
+		$this->assertEquals(array('test_plugin'), $resources);
 	}
 
 /**
@@ -203,11 +203,11 @@ class RouterTest extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')), $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')));
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => array('GET', 'POST')), $result);
 	}
 
 /**
@@ -264,25 +264,25 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Router::normalize('/');
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$result = Router::normalize('http://google.com/');
-		$this->assertEquals($result, 'http://google.com/');
+		$this->assertEquals('http://google.com/', $result);
 
 		$result = Router::normalize('http://google.com//');
-		$this->assertEquals($result, 'http://google.com//');
+		$this->assertEquals('http://google.com//', $result);
 
 		$result = Router::normalize('/users/login/scope://foo');
-		$this->assertEquals($result, '/users/login/scope:/foo');
+		$this->assertEquals('/users/login/scope:/foo', $result);
 
 		$result = Router::normalize('/recipe/recipes/add');
-		$this->assertEquals($result, '/recipe/recipes/add');
+		$this->assertEquals('/recipe/recipes/add', $result);
 
 		$request = new CakeRequest();
 		$request->base = '/us';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('/us/users/logout/');
-		$this->assertEquals($result, '/users/logout');
+		$this->assertEquals('/users/logout', $result);
 
 		Router::reload();
 
@@ -290,7 +290,7 @@ class RouterTest extends CakeTestCase {
 		$request->base = '/cake_12';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('/cake_12/users/logout/');
-		$this->assertEquals($result, '/users/logout');
+		$this->assertEquals('/users/logout', $result);
 
 		Router::reload();
 		$_back = Configure::read('App.baseUrl');
@@ -300,7 +300,7 @@ class RouterTest extends CakeTestCase {
 		$request->base = '/';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('users/login');
-		$this->assertEquals($result, '/users/login');
+		$this->assertEquals('/users/login', $result);
 		Configure::write('App.baseUrl', $_back);
 
 		Router::reload();
@@ -308,10 +308,10 @@ class RouterTest extends CakeTestCase {
 		$request->base = 'beer';
 		Router::setRequestInfo($request);
 		$result = Router::normalize('beer/admin/beers_tags/add');
-		$this->assertEquals($result, '/admin/beers_tags/add');
+		$this->assertEquals('/admin/beers_tags/add', $result);
 
 		$result = Router::normalize('/admin/beers_tags/add');
-		$this->assertEquals($result, '/admin/beers_tags/add');
+		$this->assertEquals('/admin/beers_tags/add', $result);
 	}
 
 /**
@@ -338,7 +338,7 @@ class RouterTest extends CakeTestCase {
 
 		Router::connect('/', array('controller' => 'pages', 'action' => 'display', 'home'));
 		$out = Router::url(array('controller' => 'pages', 'action' => 'display', 'home'));
-		$this->assertEquals($out, '/');
+		$this->assertEquals('/', $out);
 
 		Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 'about'));
@@ -524,7 +524,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => array('var' => null)));
-		$this->assertEquals($result, '/posts/index/0');
+		$this->assertEquals('/posts/index/0', $result);
 
 		$result = Router::url(array('controller' => 'posts', '0', '?' => 'var=test&var2=test2', '#' => 'unencoded string %'));
 		$expected = '/posts/index/0?var=test&var2=test2#unencoded+string+%25';
@@ -903,13 +903,13 @@ class RouterTest extends CakeTestCase {
 			))
 		);
 		$result = Router::url(array('plugin' => null, 'controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, '/admin/posts');
+		$this->assertEquals('/admin/posts', $result);
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, '/admin/this/posts');
+		$this->assertEquals('/admin/this/posts', $result);
 
 		$result = Router::url(array('plugin' => 'aliased', 'controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, '/admin/other/posts/index');
+		$this->assertEquals('/admin/other/posts/index', $result);
 	}
 
 /**
@@ -1433,7 +1433,7 @@ class RouterTest extends CakeTestCase {
 		Router::reload();
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::connectNamed(false);
-		$this->assertEquals(array_keys($result['rules']), array());
+		$this->assertEquals(array(), array_keys($result['rules']));
 		$this->assertFalse($result['greedyNamed']);
 		$result = Router::parse('/controller/action/param1:value1:1/param2:value2:3/param:value');
 		$expected = array('pass' => array('param1:value1:1', 'param2:value2:3', 'param:value'), 'named' => array(), 'controller' => 'controller', 'action' => 'action', 'plugin' => null);
@@ -1443,7 +1443,7 @@ class RouterTest extends CakeTestCase {
 		require CAKE . 'Config' . DS . 'routes.php';
 		$result = Router::connectNamed(true);
 		$named = Router::namedConfig();
-		$this->assertEquals(array_keys($result['rules']), $named['default']);
+		$this->assertEquals($named['default'], array_keys($result['rules']));
 		$this->assertTrue($result['greedyNamed']);
 
 		Router::reload();
@@ -1802,10 +1802,10 @@ class RouterTest extends CakeTestCase {
 		Router::reload();
 		Router::connect('/:controller/:action/*');
 		$result = Router::parse('/posts/view/something.');
-		$this->assertEquals($result['pass'][0], 'something.', 'Period was chopped off %s');
+		$this->assertEquals('something.', $result['pass'][0], 'Period was chopped off %s');
 
 		$result = Router::parse('/posts/view/something. . .');
-		$this->assertEquals($result['pass'][0], 'something. . .', 'Period was chopped off %s');
+		$this->assertEquals('something. . .', $result['pass'][0], 'Period was chopped off %s');
 	}
 
 /**
@@ -1819,10 +1819,10 @@ class RouterTest extends CakeTestCase {
 		Router::parseExtensions('json');
 
 		$result = Router::parse('/posts/view/something.');
-		$this->assertEquals($result['pass'][0], 'something.', 'Period was chopped off %s');
+		$this->assertEquals('something.', $result['pass'][0], 'Period was chopped off %s');
 
 		$result = Router::parse('/posts/view/something. . .');
-		$this->assertEquals($result['pass'][0], 'something. . .', 'Period was chopped off %s');
+		$this->assertEquals('something. . .', $result['pass'][0], 'Period was chopped off %s');
 	}
 
 /**
@@ -1982,13 +1982,13 @@ class RouterTest extends CakeTestCase {
 			))
 		);
 		$result = Router::url(array('controller' => 'users', 'action' => 'login', 'admin' => true));
-		$this->assertEquals($result, '/admin/login');
+		$this->assertEquals('/admin/login', $result);
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'login'));
-		$this->assertEquals($result, '/admin/login');
+		$this->assertEquals('/admin/login', $result);
 
 		$result = Router::url(array('controller' => 'users', 'action' => 'admin_login'));
-		$this->assertEquals($result, '/admin/login');
+		$this->assertEquals('/admin/login', $result);
 	}
 
 /**
@@ -2098,7 +2098,7 @@ class RouterTest extends CakeTestCase {
 		$url = 'example.com/' . $pluginName . '/';
 		$expected = 'example.com';
 
-		$this->assertEquals(Router::stripPlugin($url, $pluginName), $expected);
+		$this->assertEquals($expected, Router::stripPlugin($url, $pluginName));
 		$this->assertEquals(Router::stripPlugin($url), $url);
 		$this->assertEquals(Router::stripPlugin($url, null), $url);
 	}
@@ -2201,7 +2201,7 @@ class RouterTest extends CakeTestCase {
 		require CAKE . 'Config' . DS . 'routes.php';
 
 		$result = Router::url(array('plugin' => 'plugin_js', 'controller' => 'js_file', 'action' => 'index'));
-		$this->assertEquals($result, '/plugin_js/js_file');
+		$this->assertEquals('/plugin_js/js_file', $result);
 
 		$result = Router::parse('/plugin_js/js_file');
 		$expected = array(
@@ -2211,7 +2211,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('plugin' => 'test_plugin', 'controller' => 'test_plugin', 'action' => 'index'));
-		$this->assertEquals($result, '/test_plugin');
+		$this->assertEquals('/test_plugin', $result);
 
 		$result = Router::parse('/test_plugin');
 		$expected = array(
@@ -2272,7 +2272,7 @@ class RouterTest extends CakeTestCase {
 			'_Token' => array('key' => 'sekret')
 		);
 		$result = Router::reverse($params);
-		$this->assertEquals($result, '/posts/view/1');
+		$this->assertEquals('/posts/view/1', $result);
 
 		$params = array(
 			'controller' => 'posts',
@@ -2282,7 +2282,7 @@ class RouterTest extends CakeTestCase {
 			'url' => array()
 		);
 		$result = Router::reverse($params);
-		$this->assertEquals($result, '/posts/index/1/page:1/sort:Article.title/direction:desc');
+		$this->assertEquals('/posts/index/1/page:1/sort:Article.title/direction:desc', $result);
 
 		Router::connect('/:lang/:controller/:action/*', array(), array('lang' => '[a-z]{3}'));
 		$params = array(
@@ -2294,7 +2294,7 @@ class RouterTest extends CakeTestCase {
 			'url' => array('url' => 'eng/posts/view/1')
 		);
 		$result = Router::reverse($params);
-		$this->assertEquals($result, '/eng/posts/view/1');
+		$this->assertEquals('/eng/posts/view/1', $result);
 
 		$params = array(
 			'lang' => 'eng',
@@ -2307,7 +2307,7 @@ class RouterTest extends CakeTestCase {
 			'models' => array()
 		);
 		$result = Router::reverse($params);
-		$this->assertEquals($result, '/eng/posts/view/1?foo=bar&baz=quu');
+		$this->assertEquals('/eng/posts/view/1?foo=bar&baz=quu', $result);
 
 		$request = new CakeRequest('/eng/posts/view/1');
 		$request->addParams(array(
@@ -2374,11 +2374,11 @@ class RouterTest extends CakeTestCase {
 			)
 		));
 		$result = Router::getRequest();
-		$this->assertEquals($result->controller, 'images');
-		$this->assertEquals($result->action, 'index');
-		$this->assertEquals($result->base, '');
-		$this->assertEquals($result->here, '/protected/images/index');
-		$this->assertEquals($result->webroot, '/');
+		$this->assertEquals('images', $result->controller);
+		$this->assertEquals('index', $result->action);
+		$this->assertEquals('', $result->base);
+		$this->assertEquals('/protected/images/index', $result->here);
+		$this->assertEquals('/', $result->webroot);
 	}
 
 /**
@@ -2498,7 +2498,7 @@ class RouterTest extends CakeTestCase {
 			array('action' => 'update',	'method' => 'POST', 	'id' => true)
 		);
 		Router::resourceMap($custom);
-		$this->assertEquals($custom, Router::resourceMap());
+		$this->assertEquals(Router::resourceMap(), $custom);
 
 		Router::resourceMap($default);
 	}
@@ -2510,19 +2510,19 @@ class RouterTest extends CakeTestCase {
  */
 	public function testRouteRedirection() {
 		Router::redirect('/blog', array('controller' => 'posts'), array('status' => 302));
-		$this->assertEquals(count(Router::$routes), 1);
+		$this->assertEquals(1, count(Router::$routes));
 		Router::$routes[0]->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		Router::$routes[0]->stop = false;
-		$this->assertEquals(Router::$routes[0]->options['status'], 302);
+		$this->assertEquals(302, Router::$routes[0]->options['status']);
 
 		Router::parse('/blog');
 		$header = Router::$routes[0]->response->header();
-		$this->assertEquals($header['Location'], Router::url('/posts', true));
-		$this->assertEquals(Router::$routes[0]->response->statusCode(), 302);
+		$this->assertEquals(Router::url('/posts', true), $header['Location']);
+		$this->assertEquals(302, Router::$routes[0]->response->statusCode());
 
 		Router::$routes[0]->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		Router::parse('/not-a-match');
-		$this->assertEquals(Router::$routes[0]->response->header(), array());
+		$this->assertEquals(array(), Router::$routes[0]->response->header());
 	}
 
 /**

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -217,13 +217,13 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture = new CakeTestFixtureTestFixture();
 		unset($Fixture->table);
 		$Fixture->init();
-		$this->assertEquals($Fixture->table, 'fixture_tests');
-		$this->assertEquals($Fixture->primaryKey, 'id');
+		$this->assertEquals('fixture_tests', $Fixture->table);
+		$this->assertEquals('id', $Fixture->primaryKey);
 
 		$Fixture = new CakeTestFixtureTestFixture();
 		$Fixture->primaryKey = 'my_random_key';
 		$Fixture->init();
-		$this->assertEquals($Fixture->primaryKey, 'my_random_key');
+		$this->assertEquals('my_random_key', $Fixture->primaryKey);
 	}
 
 /**
@@ -242,7 +242,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 
 		$Fixture = new CakeTestFixtureTestFixture();
 		$expected = array('id', 'name', 'created');
-		$this->assertEquals(array_keys($Fixture->fields), $expected);
+		$this->assertEquals($expected, array_keys($Fixture->fields));
 
 		$config = $db->config;
 		$config['prefix'] = 'fixture_test_suite_';
@@ -258,8 +258,8 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = $Fixture->table = null;
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'test');
 		$Fixture->init();
-		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
-		$this->assertEquals($Fixture->table, 'fixture_tests');
+		$this->assertEquals(array('id', 'name', 'created'), array_keys($Fixture->fields));
+		$this->assertEquals('fixture_tests', $Fixture->table);
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -291,8 +291,8 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'test');
 
 		$Fixture->init();
-		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
-		$this->assertEquals($Fixture->table, 'fixture_tests');
+		$this->assertEquals(array('id', 'name', 'created'), array_keys($Fixture->fields));
+		$this->assertEquals('fixture_tests', $Fixture->table);
 
 		$Source->drop($db);
 		$db->config['prefix'] = $backPrefix;
@@ -316,7 +316,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = null;
 		$Fixture->import = array('model' => 'FixturePrefixTest', 'connection' => 'test', 'records' => false);
 		$Fixture->init();
-		$this->assertEquals($Fixture->table, 'fixture_tests');
+		$this->assertEquals('fixture_tests', $Fixture->table);
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -343,7 +343,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$Fixture->fields = $Fixture->records = null;
 		$Fixture->import = array('model' => 'FixtureImportTestModel', 'connection' => 'new_test_suite');
 		$Fixture->init();
-		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals(array('id', 'name', 'created'), array_keys($Fixture->fields));
 
 		$keys = array_flip(ClassRegistry::keys());
 		$this->assertFalse(array_key_exists('fixtureimporttestmodel', $keys));
@@ -373,7 +373,7 @@ class CakeTestFixtureTest extends CakeTestCase {
 			'model' => 'FixtureImportTestModel', 'connection' => 'new_test_suite', 'records' => true
 		);
 		$Fixture->init();
-		$this->assertEquals(array_keys($Fixture->fields), array('id', 'name', 'created'));
+		$this->assertEquals(array('id', 'name', 'created'), array_keys($Fixture->fields));
 		$this->assertFalse(empty($Fixture->records[0]), 'No records loaded on importing fixture.');
 		$this->assertTrue(isset($Fixture->records[0]['name']), 'No name loaded for first record');
 

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -152,8 +152,8 @@ class ControllerTestCaseTest extends CakeTestCase {
 			$this->markTestSkipped('AppController exists, cannot run.');
 		}
 		$Posts = $this->Case->generate('Posts');
-		$this->assertEquals($Posts->name, 'Posts');
-		$this->assertEquals($Posts->modelClass, 'Post');
+		$this->assertEquals('Posts', $Posts->name);
+		$this->assertEquals('Post', $Posts->modelClass);
 		$this->assertNull($Posts->response->send());
 
 		$Posts = $this->Case->generate('Posts', array(
@@ -171,7 +171,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$this->assertInstanceOf('Post', $Posts->Post);
 		$this->assertNull($Posts->Post->save(array()));
 		$this->assertNull($Posts->Post->find('all'));
-		$this->assertEquals($Posts->Post->useTable, 'posts');
+		$this->assertEquals('posts', $Posts->Post->useTable);
 		$this->assertNull($Posts->RequestHandler->isAjax());
 
 		$Posts = $this->Case->generate('Posts', array(
@@ -206,7 +206,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$Posts->Auth->Session->expects($this->any())
 			->method('write')
 			->will($this->returnValue('written!'));
-		$this->assertEquals($Posts->Auth->Session->write('something'), 'written!');
+		$this->assertEquals('written!', $Posts->Auth->Session->write('something'));
 	}
 
 /**
@@ -221,7 +221,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 				'TestPlugin.Plugins'
 			)
 		));
-		$this->assertEquals($Tests->name, 'Tests');
+		$this->assertEquals('Tests', $Tests->name);
 		$this->assertInstanceOf('PluginsComponent', $Tests->Plugins);
 
 		$result = ClassRegistry::init('TestPlugin.TestPluginComment');
@@ -299,7 +299,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 
 		include CAKE . 'Test' . DS . 'test_app' . DS . 'Config' . DS . 'routes.php';
 		$result = $this->Case->testAction('/some_alias');
-		$this->assertEquals($result, 5);
+		$this->assertEquals(5, $result);
 	}
 
 /**
@@ -322,19 +322,19 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$this->Case->autoMock = true;
 
 		$result = $this->Case->testAction('/tests_apps/some_method');
-		$this->assertEquals($result, 5);
+		$this->assertEquals(5, $result);
 
 		$data = array('var' => 'set');
 		$result = $this->Case->testAction('/tests_apps_posts/post_var', array(
 			'data' => $data,
 			'return' => 'vars'
 		));
-		$this->assertEquals($result['data'], $data);
+		$this->assertEquals($data, $result['data']);
 
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'view'
 		));
-		$this->assertEquals($result, 'This is the TestsAppsController index view string');
+		$this->assertEquals('This is the TestsAppsController index view string', $result);
 
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'contents'
@@ -367,7 +367,7 @@ class ControllerTestCaseTest extends CakeTestCase {
 		$expected = array(
 			'named' => 'param'
 		);
-		$this->assertEquals($this->Case->controller->request->named, $expected);
+		$this->assertEquals($expected, $this->Case->controller->request->named);
 		$this->assertEquals($this->Case->controller->data, $data);
 
 		$result = $this->Case->testAction('/tests_apps_posts/post_var', array(
@@ -378,11 +378,11 @@ class ControllerTestCaseTest extends CakeTestCase {
 				'pork' => 'and beans',
 			)
 		));
-		$this->assertEquals(array_keys($result['data']), array('name', 'pork'));
+		$this->assertEquals(array('name', 'pork'), array_keys($result['data']));
 
 		$result = $this->Case->testAction('/tests_apps_posts/add', array('return' => 'vars'));
 		$this->assertTrue(array_key_exists('posts', $result));
-		$this->assertEquals(count($result['posts']), 4);
+		$this->assertEquals(4, count($result['posts']));
 		$this->assertTrue($this->Case->controller->request->is('post'));
 	}
 
@@ -399,20 +399,20 @@ class ControllerTestCaseTest extends CakeTestCase {
 				'lackof' => 'creativity'
 			)
 		));
-		$this->assertEquals($this->Case->controller->request->query['some'], 'var');
-		$this->assertEquals($this->Case->controller->request->query['lackof'], 'creativity');
+		$this->assertEquals('var', $this->Case->controller->request->query['some']);
+		$this->assertEquals('creativity', $this->Case->controller->request->query['lackof']);
 
 		$result = $this->Case->testAction('/tests_apps_posts/url_var/var1:value1/var2:val2', array(
 			'return' => 'vars',
 			'method' => 'get',
 		));
-		$this->assertEquals(array_keys($result['params']['named']), array('var1', 'var2'));
+		$this->assertEquals(array('var1', 'var2'), array_keys($result['params']['named']));
 
 		$result = $this->Case->testAction('/tests_apps_posts/url_var/gogo/val2', array(
 			'return' => 'vars',
 			'method' => 'get',
 		));
-		$this->assertEquals($result['params']['pass'], array('gogo', 'val2'));
+		$this->assertEquals(array('gogo', 'val2'), $result['params']['pass']);
 
 		$result = $this->Case->testAction('/tests_apps_posts/url_var', array(
 			'return' => 'vars',
@@ -460,19 +460,19 @@ class ControllerTestCaseTest extends CakeTestCase {
  */
 	public function testNoMocking() {
 		$result = $this->Case->testAction('/tests_apps/some_method');
-		$this->Case->assertEquals($result, 5);
+		$this->Case->assertEquals(5, $result);
 
 		$data = array('var' => 'set');
 		$result = $this->Case->testAction('/tests_apps_posts/post_var', array(
 			'data' => $data,
 			'return' => 'vars'
 		));
-		$this->assertEquals($result['data'], $data);
+		$this->assertEquals($data, $result['data']);
 
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'view'
 		));
-		$this->assertEquals($result, 'This is the TestsAppsController index view string');
+		$this->assertEquals('This is the TestsAppsController index view string', $result);
 
 		$result = $this->Case->testAction('/tests_apps/set_action', array(
 			'return' => 'contents'

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -50,25 +50,25 @@ class CakeTimeTest extends CakeTestCase {
  */
 	public function testToQuarter() {
 		$result = $this->Time->toQuarter('2007-12-25');
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$result = $this->Time->toQuarter('2007-9-25');
-		$this->assertEquals($result, 3);
+		$this->assertEquals(3, $result);
 
 		$result = $this->Time->toQuarter('2007-3-25');
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 
 		$result = $this->Time->toQuarter('2007-3-25', true);
-		$this->assertEquals($result, array('2007-01-01', '2007-03-31'));
+		$this->assertEquals(array('2007-01-01', '2007-03-31'), $result);
 
 		$result = $this->Time->toQuarter('2007-5-25', true);
-		$this->assertEquals($result, array('2007-04-01', '2007-06-30'));
+		$this->assertEquals(array('2007-04-01', '2007-06-30'), $result);
 
 		$result = $this->Time->toQuarter('2007-8-25', true);
-		$this->assertEquals($result, array('2007-07-01', '2007-09-30'));
+		$this->assertEquals(array('2007-07-01', '2007-09-30'), $result);
 
 		$result = $this->Time->toQuarter('2007-12-25', true);
-		$this->assertEquals($result, array('2007-10-01', '2007-12-31'));
+		$this->assertEquals(array('2007-10-01', '2007-12-31'), $result);
 	}
 
 /**
@@ -78,40 +78,40 @@ class CakeTimeTest extends CakeTestCase {
  */
 	public function testTimeAgoInWords() {
 		$result = $this->Time->timeAgoInWords('-1 week');
-		$this->assertEquals($result, '1 week ago');
+		$this->assertEquals('1 week ago', $result);
 
 		$result = $this->Time->timeAgoInWords('+1 week');
-		$this->assertEquals($result, '1 week');
+		$this->assertEquals('1 week', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +3 days'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '4 months, 2 weeks, 3 days');
+		$this->assertEquals('4 months, 2 weeks, 3 days', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +2 days'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '4 months, 2 weeks, 2 days');
+		$this->assertEquals('4 months, 2 weeks, 2 days', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+4 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '4 months, 2 weeks, 1 day');
+		$this->assertEquals('4 months, 2 weeks, 1 day', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '3 months, 2 weeks, 1 day');
+		$this->assertEquals('3 months, 2 weeks, 1 day', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +2 weeks'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '3 months, 2 weeks');
+		$this->assertEquals('3 months, 2 weeks', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '3 months, 1 week, 6 days');
+		$this->assertEquals('3 months, 1 week, 6 days', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 weeks +1 day'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '2 months, 2 weeks, 1 day');
+		$this->assertEquals('2 months, 2 weeks, 1 day', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 weeks'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '2 months, 2 weeks');
+		$this->assertEquals('2 months, 2 weeks', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '2 months, 1 week, 6 days');
+		$this->assertEquals('2 months, 1 week, 6 days', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+1 month +1 week +6 days'), array('end' => '8 years'), true);
-		$this->assertEquals($result, '1 month, 1 week, 6 days');
+		$this->assertEquals('1 month, 1 week, 6 days', $result);
 
 		for ($i = 0; $i < 200; $i ++) {
 			$years = mt_rand(0, 3);
@@ -173,7 +173,7 @@ class CakeTimeTest extends CakeTestCase {
 				}
 
 				$relativeDate = str_replace('-', '', $relativeDate) . ' ago';
-				$this->assertEquals($result, $relativeDate);
+				$this->assertEquals($relativeDate, $result);
 
 			}
 		}
@@ -227,30 +227,30 @@ class CakeTimeTest extends CakeTestCase {
 				}
 
 				$relativeDate = str_replace('-', '', $relativeDate) . '';
-				$this->assertEquals($result, $relativeDate);
+				$this->assertEquals($relativeDate, $result);
 			}
 		}
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 years -5 months -2 days'), array('end' => '3 years'), true);
-		$this->assertEquals($result, '2 years, 5 months, 2 days ago');
+		$this->assertEquals('2 years, 5 months, 2 days ago', $result);
 
 		$result = $this->Time->timeAgoInWords('2007-9-25');
-		$this->assertEquals($result, 'on 25/9/07');
+		$this->assertEquals('on 25/9/07', $result);
 
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
-		$this->assertEquals($result, 'on 2007-09-25');
+		$this->assertEquals('on 2007-09-25', $result);
 
 		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d', true);
-		$this->assertEquals($result, 'on 2007-09-25');
+		$this->assertEquals('on 2007-09-25', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 weeks -2 days'), 'Y-m-d', false);
-		$this->assertEquals($result, '2 weeks, 2 days ago');
+		$this->assertEquals('2 weeks, 2 days ago', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 weeks +2 days'), 'Y-m-d', true);
 		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '1 month'));
-		$this->assertEquals($result, 'on ' . date('j/n/y', strtotime('+2 months +2 days')));
+		$this->assertEquals('on ' . date('j/n/y', strtotime('+2 months +2 days')), $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '3 month'));
 		$this->assertRegExp('/2 months/', $result);
@@ -259,25 +259,25 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertRegExp('/2 months, 1 week/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+3 months +5 days'), array('end' => '4 month'));
-		$this->assertEquals($result, '3 months, 5 days');
+		$this->assertEquals('3 months, 5 days', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '3 month'));
-		$this->assertEquals($result, '2 months, 2 days ago');
+		$this->assertEquals('2 months, 2 days ago', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '3 month'));
-		$this->assertEquals($result, '2 months, 2 days ago');
+		$this->assertEquals('2 months, 2 days ago', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '3 month'));
 		$this->assertRegExp('/2 months/', $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('+2 months +2 days'), array('end' => '1 month', 'format' => 'Y-m-d'));
-		$this->assertEquals($result, 'on ' . date('Y-m-d', strtotime('+2 months +2 days')));
+		$this->assertEquals('on ' . date('Y-m-d', strtotime('+2 months +2 days')), $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-2 months -2 days'), array('end' => '1 month', 'format' => 'Y-m-d'));
-		$this->assertEquals($result, 'on ' . date('Y-m-d', strtotime('-2 months -2 days')));
+		$this->assertEquals('on ' . date('Y-m-d', strtotime('-2 months -2 days')), $result);
 
 		$result = $this->Time->timeAgoInWords(strtotime('-13 months -5 days'), array('end' => '2 years'));
-		$this->assertEquals($result, '1 year, 1 month, 5 days ago');
+		$this->assertEquals('1 year, 1 month, 5 days ago', $result);
 
 		$fourHours = $this->Time->timeAgoInWords(strtotime('-5 days -2 hours'), array('userOffset' => -4));
 		$result = $this->Time->timeAgoInWords(strtotime('-5 days -2 hours'), array('userOffset' => 4));
@@ -435,7 +435,7 @@ class CakeTimeTest extends CakeTestCase {
 		}
 
 		$result = $this->Time->format('Y-m-d', null, 'never');
-		$this->assertEquals($result, 'never');
+		$this->assertEquals('never', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -289,7 +289,7 @@ class ClassRegistryTest extends CakeTestCase {
 		$TestRegistryPluginModel = ClassRegistry::init('RegistryPlugin.TestRegistryPluginModel');
 		$this->assertTrue(is_a($TestRegistryPluginModel, 'TestRegistryPluginModel'));
 
-		$this->assertEquals($TestRegistryPluginModel->tablePrefix, 'something_');
+		$this->assertEquals('something_', $TestRegistryPluginModel->tablePrefix);
 
 		$PluginUser = ClassRegistry::init(array('class' => 'RegistryPlugin.RegisterUser', 'alias' => 'RegistryPluginUser', 'table' => false));
 		$this->assertTrue(is_a($PluginUser, 'RegistryPluginAppModel'));

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -82,12 +82,12 @@ class DebuggerTest extends CakeTestCase {
 	public function testExcerpt() {
 		$result = Debugger::excerpt(__FILE__, __LINE__, 2);
 		$this->assertTrue(is_array($result));
-		$this->assertEquals(count($result), 5);
+		$this->assertEquals(5, count($result));
 		$this->assertRegExp('/function(.+)testExcerpt/', $result[1]);
 
 		$result = Debugger::excerpt(__FILE__, 2, 2);
 		$this->assertTrue(is_array($result));
-		$this->assertEquals(count($result), 4);
+		$this->assertEquals(4, count($result));
 
 		$pattern = '/<code><span style\="color\: \#\d+">.*?&lt;\?php/';
 		$this->assertRegExp($pattern, $result[0]);
@@ -106,11 +106,11 @@ class DebuggerTest extends CakeTestCase {
 		$this->_restoreError = true;
 
 		$result = Debugger::output(false);
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 		$out .= '';
 		$result = Debugger::output(true);
 
-		$this->assertEquals($result[0]['error'], 'Notice');
+		$this->assertEquals('Notice', $result[0]['error']);
 		$this->assertRegExp('/Undefined variable\:\s+out/', $result[0]['description']);
 		$this->assertRegExp('/DebuggerTest::testOutput/i', $result[0]['trace']);
 

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -141,7 +141,7 @@ class FileTest extends CakeTestCase {
 		$this->File->lock = true;
 		$result = $this->File->read();
 		$expecting = file_get_contents(__FILE__);
-		$this->assertEquals($result, trim($expecting));
+		$this->assertEquals(trim($expecting), $result);
 		$this->File->lock = null;
 
 		$data = $expecting;

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -83,7 +83,7 @@ class FolderTest extends CakeTestCase {
 		$Folder = new Folder($path);
 
 		$result = $Folder->pwd();
-		$this->assertEquals($result, $path);
+		$this->assertEquals($path, $result);
 
 		$result = Folder::addPathElement($path, 'test');
 		$expected = $path . DS . 'test';
@@ -109,13 +109,13 @@ class FolderTest extends CakeTestCase {
 		$Folder = new Folder($path);
 
 		$result = $Folder->pwd();
-		$this->assertEquals($result, $path);
+		$this->assertEquals($path, $result);
 
 		$result = Folder::isSlashTerm($inside);
 		$this->assertTrue($result);
 
 		$result = $Folder->realpath('Test/');
-		$this->assertEquals($result, $path . DS . 'Test' . DS);
+		$this->assertEquals($path . DS . 'Test' . DS, $result);
 
 		$result = $Folder->inPath('Test' . DS);
 		$this->assertTrue($result);
@@ -239,7 +239,7 @@ class FolderTest extends CakeTestCase {
 
 		$expected = $new . ' is a file';
 		$result = $Folder->errors();
-		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($expected, $result[0]);
 
 		$new = TMP . 'test_folder_new';
 		$result = $Folder->create($new);
@@ -284,15 +284,15 @@ class FolderTest extends CakeTestCase {
 
 		$this->assertTrue($Folder->chmod($new, 0755, true));
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
-		$this->assertEquals($perms, '0755');
+		$this->assertEquals('0755', $perms);
 
 		$this->assertTrue($Folder->chmod($new, 0744, true, array('skip_me.php', 'test2')));
 
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test2')), -4);
-		$this->assertEquals($perms, '0755');
+		$this->assertEquals('0755', $perms);
 
 		$perms = substr(sprintf('%o', fileperms($new . DS . 'test1')), -4);
-		$this->assertEquals($perms, '0744');
+		$this->assertEquals('0744', $perms);
 
 		$Folder->delete($new);
 	}
@@ -336,10 +336,10 @@ class FolderTest extends CakeTestCase {
  */
 	public function testAddPathElement() {
 		$result = Folder::addPathElement(DS . 'some' . DS . 'dir', 'another_path');
-		$this->assertEquals($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
+		$this->assertEquals(DS . 'some' . DS . 'dir' . DS . 'another_path', $result);
 
 		$result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, 'another_path');
-		$this->assertEquals($result, DS . 'some' . DS . 'dir' . DS . 'another_path');
+		$this->assertEquals(DS . 'some' . DS . 'dir' . DS . 'another_path', $result);
 	}
 
 /**
@@ -352,7 +352,7 @@ class FolderTest extends CakeTestCase {
 
 		$expected = array('cache', 'logs', 'sessions', 'tests');
 		$result = $Folder->read(true, true);
-		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($expected, $result[0]);
 
 		$Folder->path = TMP . 'non-existent';
 		$expected = array(array(), array());
@@ -431,16 +431,16 @@ class FolderTest extends CakeTestCase {
 		);
 
 		$result = $Folder->tree(CAKE . 'Config', false);
-		$this->assertSame(array_diff($expected[0], $result[0]), array());
-		$this->assertSame(array_diff($result[0], $expected[0]), array());
+		$this->assertSame(array(), array_diff($expected[0], $result[0]));
+		$this->assertSame(array(), array_diff($result[0], $expected[0]));
 
 		$result = $Folder->tree(CAKE . 'Config', false, 'dir');
-		$this->assertSame(array_diff($expected[0], $result), array());
-		$this->assertSame(array_diff($expected[0], $result), array());
+		$this->assertSame(array(), array_diff($expected[0], $result));
+		$this->assertSame(array(), array_diff($expected[0], $result));
 
 		$result = $Folder->tree(CAKE . 'Config', false, 'files');
-		$this->assertSame(array_diff($expected[1], $result), array());
-		$this->assertSame(array_diff($expected[1], $result), array());
+		$this->assertSame(array(), array_diff($expected[1], $result));
+		$this->assertSame(array(), array_diff($expected[1], $result));
 	}
 
 /**
@@ -554,7 +554,7 @@ class FolderTest extends CakeTestCase {
  */
 	public function testSlashTerm() {
 		$result = Folder::slashTerm('/path/to/file');
-		$this->assertEquals($result, '/path/to/file/');
+		$this->assertEquals('/path/to/file/', $result);
 	}
 
 /**
@@ -565,15 +565,15 @@ class FolderTest extends CakeTestCase {
 	public function testNormalizePath() {
 		$path = '/path/to/file';
 		$result = Folder::normalizePath($path);
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$path = '\\path\\\to\\\file';
 		$result = Folder::normalizePath($path);
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$path = 'C:\\path\\to\\file';
 		$result = Folder::normalizePath($path);
-		$this->assertEquals($result, '\\');
+		$this->assertEquals('\\', $result);
 	}
 
 /**
@@ -584,15 +584,15 @@ class FolderTest extends CakeTestCase {
 	public function testCorrectSlashFor() {
 		$path = '/path/to/file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$path = '\\path\\to\\file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEquals($result, '/');
+		$this->assertEquals('/', $result);
 
 		$path = 'C:\\path\to\\file';
 		$result = Folder::correctSlashFor($path);
-		$this->assertEquals($result, '\\');
+		$this->assertEquals('\\', $result);
 	}
 
 /**
@@ -746,13 +746,13 @@ class FolderTest extends CakeTestCase {
  */
 	public function testDirSize() {
 		$Folder = new Folder(TMP . 'config_non_existent', true);
-		$this->assertEquals($Folder->dirSize(), 0);
+		$this->assertEquals(0, $Folder->dirSize());
 
 		$File = new File($Folder->pwd() . DS . 'my.php', true, 0777);
 		$File->create();
 		$File->write('something here');
 		$File->close();
-		$this->assertEquals($Folder->dirSize(), 14);
+		$this->assertEquals(14, $Folder->dirSize());
 
 		$Folder->cd(TMP);
 		$Folder->delete($Folder->pwd() . 'config_non_existent');
@@ -780,7 +780,7 @@ class FolderTest extends CakeTestCase {
 
 		$messages = $Folder->messages();
 		$errors = $Folder->errors();
-		$this->assertEquals($errors, array());
+		$this->assertEquals(array(), $errors);
 
 		$expected = array(
 			$path . DS . 'file_1 removed',
@@ -848,7 +848,7 @@ class FolderTest extends CakeTestCase {
 		$result = $Folder->copy($folderThree);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
-		$this->assertEquals(file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'), 'untouched');
+		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));
 
 		$Folder = new Folder($path);
 		$Folder->delete();
@@ -922,7 +922,7 @@ class FolderTest extends CakeTestCase {
 		$result = $Folder->move($folderThree);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
-		$this->assertEquals(file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'), 'untouched');
+		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));
 		$this->assertFalse(file_exists($fileOne));
 		$this->assertFalse(file_exists($folderTwo));
 		$this->assertFalse(file_exists($fileTwo));

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -180,7 +180,7 @@ class ObjectCollectionTest extends CakeTestCase {
 		$result = $this->Objects->set('Second', new SecondGenericObject($this->Objects));
 		$this->assertInstanceOf('SecondGenericObject', $result['Second'], 'set failed');
 
-		$this->assertEquals(count($result), 2);
+		$this->assertEquals(2, count($result));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -90,28 +90,28 @@ class SanitizeTest extends CakeTestCase {
  */
 	public function testEscapeAlphaNumeric() {
 		$resultAlpha = Sanitize::escape('abc', 'test');
-		$this->assertEquals($resultAlpha, 'abc');
+		$this->assertEquals('abc', $resultAlpha);
 
 		$resultNumeric = Sanitize::escape('123', 'test');
-		$this->assertEquals($resultNumeric, '123');
+		$this->assertEquals('123', $resultNumeric);
 
 		$resultNumeric = Sanitize::escape(1234, 'test');
-		$this->assertEquals($resultNumeric, 1234);
+		$this->assertEquals(1234, $resultNumeric);
 
 		$resultNumeric = Sanitize::escape(1234.23, 'test');
-		$this->assertEquals($resultNumeric, 1234.23);
+		$this->assertEquals(1234.23, $resultNumeric);
 
 		$resultNumeric = Sanitize::escape('#1234.23', 'test');
-		$this->assertEquals($resultNumeric, '#1234.23');
+		$this->assertEquals('#1234.23', $resultNumeric);
 
 		$resultNull = Sanitize::escape(null, 'test');
-		$this->assertEquals($resultNull, null);
+		$this->assertEquals(null, $resultNull);
 
 		$resultNull = Sanitize::escape(false, 'test');
-		$this->assertEquals($resultNull, false);
+		$this->assertEquals(false, $resultNull);
 
 		$resultNull = Sanitize::escape(true, 'test');
-		$this->assertEquals($resultNull, true);
+		$this->assertEquals(true, $resultNull);
 	}
 
 /**
@@ -168,7 +168,7 @@ class SanitizeTest extends CakeTestCase {
 		$string = '';
 		$expected = '';
 		$result = Sanitize::clean($string, array('connection' => 'test'));
-		$this->assertEquals($string, $expected);
+		$this->assertEquals($expected, $string);
 
 		$data = array(
 			'Grant' => array(
@@ -191,7 +191,7 @@ class SanitizeTest extends CakeTestCase {
 			)
 		);
 		$result = Sanitize::clean($data, array('connection' => 'test'));
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 	}
 
 /**
@@ -217,7 +217,7 @@ class SanitizeTest extends CakeTestCase {
 
 		$string = 'The "lazy" dog \'jumped\'';
 		$result = Sanitize::html($string, array('quotes' => ENT_NOQUOTES));
-		$this->assertEquals($result, $string);
+		$this->assertEquals($string, $result);
 
 		$string = 'The "lazy" dog \'jumped\' & flew over the moon. If (1+1) = 2 <em>is</em> true, (2-1) = 1 is also true';
 		$expected = 'The &quot;lazy&quot; dog &#039;jumped&#039; &amp; flew over the moon. If (1+1) = 2 &lt;em&gt;is&lt;/em&gt; true, (2-1) = 1 is also true';
@@ -249,7 +249,7 @@ class SanitizeTest extends CakeTestCase {
 		$text = 'I    love  ßá†ö√    letters.';
 		$result = Sanitize::stripWhitespace($text);
 		$expected = 'I love ßá†ö√ letters.';
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -128,22 +128,22 @@ class SecurityTest extends CakeTestCase {
 		}
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEquals(Security::cipher($result, $key), $txt);
+		$this->assertEquals($txt, Security::cipher($result, $key));
 
 		$txt = '';
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEquals(Security::cipher($result, $key), $txt);
+		$this->assertEquals($txt, Security::cipher($result, $key));
 
 		$txt = 123456;
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEquals(Security::cipher($result, $key), $txt);
+		$this->assertEquals($txt, Security::cipher($result, $key));
 
 		$txt = '123456';
 		$key = 'my_key';
 		$result = Security::cipher($txt, $key);
-		$this->assertEquals(Security::cipher($result, $key), $txt);
+		$this->assertEquals($txt, Security::cipher($result, $key));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SetTest.php
+++ b/lib/Cake/Test/Case/Utility/SetTest.php
@@ -33,8 +33,8 @@ class SetTest extends CakeTestCase {
  */
 	public function testNumericKeyExtraction() {
 		$data = array('plugin' => null, 'controller' => '', 'action' => '', 1, 'whatever');
-		$this->assertEquals(Set::extract($data, '{n}'), array(1, 'whatever'));
-		$this->assertEquals(Set::diff($data, Set::extract($data, '{n}')), array('plugin' => null, 'controller' => '', 'action' => ''));
+		$this->assertEquals(array(1, 'whatever'), Set::extract($data, '{n}'));
+		$this->assertEquals(array('plugin' => null, 'controller' => '', 'action' => ''), Set::diff($data, Set::extract($data, '{n}')));
 	}
 
 /**
@@ -44,35 +44,35 @@ class SetTest extends CakeTestCase {
  */
 	public function testEnum() {
 		$result = Set::enum(1, 'one, two');
-		$this->assertEquals($result, 'two');
+		$this->assertEquals('two', $result);
 		$result = Set::enum(2, 'one, two');
 		$this->assertNull($result);
 
 		$set = array('one', 'two');
 		$result = Set::enum(0, $set);
-		$this->assertEquals($result, 'one');
+		$this->assertEquals('one', $result);
 		$result = Set::enum(1, $set);
-		$this->assertEquals($result, 'two');
+		$this->assertEquals('two', $result);
 
 		$result = Set::enum(1, array('one', 'two'));
-		$this->assertEquals($result, 'two');
+		$this->assertEquals('two', $result);
 		$result = Set::enum(2, array('one', 'two'));
 		$this->assertNull($result);
 
 		$result = Set::enum('first', array('first' => 'one', 'second' => 'two'));
-		$this->assertEquals($result, 'one');
+		$this->assertEquals('one', $result);
 		$result = Set::enum('third', array('first' => 'one', 'second' => 'two'));
 		$this->assertNull($result);
 
 		$result = Set::enum('no', array('no' => 0, 'yes' => 1));
-		$this->assertEquals($result, 0);
+		$this->assertEquals(0, $result);
 		$result = Set::enum('not sure', array('no' => 0, 'yes' => 1));
 		$this->assertNull($result);
 
 		$result = Set::enum(0);
-		$this->assertEquals($result, 'no');
+		$this->assertEquals('no', $result);
 		$result = Set::enum(1);
-		$this->assertEquals($result, 'yes');
+		$this->assertEquals('yes', $result);
 		$result = Set::enum(2);
 		$this->assertNull($result);
 	}
@@ -187,45 +187,45 @@ class SetTest extends CakeTestCase {
  */
 	public function testMerge() {
 		$r = Set::merge(array('foo'));
-		$this->assertEquals($r, array('foo'));
+		$this->assertEquals(array('foo'), $r);
 
 		$r = Set::merge('foo');
-		$this->assertEquals($r, array('foo'));
+		$this->assertEquals(array('foo'), $r);
 
 		$r = Set::merge('foo', 'bar');
-		$this->assertEquals($r, array('foo', 'bar'));
+		$this->assertEquals(array('foo', 'bar'), $r);
 
 		$r = Set::merge('foo', array('user' => 'bob', 'no-bar'), 'bar');
-		$this->assertEquals($r, array('foo', 'user' => 'bob', 'no-bar', 'bar'));
+		$this->assertEquals(array('foo', 'user' => 'bob', 'no-bar', 'bar'), $r);
 
 		$a = array('foo', 'foo2');
 		$b = array('bar', 'bar2');
-		$this->assertEquals(Set::merge($a, $b), array('foo', 'foo2', 'bar', 'bar2'));
+		$this->assertEquals(array('foo', 'foo2', 'bar', 'bar2'), Set::merge($a, $b));
 
 		$a = array('foo' => 'bar', 'bar' => 'foo');
 		$b = array('foo' => 'no-bar', 'bar' => 'no-foo');
-		$this->assertEquals(Set::merge($a, $b), array('foo' => 'no-bar', 'bar' => 'no-foo'));
+		$this->assertEquals(array('foo' => 'no-bar', 'bar' => 'no-foo'), Set::merge($a, $b));
 
 		$a = array('users' => array('bob', 'jim'));
 		$b = array('users' => array('lisa', 'tina'));
-		$this->assertEquals(Set::merge($a, $b), array('users' => array('bob', 'jim', 'lisa', 'tina')));
+		$this->assertEquals(array('users' => array('bob', 'jim', 'lisa', 'tina')), Set::merge($a, $b));
 
 		$a = array('users' => array('jim', 'bob'));
 		$b = array('users' => 'none');
-		$this->assertEquals(Set::merge($a, $b), array('users' => 'none'));
+		$this->assertEquals(array('users' => 'none'), Set::merge($a, $b));
 
 		$a = array('users' => array('lisa' => array('id' => 5, 'pw' => 'secret')), 'cakephp');
 		$b = array('users' => array('lisa' => array('pw' => 'new-pass', 'age' => 23)), 'ice-cream');
-		$this->assertEquals(Set::merge($a, $b), array('users' => array('lisa' => array('id' => 5, 'pw' => 'new-pass', 'age' => 23)), 'cakephp', 'ice-cream'));
+		$this->assertEquals(array('users' => array('lisa' => array('id' => 5, 'pw' => 'new-pass', 'age' => 23)), 'cakephp', 'ice-cream'), Set::merge($a, $b));
 
 		$c = array('users' => array('lisa' => array('pw' => 'you-will-never-guess', 'age' => 25, 'pet' => 'dog')), 'chocolate');
 		$expected = array('users' => array('lisa' => array('id' => 5, 'pw' => 'you-will-never-guess', 'age' => 25, 'pet' => 'dog')), 'cakephp', 'ice-cream', 'chocolate');
-		$this->assertEquals(Set::merge($a, $b, $c), $expected);
+		$this->assertEquals($expected, Set::merge($a, $b, $c));
 
 		$this->assertEquals(Set::merge($a, $b, array(), $c), $expected);
 
 		$r = Set::merge($a, $b, $c);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$a = array('Tree', 'CounterCache',
 				'Upload' => array('folder' => 'products',
@@ -245,7 +245,7 @@ class SetTest extends CakeTestCase {
 				'Validator',
 				'Transactional');
 
-		$this->assertEquals(Set::merge($a, $b), $expected);
+		$this->assertEquals($expected, Set::merge($a, $b));
 
 		$expected = array('Tree' => null, 'CounterCache' => null,
 				'Upload' => array('folder' => 'products',
@@ -256,7 +256,7 @@ class SetTest extends CakeTestCase {
 				'Validator' => null,
 				'Transactional' => null);
 
-		$this->assertEquals(Set::normalize(Set::merge($a, $b)), $expected);
+		$this->assertEquals($expected, Set::normalize(Set::merge($a, $b)));
 	}
 
 /**
@@ -490,52 +490,52 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(array('a' => $c[2]['a']));
 		$r = Set::extract('/a/II[a=3]/..', $c);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEquals(Set::extract('/User/id', $a), $expected);
+		$this->assertEquals($expected, Set::extract('/User/id', $a));
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEquals(Set::extract('/User/id', $a), $expected);
+		$this->assertEquals($expected, Set::extract('/User/id', $a));
 
 		$expected = array(
 			array('id' => 1), array('id' => 2), array('id' => 3), array('id' => 4), array('id' => 5)
 		);
 
 		$r = Set::extract('/User/id', $a, array('flatten' => false));
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
-		$this->assertEquals(Set::extract('/Deep/Nesting/test', $a), $expected);
-		$this->assertEquals(Set::extract('/Deep/Nesting/test', $b), $expected);
+		$this->assertEquals($expected, Set::extract('/Deep/Nesting/test', $a));
+		$this->assertEquals($expected, Set::extract('/Deep/Nesting/test', $b));
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/1/..', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/2/and/../..', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('test' => $a[0]['Deep']['Nesting']['test']));
 		$r = Set::extract('/Deep/Nesting/test/2/../../../Nesting/test/2/..', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(2);
 		$r = Set::extract('/User[2]/id', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(4, 5);
 		$r = Set::extract('/User[id>3]/id', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(2, 3);
 		$r = Set::extract('/User[id>1][id<=3]/id', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('I'), array('II'));
 		$r = Set::extract('/a/@*', $c);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$single = array(
 			'User' => array(
@@ -570,27 +570,27 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(1, 2, 3, 4);
 		$r = Set::extract('/User/id', $tricky);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(4);
 		$r = Set::extract('/User/id', $single);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(1, 3);
 		$r = Set::extract('/User[name=/n/]/id', $tricky);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(4);
 		$r = Set::extract('/User[name=/N/]/id', $tricky);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(1, 3, 4);
 		$r = Set::extract('/User[name=/N/i]/id', $tricky);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('id', 'name'), array('id', 'name'), array('id', 'name'), array('id', 'name'));
 		$r = Set::extract('/User/@*', $tricky);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$common = array(
 			array(
@@ -652,50 +652,50 @@ class SetTest extends CakeTestCase {
 
 		$r = Set::extract('/Comment/id', $common);
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(1, 2, 4, 5);
 		$r = Set::extract('/Comment[id!=3]/id', $common);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$r = Set::extract('/', $common);
 		$this->assertEquals($r, $common);
 
 		$expected = array(1, 2, 4, 5);
 		$r = Set::extract($common, '/Comment[id!=3]/id');
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array($common[0]['Comment'][2]);
 		$r = Set::extract($common, '/Comment/2');
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array($common[0]['Comment'][0]);
 		$r = Set::extract($common, '/Comment[1]/.[id=1]');
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array($common[1]['Comment'][1]);
 		$r = Set::extract($common, '/1/Comment/.[2]');
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array();
 		$r = Set::extract('/User/id', array());
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(5);
 		$r = Set::extract('/Comment/id[:last]', $common);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(1);
 		$r = Set::extract('/Comment/id[:first]', $common);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(3);
 		$r = Set::extract('/Article[:last]/id', $common);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('Comment' => $common[1]['Comment'][0]));
 		$r = Set::extract('/Comment[addition=]', $common);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$habtm = array(
 			array(
@@ -749,15 +749,15 @@ class SetTest extends CakeTestCase {
 		);
 
 		$r = Set::extract('/Comment/User[name=/bob|dan/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'dan');
-		$this->assertEquals(count($r), 2);
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[1]['Comment']['User']['name']);
+		$this->assertEquals(2, count($r));
 
 		$r = Set::extract('/Comment/User[name=/bob|tod/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
 
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEquals(count($r), 2);
+		$this->assertEquals('tod', $r[1]['Comment']['User']['name']);
+		$this->assertEquals(2, count($r));
 
 		$tree = array(
 			array(
@@ -779,20 +779,20 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(array('Category' => $tree[1]['Category']));
 		$r = Set::extract('/Category[name=Category 2]', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(
 			array('Category' => $tree[1]['Category'], 'children' => $tree[1]['children'])
 		);
 		$r = Set::extract('/Category[name=Category 2]/..', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(
 			array('children' => $tree[1]['children'][0]),
 			array('children' => $tree[1]['children'][1])
 		);
 		$r = Set::extract('/Category[name=Category 2]/../children', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$habtm = array(
 			array(
@@ -846,28 +846,28 @@ class SetTest extends CakeTestCase {
 		);
 
 		$r = Set::extract('/Comment/User[name=/\w+/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEquals($r[2]['Comment']['User']['name'], 'dan');
-		$this->assertEquals($r[3]['Comment']['User']['name'], 'dan');
-		$this->assertEquals(count($r), 4);
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
+		$this->assertEquals('tod', $r[1]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[2]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[3]['Comment']['User']['name']);
+		$this->assertEquals(4, count($r));
 
 		$r = Set::extract('/Comment/User[name=/[a-z]+/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEquals($r[2]['Comment']['User']['name'], 'dan');
-		$this->assertEquals($r[3]['Comment']['User']['name'], 'dan');
-		$this->assertEquals(count($r), 4);
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
+		$this->assertEquals('tod', $r[1]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[2]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[3]['Comment']['User']['name']);
+		$this->assertEquals(4, count($r));
 
 		$r = Set::extract('/Comment/User[name=/bob|dan/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'dan');
-		$this->assertEquals(count($r), 2);
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
+		$this->assertEquals('dan', $r[1]['Comment']['User']['name']);
+		$this->assertEquals(2, count($r));
 
 		$r = Set::extract('/Comment/User[name=/bob|tod/]/..', $habtm);
-		$this->assertEquals($r[0]['Comment']['User']['name'], 'bob');
-		$this->assertEquals($r[1]['Comment']['User']['name'], 'tod');
-		$this->assertEquals(count($r), 2);
+		$this->assertEquals('bob', $r[0]['Comment']['User']['name']);
+		$this->assertEquals('tod', $r[1]['Comment']['User']['name']);
+		$this->assertEquals(2, count($r));
 
 		$mixedKeys = array(
 			'User' => array(
@@ -884,7 +884,7 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array('Neo', 'Morpheus');
 		$r = Set::extract('/User/name', $mixedKeys);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$f = array(
 			array(
@@ -917,11 +917,11 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('name' => 'zipfile2.zip','type' => 'application/x-zip-compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784'));
 		$r = Set::extract('/file/.[type=application/x-zip-compressed]', $f);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('name' => 'zipfile.zip','type' => 'application/zip','tmp_name' => '/tmp/php178.tmp','error' => 0,'size' => '564647'));
 		$r = Set::extract('/file/.[type=application/zip]', $f);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$f = array(
 			array(
@@ -954,14 +954,14 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('name' => 'zipfile2.zip','type' => 'application/x zip compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784'));
 		$r = Set::extract('/file/.[type=application/x zip compressed]', $f);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(
 			array('name' => 'zipfile.zip','type' => 'application/zip','tmp_name' => '/tmp/php178.tmp','error' => 0,'size' => '564647'),
 			array('name' => 'zipfile2.zip','type' => 'application/x zip compressed','tmp_name' => '/tmp/php179.tmp','error' => 0,'size' => '354784')
 		);
 		$r = Set::extract('/file/.[tmp_name=/tmp\/php17/]', $f);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$hasMany = array(
 			'Node' => array(
@@ -1093,15 +1093,15 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(array('Category' => $tree[1]['Category']));
 		$r = Set::extract('/Category[name=Category 2]', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('Category' => $tree[1]['Category'], 'children' => $tree[1]['children']));
 		$r = Set::extract('/Category[name=Category 2]/..', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(array('children' => $tree[1]['children'][0]), array('children' => $tree[1]['children'][1]));
 		$r = Set::extract('/Category[name=Category 2]/../children', $tree);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$single = array(
 			array(
@@ -1116,7 +1116,7 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(7);
 		$r = Set::extract('/CallType[name=Internal Voice]/../x/hour', $single);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$multiple = array(
 			array(
@@ -1147,7 +1147,7 @@ class SetTest extends CakeTestCase {
 
 		$expected = array(7,2,1);
 		$r = Set::extract('/CallType[name=Internal Voice]/../x/hour', $multiple);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$a = array(
 			'Model' => array(
@@ -1215,7 +1215,7 @@ class SetTest extends CakeTestCase {
 			)
 		);
 		$r = Set::extract('/Model/SubModelsModel[type=2]/..', $a);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 	}
 
 /**
@@ -1246,7 +1246,7 @@ class SetTest extends CakeTestCase {
 		);
 		$expected = array(1, 2, 3);
 		$r = Set::extract('/User/id', $nonZero);
-		$this->assertEquals($r, $expected);
+		$this->assertEquals($expected, $r);
 
 		$expected = array(
 			array('User' => array('id' => 1, 'name' => 'John')),
@@ -1277,13 +1277,13 @@ class SetTest extends CakeTestCase {
 		);
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEquals(Set::extract('/User/id', $nonSequential), $expected);
+		$this->assertEquals($expected, Set::extract('/User/id', $nonSequential));
 
 		$result = Set::extract('/User/id', $nonZero);
 		$this->assertEquals($expected, $result, 'Failed non zero array key extract');
 
 		$expected = array(1, 2, 3, 4, 5);
-		$this->assertEquals(Set::extract('/User/id', $nonSequential), $expected);
+		$this->assertEquals($expected, Set::extract('/User/id', $nonSequential));
 
 		$result = Set::extract('/User/id', $nonZero);
 		$this->assertEquals($expected, $result, 'Failed non zero array key extract');
@@ -1335,8 +1335,8 @@ class SetTest extends CakeTestCase {
 				'Level2bis' => array('test3', 'test4')
 			)
 		);
-		$this->assertEquals(Set::extract('/Level1/Level2', $data), array(array('Level2' => array('test1', 'test2'))));
-		$this->assertEquals(Set::extract('/Level1/Level2bis', $data), array(array('Level2bis' => array('test3', 'test4'))));
+		$this->assertEquals(array(array('Level2' => array('test1', 'test2'))), Set::extract('/Level1/Level2', $data));
+		$this->assertEquals(array(array('Level2bis' => array('test3', 'test4'))), Set::extract('/Level1/Level2bis', $data));
 	}
 
 /**
@@ -1453,8 +1453,8 @@ class SetTest extends CakeTestCase {
 		);
 
 		$this->assertTrue(Set::matches('/Article/keep/Comment', $r));
-		$this->assertEquals(Set::extract('/Article/keep/Comment/fields', $r), array('comment', 'published'));
-		$this->assertEquals(Set::extract('/Article/keep/User/fields', $r), array('user'));
+		$this->assertEquals(array('comment', 'published'), Set::extract('/Article/keep/Comment/fields', $r));
+		$this->assertEquals(array('user'), Set::extract('/Article/keep/User/fields', $r));
 	}
 
 /**
@@ -1767,7 +1767,7 @@ class SetTest extends CakeTestCase {
  */
 	public function testWritingWithFunkyKeys() {
 		$set = Set::insert(array(), 'Session Test', "test");
-		$this->assertEquals(Set::extract($set, 'Session Test'), 'test');
+		$this->assertEquals('test', Set::extract($set, 'Session Test'));
 
 		$set = Set::remove($set, 'Session Test');
 		$this->assertFalse(Set::check($set, 'Session Test'));
@@ -1821,12 +1821,12 @@ class SetTest extends CakeTestCase {
 		$a = array();
 		$b = array('name' => 'bob', 'address' => 'home');
 		$result = Set::diff($a, $b);
-		$this->assertEquals($result, $b);
+		$this->assertEquals($b, $result);
 
 		$a = array('name' => 'bob', 'address' => 'home');
 		$b = array();
 		$result = Set::diff($a, $b);
-		$this->assertEquals($result, $a);
+		$this->assertEquals($a, $result);
 
 		$a = array('key' => true, 'another' => false, 'name' => 'me');
 		$b = array('key' => 1, 'another' => 0);
@@ -2013,7 +2013,7 @@ class SetTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Set::combine($a, 'fail', 'fail');
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 	}
 
 /**
@@ -2023,10 +2023,10 @@ class SetTest extends CakeTestCase {
  */
 	public function testMapReverse() {
 		$result = Set::reverse(null);
-		$this->assertEquals($result, null);
+		$this->assertEquals(null, $result);
 
 		$result = Set::reverse(false);
-		$this->assertEquals($result, false);
+		$this->assertEquals(false, $result);
 
 		$expected = array(
 		'Array1' => array(
@@ -2044,8 +2044,8 @@ class SetTest extends CakeTestCase {
 				3 => array('Array3Data1' => 4, 'Array3Data2' => 'Array3Data2 value 2', 'Array3Data3' => 'Array3Data3 value 2', 'Array3Data4' => 'Array3Data4 value 4'),
 				4 => array('Array3Data1' => 5, 'Array3Data2' => 'Array3Data2 value 2', 'Array3Data3' => 'Array3Data3 value 2', 'Array3Data4' => 'Array3Data4 value 4')));
 		$map = Set::map($expected, true);
-		$this->assertEquals($map->Array1->Array1Data1, $expected['Array1']['Array1Data1']);
-		$this->assertEquals($map->Array2[0]->Array2Data1, $expected['Array2'][0]['Array2Data1']);
+		$this->assertEquals($expected['Array1']['Array1Data1'], $map->Array1->Array1Data1);
+		$this->assertEquals($expected['Array2'][0]['Array2Data1'], $map->Array2[0]->Array2Data1);
 
 		$result = Set::reverse($map);
 		$this->assertEquals($expected, $result);
@@ -2062,11 +2062,11 @@ class SetTest extends CakeTestCase {
 			),
 		);
 		$map = Set::map($expected);
-		$this->assertEquals($map->title, $expected['Post']['title']);
+		$this->assertEquals($expected['Post']['title'], $map->title);
 		foreach ($map->Comment as $comment) {
 			$ids[] = $comment->id;
 		}
-		$this->assertEquals($ids, array(1, 2));
+		$this->assertEquals(array(1, 2), $ids);
 
 		$expected = array(
 		'Array1' => array(
@@ -2326,50 +2326,50 @@ class SetTest extends CakeTestCase {
 	public function testCountDim() {
 		$data = array('one', '2', 'three');
 		$result = Set::countDim($data);
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 
 		$data = array('1' => '1.1', '2', '3');
 		$result = Set::countDim($data);
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data);
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$data = array('1' => '1.1', '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data);
-		$this->assertEquals($result, 1);
+		$this->assertEquals(1, $result);
 
 		$data = array('1' => '1.1', '2', '3' => array('3.1' => '3.1.1'));
 		$result = Set::countDim($data, true);
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data);
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), '2', '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEquals($result, 3);
+		$this->assertEquals(3, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => '2.1.1.1'))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEquals($result, 4);
+		$this->assertEquals(4, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEquals($result, 5);
+		$this->assertEquals(5, $result);
 
 		$data = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1' => '2.1.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($data, true);
-		$this->assertEquals($result, 5);
+		$this->assertEquals(5, $result);
 
 		$set = array('1' => array('1.1' => '1.1.1'), array('2' => array('2.1' => array('2.1.1' => array('2.1.1.1' => '2.1.1.1.1')))), '3' => array('3.1' => array('3.1.1' => '3.1.1.1')));
 		$result = Set::countDim($set, false, 0);
-		$this->assertEquals($result, 2);
+		$this->assertEquals(2, $result);
 
 		$result = Set::countDim($set, true);
-		$this->assertEquals($result, 5);
+		$this->assertEquals(5, $result);
 	}
 
 /**
@@ -2441,8 +2441,8 @@ class SetTest extends CakeTestCase {
 		foreach ($mapped as $object) {
 			$ids[] = $object->id;
 		}
-		$this->assertEquals($ids, array(1, 2));
-		$this->assertEquals(get_object_vars($mapped[0]->headers), $expected[0]['IndexedPage']['headers']);
+		$this->assertEquals(array(1, 2), $ids);
+		$this->assertEquals($expected[0]['IndexedPage']['headers'], get_object_vars($mapped[0]->headers));
 
 		$result = Set::reverse($mapped);
 		$this->assertEquals($expected, $result);
@@ -2484,14 +2484,14 @@ class SetTest extends CakeTestCase {
 		$expected->created = "1195055503";
 		$expected->updated = "1195055503";
 		// @codingStandardsIgnoreEnd
-		$this->assertEquals($mapped[1], $expected);
+		$this->assertEquals($expected, $mapped[1]);
 
 		$ids = array();
 
 		foreach ($mapped as $object) {
 			$ids[] = $object->id;
 		}
-		$this->assertEquals($ids, array(1, 2));
+		$this->assertEquals(array(1, 2), $ids);
 
 		$result = Set::map(null);
 		$expected = null;
@@ -2764,7 +2764,7 @@ class SetTest extends CakeTestCase {
 
 		$result = Set::pushDiff($array1, $array2);
 
-		$this->assertEquals($result, $array1 + $array2);
+		$this->assertEquals($array1 + $array2, $result);
 
 		$array3 = array('ModelOne' => array('id' => 1003, 'field_one' => 'a3.m1.f1', 'field_two' => 'a3.m1.f2', 'field_three' => 'a3.m1.f3'));
 		$result = Set::pushDiff($array1, $array3);
@@ -2780,7 +2780,7 @@ class SetTest extends CakeTestCase {
 				1 => array('ModelTwo' => array('id' => 1002, 'field_one' => 's2.1.m2.f2', 'field_two' => 's2.1.m2.f2')));
 
 		$result = Set::pushDiff($array1, $array2);
-		$this->assertEquals($result, $array1);
+		$this->assertEquals($array1, $result);
 
 		$array3 = array(0 => array('ModelThree' => array('id' => 1003, 'field_one' => 's3.0.m3.f1', 'field_two' => 's3.0.m3.f2')));
 
@@ -2792,10 +2792,10 @@ class SetTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Set::pushDiff($array1, null);
-		$this->assertEquals($result, $array1);
+		$this->assertEquals($array1, $result);
 
 		$result = Set::pushDiff($array1, $array2);
-		$this->assertEquals($result, $array1 + $array2);
+		$this->assertEquals($array1 + $array2, $result);
 	}
 
 /**
@@ -3105,11 +3105,11 @@ class SetTest extends CakeTestCase {
 	public function testFlatten() {
 		$data = array('Larry', 'Curly', 'Moe');
 		$result = Set::flatten($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 
 		$data[9] = 'Shemp';
 		$result = Set::flatten($data);
-		$this->assertEquals($result, $data);
+		$this->assertEquals($data, $result);
 
 		$data = array(
 			array(

--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -236,34 +236,34 @@ class StringTest extends CakeTestCase {
 		$result = String::cleanInsert(':incomplete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$result = String::cleanInsert(':incomplete', array(
 			'clean' => array('method' => 'text', 'replacement' => 'complete'),
 			'before' => ':', 'after' => '')
 		);
-		$this->assertEquals($result, 'complete');
+		$this->assertEquals('complete', $result);
 
 		$result = String::cleanInsert(':in.complete', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$result = String::cleanInsert(':in.complete and', array(
 			'clean' => true, 'before' => ':', 'after' => '')
 		);
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$result = String::cleanInsert(':in.complete or stuff', array(
 			'clean' => true, 'before' => ':', 'after' => ''
 		));
-		$this->assertEquals($result, 'stuff');
+		$this->assertEquals('stuff', $result);
 
 		$result = String::cleanInsert(
 			'<p class=":missing" id=":missing">Text here</p>',
 			array('clean' => 'html', 'before' => ':', 'after' => '')
 		);
-		$this->assertEquals($result, '<p>Text here</p>');
+		$this->assertEquals('<p>Text here</p>', $result);
 	}
 
 /**
@@ -275,7 +275,7 @@ class StringTest extends CakeTestCase {
 	public function testAutoIgnoreBadInsertData() {
 		$data = array('foo' => 'alpha', 'bar' => 'beta', 'fale' => array());
 		$result = String::insert('(:foo > :bar || :fale!)', $data, array('clean' => 'text'));
-		$this->assertEquals($result, '(alpha > beta || !)');
+		$this->assertEquals('(alpha > beta || !)', $result);
 	}
 
 /**
@@ -458,7 +458,7 @@ podeís adquirirla.</span></p>
 		$text = 'This is a test text';
 		$phrases = null;
 		$result = $this->Text->highlight($text, $phrases, array('format' => '<b>\1</b>'));
-		$this->assertEquals($result, $text);
+		$this->assertEquals($text, $result);
 
 		$text = 'This is a (test) text';
 		$phrases = '(test';
@@ -485,10 +485,10 @@ podeís adquirirla.</span></p>
 		$options = array('format' => '<b>\1</b>', 'html' => true);
 
 		$expected = '<p><b>strong</b>bow isn&rsquo;t real cider</p>';
-		$this->assertEquals($this->Text->highlight($text1, 'strong', $options), $expected);
+		$this->assertEquals($expected, $this->Text->highlight($text1, 'strong', $options));
 
 		$expected = '<p><b>strong</b>bow <strong>isn&rsquo;t</strong> real cider</p>';
-		$this->assertEquals($this->Text->highlight($text2, 'strong', $options), $expected);
+		$this->assertEquals($expected, $this->Text->highlight($text2, 'strong', $options));
 
 		$this->assertEquals($this->Text->highlight($text3, 'strong', $options), $text3);
 
@@ -618,28 +618,28 @@ podeís adquirirla.</span></p>
  */
 	public function testListGeneration() {
 		$result = $this->Text->toList(array());
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$result = $this->Text->toList(array('One'));
-		$this->assertEquals($result, 'One');
+		$this->assertEquals('One', $result);
 
 		$result = $this->Text->toList(array('Larry', 'Curly', 'Moe'));
-		$this->assertEquals($result, 'Larry, Curly and Moe');
+		$this->assertEquals('Larry, Curly and Moe', $result);
 
 		$result = $this->Text->toList(array('Dusty', 'Lucky', 'Ned'), 'y');
-		$this->assertEquals($result, 'Dusty, Lucky y Ned');
+		$this->assertEquals('Dusty, Lucky y Ned', $result);
 
 		$result = $this->Text->toList(array(1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'), 'y');
-		$this->assertEquals($result, 'Dusty, Lucky y Ned');
+		$this->assertEquals('Dusty, Lucky y Ned', $result);
 
 		$result = $this->Text->toList(array(1 => 'Dusty', 2 => 'Lucky', 3 => 'Ned'), 'and', ' + ');
-		$this->assertEquals($result, 'Dusty + Lucky and Ned');
+		$this->assertEquals('Dusty + Lucky and Ned', $result);
 
 		$result = $this->Text->toList(array('name1' => 'Dusty', 'name2' => 'Lucky'));
-		$this->assertEquals($result, 'Dusty and Lucky');
+		$this->assertEquals('Dusty and Lucky', $result);
 
 		$result = $this->Text->toList(array('test_0' => 'banana', 'test_1' => 'apple', 'test_2' => 'lemon'));
-		$this->assertEquals($result, 'banana, apple and lemon');
+		$this->assertEquals('banana, apple and lemon', $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -120,38 +120,38 @@ class XmlTest extends CakeTestCase {
 		$xml = '<tag>value</tag>';
 		$obj = Xml::build($xml);
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEquals((string)$obj->getName(), 'tag');
-		$this->assertEquals((string)$obj, 'value');
+		$this->assertEquals('tag', (string)$obj->getName());
+		$this->assertEquals('value', (string)$obj);
 
 		$xml = '<?xml version="1.0" encoding="UTF-8"?><tag>value</tag>';
 		$this->assertEquals($obj, Xml::build($xml));
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
 		$this->assertTrue($obj instanceof DOMDocument);
-		$this->assertEquals($obj->firstChild->nodeName, 'tag');
-		$this->assertEquals($obj->firstChild->nodeValue, 'value');
+		$this->assertEquals('tag', $obj->firstChild->nodeName);
+		$this->assertEquals('value', $obj->firstChild->nodeValue);
 
 		$xml = CAKE . 'Test' . DS . 'Fixture' . DS . 'sample.xml';
 		$obj = Xml::build($xml);
-		$this->assertEquals($obj->getName(), 'tags');
-		$this->assertEquals(count($obj), 2);
+		$this->assertEquals('tags', $obj->getName());
+		$this->assertEquals(2, count($obj));
 
 		$this->assertEquals(Xml::build($xml), Xml::build(file_get_contents($xml)));
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
-		$this->assertEquals($obj->firstChild->nodeName, 'tags');
+		$this->assertEquals('tags', $obj->firstChild->nodeName);
 
 		$this->assertEquals(Xml::build($xml, array('return' => 'domdocument')), Xml::build(file_get_contents($xml), array('return' => 'domdocument')));
 		$this->assertEquals(Xml::build($xml, array('return' => 'simplexml')), Xml::build($xml, 'simplexml'));
 
 		$xml = array('tag' => 'value');
 		$obj = Xml::build($xml);
-		$this->assertEquals($obj->getName(), 'tag');
-		$this->assertEquals((string)$obj, 'value');
+		$this->assertEquals('tag', $obj->getName());
+		$this->assertEquals('value', (string)$obj);
 
 		$obj = Xml::build($xml, array('return' => 'domdocument'));
-		$this->assertEquals($obj->firstChild->nodeName, 'tag');
-		$this->assertEquals($obj->firstChild->nodeValue, 'value');
+		$this->assertEquals('tag', $obj->firstChild->nodeName);
+		$this->assertEquals('value', $obj->firstChild->nodeValue);
 
 		$obj = Xml::build($xml, array('return' => 'domdocument', 'encoding' => null));
 		$this->assertNotRegExp('/encoding/', $obj->saveXML());
@@ -203,18 +203,18 @@ class XmlTest extends CakeTestCase {
 	public function testFromArray() {
 		$xml = array('tag' => 'value');
 		$obj = Xml::fromArray($xml);
-		$this->assertEquals($obj->getName(), 'tag');
-		$this->assertEquals((string)$obj, 'value');
+		$this->assertEquals('tag', $obj->getName());
+		$this->assertEquals('value', (string)$obj);
 
 		$xml = array('tag' => null);
 		$obj = Xml::fromArray($xml);
-		$this->assertEquals($obj->getName(), 'tag');
-		$this->assertEquals((string)$obj, '');
+		$this->assertEquals('tag', $obj->getName());
+		$this->assertEquals('', (string)$obj);
 
 		$xml = array('tag' => array('@' => 'value'));
 		$obj = Xml::fromArray($xml);
-		$this->assertEquals($obj->getName(), 'tag');
-		$this->assertEquals((string)$obj, 'value');
+		$this->assertEquals('tag', $obj->getName());
+		$this->assertEquals('value', (string)$obj);
 
 		$xml = array(
 			'tags' => array(
@@ -232,15 +232,15 @@ class XmlTest extends CakeTestCase {
 		);
 		$obj = Xml::fromArray($xml, 'attributes');
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEquals($obj->getName(), 'tags');
-		$this->assertEquals(count($obj), 2);
+		$this->assertEquals('tags', $obj->getName());
+		$this->assertEquals(2, count($obj));
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag id="1" name="defect"/><tag id="2" name="enhancement"/></tags>';
 		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
 		$obj = Xml::fromArray($xml);
 		$this->assertTrue($obj instanceof SimpleXMLElement);
-		$this->assertEquals($obj->getName(), 'tags');
-		$this->assertEquals(count($obj), 2);
+		$this->assertEquals('tags', $obj->getName());
+		$this->assertEquals(2, count($obj));
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag><id>1</id><name>defect</name></tag><tag><id>2</id><name>enhancement</name></tag></tags>';
 		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $xmlText);
 
@@ -249,8 +249,8 @@ class XmlTest extends CakeTestCase {
 			)
 		);
 		$obj = Xml::fromArray($xml);
-		$this->assertEquals($obj->getName(), 'tags');
-		$this->assertEquals((string)$obj, '');
+		$this->assertEquals('tags', $obj->getName());
+		$this->assertEquals('', (string)$obj);
 
 		$xml = array(
 			'tags' => array(
@@ -263,7 +263,7 @@ class XmlTest extends CakeTestCase {
 			)
 		);
 		$obj = Xml::fromArray($xml, 'tags');
-		$this->assertEquals(count($obj), 6);
+		$this->assertEquals(6, count($obj));
 		$this->assertSame((string)$obj->bool, '1');
 		$this->assertSame((string)$obj->int, '1');
 		$this->assertSame((string)$obj->float, '10.2');
@@ -387,7 +387,7 @@ class XmlTest extends CakeTestCase {
 	public function testToArray() {
 		$xml = '<tag>name</tag>';
 		$obj = Xml::build($xml);
-		$this->assertEquals(Xml::toArray($obj), array('tag' => 'name'));
+		$this->assertEquals(array('tag' => 'name'), Xml::toArray($obj));
 
 		$xml = CAKE . 'Test' . DS . 'Fixture' . DS . 'sample.xml';
 		$obj = Xml::build($xml);
@@ -405,7 +405,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($obj), $expected);
+		$this->assertEquals($expected, Xml::toArray($obj));
 
 		$array = array(
 			'tags' => array(
@@ -437,8 +437,8 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
-		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument', 'format' => 'attributes'))), $expected);
+		$this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, 'attributes')));
+		$this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument', 'format' => 'attributes'))));
 		$this->assertEquals(Xml::toArray(Xml::fromArray($array)), $array);
 		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('return' => 'domdocument'))), $array);
 
@@ -474,8 +474,8 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray(Xml::fromArray($array, 'attributes')), $expected);
-		$this->assertEquals(Xml::toArray(Xml::fromArray($array, array('format' => 'attributes', 'return' => 'domdocument'))), $expected);
+		$this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, 'attributes')));
+		$this->assertEquals($expected, Xml::toArray(Xml::fromArray($array, array('format' => 'attributes', 'return' => 'domdocument'))));
 
 		$xml = '<root>';
 		$xml .= '<tag id="1">defect</tag>';
@@ -490,7 +490,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($obj), $expected);
+		$this->assertEquals($expected, Xml::toArray($obj));
 
 		$xml = '<root>';
 		$xml .= '<table xmlns="http://www.w3.org/TR/html4/"><tr><td>Apples</td><td>Bananas</td></tr></table>';
@@ -508,7 +508,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($obj), $expected);
+		$this->assertEquals($expected, Xml::toArray($obj));
 
 		$xml = '<root xmlns:cake="http://www.cakephp.org/">';
 		$xml .= '<tag>defect</tag>';
@@ -522,7 +522,7 @@ class XmlTest extends CakeTestCase {
 				'cake:bug' => 1
 			)
 		);
-		$this->assertEquals(Xml::toArray($obj), $expected);
+		$this->assertEquals($expected, Xml::toArray($obj));
 	}
 
 /**
@@ -533,12 +533,12 @@ class XmlTest extends CakeTestCase {
 	public function testRss() {
 		$rss = file_get_contents(CAKE . 'Test' . DS . 'Fixture' . DS . 'rss.xml');
 		$rssAsArray = Xml::toArray(Xml::build($rss));
-		$this->assertEquals($rssAsArray['rss']['@version'], '2.0');
-		$this->assertEquals(count($rssAsArray['rss']['channel']['item']), 2);
+		$this->assertEquals('2.0', $rssAsArray['rss']['@version']);
+		$this->assertEquals(2, count($rssAsArray['rss']['channel']['item']));
 
 		$atomLink = array('@href' => 'http://bakery.cakephp.org/articles/rss', '@rel' => 'self', '@type' => 'application/rss+xml');
 		$this->assertEquals($rssAsArray['rss']['channel']['atom:link'], $atomLink);
-		$this->assertEquals($rssAsArray['rss']['channel']['link'], 'http://bakery.cakephp.org/');
+		$this->assertEquals('http://bakery.cakephp.org/', $rssAsArray['rss']['channel']['link']);
 
 		$expected = array(
 			'title' => 'Alertpay automated sales via IPN',
@@ -673,7 +673,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($xmlRequest), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlRequest));
 
 		$xmlResponse = Xml::build(CAKE . 'Test' . DS . 'Fixture' . DS . 'soap_response.xml');
 		$expected = array(
@@ -686,7 +686,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlResponse));
 
 		$xml = array(
 			'soap:Envelope' => array(
@@ -726,7 +726,7 @@ class XmlTest extends CakeTestCase {
 				'tag' => 'Tag without ns'
 			)
 		);
-		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlResponse));
 
 		$xmlResponse = Xml::build('<root xmlns:ns="http://cakephp.org"><ns:tag id="1" /><tag><id>1</id></tag></root>');
 		$expected = array(
@@ -739,7 +739,7 @@ class XmlTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlResponse));
 
 		$xmlResponse = Xml::build('<root xmlns:ns="http://cakephp.org"><ns:attr>1</ns:attr></root>');
 		$expected = array(
@@ -747,10 +747,10 @@ class XmlTest extends CakeTestCase {
 				'ns:attr' => '1'
 			)
 		);
-		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlResponse));
 
 		$xmlResponse = Xml::build('<root><ns:attr xmlns:ns="http://cakephp.org">1</ns:attr></root>');
-		$this->assertEquals(Xml::toArray($xmlResponse), $expected);
+		$this->assertEquals($expected, Xml::toArray($xmlResponse));
 
 		$xml = array(
 			'root' => array(
@@ -864,7 +864,7 @@ class XmlTest extends CakeTestCase {
 		$expected .= '<Article><id>3</id><user_id>1</user_id><title>Third Article</title><body>Third Article Body</body>';
 		$expected .= '<published>Y</published><created>2007-03-18 10:43:23</created><updated>2007-03-18 10:45:31</updated></Article>';
 		$expected .= '</data>';
-		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $expected);
+		$this->assertEquals($expected, str_replace(array("\r", "\n"), '', $obj->asXML()));
 
 		//multiple model results - without a records key it would fatal error
 		$data = $user->find('all', array('limit' => 2));
@@ -883,7 +883,7 @@ class XmlTest extends CakeTestCase {
 		$expected .= '</records>';
 		$expected .= '</data>';
 		$result = $obj->asXML();
-		$this->assertEquals(str_replace(array("\r", "\n"), '', $obj->asXML()), $expected);
+		$this->assertEquals($expected, str_replace(array("\r", "\n"), '', $obj->asXML()));
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -716,7 +716,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testCreateClearingFields() {
 		$this->Form->fields = array('model_id');
 		$this->Form->create('Contact');
-		$this->assertEquals($this->Form->fields, array());
+		$this->assertEquals(array(), $this->Form->fields);
 	}
 
 /**
@@ -737,23 +737,23 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testDuplicateFieldNameResolution() {
 		$result = $this->Form->create('ValidateUser');
-		$this->assertEquals($this->Form->entity(), array('ValidateUser'));
+		$this->assertEquals(array('ValidateUser'), $this->Form->entity());
 
 		$result = $this->Form->input('ValidateItem.name');
-		$this->assertEquals($this->Form->entity(), array('ValidateItem', 'name'));
+		$this->assertEquals(array('ValidateItem', 'name'), $this->Form->entity());
 
 		$result = $this->Form->input('ValidateUser.name');
-		$this->assertEquals($this->Form->entity(), array('ValidateUser', 'name'));
+		$this->assertEquals(array('ValidateUser', 'name'), $this->Form->entity());
 		$this->assertRegExp('/name="data\[ValidateUser\]\[name\]"/', $result);
 		$this->assertRegExp('/type="text"/', $result);
 
 		$result = $this->Form->input('ValidateItem.name');
-		$this->assertEquals($this->Form->entity(), array('ValidateItem', 'name'));
+		$this->assertEquals(array('ValidateItem', 'name'), $this->Form->entity());
 		$this->assertRegExp('/name="data\[ValidateItem\]\[name\]"/', $result);
 		$this->assertRegExp('/<textarea/', $result);
 
 		$result = $this->Form->input('name');
-		$this->assertEquals($this->Form->entity(), array('ValidateUser', 'name'));
+		$this->assertEquals(array('ValidateUser', 'name'), $this->Form->entity());
 		$this->assertRegExp('/name="data\[ValidateUser\]\[name\]"/', $result);
 		$this->assertRegExp('/type="text"/', $result);
 	}
@@ -765,7 +765,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testNoCheckboxLocking() {
 		$this->Form->request['_Token'] = array('key' => 'foo');
-		$this->assertSame($this->Form->fields, array());
+		$this->assertSame(array(), $this->Form->fields);
 
 		$this->Form->checkbox('check', array('value' => '1'));
 		$this->assertSame($this->Form->fields, array('check'));
@@ -1329,14 +1329,14 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredFileInput() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEquals($this->Form->fields, array());
+		$this->assertEquals(array(), $this->Form->fields);
 
 		$result = $this->Form->file('Attachment.file');
 		$expected = array(
 			'Attachment.file.name', 'Attachment.file.type', 'Attachment.file.tmp_name',
 			'Attachment.file.error', 'Attachment.file.size'
 		);
-		$this->assertEquals($this->Form->fields, $expected);
+		$this->assertEquals($expected, $this->Form->fields);
 	}
 
 /**
@@ -1346,16 +1346,16 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredMultipleSelect() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEquals($this->Form->fields, array());
+		$this->assertEquals(array(), $this->Form->fields);
 		$options = array('1' => 'one', '2' => 'two');
 
 		$this->Form->select('Model.select', $options);
 		$expected = array('Model.select');
-		$this->assertEquals($this->Form->fields, $expected);
+		$this->assertEquals($expected, $this->Form->fields);
 
 		$this->Form->fields = array();
 		$this->Form->select('Model.select', $options, array('multiple' => true));
-		$this->assertEquals($this->Form->fields, $expected);
+		$this->assertEquals($expected, $this->Form->fields);
 	}
 
 /**
@@ -1365,12 +1365,12 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormSecuredRadio() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEquals($this->Form->fields, array());
+		$this->assertEquals(array(), $this->Form->fields);
 		$options = array('1' => 'option1', '2' => 'option2');
 
 		$this->Form->radio('Test.test', $options);
 		$expected = array('Test.test');
-		$this->assertEquals($this->Form->fields, $expected);
+		$this->assertEquals($expected, $this->Form->fields);
 	}
 
 /**
@@ -1614,7 +1614,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'OpenidUrl.openid_not_registered', 'Error, not registered', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Error, not registered');
+		$this->assertEquals('Error, not registered', $result);
 
 		unset($this->UserForm->OpenidUrl, $this->UserForm);
 	}
@@ -1653,17 +1653,17 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateUser.email', 'Invalid email', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid email');
+		$this->assertEquals('Invalid email', $result);
 
 		$result = $this->Form->error(
 			'ValidateProfile.full_name', 'Invalid name', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid name');
+		$this->assertEquals('Invalid name', $result);
 
 		$result = $this->Form->error(
 			'ValidateProfile.city', 'Invalid city', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid city');
+		$this->assertEquals('Invalid city', $result);
 
 		unset($this->ValidateUser->ValidateProfile);
 		unset($this->ValidateUser);
@@ -1706,12 +1706,12 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateUser.email', 'Invalid email', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid email');
+		$this->assertEquals('Invalid email', $result);
 
 		$result = $this->Form->error(
 			'ValidateProfile.full_name', 'Invalid name', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid name');
+		$this->assertEquals('Invalid name', $result);
 
 		$result = $this->Form->error(
 			'ValidateProfile.city', 'Invalid city', array('wrap' => false)
@@ -1720,7 +1720,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->error(
 			'ValidateItem.description', 'Invalid description', array('wrap' => false)
 		);
-		$this->assertEquals($result, 'Invalid description');
+		$this->assertEquals('Invalid description', $result);
 
 		unset($this->ValidateUser->ValidateProfile->ValidateItem);
 		unset($this->ValidateUser->ValidateProfile);
@@ -2985,11 +2985,11 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('div' => array('class' => 'error-message'), 'Error in field Field', '/div'));
 
 		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEquals($result, 'Error in field Field');
+		$this->assertEquals('Error in field Field', $result);
 
 		$Contact->validationErrors['field'] = array("This field contains invalid input");
 		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEquals($result, 'This field contains invalid input');
+		$this->assertEquals('This field contains invalid input', $result);
 
 		$Contact->validationErrors['field'] = array("This field contains invalid input");
 		$result = $this->Form->error('Contact.field', null, array('wrap' => 'span'));
@@ -2999,13 +2999,13 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('span' => array('class' => 'error-message'), 'There is an error fool!', '/span'));
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false));
-		$this->assertEquals($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
+		$this->assertEquals('&lt;strong&gt;Badness!&lt;/strong&gt;', $result);
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => true));
-		$this->assertEquals($result, '&lt;strong&gt;Badness!&lt;/strong&gt;');
+		$this->assertEquals('&lt;strong&gt;Badness!&lt;/strong&gt;', $result);
 
 		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => false));
-		$this->assertEquals($result, '<strong>Badness!</strong>');
+		$this->assertEquals('<strong>Badness!</strong>', $result);
 
 		$Contact->validationErrors['field'] = array("email");
 		$result = $this->Form->error('Contact.field', array('attributes' => array('class' => 'field-error'), 'email' => 'No good!'));
@@ -4171,13 +4171,13 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testSelectMultipleCheckboxSecurity() {
 		$this->Form->request['_Token'] = array('key' => 'testKey');
-		$this->assertEquals($this->Form->fields, array());
+		$this->assertEquals(array(), $this->Form->fields);
 
 		$result = $this->Form->select(
 			'Model.multi_field', array('1' => 'first', '2' => 'second', '3' => 'third'),
 			array('multiple' => 'checkbox')
 		);
-		$this->assertEquals($this->Form->fields, array('Model.multi_field'));
+		$this->assertEquals(array('Model.multi_field'), $this->Form->fields);
 
 		$result = $this->Form->secure($this->Form->fields);
 		$key = 'f7d573650a295b94e0938d32b323fde775e5f32b%3A';
@@ -7338,7 +7338,7 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testFormEnd() {
-		$this->assertEquals($this->Form->end(), '</form>');
+		$this->assertEquals('</form>', $this->Form->end());
 
 		$result = $this->Form->end('');
 		$expected = array(

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -472,7 +472,7 @@ class HtmlHelperTest extends CakeTestCase {
  */
 	public function testStyle() {
 		$result = $this->Html->style('display: none;');
-		$this->assertEquals($result, 'display: none;');
+		$this->assertEquals('display: none;', $result);
 
 		$result = $this->Html->style(array('display' => 'none', 'margin' => '10px'));
 		$expected = 'display:none; margin:10px;';
@@ -535,7 +535,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertTags($result[0], $expected);
 		$expected['link']['href'] = 'preg:/.*css\/vendor\.generic\.css/';
 		$this->assertTags($result[1], $expected);
-		$this->assertEquals(count($result), 2);
+		$this->assertEquals(2, count($result));
 
 		$this->View->expects($this->at(0))
 			->method('append')
@@ -590,7 +590,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertTags($result[0], $expected);
 		$expected['link']['href'] = 'preg:/.*test_plugin\/css\/vendor\.generic\.css/';
 		$this->assertTags($result[1], $expected);
-		$this->assertEquals(count($result), 2);
+		$this->assertEquals(2, count($result));
 
 		CakePlugin::unload('TestPlugin');
 	}
@@ -1647,13 +1647,13 @@ class HtmlHelperTest extends CakeTestCase {
  */
 	public function testUseTag() {
 		$result = $this->Html->useTag('unknowntag');
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$result = $this->Html->useTag('formend');
 		$this->assertTags($result, '/form');
 
 		$result = $this->Html->useTag('form', 'url', ' test');
-		$this->assertEquals($result, '<form action="url" test>');
+		$this->assertEquals('<form action="url" test>', $result);
 
 		$result = $this->Html->useTag('form', 'example.com', array('test' => 'ok'));
 		$this->assertTags($result, array('form' => array('test' => 'ok', 'action' => 'example.com')));
@@ -1853,16 +1853,16 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 		$tags = $this->Html->getAttribute('_tags');
-		$this->assertEquals($tags['form'], 'start form');
-		$this->assertEquals($tags['formend'], 'finish form');
-		$this->assertEquals($tags['selectend'], '</select>');
+		$this->assertEquals('start form', $tags['form']);
+		$this->assertEquals('finish form', $tags['formend']);
+		$this->assertEquals('</select>', $tags['selectend']);
 
 		$result = $this->Html->loadConfig(array('htmlhelper_minimized.ini', 'ini'), $path);
 		$expected = array(
 			'minimizedAttributeFormat' => 'format'
 		);
 		$this->assertEquals($expected, $result);
-		$this->assertEquals($this->Html->getAttribute('_minimizedAttributeFormat'), 'format');
+		$this->assertEquals('format', $this->Html->getAttribute('_minimizedAttributeFormat'));
 	}
 
 /**
@@ -1900,10 +1900,10 @@ class HtmlHelperTest extends CakeTestCase {
 			foreach (array('true', true, 1, '1', $attribute) as $value) {
 				$attrs = array($attribute => $value);
 				$expected = ' ' . $attribute . '="' . $attribute . '"';
-				$this->assertEquals($helper->parseAttributes($attrs), $expected, '%s Failed on ' . $value);
+				$this->assertEquals($expected, $helper->parseAttributes($attrs), '%s Failed on ' . $value);
 			}
 		}
-		$this->assertEquals($helper->parseAttributes(array('compact')), ' compact="compact"');
+		$this->assertEquals(' compact="compact"', $helper->parseAttributes(array('compact')));
 
 		$attrs = array('class' => array('foo', 'bar'));
 		$expected = ' class="foo bar"';
@@ -1911,9 +1911,9 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$helper = new Html5TestHelper($this->View);
 		$expected = ' require';
-		$this->assertEquals($helper->parseAttributes(array('require')), $expected);
-		$this->assertEquals($helper->parseAttributes(array('require' => true)), $expected);
-		$this->assertEquals($helper->parseAttributes(array('require' => false)), '');
+		$this->assertEquals($expected, $helper->parseAttributes(array('require')));
+		$this->assertEquals($expected, $helper->parseAttributes(array('require' => true)));
+		$this->assertEquals('', $helper->parseAttributes(array('require' => false)));
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
@@ -52,19 +52,19 @@ class JqueryEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Jquery->get('#content');
-		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery, $result);
 		$this->assertEquals($this->Jquery->selection, '$("#content")');
 
 		$result = $this->Jquery->get('document');
-		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery, $result);
 		$this->assertEquals($this->Jquery->selection, '$(document)');
 
 		$result = $this->Jquery->get('window');
-		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery, $result);
 		$this->assertEquals($this->Jquery->selection, '$(window)');
 
 		$result = $this->Jquery->get('ul');
-		$this->assertEquals($result, $this->Jquery);
+		$this->assertEquals($this->Jquery, $result);
 		$this->assertEquals($this->Jquery->selection, '$("ul")');
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -180,16 +180,16 @@ class JsHelperTest extends CakeTestCase {
  */
 	public function testConstruction() {
 		$js = new JsHelper($this->View);
-		$this->assertEquals($js->helpers, array('Html', 'Form', 'JqueryEngine'));
+		$this->assertEquals(array('Html', 'Form', 'JqueryEngine'), $js->helpers);
 
 		$js = new JsHelper($this->View, array('mootools'));
-		$this->assertEquals($js->helpers, array('Html', 'Form', 'mootoolsEngine'));
+		$this->assertEquals(array('Html', 'Form', 'mootoolsEngine'), $js->helpers);
 
 		$js = new JsHelper($this->View, 'prototype');
-		$this->assertEquals($js->helpers, array('Html', 'Form', 'prototypeEngine'));
+		$this->assertEquals(array('Html', 'Form', 'prototypeEngine'), $js->helpers);
 
 		$js = new JsHelper($this->View, 'MyPlugin.Dojo');
-		$this->assertEquals($js->helpers, array('Html', 'Form', 'MyPlugin.DojoEngine'));
+		$this->assertEquals(array('Html', 'Form', 'MyPlugin.DojoEngine'), $js->helpers);
 	}
 
 /**
@@ -227,18 +227,18 @@ class JsHelperTest extends CakeTestCase {
 
 		$this->Js->event('click', 'foo');
 		$result = $this->Js->getBuffer();
-		$this->assertEquals(count($result), 1);
-		$this->assertEquals($result[0], 'This is an event call');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals('This is an event call', $result[0]);
 
 		$result = $this->Js->event('click', 'foo', array('buffer' => false));
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEquals($result, 'This is an event call');
+		$this->assertEquals('This is an event call', $result);
 
 		$result = $this->Js->event('click', 'foo', false);
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEquals($result, 'This is an event call');
+		$this->assertEquals('This is an event call', $result);
 	}
 
 /**
@@ -255,25 +255,25 @@ class JsHelperTest extends CakeTestCase {
 		$result = $this->Js->effect('slideIn');
 		$buffer = $this->Js->getBuffer();
 		$this->assertTrue(empty($buffer));
-		$this->assertEquals($result, 'I am not buffered.');
+		$this->assertEquals('I am not buffered.', $result);
 
 		$result = $this->Js->effect('slideIn', true);
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEquals(count($buffer), 1);
-		$this->assertEquals($buffer[0], 'I am not buffered.');
+		$this->assertEquals(1, count($buffer));
+		$this->assertEquals('I am not buffered.', $buffer[0]);
 
 		$result = $this->Js->effect('slideIn', array('speed' => 'slow'), true);
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEquals(count($buffer), 1);
-		$this->assertEquals($buffer[0], 'I am not buffered.');
+		$this->assertEquals(1, count($buffer));
+		$this->assertEquals('I am not buffered.', $buffer[0]);
 
 		$result = $this->Js->effect('slideIn', array('speed' => 'slow', 'buffer' => true));
 		$buffer = $this->Js->getBuffer();
 		$this->assertNull($result);
-		$this->assertEquals(count($buffer), 1);
-		$this->assertEquals($buffer[0], 'I am not buffered.');
+		$this->assertEquals(1, count($buffer));
+		$this->assertEquals('I am not buffered.', $buffer[0]);
 	}
 
 /**
@@ -681,21 +681,21 @@ class JsHelperTest extends CakeTestCase {
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$result = $this->Js->getBuffer();
 		$expected = 'window.app = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($expected, $result[0]);
 
 		$this->Js->set('loggedIn', true);
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$this->Js->setVariable = 'WICKED';
 		$result = $this->Js->getBuffer();
 		$expected = 'window.WICKED = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($expected, $result[0]);
 
 		$this->Js->set('loggedIn', true);
 		$this->Js->set(array('height' => 'tall', 'color' => 'purple'));
 		$this->Js->setVariable = 'Application.variables';
 		$result = $this->Js->getBuffer();
 		$expected = 'Application.variables = {"loggedIn":true,"height":"tall","color":"purple"};';
-		$this->assertEquals($result[0], $expected);
+		$this->assertEquals($expected, $result[0]);
 	}
 
 /**
@@ -710,9 +710,9 @@ class JsHelperTest extends CakeTestCase {
 		$result = $this->Js->getBuffer(false);
 
 		$expected = 'window.app = {"height":"tall","color":"purple"};';
-		$this->assertEquals($result[0], $expected);
-		$this->assertEquals($result[1], 'alert("hey you!");');
-		$this->assertEquals($result[2], 'confirm("Are you sure?");');
+		$this->assertEquals($expected, $result[0]);
+		$this->assertEquals('alert("hey you!");', $result[1]);
+		$this->assertEquals('confirm("Are you sure?");', $result[2]);
 	}
 
 }
@@ -896,16 +896,16 @@ class JsBaseEngineTest extends CakeTestCase {
 	public function testOptionMapping() {
 		$JsEngine = new OptionEngineHelper($this->View);
 		$result = $JsEngine->testMap();
-		$this->assertEquals($result, array());
+		$this->assertEquals(array(), $result);
 
 		$result = $JsEngine->testMap(array('foo' => 'bar', 'baz' => 'sho'));
-		$this->assertEquals($result, array('foo' => 'bar', 'baz' => 'sho'));
+		$this->assertEquals(array('foo' => 'bar', 'baz' => 'sho'), $result);
 
 		$result = $JsEngine->testMap(array('complete' => 'myFunc', 'type' => 'json', 'update' => '#element'));
-		$this->assertEquals($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
+		$this->assertEquals(array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'), $result);
 
 		$result = $JsEngine->testMap(array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
-		$this->assertEquals($result, array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'));
+		$this->assertEquals(array('success' => 'myFunc', 'dataType' => 'json', 'update' => '#element'), $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
@@ -52,27 +52,27 @@ class MootoolsEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Moo->get('#content');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, '$("content")');
 
 		$result = $this->Moo->get('a .remove');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, '$$("a .remove")');
 
 		$result = $this->Moo->get('document');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, "$(document)");
 
 		$result = $this->Moo->get('window');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, "$(window)");
 
 		$result = $this->Moo->get('ul');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, '$$("ul")');
 
 		$result = $this->Moo->get('#some_long-id.class');
-		$this->assertEquals($result, $this->Moo);
+		$this->assertEquals($this->Moo, $result);
 		$this->assertEquals($this->Moo->selection, '$$("#some_long-id.class")');
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -359,13 +359,13 @@ class PaginatorHelperTest extends CakeTestCase {
 		$this->assertEquals('Article.title', $result);
 
 		$result = $this->Paginator->sortKey('Article', array('order' => 'Article.title'));
-		$this->assertEquals($result, 'Article.title');
+		$this->assertEquals('Article.title', $result);
 
 		$result = $this->Paginator->sortKey('Article', array('sort' => 'Article.title'));
-		$this->assertEquals($result, 'Article.title');
+		$this->assertEquals('Article.title', $result);
 
 		$result = $this->Paginator->sortKey('Article', array('sort' => 'Article'));
-		$this->assertEquals($result, 'Article');
+		$this->assertEquals('Article', $result);
 	}
 
 /**
@@ -552,20 +552,20 @@ class PaginatorHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->url();
-		$this->assertEquals($result, '/index/page:1');
+		$this->assertEquals('/index/page:1', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['page'] = 2;
 		$result = $this->Paginator->url();
-		$this->assertEquals($result, '/index/page:2');
+		$this->assertEquals('/index/page:2', $result);
 
 		$options = array('order' => array('Article' => 'desc'));
 		$result = $this->Paginator->url($options);
-		$this->assertEquals($result, '/index/page:2/sort:Article/direction:desc');
+		$this->assertEquals('/index/page:2/sort:Article/direction:desc', $result);
 
 		$this->Paginator->request->params['paging']['Article']['options']['page'] = 3;
 		$options = array('order' => array('Article.name' => 'desc'));
 		$result = $this->Paginator->url($options);
-		$this->assertEquals($result, '/index/page:3/sort:Article.name/direction:desc');
+		$this->assertEquals('/index/page:3/sort:Article.name/direction:desc', $result);
 	}
 
 /**
@@ -2329,7 +2329,7 @@ class PaginatorHelperTest extends CakeTestCase {
 			->will($this->returnValue('I am a link'));
 
 		$result = $this->Paginator->link('test', array('controller' => 'posts'), array('update' => '#content'));
-		$this->assertEquals($result, 'I am a link');
+		$this->assertEquals('I am a link', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
@@ -52,27 +52,27 @@ class PrototypeEngineHelperTest extends CakeTestCase {
  */
 	public function testSelector() {
 		$result = $this->Proto->get('#content');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, '$("content")');
 
 		$result = $this->Proto->get('a .remove');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, '$$("a .remove")');
 
 		$result = $this->Proto->get('document');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, "$(document)");
 
 		$result = $this->Proto->get('window');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, "$(window)");
 
 		$result = $this->Proto->get('ul');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, '$$("ul")');
 
 		$result = $this->Proto->get('#some_long-id.class');
-		$this->assertEquals($result, $this->Proto);
+		$this->assertEquals($this->Proto, $result);
 		$this->assertEquals($this->Proto->selection, '$$("#some_long-id.class")');
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -91,10 +91,10 @@ class SessionHelperTest extends CakeTestCase {
  */
 	public function testRead() {
 		$result = $this->Session->read('Deeply.nested.key');
-		$this->assertEquals($result, 'value');
+		$this->assertEquals('value', $result);
 
 		$result = $this->Session->read('test');
-		$this->assertEquals($result, 'info');
+		$this->assertEquals('info', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/HelperTest.php
+++ b/lib/Cake/Test/Case/View/HelperTest.php
@@ -425,21 +425,21 @@ class HelperTest extends CakeTestCase {
 		$this->Helper->request->data = array('fullname' => 'This is me');
 		$this->Helper->setEntity('fullname');
 		$result = $this->Helper->value('fullname');
-		$this->assertEquals($result, 'This is me');
+		$this->assertEquals('This is me', $result);
 
 		$this->Helper->request->data = array(
 			'Post' => array('name' => 'First Post')
 		);
 		$this->Helper->setEntity('Post.name');
 		$result = $this->Helper->value('Post.name');
-		$this->assertEquals($result, 'First Post');
+		$this->assertEquals('First Post', $result);
 
 		$this->Helper->request->data = array(
 			'Post' => array(2 => array('name' => 'First Post'))
 		);
 		$this->Helper->setEntity('Post.2.name');
 		$result = $this->Helper->value('Post.2.name');
-		$this->assertEquals($result, 'First Post');
+		$this->assertEquals('First Post', $result);
 
 		$this->Helper->request->data = array(
 			'Post' => array(
@@ -448,7 +448,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('Post.2.created');
 		$result = $this->Helper->value('Post.2.created');
-		$this->assertEquals($result, array('year' => '2008'));
+		$this->assertEquals(array('year' => '2008'), $result);
 
 		$this->Helper->request->data = array(
 			'Post' => array(
@@ -457,7 +457,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('Post.2.created.year');
 		$result = $this->Helper->value('Post.2.created.year');
-		$this->assertEquals($result, '2008');
+		$this->assertEquals('2008', $result);
 	}
 
 /**
@@ -469,15 +469,15 @@ class HelperTest extends CakeTestCase {
 		$this->Helper->request->data = array('zero' => 0);
 		$this->Helper->setEntity('zero');
 		$result = $this->Helper->value(array('default' => 'something'), 'zero');
-		$this->assertEquals($result, array('value' => 0));
+		$this->assertEquals(array('value' => 0), $result);
 
 		$this->Helper->request->data = array('zero' => '0');
 		$result = $this->Helper->value(array('default' => 'something'), 'zero');
-		$this->assertEquals($result, array('value' => '0'));
+		$this->assertEquals(array('value' => '0'), $result);
 
 		$this->Helper->setEntity('inexistent');
 		$result = $this->Helper->value(array('default' => 'something'), 'inexistent');
-		$this->assertEquals($result, array('value' => 'something'));
+		$this->assertEquals(array('value' => 'something'), $result);
 	}
 
 /**
@@ -491,7 +491,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -500,7 +500,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEquals($result, array(2, 3, 4));
+		$this->assertEquals(array(2, 3, 4), $result);
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -510,7 +510,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.HelperTestTag');
 		$result = $this->Helper->value('HelperTestTag.HelperTestTag');
-		$this->assertEquals($result, array(3 => 3, 5 => 5));
+		$this->assertEquals(array(3 => 3, 5 => 5), $result);
 
 		$this->Helper->request->data = array(
 			'HelperTestTag' => array(
@@ -520,7 +520,7 @@ class HelperTest extends CakeTestCase {
 		);
 		$this->Helper->setEntity('HelperTestTag.body');
 		$result = $this->Helper->value('HelperTestTag.body');
-		$this->assertEquals($result, '');
+		$this->assertEquals('', $result);
 	}
 
 /**
@@ -530,33 +530,33 @@ class HelperTest extends CakeTestCase {
  */
 	public function testUrlConversion() {
 		$result = $this->Helper->url('/controller/action/1');
-		$this->assertEquals($result, '/controller/action/1');
+		$this->assertEquals('/controller/action/1', $result);
 
 		$result = $this->Helper->url('/controller/action/1?one=1&two=2');
-		$this->assertEquals($result, '/controller/action/1?one=1&amp;two=2');
+		$this->assertEquals('/controller/action/1?one=1&amp;two=2', $result);
 
 		$result = $this->Helper->url(array('controller' => 'posts', 'action' => 'index', 'page' => '1" onclick="alert(\'XSS\');"'));
-		$this->assertEquals($result, "/posts/index/page:1%22%20onclick%3D%22alert%28%27XSS%27%29%3B%22");
+		$this->assertEquals("/posts/index/page:1%22%20onclick%3D%22alert%28%27XSS%27%29%3B%22", $result);
 
 		$result = $this->Helper->url('/controller/action/1/param:this+one+more');
-		$this->assertEquals($result, '/controller/action/1/param:this+one+more');
+		$this->assertEquals('/controller/action/1/param:this+one+more', $result);
 
 		$result = $this->Helper->url('/controller/action/1/param:this%20one%20more');
-		$this->assertEquals($result, '/controller/action/1/param:this%20one%20more');
+		$this->assertEquals('/controller/action/1/param:this%20one%20more', $result);
 
 		$result = $this->Helper->url('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
-		$this->assertEquals($result, '/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24');
+		$this->assertEquals('/controller/action/1/param:%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24', $result);
 
 		$result = $this->Helper->url(array(
 			'controller' => 'posts', 'action' => 'index', 'param' => '%7Baround%20here%7D%5Bthings%5D%5Bare%5D%24%24'
 		));
-		$this->assertEquals($result, "/posts/index/param:%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524");
+		$this->assertEquals("/posts/index/param:%257Baround%2520here%257D%255Bthings%255D%255Bare%255D%2524%2524", $result);
 
 		$result = $this->Helper->url(array(
 			'controller' => 'posts', 'action' => 'index', 'page' => '1',
 			'?' => array('one' => 'value', 'two' => 'value', 'three' => 'purple')
 		));
-		$this->assertEquals($result, "/posts/index/page:1?one=value&amp;two=value&amp;three=purple");
+		$this->assertEquals("/posts/index/page:1?one=value&amp;two=value&amp;three=purple", $result);
 	}
 
 /**
@@ -570,12 +570,12 @@ class HelperTest extends CakeTestCase {
 
 		Configure::write('Asset.timestamp', false);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertEquals($result, CSS_URL . 'cake.generic.css');
+		$this->assertEquals(CSS_URL . 'cake.generic.css', $result);
 
 		Configure::write('Asset.timestamp', true);
 		Configure::write('debug', 0);
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css');
-		$this->assertEquals($result, CSS_URL . 'cake.generic.css');
+		$this->assertEquals(CSS_URL . 'cake.generic.css', $result);
 
 		Configure::write('Asset.timestamp', true);
 		Configure::write('debug', 2);
@@ -588,7 +588,7 @@ class HelperTest extends CakeTestCase {
 		$this->assertRegExp('/' . preg_quote(CSS_URL . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
 		$result = $this->Helper->assetTimestamp(CSS_URL . 'cake.generic.css?someparam');
-		$this->assertEquals($result, CSS_URL . 'cake.generic.css?someparam');
+		$this->assertEquals(CSS_URL . 'cake.generic.css?someparam', $result);
 
 		$this->Helper->request->webroot = '/some/dir/';
 		$result = $this->Helper->assetTimestamp('/some/dir/' . CSS_URL . 'cake.generic.css');
@@ -748,16 +748,16 @@ class HelperTest extends CakeTestCase {
 
 		$this->Helper->request->data['HelperTestComment']['5']['id'] = 'ok';
 		$result = $this->Helper->value('HelperTestComment.5.id');
-		$this->assertEquals($result, 'ok');
+		$this->assertEquals('ok', $result);
 
 		$this->Helper->setEntity('HelperTestPost', true);
 		$this->Helper->request->data['HelperTestPost']['5']['created']['month'] = '10';
 		$result = $this->Helper->value('5.created.month');
-		$this->assertEquals($result, 10);
+		$this->assertEquals(10, $result);
 
 		$this->Helper->request->data['HelperTestPost']['0']['id'] = 100;
 		$result = $this->Helper->value('HelperTestPost.0.id');
-		$this->assertEquals($result, 100);
+		$this->assertEquals(100, $result);
 	}
 
 /**
@@ -767,13 +767,13 @@ class HelperTest extends CakeTestCase {
  */
 	public function testClean() {
 		$result = $this->Helper->clean(array());
-		$this->assertEquals($result, null);
+		$this->assertEquals(null, $result);
 
 		$result = $this->Helper->clean(array('<script>with something</script>', '<applet>something else</applet>'));
-		$this->assertEquals($result, array('with something', 'something else'));
+		$this->assertEquals(array('with something', 'something else'), $result);
 
 		$result = $this->Helper->clean('<script>with something</script>');
-		$this->assertEquals($result, 'with something');
+		$this->assertEquals('with something', $result);
 
 		$result = $this->Helper->clean('<script type="text/javascript">alert("ruined");</script>');
 		$this->assertNotRegExp('#</*script#', $result);
@@ -782,10 +782,10 @@ class HelperTest extends CakeTestCase {
 		$this->assertNotRegExp('#</*script#', $result);
 
 		$result = $this->Helper->clean('<body/onload=do(/something/)>');
-		$this->assertEquals($result, '<body/>');
+		$this->assertEquals('<body/>', $result);
 
 		$result = $this->Helper->clean('&lt;script&gt;alert(document.cookie)&lt;/script&gt;');
-		$this->assertEquals($result, '&amp;lt;script&amp;gt;alert(document.cookie)&amp;lt;/script&amp;gt;');
+		$this->assertEquals('&amp;lt;script&amp;gt;alert(document.cookie)&amp;lt;/script&amp;gt;', $result);
 	}
 
 /**
@@ -839,7 +839,7 @@ class HelperTest extends CakeTestCase {
 
 		$this->Helper->request->data['My']['title'] = 'My Title';
 		$result = $this->Helper->value('My.title');
-		$this->assertEquals($result, 'My Title');
+		$this->assertEquals('My Title', $result);
 	}
 
 	public function testWebrootPaths() {

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -384,7 +384,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->Controller);
 		$paths = $View->paths();
 		$expected = array_merge(App::path('View'), App::core('View'), App::core('Console/Templates/skel/View'));
-		$this->assertEquals($paths, $expected);
+		$this->assertEquals($expected, $paths);
 
 		$paths = $View->paths('TestPlugin');
 		$pluginPath = CakePlugin::path('TestPlugin');
@@ -395,7 +395,7 @@ class ViewTest extends CakeTestCase {
 			CAKE . 'View' . DS,
 			CAKE . 'Console' . DS . 'Templates' . DS . 'skel' . DS . 'View' . DS
 		);
-		$this->assertEquals($paths, $expected);
+		$this->assertEquals($expected, $paths);
 	}
 
 /**
@@ -588,7 +588,7 @@ class ViewTest extends CakeTestCase {
  * @return void
  */
 	public function testViewVars() {
-		$this->assertEquals($this->View->viewVars, array('testData' => 'Some test data', 'test2' => 'more data', 'test3' => 'even more data'));
+		$this->assertEquals(array('testData' => 'Some test data', 'test2' => 'more data', 'test3' => 'even more data'), $this->View->viewVars);
 	}
 
 /**
@@ -598,11 +598,11 @@ class ViewTest extends CakeTestCase {
  */
 	public function testUUIDGeneration() {
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, 'form5988016017');
+		$this->assertEquals('form5988016017', $result);
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, 'formc3dc6be854');
+		$this->assertEquals('formc3dc6be854', $result);
 		$result = $this->View->uuid('form', array('controller' => 'posts', 'action' => 'index'));
-		$this->assertEquals($result, 'form28f92cc87f');
+		$this->assertEquals('form28f92cc87f', $result);
 	}
 
 /**
@@ -614,10 +614,10 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->Controller);
 		$View->addScript('prototype.js');
 		$View->addScript('prototype.js');
-		$this->assertEquals($View->scripts(), array('prototype.js'));
+		$this->assertEquals(array('prototype.js'), $View->scripts());
 
 		$View->addScript('mainEvent', 'Event.observe(window, "load", function() { doSomething(); }, true);');
-		$this->assertEquals($View->scripts(), array('prototype.js', 'mainEvent' => 'Event.observe(window, "load", function() { doSomething(); }, true);'));
+		$this->assertEquals(array('prototype.js', 'mainEvent' => 'Event.observe(window, "load", function() { doSomething(); }, true);'), $View->scripts());
 	}
 
 /**
@@ -627,16 +627,16 @@ class ViewTest extends CakeTestCase {
  */
 	public function testElement() {
 		$result = $this->View->element('test_element');
-		$this->assertEquals($result, 'this is the test element');
+		$this->assertEquals('this is the test element', $result);
 
 		$result = $this->View->element('plugin_element', array(), array('plugin' => 'TestPlugin'));
-		$this->assertEquals($result, 'this is the plugin element using params[plugin]');
+		$this->assertEquals('this is the plugin element using params[plugin]', $result);
 
 		$result = $this->View->element('plugin_element', array(), array('plugin' => 'test_plugin'));
-		$this->assertEquals($result, 'this is the plugin element using params[plugin]');
+		$this->assertEquals('this is the plugin element using params[plugin]', $result);
 
 		$result = $this->View->element('TestPlugin.plugin_element');
-		$this->assertEquals($result, 'this is the plugin element using params[plugin]');
+		$this->assertEquals('this is the plugin element using params[plugin]', $result);
 
 		$result = $this->View->element('test_plugin.plugin_element');
 		$this->assertPattern('/Not Found:/', $result);
@@ -644,7 +644,7 @@ class ViewTest extends CakeTestCase {
 
 		$this->View->plugin = 'TestPlugin';
 		$result = $this->View->element('test_plugin_element');
-		$this->assertEquals($result, 'this is the test set using View::$plugin plugin element');
+		$this->assertEquals('this is the test set using View::$plugin plugin element', $result);
 
 		$result = $this->View->element('non_existent_element');
 		$this->assertRegExp('/Not Found:/', $result);
@@ -699,7 +699,7 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($Controller);
 		$helpers = $View->loadHelpers();
 		$result = $View->element('test_element', array('ram' => 'val', 'test' => array('foo', 'bar')));
-		$this->assertEquals($result, 'this is the test element');
+		$this->assertEquals('this is the test element', $result);
 	}
 
 /**
@@ -889,7 +889,7 @@ class ViewTest extends CakeTestCase {
 		$this->PostsController->helpers = array('Session', 'TestAfter', 'Html');
 		$View = new View($this->PostsController);
 		$View->render('index');
-		$this->assertEquals($View->Helpers->TestAfter->property, 'Valuation');
+		$this->assertEquals('Valuation', $View->Helpers->TestAfter->property);
 	}
 
 /**
@@ -920,16 +920,16 @@ class ViewTest extends CakeTestCase {
 		$View = new TestView($this->PostsController);
 
 		$result = $View->render('index', false);
-		$this->assertEquals($result, 'posts index');
+		$this->assertEquals('posts index', $result);
 
 		$attached = $View->Helpers->attached();
-		$this->assertEquals($attached, array('Session', 'Html', 'Form', 'Number'));
+		$this->assertEquals(array('Session', 'Html', 'Form', 'Number'), $attached);
 
 		$this->PostsController->helpers = array('Html', 'Form', 'Number', 'TestPlugin.PluggedHelper');
 		$View = new TestView($this->PostsController);
 
 		$result = $View->render('index', false);
-		$this->assertEquals($result, 'posts index');
+		$this->assertEquals('posts index', $result);
 
 		$attached = $View->Helpers->attached();
 		$expected = array('Html', 'Form', 'Number', 'PluggedHelper');
@@ -1132,7 +1132,7 @@ class ViewTest extends CakeTestCase {
 		$View->set(array(3 => 'three', 4 => 'four'));
 		$View->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($View->viewVars, $expected);
+		$this->assertEquals($expected, $View->viewVars);
 	}
 
 /**
@@ -1158,7 +1158,7 @@ class ViewTest extends CakeTestCase {
 		$this->PostsController->ext = '.alt';
 		$View = new TestView($this->PostsController);
 		$result = $View->render('alt_ext', false);
-		$this->assertEquals($result, 'alt ext');
+		$this->assertEquals('alt ext', $result);
 	}
 
 /**


### PR DESCRIPTION
Changed the parameter order of `assertEquals()` and `assertNotEquals()` to put `expected` before `result` where applicable.

This time I wrote a script: https://gist.github.com/2167716
Not a perfect script as I had to correct a lot of them but much easier than doing all by hand. :thumbsup:
