### PR TITLE
Include App::uses('File', 'Utility') for write() in CakeSchema

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -20,6 +20,7 @@
 App::uses('Model', 'Model');
 App::uses('AppModel', 'Model');
 App::uses('ConnectionManager', 'Model');
+App::uses('File', 'Utility');
 
 /**
  * Base Class for Schema management


### PR DESCRIPTION
I get the error:
`Fatal error: Class 'File' not found in /var/www/cake/lib/Cake/Model/CakeSchema.php on line 387`
when running the CakeSchema tests in the webrunner if the File class isn't used.
