### PR TITLE
Fixed CakeSession and test cases to pass in travis 5.2, 5.3 and 5.4 PHP environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.2
   - 5.3
   - 5.4
 

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -250,11 +250,12 @@ class Cache {
  *
  * Permanently remove all expired and deleted data
  *
- * @param string $config The config name you wish to have garbage collected. Defaults to 'default'
+ * @param string $config [optional] The config name you wish to have garbage collected. Defaults to 'default'
+ * @param integer $expires [optional] An expires timestamp. Defaults to NULL
  * @return void
  */
-	public static function gc($config = 'default') {
-		self::$_engines[$config]->gc();
+	public static function gc($config = 'default', $expires = null) {
+		self::$_engines[$config]->gc($expires);
 	}
 
 /**

--- a/lib/Cake/Cache/CacheEngine.php
+++ b/lib/Cake/Cache/CacheEngine.php
@@ -51,9 +51,11 @@ abstract class CacheEngine {
  * Garbage collection
  *
  * Permanently remove all expired and deleted data
+ * 
+ * @param integer $expires [optional] An expires timestamp, invalidataing all data before.
  * @return void
  */
-	public function gc() {
+	public function gc($expires = null) {
 	}
 
 /**

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -87,10 +87,11 @@ class FileEngine extends CacheEngine {
 
 /**
  * Garbage collection. Permanently remove all expired and deleted data
- *
+ * 
+ * @param integer $expires [optional] An expires timestamp, invalidataing all data before.
  * @return boolean True if garbage collection was successful, false on failure
  */
-	public function gc() {
+	public function gc($expires = null) {
 		return $this->clear(true);
 	}
 

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -180,7 +180,7 @@ class CakeSession {
 		if (self::started()) {
 			return true;
 		}
-		CakeSession::init();
+		self::init();
 		$id = self::id();
 		session_write_close();
 		self::_configureSession();
@@ -601,8 +601,6 @@ class CakeSession {
 			if (empty($_SESSION)) {
 				$_SESSION = array();
 			}
-		} elseif (!isset($_SESSION)) {
-			session_start();
 		} else {
 			session_start();
 		}

--- a/lib/Cake/Model/Datasource/Session/CacheSession.php
+++ b/lib/Cake/Model/Datasource/Session/CacheSession.php
@@ -43,10 +43,6 @@ class CacheSession implements CakeSessionHandlerInterface {
  * @return boolean Success
  */
 	public function close() {
-		$probability = mt_rand(1, 150);
-		if ($probability <= 3) {
-			Cache::gc();
-		}
 		return true;
 	}
 
@@ -74,7 +70,7 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Method called on the destruction of a database session.
  *
- * @param integer $id ID that uniquely identifies session in database
+ * @param integer $id ID that uniquely identifies session in cache
  * @return boolean True for successful delete, false otherwise.
  */
 	public function destroy($id) {
@@ -82,13 +78,22 @@ class CacheSession implements CakeSessionHandlerInterface {
 	}
 
 /**
- * Helper function called on gc for database sessions.
+ * Helper function called on gc for cache sessions.
  *
  * @param integer $expires Timestamp (defaults to current time)
  * @return boolean Success
  */
 	public function gc($expires = null) {
-		return Cache::gc();
+		return Cache::gc(Configure::read('Session.handler.config'), $expires);
+	}
+
+/**
+ * Writes and closes a session
+ * 
+ * @return void 
+ */
+	protected function _writeSession() {
+		session_write_close();
 	}
 
 /**
@@ -97,7 +102,7 @@ class CacheSession implements CakeSessionHandlerInterface {
  * @return void
  */
 	public function __destruct() {
-		session_write_close();
+		$this->_writeSession();
 	}
 
 }

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -79,10 +79,6 @@ class DatabaseSession implements CakeSessionHandlerInterface {
  * @return boolean Success
  */
 	public function close() {
-		$probability = mt_rand(1, 150);
-		if ($probability <= 3) {
-			$this->gc();
-		}
 		return true;
 	}
 
@@ -145,15 +141,21 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 	}
 
 /**
+ * Writes and closes a session
+ * 
+ * @return void 
+ */
+	protected function _writeSession() {
+		session_write_close();
+	}
+
+/**
  * Closes the session before the objects handling it become unavailable
  *
  * @return void
  */
 	public function __destruct() {
-		try {
-			session_write_close();
-		} catch (Exception $e) {
-		}
+		$this->_writeSession();
 	}
 
 }

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -108,7 +108,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function teardown() {
 		if (TestCakeSession::started()) {
-			TestCakeSession::clear();
+			session_write_close();
 		}
 		unset($_SESSION);
 		parent::teardown();

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -18,6 +18,8 @@
  */
 
 App::uses('CakeSession', 'Model/Datasource');
+App::uses('DatabaseSession', 'Model/Datasource/Session');
+App::uses('CacheSession', 'Model/Datasource/Session');
 
 class TestCakeSession extends CakeSession {
 
@@ -29,6 +31,20 @@ class TestCakeSession extends CakeSession {
 		self::_setHost($host);
 	}
 
+}
+
+class TestCacheSession extends CacheSession {
+
+	protected function _writeSession() {
+		return true;
+	}
+}
+
+class TestDatabaseSession extends DatabaseSession {
+
+	protected function _writeSession() {
+		return true;
+	}
 }
 
 /**
@@ -92,7 +108,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function teardown() {
 		if (TestCakeSession::started()) {
-			TestCakeSession::clear();
+			session_write_close();
 		}
 		unset($_SESSION);
 		parent::teardown();
@@ -550,6 +566,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testReadAndWriteWithCacheStorage() {
 		Configure::write('Session.defaults', 'cache');
+		Configure::write('Session.handler.engine', 'TestCacheSession');
 
 		TestCakeSession::init();
 		TestCakeSession::destroy();
@@ -585,6 +602,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testReadAndWriteWithCustomCacheConfig() {
 		Configure::write('Session.defaults', 'cache');
+		Configure::write('Session.handler.engine', 'TestCacheSession');
 		Configure::write('Session.handler.config', 'session_test');
 
 		Cache::config('session_test', array(
@@ -609,6 +627,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testReadAndWriteWithDatabaseStorage() {
 		Configure::write('Session.defaults', 'database');
+		Configure::write('Session.handler.engine', 'TestDatabaseSession');
 		Configure::write('Session.handler.table', 'sessions');
 		Configure::write('Session.handler.model', 'Session');
 		Configure::write('Session.handler.database', 'test');
@@ -651,6 +670,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function testSessionTimeout() {
 		Configure::write('debug', 2);
+		Configure::write('Session.defaults', 'cake');
 		Configure::write('Session.autoRegenerate', false);
 
 		$timeoutSeconds = Configure::read('Session.timeout') * 60;
@@ -683,7 +703,7 @@ class CakeSessionTest extends CakeTestCase {
 	public function testCookieTimeoutFallback() {
 		$_SESSION = null;
 		Configure::write('Session', array(
-			'defaults' => 'php',
+			'defaults' => 'cake',
 			'timeout' => 400,
 		));
 		TestCakeSession::start();
@@ -692,7 +712,7 @@ class CakeSessionTest extends CakeTestCase {
 
 		$_SESSION = null;
 		Configure::write('Session', array(
-			'defaults' => 'php',
+			'defaults' => 'cake',
 			'timeout' => 400,
 			'cookieTimeout' => 600
 		));

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -108,7 +108,7 @@ class CakeSessionTest extends CakeTestCase {
  */
 	public function teardown() {
 		if (TestCakeSession::started()) {
-			session_write_close();
+			TestCakeSession::clear();
 		}
 		unset($_SESSION);
 		parent::teardown();

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -353,7 +353,7 @@ class SqliteTest extends CakeTestCase {
 	public function testVirtualFieldWithFunction() {
 		$this->loadFixtures('User');
 		$User = ClassRegistry::init('User');
-		$User->virtualFields = array('name' => 'SUBSTR(User.user, 5)');
+		$User->virtualFields = array('name' => 'SUBSTR(User.user, 5, LENGTH(User.user) - 4)');
 
 		$result = $User->find('first', array(
 			'conditions' => array('User.user' => 'garrett')

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -80,7 +80,8 @@ class FileTest extends CakeTestCase {
 			'filesize' => filesize($file),
 			'mime' => 'text/x-php'
 		);
-		if (!function_exists('finfo_open') && !function_exists('mime_content_type')) {
+		if (!function_exists('finfo_open') && (!function_exists('mime_content_type') ||
+				function_exists('mime_content_type') && false === mime_content_type($this->File->pwd()))) {
 			$expecting['mime'] = false;
 		}
 
@@ -480,7 +481,11 @@ class FileTest extends CakeTestCase {
 		$this->skipIf(!function_exists('finfo_open') && !function_exists('mime_content_type'), 'Not able to read mime type');
 		$path = CAKE . 'Test' . DS . 'test_app' . DS . 'webroot' . DS . 'img' . DS . 'cake.power.gif';
 		$file = new File($path);
-		$this->assertEquals('image/gif', $file->mime());
+		$expected = 'image/gif';
+		if (function_exists('mime_content_type') && false === mime_content_type($file->pwd())) {
+			$expected = false;
+		}
+		$this->assertEquals($expected, $file->mime());
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -607,7 +607,12 @@ class RssHelperTest extends CakeTestCase {
 		$File = new File($tmpFile, true);
 
 		$this->assertTrue($File->write('123'), 'Could not write to ' . $tmpFile);
-		clearstatcache(true, $tmpFile);
+
+		if (50300 <= PHP_VERSION_ID) {
+			clearstatcache(true, $tmpFile);
+		} else {
+			clearstatcache();
+		}
 
 		$item = array(
 			'title' => array(
@@ -637,6 +642,12 @@ class RssHelperTest extends CakeTestCase {
 			)
 		);
 		$result = $this->Rss->item(null, $item);
+		if (!function_exists('finfo_open') && 
+				(function_exists('mime_content_type') && false === mime_content_type($tmpFile))) {
+			$type = false;
+		} else {
+			$type = 'text/plain';
+		}
 		$expected = array(
 			'<item',
 			'<title',
@@ -651,7 +662,7 @@ class RssHelperTest extends CakeTestCase {
 			'enclosure' => array(
 				'url' => $this->Rss->url('/tests/cakephp.file.test.tmp', true),
 				'length' => filesize($tmpFile),
-				'type' => 'text/plain'
+				'type' => $type
 			),
 			'<pubDate',
 			date('r', strtotime('2008-05-31 12:00:00')),


### PR DESCRIPTION
I did some changes to Session since CakePHP core tests segfaulted in the travis CI PHP 5.2 environments:
- Removed manual gc probablility calculation, since it is controlled by `session.gc_probability` ini value
- Added `$expires` parameter to `CakeSessionHandlerInterface::gc()` and it's implementors since a custom session_save_handler will pass expires to the registeres gc handler
- Fixed Sqlite test where older versions bail out on `SUBSTR()` as virtualField without second parameter
- Fixed `mime_content_type()` returning false if the magic mime db is corrupt or empty

Travis build: http://travis-ci.org/#!/tPl0ch/cakephp/builds/938104
