### PR TITLE
Add test/doc for reverse Folder::inPath()

### DIFF
--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -122,6 +122,9 @@ class FolderTest extends CakeTestCase {
 
 		$result = $Folder->inPath(DS . 'non-existing' . $inside);
 		$this->assertFalse($result);
+
+		$result = $Folder->inPath($path . DS . 'Model', true);
+		$this->assertTrue($result);
 	}
 
 /**

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -322,7 +322,7 @@ class Folder {
  * Returns true if the File is in given path.
  *
  * @param string $path The path to check that the current pwd() resides with in.
- * @param boolean $reverse
+ * @param boolean $reverse Reverse the search, check that pwd() resides within $path.
  * @return boolean
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::inPath
  */


### PR DESCRIPTION
The `$reverse` param of `Folder::inPath()` doesn't have a test case.
