### PR TITLE
Update tags reference in .gitignore to root of the folder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /build
 /dist
 .DS_Store
-tags
+/tags


### PR DESCRIPTION
Tags reference in the .gitignore file is now specific to the root rather than anywhere in the source tree. Users should make their own .gitignore files. However the .gitignore file is included in all CakePHP downloads and newbies(like me) to Git might not realize this is there and any file named "tags" including folders will be ignored when making new repositories.
