### PR TITLE
CakeTestCase::skipAllButThese()

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -28,7 +28,11 @@ App::uses('CakeHtmlReporter', 'TestSuite/Reporter');
  * @package       Cake.Test.Case.TestSuite
  */
 class CakeTestCaseTest extends CakeTestCase {
-
+/**
+ * setUpBeforeClass
+ *
+ * @return void
+ */
 	public static function setUpBeforeClass() {
 		require_once CAKE . 'Test' . DS . 'Fixture' . DS . 'AssertTagsTestCase.php';
 		require_once CAKE . 'Test' . DS . 'Fixture' . DS . 'FixturizedTestCase.php';

--- a/lib/Cake/Test/Case/TestSuite/SkipAllButTheseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/SkipAllButTheseTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * SkipAllButTheseTest file
+ *
+ * Test Case for CakeTestCase::skipAllButThese method
+ *
+ * PHP version 5
+ *
+ * CakePHP : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc.
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc.
+ * @link          http://cakephp.org CakePHP Project
+ * @package       Cake.Test.Case.TestSuite
+ * @since         CakePHP v 2.2.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+/**
+ * SkipAllButTheseTest
+ *
+ * @package       Cake.Test.Case.TestSuite
+ */
+class SkipAllButTheseTest extends CakeTestCase {
+/**
+ * setUpBeforeClass
+ *
+ * @return void
+ */
+	public static function setUpBeforeClass() {
+		self::skipAllButThese(
+			array('testDontSkipMe', 'testDontSkipMeEither'),
+			'This test should have been skipped by skipAllButThese()'
+		);
+	}
+
+/**
+ * testDontSkipMe
+ *
+ * @return void
+ */
+	public function testDontSkipMe() {
+		$this->assertTrue(true);
+	}
+
+/**
+ * testButYouShouldSkipMe
+ *
+ * @return void
+ */
+	public function testButYouShouldSkipMe() {
+		$this->fail('This test method should have been skipped.');
+	}
+
+/**
+ * testDontSkipMeEither
+ *
+ * @return void
+ */
+	public function testDontSkipMeEither() {
+		$this->assertTrue(true);
+	}
+
+/**
+ * testButYouShouldAlsoSkipMe
+ *
+ * @return void
+ */
+	public function testButYouShouldAlsoSkipMe() {
+		$this->fail('This test method should have been skipped.');
+	}
+}

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -63,6 +63,20 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 	protected $_pathRestore = array();
 
 /**
+ * Tests not to skip after calling $this->skipAllButThis()
+ *
+ * @var array
+ */
+	protected static $_skipAllButThese = array();
+
+/**
+ * Message to display if using skipAllButThese()
+ *
+ * @var string
+ */
+	protected static $_skipAllButTheseMessage = '';
+
+/**
  * Runs the test case and collects the results in a TestResult object.
  * If no TestResult object is passed a new one will be created.
  * This method is run for each test method in this class
@@ -89,6 +103,11 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @return void
  */
 	public function startTest($method) {
+		if (!empty(self::$_skipAllButThese)) {
+			if (!in_array($method, self::$_skipAllButThese)) {
+				$this->markTestSkipped(self::$_skipAllButTheseMessage);
+			}
+		}
 	}
 
 /**
@@ -112,6 +131,18 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 			$this->markTestSkipped($message);
 		}
 		return $shouldSkip;
+	}
+
+/**
+ * Tell the test suite to skip all tests except the tests indicated
+ *
+ * @param array $dontSkip Array of test function names to not skip
+ * @param string $message Message to display when test is skipped
+ * @return void
+ */
+	public static function skipAllButThese($dontSkip = array(), $message = '') {
+		self::$_skipAllButThese = array_merge(self::$_skipAllButThese, $dontSkip);
+		self::$_skipAllButTheseMessage = $message;
 	}
 
 /**


### PR DESCRIPTION
This creates the method `skipAllButThese()` in the class `CakeTestCase` to give the user the ability to skip all tests except the ones indicated. This would be extremely useful when debugging a method that is called by multiple tests.

Example:

``` php
public static function setUpBeforeClass() {
    self::skipAllButThese(
        array('testDontSkipMe'),
        'This test was skipped by skipAllButThese()'
    );
}
```

Will skip all tests except `testDontSkipMe()` so the user can focus on just that test method.
