### PR TITLE
Added `contain` option to AuthComponent's Authentication objects

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -30,6 +30,7 @@ abstract class BaseAuthenticate {
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
  * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
+ * - `contain` Extra models to contain and store in session.
  *
  * @var array
  */
@@ -40,7 +41,8 @@ abstract class BaseAuthenticate {
 		),
 		'userModel' => 'User',
 		'scope' => array(),
-		'recursive' => 0
+		'recursive' => 0,
+		'contain' => array(),
 	);
 
 /**
@@ -82,13 +84,16 @@ abstract class BaseAuthenticate {
 		}
 		$result = ClassRegistry::init($userModel)->find('first', array(
 			'conditions' => $conditions,
-			'recursive' => (int)$this->settings['recursive']
+			'recursive' => (int)$this->settings['recursive'],
+			'contain' => $this->settings['contain'],
 		));
 		if (empty($result) || empty($result[$model])) {
 			return false;
 		}
-		unset($result[$model][$fields['password']]);
-		return $result[$model];
+		$user = $result[$model];
+		unset($user[$fields['password']]);
+		unset($result[$model]);
+		return array_merge($user, $result);
 	}
 
 /**

--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -42,7 +42,7 @@ abstract class BaseAuthenticate {
 		'userModel' => 'User',
 		'scope' => array(),
 		'recursive' => 0,
-		'contain' => array(),
+		'contain' => null,
 	);
 
 /**

--- a/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
@@ -50,6 +50,7 @@ class BasicAuthenticate extends BaseAuthenticate {
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
  * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
+ * - `contain` Extra models to contain and store in session.
  * - `realm` The realm authentication is for.  Defaults the server name.
  *
  * @var array
@@ -62,6 +63,7 @@ class BasicAuthenticate extends BaseAuthenticate {
 		'userModel' => 'User',
 		'scope' => array(),
 		'recursive' => 0,
+		'contain' => array(),
 		'realm' => '',
 	);
 

--- a/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
@@ -63,7 +63,7 @@ class BasicAuthenticate extends BaseAuthenticate {
 		'userModel' => 'User',
 		'scope' => array(),
 		'recursive' => 0,
-		'contain' => array(),
+		'contain' => null,
 		'realm' => '',
 	);
 

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -81,7 +81,7 @@ class DigestAuthenticate extends BaseAuthenticate {
 		'userModel' => 'User',
 		'scope' => array(),
 		'recursive' => 0,
-		'contain' => array(),
+		'contain' => null,
 		'realm' => '',
 		'qop' => 'auth',
 		'nonce' => '',

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -63,6 +63,8 @@ class DigestAuthenticate extends BaseAuthenticate {
  * - `userModel` The model name of the User, defaults to User.
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
+ * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
+ * - `contain` Extra models to contain and store in session.
  * - `realm` The realm authentication is for, Defaults to the servername.
  * - `nonce` A nonce used for authentication.  Defaults to `uniqid()`.
  * - `qop` Defaults to auth, no other values are supported at this time.
@@ -79,6 +81,7 @@ class DigestAuthenticate extends BaseAuthenticate {
 		'userModel' => 'User',
 		'scope' => array(),
 		'recursive' => 0,
+		'contain' => array(),
 		'realm' => '',
 		'qop' => 'auth',
 		'nonce' => '',


### PR DESCRIPTION
So

``` php
public $components = array(
    'Auth' => array(
        'authenticate' => array(
            'Form' => array(
                'contain' => array('Profile'),
            ),
        ),
    ),
);
```

produces

``` php
array(
    'Config' => array(
        'userAgent' => 'd7e6edb6ab967103612a1c140482f1ea',
        'time' => (int) 1333603416,
        'countdown' => (int) 10
    ),
    'Auth' => array(
        'User' => array(
            'id' => '241',
            'username' => 'test',
            'Profile' => array(
                'id' => '2',
                'user_id' => '241',
                'name' => 'Hello World',
                'desc' => ''
            )
        )
    )
)
```

I'm not sure if that's how it should be.
