### PR TITLE
Allow the formHelper->label() to have default options from inputDefaults

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -795,6 +795,16 @@ class FormHelper extends AppHelper {
 			$options = array('class' => $options);
 		}
 
+		if(!isset($options['class'])) {
+			if(isset($this->_inputDefaults['label'])) {
+				if(is_string($this->_inputDefaults['label'])) {
+					$options['class'] = $this->_inputDefaults['label'];
+				} else {
+					$options = array_merge($this->_inputDefaults['label'], $options);
+				}
+			}
+		}
+
 		if (isset($options['for'])) {
 			$labelFor = $options['for'];
 			unset($options['for']);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -795,13 +795,11 @@ class FormHelper extends AppHelper {
 			$options = array('class' => $options);
 		}
 
-		if(!isset($options['class'])) {
-			if(isset($this->_inputDefaults['label'])) {
-				if(is_string($this->_inputDefaults['label'])) {
-					$options['class'] = $this->_inputDefaults['label'];
-				} else {
-					$options = array_merge($this->_inputDefaults['label'], $options);
-				}
+		if(isset($this->_inputDefaults['label'])) {
+			if(is_string($this->_inputDefaults['label']) && !isset($options['class'])) {
+				$options['class'] = $this->_inputDefaults['label'];
+			} else {
+				$options = array_merge($this->_inputDefaults['label'], $options);
 			}
 		}
 


### PR DESCRIPTION
This allows any labels to have their default options set using the inputDefaults() array.

I looked at the unit-tests for the formHelper, and I wasn't quite sure how to implement the tests, I can amend this commit with any tests, just advise me on the proper way to lay them out.
