### PR TITLE
Allow the formHelper->label() to have default options

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -80,6 +80,13 @@ class FormHelper extends AppHelper {
 	protected $_inputDefaults = array();
 
 /**
+ * Persistent default options used by label(). Set by FormHelper::create().
+ *
+ * @var array
+ */
+	protected $_labelDefaults = array();
+
+/**
  * An array of field names that have been excluded from
  * the Token hash used by SecurityComponent's validatePost method
  *
@@ -381,10 +388,13 @@ class FormHelper extends AppHelper {
 			'url' => null,
 			'default' => true,
 			'encoding' => strtolower(Configure::read('App.encoding')),
-			'inputDefaults' => array()),
+			'inputDefaults' => array(),
+			'labelDefaults' => array()),
 		$options);
 		$this->_inputDefaults = $options['inputDefaults'];
+		$this->_labelDefaults = $options['labelDefaults'];
 		unset($options['inputDefaults']);
+		unset($options['labelDefaults']);
 
 		if (!isset($options['id'])) {
 			$domId = isset($options['action']) ? $options['action'] : $this->request['action'];
@@ -824,11 +834,11 @@ class FormHelper extends AppHelper {
 			$options = array('class' => $options);
 		}
 
-		if(isset($this->_inputDefaults['label'])) {
-			if(is_string($this->_inputDefaults['label']) && !isset($options['class'])) {
-				$options['class'] = $this->_inputDefaults['label'];
+		if(isset($this->_labelDefaults)) {
+			if(is_string($this->_labelDefaults) && !isset($options['class'])) {
+				$options['class'] = $this->_labelDefaults;
 			} else {
-				$options = array_merge($this->_inputDefaults['label'], $options);
+				$options = array_merge($this->_labelDefaults, $options);
 			}
 		}
 

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -824,6 +824,14 @@ class FormHelper extends AppHelper {
 			$options = array('class' => $options);
 		}
 
+		if(isset($this->_inputDefaults['label'])) {
+			if(is_string($this->_inputDefaults['label']) && !isset($options['class'])) {
+				$options['class'] = $this->_inputDefaults['label'];
+			} else {
+				$options = array_merge($this->_inputDefaults['label'], $options);
+			}
+		}
+
 		if (isset($options['for'])) {
 			$labelFor = $options['for'];
 			unset($options['for']);


### PR DESCRIPTION
Ok, re-doing this request to the proper branch.

This allows any labels to have their default options set using a new option called 'labelDefaults'
It seems to me that 'label' is the only one missing this, as all other inputs have it.

I looked at the unit-tests for the formHelper, and I wasn't quite sure how to implement the tests, I can amend this commit with any tests, just advise me on the proper way to lay them out.
