### PR TITLE
Allow default pass params value for new attached listeners

### DIFF
--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -36,6 +36,13 @@ class CakeEventManager {
 	public static $defaultPriority = 10;
 
 /**
+ * The default pass params value for new attached listeners
+ *
+ * @var boolean
+ */
+	public $defaultPassParams = false;
+
+/**
  * The globally available instance, used for dispatching events attached from any scope
  *
  * @var CakeEventManager
@@ -107,7 +114,7 @@ class CakeEventManager {
 			$this->_attachSubscriber($callable);
 			return;
 		}
-		$options = $options + array('priority' => self::$defaultPriority, 'passParams' => false);
+		$options = $options + array('priority' => self::$defaultPriority, 'passParams' => $this->defaultPassParams);
 		$this->_listeners[$eventKey][$options['priority']][] = array(
 			'callable' => $callable,
 			'passParams' => $options['passParams'],

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2510,7 +2510,7 @@ class Model extends Object implements CakeEventListener {
 				'fields' => "{$this->alias}.{$this->primaryKey}",
 				'recursive' => 0), compact('conditions'))
 			);
-			if (empty($ids)) {
+			if ($ids === false || (empty($ids) && $callbacks)) {
 				return false;
 			}
 

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2510,7 +2510,7 @@ class Model extends Object implements CakeEventListener {
 				'fields' => "{$this->alias}.{$this->primaryKey}",
 				'recursive' => 0), compact('conditions'))
 			);
-			if ($ids === false) {
+			if (empty($ids)) {
 				return false;
 			}
 


### PR DESCRIPTION
This allows any listeners to have their default pass params options set using a new attribute called 'defaultPassParams' for a instance of event listeners manager

Please see ticket #2636
