### PR TITLE
Added "missing" comma after smtp log option

### DIFF
--- a/app/Config/email.php.default
+++ b/app/Config/email.php.default
@@ -58,7 +58,7 @@ class EmailConfig {
 		'username' => 'user',
 		'password' => 'secret',
 		'client' => null,
-		'log' => false
+		'log' => false,
 		//'charset' => 'utf-8',
 		//'headerCharset' => 'utf-8',
 	);


### PR DESCRIPTION
Just a minor detail. After the $smtp log key, there is no comma, which would cause a syntax error when uncommenting the lines below it. All other arrays do have comma's after their last uncommented key, so it seems logical to add it to the $smtp array as well.
