### PR TITLE
Correct method descriptions and remove unused property

### DIFF
--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -114,7 +114,7 @@ class SchemaShellTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
@@ -49,7 +49,7 @@ class DbConfigTaskTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -239,7 +239,7 @@ class TestTaskTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -118,7 +118,7 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -61,13 +61,6 @@ class DboTestSource extends DboSource {
 class DboSourceTest extends CakeTestCase {
 
 /**
- * debug property
- *
- * @var mixed null
- */
-	public $debug = null;
-
-/**
  * autoFixtures property
  *
  * @var bool false
@@ -102,7 +95,7 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/View/MediaViewTest.php
+++ b/lib/Cake/Test/Case/View/MediaViewTest.php
@@ -40,7 +40,7 @@ class MediaViewTest extends CakeTestCase {
 	}
 
 /**
- * endTest method
+ * tearDown method
  *
  * @return void
  */


### PR DESCRIPTION
`$debug` property is unused in the DboSourceTest and correcting remaining `endTest -> tearDown` method docblocks.
