### PR TITLE
Let the web server handle missing 'favicon.ico' files.

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -2,5 +2,6 @@
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_URI} !^/favicon.ico$
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>

--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -86,10 +86,6 @@
 		trigger_error("CakePHP core could not be found.  Check the value of CAKE_CORE_INCLUDE_PATH in APP/webroot/index.php.  It should point to the directory containing your " . DS . "cake core directory and your " . DS . "vendors root directory.", E_USER_ERROR);
 	}
 
-	if (isset($_SERVER['PATH_INFO']) && $_SERVER['PATH_INFO'] == '/favicon.ico') {
-		return;
-	}
-
 	App::uses('Dispatcher', 'Routing');
 
 	$Dispatcher = new Dispatcher();


### PR DESCRIPTION
If a `favicon.ico` file is missing, the web server should handle it, not Cake.
