### PR TITLE
Added the error-message parameter to the flash message

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -313,6 +313,7 @@ class AuthComponent extends Component {
 		} else {
 			if (!$this->_getUser()) {
 				if (!$request->is('ajax')) {
+					$this->flash['params'] = array('class'=>'error-message');
 					$this->flash($this->authError);
 					$this->Session->write('Auth.redirect', $request->here());
 					$controller->redirect($loginAction);
@@ -330,7 +331,8 @@ class AuthComponent extends Component {
 		if (empty($this->authorize) || $this->isAuthorized($this->user())) {
 			return true;
 		}
-
+		
+		$this->flash['params'] = array('class'=>'error-message');
 		$this->flash($this->authError);
 		$controller->redirect($controller->referer('/'), null, true);
 		return false;


### PR DESCRIPTION
When an authError is triggered the 'message' class is still sent, when the error-message class should be sent.
