### PR TITLE
allow missing tmp directories to be autocreated in debug mode

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -315,6 +315,9 @@ class FileEngine extends CacheEngine {
  */
 	protected function _active() {
 		$dir = new SplFileInfo($this->settings['path']);
+		if (Configure::read('debug') && !is_dir($path = $dir->getPathname())) {
+			mkdir($path, 0755, true);
+		}
 		if ($this->_init && !($dir->isDir() && $dir->isWritable())) {
 			$this->_init = false;
 			trigger_error(__d('cake_dev', '%s is not writable', $this->settings['path']), E_USER_WARNING);

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -66,6 +66,11 @@ class FileLog implements CakeLogInterface {
 			$filename = $this->_path . $type . '.log';
 		}
 		$output = date('Y-m-d H:i:s') . ' ' . ucfirst($type) . ': ' . $message . "\n";
+		if (Configure::read('debug') && !is_dir($dir = dirname($filename))) {
+			if (!mkdir($dir, 0755, true)) {
+				return false;
+			}
+		}
 		return file_put_contents($filename, $output, FILE_APPEND);
 	}
 


### PR DESCRIPTION
allow creating of missing tmp directories in debug (development) mode for cache and log to avoid unnecessary errors thrown

@see http://cakephp.lighthouseapp.com/projects/42648/tickets/885-tmp-cache-folders-autocreation
