### PR TITLE
Added prefix to array of passed arguments

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -485,6 +485,7 @@ class Router {
 					array(
 						'plugin' => $plugin,
 						'controller' => $urlName,
+						'prefix' => str_replace('/', '', $prefix),
 						'action' => $params['action'],
 						'[method]' => $params['method']
 					),


### PR DESCRIPTION
Prefix from Routing.prefixes wasn't getting propogated for mapResourced routes.

Adding the prefix parameter to the Router::connect within mapResources() fixes this.

To reproduce the problem:

core.php:
// Add this
Configure::write('Routing.prefixes', array('admin', 'api'));

routes.php
// Add this (projects is an example controller)
Router::mapResources('projects', array('prefix' => '/api/'));

Then do a POST request to /api/projects
This will end up at the "add" method instead of ":prefix_add"
