### PR TITLE
2.2 test cases fix for windows

### DIFF
--- a/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
@@ -496,7 +496,7 @@ cake mycommand method [-h] [--connection]
 --connection      Db connection.
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help is not correct.');
+		$this->assertTextEquals($expected, $result, 'Help is not correct.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/HelpFormatterTest.php
+++ b/lib/Cake/Test/Case/Console/HelpFormatterTest.php
@@ -63,7 +63,7 @@ four  this is help text this
       <comment>(optional)</comment>
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Generated help is too wide');
+		$this->assertTextEquals($expected, $result, 'Generated help is too wide');
 	}
 
 /**
@@ -98,7 +98,7 @@ type          Resource type. <comment>(choices: aco|aro)</comment>
 other_longer  Another argument. <comment>(optional)</comment>
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help does not match');
+		$this->assertTextEquals($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -133,7 +133,7 @@ model  The model to make.
 epilog text
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help is wrong.');
+		$this->assertTextEquals($expected, $result, 'Help is wrong.');
 	}
 
 /**
@@ -164,7 +164,7 @@ To see help on a subcommand use <info>`cake mycommand [subcommand] --help`</info
 --test      A test option.
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help is not correct.');
+		$this->assertTextEquals($expected, $result, 'Help is not correct.');
 	}
 
 /**
@@ -193,7 +193,7 @@ cake mycommand [-h] [--test] [-c default]
                   default)</comment>
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help does not match');
+		$this->assertTextEquals($expected, $result, 'Help does not match');
 	}
 
 /**
@@ -224,7 +224,7 @@ model         The model to make.
 other_longer  Another argument. <comment>(optional)</comment>
 
 TEXT;
-		$this->assertEquals($expected, $result, 'Help does not match');
+		$this->assertTextEquals($expected, $result, 'Help does not match');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -544,7 +544,7 @@ class ShellTest extends CakeTestCase {
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));
-		$this->assertEquals(file_get_contents($file), $contents);
+		$this->assertTextEquals(file_get_contents($file), $contents);
 	}
 
 /**
@@ -596,10 +596,14 @@ class ShellTest extends CakeTestCase {
  * @return void
  */
 	public function testCreateFileNoPermissions() {
+		$this->skipIf(DIRECTORY_SEPARATOR === '\\', 'Cant perform operations using permissions on windows.');
+		
 		$path = TMP . 'shell_test';
 		$file = $path . DS . 'no_perms';
-
-		mkdir($path);
+		
+		if (!is_dir($path)) {
+			mkdir($path);
+		}
 		chmod($path, 0444);
 
 		$this->Shell->createFile($file, 'testing');
@@ -759,7 +763,7 @@ This is the song that never ends.
 This is the song that never ends.
 This is the song that never ends.
 TEXT;
-		$this->assertEquals($expected, $result, 'Text not wrapped.');
+		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
 
 		$result = $this->Shell->wrapText($text, array('indent' => '  ', 'width' => 33));
 		$expected = <<<TEXT
@@ -767,7 +771,7 @@ TEXT;
   This is the song that never ends.
   This is the song that never ends.
 TEXT;
-		$this->assertEquals($expected, $result, 'Text not wrapped.');
+		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -168,7 +168,7 @@ class SessionHelperTest extends CakeTestCase {
 			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
 		));
 		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a calling</p>\n</div>";
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
99% is up and running now.
### Remaining problem:
#### AllComponents:

```
Fatal Error
Error: Cannot redeclare class AppModel  
File: E:\...\lib\Cake\Test\Case\Model\models.php    
Line: 56
```

it is a clean freshly baked app + current 2.2head
