### PR TITLE
CakeTestSuite::addTestDirectory() ignore non-php files

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
@@ -78,4 +78,27 @@ class CakeTestSuiteTest extends CakeTestCase {
 
 		$Folder->delete();
 	}
+	
+/**
+ * testAddTestDirectoryRecursiveWithNonPhp
+ * 
+ * @return void
+ */
+	public function testAddTestDirectoryRecursiveWithNonPhp() {
+		$this->skipIf(!is_writeable(TMP), 'Cant addTestDirectoryRecursiveWithNonPhp unless the tmp folder is writable.');
+
+		$Folder = new Folder(TMP . 'MyTestFolder', true, 0777);
+		touch($Folder->path . DS . 'BackupTest.php~');
+		touch($Folder->path . DS . 'SomeNotesTest.txt');
+		touch($Folder->path . DS . 'NotHiddenTest.php');
+
+		$suite = $this->getMock('CakeTestSuite', array('addTestFile'));
+		$suite
+			->expects($this->exactly(1))
+			->method('addTestFile');
+
+		$suite->addTestDirectoryRecursive($Folder->pwd());
+
+		$Folder->delete();
+	}
 }

--- a/lib/Cake/TestSuite/CakeTestSuite.php
+++ b/lib/Cake/TestSuite/CakeTestSuite.php
@@ -37,7 +37,9 @@ class CakeTestSuite extends PHPUnit_Framework_TestSuite {
 		list($dirs, $files) = $Folder->read(true, true, true);
 
 		foreach ($files as $file) {
-			$this->addTestFile($file);
+			if (substr($file, -4) === '.php') {
+				$this->addTestFile($file);
+			}
 		}
 	}
 
@@ -52,7 +54,9 @@ class CakeTestSuite extends PHPUnit_Framework_TestSuite {
 		$files = $Folder->tree(null, true, 'files');
 
 		foreach ($files as $file) {
-			$this->addTestFile($file);
+			if (substr($file, -4) === '.php') {
+				$this->addTestFile($file);
+			}
 		}
 	}
 


### PR DESCRIPTION
CakeTestSuite::addTestDirectory() and addTestDirectoryRecursive() now ignore any files that do not end in .php

This avoids any stray non-php files being parsed, especially tilde-style backup files that end in .php~

Improves #2031
