### PR TITLE
2.2 bake theme order

### DIFF
--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -55,11 +55,18 @@ class TemplateTask extends AppShell {
  * Find the paths to all the installed shell themes in the app.
  *
  * Bake themes are directories not named `skel` inside a `Console/Templates` path.
- *
+ * They are listed in this order: app -> plugin -> default
+ * 
  * @return array Array of bake themes that are installed.
  */
 	protected function _findThemes() {
-		$paths = array();
+		$paths = App::path('Console');
+		
+		$plugins = App::objects('plugin');
+		foreach ($plugins as $plugin) {
+			$paths[] = $this->_pluginPath($plugin) . 'Console' . DS;
+		}
+
 		$core = current(App::core('Console'));
 		$separator = DS === '/' ? '/' : '\\\\';
 		$core = preg_replace('#shells' . $separator . '$#', '', $core);
@@ -69,13 +76,7 @@ class TemplateTask extends AppShell {
 		$contents = $Folder->read();
 		$themeFolders = $contents[0];
 
-		$plugins = App::objects('plugin');
 		$paths[] = $core;
-		foreach ($plugins as $plugin) {
-			$paths[] = $this->_pluginPath($plugin) . 'Console' . DS;
-		}
-
-		$paths = array_merge($paths, App::path('Console'));
 
 		// TEMPORARY TODO remove when all paths are DS terminated
 		foreach ($paths as $i => $path) {

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -134,7 +134,7 @@ class TemplateTaskTest extends CakeTestCase {
 
 		$result = $this->Task->generate('classes', 'test_object', array('test' => 'foo'));
 		$expected = "I got rendered\nfoo";
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -107,15 +107,15 @@ class TemplateTaskTest extends CakeTestCase {
 		$result = $this->Task->getThemePath();
 		$this->assertEquals($defaultTheme, $result);
 
-		$this->Task->templatePaths = array('default' => $defaultTheme, 'other' => '/some/path');
+		$this->Task->templatePaths = array('other' => '/some/path', 'default' => $defaultTheme);
 		$this->Task->params['theme'] = 'other';
 		$result = $this->Task->getThemePath();
 		$this->assertEquals('/some/path', $result);
 
 		$this->Task->params = array();
 		$result = $this->Task->getThemePath();
-		$this->assertEquals($defaultTheme, $result);
-		$this->assertEquals('default', $this->Task->params['theme']);
+		$this->assertEquals('/some/path', $result);
+		$this->assertEquals('other', $this->Task->params['theme']);
 	}
 
 /**


### PR DESCRIPTION
They are now correctly listed in this order: app -> plugin -> default.
Also fixed a single test case to work with windows line breaks.
