### PR TITLE
Ignore everything but folders in /app/tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /app/Config
-/app/tmp
 /lib/Cake/Console/Templates/skel/tmp/
 /plugins
 /vendors
@@ -7,3 +6,16 @@
 /dist
 .DS_Store
 /tags
+/app/tmp
+/app/tmp/cache/models/*
+/app/tmp/cache/persistent/*
+/app/tmp/cache/views/*
+!/app/tmp/cache/models/empty
+!/app/tmp/cache/persistent/empty
+!/app/tmp/cache/views/empty
+/app/tmp/logs/*
+!/app/tmp/logs/empty
+/app/tmp/sessions/*
+!/app/tmp/sessions/empty
+/app/tmp/tests/*
+!/app/tmp/tests/empty


### PR DESCRIPTION
I recall reading previous discussions about this topic, but don't remember the core team arguments. Anyway, this is something I have to do everytime I start a new CakePHP project at work so...

Basically, I want to ignore everything under `tmp` directory except the directory tree itself, so that everytime I deploy the application don't have to execute a bunch of `mkdir` commands.
