### PR TITLE
2.2 folder merge

### DIFF
--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -820,7 +820,7 @@ class FolderTest extends CakeTestCase {
 	 * - file3.php
 	 * $folderFour: folder_test/folder2/folder4/
 	 * - file4.php
-	 * $folderFive: folder_test/folder4/
+	 * $folderFive: folder_test/folder5/
 	 */
 	public function testCopy() {
 		$path = TMP . 'folder_test';
@@ -880,7 +880,7 @@ class FolderTest extends CakeTestCase {
 	 * - file3.php
 	 * $folderFour: folder_test/folder2/folder4/
 	 * - file4.php
-	 * $folderFive: folder_test/folder4/
+	 * $folderFive: folder_test/folder5/
 	 */
 	public function testCopyWithMerge() {
 		$path = TMP . 'folder_test';
@@ -914,7 +914,7 @@ class FolderTest extends CakeTestCase {
 		$this->assertTrue(file_exists($folderFive . DS . 'folder3' . DS . 'file3.php'));
 		
 		$Folder = new Folder($folderTwo);
-		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::MERGE));
+		$result = $Folder->copy(array('to' => $folderFive, 'scheme' => Folder::MERGE));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderFive . DS . 'file2.php'));
@@ -951,7 +951,7 @@ class FolderTest extends CakeTestCase {
 		touch($fileTwo);
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->copy(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
@@ -960,7 +960,7 @@ class FolderTest extends CakeTestCase {
 		$Folder->delete();
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->copy(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
@@ -973,7 +973,7 @@ class FolderTest extends CakeTestCase {
 		file_put_contents($folderThree . DS . 'folder2' . DS . 'file2.php', 'untouched');
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->copy(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));
@@ -1023,14 +1023,14 @@ class FolderTest extends CakeTestCase {
 		touch($file4);
 		
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::OVERWRITE));
+		$result = $Folder->copy(array('to' => $folderFive, 'scheme' => Folder::OVERWRITE));
 		
 		
 		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderFive . DS . 'folder' . DS . 'file3.php'));
 		
 		$Folder = new Folder($folderTwo);
-		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::OVERWRITE));
+		$result = $Folder->copy(array('to' => $folderFive, 'scheme' => Folder::OVERWRITE));
 		$this->assertTrue($result);
 		
 		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
@@ -1147,7 +1147,7 @@ class FolderTest extends CakeTestCase {
 		touch($fileTwo);
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->move(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(is_dir($folderThree . DS . 'folder2'));
@@ -1165,7 +1165,7 @@ class FolderTest extends CakeTestCase {
 		touch($fileTwo);
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->move(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(is_dir($folderThree . DS . 'folder2'));
@@ -1186,7 +1186,7 @@ class FolderTest extends CakeTestCase {
 		file_put_contents($folderThree . DS . 'folder2' . DS . 'file2.php', 'untouched');
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$result = $Folder->move(array('to' => $folderThree, 'scheme' => Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -997,7 +997,7 @@ class FolderTest extends CakeTestCase {
 	 * - file3.php
 	 * $folderFour: folder_test/folder2/folder4/
 	 * - file4.php
-	 * $folderFive: folder_test/folder4/
+	 * $folderFive: folder_test/folder5/
 	 */
 	function testCopyWithOverwrite() {
 		$path = TMP . 'folder_test';

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -29,11 +29,16 @@ class FolderTest extends CakeTestCase {
 	protected static $_tmp = array();
 
 /**
- * Save the directory names in TMP
+ * Save the directory names in TMP and make sure default directories exist
  *
  * @return void
  */
 	public static function setUpBeforeClass() {
+		$dirs = array('cache', 'logs', 'sessions', 'tests');
+		foreach ($dirs as $dir) {
+			new Folder(TMP . $dir, true);
+		}
+		
 		foreach (scandir(TMP) as $file) {
 			if (is_dir(TMP . $file) && !in_array($file, array('.', '..'))) {
 				self::$_tmp[] = $file;
@@ -800,8 +805,128 @@ class FolderTest extends CakeTestCase {
 		$this->assertEquals($expected, $messages);
 	}
 
+	/**
+	 * testCopy method
+	 * 
+	 * Verify that subdirectories existing in both destination and source directory
+	 * are merged recursivly.
+	 * 
+	 * $path: folder_test/
+	 * $folderOne: folder_test/folder1/
+	 * - file1.php
+	 * $folderTwo: folder_test/folder2/
+	 * - file2.php
+	 * $folderThree: folder_test/folder1/folder3/
+	 * - file3.php
+	 * $folderFour: folder_test/folder2/folder4/
+	 * - file4.php
+	 * $folderFive: folder_test/folder4/
+	 */
+	public function testCopy() {
+		$path = TMP . 'folder_test';
+		$folderOne = $path . DS . 'folder1';
+		$folderTwo = $path . DS . 'folder2';
+		$folderThree = $folderOne . DS . 'folder3';
+		$folderFour = $folderTwo . DS . 'folder4';
+		$folderFive = $path . DS . 'folder5';
+		$fileOne = $folderOne . DS . 'file1.php';
+		$fileTwo = $folderTwo . DS . 'file2.php';
+		$file3 = $folderThree . DS . 'file3.php';
+		$file4 = $folderFour . DS . 'file4.php';
+		$file5 = $folderThree . DS . 'file5.php';
+		$file6 = $folderFour . DS . 'file6.php';
+	
+		new Folder($path, true);
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		new Folder($folderThree, true);
+		new Folder($folderFour, true);
+		new Folder($folderFive, true);
+		touch($fileOne);
+		touch($fileTwo);
+		touch($file3);
+		touch($file4);
+
+		$Folder = new Folder($folderOne);
+		$result = $Folder->copy($folderFive);
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder3' . DS . 'file3.php'));
+		
+		$Folder = new Folder($folderTwo);
+		$result = $Folder->copy($folderFive);
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'file2.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder3' . DS . 'file3.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder4' . DS . 'file4.php'));
+		
+		$Folder = new Folder($path);
+		$Folder->delete();
+	}
+	
+	/**
+	 * testCopyWithMerge method
+	 * 
+	 * Verify that subdirectories existing in both destination and source directory
+	 * are merged recursivly.
+	 * 
+	 * $path: folder_test/
+	 * $folderOne: folder_test/folder1/
+	 * - file1.php
+	 * $folderTwo: folder_test/folder2/
+	 * - file2.php
+	 * $folderThree: folder_test/folder1/folder3/
+	 * - file3.php
+	 * $folderFour: folder_test/folder2/folder4/
+	 * - file4.php
+	 * $folderFive: folder_test/folder4/
+	 */
+	public function testCopyWithMerge() {
+		$path = TMP . 'folder_test';
+		$folderOne = $path . DS . 'folder1';
+		$folderTwo = $path . DS . 'folder2';
+		$folderThree = $folderOne . DS . 'folder3';
+		$folderFour = $folderTwo . DS . 'folder4';
+		$folderFive = $path . DS . 'folder5';
+		$fileOne = $folderOne . DS . 'file1.php';
+		$fileTwo = $folderTwo . DS . 'file2.php';
+		$file3 = $folderThree . DS . 'file3.php';
+		$file4 = $folderFour . DS . 'file4.php';
+		$file5 = $folderThree . DS . 'file5.php';
+		$file6 = $folderFour . DS . 'file6.php';
+	
+		new Folder($path, true);
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		new Folder($folderThree, true);
+		new Folder($folderFour, true);
+		new Folder($folderFive, true);
+		touch($fileOne);
+		touch($fileTwo);
+		touch($file3);
+		touch($file4);
+
+		$Folder = new Folder($folderOne);
+		$result = $Folder->copy($folderFive);
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder3' . DS . 'file3.php'));
+		
+		$Folder = new Folder($folderTwo);
+		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::MERGE));
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'file2.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder3' . DS . 'file3.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder4' . DS . 'file4.php'));
+		
+		$Folder = new Folder($path);
+		$Folder->delete();
+	}
+
 /**
- * testCopy method
+ * testCopyWithSkip method
  *
  * Verify that directories and files are copied recursively
  * even if the destination directory already exists.
@@ -810,7 +935,7 @@ class FolderTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testCopy() {
+	public function testCopyWithSkip() {
 		$path = TMP . 'folder_test';
 		$folderOne = $path . DS . 'folder1';
 		$folderTwo = $folderOne . DS . 'folder2';
@@ -826,7 +951,7 @@ class FolderTest extends CakeTestCase {
 		touch($fileTwo);
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy($folderThree);
+		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
@@ -835,7 +960,7 @@ class FolderTest extends CakeTestCase {
 		$Folder->delete();
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy($folderThree);
+		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
@@ -848,14 +973,76 @@ class FolderTest extends CakeTestCase {
 		file_put_contents($folderThree . DS . 'folder2' . DS . 'file2.php', 'untouched');
 
 		$Folder = new Folder($folderOne);
-		$result = $Folder->copy($folderThree);
+		$result = $Folder->copy(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));
 
 		$Folder = new Folder($path);
 		$Folder->delete();
+	}	
+	
+	/**
+	 * testCopyWithOverwrite
+	 * 
+	 * Verify that subdirectories existing in both destination and source directory
+	 * are overwritten/replaced recursivly.
+	 * 
+	 * $path: folder_test/
+	 * $folderOne: folder_test/folder1/
+	 * - file1.php
+	 * $folderTwo: folder_test/folder2/
+	 * - file2.php
+	 * $folderThree: folder_test/folder1/folder3/
+	 * - file3.php
+	 * $folderFour: folder_test/folder2/folder4/
+	 * - file4.php
+	 * $folderFive: folder_test/folder4/
+	 */
+	function testCopyWithOverwrite() {
+		$path = TMP . 'folder_test';
+		$folderOne = $path . DS . 'folder1';
+		$folderTwo = $path . DS . 'folder2';
+		$folderThree = $folderOne . DS . 'folder';
+		$folderFour = $folderTwo . DS . 'folder';
+		$folderFive = $path . DS . 'folder5';
+		$fileOne = $folderOne . DS . 'file1.php';
+		$fileTwo = $folderTwo . DS . 'file2.php';
+		$file3 = $folderThree . DS . 'file3.php';
+		$file4 = $folderFour . DS . 'file4.php';
+	
+		new Folder($path, true);
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		new Folder($folderThree, true);
+		new Folder($folderFour, true);
+		new Folder($folderFive, true);
+		touch($fileOne);
+		touch($fileTwo);
+		touch($file3);
+		touch($file4);
+		
+		$Folder = new Folder($folderOne);
+		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::OVERWRITE));
+		
+		
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder' . DS . 'file3.php'));
+		
+		$Folder = new Folder($folderTwo);
+		$result = $Folder->copy(array('to'=>$folderFive, 'scheme'=>Folder::OVERWRITE));
+		$this->assertTrue($result);
+		
+		$this->assertTrue(file_exists($folderFive . DS . 'file1.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'file2.php'));
+		$this->assertTrue(!file_exists($folderFive . DS . 'folder' . DS . 'file3.php'));
+		$this->assertTrue(file_exists($folderFive . DS . 'folder' . DS . 'file4.php'));
+		
+		$Folder = new Folder($path);
+		$Folder->delete();
 	}
+	
+		
 
 /**
  * testMove method
@@ -863,7 +1050,7 @@ class FolderTest extends CakeTestCase {
  * Verify that directories and files are moved recursively
  * even if the destination directory already exists.
  * Subdirectories existing in both destination and source directory
- * are skipped and not merged or overwritten.
+ * are merged recursivly.
  *
  * @return void
  */
@@ -923,6 +1110,83 @@ class FolderTest extends CakeTestCase {
 
 		$Folder = new Folder($folderOne);
 		$result = $Folder->move($folderThree);
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
+		$this->assertEquals('', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));
+		$this->assertFalse(file_exists($fileOne));
+		$this->assertFalse(file_exists($folderTwo));
+		$this->assertFalse(file_exists($fileTwo));
+
+		$Folder = new Folder($path);
+		$Folder->delete();
+	}
+
+/**
+ * testMoveWithSkip method
+ *
+ * Verify that directories and files are moved recursively
+ * even if the destination directory already exists.
+ * Subdirectories existing in both destination and source directory
+ * are skipped and not merged or overwritten.
+ *
+ * @return void
+ */
+	public function testMoveWithSkip() {
+		$path = TMP . 'folder_test';
+		$folderOne = $path . DS . 'folder1';
+		$folderTwo = $folderOne . DS . 'folder2';
+		$folderThree = $path . DS . 'folder3';
+		$fileOne = $folderOne . DS . 'file1.php';
+		$fileTwo = $folderTwo . DS . 'file2.php';
+
+		new Folder($path, true);
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		new Folder($folderThree, true);
+		touch($fileOne);
+		touch($fileTwo);
+
+		$Folder = new Folder($folderOne);
+		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
+		$this->assertTrue(is_dir($folderThree . DS . 'folder2'));
+		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
+		$this->assertFalse(file_exists($fileOne));
+		$this->assertFalse(file_exists($folderTwo));
+		$this->assertFalse(file_exists($fileTwo));
+
+		$Folder = new Folder($folderThree);
+		$Folder->delete();
+
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		touch($fileOne);
+		touch($fileTwo);
+
+		$Folder = new Folder($folderOne);
+		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
+		$this->assertTrue($result);
+		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
+		$this->assertTrue(is_dir($folderThree . DS . 'folder2'));
+		$this->assertTrue(file_exists($folderThree . DS . 'folder2' . DS . 'file2.php'));
+		$this->assertFalse(file_exists($fileOne));
+		$this->assertFalse(file_exists($folderTwo));
+		$this->assertFalse(file_exists($fileTwo));
+
+		$Folder = new Folder($folderThree);
+		$Folder->delete();
+
+		new Folder($folderOne, true);
+		new Folder($folderTwo, true);
+		new Folder($folderThree, true);
+		new Folder($folderThree . DS . 'folder2', true);
+		touch($fileOne);
+		touch($fileTwo);
+		file_put_contents($folderThree . DS . 'folder2' . DS . 'file2.php', 'untouched');
+
+		$Folder = new Folder($folderOne);
+		$result = $Folder->move(array('to'=>$folderThree, 'scheme'=>Folder::SKIP));
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($folderThree . DS . 'file1.php'));
 		$this->assertEquals('untouched', file_get_contents($folderThree . DS . 'folder2' . DS . 'file2.php'));

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -618,7 +618,7 @@ class Folder {
  * - `from` The directory to copy from, this will cause a cd() to occur, changing the results of pwd().
  * - `mode` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
- * - `schema` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
+ * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
  * @param mixed $options Either an array of options (see above) or a string of the destination directory.
  * @return boolean Success
@@ -633,7 +633,7 @@ class Folder {
 			$to = $options;
 			$options = array();
 		}
-		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme'=>Folder::MERGE), $options);
+		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme' => Folder::MERGE), $options);
 
 		$fromDir = $options['from'];
 		$toDir = $options['to'];
@@ -687,7 +687,7 @@ class Folder {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);
 						}
 					} elseif (is_dir($from) && $options['scheme'] == Folder::MERGE) {
-						$options = array_merge($options, array('to'=> $to, 'from'=> $from));
+						$options = array_merge($options, array('to' => $to, 'from' => $from));
 						$this->copy($options);
 					}
 				}
@@ -712,9 +712,9 @@ class Folder {
  * - `from` The directory to copy from, this will cause a cd() to occur, changing the results of pwd().
  * - `chmod` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
- * - `schema` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
+ * - `scheme` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
- * @param array $options (to, from, chmod, skip, schema)
+ * @param array $options (to, from, chmod, skip, scheme)
  * @return boolean Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::move
  */

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -22,6 +22,30 @@
 class Folder {
 
 /**
+ * Default scheme for Folder::copy
+ * Recursivly merges subfolders with the same name 
+ *
+ * @constant MERGE
+ */
+	const MERGE = 'merge';
+
+/**
+ * Overwrite scheme for Folder::copy
+ * subfolders with the same name will be replaced
+ *
+ * @constant OVERWRITE
+ */
+	const OVERWRITE = 'overwrite';
+
+/**
+ * Skip scheme for Folder::copy
+ * if a subfolder with the same name exists it will be skipped
+ *
+ * @constant SKIP
+ */
+	const SKIP = 'skip';
+	
+/**
  * Path to Folder.
  *
  * @var string
@@ -594,6 +618,7 @@ class Folder {
  * - `from` The directory to copy from, this will cause a cd() to occur, changing the results of pwd().
  * - `mode` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
+ * - `schema` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
  * @param mixed $options Either an array of options (see above) or a string of the destination directory.
  * @return boolean Success
@@ -608,7 +633,7 @@ class Folder {
 			$to = $options;
 			$options = array();
 		}
-		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array()), $options);
+		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme'=>Folder::MERGE), $options);
 
 		$fromDir = $options['from'];
 		$toDir = $options['to'];
@@ -630,10 +655,10 @@ class Folder {
 
 		$exceptions = array_merge(array('.', '..', '.svn'), $options['skip']);
 		if ($handle = @opendir($fromDir)) {
-			while (false !== ($item = readdir($handle))) {
-				if (!in_array($item, $exceptions)) {
-					$from = Folder::addPathElement($fromDir, $item);
-					$to = Folder::addPathElement($toDir, $item);
+			while (($item = readdir($handle)) !== false) {
+				$to = Folder::addPathElement($toDir, $item);
+				if (($options['scheme'] != Folder::SKIP || !is_dir($to)) && !in_array($item, $exceptions)) {
+					$from = Folder::addPathElement($fromDir, $item);				
 					if (is_file($from)) {
 						if (copy($from, $to)) {
 							chmod($to, intval($mode, 8));
@@ -642,6 +667,10 @@ class Folder {
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s NOT copied to %s', $from, $to);
 						}
+					}
+					
+					if (is_dir($from) && file_exists($to) && $options['scheme'] == Folder::OVERWRITE) {
+						$this->delete($to);
 					}
 
 					if (is_dir($from) && !file_exists($to)) {
@@ -657,6 +686,9 @@ class Folder {
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);
 						}
+					} elseif (is_dir($from) && $options['scheme'] == Folder::MERGE) {
+						$options = array_merge($options, array('to'=> $to, 'from'=> $from));
+						$this->copy($options);
 					}
 				}
 			}
@@ -680,8 +712,9 @@ class Folder {
  * - `from` The directory to copy from, this will cause a cd() to occur, changing the results of pwd().
  * - `chmod` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
+ * - `schema` Folder::MERGE, Folder::OVERWRITE, Folder::SKIP
  *
- * @param array $options (to, from, chmod, skip)
+ * @param array $options (to, from, chmod, skip, schema)
  * @return boolean Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::move
  */


### PR DESCRIPTION
folder fix for merging by default to ensure the class works correctly in all cases, especially with multilevel folders. manual change to other merge schemes added. fix for default dirs in test added.
