### PR TITLE
Fixed bug in model validation translate

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3191,7 +3191,9 @@ class Model extends Object implements CakeEventListener {
 						}
 						if (!empty($args)) {
 							foreach ($args as $k => $arg) {
-								$args[$k] = __d($validationDomain, $arg);
+								if (is_string($arg)) {
+									$args[$k] = __d($validationDomain, $arg);
+								}
 							}
 						}
 						$message = __d($validationDomain, $message, $args);


### PR DESCRIPTION
Validation rules like:

``` php
'name' => array(
    'rule' => array('multiple', array('min' => 1, 'max' => 7)),
    'message' => 'The course must meet one day, right?',
),
```

would throw a warning because it would try to translate `array('min' => 1, 'max' => 7)` so I added a check to see if the arg was a string first.
