### PR TITLE
Redirect check is breaking AuthComponent redirect status codes

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -774,13 +774,14 @@ class Controller extends Object implements CakeEventListener {
 			$this->response->header('Location', Router::url($url, true));
 		}
 
-		if (!empty($status)) {
-			if (is_string($status)) {
-				$codes = array_flip($this->response->httpCodes());
-				if (isset($codes[$status])) {
-					$status = $codes[$status];
-				}
+		if (is_string($status)) {
+			$codes = array_flip($this->response->httpCodes());
+			if (isset($codes[$status])) {
+				$status = $codes[$status];
 			}
+		}
+
+		if ($status) {
 			$this->response->statusCode($status);
 		}
 

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -531,7 +531,7 @@ class Controller extends Object implements CakeEventListener {
 	}
 
 /**
- * Merge components, helpers, and uses vars from 
+ * Merge components, helpers, and uses vars from
  * Controller::$_mergeParent and PluginAppController.
  *
  * @return void
@@ -770,18 +770,17 @@ class Controller extends Object implements CakeEventListener {
 			session_write_close();
 		}
 
-		if (!empty($status) && is_string($status)) {
-			$codes = array_flip($this->response->httpCodes());
-			if (isset($codes[$status])) {
-				$status = $codes[$status];
-			}
-		}
-
 		if ($url !== null) {
 			$this->response->header('Location', Router::url($url, true));
 		}
 
-		if (!empty($status) && ($status >= 300 && $status < 400)) {
+		if (!empty($status)) {
+			if (is_string($status)) {
+				$codes = array_flip($this->response->httpCodes());
+				if (isset($codes[$status])) {
+					$status = $codes[$status];
+				}
+			}
 			$this->response->statusCode($status);
 		}
 

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -387,7 +387,7 @@ class AnotherTestController extends ControllerTestAppController {
 
 /**
  * merge parent
- * 
+ *
  * @var string
  */
 	protected $_mergeParent = 'ControllerTestAppController';
@@ -729,7 +729,8 @@ class ControllerTest extends CakeTestCase {
 			array(303, "See Other"),
 			array(304, "Not Modified"),
 			array(305, "Use Proxy"),
-			array(307, "Temporary Redirect")
+			array(307, "Temporary Redirect"),
+			array(403, "Forbidden"),
 		);
 	}
 


### PR DESCRIPTION
The AuthComponent is supposed to send a 403 HTTP status code for denied AJAX requests, but it doesn't since Controller::redirect() was refactored to use the CakeRequest object.

See: https://github.com/cakephp/cakephp/blob/master/lib/Cake/Controller/Component/AuthComponent.php#L326

It used to work (in 1.3), because it worked a bit differently. There Controller::header() was called twice making sure the status code was set.

See: https://github.com/cakephp/cakephp/blob/1.3/cake/libs/controller/controller.php#L717

This pull request contains a test case for this and the fix.

Cheers!
