### PR TITLE
Support for PHP 5.4 built-in web server

### DIFF
--- a/app/Console/server
+++ b/app/Console/server
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+################################################################################
+#
+# Bake is a shell script for running CakePHP bake script
+# PHP 5
+#
+# CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
+# Copyright 2005-2012, Cake Software Foundation, Inc.
+#
+# Licensed under The MIT License
+# Redistributions of files must retain the above copyright notice.
+#
+# @copyright		Copyright 2005-2012, Cake Software Foundation, Inc.
+# @link			http://cakephp.org CakePHP(tm) Project
+# @package   		app.Console
+# @since		CakePHP(tm) v 2.0
+# @license		MIT License (http://www.opensource.org/licenses/mit-license.php)
+#
+################################################################################
+LIB=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && LIB=$LIB/$(basename -- "$0")
+
+while [ -h "$LIB" ]; do
+    DIR=$(dirname -- "$LIB")
+    SYM=$(readlink "$LIB")
+    LIB=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+done
+
+LIB=$(dirname -- "$LIB")/
+APP=`pwd`
+
+exec php -S localhost:8080 -t $APP/webroot
+
+exit;

--- a/app/Console/server.bat
+++ b/app/Console/server.bat
@@ -1,0 +1,31 @@
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::
+:: Bake is a shell script for running CakePHP bake script
+:: PHP 5
+::
+:: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+:: Copyright 2005-2012, Cake Software Foundation, Inc.
+::
+:: Licensed under The MIT License
+:: Redistributions of files must retain the above copyright notice.
+::
+:: @copyright		Copyright 2005-2012, Cake Software Foundation, Inc.
+:: @link		http://cakephp.org CakePHP(tm) Project
+:: @package   		app.Console
+:: @since		CakePHP(tm) v 2.0
+:: @license		MIT License (http://www.opensource.org/licenses/mit-license.php)
+::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:: In order for this script to work as intended, the cake\console\ folder must be in your PATH
+
+@echo.
+@echo off
+
+SET lib=%~dp0
+
+php -S localhost:8080 -t "%lib%"/../webroot
+
+echo.
+
+exit /B %ERRORLEVEL%

--- a/lib/Cake/Console/Templates/skel/Console/server
+++ b/lib/Cake/Console/Templates/skel/Console/server
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+################################################################################
+#
+# Bake is a shell script for running CakePHP bake script
+# PHP 5
+#
+# CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
+# Copyright 2005-2012, Cake Software Foundation, Inc.
+#
+# Licensed under The MIT License
+# Redistributions of files must retain the above copyright notice.
+#
+# @copyright		Copyright 2005-2012, Cake Software Foundation, Inc.
+# @link			http://cakephp.org CakePHP(tm) Project
+# @package   		app.Console
+# @since		CakePHP(tm) v 2.0
+# @license		MIT License (http://www.opensource.org/licenses/mit-license.php)
+#
+################################################################################
+LIB=$(cd -P -- "$(dirname -- "$0")" && pwd -P) && LIB=$LIB/$(basename -- "$0")
+
+while [ -h "$LIB" ]; do
+    DIR=$(dirname -- "$LIB")
+    SYM=$(readlink "$LIB")
+    LIB=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+done
+
+LIB=$(dirname -- "$LIB")/
+APP=`pwd`
+
+exec php -S localhost:8080 -t $APP/webroot
+
+exit;

--- a/lib/Cake/Console/Templates/skel/Console/server.bat
+++ b/lib/Cake/Console/Templates/skel/Console/server.bat
@@ -1,0 +1,31 @@
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+::
+:: Bake is a shell script for running CakePHP bake script
+:: PHP 5
+::
+:: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+:: Copyright 2005-2012, Cake Software Foundation, Inc.
+::
+:: Licensed under The MIT License
+:: Redistributions of files must retain the above copyright notice.
+::
+:: @copyright		Copyright 2005-2012, Cake Software Foundation, Inc.
+:: @link		http://cakephp.org CakePHP(tm) Project
+:: @package   		app.Console
+:: @since		CakePHP(tm) v 2.0
+:: @license		MIT License (http://www.opensource.org/licenses/mit-license.php)
+::
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:: In order for this script to work as intended, the cake\console\ folder must be in your PATH
+
+@echo.
+@echo off
+
+SET lib=%~dp0
+
+php -S localhost:8080 -t "%lib%"/../webroot
+
+echo.
+
+exit /B %ERRORLEVEL%


### PR DESCRIPTION
Very basic Bash script to provide support for the PHP 5.4 built-in web server. 

It assumes that App.baseUrl is set to env('SCRIPT_NAME') in core.php.

The ideal would be that CakePHP has/uses its own router.

More info: http://php.net/manual/en/features.commandline.webserver.php
