### PR TITLE
Fix SMTP Transparency

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1238,9 +1238,6 @@ class CakeEmail {
 				$formatted[] = '';
 				continue;
 			}
-			if ($line[0] === '.') {
-				$line = '.' . $line;
-			}
 			if (!preg_match('/\<[a-z]/i', $line)) {
 				$formatted = array_merge($formatted, explode("\n", wordwrap($line, self::LINE_LENGTH_SHOULD, "\n")));
 				continue;

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -171,7 +171,7 @@ class SmtpTransport extends AbstractTransport {
 		$lines = $this->_cakeEmail->message();
 		$messages = array();
 		foreach ($lines as $line) {
-			if ((! empty($line)) && ($line[0] === '.')) {
+			if ((!empty($line)) && ($line[0] === '.')) {
 				$messages[] = '.' . $line;
 			} else {
 				$messages[] = $line;

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -168,7 +168,16 @@ class SmtpTransport extends AbstractTransport {
 
 		$headers = $this->_cakeEmail->getHeaders(array('from', 'sender', 'replyTo', 'readReceipt', 'returnPath', 'to', 'cc', 'subject'));
 		$headers = $this->_headersToString($headers);
-		$message = implode("\r\n", $this->_cakeEmail->message());
+		$lines = $this->_cakeEmail->message();
+		$messages = array();
+		foreach ($lines as $line) {
+			if ((! empty($line)) && ($line[0] === '.')) {
+				$messages[] = '.' . $line;
+			} else {
+				$messages[] = $line;
+			}
+		}
+		$message = implode("\r\n", $messages);
 		$this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");
 		$this->_content = array('headers' => $headers, 'message' => $message);
 	}

--- a/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
@@ -51,7 +51,7 @@ class DebugTransportTest extends CakeTestCase {
 		$email->subject('Testing Message');
 		$date = date(DATE_RFC2822);
 		$email->setHeaders(array('X-Mailer' => DebugCakeEmail::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '')));
+		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
 
 		$headers = "From: CakePHP Test <noreply@cakephp.org>\r\n";
 		$headers .= "To: CakePHP <cake@cakephp.org>\r\n";
@@ -66,6 +66,7 @@ class DebugTransportTest extends CakeTestCase {
 
 		$data = "First Line\r\n";
 		$data .= "Second Line\r\n";
+		$data .= ".Third Line\r\n"; // Not use 'RFC5321 4.5.2.Transparency' in DebugTransport.
 
 		$result = $this->DebugTransport->send($email);
 

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -221,7 +221,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$email->subject('Testing SMTP');
 		$date = date(DATE_RFC2822);
 		$email->setHeaders(array('X-Mailer' => SmtpCakeEmail::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '')));
+		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
 
 		$data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
 		$data .= "Return-Path: CakePHP Return <pleasereply@cakephp.org>\r\n";
@@ -237,6 +237,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$data .= "\r\n";
 		$data .= "First Line\r\n";
 		$data .= "Second Line\r\n";
+		$data .= "..Third Line\r\n"; // RFC5321 4.5.2.Transparency
 		$data .= "\r\n";
 		$data .= "\r\n\r\n.\r\n";
 


### PR DESCRIPTION
If you use MailTransport in CakeEmail and the top of line your email is dot(.), you will find two dots top of line.

This is a bug.

The additional dots is needed only SmtpTransport.

See. RFC5321 4.5.2.  Transparency.
