### PR TITLE
If a model column formatter has been defined, execute it

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1263,7 +1263,8 @@ class Model extends Object implements CakeEventListener {
 
 				$result = str_replace(array_keys($date), array_values($date), $format);
 
-				if (isset($columnTypes['formatter'])) {
+				// Don't trigger on date()
+				if (isset($columnTypes['formatter']) && $columnTypes['formatter'] !== 'date') {
 					$result = call_user_func($columnTypes['formatter'], $format, $result);
 				}
 

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1252,13 +1252,22 @@ class Model extends Object implements CakeEventListener {
 			}
 
 			if ($useNewDate && !empty($date)) {
-				$format = $this->getDataSource()->columns[$type]['format'];
+				$columnTypes = $this->getDataSource()->columns[$type];
+				$format = $columnTypes['format'];
+
 				foreach (array('m', 'd', 'H', 'i', 's') as $index) {
 					if (isset($date[$index])) {
 						$date[$index] = sprintf('%02d', $date[$index]);
 					}
 				}
-				return str_replace(array_keys($date), array_values($date), $format);
+
+				$result = str_replace(array_keys($date), array_values($date), $format);
+
+				if (isset($columnTypes['formatter'])) {
+					$result = call_user_func($columnTypes['formatter'], $format, $result);
+				}
+
+				return $result;
 			}
 		}
 		return $data;
@@ -1629,7 +1638,7 @@ class Model extends Object implements CakeEventListener {
 				if (!array_key_exists('format', $colType)) {
 					$time = strtotime('now');
 				} else {
-					$time = call_user_func($colType['formatter'], $colType['format']);
+					$time = call_user_func($colType['formatter'], $colType['format'], time());
 				}
 				if (!empty($this->whitelist)) {
 					$this->whitelist[] = $updateCol;


### PR DESCRIPTION
This support is mainly for MongoDB allowing us to wrap the formatted timestamp into a MongoDate object, but should work for other use cases.
