### PR TITLE
Copy changes made to $this->data in beforeValidate callbacks 

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2178,6 +2178,7 @@ class Model extends Object implements CakeEventListener {
 
 		if ($options['validate'] === 'first') {
 			$validates = $this->validateAssociated($data, $options);
+			$data = $this->data;
 			if ((!$validates && $options['atomic']) || (!$options['atomic'] && in_array(false, $validates, true))) {
 				return $validates;
 			}


### PR DESCRIPTION
Back to saveAssociated data variable

This allow changes in beforeValidate to be saved

Code like this will not work without this patch

It used to work in 1.3 and 2.0

``` php

<?php
class DemoModel extends AppModel {
    public function beforeValidate() {
        $this->data[$this->alias]['test'] = 1;
        return parent::beforeValidate();
    }

    public function beforeSave($options = array()) {
        if (empty($this->data[$this->alias]['test'])) {
            die('fail');
        }
        die('ok');
    }
}
```
