### PR TITLE
Warning is occurred by calling saveAll without arguments

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1994,6 +1994,10 @@ class Model extends Object implements CakeEventListener {
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-saveall-array-data-null-array-options-array
  */
 	public function saveAll($data = null, $options = array()) {
+		if (empty($data)) {
+			$data = $this->data;
+		}
+
 		$options = array_merge(array('validate' => 'first'), $options);
 		if (Set::numeric(array_keys($data))) {
 			if ($options['validate'] === 'only') {

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -4709,6 +4709,30 @@ class ModelWriteTest extends BaseModelTest {
 		$model = new ProductUpdateAll();
 		$result = $model->saveAll(array());
 		$this->assertFalse($result);
+}
+
+/**
+ * test that saveAll behaves like plain save() without argument
+ *
+ * @link http://cakephp.lighthouseapp.com/projects/42648/tickets/277-test-saveall-with-validation-returns-incorrect-boolean-when-saving-empty-data
+ * @return void
+ */
+	public function testSaveAllWithoutArgument() {
+		$this->skipIf($this->db instanceof Sqlserver, 'This test is not compatible with SQL Server.');
+
+		$this->loadFixtures('Article', 'ProductUpdateAll', 'Comment', 'Attachment');
+		$model = new Comment();
+		$model->set(array(
+			'Comment' => array(
+				'article_id' => 2,
+				'user_id' => 2,
+				'comment' => 'New comment with attachment',
+				'published' => 'Y'
+			)
+		));
+		$model->set(array());
+		$result = $model->saveAll();
+		$this->assertTrue($result);
 	}
 
 /**


### PR DESCRIPTION
<pre>
$Model->set($data);
$Model->saveAll();
</pre>


This case has occurred warning

> Warning Error: array_keys() expects parameter 1 to be array, null given in [/path/to/cakephp/lib/Cake/Model/Model.php, line 1998]
