### PR TITLE
If value is array retrieve and use the associated response status message

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -375,6 +375,8 @@ class CakeResponse {
 		$this->_setContentLength();
 		$this->_setContentType();
 		foreach ($this->_headers as $header => $value) {
+			if (is_array($value))
+				$value = $value[$this->_status];
 			$this->_sendHeader($header, $value);
 		}
 		$this->_sendContent($this->_body);


### PR DESCRIPTION
Variable $value may be an array. This removes annoying "Array to string conversion" notices like this:

```
Notice (8): Array to string conversion [CORE/Cake/Network/CakeResponse.php, line 461]

        $this->_setContentType();
        foreach ($this->_headers as $header => $value) {
            $this->_sendHeader($header, $value);

$name   =   'HTTP/1.1 200'
$value  =   array(
    (int) 200 => 'OK'
)
```
