### PR TITLE
changing log levels to match syslog (rfc5424) + removing LOG_ERROR from core files

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -163,6 +163,6 @@ CakeLog::config('debug', array(
 ));
 CakeLog::config('error', array(
 	'engine' => 'FileLog',
-	'types' => array('error', 'warning'),
+	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -133,7 +133,7 @@
  * Defines the default error type when using the log() function. Used for
  * differentiating error logging and debugging. Currently PHP supports LOG_DEBUG.
  */
-	define('LOG_ERROR', 2);
+	define('LOG_ERROR', LOG_ERR);
 
 /**
  * Session configuration.

--- a/lib/Cake/Console/Templates/skel/Config/bootstrap.php
+++ b/lib/Cake/Console/Templates/skel/Config/bootstrap.php
@@ -103,6 +103,6 @@ CakeLog::config('debug', array(
 ));
 CakeLog::config('error', array(
 	'engine' => 'FileLog',
-	'scopes' => array('error', 'warning'),
+	'scopes' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -133,7 +133,7 @@
  * Defines the default error type when using the log() function. Used for
  * differentiating error logging and debugging. Currently PHP supports LOG_DEBUG.
  */
-	define('LOG_ERROR', 2);
+	define('LOG_ERROR', LOG_ERR);
 
 /**
  * Session configuration.

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -909,7 +909,7 @@ class App {
 		}
 
 		list(, $log) = ErrorHandler::mapErrorCode($lastError['type']);
-		if ($log !== LOG_ERROR) {
+		if ($log !== LOG_ERR) {
 			return;
 		}
 

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -146,7 +146,7 @@ class Object {
  * @param integer $type Error type constant. Defined in app/Config/core.php.
  * @return boolean Success of log write
  */
-	public function log($msg, $type = LOG_ERROR) {
+	public function log($msg, $type = LOG_ERR) {
 		App::uses('CakeLog', 'Log');
 		if (!is_string($msg)) {
 			$msg = print_r($msg, true);

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -158,7 +158,7 @@ class ErrorHandler {
 		}
 		$errorConfig = Configure::read('Error');
 		list($error, $log) = self::mapErrorCode($code);
-		if ($log === LOG_ERROR) {
+		if ($log === LOG_ERR) {
 			return self::handleFatalError($code, $description, $file, $line);
 		}
 
@@ -197,7 +197,7 @@ class ErrorHandler {
  */
 	public static function handleFatalError($code, $description, $file, $line) {
 		$logMessage = 'Fatal Error (' . $code . '): ' . $description . ' in [' . $file . ', line ' . $line . ']';
-		CakeLog::write(LOG_ERROR, $logMessage);
+		CakeLog::write(LOG_ERR, $logMessage);
 
 		$exceptionHandler = Configure::read('Exception.handler');
 		if (!is_callable($exceptionHandler)) {
@@ -231,7 +231,7 @@ class ErrorHandler {
 			case E_COMPILE_ERROR:
 			case E_USER_ERROR:
 				$error = 'Fatal Error';
-				$log = LOG_ERROR;
+				$log = LOG_ERR;
 			break;
 			case E_WARNING:
 			case E_USER_WARNING:

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -374,8 +374,12 @@ class CakeLog {
 			$scopes = array();
 			if ($logger instanceof BaseLog) {
 				$config = $logger->config();
-				$types = $config['types'];
-				$scopes = $config['scopes'];
+				if (isset($config['types'])) {
+					$types = $config['types'];
+				}
+				if (isset($config['scopes'])) {
+					$scopes = $config['scopes'];
+				}
 			}
 			if (is_string($scope)) {
 				$inScope = in_array($scope, $scopes);

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -19,39 +19,6 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-/**
- * Set up error level constants to be used within the framework if they are not defined within the
- * system.
- *
- */
-if (!defined('LOG_EMERG')) {
-	define('LOG_EMERG', 0);
-}
-if (!defined('LOG_ALERT')) {
-	define('LOG_ALERT', 1);
-}
-if (!defined('LOG_CRIT')) {
-	define('LOG_CRIT', 2);
-}
-if (!defined('LOG_ERR')) {
-	define('LOG_ERR', 3);
-}
-if (!defined('LOG_ERROR')) {
-	define('LOG_ERROR', LOG_ERR);
-}
-if (!defined('LOG_WARNING')) {
-	define('LOG_WARNING', 4);
-}
-if (!defined('LOG_NOTICE')) {
-	define('LOG_NOTICE', 5);
-}
-if (!defined('LOG_INFO')) {
-	define('LOG_INFO', 6);
-}
-if (!defined('LOG_DEBUG')) {
-	define('LOG_DEBUG', 7);
-}
-
 App::uses('LogEngineCollection', 'Log');
 
 /**

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -64,6 +64,8 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$this->assertEquals(CakeLog::configured(), array('libtest', 'plugintest'));
 
+		CakeLog::write(LOG_INFO, 'TestPluginLog is not a BaseLog descendant');
+
 		App::build();
 		CakePlugin::unload();
 	}

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -443,44 +443,142 @@ class CakeLogTest extends CakeTestCase {
 		));
 		CakeLog::config('error', array(
 			'engine' => 'FileLog',
-			'types' => array('error', 'warning'),
+			'types' => array('emergency', 'alert', 'critical', 'error', 'warning'),
 			'file' => 'error',
 		));
+
+		$testMessage = 'emergency message';
+		CakeLog::emergency($testMessage);
+		$contents = file_get_contents(LOGS . 'error.log');
+		$this->assertContains('Emergency: ' . $testMessage, $contents);
+		$this->assertFalse(file_exists(LOGS . 'debug.log'));
+		$this->_deleteLogs();
+
+		$testMessage = 'alert message';
+		CakeLog::alert($testMessage);
+		$contents = file_get_contents(LOGS . 'error.log');
+		$this->assertContains('Alert: ' . $testMessage, $contents);
+		$this->assertFalse(file_exists(LOGS . 'debug.log'));
+		$this->_deleteLogs();
+
+		$testMessage = 'critical message';
+		CakeLog::critical($testMessage);
+		$contents = file_get_contents(LOGS . 'error.log');
+		$this->assertContains('Critical: ' . $testMessage, $contents);
+		$this->assertFalse(file_exists(LOGS . 'debug.log'));
+		$this->_deleteLogs();
 
 		$testMessage = 'error message';
 		CakeLog::error($testMessage);
 		$contents = file_get_contents(LOGS . 'error.log');
-		$this->assertContains($testMessage, $contents);
+		$this->assertContains('Error: ' . $testMessage, $contents);
 		$this->assertFalse(file_exists(LOGS . 'debug.log'));
 		$this->_deleteLogs();
 
 		$testMessage = 'warning message';
 		CakeLog::warning($testMessage);
 		$contents = file_get_contents(LOGS . 'error.log');
-		$this->assertContains($testMessage, $contents);
+		$this->assertContains('Warning: ' . $testMessage, $contents);
 		$this->assertFalse(file_exists(LOGS . 'debug.log'));
+		$this->_deleteLogs();
+
+		$testMessage = 'notice message';
+		CakeLog::notice($testMessage);
+		$contents = file_get_contents(LOGS . 'debug.log');
+		$this->assertContains('Notice: ' . $testMessage, $contents);
+		$this->assertFalse(file_exists(LOGS . 'error.log'));
 		$this->_deleteLogs();
 
 		$testMessage = 'info message';
 		CakeLog::info($testMessage);
 		$contents = file_get_contents(LOGS . 'debug.log');
-		$this->assertContains($testMessage, $contents);
+		$this->assertContains('Info: ' . $testMessage, $contents);
 		$this->assertFalse(file_exists(LOGS . 'error.log'));
 		$this->_deleteLogs();
 
 		$testMessage = 'debug message';
 		CakeLog::debug($testMessage);
 		$contents = file_get_contents(LOGS . 'debug.log');
-		$this->assertContains($testMessage, $contents);
+		$this->assertContains('Debug: ' . $testMessage, $contents);
 		$this->assertFalse(file_exists(LOGS . 'error.log'));
 		$this->_deleteLogs();
+	}
 
-		$testMessage = 'notice message';
-		CakeLog::notice($testMessage);
-		$contents = file_get_contents(LOGS . 'debug.log');
-		$this->assertContains($testMessage, $contents);
-		$this->assertFalse(file_exists(LOGS . 'error.log'));
+/**
+ * test levels customization
+ */
+	public function testLevelCustomization() {
+		$this->skipIf(DIRECTORY_SEPARATOR === '\\', 'Log level tests not supported on Windows.');
+
+		$levels = CakeLog::defaultLevels();
+		$this->assertNotEmpty($levels);
+		$result = array_keys($levels);
+		$this->assertEquals(array(0, 1, 2, 3, 4, 5, 6, 7), $result);
+
+		$levels = CakeLog::levels(array('foo', 'bar'));
+		CakeLog::defaultLevels();
+		$this->assertEquals('foo', $levels[8]);
+		$this->assertEquals('bar', $levels[9]);
+
+		$levels = CakeLog::levels(array(11 => 'spam', 'bar' => 'eggs'));
+		CakeLog::defaultLevels();
+		$this->assertEquals('spam', $levels[8]);
+		$this->assertEquals('eggs', $levels[9]);
+
+		$levels = CakeLog::levels(array(11 => 'spam', 'bar' => 'eggs'), false);
+		CakeLog::defaultLevels();
+		$this->assertEquals(array('spam', 'eggs'), $levels);
+
+		$levels = CakeLog::levels(array('ham', 9 => 'spam', '12' => 'fam'), false);
+		CakeLog::defaultLevels();
+		$this->assertEquals(array('ham', 'spam', 'fam'), $levels);
+	}
+
+/**
+ * Test writing log files with custom levels
+ */
+	public function testCustomLevelWrites() {
 		$this->_deleteLogs();
+		$this->_resetLogConfig();
+
+		$levels = CakeLog::levels(array('spam', 'eggs'));
+
+		$testMessage = 'error message';
+		CakeLog::write('error', $testMessage);
+		CakeLog::defaultLevels();
+		$this->assertTrue(file_exists(LOGS . 'error.log'));
+		$contents = file_get_contents(LOGS . 'error.log');
+		$this->assertContains('Error: ' . $testMessage, $contents);
+
+		CakeLog::config('spam', array(
+			'engine' => 'FileLog',
+			'file' => 'spam.log',
+			'types' => 'spam',
+			));
+		CakeLog::config('eggs', array(
+			'engine' => 'FileLog',
+			'file' => 'eggs.log',
+			'types' => array('spam', 'eggs'),
+			));
+
+		$testMessage = 'spam message';
+		CakeLog::write('spam', $testMessage);
+		CakeLog::defaultLevels();
+		$this->assertTrue(file_exists(LOGS . 'spam.log'));
+		$this->assertTrue(file_exists(LOGS . 'eggs.log'));
+		$contents = file_get_contents(LOGS . 'spam.log');
+		$this->assertContains('Spam: ' . $testMessage, $contents);
+
+		$testMessage = 'egg message';
+		CakeLog::write('eggs', $testMessage);
+		CakeLog::defaultLevels();
+		$contents = file_get_contents(LOGS . 'spam.log');
+		$this->assertNotContains('Eggs: ' . $testMessage, $contents);
+		$contents = file_get_contents(LOGS . 'eggs.log');
+		$this->assertContains('Eggs: ' . $testMessage, $contents);
+
+		CakeLog::drop('spam');
+		CakeLog::drop('eggs');
 	}
 
 }

--- a/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
@@ -77,7 +77,7 @@ class ConsoleLogTest extends CakeTestCase {
 		$message = 'Test error message';
 		$mock->expects($this->once())
 			->method('write');
-		TestCakeLog::write(LOG_ERROR, $message);
+		TestCakeLog::write(LOG_ERR, $message);
 	}
 
 /**
@@ -96,7 +96,7 @@ class ConsoleLogTest extends CakeTestCase {
 		$message = 'Test error message';
 		$mock->expects($this->once())
 			->method('write');
-		TestCakeLog::write(LOG_ERROR, $message);
+		TestCakeLog::write(LOG_ERR, $message);
 		$this->assertTrue(file_exists(LOGS . 'error.log'), 'error.log missing');
 		$logOutput = file_get_contents(LOGS . 'error.log');
 		$this->assertContains($message, $logOutput);

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Log/Engine/TestPluginLog.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Log/Engine/TestPluginLog.php
@@ -17,9 +17,10 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-App::uses('BaseLog', 'Log/Engine');
+App::uses('CakeLogInterface', 'Log');
 
-class TestPluginLog extends BaseLog {
+class TestPluginLog implements CakeLogInterface
+{
 
 	public function write($type, $message) {
 	}

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -227,7 +227,7 @@ class Debugger {
 			case E_COMPILE_ERROR:
 			case E_USER_ERROR:
 				$error = 'Fatal Error';
-				$level = LOG_ERROR;
+				$level = LOG_ERR;
 			break;
 			case E_WARNING:
 			case E_USER_WARNING:


### PR DESCRIPTION
## pros
- more complete log levels
- PHP default constants (we probably could remove the ifndef(LOG_*) statements)
## cons
- changing const LOG_ERROR value in Config/core from 2 from 3 (LOG_ERR)
- most likely incompatible with windows, since it only has 3 logs levels afaik (https://bugs.php.net/bug.php?id=55129)

Please comment
