### PR TITLE
Smarter model labels

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -113,6 +113,31 @@ class Model extends Object implements CakeEventListener {
 	public $primaryKey = null;
 
 /**
+ * Field-by-field label. This will be the default label on model inputs. It can, for 
+ * example, be specified as below:
+ * 
+ * {{{
+ * public $label = array(
+ *     // 'field-name' => 'Label',
+ *     'id' => '#',
+ *     'title' => 'Title',
+ *     'content' => 'Article content',
+ * );
+ * }}}
+ * 
+ * Or like so, in the constructor for the model:
+ * 
+ * {{{
+ * function TestModel() {
+ *     $this->label['title'] = __('Title');
+ * }
+ * }}}
+ *
+ * @var array
+ */
+	public $label = null;
+
+/**
  * Field-by-field table metadata.
  *
  * @var array
@@ -3400,6 +3425,16 @@ class Model extends Object implements CakeEventListener {
  */
 	public function getAffectedRows() {
 		return $this->getDataSource()->lastAffected();
+	}
+
+/**
+ * Returns the label, if set, for the specified field.
+ *
+ * @param string $fieldName Field name to get label for
+ * @return string Label text
+ */
+	public function getLabelForField($fieldName, $default = null) {
+		return isset($this->label) && isset($this->label[$fieldName]) ? $this->label[$fieldName] : $default;
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1859,7 +1859,7 @@ class FormHelperTest extends CakeTestCase {
 			'/div',
 		);
 		$this->assertTags($result, $expected);
-
+		
 		$result = $this->Form->input('Contact.email', array('id' => 'custom'));
 		$expected = array(
 			'div' => array('class' => 'input text'),
@@ -1873,7 +1873,83 @@ class FormHelperTest extends CakeTestCase {
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+		
+		$result = $this->Form->input('Contact.email', array('id' => 'custom', 'label' => 'Email address'));
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'custom'),
+			'Email address',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][email]',
+				'id' => 'custom', 'maxlength' => 255
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+		
+		$model = ClassRegistry::getObject('Contact');
+		$model->label['email'] = 'Default label for email address';
+		$result = $this->Form->input('Contact.email', array('id' => 'custom', 'label' => array('class' => 'css-class')));
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'custom', 'class' => 'css-class'),
+			'Default label for email address',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][email]',
+				'id' => 'custom', 'maxlength' => 255
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+		
+		$model = ClassRegistry::getObject('Contact');
+		$model->label['email'] = 'Default label for email address';
+		$result = $this->Form->input('Contact.email', array('id' => 'custom', 'label' => array('class' => 'css-class', 'text' => 'Overwriting label for email address')));
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'custom', 'class' => 'css-class'),
+			'Overwriting label for email address',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][email]',
+				'id' => 'custom', 'maxlength' => 255
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+		
+		$model = ClassRegistry::getObject('Contact');
+		$model->label['email'] = 'Default label for email address';
+		$result = $this->Form->input('Contact.email', array('id' => 'custom', 'label' => null));
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'custom'),
+			'Default label for email address',
+			'/label',
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][email]',
+				'id' => 'custom', 'maxlength' => 255
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+		
+		$model = ClassRegistry::getObject('Contact');
+		$model->label['email'] = 'Default label for email address';
+		$result = $this->Form->input('Contact.email', array('id' => 'custom', 'label' => false));
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			array('input' => array(
+				'type' => 'text', 'name' => 'data[Contact][email]',
+				'id' => 'custom', 'maxlength' => 255
+			)),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
 
+		unset($model->label['email']);
 		$result = $this->Form->input('Contact.email', array('div' => array('class' => false)));
 		$expected = array(
 			'<div',


### PR DESCRIPTION
This lets the user specify a label or title in the Model for each field. They will automatically be used when outputting a FormHelper input. Since the label/title rest as a Model attribute, it can be altered or set at many places (e.g. in constructor, at definition or in a Controller).
