### PR TITLE
2.2 signed numbers

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -71,15 +71,15 @@ class CakeNumberTest extends CakeTestCase {
 		$expected = '100-100-100';
 		$this->assertEquals($expected, $result);
 		
-		$result = $this->Number->format($value, array('signed'=>true, 'before'=>'', 'after'=>''));
+		$result = $this->Number->format($value, array('signed' => true, 'before' => '', 'after' => ''));
 		$expected = '+100,100,100.00';
 		$this->assertEquals($expected, $result);
 		
-		$result = $this->Number->format($value, array('signed'=>true, 'before'=>'[', 'after'=>']'));
+		$result = $this->Number->format($value, array('signed' => true, 'before' => '[', 'after' => ']'));
 		$expected = '[+100,100,100.00]';
 		$this->assertEquals($expected, $result);
 		
-		$result = $this->Number->format(-$value, array('signed'=>true, 'before'=>'[', 'after'=>']'));
+		$result = $this->Number->format(-$value, array('signed' => true, 'before' => '[', 'after' => ']'));
 		$expected = '[-100,100,100.00]';
 		$this->assertEquals($expected, $result);
 	}

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -70,6 +70,18 @@ class CakeNumberTest extends CakeTestCase {
 		$result = $this->Number->format($value, '-');
 		$expected = '100-100-100';
 		$this->assertEquals($expected, $result);
+		
+		$result = $this->Number->format($value, array('signed'=>true, 'before'=>'', 'after'=>''));
+		$expected = '+100,100,100.00';
+		$this->assertEquals($expected, $result);
+		
+		$result = $this->Number->format($value, array('signed'=>true, 'before'=>'[', 'after'=>']'));
+		$expected = '[+100,100,100.00]';
+		$this->assertEquals($expected, $result);
+		
+		$result = $this->Number->format(-$value, array('signed'=>true, 'before'=>'[', 'after'=>']'));
+		$expected = '[-100,100,100.00]';
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -60,7 +60,9 @@ class CakeTimeTest extends CakeTestCase {
  */
 	protected function _restoreSystemTimezone() {
 		date_default_timezone_set($this->_systemTimezoneIdentifier);
+		Configure::delete('Config.timezone');
 	}
+	
 /**
  * testToQuarter method
  *

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -124,6 +124,7 @@ class CakeNumber {
  */
 	public static function format($number, $options = false) {
 		$places = 0;
+		$signed = false;
 		if (is_int($options)) {
 			$places = $options;
 		}
@@ -145,11 +146,11 @@ class CakeNumber {
 
 		$escape = true;
 		if (is_array($options)) {
-			$options = array_merge(array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.'), $options);
+			$options = array_merge(array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'signed'=>false), $options);
 			extract($options);
 		}
 
-		$out = $before . self::_numberFormat($number, $places, $decimals, $thousands) . $after;
+		$out = $before . self::_numberFormat($number, $places, $decimals, $thousands, $signed) . $after;
 
 		if ($escape) {
 			return h($out);
@@ -166,12 +167,16 @@ class CakeNumber {
  * @param string $thousands
  * @return string
  */
-	protected static function _numberFormat($number, $places = 0, $decimals = '.', $thousands = ',') {
+	protected static function _numberFormat($number, $places = 0, $decimals = '.', $thousands = ',', $signed = false) {
 		if (!isset(self::$_numberFormatSupport)) {
 			self::$_numberFormatSupport = version_compare(PHP_VERSION, '5.4.0', '>=');
 		}
+		$sign = '';
+		if ($number > 0 && $signed) {
+			$sign = '+';
+		}
 		if (self::$_numberFormatSupport) {
-			return number_format($number, $places, $decimals, $thousands);
+			return $sign . number_format($number, $places, $decimals, $thousands);
 		}
 		$number = number_format($number, $places, '.', '');
 		$after = '';
@@ -184,7 +189,7 @@ class CakeNumber {
 			$number = $foundThousand;
 		}
 		$number .= $after;
-		return strtr($number, array(' ' => $thousands, '.' => $decimals));
+		return $sign . strtr($number, array(' ' => $thousands, '.' => $decimals));
 	}
 
 /**

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -146,7 +146,8 @@ class CakeNumber {
 
 		$escape = true;
 		if (is_array($options)) {
-			$options = array_merge(array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'signed'=>false), $options);
+			$defaults = array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'signed' => false);
+			$options = array_merge($defaults, $options);
 			extract($options);
 		}
 


### PR DESCRIPTION
fixing a test case
and adding `signed` for CakeNumber::format()

more often you just want to display the values as signed values in the view than first figuring out the sign and passing this on to the format() method.

So

```
$sign = ($value > 0 ? '+', '');
echo $this->Number->format($value, array('before'=>$sign);
```

becomes

```
echo $this->Number->format($value, array('signed'=>true);
```

it also keeps any existing `before` values (currently they would get lost) and is therefore more powerful without losing any of previous functionality - also 100% BC

test cases attached
