### PR TITLE
Removing an unnecessary if statement in HttpSocket

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -768,9 +768,6 @@ class HttpSocket extends CakeSocket {
 			return $query;
 		}
 
-		if (is_array($query)) {
-			return $query;
-		}
 		$parsedQuery = array();
 
 		if (is_string($query) && !empty($query)) {


### PR DESCRIPTION
The second if statement was never going to be executed
