### PR TITLE
Adding validation rule for natural numbers

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1961,6 +1961,26 @@ class ValidationTest extends CakeTestCase {
 	}
 
 /**
+ * testNaturalNumber method
+ *
+ * @return void
+ */
+	public function testNaturalNumber() {
+		$this->assertFalse(Validation::naturalNumber('teststring'));
+		$this->assertFalse(Validation::naturalNumber('5.4'));
+		$this->assertFalse(Validation::naturalNumber(99.004));
+		$this->assertFalse(Validation::naturalNumber('0,05'));
+		$this->assertFalse(Validation::naturalNumber('-2'));
+		$this->assertFalse(Validation::naturalNumber(-2));
+		$this->assertFalse(Validation::naturalNumber('0'));
+
+		$this->assertTrue(Validation::naturalNumber('2'));
+		$this->assertTrue(Validation::naturalNumber(49));
+		$this->assertTrue(Validation::naturalNumber('0', true));
+		$this->assertTrue(Validation::naturalNumber(0, true));
+	}
+
+/**
  * testPhone method
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1973,6 +1973,7 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::naturalNumber('-2'));
 		$this->assertFalse(Validation::naturalNumber(-2));
 		$this->assertFalse(Validation::naturalNumber('0'));
+		$this->assertFalse(Validation::naturalNumber('050'));
 
 		$this->assertTrue(Validation::naturalNumber('2'));
 		$this->assertTrue(Validation::naturalNumber(49));

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -564,6 +564,19 @@ class Validation {
 	}
 
 /**
+ * Checks if a value is a natural value.
+ *
+ * @param string $check Value to check
+ * @param boolean $allowZero Set true to allow zero, defaults to false
+ * @return boolean Success
+ * @see http://en.wikipedia.org/wiki/Natural_number
+ */
+	public static function naturalNumber($check, $allowZero = false) {
+		$regex = $allowZero ? '/^(?:0|[1-9][0-9]*)$/' : '/^[1-9][0-9]*$/';
+		return self::_check($check, $regex);
+	}
+
+/**
  * Check that a value is a valid phone number.
  *
  * @param mixed $check Value to check (string or array)

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -564,7 +564,7 @@ class Validation {
 	}
 
 /**
- * Checks if a value is a natural value.
+ * Checks if a value is a natural number.
  *
  * @param string $check Value to check
  * @param boolean $allowZero Set true to allow zero, defaults to false


### PR DESCRIPTION
A natural number are whole numbers from 1 to .. or from 0 to ..

validating with numeric() is sometimes not strict enough when you want to validate to whole numbers.
