### PR TITLE
Updating @param mixed docblock lines to proper multi type @param's

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -213,7 +213,7 @@ class Cache {
  *
  * `Cache::set(null, 'my_config');`
  *
- * @param mixed $settings Optional string for simple name-value pair or array
+ * @param string|array $settings Optional string for simple name-value pair or array
  * @param string $value Optional for a simple name-value pair
  * @param string $config The configuration name you are changing. Defaults to 'default'
  * @return array Array of settings.

--- a/lib/Cake/Cache/CacheEngine.php
+++ b/lib/Cake/Cache/CacheEngine.php
@@ -77,7 +77,7 @@ abstract class CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param mixed $duration How long to cache for.
+ * @param integer $duration How long to cache for.
  * @return boolean True if the data was successfully cached, false on failure
  */
 	abstract public function write($key, $value, $duration);

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -106,7 +106,7 @@ class FileEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $data Data to be cached
- * @param mixed $duration How long to cache the data, in seconds
+ * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
 	public function write($key, $data, $duration) {

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -549,7 +549,7 @@ class AclShell extends AppShell {
  * or an array of properties to use in AcoNode::node()
  *
  * @param string $class Class type you want (Aro/Aco)
- * @param mixed $identifier A mixed identifier for finding the node.
+ * @param string|array $identifier A mixed identifier for finding the node.
  * @return integer Integer of NodeId. Will trigger an error if nothing is found.
  */
 	protected function _getNodeId($class, $identifier) {

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -765,8 +765,8 @@ class ModelTask extends BakeTask {
 /**
  * Assembles and writes a Model file.
  *
- * @param mixed $name Model name or object
- * @param mixed $data if array and $name is not an object assume bake data, otherwise boolean.
+ * @param string|object $name Model name or object
+ * @param array|boolean $data if array and $name is not an object assume bake data, otherwise boolean.
  * @return string
  */
 	public function bake($name, $data = array()) {

--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -108,7 +108,7 @@ class TemplateTask extends AppShell {
  * Set variable values to the template scope
  *
  * @param string|array $one A string or an array of data.
- * @param mixed $two Value in case $one is a string (which then works as the key).
+ * @param string|array $two Value in case $one is a string (which then works as the key).
  *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
  * @return void
  */

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -334,9 +334,9 @@ class TestShell extends Shell {
 /**
  * Find the test case for the passed file. The file could itself be a test.
  *
- * @param mixed $file
- * @param mixed $category 
- * @param mixed $throwOnMissingFile 
+ * @param string $file
+ * @param string $category 
+ * @param boolean $throwOnMissingFile 
  * @access protected
  * @return array(type, case)
  * @throws Exception
@@ -412,7 +412,7 @@ class TestShell extends Shell {
 /**
  * For the given file, what category of test is it? returns app, core or the name of the plugin
  *
- * @param mixed $file
+ * @param string $file
  * @access protected
  * @return string
  */

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -634,8 +634,8 @@ class UpgradeShell extends AppShell {
  * Find all php files in the folder (honoring recursive) and determine where cake expects the file to be
  * If the file is not exactly where cake expects it - move it.
  *
- * @param mixed $path
- * @param mixed $options array(recursive, checkFolder)
+ * @param string $path
+ * @param array $options array(recursive, checkFolder)
  * @return void
  */
 	protected function _movePhpFiles($path, $options) {

--- a/lib/Cake/Console/ConsoleInputArgument.php
+++ b/lib/Cake/Console/ConsoleInputArgument.php
@@ -55,7 +55,7 @@ class ConsoleInputArgument {
 /**
  * Make a new Input Argument
  *
- * @param mixed $name The long name of the option, or an array with all the properties.
+ * @param string|array $name The long name of the option, or an array with all the properties.
  * @param string $help The help text for this option
  * @param boolean $required Whether this argument is required. Missing required args will trigger exceptions
  * @param array $choices Valid choices for this option.

--- a/lib/Cake/Console/ConsoleInputOption.php
+++ b/lib/Cake/Console/ConsoleInputOption.php
@@ -70,7 +70,7 @@ class ConsoleInputOption {
 /**
  * Make a new Input Option
  *
- * @param mixed $name The long name of the option, or an array with all the properties.
+ * @param string|array $name The long name of the option, or an array with all the properties.
  * @param string $short The short alias for this option
  * @param string $help The help text for this option
  * @param boolean $boolean Whether this option is a boolean option.  Boolean options don't consume extra tokens

--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -49,9 +49,9 @@ class ConsoleInputSubcommand {
 /**
  * Make a new Subcommand
  *
- * @param mixed $name The long name of the subcommand, or an array with all the properties.
+ * @param string|array $name The long name of the subcommand, or an array with all the properties.
  * @param string $help The help text for this option
- * @param mixed $parser A parser for this subcommand. Either a ConsoleOptionParser, or an array that can be
+ * @param ConsoleOptionParser|array $parser A parser for this subcommand. Either a ConsoleOptionParser, or an array that can be
  *   used with ConsoleOptionParser::buildFromArray()
  */
 	public function __construct($name, $help = '', $parser = null) {

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -232,7 +232,7 @@ class ConsoleOptionParser {
 /**
  * Get or set the description text for shell/task.
  *
- * @param mixed $text The text to set, or null if you want to read. If an array the
+ * @param string|array $text The text to set, or null if you want to read. If an array the
  *   text will be imploded with "\n"
  * @return mixed If reading, the value of the description. If setting $this will be returned
  */
@@ -251,7 +251,7 @@ class ConsoleOptionParser {
  * Get or set an epilog to the parser.  The epilog is added to the end of
  * the options and arguments listing when help is generated.
  *
- * @param mixed $text Text when setting or null when reading. If an array the text will be imploded with "\n"
+ * @param string|array $text Text when setting or null when reading. If an array the text will be imploded with "\n"
  * @return mixed If reading, the value of the epilog. If setting $this will be returned.
  */
 	public function epilog($text = null) {
@@ -282,7 +282,7 @@ class ConsoleOptionParser {
  * - `choices` A list of valid choices for this option.  If left empty all values are valid..
  *   An exception will be raised when parse() encounters an invalid value.
  *
- * @param mixed $name The long name you want to the value to be parsed out as when options are parsed.
+ * @param ConsoleInputOption|string $name The long name you want to the value to be parsed out as when options are parsed.
  *   Will also accept an instance of ConsoleInputOption
  * @param array $options An array of parameters that define the behavior of the option
  * @return ConsoleOptionParser $this.
@@ -323,7 +323,7 @@ class ConsoleOptionParser {
  * - `choices` A list of valid choices for this argument.  If left empty all values are valid..
  *   An exception will be raised when parse() encounters an invalid value.
  *
- * @param mixed $name The name of the argument.  Will also accept an instance of ConsoleInputArgument
+ * @param ConsoleInputArgument|string $name The name of the argument.  Will also accept an instance of ConsoleInputArgument
  * @param array $params Parameters for the argument, see above.
  * @return ConsoleOptionParser $this.
  */
@@ -389,7 +389,7 @@ class ConsoleOptionParser {
  *    specific option parsers.  When help is generated for a subcommand, if a parser is present
  *    it will be used.
  *
- * @param mixed $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
+ * @param ConsoleInputSubcommand|string $name Name of the subcommand. Will also accept an instance of ConsoleInputSubcommand
  * @param array $options Array of params, see above.
  * @return ConsoleOptionParser $this.
  */

--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -156,7 +156,7 @@ class ConsoleOutput {
  * Outputs a single or multiple messages to stdout. If no parameters
  * are passed, outputs just a newline.
  *
- * @param mixed $message A string or a an array of strings to output
+ * @param string|array $message A string or a an array of strings to output
  * @param integer $newlines Number of newlines to append
  * @return integer Returns the number of bytes returned from writing to stdout.
  */
@@ -244,7 +244,7 @@ class ConsoleOutput {
  * `$this->output->styles('annoy', false);`
  *
  * @param string $style The style to get or create.
- * @param mixed $definition The array definition of the style to change or create a style
+ * @param array $definition The array definition of the style to change or create a style
  *   or false to remove a style.
  * @return mixed If you are getting styles, the style or null will be returned. If you are creating/modifying
  *   styles true will be returned.

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -454,7 +454,7 @@ class Shell extends Object {
  * Prompts the user for input, and returns it.
  *
  * @param string $prompt Prompt text.
- * @param mixed $options Array or string of options.
+ * @param string|array $options Array or string of options.
  * @param string $default Default input value.
  * @return mixed Either the default value, or the user-provided input.
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::in
@@ -492,7 +492,7 @@ class Shell extends Object {
  * Prompts the user for input, and returns it.
  *
  * @param string $prompt Prompt text.
- * @param mixed $options Array or string of options.
+ * @param string|array $options Array or string of options.
  * @param string $default Default input value.
  * @return Either the default value, or the user-provided input.
  */
@@ -532,7 +532,7 @@ class Shell extends Object {
  * - `indent` Indent the text with the string provided. Defaults to null.
  *
  * @param string $text Text the text to format.
- * @param mixed $options Array of options to use, or an integer to wrap the text to.
+ * @param string|integer|array $options Array of options to use, or an integer to wrap the text to.
  * @return string Wrapped / indented text
  * @see String::wrap()
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::wrapText
@@ -552,7 +552,7 @@ class Shell extends Object {
  * present in  most shells.  Using Shell::QUIET for a message means it will always display.
  * While using Shell::VERBOSE means it will only display when verbose output is toggled.
  *
- * @param mixed $message A string or a an array of strings to output
+ * @param string|array $message A string or a an array of strings to output
  * @param integer $newlines Number of newlines to append
  * @param integer $level The message's output level, see above.
  * @return integer|boolean Returns the number of bytes returned from writing to stdout.
@@ -576,7 +576,7 @@ class Shell extends Object {
  * Outputs a single or multiple error messages to stderr. If no parameters
  * are passed outputs just a newline.
  *
- * @param mixed $message A string or a an array of strings to output
+ * @param string|array $message A string or a an array of strings to output
  * @param integer $newlines Number of newlines to append
  * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::err

--- a/lib/Cake/Console/Templates/skel/Controller/PagesController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/PagesController.php
@@ -39,7 +39,7 @@ class PagesController extends AppController {
 /**
  * Displays a view
  *
- * @param mixed What page to display
+ * @param string What page to display
  */
 	public function display() {
 		$path = func_get_args();

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -403,7 +403,7 @@ class PhpAro {
  * index. The resulting array will contain a prioritized list of (list of) roles ordered from 
  * the most distant AROs to the requested one itself.
  * 
- * @param mixed $aro An ARO identifier
+ * @param string|array $aro An ARO identifier
  * @return array prioritized AROs
  */
 	public function roles($aro) {
@@ -429,7 +429,7 @@ class PhpAro {
  * resolve an ARO identifier to an internal ARO string using
  * the internal mapping information. 
  *
- * @param mixed $aro ARO identifier (User.jeff, array('User' => ...), etc)
+ * @param string|array $aro ARO identifier (User.jeff, array('User' => ...), etc)
  * @return string internal aro string (e.g. User/jeff, Role/default)
  */
 	public function resolve($aro) {

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -76,8 +76,8 @@ class AclComponent extends Component {
  *
  * Will call the initialize method on the adapter if setting a new one.
  *
- * @param mixed $adapter Instance of AclInterface or a string name of the class to use. (optional)
- * @return mixed either null, or the adapter implementation.
+ * @param AclInterface|string $adapter Instance of AclInterface or a string name of the class to use. (optional)
+ * @return AclInterface|void either null, or the adapter implementation.
  * @throws CakeException when the given class is not an instance of AclInterface
  */
 	public function adapter($adapter = null) {
@@ -99,8 +99,8 @@ class AclComponent extends Component {
  * Pass-thru function for ACL check instance.  Check methods
  * are used to check whether or not an ARO can access an ACO
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  */
@@ -112,8 +112,8 @@ class AclComponent extends Component {
  * Pass-thru function for ACL allow instance. Allow methods
  * are used to grant an ARO access to an ACO.
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  */
@@ -125,8 +125,8 @@ class AclComponent extends Component {
  * Pass-thru function for ACL deny instance. Deny methods
  * are used to remove permission from an ARO to access an ACO.
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  */
@@ -138,8 +138,8 @@ class AclComponent extends Component {
  * Pass-thru function for ACL inherit instance. Inherit methods
  * modify the permission for an ARO to be that of its parent object.
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  */
@@ -150,8 +150,8 @@ class AclComponent extends Component {
 /**
  * Pass-thru function for ACL grant instance. An alias for AclComponent::allow()
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  * @deprecated
@@ -164,8 +164,8 @@ class AclComponent extends Component {
 /**
  * Pass-thru function for ACL grant instance. An alias for AclComponent::deny()
  *
- * @param mixed $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param mixed $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
+ * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
  * @param string $action Action (defaults to *)
  * @return boolean Success
  * @deprecated

--- a/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
@@ -85,7 +85,7 @@ abstract class BaseAuthorize {
 /**
  * Accessor to the controller object.
  *
- * @param mixed $controller null to get, a controller to set.
+ * @param Controller $controller null to get, a controller to set.
  * @return mixed
  * @throws CakeException
  */
@@ -139,7 +139,7 @@ abstract class BaseAuthorize {
  * permissions lookup.  When using with DbAcl, you'll have to add additional _admin type columns
  * to the `aros_acos` table.
  *
- * @param mixed $map Either an array of mappings, or undefined to get current values.
+ * @param array $map Either an array of mappings, or undefined to get current values.
  * @return mixed Either the current mappings or null when setting.
  * @see AuthComponent::mapActions()
  */

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -40,7 +40,7 @@ class ControllerAuthorize extends BaseAuthorize {
 /**
  * Get/set the controller this authorize object will be working with.  Also checks that isAuthorized is implemented.
  *
- * @param mixed $controller null to get, a controller to set.
+ * @param Controller $controller null to get, a controller to set.
  * @return mixed
  * @throws CakeException
  */

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -363,7 +363,7 @@ class AuthComponent extends Component {
  * Each adapter will be checked in sequence, if any of them return true, then the user will
  * be authorized for the request.
  *
- * @param mixed $user The user to check the authorization of. If empty the user in the session will be used.
+ * @param array $user The user to check the authorization of. If empty the user in the session will be used.
  * @param CakeRequest $request The request to authenticate for.  If empty, the current request will be used.
  * @return boolean True if $user is authorized, otherwise false
  */
@@ -430,7 +430,7 @@ class AuthComponent extends Component {
  * `$this->Auth->allow('edit', 'add');` or
  * `$this->Auth->allow();` to allow all actions
  *
- * @param mixed $action,... Controller action name or array of actions
+ * @param string|array $action,... Controller action name or array of actions
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#making-actions-public
  */
@@ -455,7 +455,7 @@ class AuthComponent extends Component {
  * `$this->Auth->deny('edit', 'add');` or
  * `$this->Auth->deny();` to remove all items from the allowed list
  *
- * @param mixed $action,... Controller action name or array of actions
+ * @param string|array $action,... Controller action name or array of actions
  * @return void
  * @see AuthComponent::allow()
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#making-actions-require-authorization
@@ -503,7 +503,7 @@ class AuthComponent extends Component {
  * the user record is written to the session key specified in AuthComponent::$sessionKey. Logging in
  * will also change the session id in order to help mitigate session replays.
  *
- * @param mixed $user Either an array of user data, or null to identify a user using the current request.
+ * @param array $user Either an array of user data, or null to identify a user using the current request.
  * @return boolean True on login success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
  */
@@ -604,7 +604,7 @@ class AuthComponent extends Component {
  * set the destination a user should be redirected to upon logging in.  Will fallback to
  * AuthComponent::$loginRedirect if there is no stored redirect value.
  *
- * @param mixed $url Optional URL to write as the login redirect URL.
+ * @param string|array $url Optional URL to write as the login redirect URL.
  * @return string Redirect URL
  */
 	public function redirect($url = null) {

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -209,10 +209,10 @@ class CookieComponent extends Component {
  * You must use this method before any output is sent to the browser.
  * Failure to do so will result in header already sent errors.
  *
- * @param mixed $key Key for the value
+ * @param string|array $key Key for the value
  * @param mixed $value Value
  * @param boolean $encrypt Set to true to encrypt value, false otherwise
- * @param string $expires Can be either Unix timestamp, or date string
+ * @param integer|string $expires Can be either Unix timestamp, or date string
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html#CookieComponent::write
  */
@@ -253,7 +253,7 @@ class CookieComponent extends Component {
  * Optional [Name.], required key
  * $this->Cookie->read(Name.key);
  *
- * @param mixed $key Key of the value to be obtained. If none specified, obtain map key => values
+ * @param string $key Key of the value to be obtained. If none specified, obtain map key => values
  * @return string or null, value for specified key
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html#CookieComponent::read
  */
@@ -363,7 +363,7 @@ class CookieComponent extends Component {
  * CookieComponent::write(string, string, boolean, 8400);
  * CookieComponent::write(string, string, boolean, '5 Days');
  *
- * @param mixed $expires Can be either Unix timestamp, or date string
+ * @param integer|string $expires Can be either Unix timestamp, or date string
  * @return integer Unix timestamp
  */
 	protected function _expire($expires = null) {

--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -279,7 +279,7 @@ class EmailComponent extends Component {
 /**
  * Send an email using the specified content, template and layout
  *
- * @param mixed $content Either an array of text lines, or a string with contents
+ * @param string|array $content Either an array of text lines, or a string with contents
  *  If you are rendering a template this variable will be sent to the templates as `$content`
  * @param string $template Template to use when sending email
  * @param string $layout Layout to use to enclose email body

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -101,8 +101,8 @@ class PaginatorComponent extends Component {
 /**
  * Handles automatic pagination of model records.
  *
- * @param mixed $object Model to paginate (e.g: model instance, or 'Model', or 'Model.InnerModel')
- * @param mixed $scope Additional find conditions to use while paginating
+ * @param Model|string $object Model to paginate (e.g: model instance, or 'Model', or 'Model.InnerModel')
+ * @param string|array $scope Additional find conditions to use while paginating
  * @param array $whitelist List of allowed fields for ordering.  This allows you to prevent ordering
  *   on non-indexed, or undesirable columns.
  * @return array Model query results
@@ -218,7 +218,7 @@ class PaginatorComponent extends Component {
 /**
  * Get the object pagination will occur on.
  *
- * @param mixed $object The object you are looking for.
+ * @param string|Model $object The object you are looking for.
  * @return mixed The model object to paginate on.
  */
 	protected function _getObject($object) {

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -220,7 +220,7 @@ class RequestHandlerComponent extends Component {
  *
  * @param Controller $controller A reference to the controller
  * @param string|array $url A string or array containing the redirect location
- * @param mixed $status HTTP Status for redirect
+ * @param integer|array $status HTTP Status for redirect
  * @param boolean $exit
  * @return void
  */
@@ -396,7 +396,7 @@ class RequestHandlerComponent extends Component {
  * startup method.
  *
  * @param string $name The name of the Content-type, i.e. "html", "xml", "css"
- * @param mixed $type The Content-type or array of Content-types assigned to the name,
+ * @param string|array $type The Content-type or array of Content-types assigned to the name,
  *    i.e. "text/html", or "application/xml"
  * @return void
  * @deprecated use `$this->response->type()` instead.
@@ -441,7 +441,7 @@ class RequestHandlerComponent extends Component {
  *
  * Returns true if the client accepts xml.
  *
- * @param mixed $type Can be null (or no parameter), a string type name, or an
+ * @param string|array $type Can be null (or no parameter), a string type name, or an
  *   array of types
  * @return mixed If null or no parameter is passed, returns an array of content
  *   types the client accepts.  If a string is passed, returns true
@@ -472,7 +472,7 @@ class RequestHandlerComponent extends Component {
 /**
  * Determines the content type of the data the client has sent (i.e. in a POST request)
  *
- * @param mixed $type Can be null (or no parameter), a string type name, or an array of types
+ * @param string|array $type Can be null (or no parameter), a string type name, or an array of types
  * @return mixed If a single type is supplied a boolean will be returned.  If no type is provided
  *   The mapped value of CONTENT_TYPE will be returned. If an array is supplied the first type
  *   in the request content type will be returned.
@@ -505,7 +505,7 @@ class RequestHandlerComponent extends Component {
  * if provided, and secondarily by the list of content-types provided in
  * HTTP_ACCEPT.
  *
- * @param mixed $type An optional array of 'friendly' content-type names, i.e.
+ * @param string|array $type An optional array of 'friendly' content-type names, i.e.
  *   'html', 'xml', 'js', etc.
  * @return mixed If $type is null or not provided, the first content-type in the
  *    list, based on preference, is returned.  If a single type is provided
@@ -619,7 +619,7 @@ class RequestHandlerComponent extends Component {
  * Sets the response header based on type map index name.  This wraps several methods
  * available on CakeResponse. It also allows you to use Content-Type aliases.
  *
- * @param mixed $type Friendly type name, i.e. 'html' or 'xml', or a full content-type,
+ * @param string|array $type Friendly type name, i.e. 'html' or 'xml', or a full content-type,
  *    like 'application/x-shockwave'.
  * @param array $options If $type is a friendly type name that is associated with
  *    more than one type of content, $index is used to select which content-type to use.
@@ -680,8 +680,8 @@ class RequestHandlerComponent extends Component {
 /**
  * Maps a content-type back to an alias
  *
- * @param mixed $cType Either a string content type to map, or an array of types.
- * @return mixed Aliases for the types provided.
+ * @param string|array $cType Either a string content type to map, or an array of types.
+ * @return string|array Aliases for the types provided.
  * @deprecated Use $this->response->mapType() in your controller instead.
  */
 	public function mapType($cType) {
@@ -691,8 +691,8 @@ class RequestHandlerComponent extends Component {
 /**
  * Maps a content type alias back to its mime-type(s)
  *
- * @param mixed $alias String alias to convert back into a content type. Or an array of aliases to map.
- * @return mixed Null on an undefined alias.  String value of the mapped alias type.  If an
+ * @param string|array $alias String alias to convert back into a content type. Or an array of aliases to map.
+ * @return string Null on an undefined alias.  String value of the mapped alias type.  If an
  *   alias maps to more than one content type, the first one will be returned.
  */
 	public function mapAlias($alias) {

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -589,7 +589,7 @@ class Controller extends Object implements CakeEventListener {
  * Merges the elements not already in $this->uses into
  * $this->uses.
  *
- * @param mixed $merge The data to merge in.
+ * @param array $merge The data to merge in.
  * @return void
  */
 	protected function _mergeUses($merge) {
@@ -687,7 +687,7 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param mixed $code If $code is an integer, then the corresponding code/message is
+ * @param integer|array $code If $code is an integer, then the corresponding code/message is
  *        returned if it exists, null if it does not exist. If $code is an array,
  *        then the 'code' and 'message' keys of each nested array are added to the default
  *        HTTP codes. Example:
@@ -699,7 +699,7 @@ class Controller extends Object implements CakeEventListener {
  *            800 => 'Unexpected Minotaur'
  *        )); // sets these new values, and returns true
  *
- * @return mixed Associative array of the HTTP codes as keys, and the message
+ * @return array Associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
  * @deprecated Use CakeResponse::httpCodes();
  */
@@ -713,7 +713,7 @@ class Controller extends Object implements CakeEventListener {
  * dynamic models for the time being.
  *
  * @param string $modelClass Name of model class to load
- * @param mixed $id Initial ID the instanced model class should have
+ * @param integer|string $id Initial ID the instanced model class should have
  * @return mixed true when single model found and instance created, error returned if model not found.
  * @throws MissingModelException if the model class cannot be found.
  */
@@ -742,7 +742,7 @@ class Controller extends Object implements CakeEventListener {
  * Redirects to given $url, after turning off $this->autoRender.
  * Script execution is halted after the redirect.
  *
- * @param mixed $url A string or array-based URL pointing to another location within the app,
+ * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
  * @param integer $status Optional HTTP status code (eg: 404)
  * @param boolean $exit If true, exit() will be called after the redirect
@@ -795,7 +795,7 @@ class Controller extends Object implements CakeEventListener {
  * Parse beforeRedirect Response
  *
  * @param mixed $response Response from beforeRedirect callback
- * @param mixed $url The same value of beforeRedirect
+ * @param string|array $url The same value of beforeRedirect
  * @param integer $status The same value of beforeRedirect
  * @param boolean $exit The same value of beforeRedirect
  * @return array Array with keys url, status and exit
@@ -827,8 +827,8 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Saves a variable for use inside a view template.
  *
- * @param mixed $one A string or an array of data.
- * @param mixed $two Value in case $one is a string (which then works as the key).
+ * @param string|array $one A string or an array of data.
+ * @param string|array $two Value in case $one is a string (which then works as the key).
  *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#interacting-with-views
@@ -996,7 +996,7 @@ class Controller extends Object implements CakeEventListener {
  * Does not work if the current debug level is higher than 0.
  *
  * @param string $message Message to display to the user
- * @param mixed $url Relative string or array-based URL to redirect to after the time expires
+ * @param string|array $url Relative string or array-based URL to redirect to after the time expires
  * @param integer $pause Time to show the message
  * @param string $layout Layout you want to use, defaults to 'flash'
  * @return void Renders flash layout
@@ -1015,7 +1015,7 @@ class Controller extends Object implements CakeEventListener {
  * Converts POST'ed form data to a model conditions array, suitable for use in a Model::find() call.
  *
  * @param array $data POST'ed data organized by model and field
- * @param mixed $op A string containing an SQL comparison operator, or an array matching operators
+ * @param string|array $op A string containing an SQL comparison operator, or an array matching operators
  *        to fields
  * @param string $bool SQL boolean operator: AND, OR, XOR, etc.
  * @param boolean $exclusive If true, and $op is an array, fields not included in $op will not be
@@ -1073,8 +1073,8 @@ class Controller extends Object implements CakeEventListener {
 /**
  * Handles automatic pagination of model records.
  *
- * @param mixed $object Model to paginate (e.g: model instance, or 'Model', or 'Model.InnerModel')
- * @param mixed $scope Conditions to use while paginating
+ * @param Model|string $object Model to paginate (e.g: model instance, or 'Model', or 'Model.InnerModel')
+ * @param string|array $scope Conditions to use while paginating
  * @param array $whitelist List of allowed options for paging
  * @return array Model query results
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::paginate
@@ -1111,7 +1111,7 @@ class Controller extends Object implements CakeEventListener {
  * return a string which will be interpreted as the url to redirect to or return associative array with
  * key 'url' and optionally 'status' and 'exit'.
  *
- * @param mixed $url A string or array-based URL pointing to another location within the app,
+ * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
  * @param integer $status Optional HTTP status code (eg: 404)
  * @param boolean $exit If true, exit() will be called after the redirect

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -268,7 +268,7 @@ class App {
  * If reset is set to true, all loaded plugins will be forgotten and they will be needed to be loaded again.
  *
  * @param array $paths associative array with package names as keys and a list of directories for new search paths
- * @param mixed $mode App::RESET will set paths, App::APPEND with append paths, App::PREPEND will prepend paths (default)
+ * @param boolean|string $mode App::RESET will set paths, App::APPEND with append paths, App::PREPEND will prepend paths (default)
  * 	App::REGISTER will register new packages and their paths, %s in path will be replaced by APP path
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::build
@@ -418,7 +418,7 @@ class App {
  * are commonly used by version control systems.
  *
  * @param string $type Type of object, i.e. 'Model', 'Controller', 'View/Helper', 'file', 'class' or 'plugin'
- * @param mixed $path Optional Scan only the path given. If null, paths for the chosen type will be used.
+ * @param string|array $path Optional Scan only the path given. If null, paths for the chosen type will be used.
  * @param boolean $cache Set to false to rescan objects of the chosen type. Defaults to true.
  * @return mixed Either false on incorrect / miss.  Or an array of found objects.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::objects
@@ -581,10 +581,10 @@ class App {
  * not construct any classes contained in the files. It will only find and require() the file.
  *
  * @link          http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#including-files-with-app-import
- * @param mixed $type The type of Class if passed as a string, or all params can be passed as
+ * @param string|array $type The type of Class if passed as a string, or all params can be passed as
  *                    an single array to $type,
  * @param string $name Name of the Class or a unique name for the file
- * @param mixed $parent boolean true if Class Parent should be searched, accepts key => value
+ * @param boolean|array $parent boolean true if Class Parent should be searched, accepts key => value
  *              array('parent' => $parent ,'file' => $file, 'search' => $search, 'ext' => '$ext');
  *              $ext allows setting the extension of the file name
  *              based on Inflector::underscore($name) . ".$ext";

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -61,7 +61,7 @@ class CakePlugin {
  *
  * Will only load the bootstrap for ApiGenerator and only the routes for DebugKit
  *
- * @param mixed $plugin name of the plugin to be loaded in CamelCase format or array or plugins to load
+ * @param string|array $plugin name of the plugin to be loaded in CamelCase format or array or plugins to load
  * @param array $config configuration options for the plugin
  * @throws MissingPluginException if the folder for the plugin to be loaded is not found
  * @return void

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -56,7 +56,7 @@ class Object {
  * POST and GET data can be simulated in requestAction.  Use `$extra['url']` for
  * GET data.  The `$extra['data']` parameter allows POST data simulation.
  *
- * @param mixed $url String or array-based url.  Unlike other url arrays in CakePHP, this
+ * @param string|array $url String or array-based url.  Unlike other url arrays in CakePHP, this
  *    url will not automatically handle passed and named arguments in the $url parameter.
  * @param array $extra if array includes the key "return" it sets the AutoRender to true.  Can
  *    also be used to submit GET/POST data, and named/passed arguments.

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -191,7 +191,7 @@ class CakeException extends RuntimeException {
  * Allows you to create exceptions that are treated as framework errors and disabled
  * when debug = 0.
  *
- * @param mixed $message Either the string of the error message, or an array of attributes
+ * @param string|array $message Either the string of the error message, or an array of attributes
  *   that are made available in the view, and sprintf()'d into CakeException::$_messageTemplate
  * @param string $code The code of the error, is also the HTTP status code for the error.
  */

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -87,7 +87,7 @@ class CakeEventManager {
  * method will be called on the object to register the declared events individually as methods to be managed by this class.
  * It is possible to define multiple event handlers per event name.
  *
- * @param mixed $eventKey The event unique identifier name to with the callback will be associated. If $callable
+ * @param string $eventKey The event unique identifier name to with the callback will be associated. If $callable
  * is an instance of CakeEventListener this argument will be ignored
  *
  * @param array $options used to set the `priority` and `passParams` flags to the listener.
@@ -220,7 +220,7 @@ class CakeEventManager {
 /**
  * Dispatches a new event to all configured listeners
  *
- * @param mixed $event the event key name or instance of CakeEvent
+ * @param string|CakeEvent $event the event key name or instance of CakeEvent
  * @return void
  */
 	public function dispatch($event) {

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -426,8 +426,8 @@ class L10n {
 /**
  * Attempts to find locale for language, or language for locale
  *
- * @param mixed $mixed 2/3 char string (language/locale), array of those strings, or null
- * @return mixed string language/locale, array of those values, whole map as an array,
+ * @param string|array $mixed 2/3 char string (language/locale), array of those strings, or null
+ * @return string|array|boolean string language/locale, array of those values, whole map as an array,
  *    or false when language/locale doesn't exist
  */
 	public function map($mixed = null) {
@@ -453,8 +453,8 @@ class L10n {
 /**
  * Attempts to find catalog record for requested language
  *
- * @param mixed $language string requested language, array of requested languages, or null for whole catalog
- * @return mixed array catalog record for requested language, array of catalog records, whole catalog,
+ * @param string|array $language string requested language, array of requested languages, or null for whole catalog
+ * @return array|boolean array catalog record for requested language, array of catalog records, whole catalog,
  *    or false when language doesn't exist
  */
 	public function catalog($language = null) {

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -249,7 +249,7 @@ class CakeLog {
  * );
  * }}}
  *
- * @param mixed $levels array
+ * @param array $levels array
  * @param bool $append true to append, false to replace
  * @return array active log levels
  */
@@ -397,7 +397,7 @@ class CakeLog {
  *
  * `CakeLog::write('warning', 'Stuff is broken here');`
  *
- * @param mixed $type Type of message being written. When value is an integer
+ * @param integer|string $type Type of message being written. When value is an integer
  *    or a string matching the recognized levels, then it will
  *    be treated log levels. Otherwise it's treated as scope.
  * @param string $message Message content to log

--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -54,7 +54,7 @@ class AclNode extends Model {
 /**
  * Retrieves the Aro/Aco node for this model
  *
- * @param mixed $ref Array with 'model' and 'foreign_key', model object, or string value
+ * @param string|array|Model $ref Array with 'model' and 'foreign_key', model object, or string value
  * @return array Node found in database
  * @throws CakeException when binding to a model that doesn't exist.
  */

--- a/lib/Cake/Model/Behavior/AclBehavior.php
+++ b/lib/Cake/Model/Behavior/AclBehavior.php
@@ -70,7 +70,7 @@ class AclBehavior extends ModelBehavior {
  * Retrieves the Aro/Aco node for this model
  *
  * @param Model $model
- * @param mixed $ref
+ * @param string|array|Model $ref Array with 'model' and 'foreign_key', model object, or string value
  * @param string $type Only needed when Acl is set up as 'both', specify 'Aro' or 'Aco' to get the correct node
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/acl.html#node

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -362,7 +362,7 @@ class ContainableBehavior extends ModelBehavior {
  *
  * @param Model $Model Model
  * @param array $map Map of relations for given model
- * @param mixed $fields If array, fields to initially load, if false use $Model as primary model
+ * @param array|boolean $fields If array, fields to initially load, if false use $Model as primary model
  * @return array Fields
  */
 	public function fieldDependencies(Model $Model, $map, $fields = array()) {

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -207,7 +207,7 @@ class TranslateBehavior extends ModelBehavior {
  * @param array $query The query array to append a join to.
  * @param string $field The field name being joined.
  * @param string $aliasField The aliased field name being joined.
- * @param mixed $locale The locale(s) having joins added.
+ * @param string|array $locale The locale(s) having joins added.
  * @param boolean $addField Whether or not to add a field.
  * @return array The modfied query
  */
@@ -572,7 +572,7 @@ class TranslateBehavior extends ModelBehavior {
  * fake field
  *
  * @param Model $model instance of model
- * @param mixed $fields string with field, or array(field1, field2=>AssocName, field3), or null for
+ * @param string|array $fields string with field, or array(field1, field2=>AssocName, field3), or null for
  *    unbind all original translations
  * @return boolean
  */

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -237,7 +237,7 @@ class TreeBehavior extends ModelBehavior {
  * If false is passed for the id parameter, all top level nodes are counted, or all nodes are counted.
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to read or false to read all top level nodes
+ * @param integer|string|boolean $id The ID of the record to read or false to read all top level nodes
  * @param boolean $direct whether to count direct, or all, children
  * @return integer number of child nodes
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::childCount
@@ -278,9 +278,9 @@ class TreeBehavior extends ModelBehavior {
  * If false is passed for the id parameter, top level, or all (depending on direct parameter appropriate) are counted.
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to read
+ * @param integer|string $id The ID of the record to read
  * @param boolean $direct whether to return only the direct, or all, children
- * @param mixed $fields Either a single string of a field name, or an array of field names
+ * @param string|array $fields Either a single string of a field name, or an array of field names
  * @param string $order SQL ORDER BY conditions (e.g. "price DESC" or "name ASC") defaults to the tree order
  * @param integer $limit SQL LIMIT clause, for calculating items per page.
  * @param integer $page Page number, for accessing paged data
@@ -337,7 +337,7 @@ class TreeBehavior extends ModelBehavior {
  * A convenience method for returning a hierarchical array used for HTML select boxes
  *
  * @param Model $Model Model instance
- * @param mixed $conditions SQL conditions as a string or as an array('field' =>'value',...)
+ * @param string|array $conditions SQL conditions as a string or as an array('field' =>'value',...)
  * @param string $keyPath A string path to the key, i.e. "{n}.Post.id"
  * @param string $valuePath A string path to the value, i.e. "{n}.Post.title"
  * @param string $spacer The character or characters which will be repeated
@@ -395,7 +395,7 @@ class TreeBehavior extends ModelBehavior {
  * reads the parent id and returns this node
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to read
+ * @param integer|string $id The ID of the record to read
  * @param string|array $fields
  * @param integer $recursive The number of levels deep to fetch associated records
  * @return array|boolean Array of data for the parent node
@@ -428,8 +428,8 @@ class TreeBehavior extends ModelBehavior {
  * Get the path to the given node
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to read
- * @param mixed $fields Either a single string of a field name, or an array of field names
+ * @param integer|string $id The ID of the record to read
+ * @param string|array $fields Either a single string of a field name, or an array of field names
  * @param integer $recursive The number of levels deep to fetch associated records
  * @return array Array of nodes from top most parent to current node
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::getPath
@@ -466,7 +466,7 @@ class TreeBehavior extends ModelBehavior {
  * If the node is the last child, or is a top level node with no subsequent node this method will return false
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to move
+ * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number how many places to move the node or true to move to last position
  * @return boolean true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::moveDown
@@ -524,7 +524,7 @@ class TreeBehavior extends ModelBehavior {
  * If the node is the first child, or is a top level node with no previous node this method will return false
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to move
+ * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number how many places to move the node, or true to move to first position
  * @return boolean true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::moveUp
@@ -588,7 +588,7 @@ class TreeBehavior extends ModelBehavior {
  * @todo Could be written to be faster, *maybe*. Ideally using a subquery and putting all the logic burden on the DB.
  * @param Model $Model Model instance
  * @param string $mode parent or tree
- * @param mixed $missingParentAction 'return' to do nothing and return, 'delete' to
+ * @param string|integer $missingParentAction 'return' to do nothing and return, 'delete' to
  * delete, or the id of the parent to set as the parent_id
  * @return boolean true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::recover
@@ -706,7 +706,7 @@ class TreeBehavior extends ModelBehavior {
  * after the children are reparented.
  *
  * @param Model $Model Model instance
- * @param mixed $id The ID of the record to remove
+ * @param integer|string $id The ID of the record to remove
  * @param boolean $delete whether to delete the node after reparenting children (if any)
  * @return boolean true on success, false on failure
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::removeFromTree
@@ -850,7 +850,7 @@ class TreeBehavior extends ModelBehavior {
  * method could be private, since calling save with parent_id set also calls setParent
  *
  * @param Model $Model Model instance
- * @param mixed $parentId
+ * @param integer|string $parentId
  * @param boolean $created
  * @return boolean true on success, false on failure
  */

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -338,7 +338,7 @@ class CakeSchema extends Object {
 /**
  * Writes schema file from object or options
  *
- * @param mixed $object schema object or options array
+ * @param array|object $object schema object or options array
  * @param array $options schema object properties to override object
  * @return mixed false or string written to file
  */
@@ -440,8 +440,8 @@ class CakeSchema extends Object {
 /**
  * Compares two sets of schemas
  *
- * @param mixed $old Schema object or array
- * @param mixed $new Schema object or array
+ * @param array|object $old Schema object or array
+ * @param array|object $new Schema object or array
  * @return array Tables (that are added, dropped, or changed)
  */
 	public function compare($old, $new = null) {

--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -140,7 +140,7 @@ class ConnectionManager {
 /**
  * Loads the DataSource class for the given connection name
  *
- * @param mixed $connName A string name of the connection, as defined in app/Config/database.php,
+ * @param string|array $connName A string name of the connection, as defined in app/Config/database.php,
  *                        or an array containing the filename (without extension) and class name of the object,
  *                        to be found in app/Model/Datasource/ or lib/Cake/Model/Datasource/.
  * @return boolean True on success, null on failure or false if the class is already loaded

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -351,7 +351,7 @@ class CakeSession {
 /**
  * Returns given session variable, or all of them, if no parameters given.
  *
- * @param mixed $name The name of the session variable (or a path as sent to Set.extract)
+ * @param string|array $name The name of the session variable (or a path as sent to Set.extract)
  * @return mixed The value of the session variable
  */
 	public static function read($name = null) {
@@ -389,7 +389,7 @@ class CakeSession {
 /**
  * Writes value to given session variable name.
  *
- * @param mixed $name Name of variable
+ * @param string|array $name Name of variable
  * @param string $value Value to write
  * @return boolean True if the write was successful, false if the write failed
  */

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -275,7 +275,7 @@ class Postgres extends DboSource {
 /**
  * Gets the associated sequence for the given table/field
  *
- * @param mixed $table Either a full table name (with prefix) as a string, or a model object
+ * @param string|Model $table Either a full table name (with prefix) as a string, or a model object
  * @param string $field Name of the ID database field. Defaults to "id"
  * @return string The associated sequence name from the sequence map, defaults to "{$table}_{$field}_seq"
  */
@@ -293,7 +293,7 @@ class Postgres extends DboSource {
 /**
  * Deletes all the records in a table and drops all associated auto-increment sequences
  *
- * @param mixed $table A string or model class representing the table to be truncated
+ * @param string|Model $table A string or model class representing the table to be truncated
  * @param boolean $reset true for resetting the sequence, false to leave it as is.
  *    and if 1, sequences are not modified
  * @return boolean	SQL TRUNCATE TABLE statement, false if not applicable.

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -221,7 +221,7 @@ class Sqlite extends DboSource {
  * Deletes all the records in a table and resets the count of the auto-incrementing
  * primary key, where applicable.
  *
- * @param mixed $table A string or model class representing the table to be truncated
+ * @param string|Model $table A string or model class representing the table to be truncated
  * @return boolean	SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table) {

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -690,7 +690,7 @@ class Sqlserver extends DboSource {
 /**
  * Makes sure it will return the primary key
  *
- * @param mixed $model Model instance of table name
+ * @param Model|string $model Model instance of table name
  * @return string
  */
 	protected function _getPrimaryKey($model) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -937,7 +937,7 @@ class DboSource extends DataSource {
 /**
  * Gets full table name including prefix
  *
- * @param mixed $model Either a Model object or a string table name.
+ * @param Model|string $model Either a Model object or a string table name.
  * @param boolean $quote Whether you want the table name quoted.
  * @param boolean $schema Whether you want the schema name included.
  * @return string Full quoted table name
@@ -2019,7 +2019,7 @@ class DboSource extends DataSource {
  * Deletes all the records in a table and resets the count of the auto-incrementing
  * primary key, where applicable.
  *
- * @param mixed $table A string or model class representing the table to be truncated
+ * @param Model|string $table A string or model class representing the table to be truncated
  * @return boolean	SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table) {
@@ -2172,7 +2172,7 @@ class DboSource extends DataSource {
  * were provided either null or false will be returned based on what was input.
  *
  * @param Model $model
- * @param mixed $conditions Array of conditions, conditions string, null or false. If an array of conditions,
+ * @param string|array|boolean $conditions Array of conditions, conditions string, null or false. If an array of conditions,
  *   or string conditions those conditions will be returned.  With other values the model's existence will be checked.
  *   If the model doesn't exist a null or false will be returned depending on the input value.
  * @param boolean $useAlias Use model aliases rather than table names when generating conditions
@@ -2233,7 +2233,7 @@ class DboSource extends DataSource {
  *
  * @param Model $model
  * @param string $alias Alias table name
- * @param mixed $fields virtual fields to be used on query
+ * @param array $fields virtual fields to be used on query
  * @return array
  */
 	protected function _constructVirtualFields(Model $model, $alias, $fields) {

--- a/lib/Cake/Model/Datasource/Session/CacheSession.php
+++ b/lib/Cake/Model/Datasource/Session/CacheSession.php
@@ -49,7 +49,7 @@ class CacheSession implements CakeSessionHandlerInterface {
 /**
  * Method used to read from a database session.
  *
- * @param mixed $id The key of the value to read
+ * @param string $id The key of the value to read
  * @return mixed The value of the key or false if it does not exist
  */
 	public function read($id) {

--- a/lib/Cake/Model/Datasource/Session/CakeSessionHandlerInterface.php
+++ b/lib/Cake/Model/Datasource/Session/CakeSessionHandlerInterface.php
@@ -38,7 +38,7 @@ interface CakeSessionHandlerInterface {
 /**
  * Method used to read from a session.
  *
- * @param mixed $id The key of the value to read
+ * @param string $id The key of the value to read
  * @return mixed The value of the key or false if it does not exist
  */
 	public function read($id);

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -86,7 +86,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method used to read from a database session.
  *
- * @param int|string $id The key of the value to read
+ * @param integer|string $id The key of the value to read
  * @return mixed The value of the key or false if it does not exist
  */
 	public function read($id) {

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -86,7 +86,7 @@ class DatabaseSession implements CakeSessionHandlerInterface {
 /**
  * Method used to read from a database session.
  *
- * @param mixed $id The key of the value to read
+ * @param int|string $id The key of the value to read
  * @return mixed The value of the key or false if it does not exist
  */
 	public function read($id) {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -654,7 +654,7 @@ class Model extends Object implements CakeEventListener {
  * Would create a model attached to the posts table on connection2.  Dynamic model creation is useful
  * when you want a model object that contains no associations or attached behaviors.
  *
- * @param mixed $id Set this ID for this model on startup, can also be an array of options, see above.
+ * @param integer|string|array $id Set this ID for this model on startup, can also be an array of options, see above.
  * @param string $table Name of database table to use.
  * @param string $ds DataSource connection name.
  */
@@ -1118,7 +1118,7 @@ class Model extends Object implements CakeEventListener {
  * (Alternative indata: two strings, which are mangled to
  * a one-item, two-dimensional array using $one for a key and $two as its value.)
  *
- * @param mixed $one Array or string of data
+ * @param string|array|SimpleXmlElement|DomNode $one Array or string of data
  * @param string $two Value string for the alternative indata method
  * @return array Data with all of $one's keys and values
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html
@@ -1209,7 +1209,7 @@ class Model extends Object implements CakeEventListener {
  * Deconstructs a complex data type (array or object) into a single field value.
  *
  * @param string $field The name of the field to be deconstructed
- * @param mixed $data An array or object to be deconstructed into a field
+ * @param array|object $data An array or object to be deconstructed into a field
  * @return mixed The resulting data that should be assigned to a field
  */
 	public function deconstruct($field, $data) {
@@ -1293,7 +1293,7 @@ class Model extends Object implements CakeEventListener {
  * Returns an array of table metadata (column names and types) from the database.
  * $field => keys(type, null, default, key, length, extra)
  *
- * @param mixed $field Set to true to reload schema, or a string to return a specific field
+ * @param boolean|string $field Set to true to reload schema, or a string to return a specific field
  * @return array Array of table metadata
  */
 	public function schema($field = false) {
@@ -1363,7 +1363,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Returns true if the supplied field exists in the model's database table.
  *
- * @param mixed $name Name of field to look for, or an array of names
+ * @param string|array $name Name of field to look for, or an array of names
  * @param boolean $checkVirtual checks if the field is declared as virtual
  * @return mixed If $name is a string, returns a boolean indicating whether the field exists.
  *               If $name is an array of field names, returns the first field that exists,
@@ -1460,7 +1460,7 @@ class Model extends Object implements CakeEventListener {
  * for those fields that are not defined in $data, and clearing previous validation errors.
  * Especially helpful for saving data in loops.
  *
- * @param mixed $data Optional data array to assign to the model after it is created.  If null or false,
+ * @param boolean|array $data Optional data array to assign to the model after it is created.  If null or false,
  *   schema data defaults are not merged.
  * @param boolean $filterKey If true, overwrites any primary key input with an empty value
  * @return array The current Model::data; after merging $data and/or defaults from database
@@ -1491,8 +1491,8 @@ class Model extends Object implements CakeEventListener {
  * Returns a list of fields from the database, and sets the current model
  * data (Model::$data) with the record found.
  *
- * @param mixed $fields String of single field name, or an array of field names.
- * @param mixed $id The ID of the record to read
+ * @param string|array $fields String of single field name, or an array of field names.
+ * @param integer|string $id The ID of the record to read
  * @return array Array of database fields, or false if not found
  * @link http://book.cakephp.org/2.0/en/models/retrieving-your-data.html#model-read
  */
@@ -1587,7 +1587,7 @@ class Model extends Object implements CakeEventListener {
  * default, validation occurs before save.
  *
  * @param array $data Data to save.
- * @param mixed $validate Either a boolean, or an array.
+ * @param boolean|array $validate Either a boolean, or an array.
  *   If a boolean, indicates whether or not to validate before saving.
  *   If an array, allows control of validate, callbacks, and fieldList
  * @param array $fieldList List of fields to allow to be written
@@ -1769,7 +1769,7 @@ class Model extends Object implements CakeEventListener {
  * Saves model hasAndBelongsToMany data to the database.
  *
  * @param array $joined Data to save
- * @param mixed $id ID of record in this model
+ * @param integer|string $id ID of record in this model
  * @param DataSource $db
  * @return void
  */
@@ -2336,7 +2336,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Removes record for given ID. If no ID is given, the current ID is used. Returns true on success.
  *
- * @param mixed $id ID of record to delete
+ * @param integer|string $id ID of record to delete
  * @param boolean $cascade Set to true to delete records that depend on this record
  * @return boolean True on success
  * @link http://book.cakephp.org/2.0/en/models/deleting-data.html
@@ -2538,7 +2538,7 @@ class Model extends Object implements CakeEventListener {
  * and then performs a Model::find('count') on the currently configured datasource
  * to ascertain the existence of the record in persistent storage.
  *
- * @param mixed $id ID of record to check for existence
+ * @param integer|string $id ID of record to check for existence
  * @return boolean True if such a record exists
  */
 	public function exists($id = null) {
@@ -2821,7 +2821,7 @@ class Model extends Object implements CakeEventListener {
  * rows and return them.
  *
  * @param string $state Either "before" or "after"
- * @param mixed $query
+ * @param array $query
  * @param array $results
  * @return array
  */
@@ -2877,7 +2877,7 @@ class Model extends Object implements CakeEventListener {
  * In the event of ambiguous results returned (multiple top level results, with different parent_ids)
  * top level results with different parent_ids to the first result will be dropped
  *
- * @param mixed $state
+ * @param string $state
  * @param mixed $query
  * @param array $results
  * @return array Threaded results
@@ -3114,7 +3114,7 @@ class Model extends Object implements CakeEventListener {
 /**
  * Sets the ID of the last record this model inserted
  *
- * @param mixed $id Last inserted ID
+ * @param integer|string $id Last inserted ID
  * @return void
  */
 	public function setInsertID($id) {

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -175,7 +175,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *			->setRule('inRange', array('rule' => array('between', 4, 10))
  * }}}
  *
- * @param mixed $name The name under which the rule should be set
+ * @param string $name The name under which the rule should be set
  * @param CakeValidationRule|array $rule The validation rule to be set
  * @return CakeValidationSet this instance
  */
@@ -198,7 +198,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *			->removeRule('inRange')
  * }}}
  *
- * @param mixed $name The name under which the rule should be unset
+ * @param string $name The name under which the rule should be unset
  * @return CakeValidationSet this instance
  */
 	public function removeRule($name) {

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -494,10 +494,10 @@ class CakeResponse {
  *  e.g `header('WWW-Authenticate: Negotiate'); header('WWW-Authenticate: Not-Negotiate');`
  * will have the same effect as only doing `header('WWW-Authenticate: Not-Negotiate');`
  *
- * @param mixed $header. An array of header strings or a single header string
+ * @param string|array $header. An array of header strings or a single header string
  *	- an associative array of "header name" => "header value" is also accepted
  *	- an array of string headers is also accepted
- * @param mixed $value. The header value.
+ * @param string $value. The header value.
  * @return array list of headers to be sent
  */
 	public function header($header = null, $value = null) {
@@ -560,7 +560,7 @@ class CakeResponse {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param mixed $code If $code is an integer, then the corresponding code/message is
+ * @param integer|array $code If $code is an integer, then the corresponding code/message is
  *        returned if it exists, null if it does not exist. If $code is an array,
  *        then the 'code' and 'message' keys of each nested array are added to the default
  *        HTTP codes. Example:
@@ -656,7 +656,7 @@ class CakeResponse {
  *
  * e.g `mapType('application/pdf'); // returns 'pdf'`
  *
- * @param mixed $ctype Either a string content type to map, or an array of types.
+ * @param string|array $ctype Either a string content type to map, or an array of types.
  * @return mixed Aliases for the types provided.
  */
 	public function mapType($ctype) {
@@ -729,7 +729,7 @@ class CakeResponse {
  * @param boolean $public  if set to true, the Cache-Control header will be set as public
  * if set to false, the response will be set to private
  * if no value is provided, it will return whether the response is sharable or not
- * @param int $time time in seconds after which the response should no longer be considered fresh
+ * @param integer $time time in seconds after which the response should no longer be considered fresh
  * @return boolean
  */
 	public function sharable($public = null, $time = null) {
@@ -764,7 +764,7 @@ class CakeResponse {
  * a good candidate to be fetched from a shared cache (like in a proxy server).
  * If called with no parameters, this function will return the current max-age value if any
  *
- * @param int $seconds if null, the method will return the current s-maxage value
+ * @param integer $seconds if null, the method will return the current s-maxage value
  * @return int
  */
 	public function sharedMaxAge($seconds = null) {
@@ -784,7 +784,7 @@ class CakeResponse {
  * a good candidate to be fetched from the local (client) cache.
  * If called with no parameters, this function will return the current max-age value if any
  *
- * @param int $seconds if null, the method will return the current max-age value
+ * @param integer $seconds if null, the method will return the current max-age value
  * @return int
  */
 	public function maxAge($seconds = null) {
@@ -805,7 +805,7 @@ class CakeResponse {
  * with the origin.
  * If called with no parameters, this function will return wheter must-revalidate is present.
  *
- * @param int $seconds if null, the method will return the current
+ * @param integer $seconds if null, the method will return the current
  * must-revalidate value
  * @return boolean
  */
@@ -965,7 +965,7 @@ class CakeResponse {
  * Returns a DateTime object initialized at the $time param and using UTC
  * as timezone
  *
- * @param string|int|DateTime $time
+ * @param string|integer|DateTime $time
  * @return DateTime
  */
 	protected function _getUTCDate($time = null) {

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -136,7 +136,7 @@ class CakeEmail {
 /**
  * Message ID
  *
- * @var mixed True to generate, False to ignore, String with value
+ * @var boolean|string True to generate, False to ignore, String with value
  */
 	protected $_messageId = true;
 
@@ -295,7 +295,7 @@ class CakeEmail {
 /**
  * Configuration to transport
  *
- * @var mixed
+ * @var string|array
  */
 	protected $_config = array();
 
@@ -308,7 +308,7 @@ class CakeEmail {
 
 /**
  * Constructor
- * @param mixed $config Array of configs, or string to load configs from email.php
+ * @param array|string $config Array of configs, or string to load configs from email.php
  *
  */
 	public function __construct($config = null) {
@@ -332,9 +332,9 @@ class CakeEmail {
 /**
  * From
  *
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  * @throws SocketException
  */
 	public function from($email = null, $name = null) {
@@ -347,9 +347,9 @@ class CakeEmail {
 /**
  * Sender
  *
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  * @throws SocketException
  */
 	public function sender($email = null, $name = null) {
@@ -362,9 +362,9 @@ class CakeEmail {
 /**
  * Reply-To
  *
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  * @throws SocketException
  */
 	public function replyTo($email = null, $name = null) {
@@ -377,9 +377,9 @@ class CakeEmail {
 /**
  * Read Receipt (Disposition-Notification-To header)
  *
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  * @throws SocketException
  */
 	public function readReceipt($email = null, $name = null) {
@@ -392,9 +392,9 @@ class CakeEmail {
 /**
  * Return Path
  *
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  * @throws SocketException
  */
 	public function returnPath($email = null, $name = null) {
@@ -407,9 +407,9 @@ class CakeEmail {
 /**
  * To
  *
- * @param mixed $email Null to get, String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email Null to get, String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  */
 	public function to($email = null, $name = null) {
 		if ($email === null) {
@@ -421,7 +421,7 @@ class CakeEmail {
 /**
  * Add To
  *
- * @param mixed $email String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
  * @return CakeEmail $this
  */
@@ -432,9 +432,9 @@ class CakeEmail {
 /**
  * Cc
  *
- * @param mixed $email String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  */
 	public function cc($email = null, $name = null) {
 		if ($email === null) {
@@ -446,7 +446,7 @@ class CakeEmail {
 /**
  * Add Cc
  *
- * @param mixed $email String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
  * @return CakeEmail $this
  */
@@ -457,9 +457,9 @@ class CakeEmail {
 /**
  * Bcc
  *
- * @param mixed $email String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return mixed
+ * @return array|CakeEmail
  */
 	public function bcc($email = null, $name = null) {
 		if ($email === null) {
@@ -471,7 +471,7 @@ class CakeEmail {
 /**
  * Add Bcc
  *
- * @param mixed $email String with email, Array with email as key, name as value or email as value (without name)
+ * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
  * @return CakeEmail $this
  */
@@ -513,8 +513,8 @@ class CakeEmail {
  * Set email
  *
  * @param string $varName
- * @param mixed $email
- * @param mixed $name
+ * @param string|array $email
+ * @param string $name
  * @return CakeEmail $this
  * @throws SocketException
  */
@@ -547,7 +547,7 @@ class CakeEmail {
  * Set only 1 email
  *
  * @param string $varName
- * @param mixed $email
+ * @param string|array $email
  * @param string $name
  * @param string $throwMessage
  * @return CakeEmail $this
@@ -567,8 +567,8 @@ class CakeEmail {
  * Add email
  *
  * @param string $varName
- * @param mixed $email
- * @param mixed $name
+ * @param string|array $email
+ * @param string $name
  * @return CakeEmail $this
  * @throws SocketException
  */
@@ -600,8 +600,8 @@ class CakeEmail {
 /**
  * Get/Set Subject.
  *
- * @param null|string $subject
- * @return mixed
+ * @param string $subject
+ * @return string|CakeEmail
  */
 	public function subject($subject = null) {
 		if ($subject === null) {
@@ -749,9 +749,9 @@ class CakeEmail {
 /**
  * Template and layout
  *
- * @param mixed $template Template name or null to not use
- * @param mixed $layout Layout name or null to not use
- * @return mixed
+ * @param boolean|string $template Template name or null to not use
+ * @param boolean|string $layout Layout name or null to not use
+ * @return array|CakeEmail
  */
 	public function template($template = false, $layout = false) {
 		if ($template === false) {
@@ -771,7 +771,7 @@ class CakeEmail {
  * View class for render
  *
  * @param string $viewClass
- * @return mixed
+ * @return string|CakeEmail
  */
 	public function viewRender($viewClass = null) {
 		if ($viewClass === null) {
@@ -785,7 +785,7 @@ class CakeEmail {
  * Variables to be set on render
  *
  * @param array $viewVars
- * @return mixed
+ * @return array|CakeEmail
  */
 	public function viewVars($viewVars = null) {
 		if ($viewVars === null) {
@@ -799,7 +799,7 @@ class CakeEmail {
  * Theme to use when rendering
  *
  * @param string $theme
- * @return mixed
+ * @return string|CakeEmail
  */
 	public function theme($theme = null) {
 		if ($theme === null) {
@@ -813,7 +813,7 @@ class CakeEmail {
  * Helpers to be used in render
  *
  * @param array $helpers
- * @return mixed
+ * @return array|CakeEmail
  */
 	public function helpers($helpers = null) {
 		if ($helpers === null) {
@@ -827,7 +827,7 @@ class CakeEmail {
  * Email format
  *
  * @param string $format
- * @return mixed
+ * @return string|CakeEmail
  * @throws SocketException
  */
 	public function emailFormat($format = null) {
@@ -845,7 +845,7 @@ class CakeEmail {
  * Transport name
  *
  * @param string $name
- * @return mixed
+ * @return string|CakeEmail
  */
 	public function transport($name = null) {
 		if ($name === null) {
@@ -881,8 +881,8 @@ class CakeEmail {
 /**
  * Message-ID
  *
- * @param mixed $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
- * @return mixed
+ * @param boolean|string $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
+ * @return boolean|string|CakeEmail
  * @throws SocketException
  */
 	public function messageId($message = null) {
@@ -904,7 +904,7 @@ class CakeEmail {
  * Domain as top level (the part after @)
  *
  * @param string $domain Manually set the domain for CLI mailing
- * @return mixed
+ * @return string|CakeEmail
  */
 	public function domain($domain = null) {
 		if ($domain === null) {
@@ -944,8 +944,8 @@ class CakeEmail {
  * The `contentId` key allows you to specify an inline attachment. In your email text, you
  * can use `<img src="cid:abc123" />` to display the image inline.
  *
- * @param mixed $attachments String with the filename or array with filenames
- * @return mixed Either the array of attachments when getting or $this when setting.
+ * @param string|array $attachments String with the filename or array with filenames
+ * @return array|CakeEmail Either the array of attachments when getting or $this when setting.
  * @throws SocketException
  */
 	public function attachments($attachments = null) {
@@ -979,7 +979,7 @@ class CakeEmail {
 /**
  * Add attachments
  *
- * @param mixed $attachments String with the filename or array with filenames
+ * @param string|array $attachments String with the filename or array with filenames
  * @return CakeEmail $this
  * @throws SocketException
  */
@@ -993,8 +993,8 @@ class CakeEmail {
 /**
  * Get generated message (used by transport classes)
  *
- * @param mixed $type Use MESSAGE_* constants or null to return the full message as array
- * @return mixed String if have type, array if type is null
+ * @param string $type Use MESSAGE_* constants or null to return the full message as array
+ * @return string|array String if have type, array if type is null
  */
 	public function message($type = null) {
 		switch ($type) {
@@ -1009,8 +1009,8 @@ class CakeEmail {
 /**
  * Configuration to use when send email
  *
- * @param mixed $config String with configuration name (from email.php), array with config or null to return current config
- * @return mixed
+ * @param string|array $config String with configuration name (from email.php), array with config or null to return current config
+ * @return string|array|CakeEmail
  */
 	public function config($config = null) {
 		if ($config === null) {
@@ -1027,7 +1027,7 @@ class CakeEmail {
 /**
  * Send an email using the specified content, template and layout
  * 
- * @param mixed $content String with message or array with messages
+ * @param string|array $content String with message or array with messages
  * @return array
  * @throws SocketException
  */
@@ -1061,10 +1061,10 @@ class CakeEmail {
 /**
  * Static method to fast create an instance of CakeEmail
  *
- * @param mixed $to Address to send (see CakeEmail::to()). If null, will try to use 'to' from transport config
- * @param mixed $subject String of subject or null to use 'subject' from transport config
- * @param mixed $message String with message or array with variables to be used in render
- * @param mixed $transportConfig String to use config from EmailConfig or array with configs
+ * @param string|array $to Address to send (see CakeEmail::to()). If null, will try to use 'to' from transport config
+ * @param string $subject String of subject or null to use 'subject' from transport config
+ * @param string|array $message String with message or array with variables to be used in render
+ * @param string|array $transportConfig String to use config from EmailConfig or array with configs
  * @param boolean $send Send the email or just return the instance pre-configured
  * @return CakeEmail Instance of CakeEmail
  * @throws SocketException

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -207,7 +207,7 @@ class SmtpTransport extends AbstractTransport {
  * Protected method for sending data to SMTP connection
  *
  * @param string $data data to be sent to SMTP server
- * @param mixed $checkCode code to check for in server response, false to skip
+ * @param string|boolean $checkCode code to check for in server response, false to skip
  * @return void
  * @throws SocketException
  */

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -178,7 +178,7 @@ class HttpResponse implements ArrayAccess {
  * 'body' and 'header' or false on failure.
  *
  * @param string $body A string containing the body to decode.
- * @param mixed $encoding Can be false in case no encoding is being used, or a string representing the encoding.
+ * @param string|boolean $encoding Can be false in case no encoding is being used, or a string representing the encoding.
  * @return mixed Array of response headers and body or false.
  */
 	protected function _decodeBody($body, $encoding = 'chunked') {
@@ -373,7 +373,7 @@ class HttpResponse implements ArrayAccess {
 /**
  * ArrayAccess - Offset Exists
  *
- * @param mixed $offset
+ * @param string $offset
  * @return boolean
  */
 	public function offsetExists($offset) {
@@ -383,7 +383,7 @@ class HttpResponse implements ArrayAccess {
 /**
  * ArrayAccess - Offset Get
  *
- * @param mixed $offset
+ * @param string $offset
  * @return mixed
  */
 	public function offsetGet($offset) {
@@ -420,7 +420,7 @@ class HttpResponse implements ArrayAccess {
 /**
  * ArrayAccess - Offset Set
  *
- * @param mixed $offset
+ * @param string $offset
  * @param mixed $value
  * @return void
  */
@@ -430,7 +430,7 @@ class HttpResponse implements ArrayAccess {
 /**
  * ArrayAccess - Offset Unset
  *
- * @param mixed $offset
+ * @param string $offset
  * @return void
  */
 	public function offsetUnset($offset) {

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -143,7 +143,7 @@ class HttpSocket extends CakeSocket {
  *
  * See HttpSocket::$config for options that can be used.
  *
- * @param mixed $config Configuration information, either a string url or an array of options.
+ * @param string|array $config Configuration information, either a string url or an array of options.
  */
 	public function __construct($config = array()) {
 		if (is_string($config)) {
@@ -185,7 +185,7 @@ class HttpSocket extends CakeSocket {
  * `$http->configAuth();`
  *
  * @param string $method Authentication method (ie. Basic, Digest). If empty, disable authentication
- * @param mixed $user Username for authentication. Can be an array with settings to authentication class
+ * @param string|array $user Username for authentication. Can be an array with settings to authentication class
  * @param string $pass Password for authentication
  * @return void
  */
@@ -204,7 +204,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Set proxy settings
  *
- * @param mixed $host Proxy host. Can be an array with settings to authentication class
+ * @param string|array $host Proxy host. Can be an array with settings to authentication class
  * @param integer $port Port. Default 3128.
  * @param string $method Proxy method (ie, Basic, Digest). If empty, disable proxy authentication
  * @param string $user Username if your proxy need authentication
@@ -226,7 +226,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Set the resource to receive the request content. This resource must support fwrite.
  *
- * @param mixed $resource Resource or false to disable the resource use
+ * @param resource|boolean $resource Resource or false to disable the resource use
  * @return void
  * @throws SocketException
  */
@@ -245,7 +245,7 @@ class HttpSocket extends CakeSocket {
  * Issue the specified request. HttpSocket::get() and HttpSocket::post() wrap this
  * method and provide a more granular interface.
  *
- * @param mixed $request Either an URI string, or an array defining host/uri
+ * @param string|array $request Either an URI string, or an array defining host/uri
  * @return mixed false on error, HttpResponse on success
  * @throws SocketException
  */
@@ -429,7 +429,7 @@ class HttpSocket extends CakeSocket {
  * );
  * }}}
  *
- * @param mixed $uri URI to request. Either a string uri, or a uri array, see HttpSocket::_parseUri()
+ * @param string|array $uri URI to request. Either a string uri, or a uri array, see HttpSocket::_parseUri()
  * @param array $query Querystring parameters to append to URI
  * @param array $request An indexed array with indexes such as 'method' or uri
  * @return mixed Result of request, either false on failure or the response to the request.
@@ -461,7 +461,7 @@ class HttpSocket extends CakeSocket {
  * ));
  * }}}
  *
- * @param mixed $uri URI to request. See HttpSocket::_parseUri()
+ * @param string|array $uri URI to request. See HttpSocket::_parseUri()
  * @param array $data Array of POST data keys and values.
  * @param array $request An indexed array with indexes such as 'method' or uri
  * @return mixed Result of request, either false on failure or the response to the request.
@@ -474,7 +474,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Issues a PUT request to the specified URI, query, and request.
  *
- * @param mixed $uri URI to request, See HttpSocket::_parseUri()
+ * @param string|array $uri URI to request, See HttpSocket::_parseUri()
  * @param array $data Array of PUT data keys and values.
  * @param array $request An indexed array with indexes such as 'method' or uri
  * @return mixed Result of request
@@ -487,7 +487,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Issues a DELETE request to the specified URI, query, and request.
  *
- * @param mixed $uri URI to request (see {@link _parseUri()})
+ * @param string|array $uri URI to request (see {@link _parseUri()})
  * @param array $data Query to append to URI
  * @param array $request An indexed array with indexes such as 'method' or uri
  * @return mixed Result of request
@@ -520,7 +520,7 @@ class HttpSocket extends CakeSocket {
  *
  * Would return `/search?q=socket`.
  *
- * @param mixed $url Either a string or array of url options to create a url with.
+ * @param string|array Either a string or array of url options to create a url with.
  * @param string $uriTemplate A template string to use for url formatting.
  * @return mixed Either false on failure or a string containing the composed url.
  */
@@ -616,7 +616,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Parses and sets the specified URI into current request configuration.
  *
- * @param mixed $uri URI, See HttpSocket::_parseUri()
+ * @param string|array $uri URI, See HttpSocket::_parseUri()
  * @return boolean If uri has merged in config
  */
 	protected function _configUri($uri = null) {
@@ -646,7 +646,7 @@ class HttpSocket extends CakeSocket {
 /**
  * Takes a $uri array and turns it into a fully qualified URL string
  *
- * @param mixed $uri Either A $uri array, or a request string. Will use $this->config if left empty.
+ * @param string|array $uri Either A $uri array, or a request string. Will use $this->config if left empty.
  * @param string $uriTemplate The Uri template/format to use.
  * @return mixed A fully qualified URL formatted according to $uriTemplate, or false on failure
  */
@@ -694,8 +694,8 @@ class HttpSocket extends CakeSocket {
  * Parses the given URI and breaks it down into pieces as an indexed array with elements
  * such as 'scheme', 'port', 'query'.
  *
- * @param string $uri URI to parse
- * @param mixed $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
+ * @param string|array $uri URI to parse
+ * @param boolean|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
  * @return array Parsed URI
  */
 	protected function _parseUri($uri = null, $base = array()) {
@@ -759,7 +759,7 @@ class HttpSocket extends CakeSocket {
  * A leading '?' mark in $query is optional and does not effect the outcome of this function.
  * For the complete capabilities of this implementation take a look at HttpSocketTest::testparseQuery()
  *
- * @param mixed $query A query string to parse into an array or an array to return directly "as is"
+ * @param string|array $query A query string to parse into an array or an array to return directly "as is"
  * @return array The $query parsed into a possibly multi-level array. If an empty $query is
  *     given, an empty array is returned.
  */

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -457,7 +457,7 @@ class Router {
  *    integer values and UUIDs.
  * - 'prefix' - URL prefix to use for the generated routes.  Defaults to '/'.
  *
- * @param mixed $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
+ * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
  * @param array $options Options to use when generating REST routes
  * @return array Array of mapped resources
  */
@@ -729,11 +729,11 @@ class Router {
  * - `#` - Allows you to set url hash fragments.
  * - `full_base` - If true the `FULL_BASE_URL` constant will be prepended to generated urls.
  *
- * @param mixed $url Cake-relative URL, like "/products/edit/92" or "/presidents/elect/4"
+ * @param string|array $url Cake-relative URL, like "/products/edit/92" or "/presidents/elect/4"
  *   or an array specifying any of the following: 'controller', 'action',
  *   and/or 'plugin', in addition to named arguments (keyed array elements),
  *   and standard URL arguments (indexed array elements)
- * @param mixed $full If (bool) true, the full base URL will be prepended to the result.
+ * @param bool|array $full If (bool) true, the full base URL will be prepended to the result.
  *   If an array accepts the following keys
  *    - escape - used when making urls embedded in html escapes query string '&'
  *    - full - if true the full base URL will be prepended.
@@ -1016,7 +1016,7 @@ class Router {
  * and replace any double /'s.  It will not unify the casing and underscoring
  * of the input value.
  *
- * @param mixed $url URL to normalize Either an array or a string url.
+ * @param array|string $url URL to normalize Either an array or a string url.
  * @return string Normalized URL
  */
 	public static function normalize($url = '/') {

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -76,7 +76,7 @@ class TestShellDispatcher extends ShellDispatcher {
 /**
  * getShell
  *
- * @param mixed $shell
+ * @param string $shell
  * @return mixed
  */
 	public function getShell($shell) {
@@ -86,7 +86,7 @@ class TestShellDispatcher extends ShellDispatcher {
 /**
  * _getShell
  *
- * @param mixed $plugin
+ * @param string $plugin
  * @return mixed
  */
 	protected function _getShell($shell) {

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -534,7 +534,7 @@ class DbAclTest extends CakeTestCase {
  * Used by debug to format strings used in the data dump
  *
  * @param string $string
- * @param int $len
+ * @param integer $len
  * @return void
  */
 	protected function __pad($string = '', $len = 14) {

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -178,7 +178,7 @@ class AuthTestController extends Controller {
 /**
  * redirect method
  *
- * @param mixed $url
+ * @param string|array $url
  * @param mixed $status
  * @param mixed $exit
  * @return void
@@ -258,7 +258,7 @@ class AjaxAuthController extends Controller {
 /**
  * redirect method
  *
- * @param mixed $url
+ * @param string|array $url
  * @param mixed $status
  * @param mixed $exit
  * @return void

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -589,7 +589,7 @@ class CookieComponentTest extends CakeTestCase {
 /**
  * encrypt method
  *
- * @param mixed $value
+ * @param array|string $value
  * @return string
  */
 	protected function __encrypt($value) {

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -86,7 +86,7 @@ class SecurityTestController extends Controller {
 /**
  * redirect method
  *
- * @param mixed $option
+ * @param string|array $url
  * @param mixed $code
  * @param mixed $exit
  * @return void

--- a/lib/Cake/Test/Case/Controller/ComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentTest.php
@@ -89,7 +89,7 @@ class AppleComponent extends Component {
 /**
  * startup method
  *
- * @param mixed $controller
+ * @param Controller $controller
  * @return void
  */
 	public function startup(Controller $controller) {
@@ -115,7 +115,7 @@ class OrangeComponent extends Component {
 /**
  * initialize method
  *
- * @param mixed $controller
+ * @param Controller $controller
  * @return void
  */
 	public function initialize(Controller $controller) {

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -97,7 +97,7 @@ class ControllerPost extends CakeTestModel {
 /**
  * find method
  *
- * @param mixed $type
+ * @param string $type
  * @param array $options
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -188,7 +188,7 @@ class DbAroUserTest extends CakeTestModel {
 /**
  * bindNode method
  *
- * @param mixed $ref
+ * @param string|array|Model $ref
  * @return void
  */
 	public function bindNode($ref = null) {

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -39,7 +39,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * setup method
  *
- * @param mixed $model
+ * @param Model $model
  * @param array $config
  * @return void
  */
@@ -54,8 +54,8 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeFind method
  *
- * @param mixed $model
- * @param mixed $query
+ * @param Model $model
+ * @param array $query
  * @return void
  */
 	public function beforeFind(Model $model, $query) {
@@ -81,9 +81,9 @@ class TestBehavior extends ModelBehavior {
 /**
  * afterFind method
  *
- * @param mixed $model
- * @param mixed $results
- * @param mixed $primary
+ * @param Model $model
+ * @param array $results
+ * @param boolean $primary
  * @return void
  */
 	public function afterFind(Model $model, $results, $primary) {
@@ -110,7 +110,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeSave method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function beforeSave(Model $model) {
@@ -135,8 +135,8 @@ class TestBehavior extends ModelBehavior {
 /**
  * afterSave method
  *
- * @param mixed $model
- * @param mixed $created
+ * @param Model $model
+ * @param boolean $created
  * @return void
  */
 	public function afterSave(Model $model, $created) {
@@ -167,7 +167,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeValidate method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function beforeValidate(Model $model) {
@@ -197,7 +197,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeDelete method
  *
- * @param mixed $model
+ * @param Model $model
  * @param bool $cascade
  * @return void
  */
@@ -226,7 +226,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * afterDelete method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function afterDelete(Model $model) {
@@ -244,7 +244,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * onError method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function onError(Model $model, $error) {
@@ -258,7 +258,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeTest method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function beforeTest(Model $model) {
@@ -272,7 +272,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * testMethod method
  *
- * @param mixed $model
+ * @param Model $model
  * @param bool $param
  * @return void
  */
@@ -285,7 +285,7 @@ class TestBehavior extends ModelBehavior {
 /**
  * testData method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	public function testData(Model $model) {
@@ -299,8 +299,8 @@ class TestBehavior extends ModelBehavior {
 /**
  * validateField method
  *
- * @param mixed $model
- * @param mixed $field
+ * @param Model $model
+ * @param string|array $field
  * @return void
  */
 	public function validateField(Model $model, $field) {
@@ -310,9 +310,9 @@ class TestBehavior extends ModelBehavior {
 /**
  * speakEnglish method
  *
- * @param mixed $model
- * @param mixed $method
- * @param mixed $query
+ * @param Model $model
+ * @param string $method
+ * @param string $query
  * @return void
  */
 	public function speakEnglish(Model $model, $method, $query) {

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -1051,7 +1051,7 @@ class MysqlTest extends CakeTestCase {
 /**
  * buildRelatedModels method
  *
- * @param mixed $model
+ * @param Model $model
  * @return void
  */
 	protected function _buildRelatedModels(Model $model) {
@@ -1071,9 +1071,9 @@ class MysqlTest extends CakeTestCase {
 /**
  * &_prepareAssociationQuery method
  *
- * @param mixed $model
- * @param mixed $queryData
- * @param mixed $binding
+ * @param Model $model
+ * @param array $queryData
+ * @param array $binding
  * @return void
  */
 	protected function &_prepareAssociationQuery(Model $model, &$queryData, $binding) {

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -294,7 +294,7 @@ class Article extends CakeTestModel {
 /**
  * titleDuplicate method
  *
- * @param mixed $title
+ * @param string $title
  * @return void
  */
 	public static function titleDuplicate($title) {
@@ -959,7 +959,7 @@ class Author extends CakeTestModel {
 /**
  * afterFind method
  *
- * @param mixed $results
+ * @param array $results
  * @return void
  */
 	public function afterFind($results, $primary = false) {
@@ -986,7 +986,7 @@ class ModifiedAuthor extends Author {
 /**
  * afterFind method
  *
- * @param mixed $results
+ * @param array $results
  * @return void
  */
 	public function afterFind($results, $primary = false) {
@@ -1208,7 +1208,7 @@ class NodeAfterFind extends CakeTestModel {
  * afterFind method
  *
  * @param mixed $results
- * @return void
+ * @return array
  */
 	public function afterFind($results, $primary = false) {
 		return $results;
@@ -2532,8 +2532,8 @@ class NumberTree extends CakeTestModel {
 /**
  * initialize method
  *
- * @param int $levelLimit
- * @param int $childLimit
+ * @param integer $levelLimit
+ * @param integer $childLimit
  * @param mixed $currentLevel
  * @param mixed $parent_id
  * @param string $prefix

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1748,7 +1748,7 @@ XML;
 /**
  * loadEnvironment method
  *
- * @param mixed $env
+ * @param array $env
  * @return void
  */
 	protected function __loadEnvironment($env) {

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -40,7 +40,7 @@ class TestHttpResponse extends HttpResponse {
  * Convenience method for testing protected method
  *
  * @param string $body A string containing the body to decode
- * @param mixed $encoding Can be false in case no encoding is being used, or a string representing the encoding
+ * @param boolean|string $encoding Can be false in case no encoding is being used, or a string representing the encoding
  * @return mixed Array or false
  */
 	public function decodeBody($body, $encoding = 'chunked') {

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -84,7 +84,7 @@ class TestHttpSocket extends HttpSocket {
 /**
  * Convenience method for testing protected method
  *
- * @param mixed $uri URI (see {@link _parseUri()})
+ * @param string|array $uri URI (see {@link _parseUri()})
  * @return array Current configuration settings
  */
 	public function configUri($uri = null) {
@@ -94,8 +94,8 @@ class TestHttpSocket extends HttpSocket {
 /**
  * Convenience method for testing protected method
  *
- * @param string $uri URI to parse
- * @param mixed $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
+ * @param string|array $uri URI to parse
+ * @param boolean|array $base If true use default URI config, otherwise indexed array to set 'scheme', 'host', 'port', etc.
  * @return array Parsed URI
  */
 	public function parseUri($uri = null, $base = array()) {
@@ -126,7 +126,7 @@ class TestHttpSocket extends HttpSocket {
 /**
  * Convenience method for testing protected method
  *
- * @param mixed $query A query string to parse into an array or an array to return directly "as is"
+ * @param string|array $query A query string to parse into an array or an array to return directly "as is"
  * @return array The $query parsed into a possibly multi-level array. If an empty $query is given, an empty array is returned.
  */
 	public function parseQuery($query) {

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -54,8 +54,9 @@ class TestDispatcher extends Dispatcher {
 /**
  * invoke method
  *
- * @param mixed $controller
- * @param mixed $request
+ * @param Controller $controller
+ * @param CakeRequest $request
+ * @param CakeResponse $response
  * @return void
  */
 	protected function _invoke(Controller $controller, CakeRequest $request, CakeResponse $response) {
@@ -66,7 +67,7 @@ class TestDispatcher extends Dispatcher {
 /**
  * Helper function to test single method attaching for dispatcher filters
  *
- * @param CakeEvent
+ * @param CakeEvent $event
  * @return void
  */
 	public function filterTest($event) {
@@ -181,7 +182,7 @@ class SomePagesController extends AppController {
 /**
  * display method
  *
- * @param mixed $page
+ * @param string $page
  * @return void
  */
 	public function display($page = null) {
@@ -232,7 +233,7 @@ class OtherPagesController extends MyPluginAppController {
 /**
  * display method
  *
- * @param mixed $page
+ * @param string $page
  * @return void
  */
 	public function display($page = null) {
@@ -1691,7 +1692,7 @@ class DispatcherTest extends CakeTestCase {
 /**
  * loadEnvironment method
  *
- * @param mixed $env
+ * @param array $env
  * @return void
  */
 	protected function __loadEnvironment($env) {
@@ -1725,7 +1726,7 @@ class DispatcherTest extends CakeTestCase {
 /**
  * cachePath method
  *
- * @param mixed $her
+ * @param string $here
  * @return string
  */
 	protected function __cachePath($here) {

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -33,7 +33,7 @@ class TestScaffoldView extends ScaffoldView {
 /**
  * testGetFilename method
  *
- * @param mixed $action
+ * @param string $action
  * @return void
  */
 	public function testGetFilename($action) {

--- a/lib/Cake/Test/Case/View/ThemeViewTest.php
+++ b/lib/Cake/Test/Case/View/ThemeViewTest.php
@@ -62,7 +62,7 @@ class TestTheme2View extends ThemeView {
 /**
  * renderElement method
  *
- * @param mixed $name
+ * @param string $name
  * @param array $params
  * @return void
  */
@@ -73,7 +73,7 @@ class TestTheme2View extends ThemeView {
 /**
  * getViewFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getViewFileName($name = null) {
@@ -83,7 +83,7 @@ class TestTheme2View extends ThemeView {
 /**
  * getLayoutFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getLayoutFileName($name = null) {

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -110,7 +110,7 @@ class TestThemeView extends View {
 /**
  * renderElement method
  *
- * @param mixed $name
+ * @param string $name
  * @param array $params
  * @return void
  */
@@ -121,7 +121,7 @@ class TestThemeView extends View {
 /**
  * getViewFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getViewFileName($name = null) {
@@ -131,7 +131,7 @@ class TestThemeView extends View {
 /**
  * getLayoutFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getLayoutFileName($name = null) {
@@ -150,7 +150,7 @@ class TestView extends View {
 /**
  * getViewFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getViewFileName($name = null) {
@@ -160,7 +160,7 @@ class TestView extends View {
 /**
  * getLayoutFileName method
  *
- * @param mixed $name
+ * @param string $name
  * @return void
  */
 	public function getLayoutFileName($name = null) {

--- a/lib/Cake/TestSuite/Fixture/CakeTestModel.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestModel.php
@@ -57,7 +57,7 @@ class CakeTestModel extends Model {
  * Overriding save() to set CakeTestSuiteDispatcher::date() as formatter for created, modified and updated fields
  *
  * @param array $data
- * @param mixed $validate
+ * @param boolean|array $validate
  * @param array $fieldList
  */
 

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -302,7 +302,7 @@ class CakeTime {
 /**
  * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Parsed timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -340,7 +340,7 @@ class CakeTime {
  * See http://php.net/manual/en/function.strftime.php for information on formatting
  * using locale strings.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @param string $format The format to use. If null, `TimeHelper::$niceFormat` is used
  * @return string Formatted date string
@@ -369,7 +369,7 @@ class CakeTime {
  * If $dateString's year is the current year, the returned string does not
  * include mention of the year.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Described, relative date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -413,8 +413,8 @@ class CakeTime {
 /**
  * Returns a partial SQL string to search for all records between two dates.
  *
- * @param int|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
- * @param int|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -433,7 +433,7 @@ class CakeTime {
  * Returns a partial SQL string to search for all records between two times
  * occurring on the same day.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -446,7 +446,7 @@ class CakeTime {
 /**
  * Returns true if given datetime string is today.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string is today
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -459,7 +459,7 @@ class CakeTime {
 /**
  * Returns true if given datetime string is within this week.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current week
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -471,7 +471,7 @@ class CakeTime {
 
 /**
  * Returns true if given datetime string is within this month
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current month
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -484,7 +484,7 @@ class CakeTime {
 /**
  * Returns true if given datetime string is within current year.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current year
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -497,7 +497,7 @@ class CakeTime {
 /**
  * Returns true if given datetime string was yesterday.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -511,7 +511,7 @@ class CakeTime {
 /**
  * Returns true if given datetime string is tomorrow.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -524,7 +524,7 @@ class CakeTime {
 /**
  * Returns the quarter
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param boolean $range if true returns a range in Y-m-d format
  * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -560,8 +560,7 @@ class CakeTime {
 
 /**
  * Returns a UNIX timestamp from a textual datetime description. Wrapper for PHP function strtotime().
- *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return integer Unix timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -579,7 +578,7 @@ class CakeTime {
  * If no timezone parameter is given and no DateTime object, the passed $dateString will be
  * considered to be in the UTC timezone.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @param string $format date format string
  * @return mixed Formatted date
@@ -624,7 +623,7 @@ class CakeTime {
 /**
  * Formats date for RSS feeds
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -687,7 +686,7 @@ class CakeTime {
  *
  * NOTE: If the difference is one week or more, the lowest level of accuracy is day
  *
- * @param int|string|DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object
  * @param array $options Default format if timestamp is used in $dateString
  * @return string Relative time string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -854,9 +853,9 @@ class CakeTime {
 /**
  * Returns true if specified datetime was within the interval specified, else false.
  *
- * @param mixed $timeInterval the numeric value with space then time type.
+ * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -879,9 +878,9 @@ class CakeTime {
 /**
  * Returns true if specified datetime is within the interval specified, else false.
  *
- * @param mixed $timeInterval the numeric value with space then time type.
+ * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return boolean
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -904,7 +903,7 @@ class CakeTime {
 /**
  * Returns gmt as a UNIX timestamp.
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @return integer UNIX timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -928,8 +927,8 @@ class CakeTime {
  * This function also accepts a time string and a format string as first and second parameters.
  * In that case this function behaves as a wrapper for TimeHelper::i18nFormat()
  *
- * @param int|string|DateTime $format date format string (or UNIX timestamp, strtotime() valid string or DateTime object)
- * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
+ * @param integer|string|DateTime $format date format string (or UNIX timestamp, strtotime() valid string or DateTime object)
+ * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
  * @param boolean $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted date string
@@ -953,7 +952,7 @@ class CakeTime {
  * Returns a formatted date string, given either a UNIX timestamp or a valid strtotime() date string.
  * It take in account the default date format for the current language if a LC_TIME file is used.
  *
- * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format strftime format string.
  * @param boolean $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
@@ -1031,7 +1030,7 @@ class CakeTime {
  * Handles utf8_encoding the result of strftime when necessary.
  *
  * @param string $format Format string.
- * @param int $date Timestamp to format.
+ * @param integer $date Timestamp to format.
  * @return string formatted string with correct encoding.
  */
 	protected static function _strftime($format, $date) {

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -974,7 +974,7 @@ class CakeTime {
 /**
  * Get list of timezone identifiers
  *
- * @param int|string $filter A regex to filter identifer
+ * @param integer|string $filter A regex to filter identifer
  * 	Or one of DateTimeZone class constants (PHP 5.3 and above)
  * @param string $country A two-letter ISO 3166-1 compatible country code.
  * 	This option is only used when $filter is set to DateTimeZone::PER_COUNTRY (available only in PHP 5.3 and above)

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -85,7 +85,7 @@ class ClassRegistry {
  *		array('class' => 'ClassName', 'alias' => 'AliasNameStoredInTheRegistry')
  * );
  * }}}
- * @param mixed $class as a string or a single key => value array instance will be created,
+ * @param string|array $class as a string or a single key => value array instance will be created,
  *  stored in the registry and returned.
  * @param boolean $strict if set to true it will return false if the class was not found instead
  *	of trying to create an AppModel
@@ -195,8 +195,8 @@ class ClassRegistry {
 /**
  * Add $object to the registry, associating it with the name $key.
  *
- * @param string $key	Key for the object in registry
- * @param mixed $object	Object to store
+ * @param string $key		Key for the object in registry
+ * @param object $object	Object to store
  * @return boolean True if the object was written, false if $key already exists
  */
 	public static function addObject($key, $object) {

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -183,7 +183,7 @@ class File {
 /**
  * Sets or gets the offset for the currently opened file.
  *
- * @param mixed $offset The $offset in bytes to seek. If set to false then the current offset is returned.
+ * @param integer|boolean $offset The $offset in bytes to seek. If set to false then the current offset is returned.
  * @param integer $seek PHP Constant SEEK_SET | SEEK_CUR | SEEK_END determining what the $offset is relative to
  * @return mixed True on success, false on failure (set mode), false on failure or integer offset on success (get mode)
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::offset
@@ -372,7 +372,7 @@ class File {
 /**
  * Get md5 Checksum of file with previous check of Filesize
  *
- * @param mixed $maxsize in MB or true to force
+ * @param integer|boolean $maxsize in MB or true to force
  * @return string md5 Checksum {@link http://php.net/md5_file See md5_file()}
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::md5
  */

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -79,7 +79,7 @@ class Folder {
  *
  * @param string $path Path to folder
  * @param boolean $create Create folder if not found
- * @param mixed $mode Mode (CHMOD) to apply to created folder, false to ignore
+ * @param string|boolean $mode Mode (CHMOD) to apply to created folder, false to ignore
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder
  */
 	public function __construct($path = false, $create = false, $mode = false) {
@@ -132,7 +132,7 @@ class Folder {
  *
  * @param boolean $sort Whether you want the results sorted, set this and the sort property
  *   to false to get unsorted results.
- * @param mixed $exceptions Either an array or boolean true will not grab dot files
+ * @param array|boolean $exceptions Either an array or boolean true will not grab dot files
  * @param boolean $fullPath True returns the full path
  * @return mixed Contents of current directory as an array, an empty array on failure
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::read
@@ -394,7 +394,7 @@ class Folder {
  * Returns an array of nested directories and files in each directory
  *
  * @param string $path the directory path to build the tree from
- * @param mixed $exceptions Either an array of files/folder to exclude
+ * @param array|boolean $exceptions Either an array of files/folder to exclude
  *   or boolean true to not grab dot files/folders
  * @param string $type either 'file' or 'dir'. null returns both files and directories
  * @return mixed array of nested directories and files in each directory
@@ -595,7 +595,7 @@ class Folder {
  * - `mode` The mode to copy the files/directories with.
  * - `skip` Files/directories to skip.
  *
- * @param mixed $options Either an array of options (see above) or a string of the destination directory.
+ * @param array|string $options Either an array of options (see above) or a string of the destination directory.
  * @return boolean Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::copy
  */

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -34,7 +34,7 @@ class Hash {
  * but is faster for simple read operations.
  *
  * @param array $data Array of data to operate on.
- * @param mixed $path The path being searched for. Either a dot
+ * @param string|array $path The path being searched for. Either a dot
  *   separated string, or an array of path segments.
  * @return mixed The value fetched from the array, or null.
  */
@@ -224,7 +224,7 @@ class Hash {
  *
  * @param array $data The data to insert into.
  * @param string $path The path to insert at.
- * @param mixed $values The values to insert.
+ * @param array $values The values to insert.
  * @return array The data with $values inserted.
  */
 	public static function insert(array $data, $path, $values = null) {
@@ -821,8 +821,8 @@ class Hash {
  * This method differs from the built-in array_diff() in that it will preserve keys
  * and work on multi-dimensional arrays.
  *
- * @param mixed $data First value
- * @param mixed $compare Second value
+ * @param array $data First value
+ * @param array $compare Second value
  * @return array Returns the key => value pairs that are not common in $data and $compare
  *    The expression for this function is ($data - $compare) + ($compare - ($data - $compare))
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::diff
@@ -872,7 +872,7 @@ class Hash {
 /**
  * Normalizes an array, and converts it to a standard format.
  *
- * @param mixed $data List to normalize
+ * @param array $data List to normalize
  * @param boolean $assoc If true, $data will be converted to an associative array.
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::normalize
@@ -916,7 +916,7 @@ class Hash {
  *   Should be compatible with Hash::extract(). Defaults to `{n}.$alias.parent_id`
  * - `root` The id of the desired top-most result.
  *
- * @param mixed $data The data to nest.
+ * @param array $data The data to nest.
  * @param array $options Options are:
  * @return array of results, nested
  * @see Hash::extract()

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -211,7 +211,7 @@ abstract class ObjectCollection {
  * @param string|array $name CamelCased name of the object(s) to enable (string or array)
  * 	If string the second param $priority is used else it should be an associative array
  * 	with keys as object names and values as priorities to set.
- * @param int|null Integer priority to set or null for default
+ * @param integer|null Integer priority to set or null for default
  * @return void
  */
 	public function setPriority($name, $priority = null) {

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -203,8 +203,8 @@ class Sanitize {
  * - backslash -
  * - remove_html - Strip HTML with strip_tags. `encode` must be true for this option to work.
  *
- * @param mixed $data Data to sanitize
- * @param mixed $options If string, DB connection being used, otherwise set of options
+ * @param string|array $data Data to sanitize
+ * @param string|array $options If string, DB connection being used, otherwise set of options
  * @return mixed Sanitized data
  */
 	public static function clean($data, $options = array()) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -68,8 +68,8 @@ class Set {
 /**
  * Pushes the differences in $array2 onto the end of $array
  *
- * @param mixed $array Original array
- * @param mixed $array2 Differences to push
+ * @param array $array Original array
+ * @param array $array2 Differences to push
  * @return array Combined array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::pushDiff
  */
@@ -203,8 +203,8 @@ class Set {
  *
  * $list defaults to 0 = no 1 = yes if param is not passed
  *
- * @param mixed $select Key in $list to return
- * @param mixed $list can be an array or a comma-separated list.
+ * @param array $select Key in $list to return
+ * @param array|string $list can be an array or a comma-separated list.
  * @return string the value of the array key or null if no match
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::enum
  */
@@ -455,7 +455,7 @@ class Set {
 /**
  * This function can be used to see if a single item or a given xpath match certain conditions.
  *
- * @param mixed $conditions An array of condition strings or an XPath expression
+ * @param string|array $conditions An array of condition strings or an XPath expression
  * @param array $data  An array of data to execute the match on
  * @param integer $i Optional: The 'nth'-number of the item being matched.
  * @param integer $length
@@ -532,7 +532,7 @@ class Set {
  * a regular expression.
  *
  * @param array $data Array from where to extract
- * @param mixed $path As an array, or as a dot-separated string.
+ * @param string|array $path As an array, or as a dot-separated string.
  * @return array Extracted data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::classicExtract
  */
@@ -618,8 +618,8 @@ class Set {
 /**
  * Inserts $data into an array as defined by $path.
  *
- * @param mixed $list Where to insert into
- * @param mixed $path A dot-separated string.
+ * @param array $list Where to insert into
+ * @param string $path A dot-separated string.
  * @param array $data Data to insert
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::insert
@@ -631,8 +631,8 @@ class Set {
 /**
  * Removes an element from a Set or array as defined by $path.
  *
- * @param mixed $list From where to remove
- * @param mixed $path A dot-separated string.
+ * @param array $list From where to remove
+ * @param string $path A dot-separated string.
  * @return array Array with $path removed from its value
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::remove
  */
@@ -643,8 +643,8 @@ class Set {
 /**
  * Checks if a particular path is set in an array
  *
- * @param mixed $data Data to check on
- * @param mixed $path A dot-separated string.
+ * @param string|array $data Data to check on
+ * @param string|array $path A dot-separated string.
  * @return boolean true if path is found, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::check
  */
@@ -787,9 +787,9 @@ class Set {
  * to null (useful for Set::merge). You can optionally group the values by what is obtained when
  * following the path specified in $groupPath.
  *
- * @param mixed $data Array or object from where to extract keys and values
- * @param mixed $path1 As an array, or as a dot-separated string.
- * @param mixed $path2 As an array, or as a dot-separated string.
+ * @param array|object $data Array or object from where to extract keys and values
+ * @param string|array $path1 As an array, or as a dot-separated string.
+ * @param string|array $path2 As an array, or as a dot-separated string.
  * @param string $groupPath As an array, or as a dot-separated string.
  * @return array Combined array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::combine
@@ -1088,8 +1088,8 @@ class Set {
 /**
  * Return the value at the specified position
  *
- * @param mixed $input an array
- * @param mixed $path string or array of array keys
+ * @param array $input an array
+ * @param string|array $path string or array of array keys
  * @return the value at the specified position or null if it doesn't exist
  */
 	public static function get($input, $path = null) {

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -330,7 +330,7 @@ class String {
  * - `indentAt` 0 based index to start indenting at. Defaults to 0.
  *
  * @param string $text Text the text to format.
- * @param mixed $options Array of options to use, or an integer to wrap the text to.
+ * @param array|integer $options Array of options to use, or an integer to wrap the text to.
  * @return string Formatted text.
  */
 	public static function wrap($text, $options = array()) {

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -56,7 +56,7 @@ class Validation {
  * $check can be passed as an array:
  * array('check' => 'valueToCheck');
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @return boolean Success
  */
 	public static function notEmpty($check) {
@@ -78,7 +78,7 @@ class Validation {
  * $check can be passed as an array:
  * array('check' => 'valueToCheck');
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @return boolean Success
  */
 	public static function alphaNumeric($check) {
@@ -114,7 +114,7 @@ class Validation {
  * $check can be passed as an array:
  * array('check' => 'valueToCheck');
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @return boolean Success
  */
 	public static function blank($check) {
@@ -128,8 +128,8 @@ class Validation {
  * Validation of credit card numbers.
  * Returns true if $check is in the proper credit card format.
  *
- * @param mixed $check credit card number to validate
- * @param mixed $type 'all' may be passed as a sting, defaults to fast which checks format of most major credit cards
+ * @param string|array $check credit card number to validate
+ * @param string|array $type 'all' may be passed as a sting, defaults to fast which checks format of most major credit cards
  *    if an array is used only the values of the array are checked.
  *    Example: array('amex', 'bankcard', 'maestro')
  * @param boolean $deep set to true this will check the Luhn algorithm of the credit card.
@@ -200,7 +200,7 @@ class Validation {
 /**
  * Used to compare 2 numeric values.
  *
- * @param mixed $check1 if string is passed for a string must also be passed for $check2
+ * @param string|array $check1 if string is passed for a string must also be passed for $check2
  *    used as an array it must be passed as array('check1' => value, 'operator' => 'value', 'check2' -> value)
  * @param string $operator Can be either a word or operand
  *    is greater >, is less <, greater or equal >=
@@ -261,7 +261,7 @@ class Validation {
 /**
  * Used when a custom regular expression is needed.
  *
- * @param mixed $check When used as a string, $regex must also be a valid regular expression.
+ * @param string|array $check When used as a string, $regex must also be a valid regular expression.
  *								As and array: array('check' => value, 'regex' => 'valid regular expression')
  * @param string $regex If $check is passed as a string, $regex must also be set to valid regular expression
  * @return boolean Success
@@ -282,7 +282,7 @@ class Validation {
  * keys that expect full month, day and year will validate leap years
  *
  * @param string $check a valid date string
- * @param mixed $format Use a string or an array of the keys below. Arrays should be passed as array('dmy', 'mdy', etc)
+ * @param string|array $format Use a string or an array of the keys below. Arrays should be passed as array('dmy', 'mdy', etc)
  * 	      Keys: dmy 27-12-2006 or 27-12-06 separators can be a space, period, dash, forward slash
  * 	            mdy 12-27-2006 or 12-27-06 separators can be a space, period, dash, forward slash
  * 	            ymd 2006-12-27 or 06-12-27 separators can be a space, period, dash, forward slash
@@ -320,7 +320,7 @@ class Validation {
  * All values matching the "date" core validation rule, and the "time" one will be valid
  *
  * @param array $check Value to check
- * @param mixed $dateFormat Format of the date part
+ * @param string|array $dateFormat Format of the date part
  * Use a string or an array of the keys below. Arrays should be passed as array('dmy', 'mdy', etc)
  * ## Keys:
  *
@@ -440,7 +440,7 @@ class Validation {
 /**
  * Check that value has a valid file extension.
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @param array $extensions file extensions to allow
  * @return boolean Success
  */
@@ -525,8 +525,8 @@ class Validation {
  * - max => maximum number of non-zero choices that can be made
  * - min => minimum number of non-zero choices that can be made
  *
- * @param mixed $check Value to check
- * @param mixed $options Options for the check.
+ * @param array $check Value to check
+ * @param array $options Options for the check.
  * @param boolean $strict Defaults to true, set to false to disable strict type check
  * @return boolean Success
  */
@@ -566,7 +566,7 @@ class Validation {
 /**
  * Check that a value is a valid phone number.
  *
- * @param mixed $check Value to check (string or array)
+ * @param string|array $check Value to check (string or array)
  * @param string $regex Regular expression to use
  * @param string $country Country code (defaults to 'all')
  * @return boolean Success
@@ -596,7 +596,7 @@ class Validation {
 /**
  * Checks that a given value is a valid postal code.
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @param string $regex Regular expression to use
  * @param string $country Country to use for formatting
  * @return boolean Success
@@ -655,7 +655,7 @@ class Validation {
 /**
  * Checks that a value is a valid Social Security Number.
  *
- * @param mixed $check Value to check
+ * @param string|array $check Value to check
  * @param string $regex Regular expression to use
  * @param string $country Country
  * @return boolean Success
@@ -727,7 +727,7 @@ class Validation {
 /**
  * Runs an user-defined validation.
  *
- * @param mixed $check value that will be validated in user-defined methods.
+ * @param string|array $check value that will be validated in user-defined methods.
  * @param object $object class that holds validation method
  * @param string $method class method name for validation to run
  * @param array $args arguments to send to method
@@ -775,7 +775,7 @@ class Validation {
 /**
  * Runs a regular expression match.
  *
- * @param mixed $check Value to check against the $regex expression
+ * @param string $check Value to check against the $regex expression
  * @param string $regex Regular expression
  * @return boolean Success of match
  */

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -76,7 +76,7 @@ class Xml {
  * - `return` Can be 'simplexml' to return object of SimpleXMLElement or 'domdocument' to return DOMDocument.
  * - If using array as input, you can pass `options` from Xml::fromArray.
  *
- * @param mixed $input XML string, a path to a file, an URL or an array
+ * @param string|array $input XML string, a path to a file, an URL or an array
  * @param array $options The options to use
  * @return SimpleXMLElement|DOMDocument SimpleXMLElement or DOMDocument
  * @throws XmlException

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -231,7 +231,7 @@ class Helper extends Object {
  *
  * Returns a URL pointing at the provided parameters.
  *
- * @param mixed $url Either a relative string url like `/products/view/23` or
+ * @param string|array $url Either a relative string url like `/products/view/23` or
  *    an array of url parameters.  Using an array for urls will allow you to leverage
  *    the reverse routing features of CakePHP.
  * @param boolean $full If true, the full base URL will be prepended to the result
@@ -360,7 +360,7 @@ class Helper extends Object {
  * from content.  However, is not guaranteed to remove all possibilities.  Escaping
  * content is the best way to prevent all possible attacks.
  *
- * @param mixed $output Either an array of strings to clean or a single string to clean.
+ * @param string|array $output Either an array of strings to clean or a single string to clean.
  * @return string|array cleaned content for output
  */
 	public function clean($output) {
@@ -474,7 +474,7 @@ class Helper extends Object {
 /**
  * Sets this helper's model and field properties to the dot-separated value-pair in $entity.
  *
- * @param mixed $entity A field name, like "ModelName.fieldName" or "ModelName.ID.fieldName"
+ * @param string $entity A field name, like "ModelName.fieldName" or "ModelName.ID.fieldName"
  * @param boolean $setScope Sets the view scope to the model specified in $tagValue
  * @return void
  */
@@ -583,7 +583,7 @@ class Helper extends Object {
  * Generates a DOM ID for the selected element, if one is not set.
  * Uses the current View::entity() settings to generate a CamelCased id attribute.
  *
- * @param mixed $options Either an array of html attributes to add $id into, or a string
+ * @param array|string $options Either an array of html attributes to add $id into, or a string
  *   with a view entity path to get a domId for.
  * @param string $id The name of the 'id' attribute.
  * @return mixed If $options was an array, an array will be returned with $id set.  If a string
@@ -615,7 +615,7 @@ class Helper extends Object {
  * Gets the input field name for the current tag. Creates input name attributes
  * using CakePHP's data[Model][field] formatting.
  *
- * @param mixed $options If an array, should be an array of attributes that $key needs to be added to.
+ * @param array|string $options If an array, should be an array of attributes that $key needs to be added to.
  *   If a string or null, will be used as the View entity.
  * @param string $field
  * @param string $key The name of the attribute to be set, defaults to 'name'
@@ -659,7 +659,7 @@ class Helper extends Object {
 /**
  * Gets the data for the current tag
  *
- * @param mixed $options If an array, should be an array of attributes that $key needs to be added to.
+ * @param array|string $options If an array, should be an array of attributes that $key needs to be added to.
  *   If a string or null, will be used as the View entity.
  * @param string $field
  * @param string $key The name of the attribute to be set, defaults to 'value'
@@ -839,7 +839,7 @@ class Helper extends Object {
  * Transforms a recordset from a hasAndBelongsToMany association to a list of selected
  * options for a multiple select element
  *
- * @param mixed $data
+ * @param string|array $data
  * @param string $key
  * @return array
  */

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -475,7 +475,7 @@ class FormHelper extends AppHelper {
  * array('label' => 'save', 'name' => 'Whatever', 'div' => array('class' => 'good')); <div class="good"> value="save" name="Whatever"
  * }}}
  *
- * @param mixed $options as a string will use $options as the value of button,
+ * @param string|array $options as a string will use $options as the value of button,
  * @return string a closing FORM tag optional submit button.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#closing-the-form
  */
@@ -578,7 +578,7 @@ class FormHelper extends AppHelper {
  *
  * @param boolean $lock Whether this field should be part of the validation
  *     or excluded as part of the unlockedFields.
- * @param mixed $field Reference to field to be secured.  Should be dot separated to indicate nesting.
+ * @param string|array $field Reference to field to be secured.  Should be dot separated to indicate nesting.
  * @param mixed $value Field value, if value should not be tampered with.
  * @return void
  */
@@ -634,7 +634,7 @@ class FormHelper extends AppHelper {
  * - `class` string  The classname for the error message
  *
  * @param string $field A field name, like "Modelname.fieldname"
- * @param mixed $text Error message as string or array of messages.
+ * @param string|array $text Error message as string or array of messages.
  * If array contains `attributes` key it will be used as options for error container
  * @param array $options Rendering options for <div /> wrapper tag
  * @return string If there are errors this method returns an error message, otherwise null.
@@ -761,7 +761,7 @@ class FormHelper extends AppHelper {
  * @param string $text Text that will appear in the label field.  If
  *   $text is left undefined the text will be inflected from the
  *   fieldName.
- * @param mixed $options An array of HTML attributes, or a string, to be used as a class name.
+ * @param array|string $options An array of HTML attributes, or a string, to be used as a class name.
  * @return string The formatted LABEL element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::label
  */
@@ -819,7 +819,7 @@ class FormHelper extends AppHelper {
  * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
  *	to customize the legend text.
  *
- * @param mixed $fields An array of fields to generate inputs for, or null.
+ * @param array $fields An array of fields to generate inputs for, or null.
  * @param array $blacklist a simple array of fields to not create inputs for.
  * @return string Completed form inputs.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
@@ -1555,7 +1555,7 @@ class FormHelper extends AppHelper {
  * - Other options is the same of button method.
  *
  * @param string $title The button's caption. Not automatically HTML encoded
- * @param mixed $url URL as string or array
+ * @param string|array $url URL as string or array
  * @param array $options Array of options and HTML attributes.
  * @return string A HTML button tag.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postButton
@@ -1588,7 +1588,7 @@ class FormHelper extends AppHelper {
  * - The option `onclick` will be replaced.
  *
  * @param string $title The content to be wrapped by <a> tags.
- * @param mixed $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
+ * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
  * @param array $options Array of HTML attributes.
  * @param string $confirmMessage JavaScript confirmation message.
  * @return string An `<a />` element.

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -171,7 +171,7 @@ class HtmlHelper extends AppHelper {
  *
  * @param string $name Text for link
  * @param string $link URL for link (if empty it won't be a link)
- * @param mixed $options Link attributes e.g. array('id' => 'selected')
+ * @param string|array $options Link attributes e.g. array('id' => 'selected')
  * @return void
  * @see HtmlHelper::link() for details on $options that can be used.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
@@ -228,7 +228,7 @@ class HtmlHelper extends AppHelper {
  *   will override the inline option.
  *
  * @param string $type The title of the external resource
- * @param mixed $url The address of the external resource or string for content attribute
+ * @param string|array $url The address of the external resource or string for content attribute
  * @param array $options Other attributes for the generated tag. If the type attribute is html,
  *    rss, atom, or icon, the mime-type is returned.
  * @return string A completed `<link />` element.
@@ -323,7 +323,7 @@ class HtmlHelper extends AppHelper {
  * - `confirm` JavaScript confirmation message.
  *
  * @param string $title The content to be wrapped by <a> tags.
- * @param mixed $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
+ * @param string|array $url Cake-relative URL or array of URL parameters, or external URL (starts with http://)
  * @param array $options Array of HTML attributes.
  * @param string $confirmMessage JavaScript confirmation message.
  * @return string An `<a />` element.
@@ -397,7 +397,7 @@ class HtmlHelper extends AppHelper {
  *   option.
  * - `plugin` False value will prevent parsing path as a plugin
  *
- * @param mixed $path The name of a CSS style sheet or an array containing names of
+ * @param string|array $path The name of a CSS style sheet or an array containing names of
  *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
  *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
  * @param string $rel Rel attribute. Defaults to "stylesheet". If equal to 'import' the stylesheet will be imported.
@@ -487,8 +487,8 @@ class HtmlHelper extends AppHelper {
  *   included once, use false to allow the same script to be included more than once per request.
  * - `plugin` False value will prevent parsing path as a plugin
  *
- * @param mixed $url String or array of javascript files to include
- * @param mixed $options Array of options, and html attributes see above. If boolean sets $options['inline'] = value
+ * @param string|array $url String or array of javascript files to include
+ * @param array|boolean $options Array of options, and html attributes see above. If boolean sets $options['inline'] = value
  * @return mixed String of `<script />` tags or null if $inline is false or if $once is true and the file has been
  *   included before.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::script
@@ -651,7 +651,7 @@ class HtmlHelper extends AppHelper {
  * All other keys will be passed to HtmlHelper::link() as the `$options` parameter.
  *
  * @param string $separator Text to separate crumbs.
- * @param mixed $startText This will be the first crumb, if false it defaults to first crumb in array. Can
+ * @param string|array|boolean $startText This will be the first crumb, if false it defaults to first crumb in array. Can
  *   also be an array, see above for details.
  * @return string Composed bread crumbs
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
@@ -681,7 +681,7 @@ class HtmlHelper extends AppHelper {
  * crumb was added with.
  *
  * @param array $options Array of html attributes to apply to the generated list elements.
- * @param mixed $startText This will be the first crumb, if false it defaults to first crumb in array. Can
+ * @param string|array|boolean $startText This will be the first crumb, if false it defaults to first crumb in array. Can
  *   also be an array, see `HtmlHelper::getCrumbs` for details.
  * @return string breadcrumbs html list
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
@@ -1155,7 +1155,7 @@ class HtmlHelper extends AppHelper {
  * - `attributeFormat` Format for long attributes e.g. `'%s="%s"'`
  * - `minimizedAttributeFormat` Format for minimized attributes e.g. `'%s="%s"'`
  *
- * @param mixed $configFile String with the config file (load using PhpReader) or an array with file and reader name
+ * @param string|array $configFile String with the config file (load using PhpReader) or an array with file and reader name
  * @param string $path Path with config file
  * @return mixed False to error or loaded configs
  * @throws ConfigureException

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -244,7 +244,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
  *
  * If the 'update' key is set, success callback will be overridden.
  *
- * @param mixed $url
+ * @param string|array $url
  * @param array $options See JsHelper::request() for options.
  * @return string The completed ajax call.
  * @see JsBaseEngineHelper::request() for options list.

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -69,7 +69,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
  * Redirects to a URL.  Creates a window.location modification snippet
  * that can be used to trigger 'redirects' from Javascript.
  *
- * @param mixed $url
+ * @param string|array $url
  * @param array  $options
  * @return string completed redirect in javascript
  */
@@ -366,7 +366,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
  * - `dataExpression` - Should the `data` key be treated as a callback.  Useful for supplying `$options['data']` as
  *    another Javascript expression.
  *
- * @param mixed $url Array or String URL to target with the request.
+ * @param string|array $url Array or String URL to target with the request.
  * @param array $options Array of options. See above for cross library supported options
  * @return string XHR request.
  */

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -283,7 +283,7 @@ class JsHelper extends AppHelper {
  * - `buffer` - Disable the buffering and return a script tag in addition to the link.
  *
  * @param string $title Title for the link.
- * @param mixed $url Mixed either a string URL or an cake url array.
+ * @param string|array $url Mixed either a string URL or an cake url array.
  * @param array $options Options for both the HTML element and Js::request()
  * @return string Completed link. If buffering is disabled a script tag will be returned as well.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::link
@@ -321,8 +321,8 @@ class JsHelper extends AppHelper {
  * output when the buffer is fetched with `JsHelper::getBuffer()` or `JsHelper::writeBuffer()`
  * The Javascript variable used to output set variables can be controlled with `JsHelper::$setVariable`
  *
- * @param mixed $one Either an array of variables to set, or the name of the variable to set.
- * @param mixed $two If $one is a string, $two is the value for that key.
+ * @param string|array $one Either an array of variables to set, or the name of the variable to set.
+ * @param string|array $two If $one is a string, $two is the value for that key.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/js.html#JsHelper::set
  */

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -229,7 +229,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
  * Requires `Request`.  If you wish to use 'update' key you must have ```Request.HTML```
  * if you wish to do Json requests you will need ```JSON``` and ```Request.JSON```.
  *
- * @param mixed $url
+ * @param string|array $url
  * @param array $options
  * @return string The completed ajax call.
  */

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -135,7 +135,7 @@ class PaginatorHelper extends AppHelper {
 /**
  * Sets default options for all pagination links
  *
- * @param mixed $options Default options for pagination links. If a string is supplied - it
+ * @param array|string $options Default options for pagination links. If a string is supplied - it
  *   is used as the DOM id element to update. See PaginatorHelper::$options for list of keys.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::options
@@ -189,7 +189,7 @@ class PaginatorHelper extends AppHelper {
  * Gets the current key by which the recordset is sorted
  *
  * @param string $model Optional model name.  Uses the default if none is specified.
- * @param mixed $options Options for pagination links. See #options for list of keys.
+ * @param array $options Options for pagination links. See #options for list of keys.
  * @return string The name of the key by which the recordset is being sorted, or
  *  null if the results are not currently sorted.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sortKey
@@ -215,7 +215,7 @@ class PaginatorHelper extends AppHelper {
  * Gets the current direction the recordset is sorted
  *
  * @param string $model Optional model name.  Uses the default if none is specified.
- * @param mixed $options Options for pagination links. See #options for list of keys.
+ * @param array $options Options for pagination links. See #options for list of keys.
  * @return string The direction by which the recordset is being sorted, or
  *  null if the results are not currently sorted.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sortDir
@@ -276,9 +276,9 @@ class PaginatorHelper extends AppHelper {
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
  *
  * @param string $title Title for the link. Defaults to 'Next >>'.
- * @param mixed $options Options for pagination link. See above for list of keys.
+ * @param array $options Options for pagination link. See above for list of keys.
  * @param string $disabledTitle Title when the link is disabled.
- * @param mixed $disabledOptions Options for the disabled pagination link. See above for list of keys.
+ * @param array $disabledOptions Options for the disabled pagination link. See above for list of keys.
  * @return string A "next" link or or $disabledTitle text if the link is disabled.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::next
  */
@@ -356,7 +356,7 @@ class PaginatorHelper extends AppHelper {
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
  *
  * @param string $title Title for the link.
- * @param mixed $url Url for the action. See Router::url()
+ * @param string|array $url Url for the action. See Router::url()
  * @param array $options Options for the link. See #options for list of keys.
  * @return string A link with pagination parameters.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::link
@@ -564,7 +564,7 @@ class PaginatorHelper extends AppHelper {
  * - `separator` The separator string to use, default to ' of '
  *
  * The `%page%` style placeholders also work, but are deprecated and will be removed in a future version.
- * @param mixed $options Options for the counter string. See #options for list of keys.
+ * @param array $options Options for the counter string. See #options for list of keys.
  * @return string Counter string.
  * @deprecated The %page% style placeholders are deprecated.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
@@ -651,7 +651,7 @@ class PaginatorHelper extends AppHelper {
  * - `class` Class for wrapper tag
  * - `currentClass` Class for wrapper tag on current active page, defaults to 'current'
  *
- * @param mixed $options Options for the numbers, (before, after, model, modulus, separator)
+ * @param array $options Options for the numbers, (before, after, model, modulus, separator)
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::numbers
  */
@@ -782,9 +782,9 @@ class PaginatorHelper extends AppHelper {
  * - `separator` Content between the generated links, defaults to ' | '
  * - `ellipsis` Content for ellipsis, defaults to '...'
  *
- * @param mixed $first if string use as label for the link. If numeric, the number of page links
+ * @param string|integer $first if string use as label for the link. If numeric, the number of page links
  *   you want at the beginning of the range.
- * @param mixed $options An array of options.
+ * @param array $options An array of options.
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::first
  */
@@ -848,8 +848,8 @@ class PaginatorHelper extends AppHelper {
  * - `separator` Content between the generated links, defaults to ' | '
  * - `ellipsis` Content for ellipsis, defaults to '...'
  *
- * @param mixed $last if string use as label for the link, if numeric print page numbers
- * @param mixed $options Array of options
+ * @param string|integer $last if string use as label for the link, if numeric print page numbers
+ * @param array $options Array of options
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last
  */

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -229,7 +229,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 /**
  * Create an Ajax or Ajax.Updater call.
  *
- * @param mixed $url
+ * @param string|array $url
  * @param array $options
  * @return string The completed ajax call.
  */

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -116,8 +116,8 @@ class RssHelper extends AppHelper {
  * Returns an RSS `<channel />` element
  *
  * @param array $attrib `<channel />` tag attributes
- * @param mixed $elements Named array elements which are converted to tags
- * @param mixed $content Content (`<item />`'s belonging to this channel
+ * @param array $elements Named array elements which are converted to tags
+ * @param string $content Content (`<item />`'s belonging to this channel
  * @return string An RSS `<channel />`
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::channel
  */
@@ -161,7 +161,7 @@ class RssHelper extends AppHelper {
  * of `<item />` tags
  *
  * @param array $items The list of items to be mapped
- * @param mixed $callback A string function name, or array containing an object
+ * @param string|array $callback A string function name, or array containing an object
  *     and a string method name
  * @return string A set of RSS `<item />` elements
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::items
@@ -271,7 +271,7 @@ class RssHelper extends AppHelper {
 /**
  * Converts a time in any format to an RSS time
  *
- * @param mixed $time
+ * @param integer|string|DateTime $time
  * @return string An RSS-formatted timestamp
  * @see TimeHelper::toRSS
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::time
@@ -285,7 +285,7 @@ class RssHelper extends AppHelper {
  *
  * @param string $name The name of the XML element
  * @param array $attrib The attributes of the XML element
- * @param mixed $content XML element content
+ * @param string|array $content XML element content
  * @param boolean $endTag Whether the end tag of the element should be printed
  * @return string XML
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/rss.html#RssHelper::elem

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -137,7 +137,7 @@ class TimeHelper extends AppHelper {
  * @see CakeTime::convert()
  *
  * @param string $serverTime UNIX timestamp
- * @param mixed $timezone User's timezone string or DateTimeZone object
+ * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return integer UNIX timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -158,7 +158,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::fromString()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Parsed timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -170,7 +170,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::nice()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @param string $format The format to use. If null, `TimeHelper::$niceFormat` is used
  * @return string Formatted date string
@@ -183,7 +183,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::niceShort()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime objectp
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime objectp
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Described, relative date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -195,8 +195,8 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::daysAsSql()
  *
- * @param int|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
- * @param int|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -209,7 +209,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::dayAsSql()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Partial SQL string.
@@ -222,7 +222,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isToday()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string is today
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -234,7 +234,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isThisWeek()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current week
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -246,7 +246,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isThisMonth()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current month
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -258,7 +258,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isThisYear()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string is within current year
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -270,7 +270,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::wasYesterday()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -283,7 +283,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isTomorrow()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean True if datetime string was yesterday
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -295,7 +295,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::toQuarter()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param boolean $range if true returns a range in Y-m-d format
  * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -307,7 +307,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::toUnix()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return integer Unix timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -319,7 +319,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::toAtom()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -331,7 +331,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::toRSS()
  *
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -351,7 +351,7 @@ class TimeHelper extends AppHelper {
  *   - `class` - The classname to use, defaults to `time-ago-in-words`.
  *   - `title` - Defaults to the $dateTime input.
  *
- * @param int|string|DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateTime UNIX timestamp, strtotime() valid string or DateTime object
  * @param array $options Default format if timestamp is used in $dateString
  * @return string Relative time string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
@@ -391,9 +391,9 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::wasWithinLast()
  *
- * @param mixed $timeInterval the numeric value with space then time type.
+ * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -405,9 +405,9 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::isWithinLast()
  *
- * @param mixed $timeInterval the numeric value with space then time type.
+ * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
- * @param int|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return boolean
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#testing-time
@@ -419,7 +419,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::gmt()
  *
- * @param int|string|DateTime $string UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $string UNIX timestamp, strtotime() valid string or DateTime object
  * @return integer UNIX timestamp
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
@@ -430,8 +430,8 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::format()
  *
- * @param int|string|DateTime $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
- * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
+ * @param integer|string|DateTime $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
+ * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
  * @param boolean $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
  * @return string Formatted date string
@@ -444,7 +444,7 @@ class TimeHelper extends AppHelper {
 /**
  * @see CakeTime::i18nFormat()
  *
- * @param int|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
+ * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format strftime format string.
  * @param boolean $invalid flag to ignore results of fromString == false
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -762,8 +762,8 @@ class View extends Object {
  * Allows a template or element to set a variable that will be available in
  * a layout or other element. Analogous to Controller::set().
  *
- * @param mixed $one A string or an array of data.
- * @param mixed $two Value in case $one is a string (which then works as the key).
+ * @param string|array $one A string or an array of data.
+ * @param string|array $two Value in case $one is a string (which then works as the key).
  *    Unused if $one is an associative array, otherwise serves as the values to $one's keys.
  * @return void
  */

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -154,7 +154,7 @@ if (!function_exists('sortByKey')) {
 /**
  * Convenience method for htmlspecialchars.
  *
- * @param mixed $text Text to wrap through htmlspecialchars.  Also works with arrays, and objects.
+ * @param string|array|object $text Text to wrap through htmlspecialchars.  Also works with arrays, and objects.
  *    Arrays will be mapped and have all their elements escaped.  Objects will be string cast if they
  *    implement a `__toString` method.  Otherwise the class name will be used.
  * @param boolean $double Encode existing html entities
@@ -415,7 +415,7 @@ function cache($path, $data = null, $expires = '+1 day', $target = 'cache') {
 /**
  * Used to delete files in the cache directories, or clear contents of cache directories
  *
- * @param mixed $params As String name to be searched for deletion, if name is a directory all files in
+ * @param string|array $params As String name to be searched for deletion, if name is a directory all files in
  *   directory will be deleted. If array, names to be searched for deletion. If clearCache() without params,
  *   all files in app/tmp/cache/views will be deleted
  * @param string $type Directory in tmp/cache defaults to view directory


### PR DESCRIPTION
Having "mixed" as a param type is not very informative while a lot of functions have a specific set of accepted variable types.

In this pull request, i went through the core code and updated all the mixed params to a proper list of well defined accepted variable types, which makes reading the API much easier.
