### PR TITLE
Fixed XmlArticle and XmlUser Models associations.

### DIFF
--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -39,8 +39,8 @@ class XmlArticle extends CakeTestModel {
  * @var array
  */
 	public $belongsTo = array(
-		'XmlUser' => array(
-			'className' => 'XmlArticle',
+		'User' => array(
+			'className' => 'XmlUser',
 			'foreignKey' => 'user_id'
 		)
 	);
@@ -65,7 +65,11 @@ class XmlUser extends CakeTestModel {
  *
  * @var array
  */
-	public $hasMany = array('Article');
+	public $hasMany = array(
+		'Article' => array(
+			'className' => 'XmlArticle'
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
Fixes failing `testWithModel` test and does no longer try to use the 'default' datasource. Pull Request #666 and 2.2 in one day, congrats' cakephp :)
