### PR TITLE
Overwrite option to skip file exists warnings in cake i18n extract

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -302,6 +302,11 @@ class ExtractTask extends AppShell {
 			->addOption('exclude', array(
 				'help' => __d('cake_console', 'Comma separated list of directories to exclude.' .
 					' Any path containing a path segment with the provided values will be skipped. E.g. test,vendors')
+			))
+			->addOption('overwrite', array(
+				'boolean' => true,
+				'default' => false,
+				'help' => __d('cake_console', 'Always overwrite existing .pot files.')
 			));
 	}
 
@@ -537,6 +542,10 @@ class ExtractTask extends AppShell {
  */
 	protected function _writeFiles() {
 		$overwriteAll = false;
+		if (!empty($this->params['overwrite'])) {
+			$overwriteAll = true;
+		}
+
 		foreach ($this->_storage as $domain => $sentences) {
 			$output = $this->_writeHeader();
 			foreach ($sentences as $sentence => $header) {

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -399,4 +399,26 @@ class ExtractTaskTest extends CakeTestCase {
 		$pattern = '#Plugin/TestPlugin/Model/TestPluginPost.php:validation for field title#';
 		$this->assertNotRegExp($pattern, $result);
 	}
+
+
+/**
+ *  Test that the extract shell overwrites existing files with the overwrite parameter
+ *
+ * @return void
+ */
+	public function testExtractOverwrite() {
+		$this->Task->interactive = false;
+
+		$this->Task->params['paths'] = CAKE . 'Test' . DS . 'test_app' . DS;
+		$this->Task->params['output'] = $this->path . DS;
+		$this->Task->params['overwrite'] = true;
+
+		file_put_contents($this->path . DS . 'default.pot', 'will be overwritten');
+		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
+		$original = file_get_contents($this->path . DS . 'default.pot');
+
+		$this->Task->execute();
+		$result = file_get_contents($this->path . DS . 'default.pot');
+		$this->assertNotEquals($original, $result);
+	}
 }


### PR DESCRIPTION
Currently the cake shell script doesn't like automation because it will always ask the user to confirm overwriting of existing .pot files.

The --overwrite parameter will make it default to overwrite all files which allows the extract shell script to be used in automation.
