### PR TITLE
Fixed failing test case in ModelValidationTest

### DIFF
--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -1972,7 +1972,7 @@ class ModelValidationTest extends BaseModelTest {
 			array('body' => 'foo3')
 		);
 		$user = new User();
-		$user->hasMany['CustomArticle'] = array('foreignKey' => 'user_id');
+		$user->bindModel(array('hasMany' => array('CustomArticle')));
 		$data = array(
 			'User' => array('user' => 'foo', 'password' => 'bar'),
 			'CustomArticle' => $articles


### PR DESCRIPTION
I would get an `undefined index 'className'` error. On-the-fly associations should use bindModel
