### PR TITLE
More support for Model/Datasource date formatters

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1252,13 +1252,23 @@ class Model extends Object implements CakeEventListener {
 			}
 
 			if ($useNewDate && !empty($date)) {
-				$format = $this->getDataSource()->columns[$type]['format'];
+				$columnTypes = $this->getDataSource()->columns[$type];
+				$format = $columnTypes['format'];
+
 				foreach (array('m', 'd', 'H', 'i', 's') as $index) {
 					if (isset($date[$index])) {
 						$date[$index] = sprintf('%02d', $date[$index]);
 					}
 				}
-				return str_replace(array_keys($date), array_values($date), $format);
+
+				$result = str_replace(array_keys($date), array_values($date), $format);
+
+				// Don't trigger on date()
+				if (!empty($columnTypes['formatter']) && $columnTypes['formatter'] !== 'date') {
+					$result = call_user_func($columnTypes['formatter'], $format, $result);
+				}
+
+				return $result;
 			}
 		}
 		return $data;

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -1188,7 +1188,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$timestamp = mktime(10, 12, 9, 8, 20, 2007);
 
 		// Test with formatter
-		$TestModel->getDataSource()->columns['datetime']['formatter'] = 'dateFormatter';
+		$TestModel->getDataSource()->columns['datetime']['formatter'] = 'ModelIntegrationTest::dateFormatter';
 		$TestModel->data = null;
 		$TestModel->set($data);
 		$expected = array('Apple' => array('created' => $timestamp));
@@ -2459,7 +2459,6 @@ class ModelIntegrationTest extends BaseModelTest {
 		$model->expects($this->never())->method('getDataSource');
 		$this->assertEmpty($model->schema());
 	}
-}
 
 /**
  * Global function used for datetime formatting during Model::deconstruct() and defined in the Datasource.
@@ -2468,10 +2467,12 @@ class ModelIntegrationTest extends BaseModelTest {
  * @param int $time
  * @return int
  */
-function dateFormatter($format, $time) {
-	if (is_string($time)) {
-		return strtotime($time);
+	public static function dateFormatter($format, $time) {
+		if (is_string($time)) {
+			return strtotime($time);
+		}
+
+		return (int) $time;
 	}
 
-	return (int) $time;
 }

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -277,10 +277,19 @@ class CakeTestSuiteDispatcher {
  * This method is being used as formatter for created, modified and updated fields in Model::save()
  *
  * @param string $format format to be used.
+ * @param mixed $time the timestamp to use
  * @return string formatted date
  */
-	public static function date($format) {
-		return date($format, self::time());
+	public static function date($format, $time = null) {
+		if (!$time) {
+			$time = self::time();
+		}
+
+		if (is_string($time)) {
+			$time = strtotime($time);
+		}
+
+		return date($format, $time);
 	}
 
 }


### PR DESCRIPTION
This allows date formatter functions to be called during the deconstruct() process and not just the save() process. This is helpful for systems that need custom date objects/strings, like MongoDB.

Example when setting the formatter to 'MongoDbDateFormatter' within the datasource.

``` php
function MongoDbDateFormatter($format, $time = null) {
    if (is_string($time)) {
        $time = strtotime($time);
    } else if (!$time) {
        $time = time();
    }

    return new MongoDate($time);
}
```

This is primarily to support non-created/modified datetime fields.
