### PR TITLE
Correctly identify absolute paths in HTMLHelper

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -423,7 +423,7 @@ class HtmlHelper extends AppHelper {
 			return;
 		}
 
-		if (strpos($path, '//') !== false) {
+		if (strpos($path, '//') !== false || substr($path, 0, 1) == '/') {
 			$url = $path;
 		} else {
 			$url = $this->assetUrl($path, $options + array('pathPrefix' => CSS_URL, 'ext' => '.css'));
@@ -518,8 +518,7 @@ class HtmlHelper extends AppHelper {
 			return null;
 		}
 		$this->_includedScripts[$url] = true;
-
-		if (strpos($url, '//') === false) {
+		if (strpos($url, '//') === false && substr($url, 0, 1) != '/') {
 			$url = $this->assetUrl($url, $options + array('pathPrefix' => JS_URL, 'ext' => '.js'));
 
 			if (Configure::read('Asset.filter.js')) {


### PR DESCRIPTION
http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html
states that absolute paths can be used for CSS and JS files.  The code only
checks for the presence of '//' in the path to determine if a path is absolute.
This patch adds checking the first character of the path for '/' to determine
if a path is an absolute path.  This is necessary if your CakePHP installation
isn't at the root directory.  For example, if your site lived at
/this/is/the/webroot and you wanted to include a script file located at
/some/other/directory/script.js then the HTMLHelper would incorrectly output
/this/is/the/webroot/some/other/directory/script.js

Example View code:
<?php echo $this->Html->script('/some/other/directory/script.js'); ?>
Works correctly if site is on the root of the domain, incorrectly if it is not.
