### PR TITLE
fixed pcre named capture bug from ticket #1763

### DIFF
--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -182,7 +182,7 @@ class ConsoleOutput {
 			return preg_replace('#</?(?:' . $tags . ')>#', '', $text);
 		}
 		return preg_replace_callback(
-			'/<(?<tag>[a-z0-9-_]+)>(?<text>.*?)<\/(\1)>/ims', array($this, '_replaceTags'), $text
+			'/<(?P<tag>[a-z0-9-_]+)>(?P<text>.*?)<\/(\1)>/ims', array($this, '_replaceTags'), $text
 		);
 	}
 


### PR DESCRIPTION
Use backwards compatible named capture, i.e. "(?P<name>...)" instead of "(?<name>...)"

Fixes 
http://cakephp.lighthouseapp.com/projects/42648/tickets/1763-php-warning-in-libcakeconsoleconsoleoutputphp-line-186

See changelog in http://de2.php.net/manual/en/function.preg-match.php

I was still having this issue with the latest standard CentOs packages php53-5.3.3-7.el5_8 and pcre-6.6-6.el5_6.1  despite the claim that named capture options were fixed in PHP 5.2.2
