### PR TITLE
2.2 cache logging

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -15,6 +15,7 @@
 
 App::uses('Inflector', 'Utility');
 App::uses('CacheEngine', 'Cache');
+App::uses('CakeLog', 'Log');
 
 /**
  * Cache provides a consistent interface to Caching in your application. It allows you
@@ -37,7 +38,7 @@ App::uses('CacheEngine', 'Cache');
  * general all Cache operations are supported by all cache engines.  However, Cache::increment() and
  * Cache::decrement() are not supported by File caching.
  *
- * @package       Cake.Cache
+ * @package	   Cake.Cache
  */
 class Cache {
 
@@ -63,6 +64,20 @@ class Cache {
  * @var array
  */
 	protected static $_engines = array();
+
+/**
+ * Cache query log entries mapped on cache config name.
+ *
+ * @var array
+ */
+	protected static $_logEntries = array();
+
+/**
+ * Number of cache operations to log, per cache engine.
+ *
+ * @var int
+ */
+	protected static $_logLimit = 200;
 
 /**
  * Set the cache configuration to use.  config() can
@@ -138,6 +153,41 @@ class Cache {
 			self::$_config[$name] = $settings;
 		}
 		return compact('engine', 'settings');
+	}
+
+
+/**
+ * Add cache query log entry to log list
+ *
+ * Any log entry is expected to have following keys:
+ * - `error` String describing error, that happened, or null, to indicate success.
+ * - `time` How long query took (SHALL be float)
+ * - `action` Name of method performed (i.e. 'write', 'decrement', etc.)
+ * - `key` Key being accessed/modified (non-transformed, i.e. as supplied by developer)
+ * - `value` Value being set/read
+ * - `config` Name of cache config used for operation
+ *
+ * @param array $log Cache query log entry
+ * @return void
+ */
+	protected static function _logAction(array $log) {
+		$defaults = array('error' => null, 'time' => 0, 'key' => null, 'value' => null);
+		$log = array_merge($defaults, $log);
+		if (!isset(self::$_logEntries[$log['config']])) {
+			self::$_logEntries[$log['config']] = array(
+				'count' => 0,
+				'time'  => 0,
+				'logs'  => array(),
+			);
+		}
+		++self::$_logEntries[$log['config']]['count'];
+		if ($log['time'] > 0 && $log['time'] < 1000000) {
+			self::$_logEntries[$log['config']]['time'] += $log['time'];
+		}
+		self::$_logEntries[$log['config']]['logs'][] = $log;
+		if (self::$_logLimit < count(self::$_logEntries[$log['config']]['logs'])) {
+			array_pop(self::$_logEntries[$log['config']]['logs']);
+		}
 	}
 
 /**
@@ -283,21 +333,34 @@ class Cache {
 	public static function write($key, $value, $config = 'default') {
 		$settings = self::settings($config);
 
+		$logEntry = compact('key', 'value', 'config');
+		$logEntry['action'] = __FUNCTION__;
+
 		if (empty($settings)) {
+			$logEntry['error'] = 'Settings for config not present';
+			self::_logAction($logEntry);
 			return false;
 		}
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
 		$key = self::$_engines[$config]->key($key);
 
 		if (!$key || is_resource($value)) {
+			$logEntry['error'] = 'Invalid key/value';
+			self::_logAction($logEntry);
 			return false;
 		}
 
+		$logEntry['time'] = microtime(true);
 		$success = self::$_engines[$config]->write($settings['prefix'] . $key, $value, $settings['duration']);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
 		self::set(null, $config);
 		if ($success === false && $value !== '') {
+			$logEntry['error'] = 'Write failed';
+			self::_logAction($logEntry);
 			trigger_error(
 				__d('cake_dev',
 					"%s cache was unable to write '%s' to %s cache",
@@ -307,6 +370,8 @@ class Cache {
 				),
 				E_USER_WARNING
 			);
+		} else {
+			self::_logAction($logEntry);
 		}
 		return $success;
 	}
@@ -333,17 +398,31 @@ class Cache {
 	public static function read($key, $config = 'default') {
 		$settings = self::settings($config);
 
+		$logEntry = compact('key', 'config');
+		$logEntry['action'] = __FUNCTION__;
+
 		if (empty($settings)) {
+			$logEntry['error'] = 'Settings for config not present';
+			self::_logAction($logEntry);
 			return false;
 		}
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
 		$key = self::$_engines[$config]->key($key);
 		if (!$key) {
+			$logEntry['error'] = 'Failed to transform key';
+			self::_logAction($logEntry);
 			return false;
 		}
-		return self::$_engines[$config]->read($settings['prefix'] . $key);
+		$logEntry['time'] = microtime(true);
+		$value = self::$_engines[$config]->read($settings['prefix'] . $key);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		$logEntry['value'] = $value;
+		self::_logAction($logEntry);
+		return $value;
 	}
 
 /**
@@ -353,23 +432,39 @@ class Cache {
  * @param integer $offset How much to add
  * @param string $config Optional string configuration name. Defaults to 'default'
  * @return mixed new value, or false if the data doesn't exist, is not integer,
- *    or if there was an error fetching it.
+ *	or if there was an error fetching it.
  */
 	public static function increment($key, $offset = 1, $config = 'default') {
 		$settings = self::settings($config);
 
+		$logEntry = compact('key', 'config');
+		$logEntry['value']  = $offset;
+		$logEntry['action'] = __FUNCTION__;
+
 		if (empty($settings)) {
+			$logEntry['error'] = 'Settings for config not present';
+			self::_logAction($logEntry);
 			return false;
 		}
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
 		$key = self::$_engines[$config]->key($key);
 
 		if (!$key || !is_integer($offset) || $offset < 0) {
+			$logEntry['error'] = 'Invalid key/offset';
+			self::_logAction($logEntry);
 			return false;
 		}
+		$logEntry['time'] = microtime(true);
 		$success = self::$_engines[$config]->increment($settings['prefix'] . $key, $offset);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		if (!$success) {
+			$logEntry['error'] = 'Increment operation failed';
+		}
+		self::_logAction($logEntry);
 		self::set(null, $config);
 		return $success;
 	}
@@ -386,18 +481,34 @@ class Cache {
 	public static function decrement($key, $offset = 1, $config = 'default') {
 		$settings = self::settings($config);
 
+		$logEntry = compact('key', 'config');
+		$logEntry['value']  = $offset;
+		$logEntry['action'] = __FUNCTION__;
+
 		if (empty($settings)) {
+			$logEntry['error'] = 'Settings for config not present';
+			self::_logAction($logEntry);
 			return false;
 		}
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
 		$key = self::$_engines[$config]->key($key);
 
 		if (!$key || !is_integer($offset) || $offset < 0) {
+			$logEntry['error'] = 'Invalid key/offset';
+			self::_logAction($logEntry);
 			return false;
 		}
+		$logEntry['time'] = microtime(true);
 		$success = self::$_engines[$config]->decrement($settings['prefix'] . $key, $offset);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		if (!$success) {
+			$logEntry['error'] = 'Decrement operation failed';
+		}
+		self::_logAction($logEntry);
 		self::set(null, $config);
 		return $success;
 	}
@@ -422,18 +533,33 @@ class Cache {
 	public static function delete($key, $config = 'default') {
 		$settings = self::settings($config);
 
+		$logEntry = compact('key', 'config');
+		$logEntry['action'] = __FUNCTION__;
+
 		if (empty($settings)) {
+			$logEntry['error'] = 'Settings for config not present';
+			self::_logAction($logEntry);
 			return false;
 		}
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
 		$key = self::$_engines[$config]->key($key);
 		if (!$key) {
+			$logEntry['error'] = 'Invalid key';
+			self::_logAction($logEntry);
 			return false;
 		}
 
+		$logEntry['time'] = microtime(true);
 		$success = self::$_engines[$config]->delete($settings['prefix'] . $key);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		if (!$success) {
+			$logEntry['error'] = 'Delete operation failed';
+		}
+		self::_logAction($logEntry);
 		self::set(null, $config);
 		return $success;
 	}
@@ -446,10 +572,22 @@ class Cache {
  * @return boolean True if the cache was successfully cleared, false otherwise
  */
 	public static function clear($check = false, $config = 'default') {
+		$logEntry = compact('config');
+		$logEntry['value'] = $check;
+		$logEntry['action'] = __FUNCTION__;
+
 		if (!self::isInitialized($config)) {
+			$logEntry['error'] = 'Engine not initialized';
+			self::_logAction($logEntry);
 			return false;
 		}
+		$logEntry['time'] = microtime(true);
 		$success = self::$_engines[$config]->clear($check);
+		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		if (!$success) {
+			$logEntry['error'] = 'Clear operation failed';
+		}
+		self::_logAction($logEntry);
 		self::set(null, $config);
 		return $success;
 	}
@@ -497,5 +635,15 @@ class Cache {
 		return array();
 	}
 
-}
+/**
+ * Return logged cache operations
+ *
+ * @param string $name Name of the configuration to get settings for. Defaults to 'default'
+ * @return array list of settings for this engine
+ * @see Cache::config()
+ */
+	public static function getLog() {
+		return self::$_logEntries;
+	}
 
+}

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -373,6 +373,7 @@ class Cache {
 		} else {
 			self::_logAction($logEntry);
 		}
+		CakeLog::write('_cake_cache_hits_', $config . '.write', array('performance'));
 		return $success;
 	}
 
@@ -420,6 +421,11 @@ class Cache {
 		$logEntry['time'] = microtime(true);
 		$value = self::$_engines[$config]->read($settings['prefix'] . $key);
 		$logEntry['time'] = microtime(true) - $logEntry['time'];
+		if (!$value) {
+			CakeLog::write('_cake_cache_hits_', $config . '.miss', array('performance'));
+		} else {
+			CakeLog::write('_cake_cache_hits_', $config . '.hit', array('performance'));
+		}
 		$logEntry['value'] = $value;
 		self::_logAction($logEntry);
 		return $value;

--- a/lib/Cake/Log/Engine/CountingFileLog.php
+++ b/lib/Cake/Log/Engine/CountingFileLog.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * File Storage stream using counting instead of appending for Logging
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://www.cakefoundation.org/projects/info/cakephp CakePHP(tm) Project
+ * @package       Cake.Log.Engine
+ * @since         CakePHP(tm) v 1.3
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('FileLog', 'Log/Engine');
+
+/**
+ * File Storage stream using counting instead of appending for Logging.
+ * Writes logs to different files based on the configuration type.
+ *
+ * @package	   Cake.Log.Engine
+ */
+class CountingFileLog extends FileLog {
+
+/**
+ * Constructs a new Counting File Logger.
+ *
+ * Config
+ *
+ * - `file` log file name
+ * - `path` the path to save logs on.
+ *
+ * @param array $options Options for the CountingFileLog, see above.
+ */
+	public function __construct(array $config = array()) {
+		$config = Hash::merge(array(
+			'file' => 'incremental.json.log',
+			), $config);
+		parent::__construct($config);
+	}
+
+/**
+ * Implements writing to log files.
+ *
+ * @param string $type  Type of error log
+ * @param string $value The message you want to log.
+ * @return boolean success of write.
+ */
+	public function write($type, $path) {
+		$useFile = $this->_path . $this->_file;
+		if (is_file($useFile)) {
+			$content = file_get_contents($useFile);
+			$content = json_decode($content, true);
+		} else {
+			$content = array();
+		}
+		if (!is_array($content)) {
+			$content = array();
+		}
+		$value = ((int)Hash::get($content, $path)) + 1;
+		$content = Hash::insert($content, $path, $value);
+		return file_put_contents($useFile, json_encode($content), LOCK_EX);
+	}
+
+}

--- a/lib/Cake/View/Elements/cache_dump.ctp
+++ b/lib/Cake/View/Elements/cache_dump.ctp
@@ -1,0 +1,42 @@
+<?php
+
+if (!class_exists('Cache') || Configure::read('debug') < 2) {
+	return false;
+}
+
+$noLogs = !isset($logs);
+if ($noLogs):
+	$logs = Cache::getLog();
+endif;
+
+foreach ($logs as $config => $logInfo):
+	$text = $logInfo['count'] > 1 ? 'queries' : 'query';
+	printf(
+		'<table class="cake-sql-log cake-cache-log" id="cakeCacheLog_%s" summary="Cake Cache Log" cellspacing="0" border="0">',
+		preg_replace('/[^A-Za-z0-9_]/', '_', uniqid(time(), true))
+	);
+	printf('<caption>(%s) %s %s took %s ms</caption>', $config, $logInfo['count'], $text, round($logInfo['time'], 5));
+?>
+<thead>
+	<tr><th>Nr</th><th>Operation</th><th>Key</th><th>Value</th><th>Error</th><th>Took (ms)</th></tr>
+</thead>
+<tbody>
+<?php
+	foreach ($logInfo['logs'] as $k => $i) :
+		$outputValue = var_export($i['value'], true);
+		if (isset($outputValue{1024})) {
+			$outputValue = substr($outputValue, 0, 1024) . ' [...]';
+		}
+		echo '<tr>',
+			'<td>', ($k + 1), '</td>',
+			'<td>', $i['action'], '</td>',
+			'<td>', h($i['key']), '</td>',
+			'<td>', h($outputValue), '</td>',
+			'<td>', $i['error'], '</td>',
+			'<td style="text-align: right">', round($i['time'], 5), '</td>',
+			'</tr>', "\n";
+	endforeach;
+?>
+</tbody></table>
+<?php
+endforeach;

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -141,6 +141,11 @@ App::$bootstrapping = true;
 
 Configure::bootstrap(isset($boot) ? $boot : true);
 
+CakeLog::config('_cake_cache_hits_', array(
+	'engine' => 'CountingFileLog',
+	'file'   => '_cake_cache_hits_counter_',
+));
+
 
 /**
  *  Full url prefix


### PR DESCRIPTION
Hello.

This is a modified attempt, based on previous pull request:
https://github.com/cakephp/cakephp/pull/675

There may be two branches, although it is more of a proposal, than actual pull request.

I have merged previously proposed cache queries logging.
Might be useful, to the extent of my experience, while discussing actual timings with sysops, or checking amount of queries done (to optimize several hundreds (sigh!) away).

Also I have created example logger, which allows values counting.
It shall be clearly visible, how it would kill any server instantly.
Although it is more of an example - how I see a possibility for cache hit/miss ratio calculation (despite the fact, that I prefer something on the lines of this: http://dealnews.com/developers/cacti/memcached.html). It may be implemented using write-once per session mechanism.

Hope for your suggestions/insights, about how this could find it's way.
## 

Best regards,
Justas B.
