### PR TITLE
2.2 - Model getter function

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3400,4 +3400,37 @@ class Model extends Object implements CakeEventListener {
 		return $this->_validator;
 	}
 
+/**
+ * Extract from model->data the value of a field or field path (ie: User.name)
+ * @param string $field indicates the path to the value
+ * @param mixed $defaultValue indicates the default value to be returned in case of $fieldPath was not found
+ * @return mixed
+ */
+	public function get($field, $defaultValue = null){
+		if (empty($this->data)) {
+			trigger_error(__d('cake_dev', 'Data is empty'), E_USER_WARNING);
+		}
+
+		if (strpos($field, '.') === false) {
+			$field = "{$this->alias}.{$field}";
+		}
+
+		$value = Hash::get($this->data, $field);
+		if ($value === null) {
+			$value = $default;
+		}
+
+		return $value;
+	}
+
+/**
+ * Checks if a value of model->data is not empty
+ * @param type $field
+ * @return boolean true if has value, false otherwise
+ */
+	public function check($field) {
+		$v = $this->get($field);
+		return !empty($v);
+	}
+
 }

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7910,8 +7910,6 @@ class ModelReadTest extends BaseModelTest {
 
 		$User->set('user', '');
 
-		debug($User->data);
-
 		$this->assertFalse($User->check('user'));
 		$this->assertFalse($User->check('User.user'));
 		$this->assertTrue($User->check('id'));

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7878,4 +7878,45 @@ class ModelReadTest extends BaseModelTest {
 		$this->assertEquals(1, count($result));
 	}
 
+/**
+ * test Model::get() method
+ *
+ * @retun void
+ */
+	public function testGet() {
+		$this->loadFixtures('User');
+		$User = new User();
+
+		$User->id = 1;
+		$User->read();
+
+		$this->assertEqual($User->get('user'), $User->data['User']['user']);
+		$this->assertEqual($User->get('User.user'), $User->data['User']['user']);
+		$this->assertEqual($User->get('id'), $User->id);
+		$this->assertEqual($User->get('User.id'), $User->id);
+	}
+
+/**
+ * test Model::check() method
+ *
+ * @return void
+ */
+	public function testCheck(){
+		$this->loadFixtures('User');
+		$User = new User();
+
+		$User->id = 1;
+		$User->read();
+
+		$User->set('user', '');
+
+		debug($User->data);
+
+		$this->assertFalse($User->check('user'));
+		$this->assertFalse($User->check('User.user'));
+		$this->assertTrue($User->check('id'));
+		$this->assertTrue($User->check('User.id'));
+	}
+
+
 }


### PR DESCRIPTION
I have add to Model two functions (and the corresponding tests in ModelReadTest):

```
public function get($field, $defaultValue = null);
public function check($field);
```

To facilitate use of data in model and get rid of

```
$this->data[$this->alias]['user_name'];
```

that could be

```
$this->get('user_name')
```

I have more proposals on model layer, but are difficult for me to explain them in english, so I'm trying to send the pull requests atomic and concise.

Hope you like!
Best regards.
