### PR TITLE
Update function validateSort in paginatorComponent

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php~
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php~
@@ -355,8 +355,6 @@ class PaginatorComponent extends Component {
 					$order[$field] = $value;
 				} elseif (isset($object->{$alias}) && $object->{$alias}->hasField($field, true)) {
 					$order[$alias . '.' . $field] = $value;
-				} else {
-					$order[$field] = $value;
 				}
 			}
 			$options['order'] = $order;


### PR DESCRIPTION
... as alias' just when the order value is an array
When i use an alias and wish order it, the value is null by the function, that's why i updated, thanks
