### PR TITLE
Xcache is not available for php-cli

### DIFF
--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -45,14 +45,17 @@ class XcacheEngine extends CacheEngine {
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($settings = array()) {
-		parent::init(array_merge(array(
-			'engine' => 'Xcache',
-			'prefix' => Inflector::slug(APP_DIR) . '_',
-			'PHP_AUTH_USER' => 'user',
-			'PHP_AUTH_PW' => 'password'
-			), $settings)
-		);
-		return function_exists('xcache_info');
+		if ( php_sapi_name() !== 'cli' ){
+			parent::init(array_merge(array(
+				'engine' => 'Xcache',
+				'prefix' => Inflector::slug(APP_DIR) . '_',
+				'PHP_AUTH_USER' => 'user',
+				'PHP_AUTH_PW' => 'password'
+				), $settings)
+			);
+			return function_exists('xcache_info');
+		}
+		return false;
 	}
 
 /**


### PR DESCRIPTION
Xcache is not available for php-cli.

The xcache team has not decided possibile solutions to avoid errors:
http://xcache.lighttpd.net/ticket/228

Then is necessary a check if (php_sapi_name ()==='cli')
