### PR TITLE
Remove suppression of error messages when including PHPUnit

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -138,21 +138,17 @@ class CakeTestSuiteDispatcher {
 	public function loadTestFramework() {
 		$found = $path = null;
 
-		if (@include 'PHPUnit' . DS . 'Autoload.php') {
-			$found = true;
-		}
-
-		if (!$found) {
-			foreach (App::path('vendors') as $vendor) {
-				if (is_dir($vendor . 'PHPUnit')) {
-					$path = $vendor;
-				}
-			}
-
-			if ($path && ini_set('include_path', $path . PATH_SEPARATOR . ini_get('include_path'))) {
-				$found = include 'PHPUnit' . DS . 'Autoload.php';
+		foreach (App::path('vendors') as $vendor) {
+			if (is_dir($vendor . 'PHPUnit')) {
+				$path = $vendor;
 			}
 		}
+
+		if($path){
+			ini_set('include_path', $path . PATH_SEPARATOR . ini_get('include_path'));
+		}
+
+		$found = include 'PHPUnit' . DS . 'Autoload.php';
 		return $found;
 	}
 


### PR DESCRIPTION
No longer suppress the include path to PHPUnit/Autoload.php as Autoload.php require_once() on two files, if either of them aren't there the shell exits without message.  Explanation of issue here: http://www.webtechnick.com/wtn/blogs/view/247/Fixing_PHPUnit_for_CakePHP_2_x_testing_on_Mac_OS_X
