### PR TITLE
TestSuite no longer dependent on app AppController, AppModel, AppHelper

### DIFF
--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -415,7 +415,9 @@ class ControllerTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		App::objects('plugin', null, false);
-		App::build();
+		App::build(array(
+			'View/Helper' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Helper' . DS),
+		), App::RESET);
 		Router::reload();
 	}
 
@@ -670,10 +672,8 @@ class ControllerTest extends CakeTestCase {
  */
 	public function testComponentBeforeRenderChangingViewClass() {
 		App::build(array(
-			'View' => array(
-				CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS
-			)
-		), true);
+			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
+		), App::RESET);
 		$Controller = new Controller($this->getMock('CakeRequest'), new CakeResponse());
 		$Controller->uses = array();
 		$Controller->components = array('Test');

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -40,6 +40,8 @@ class AppTest extends CakeTestCase {
  * @return void
  */
 	public function testBuild() {
+		App::build();
+
 		$old = App::path('Model');
 		$expected = array(
 			APP . 'Model' . DS
@@ -101,6 +103,8 @@ class AppTest extends CakeTestCase {
  * @return void
  */
 	public function testCompatibleBuild() {
+		App::build();
+
 		$old = App::path('models');
 		$expected = array(
 			APP . 'Model' . DS
@@ -251,6 +255,8 @@ class AppTest extends CakeTestCase {
  * @return void
  */
 	public function testBuildWithReset() {
+		App::build();
+
 		$old = App::path('Model');
 		$expected = array(
 			APP . 'Model' . DS

--- a/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestSuiteTest.php
@@ -21,6 +21,25 @@
 class CakeTestSuiteTest extends CakeTestCase {
 
 /**
+ * testCoreTestAppsLocations
+ *
+ * @return void
+ */
+	public function testCoreTestAppsLocations() {
+		$result = App::path('Model');
+		$expected = array(CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS);
+		$this->assertEquals($expected, $result);
+
+		$result = App::path('Controller');
+		$expected = array(CAKE . 'Test' . DS . 'test_app' . DS . 'Controller' . DS);
+		$this->assertEquals($expected, $result);
+
+		$result = App::path('View/Helper');
+		$expected = array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Helper' . DS);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testAddTestDirectory
  * 
  * @return void

--- a/lib/Cake/Test/test_app/View/Helper/AppHelper.php
+++ b/lib/Cake/Test/test_app/View/Helper/AppHelper.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Application level View Helper
+ *
+ * This file is application-wide helper file. You can put all
+ * application-wide helper-related methods here.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.View.Helper
+ * @since         CakePHP(tm) v 0.2.9
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('Helper', 'View');
+
+/**
+ * Application helper
+ *
+ * Add your application-wide methods in the class below, your helpers
+ * will inherit them.
+ *
+ * @package       app.View.Helper
+ */
+class AppHelper extends Helper {
+}

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -48,6 +48,14 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
 		$this->arguments['testFile'] = $params;
 		$this->_params = $params;
 
+		if ($params['core']) {
+			App::build(array(
+				'Model' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS),
+				'View/Helper' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS . 'Helper' . DS),
+				'Controller' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Controller' . DS),
+			), App::RESET);
+		}
+
 		$this->longOptions['fixture='] = 'handleFixture';
 		$this->longOptions['output='] = 'handleReporter';
 	}


### PR DESCRIPTION
Closes #2835: http://cakephp.lighthouseapp.com/projects/42648/tickets/2835-apphelper-dependency-causes-fatal-error-in-test-suite

TestSuite will use the test_app AppController, AppModel and AppHelper instead.

Tested locally and on travis-ci by removing the Apps: http://travis-ci.org/#!/shama/cakephp/builds/1596496 (All passing excluding the usual travis-ci failures)
