### PR TITLE
Fix custom validation methods with CakeValidationSet

### DIFF
--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -331,7 +331,8 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 		$this->_fields = array();
 		$methods = $this->getMethods();
 		foreach ($this->_validate as $fieldName => $ruleSet) {
-			$this->_fields[$fieldName] = new CakeValidationSet($fieldName, $ruleSet, $methods);
+			$this->_fields[$fieldName] = new CakeValidationSet($fieldName, $ruleSet);
+			$this->_fields[$fieldName]->setMethods($methods);
 		}
 		return true;
 	}
@@ -483,7 +484,9 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 	public function offsetSet($field, $rules) {
 		$this->_parseRules();
 		if (!$rules instanceof CakeValidationSet) {
-			$rules = new CakeValidationSet($field, $rules, $this->getMethods());
+			$rules = new CakeValidationSet($field, $rules);
+			$methods = $this->getMethods();
+			$rules->setMethods($methods);
 		}
 		$this->_fields[$field] = $rules;
 	}
@@ -551,7 +554,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 
 		if (!isset($this->_fields[$field])) {
 			$rule = (is_string($name)) ? array($name => $rule) : $name;
-			$this->_fields[$field] = new CakeValidationSet($field, $rule, $this->getMethods());
+			$this->_fields[$field] = new CakeValidationSet($field, $rule);
 		} else {
 			if (is_string($name)) {
 				$this->_fields[$field]->setRule($name, $rule);
@@ -559,6 +562,10 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 				$this->_fields[$field]->setRules($name);
 			}
 		}
+
+		$methods = $this->getMethods();
+		$this->_fields[$field]->setMethods($methods);
+
 		return $this;
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -2106,4 +2106,28 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertEquals('awesome', $rules['isAwesome']->rule);
 	}
 
+/**
+ * Test to ensure custom validation methods work with CakeValidationSet
+ *
+ * @return void
+ */
+	public function testCustomMethodsWithCakeValidationSet() {
+		$TestModel = new TestValidate();
+		$Validator = $TestModel->validator();
+
+		$Validator->add('title', 'validateTitle', array(
+			'rule' => 'validateTitle',
+			'message' => 'That aint right',
+		));
+		$data = array('title' => 'notatitle');
+		$result = $Validator->getField('title')->validate($data);
+		$expected = array(0 => 'That aint right');
+		$this->assertEquals($expected, $result);
+
+		$data = array('title' => 'title-is-good');
+		$result = $Validator->getField('title')->validate($data);
+		$expected = array();
+		$this->assertEquals($expected, $result);
+	}
+
 }


### PR DESCRIPTION
Ran into an error while working on Croogo. When `CakeValidationSet` is instantiated in `ModelValidator` it mistakenly thinks the constructor has a 3rd arg to set methods. It doesn't. Thus custom validation methods are never checked in `CakeValidationRule::process`. This PR fixes this.

Also a note... previously one could set `protected` validation methods. With the new validator custom validation methods must be `public`. If this is correct I can add a note to the docs.

http://travis-ci.org/#!/shama/cakephp/builds/1598610
