### PR TITLE
2.2 html link fix

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -333,6 +333,10 @@ class HtmlHelperTest extends CakeTestCase {
 			'/a'
 		);
 		$this->assertTags($result, $expected);
+		
+		$result = $this->Html->link('http://www.example.org?param1=value1&param2=value2');
+		$expected = array('a' => array('href' => 'http://www.example.org?param1=value1&amp;param2=value2'), 'http://www.example.org?param1=value1&amp;param2=value2', '/a');
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -333,7 +333,7 @@ class HtmlHelperTest extends CakeTestCase {
 			'/a'
 		);
 		$this->assertTags($result, $expected);
-		
+
 		$result = $this->Html->link('http://www.example.org?param1=value1&param2=value2');
 		$expected = array('a' => array('href' => 'http://www.example.org?param1=value1&amp;param2=value2'), 'http://www.example.org?param1=value1&amp;param2=value2', '/a');
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -335,7 +335,8 @@ class HtmlHelper extends AppHelper {
 			$url = $this->url($url);
 		} else {
 			$url = $this->url($title);
-			$title = h(urldecode($url));
+			$title = htmlspecialchars_decode($url, ENT_QUOTES);
+			$title = h(urldecode($title));
 			$escapeTitle = false;
 		}
 


### PR DESCRIPTION
currently the displayed url would be encoded twice  - resulting in `&amp;amp;` for `&`

PS: additional ticket necessary? probably not
