### PR TITLE
2.2 shell command sort

### DIFF
--- a/lib/Cake/Console/Command/CommandListShell.php
+++ b/lib/Cake/Console/Command/CommandListShell.php
@@ -55,18 +55,14 @@ class CommandListShell extends AppShell {
 		}
 
 		$shellList = $this->_getShellList();
+		if(empty($shellList)) {
+			return;
+		}
 
-		if ($shellList) {
-			ksort($shellList);
-			if (empty($this->params['xml'])) {
-				if (!empty($this->params['sort'])) {
-					$this->_asSorted($shellList);
-				} else {
-					$this->_asText($shellList);
-				}
-			} else {
-				$this->_asXml($shellList);
-			}
+		if (empty($this->params['xml'])) {
+			$this->_asText($shellList);
+		} else {
+			$this->_asXml($shellList);
 		}
 	}
 
@@ -76,25 +72,26 @@ class CommandListShell extends AppShell {
  * @return array
  */
 	protected function _getShellList() {
-		$shellList = array();
 		$skipFiles = array('AppShell');
+
+		$plugins = CakePlugin::loaded();
+		$shellList = array_fill_keys($plugins, null) + array('CORE' => null, 'app' => null);
 
 		$corePath = App::core('Console/Command');
 		$shells = App::objects('file', $corePath[0]);
 		$shells = array_diff($shells, $skipFiles);
-		$shellList = $this->_appendShells('CORE', $shells, $shellList);
+		$this->_appendShells('CORE', $shells, $shellList);
 
 		$appShells = App::objects('Console/Command', null, false);
 		$appShells = array_diff($appShells, $shells, $skipFiles);
-		$shellList = $this->_appendShells('app', $appShells, $shellList);
+		$this->_appendShells('app', $appShells, $shellList);
 
-		$plugins = CakePlugin::loaded();
 		foreach ($plugins as $plugin) {
 			$pluginShells = App::objects($plugin . '.Console/Command');
-			$shellList = $this->_appendShells($plugin, $pluginShells, $shellList);
+			$this->_appendShells($plugin, $pluginShells, $shellList);
 		}
 
-		return $shellList;
+		return array_filter($shellList);
 	}
 
 /**
@@ -105,12 +102,10 @@ class CommandListShell extends AppShell {
  * @param array $shellList
  * @return array
  */
-	protected function _appendShells($type, $shells, $shellList) {
+	protected function _appendShells($type, $shells, &$shellList) {
 		foreach ($shells as $shell) {
-			$shell = Inflector::underscore(str_replace('Shell', '', $shell));
-			$shellList[$shell][$type] = $type;
+			$shellList[$type][] = Inflector::underscore(str_replace('Shell', '', $shell));
 		}
-		return $shellList;
 	}
 
 /**
@@ -120,73 +115,15 @@ class CommandListShell extends AppShell {
  * @return void
  */
 	protected function _asText($shellList) {
-		if (DS === '/') {
-			$width = exec('tput cols') - 2;
+		foreach ($shellList as $plugin => $commands) {
+			sort($commands);
+			$this->out(sprintf('[<info>%s</info>] %s', $plugin, implode(', ', $commands)));
+			$this->out();
 		}
-		if (empty($width)) {
-			$width = 80;
-		}
-		$columns = max(1, floor($width / 30));
-		$rows = ceil(count($shellList) / $columns);
 
-		foreach ($shellList as $shell => $types) {
-			sort($types);
-			$shellList[$shell] = str_pad($shell . ' [' . implode ($types, ', ') . ']', $width / $columns);
-		}
-		$out = array_chunk($shellList, $rows);
-		for ($i = 0; $i < $rows; $i++) {
-			$row = '';
-			for ($j = 0; $j < $columns; $j++) {
-				if (!isset($out[$j][$i])) {
-					continue;
-				}
-				$row .= $out[$j][$i];
-			}
-			$this->out(" " . $row);
-		}
-		$this->out();
 		$this->out(__d('cake_console', "To run an app or core command, type <info>cake shell_name [args]</info>"));
 		$this->out(__d('cake_console', "To run a plugin command, type <info>cake Plugin.shell_name [args]</info>"));
 		$this->out(__d('cake_console', "To get help on a specific command, type <info>cake shell_name --help</info>"), 2);
-	}
-
-/**
- * Generates the shell list sorted by where the shells are found.
- *
- * @param array $shellList
- * @return void
- */
-	protected function _asSorted($shellList) {
-		$grouped = array();
-		foreach ($shellList as $shell => $types) {
-			foreach ($types as $type) {
-				$type = Inflector::camelize($type);
-				if (empty($grouped[$type])) {
-					$grouped[$type] = array();
-				}
-				$grouped[$type][] = $shell;
-			}
-		}
-		if (!empty($grouped['App'])) {
-			sort($grouped['App'], SORT_STRING);
-			$this->out('[ App ]');
-			$this->out('  ' . implode(', ', $grouped['App']), 2);
-			unset($grouped['App']);
-		}
-		foreach ($grouped as $section => $shells) {
-			if ($section == 'CORE') {
-				continue;
-			}
-			sort($shells, SORT_STRING);
-			$this->out('[ ' . $section . ' ]');
-			$this->out('  ' . implode(', ', $shells), 2);
-		}
-		if (!empty($grouped['CORE'])) {
-			sort($grouped['CORE'], SORT_STRING);
-			$this->out('[ Core ]');
-			$this->out('  ' . implode(', ', $grouped['CORE']), 2);
-		}
-		$this->out();
 	}
 
 /**
@@ -198,17 +135,19 @@ class CommandListShell extends AppShell {
 	protected function _asXml($shellList) {
 		$plugins = CakePlugin::loaded();
 		$shells = new SimpleXmlElement('<shells></shells>');
-		foreach ($shellList as $name => $location) {
-			$source = current($location);
-			$callable = $name;
-			if (in_array($source, $plugins)) {
-				$callable = Inflector::camelize($source) . '.' . $name;
+		foreach ($shellList as $plugin => $commands) {
+			foreach($commands as $command) {
+				$callable = $command;
+				if (in_array($plugin, $plugins)) {
+					$callable = Inflector::camelize($plugin) . '.' . $command;
+				}
+
+				$shell = $shells->addChild('shell');
+				$shell->addAttribute('name', $command);
+				$shell->addAttribute('call_as', $callable);
+				$shell->addAttribute('provider', $plugin);
+				$shell->addAttribute('help', $callable . ' -h');
 			}
-			$shell = $shells->addChild('shell');
-			$shell->addAttribute('name', $name);
-			$shell->addAttribute('call_as', $callable);
-			$shell->addAttribute('provider', $source);
-			$shell->addAttribute('help', $callable . ' -h');
 		}
 		$this->stdout->outputAs(ConsoleOutput::RAW);
 		$this->out($shells->saveXml());
@@ -224,9 +163,6 @@ class CommandListShell extends AppShell {
 		return $parser->description(__d('cake_console', 'Get the list of available shells for this CakePHP application.'))
 			->addOption('xml', array(
 				'help' => __d('cake_console', 'Get the listing as XML.'),
-				'boolean' => true
-			))->addOption('sort', array(
-				'help' => __d('cake_console', 'Sorts the commands by where they are located.'),
 				'boolean' => true
 			));
 	}

--- a/lib/Cake/Console/Command/CommandListShell.php
+++ b/lib/Cake/Console/Command/CommandListShell.php
@@ -55,7 +55,7 @@ class CommandListShell extends AppShell {
 		}
 
 		$shellList = $this->_getShellList();
-		if(empty($shellList)) {
+		if (empty($shellList)) {
 			return;
 		}
 
@@ -136,7 +136,7 @@ class CommandListShell extends AppShell {
 		$plugins = CakePlugin::loaded();
 		$shells = new SimpleXmlElement('<shells></shells>');
 		foreach ($shellList as $plugin => $commands) {
-			foreach($commands as $command) {
+			foreach ($commands as $command) {
 				$callable = $command;
 				if (in_array($plugin, $plugins)) {
 					$callable = Inflector::camelize($plugin) . '.' . $command;

--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -82,58 +82,16 @@ class CommandListShellTest extends CakeTestCase {
 		$this->Shell->main();
 		$output = $this->Shell->stdout->output;
 
-		$expected = "/example \[.*TestPlugin, TestPluginTwo.*\]/";
+		$expected = "/\[.*TestPlugin.*\] example/";
 		$this->assertRegExp($expected, $output);
 
-		$expected = "/welcome \[.*TestPluginTwo.*\]/";
+		$expected = "/\[.*TestPluginTwo.*\] example, welcome/";
 		$this->assertRegExp($expected, $output);
 
-		$expected = "/acl \[.*CORE.*\]/";
+		$expected = "/\[.*CORE.*\] acl, api, bake, command_list, console, i18n, schema, test, testsuite, upgrade/";
 		$this->assertRegExp($expected, $output);
 
-		$expected = "/api \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/bake \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/console \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/i18n \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/schema \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/testsuite \[.*CORE.*\]/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/sample \[.*app.*\]/";
-		$this->assertRegExp($expected, $output);
-	}
-
-/**
- * Test the sort param
- *
- * @return void
- */
-	public function testSortPlugin() {
-		$this->Shell->params['sort'] = true;
-		$this->Shell->main();
-
-		$output = $this->Shell->stdout->output;
-
-		$expected = "/\[.*App.*\]\\v*[ ]+sample/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/\[.*TestPluginTwo.*\]\\v*[ ]+example, welcome/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/\[.*TestPlugin.*\]\\v*[ ]+example/";
-		$this->assertRegExp($expected, $output);
-
-		$expected = "/\[.*Core.*\]\\v*[ ]+acl, api, bake, command_list, console, i18n, schema, test, testsuite/";
+		$expected = "/\[.*app.*\] sample/";
 		$this->assertRegExp($expected, $output);
 	}
 


### PR DESCRIPTION
The default output is now (with Plugin name highlighted):

```
[Crons] cron

[Data] clear_cache

[DebugKit] benchmark, whitespace

[Dev] infinitas_todo, relations

[Installer] install, release

[Libs] fixturize, infinitas_fixtures, reset_data, test_rename

[Migrations] migration

[CORE] acl, api, bake, command_list, console, i18n, schema, test, testsuite, upgrade
```

and with `--xml` example (I formatted it here for readability):

```
 <shells>
    <shell name="cron" call_as="Crons.cron" provider="Crons" help="Crons.cron -h"/>
    <shell name="clear_cache" call_as="Data.clear_cache" provider="Data" help="Data.clear_cache -h"/>
    <shell name="benchmark" call_as="DebugKit.benchmark" provider="DebugKit" help="DebugKit.benchmark -h"/>
    <shell name="whitespace" call_as="DebugKit.whitespace" provider="DebugKit" help="DebugKit.whitespace -h"/>
    <shell name="infinitas_todo" call_as="Dev.infinitas_todo" provider="Dev" help="Dev.infinitas_todo -h"/>
    <shell name="relations" call_as="Dev.relations" provider="Dev" help="Dev.relations -h"/>
    <shell name="install" call_as="Installer.install" provider="Installer" help="Installer.install -h"/>
    <shell name="release" call_as="Installer.release" provider="Installer" help="Installer.release -h"/>
    ...
```

for http://cakephp.lighthouseapp.com/projects/42648/tickets/2971-rfc-change-cake-shell-to-group-by-plugin-by-default
