### PR TITLE
Displaying actual vs expected messages when the result is an array or string.

### DIFF
--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -249,22 +249,17 @@ class CakeHtmlReporter extends CakeBaseReporter {
 
 		$failure = $message->getComparisonFailure();
 		if (is_object($failure)) {
-		  $actualMsg   = $message->getComparisonFailure()->getActual();
-		  $expectedMsg = $message->getComparisonFailure()->getExpected();
+		  $actualMsg   = $message->getComparisonFailure()->getActualAsString();
+		  $expectedMsg = $message->getComparisonFailure()->getExpectedAsString();
 		}
 
 		echo "<li class='fail'>\n";
 		echo "<span>Failed</span>";
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
+
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
-		  echo "<br/>--- Expected <br/>+++ Actual";
-		  echo "<br/>@@ @@<br/>";
-		  echo "- '";
-		  print_r($expectedMsg);
-		  echo "'<br/>+ '";
-		  print_r($actualMsg);
-		  echo "'";
+		  echo "<br />". PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
 		}
 
 		echo "</pre></div>\n";

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -258,10 +258,13 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
-		  echo "<br/>Actual: ";
-		  print_r($actualMsg);
-		  echo "<br/>Expected: ";
+		  echo "<br/>--- Expected <br/>+++ Actual";
+		  echo "<br/>@@ @@<br/>";
+		  echo "- '";
 		  print_r($expectedMsg);
+		  echo "'<br/>+ '";
+		  print_r($actualMsg);
+		  echo "'";
 		}
 
 		echo "</pre></div>\n";

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -257,7 +257,6 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		echo "<span>Failed</span>";
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
-
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
 		  echo "<br />". PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
 		}

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -247,9 +247,24 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		$trace = $this->_getStackTrace($message);
 		$testName = get_class($test) . '(' . $test->getName() . ')';
 
+		$failure = $message->getComparisonFailure();
+		if (is_object($failure)) {
+		  $actualMsg   = $message->getComparisonFailure()->getActual();
+		  $expectedMsg = $message->getComparisonFailure()->getExpected();
+		}
+
 		echo "<li class='fail'>\n";
 		echo "<span>Failed</span>";
-		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString()) . "</pre></div>\n";
+		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
+
+		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
+		  echo "<br/>Actual: ";
+		  print_r($actualMsg);
+		  echo "<br/>Expected: ";
+		  print_r($expectedMsg);
+		}
+
+		echo "</pre></div>\n";
 		echo "<div class='msg'>" . __d('cake_dev', 'Test case: %s', $testName) . "</div>\n";
 		echo "<div class='msg'>" . __d('cake_dev', 'Stack trace:') . '<br />' . $trace . "</div>\n";
 		echo "</li>\n";

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -248,6 +248,8 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		$testName = get_class($test) . '(' . $test->getName() . ')';
 
 		$failure = $message->getComparisonFailure();
+		$actualMsg = NULL;
+		$expectedMsg = NULL;
 		if (is_object($failure)) {
 		  $actualMsg   = $message->getComparisonFailure()->getActualAsString();
 		  $expectedMsg = $message->getComparisonFailure()->getExpectedAsString();


### PR DESCRIPTION
When we have two different strings/arrays we can't see them in the browser, as you can see in the following image:
[Current behavior](http://cl.ly/350t4608383J3F2N1S3R)

With this change, we can see the actual and expected strings/arrays: 
[String](http://cl.ly/3Q3J3C2C2K1D440t3K0C)
[Array](http://cl.ly/08073R2i3k2U2j092f1Q)

Hope this helps somebody else.
