### PR TITLE
This make possible to create "join" using associated models. 

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1059,12 +1059,12 @@ class DboSource extends DataSource {
 		} elseif ($model->recursive == 0) {
 			unset($_associations[2], $_associations[3]);
 		}
-		
-        if(!empty($queryData['joins'])){
-          $joins = $queryData['joins'];
-          $queryData['joins'] = array();
-        }
-        
+
+		if (!empty($queryData['joins'])) {
+			$joins = $queryData['joins'];
+			$queryData['joins'] = array();
+		}
+
 		foreach ($_associations as $type) {
 			foreach ($model->{$type} as $assoc => $assocData) {
 				$linkModel = $model->{$assoc};
@@ -1082,10 +1082,10 @@ class DboSource extends DataSource {
 			}
 		}
 
-        if(!empty($joins)){
-          $queryData['joins'] = array_merge($queryData['joins'], $joins);
-        }
-        
+		if (!empty($joins)) {
+			$queryData['joins'] = array_merge($queryData['joins'], $joins);
+		}
+
 		$query = trim($this->generateAssociationQuery($model, null, null, null, null, $queryData, false, $null));
 
 		$resultSet = $this->fetchAll($query, $model->cacheQueries);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1059,7 +1059,12 @@ class DboSource extends DataSource {
 		} elseif ($model->recursive == 0) {
 			unset($_associations[2], $_associations[3]);
 		}
-
+		
+        if(!empty($queryData['joins'])){
+          $joins = $queryData['joins'];
+          $queryData['joins'] = array();
+        }
+        
 		foreach ($_associations as $type) {
 			foreach ($model->{$type} as $assoc => $assocData) {
 				$linkModel = $model->{$assoc};
@@ -1077,6 +1082,10 @@ class DboSource extends DataSource {
 			}
 		}
 
+        if(!empty($joins)){
+          $queryData['joins'] = array_merge($queryData['joins'], $joins);
+        }
+        
 		$query = trim($this->generateAssociationQuery($model, null, null, null, null, $queryData, false, $null));
 
 		$resultSet = $this->fetchAll($query, $model->cacheQueries);


### PR DESCRIPTION
Scenario: There is relationship: Post belongsTo User. Now, for some weird reason, You want to create custom "join" to "bars" table inside Post model basing on condition User.bar_id = Bar.id. 
Post->find('first', array('joins' => array('type' => 'LEFT', 'table' => 'bars', 'alias' => 'Bar', 'conditions' => array('User.bar_id = Bar.id'))));

Then internally: first in join array is join from params, and then goes all associations from belongsTo and hasOne.
In mysql joins order matters, and there is a bug in query. 

I'm using join key in 'finds' form time to time, and every time it is necessary to set recursive = -1 and setting all associations in low level.

This fix is resolving problem, by changing joins order.
