### PR TITLE
2.3 cakerequest method override

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -175,7 +175,7 @@ class CakeRequest implements ArrayAccess {
 		if (env('HTTP_X_HTTP_METHOD_OVERRIDE')) {
 			$this->data['_method'] = env('HTTP_X_HTTP_METHOD_OVERRIDE');
 		}
-		if (isset($this->data['_method'])) {
+		if (is_array($this->data) && array_key_exists('_method', $this->data)) {
 			if (!empty($_SERVER)) {
 				$_SERVER['REQUEST_METHOD'] = $this->data['_method'];
 			} else {
@@ -184,7 +184,7 @@ class CakeRequest implements ArrayAccess {
 			unset($this->data['_method']);
 		}
 
-		if (isset($this->data['data'])) {
+		if (is_array($this->data) && array_key_exists('data', $this->data)) {
 			$data = $this->data['data'];
 			if (count($this->data) <= 1) {
 				$this->data = $data;

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -301,6 +301,22 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * test parsing json PUT data into the object.
+ *
+ * @return void
+ */
+	public function testPutParsingJSON() {
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$_SERVER['CONTENT_TYPE'] = 'application/application/json';
+
+		$request = $this->getMock('TestCakeRequest', array('_readInput'));
+		$request->expects($this->at(0))->method('_readInput')
+			->will($this->returnValue('{Article":["title"]}'));
+		$request->reConstruct();
+		$this->assertEquals('{Article":["title"]}', $request->data);
+	}
+
+/**
  * test parsing of FILES array
  *
  * @return void


### PR DESCRIPTION
I have found a error when using `JSON` `PUT` request with 2.2 version of `CakeRequest`.
