### PR TITLE
When blackHoleCallback is set, requests _must_ get blackholed

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -590,7 +590,7 @@ class SecurityComponent extends Component {
 		if (is_callable(array($controller, $method))) {
 			return call_user_func_array(array(&$controller, $method), empty($params) ? null : $params);
 		} else {
-			return null;
+			throw new BadRequestException(__d('cake_dev', 'The request has been black-holed'));
 		}
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -107,6 +107,20 @@ class SecurityTestController extends Controller {
 
 }
 
+class BrokenCallbackController extends Controller {
+
+	public $name = 'UncallableCallback';
+
+	public $components = array('Session', 'TestSecurity');
+
+	public function index() {
+	}
+
+	protected function _fail() {
+	}
+
+}
+
 /**
  * SecurityComponentTest class
  *
@@ -159,6 +173,25 @@ class SecurityComponentTest extends CakeTestCase {
 		unset($this->Controller->Security);
 		unset($this->Controller->Component);
 		unset($this->Controller);
+	}
+
+/**
+ * Test that requests are still blackholed when controller has incorrect
+ * visibility keyword in the blackhole callback
+ *
+ * @expectedException BadRequestException
+ */
+	public function testBlackholeWithBrokenCallback() {
+		$request = new CakeRequest('posts/index', false);
+		$request->addParams(array(
+			'controller' => 'posts', 'action' => 'index')
+		);
+		$this->Controller = new BrokenCallbackController($request);
+		$this->Controller->Components->init($this->Controller);
+		$this->Controller->Security = $this->Controller->TestSecurity;
+		$this->Controller->Security->blackHoleCallback = '_fail';
+		$this->Controller->Security->startup($this->Controller);
+		$this->Controller->Security->blackHole($this->Controller, 'csrf');
 	}
 
 /**


### PR DESCRIPTION
Currently, when blackHoleCallback is set, but the given method has incorrect visibility keyword, requests do not get blackholed.

We should fail spectacularly and do not let the request through.

Even though this introduce a change, i think this should be considered a bug and should go to the next stable release instead of 2.3.
