### PR TITLE
Remove unneeded use of Set

### DIFF
--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -23,7 +23,6 @@ use Cake\Controller\ComponentCollection;
 use Cake\Controller\Component\AclComponent;
 use Cake\Core\Configure;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * Shell for ACL management.  This console is known to have issues with zend.ze1_compatibility_mode

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -24,7 +24,6 @@ use Cake\Utility\File;
 use Cake\Utility\Folder;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * Language string extractor

--- a/lib/Cake/Controller/Component/Acl/DbAcl.php
+++ b/lib/Cake/Controller/Component/Acl/DbAcl.php
@@ -19,7 +19,6 @@ use Cake\Controller\Component\Acl\AclInterface;
 use Cake\Core\Object;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * DbAcl implements an ACL control system in the database.  ARO's and ACO's are

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -23,7 +23,6 @@ use Cake\Core\Object;
 use Cake\Error;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * Access Control List factory class.

--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -20,7 +20,6 @@ use Cake\Network\Response;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
-use Cake\Utility\Set;
 
 /**
  * Base Authentication class with common methods and properties.

--- a/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
@@ -21,7 +21,6 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * Abstract base authorization adapter for AuthComponent.

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -33,7 +33,6 @@ use Cake\Routing\Router;
 use Cake\Utility\Debugger;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
-use Cake\Utility\Set;
 
 /**
  * Authentication control component class

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -25,7 +25,6 @@ use Cake\Core\Configure;
 use Cake\Network\Response;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
-use Cake\Utility\Set;
 
 /**
  * Cookie Component.

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -22,7 +22,6 @@ use Cake\Controller\Component;
 use Cake\Controller\ComponentCollection;
 use Cake\Error;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * This component is used to handle automatic model data pagination.  The primary way to use this

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -25,7 +25,6 @@ use Cake\Error;
 use Cake\Network\Request;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
-use Cake\Utility\Set;
 
 /**
  * The Security Component creates an easy way to integrate tighter security in 

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -19,7 +19,6 @@ use Cake\Configure\ConfigReaderInterface;
 use Cake\Configure\PhpReader;
 use Cake\Error;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * Configuration class. Used for managing runtime configuration information.

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -19,7 +19,6 @@ use Cake\Network\Response;
 use Cake\Routing\Dispatcher;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * Object class provides a few generic methods used in several subclasses.

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -21,7 +21,7 @@
 namespace Cake\Model\Behavior;
 use Cake\Model\Model;
 use Cake\Model\ModelBehavior;
-use Cake\Utility\Set;
+use Cake\Utility\Hash;
 
 /**
  * Behavior to allow for dynamic and atomic manipulation of a Model's associations 

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -22,6 +22,7 @@ namespace Cake\Model\Behavior;
 use Cake\Model\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Model\ModelBehavior;
+use Cake\Utility\Hash;
 
 /**
  * Tree Behavior.

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -22,7 +22,6 @@ use Cake\Error;
 use Cake\Network\Socket;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * Cake network socket connection class.

--- a/lib/Cake/Network/Request.php
+++ b/lib/Cake/Network/Request.php
@@ -19,7 +19,6 @@ namespace Cake\Network;
 use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -347,7 +346,7 @@ class Request implements \ArrayAccess {
 				$this->_processFileData($newPath, $fields, $field);
 			} else {
 				$newPath .= '.' . $field;
-				$this->data = Set::insert($this->data, $newPath, $fields);
+				$this->data = Hash::insert($this->data, $newPath, $fields);
 			}
 		}
 	}

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -25,7 +25,6 @@ use Cake\Network\Response;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * Parses the request URL into controller, action, and parameters.  Uses the connected routes

--- a/lib/Cake/Test/TestApp/Model/PaginatorControllerPost.php
+++ b/lib/Cake/Test/TestApp/Model/PaginatorControllerPost.php
@@ -18,7 +18,7 @@
  */
 namespace TestApp\Model;
 use Cake\TestSuite\Fixture\TestModel;
-use Cake\Utility\Set;
+use Cake\Utility\Hash;
 
 /**
  * PaginatorControllerPost class
@@ -81,7 +81,7 @@ class PaginatorControllerPost extends TestModel {
 	public function find($conditions = null, $fields = array(), $order = null, $recursive = null) {
 		if ($conditions == 'popular') {
 			$conditions = array($this->name . '.' . $this->primaryKey .' > ' => '1');
-			$options = Set::merge($fields, compact('conditions'));
+			$options = Hash::merge($fields, compact('conditions'));
 			return parent::find('all', $options);
 		}
 		return parent::find($conditions, $fields);

--- a/lib/Cake/Test/TestCase/Console/ShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/ShellTest.php
@@ -25,7 +25,6 @@ use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Folder;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * ShellTestShell class

--- a/lib/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -24,7 +24,6 @@ use Cake\TestSuite\Fixture\TestModel;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 use TestPlugin\Controller\TestPluginController;
 
 /**

--- a/lib/Cake/Test/TestCase/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/TestCase/Network/Http/HttpSocketTest.php
@@ -21,7 +21,6 @@ use Cake\Network\Http\HttpResponse;
 use Cake\Network\Http\HttpSocket;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
-use Cake\Utility\Set;
 
 /**
  * TestAuthentication class

--- a/lib/Cake/TestSuite/Fixture/TestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/TestFixture.php
@@ -21,7 +21,6 @@ use Cake\Model\Schema;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
-use Cake\Utility\Set;
 
 /**
  * TestFixture is responsible for building and destroying tables to be used 

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -13,7 +13,7 @@
 namespace Cake\View;
 use Cake\Controller\Controller;
 use Cake\Network\Response;
-use Cake\Utility\Set;
+use Cake\Utility\Hash;
 use Cake\Utility\Xml;
 
 /**
@@ -95,7 +95,7 @@ class XmlView extends View {
 				}
 			} else {
 				$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
-				if (is_array($data) && Set::numeric(array_keys($data))) {
+				if (is_array($data) && Hash::numeric(array_keys($data))) {
 					$data = array('response' => array($serialize => $data));
 				}
 			}


### PR DESCRIPTION
The only place left where `Set` is still needed is https://github.com/cakephp/cakephp/blob/3.0/lib/Cake/Model/Model.php#L1141 with `Set::reverse()`.
