### PR TITLE
2.3 element refactor

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -394,7 +394,7 @@ class View extends Object {
 		}
 
 		if (isset($options['cache'])) {
-			$contents = $this->_elementCache($name, $plugin, $options);
+			$contents = $this->_elementCache($name, $plugin, $data, $options);
 			if ($contents !== false) {
 				return $contents;
 			}
@@ -1107,7 +1107,7 @@ class View extends Object {
  * @param string $plugin Plugin name
  * @param array $options Element options
  */
-	protected function _elementCache($name, $plugin, $options) {
+	protected function _elementCache($name, $plugin, $data, $options) {
 		$underscored = null;
 		if ($plugin) {
 			$underscored = Inflector::underscore($plugin);
@@ -1124,8 +1124,8 @@ class View extends Object {
 			);
 			$this->elementCacheSettings = array_merge($defaults, $options['cache']);
 		}
-		$key = 'element_' . $this->elementCacheSettings['key'];
-		return = Cache::read($key, $this->elementCacheSettings['config']);
+		$this->elementCacheSettings['key'] = 'element_' . $this->elementCacheSettings['key'];
+		return Cache::read($this->elementCacheSettings['key'], $this->elementCacheSettings['config']);
 	}
 
 /**
@@ -1140,7 +1140,7 @@ class View extends Object {
 		if (!$this->_helpersLoaded) {
 			$this->loadHelpers();
 		}
-		if ($callbacks) {
+		if ($options['callbacks']) {
 			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($file)));
 		}
 
@@ -1151,7 +1151,7 @@ class View extends Object {
 			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($file, $element)));
 		}
 		if (isset($options['cache'])) {
-			Cache::write($key, $element, $this->elementCacheSettings['config']);
+			Cache::write($this->elementCacheSettings['key'], $element, $this->elementCacheSettings['config']);
 		}
 		return $element;
 	}

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -220,6 +220,14 @@ class View extends Object {
 	public $elementCache = 'default';
 
 /**
+ * Element cache settings
+ *
+ * @see View::_elementCache();
+ * @see View::_renderElement
+ */
+	public $elementCacheSettings = array();
+
+/**
  * List of variables to collect from the associated controller.
  *
  * @var array
@@ -375,62 +383,28 @@ class View extends Object {
  *   `Plugin.element_name` instead.
  */
 	public function element($name, $data = array(), $options = array()) {
-		$file = $plugin = $key = null;
-		$callbacks = false;
+		$file = $plugin = null;
 
 		if (isset($options['plugin'])) {
 			$name = Inflector::camelize($options['plugin']) . '.' . $name;
 		}
 
-		if (isset($options['callbacks'])) {
-			$callbacks = $options['callbacks'];
+		if (!isset($options['callbacks'])) {
+			$options['callbacks'] = false;
 		}
 
 		if (isset($options['cache'])) {
-			$underscored = null;
-			if ($plugin) {
-				$underscored = Inflector::underscore($plugin);
-			}
-			$keys = array_merge(array($underscored, $name), array_keys($options), array_keys($data));
-			$caching = array(
-				'config' => $this->elementCache,
-				'key' => implode('_', $keys)
-			);
-			if (is_array($options['cache'])) {
-				$defaults = array(
-					'config' => $this->elementCache,
-					'key' => $caching['key']
-				);
-				$caching = array_merge($defaults, $options['cache']);
-			}
-			$key = 'element_' . $caching['key'];
-			$contents = Cache::read($key, $caching['config']);
+			$contents = $this->_elementCache($name, $plugin, $options);
 			if ($contents !== false) {
 				return $contents;
 			}
 		}
 
 		$file = $this->_getElementFilename($name);
-
 		if ($file) {
-			if (!$this->_helpersLoaded) {
-				$this->loadHelpers();
-			}
-			if ($callbacks) {
-				$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($file)));
-			}
-
-			$this->_currentType = self::TYPE_ELEMENT;
-			$element = $this->_render($file, array_merge($this->viewVars, $data));
-
-			if ($callbacks) {
-				$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($file, $element)));
-			}
-			if (isset($options['cache'])) {
-				Cache::write($key, $element, $caching['config']);
-			}
-			return $element;
+			return $this->_renderElement($file, $data, $options);
 		}
+
 		$file = 'Elements' . DS . $name . $this->ext;
 
 		if (Configure::read('debug') > 0) {
@@ -1126,4 +1100,59 @@ class View extends Object {
 		return $this->_paths = $paths;
 	}
 
+/**
+ * Checks if an element is cached and returns the cached data if present
+ *
+ * @param string $name Element name
+ * @param string $plugin Plugin name
+ * @param array $options Element options
+ */
+	protected function _elementCache($name, $plugin, $options) {
+		$underscored = null;
+		if ($plugin) {
+			$underscored = Inflector::underscore($plugin);
+		}
+		$keys = array_merge(array($underscored, $name), array_keys($options), array_keys($data));
+		$this->elementCacheSettings = array(
+			'config' => $this->elementCache,
+			'key' => implode('_', $keys)
+		);
+		if (is_array($options['cache'])) {
+			$defaults = array(
+				'config' => $this->elementCache,
+				'key' => $this->elementCacheSettings['key']
+			);
+			$this->elementCacheSettings = array_merge($defaults, $options['cache']);
+		}
+		$key = 'element_' . $this->elementCacheSettings['key'];
+		return = Cache::read($key, $this->elementCacheSettings['config']);
+	}
+
+/**
+ * Renders an element and fires the before and afterRender callbacks for it
+ * and writes to the cache if a cache is used
+ *
+ * @param string $file Element file path
+ * @param array $data Data to render
+ * @param array $options Element options
+ */
+	protected function _renderElement($file, $data, $options) {
+		if (!$this->_helpersLoaded) {
+			$this->loadHelpers();
+		}
+		if ($callbacks) {
+			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($file)));
+		}
+
+		$this->_currentType = self::TYPE_ELEMENT;
+		$element = $this->_render($file, array_merge($this->viewVars, $data));
+
+		if (isset($options['callbacks'])) {
+			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($file, $element)));
+		}
+		if (isset($options['cache'])) {
+			Cache::write($key, $element, $this->elementCacheSettings['config']);
+		}
+		return $element;
+	}
 }

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -394,7 +394,7 @@ class View extends Object {
 		}
 
 		if (isset($options['cache'])) {
-			$contents = $this->_elementCache($name, $plugin, $data, $options);
+			$contents = $this->_elementCache($name, $data, $options);
 			if ($contents !== false) {
 				return $contents;
 			}
@@ -1107,7 +1107,10 @@ class View extends Object {
  * @param string $plugin Plugin name
  * @param array $options Element options
  */
-	protected function _elementCache($name, $plugin, $data, $options) {
+	protected function _elementCache($name, $data, $options) {
+		$plugin = null;
+		list($plugin, $name) = $this->pluginSplit($name);
+
 		$underscored = null;
 		if ($plugin) {
 			$underscored = Inflector::underscore($plugin);


### PR DESCRIPTION
I've refactored the View::element() method to call two methods_elementCache() and _elementRender() now to make it possible to override these parts without (made them protected) the need to overwrite the whole element() method. I think its also better to have small methods with a distinct duty.
