### PR TITLE
Fix for CakeEmailTest.php that failed unless using 'localhost'

### DIFF
--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1119,7 +1119,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->template('image');
 		$this->CakeEmail->emailFormat('html');
 
-		$expected = '<img src="http://localhost/img/image.gif" alt="cool image" width="100" height="100" />';
+		$expected = '<img src="http://' . env('SERVER_NAME') . '/img/image.gif" alt="cool image" width="100" height="100" />';
 		$result = $this->CakeEmail->send();
 		$this->assertContains($expected, $result['message']);
 	}


### PR DESCRIPTION
Test was failing when a developer doesn't use "localhost" for their app.
