### PR TITLE
Translated models and empty fields

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -392,6 +392,16 @@ class TranslateBehavior extends ModelBehavior {
 		unset($this->runtime[$model->alias]['beforeValidate'], $this->runtime[$model->alias]['beforeSave']);
 		$conditions = array('model' => $model->alias, 'foreign_key' => $model->id);
 		$RuntimeModel = $this->translateModel($model);
+		
+		$fields = array_merge($this->settings[$model->alias], $this->runtime[$model->alias]['fields']);
+		if ($created) {
+			foreach ($fields as $field) {
+				if (!array_key_exists($field, $tempData)) {
+					//save an empty string
+					$tempData[$field] = '';
+				}
+			}
+		}
 
 		foreach ($tempData as $field => $value) {
 			unset($conditions['content']);


### PR DESCRIPTION
To assure translated models have all fields so find methods on these models always find something

See lighthouse ticket #3009
