### PR TITLE
Updates afterSave to ensure newly created entires have all fields set

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -396,7 +396,7 @@ class TranslateBehavior extends ModelBehavior {
 		$fields = array_merge($this->settings[$model->alias], $this->runtime[$model->alias]['fields']);
 		if ($created) {
 			foreach ($fields as $field) {
-				if (isset($tempData[$field])) {
+				if (!isset($tempData[$field])) {
 					//set the field value to an empty string
 					$tempData[$field] = '';
 				}

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -396,7 +396,7 @@ class TranslateBehavior extends ModelBehavior {
 		$fields = array_merge($this->settings[$model->alias], $this->runtime[$model->alias]['fields']);
 		if ($created) {
 			foreach ($fields as $field) {
-				if (!array_key_exists($field, $tempData)) {
+				if (isset($tempData[$field])) {
 					//set the field value to an empty string
 					$tempData[$field] = '';
 				}

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -392,6 +392,16 @@ class TranslateBehavior extends ModelBehavior {
 		unset($this->runtime[$model->alias]['beforeValidate'], $this->runtime[$model->alias]['beforeSave']);
 		$conditions = array('model' => $model->alias, 'foreign_key' => $model->id);
 		$RuntimeModel = $this->translateModel($model);
+	
+		$fields = array_merge($this->settings[$model->alias], $this->runtime[$model->alias]['fields']);
+		if ($created) {
+			foreach ($fields as $field) {
+				if (!array_key_exists($field, $tempData)) {
+					//set the field value to an empty string
+					$tempData[$field] = '';
+				}
+			}
+		}
 
 		foreach ($tempData as $field => $value) {
 			unset($conditions['content']);


### PR DESCRIPTION
Updates afterSave() to ensure newly created entires have all the translated fields present in the i18n table. (otherwise find()'s return no matches)

Current code only sets the fields that are set in the save()

This causes find() not to find any matches for a given locale.

See also: http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3009
