### PR TITLE
Added ServerShell for PHP Built-in Server

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -70,6 +70,11 @@ if (!defined('WWW_ROOT')) {
 	define('WWW_ROOT', dirname(__FILE__) . DS);
 }
 
+// for built-in server
+if (php_sapi_name() == 'cli-server') {
+  $_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
+}
+
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {
 	if (function_exists('ini_set')) {
 		ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));

--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -72,7 +72,7 @@ if (!defined('WWW_ROOT')) {
 
 // for built-in server
 if (php_sapi_name() == 'cli-server') {
-  $_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
+	$_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
 }
 
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -2,8 +2,6 @@
 /**
  * built-in Server Shell
  *
- * Implementation of a Cake Shell to show CakePHP core method signatures.
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
@@ -14,7 +12,7 @@
  *
  * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         CakePHP(tm) v 1.2.0.5012
+ * @since         CakePHP(tm) v 2.3.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
@@ -26,123 +24,129 @@ App::uses('AppShell', 'Console/Command');
  * @package       Cake.Console.Command
  */
 class ServerShell extends AppShell {
-    const DEFAULT_HOST = 'localhost';
-    const DEFAULT_PORT = 80;
+	/**
+	 * Default ServerHost
+	 */
+	const DEFAULT_HOST = 'localhost';
+	/**
+	 * Default ListenPort
+	 */
+	const DEFAULT_PORT = 80;
 
-    /**
-     * server host
-     *
-     * @var string
-     */
-    protected $_host = null;
+	/**
+	 * server host
+	 *
+	 * @var string
+	 */
+	protected $_host = null;
 
-    /**
-     * listern port
-     *
-     * @var string
-     */
-    protected $_port = null;
+	/**
+	 * listen port
+	 *
+	 * @var string
+	 */
+	protected $_port = null;
 
-    /**
-     * document root
-     *
-     * @var string
-     */
-    protected $_documentRoot = null;
+	/**
+	 * document root
+	 *
+	 * @var string
+	 */
+	protected $_documentRoot = null;
 
-    /**
-     * Override initialize of the Shell
-     *
-     * @return void
-     */
-    public function initialize() {
-        $this->_host = self::DEFAULT_HOST;
-        $this->_port = self::DEFAULT_PORT;
-        $this->_documentRoot = WWW_ROOT;
-    }
+	/**
+	 * Override initialize of the Shell
+	 *
+	 * @return void
+	 */
+	public function initialize() {
+		$this->_host = self::DEFAULT_HOST;
+		$this->_port = self::DEFAULT_PORT;
+		$this->_documentRoot = WWW_ROOT;
+	}
 
-    /**
-     * Starts up the Shell and displays the welcome message.
-     * Allows for checking and configuring prior to command or main execution
-     *
-     * Override this method if you want to remove the welcome information,
-     * or otherwise modify the pre-command flow.
-     *
-     * @return void
-     * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
-     */
-    public function startup() {
-        parent::startup();
+	/**
+	 * Starts up the Shell and displays the welcome message.
+	 * Allows for checking and configuring prior to command or main execution
+	 *
+	 * Override this method if you want to remove the welcome information,
+	 * or otherwise modify the pre-command flow.
+	 *
+	 * @return void
+	 * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
+	 */
+	public function startup() {
+		parent::startup();
 
-        if (!empty($this->params['host'])) {
-            $this->_host = $this->params['host'];
-        }
-        if (!empty($this->params['port'])) {
-            $this->_port = $this->params['port'];
-        }
-        if (!empty($this->params['document_root'])) {
-            $this->_documentRoot = $this->params['document_root'];
-        }
+		if (!empty($this->params['host'])) {
+			$this->_host = $this->params['host'];
+		}
+		if (!empty($this->params['port'])) {
+			$this->_port = $this->params['port'];
+		}
+		if (!empty($this->params['document_root'])) {
+			$this->_documentRoot = $this->params['document_root'];
+		}
 
-        // for windows
-        if (substr($this->_documentRoot, -1, 1) == DIRECTORY_SEPARATOR) {
-          $this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) -1);
-        }
-        if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {
-          $this->_documentRoot = $m[1].'\\'.$m[2];
-        }
-    }
+		// for windows
+		if (substr($this->_documentRoot, -1, 1) == DIRECTORY_SEPARATOR) {
+			$this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) -1);
+		}
+		if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {
+			$this->_documentRoot = $m[1].'\\'.$m[2];
+		}
+	}
 
-    /**
-     * Override main() to handle action
-     *
-     * @return void
-     */
-    public function main() {
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            $this->out(__d('cake_console', '<warning>This command is available on PHP5.4 or above</warning>'));
-            return;
-        }
+	/**
+	 * Override main() to handle action
+	 *
+	 * @return void
+	 */
+	public function main() {
+		if (version_compare(PHP_VERSION, '5.4.0') < 0) {
+			$this->out(__d('cake_console', '<warning>This command is available on PHP5.4 or above</warning>'));
+			return;
+		}
 
-        $this->out(__d('cake_console', 'ServerHost  : %s', $this->_host));
-        $this->out(__d('cake_console', 'ListenPort  : %d', $this->_port));
-        $this->out(__d('cake_console', 'DocumentRoot: %s', $this->_documentRoot));
-        $this->hr();
+		$this->out(__d('cake_console', 'ServerHost  : %s', $this->_host));
+		$this->out(__d('cake_console', 'ListenPort  : %d', $this->_port));
+		$this->out(__d('cake_console', 'DocumentRoot: %s', $this->_documentRoot));
+		$this->hr();
 
-        $command = sprintf("php -S %s:%d -t %s",
-                      $this->_host,
-                      $this->_port,
-                      $this->_documentRoot
-                    );
+		$command = sprintf("php -S %s:%d -t %s",
+			$this->_host,
+			$this->_port,
+			$this->_documentRoot
+		);
 
-        $this->out(__d('cake_console', '<warning>[WARNING] Don\'t use this at the production enviroment</warning>'));
-        $this->out(__d('cake_console', 'built-in server is running...'));
-        $ret = system($command);
-    }
+		$this->out(__d('cake_console', '<warning>[WARNING] Don\'t use this at the production environment</warning>'));
+		$this->out(__d('cake_console', 'built-in server is running...'));
+		$ret = system($command);
+	}
 
-      /**
-       * Get and configure the optionparser.
-       *
-       * @return ConsoleOptionParser
-       */
-      public function getOptionParser() {
-          $parser = parent::getOptionParser();
+	/**
+	 * Get and configure the optionparser.
+	 *
+	 * @return ConsoleOptionParser
+	 */
+	public function getOptionParser() {
+		$parser = parent::getOptionParser();
 
-          $parser->addOption('host', array(
-              'short' => 'H',
-              'help' => __d('cake_console', 'ServerHost')
-          ));
-          $parser->addOption('port', array(
-              'short' => 'p',
-              'help' => __d('cake_console', 'ListenPort')
-          ));
-          $parser->addOption('document_root', array(
-              'short' => 'd',
-              'help' => __d('cake_console', 'DocumentRoot')
-          ));
+		$parser->addOption('host', array(
+			'short' => 'H',
+			'help' => __d('cake_console', 'ServerHost')
+		));
+		$parser->addOption('port', array(
+			'short' => 'p',
+			'help' => __d('cake_console', 'ListenPort')
+		));
+		$parser->addOption('document_root', array(
+			'short' => 'd',
+			'help' => __d('cake_console', 'DocumentRoot')
+		));
 
-          $parser->description(__('PHP Built-in Server for CakePHP'));
+		$parser->description(__d('cake_console', 'PHP Built-in Server for CakePHP'));
 
-          return $parser;
-      }
+		return $parser;
+	}
 }

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -88,7 +88,7 @@ class ServerShell extends AppShell {
 
 		// for windows
 		if (substr($this->_documentRoot, -1, 1) == DIRECTORY_SEPARATOR) {
-			$this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) -1);
+			$this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) - 1);
 		}
 		if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {
 			$this->_documentRoot = $m[1].'\\'.$m[2];
@@ -157,7 +157,7 @@ class ServerShell extends AppShell {
 
 		$parser->description(array(
 			__d('cake_console', 'PHP Built-in Server for CakePHP'),
-			__d('cake_console', '<warning>Don\'t use this at the production environment</warning>'),
+			__d('cake_console', '<warning>[WARN] Don\'t use this at the production environment</warning>'),
 		));
 
 		return $parser;

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -24,60 +24,58 @@ App::uses('AppShell', 'Console/Command');
  * @package       Cake.Console.Command
  */
 class ServerShell extends AppShell {
-	/**
-	 * Default ServerHost
-	 */
+/**
+ * Default ServerHost
+ */
 	const DEFAULT_HOST = 'localhost';
-	/**
-	 * Default ListenPort
-	 */
+/**
+ * Default ListenPort
+ */
 	const DEFAULT_PORT = 80;
 
-	/**
-	 * server host
-	 *
-	 * @var string
-	 */
+/**
+ * server host
+ *
+ * @var string
+ */
 	protected $_host = null;
 
-	/**
-	 * listen port
-	 *
-	 * @var string
-	 */
+/**
+ * listen port
+ *
+ * @var string
+ */
 	protected $_port = null;
 
-	/**
-	 * document root
-	 *
-	 * @var string
-	 */
+/**
+ * document root
+ *
+ * @var string
+ */
 	protected $_documentRoot = null;
 
-	/**
-	 * Override initialize of the Shell
-	 *
-	 * @return void
-	 */
+/**
+ * Override initialize of the Shell
+ *
+ * @return void
+ */
 	public function initialize() {
 		$this->_host = self::DEFAULT_HOST;
 		$this->_port = self::DEFAULT_PORT;
 		$this->_documentRoot = WWW_ROOT;
 	}
 
-	/**
-	 * Starts up the Shell and displays the welcome message.
-	 * Allows for checking and configuring prior to command or main execution
-	 *
-	 * Override this method if you want to remove the welcome information,
-	 * or otherwise modify the pre-command flow.
-	 *
-	 * @return void
-	 * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
-	 */
+/**
+ * Starts up the Shell and displays the welcome message.
+ * Allows for checking and configuring prior to command or main execution
+ *
+ * Override this method if you want to remove the welcome information,
+ * or otherwise modify the pre-command flow.
+ *
+ * @return void
+ * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
+ */
 	public function startup() {
-		parent::startup();
-
 		if (!empty($this->params['host'])) {
 			$this->_host = $this->params['host'];
 		}
@@ -95,23 +93,35 @@ class ServerShell extends AppShell {
 		if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {
 			$this->_documentRoot = $m[1].'\\'.$m[2];
 		}
+
+		parent::startup();
 	}
 
-	/**
-	 * Override main() to handle action
-	 *
-	 * @return void
-	 */
+/**
+ * Displays a header for the shell
+ *
+ * @return void
+ */
+	protected function _welcome() {
+		$this->out();
+		$this->out(__d('cake_console', '<info>Welcome to CakePHP %s Console</info>', 'v' . Configure::version()));
+		$this->hr();
+		$this->out(__d('cake_console', 'App : %s', APP_DIR));
+		$this->out(__d('cake_console', 'Path: %s', APP));
+		$this->out(__d('cake_console', 'DocumentRoot: %s', $this->_documentRoot));
+		$this->hr();
+	}
+
+/**
+ * Override main() to handle action
+ *
+ * @return void
+ */
 	public function main() {
 		if (version_compare(PHP_VERSION, '5.4.0') < 0) {
 			$this->out(__d('cake_console', '<warning>This command is available on PHP5.4 or above</warning>'));
 			return;
 		}
-
-		$this->out(__d('cake_console', 'ServerHost  : %s', $this->_host));
-		$this->out(__d('cake_console', 'ListenPort  : %d', $this->_port));
-		$this->out(__d('cake_console', 'DocumentRoot: %s', $this->_documentRoot));
-		$this->hr();
 
 		$command = sprintf("php -S %s:%d -t %s",
 			$this->_host,
@@ -120,15 +130,16 @@ class ServerShell extends AppShell {
 		);
 
 		$this->out(__d('cake_console', '<warning>[WARNING] Don\'t use this at the production environment</warning>'));
-		$this->out(__d('cake_console', 'built-in server is running...'));
+		$port = ($this->_port == self::DEFAULT_PORT) ? '' : ':'.$this->_port;
+		$this->out(__d('cake_console', 'built-in server is running in http://%s%s/', $this->_host, $port));
 		$ret = system($command);
 	}
 
-	/**
-	 * Get and configure the optionparser.
-	 *
-	 * @return ConsoleOptionParser
-	 */
+/**
+ * Get and configure the optionparser.
+ *
+ * @return ConsoleOptionParser
+ */
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
 

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * built-in Server Shell
+ *
+ * Implementation of a Cake Shell to show CakePHP core method signatures.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 1.2.0.5012
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('AppShell', 'Console/Command');
+
+/**
+ * built-in Server Shell
+ *
+ * @package       Cake.Console.Command
+ */
+class ServerShell extends AppShell {
+    const DEFAULT_HOST = 'localhost';
+    const DEFAULT_PORT = 80;
+
+    /**
+     * server host
+     *
+     * @var string
+     */
+    protected $_host = null;
+
+    /**
+     * listern port
+     *
+     * @var string
+     */
+    protected $_port = null;
+
+    /**
+     * document root
+     *
+     * @var string
+     */
+    protected $_documentRoot = null;
+
+    /**
+     * Override initialize of the Shell
+     *
+     * @return void
+     */
+    public function initialize() {
+        $this->_host = self::DEFAULT_HOST;
+        $this->_port = self::DEFAULT_PORT;
+        $this->_documentRoot = WWW_ROOT;
+    }
+
+    /**
+     * Starts up the Shell and displays the welcome message.
+     * Allows for checking and configuring prior to command or main execution
+     *
+     * Override this method if you want to remove the welcome information,
+     * or otherwise modify the pre-command flow.
+     *
+     * @return void
+     * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::startup
+     */
+    public function startup() {
+        parent::startup();
+
+        if (!empty($this->params['host'])) {
+            $this->_host = $this->params['host'];
+        }
+        if (!empty($this->params['port'])) {
+            $this->_port = $this->params['port'];
+        }
+        if (!empty($this->params['document_root'])) {
+            $this->_documentRoot = $this->params['document_root'];
+        }
+
+        // for windows
+        if (substr($this->_documentRoot, -1, 1) == DIRECTORY_SEPARATOR) {
+          $this->_documentRoot = substr($this->_documentRoot, 0, strlen($this->_documentRoot) -1);
+        }
+        if (preg_match("/^([a-z]:)[\\\]+(.+)$/i", $this->_documentRoot, $m)) {
+          $this->_documentRoot = $m[1].'\\'.$m[2];
+        }
+    }
+
+    /**
+     * Override main() to handle action
+     *
+     * @return void
+     */
+    public function main() {
+        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
+            $this->out(__d('cake_console', '<warning>This command is available on PHP5.4 or above</warning>'));
+            return;
+        }
+
+        $this->out(__d('cake_console', 'ServerHost  : %s', $this->_host));
+        $this->out(__d('cake_console', 'ListenPort  : %d', $this->_port));
+        $this->out(__d('cake_console', 'DocumentRoot: %s', $this->_documentRoot));
+        $this->hr();
+
+        $command = sprintf("php -S %s:%d -t %s",
+                      $this->_host,
+                      $this->_port,
+                      $this->_documentRoot
+                    );
+
+        $this->out(__d('cake_console', '<warning>[WARNING] Don\'t use this at the production enviroment</warning>'));
+        $this->out(__d('cake_console', 'built-in server is running...'));
+        $ret = system($command);
+    }
+
+      /**
+       * Get and configure the optionparser.
+       *
+       * @return ConsoleOptionParser
+       */
+      public function getOptionParser() {
+          $parser = parent::getOptionParser();
+
+          $parser->addOption('host', array(
+              'short' => 'H',
+              'help' => __d('cake_console', 'ServerHost')
+          ));
+          $parser->addOption('port', array(
+              'short' => 'p',
+              'help' => __d('cake_console', 'ListenPort')
+          ));
+          $parser->addOption('document_root', array(
+              'short' => 'd',
+              'help' => __d('cake_console', 'DocumentRoot')
+          ));
+
+          $parser->description(__('PHP Built-in Server for CakePHP'));
+
+          return $parser;
+      }
+}

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -129,7 +129,6 @@ class ServerShell extends AppShell {
 			$this->_documentRoot
 		);
 
-		$this->out(__d('cake_console', '<warning>[WARNING] Don\'t use this at the production environment</warning>'));
 		$port = ($this->_port == self::DEFAULT_PORT) ? '' : ':'.$this->_port;
 		$this->out(__d('cake_console', 'built-in server is running in http://%s%s/', $this->_host, $port));
 		$ret = system($command);
@@ -156,7 +155,10 @@ class ServerShell extends AppShell {
 			'help' => __d('cake_console', 'DocumentRoot')
 		));
 
-		$parser->description(__d('cake_console', 'PHP Built-in Server for CakePHP'));
+		$parser->description(array(
+			__d('cake_console', 'PHP Built-in Server for CakePHP'),
+			__d('cake_console', '<warning>Don\'t use this at the production environment</warning>'),
+		));
 
 		return $parser;
 	}

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -414,7 +414,7 @@ class ModelTask extends BakeTask {
 				for ($i = 1, $m = $defaultChoice / 2; $i < $m; $i++) {
 					$line = sprintf("%2d. %s", $i, $this->_validations[$i]);
 					$optionText .= $line . str_repeat(" ", 31 - strlen($line));
-					$optionText .= sprintf("%2d. %s", $m + $i, $this->_validations[$m + $i]);
+					$optionText .= sprintf("%2d. %s\n", $m + $i, $this->_validations[$m + $i]);
 				}
 				$this->out($optionText);
 				$this->out(__d('cake_console', "%s - Do not do any validation on this field.", $defaultChoice));

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -72,6 +72,11 @@ if (!defined('WWW_ROOT')) {
 	define('WWW_ROOT', dirname(__FILE__) . DS);
 }
 
+// for built-in server
+if (php_sapi_name() == 'cli-server') {
+	$_SERVER['PHP_SELF'] = '/'.basename(__FILE__);
+}
+
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {
 	if (function_exists('ini_set')) {
 		ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -229,7 +229,7 @@ class SecurityComponent extends Component {
 			}
 		}
 		$this->generateToken($controller->request);
-		if ($isPost) {
+		if ($isPost && is_array($controller->request->data)) {
 			unset($controller->request->data['_Token']);
 		}
 	}

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -392,7 +392,7 @@ class TranslateBehavior extends ModelBehavior {
 		unset($this->runtime[$model->alias]['beforeValidate'], $this->runtime[$model->alias]['beforeSave']);
 		$conditions = array('model' => $model->alias, 'foreign_key' => $model->id);
 		$RuntimeModel = $this->translateModel($model);
-	
+
 		$fields = array_merge($this->settings[$model->alias], $this->runtime[$model->alias]['fields']);
 		if ($created) {
 			foreach ($fields as $field) {


### PR DESCRIPTION
Hi, I would propose adding new Shell Command.It is ServerShell.

ServerShell provides a httpd server for CakePHP application without other httpd server(Apache, nginx etc).

It is use PHP CLI build-in server.

Use case is below.
### 1. default (http://localhost/)

```
$ cd /path/to/app
$ ./Console/cake server

Welcome to CakePHP v2.2.0 Console
---------------------------------------------------------------
App : app
Path: /path/to/app/
---------------------------------------------------------------
ServerHost  : localhost
ListenPort  : 80
DocumentRoot: /path/to/app/webroot
---------------------------------------------------------------
[WARNING] Don't use this at the production enviroment
built-in server is running...
```
### 2. specify ListenPort (http://localhost:8000/)

```
$ ./Console/cake server -p 8000

Welcome to CakePHP v2.2.0 Console
---------------------------------------------------------------
App : app
Path: /path/to/app/
---------------------------------------------------------------
ServerHost  : localhost
ListenPort  : 8000
DocumentRoot: /path/to/app/webroot
---------------------------------------------------------------
[WARNING] Don't use this at the production enviroment
built-in server is running...
```
### 3. usage

```
$ ./Console/cake -h

Welcome to CakePHP v2.2.0 Console
---------------------------------------------------------------
App : app
Path: /Users/shin/sandbox/cakephp_shin1x1/app/
---------------------------------------------------------------
PHP Built-in Server for CakePHP

Usage:
cake server [-h] [-v] [-q] [-H] [-p] [-d]

Options:

--help, -h           Display this help.
--verbose, -v        Enable verbose output.
--quiet, -q          Enable quiet output.
--host, -H           ServerHost
--port, -p           ListenPort
--document_root, -d  DocumentRoot 
```
### 4. PHP 5.3 or lower

```
$ ./Console/cake server

Welcome to CakePHP v2.2.0 Console
---------------------------------------------------------------
App : app
Path: /path/to/app/
---------------------------------------------------------------
ServerHost  : localhost
ListenPort  : 80
DocumentRoot: /path/to/app/webroot
---------------------------------------------------------------
This command is available on PHP5.4 or above    
```
