### PR TITLE
2.3 fix validation error message

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -274,7 +274,7 @@ class CakeValidationRule {
 			$this->_valid = call_user_func_array(array('Validation', $this->_rule), $this->_ruleParams);
 		} elseif (is_string($validator['rule'])) {
 			$this->_valid = preg_match($this->_rule, $data[$field]);
-		} elseif (Configure::read('debug') > 0) {
+		} else {
 			trigger_error(__d('cake_dev', 'Could not find validation handler %s for %s', $this->_rule, $field), E_USER_WARNING);
 			return false;
 		}


### PR DESCRIPTION
make sure a missing validation rule always triggers a warning (in productive mode this will be logged to the error log file)

as outlined in http://cakephp.lighthouseapp.com/projects/42648/tickets/3039 it is better to catch/log this coding error even in productive mode to be able to fix it.
