### PR TITLE
Proposed simple fix for ticket #3042, added a switch for the content dis...

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1355,8 +1355,9 @@ class CakeEmail {
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];
 			$msg[] = 'Content-Transfer-Encoding: base64';
-			if (!isset($fileInfo['contentDisposition']) || $fileInfo['contentDisposition'])
+			if (!isset($fileInfo['contentDisposition']) || $fileInfo['contentDisposition']) {
 				$msg[] = 'Content-Disposition: attachment; filename="' . $filename . '"';
+			}
 			$msg[] = '';
 			$msg[] = $data;
 			$msg[] = '';

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1355,7 +1355,8 @@ class CakeEmail {
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];
 			$msg[] = 'Content-Transfer-Encoding: base64';
-			$msg[] = 'Content-Disposition: attachment; filename="' . $filename . '"';
+			if (!isset($fileInfo['contentDisposition']) || $fileInfo['contentDisposition'])
+				$msg[] = 'Content-Disposition: attachment; filename="' . $filename . '"';
 			$msg[] = '';
 			$msg[] = $data;
 			$msg[] = '';


### PR DESCRIPTION
Added a switch for adding the content disposition header to CakeEmail attachments. By default it will still be added, but now there is a way to disable it for specific attachments.

Example use

``` php
$email = new CakeEmail('smtp');
$email->attachments(array(
    'meeting.ics'=>array(
      'file'=>'/tmp/meeting.ics',
      'mimetype'=>'text/calendar; charset="utf-8"; method=REQUEST',
      'contentDisposition'=>false
    )
  );
```
