### PR TITLE
Fix Shell::nl() to be outputting newlines instead of returning.

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -580,14 +580,14 @@ class Shell extends Object {
 	}
 
 /**
- * Returns a single or multiple linefeeds sequences.
+ * Outputs a single or multiple linefeeds sequences to the standard output.
  *
  * @param integer $multiplier Number of times the linefeed sequence should be repeated
- * @return string
+ * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::nl
  */
 	public function nl($multiplier = 1) {
-		return str_repeat(ConsoleOutput::LF, $multiplier);
+	    $this->out(null, $multiplier);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -378,15 +378,35 @@ class ShellTest extends CakeTestCase {
  * @return void
  */
 	public function testNl() {
-		$newLine = "\n";
-		if (DS === '\\') {
-			$newLine = "\r\n";
-		}
-		$this->assertEquals($this->Shell->nl(), $newLine);
-		$this->assertEquals($this->Shell->nl(true), $newLine);
-		$this->assertEquals("", $this->Shell->nl(false));
-		$this->assertEquals($this->Shell->nl(2), $newLine . $newLine);
-		$this->assertEquals($this->Shell->nl(1), $newLine);
+		$this->Shell->stdout->expects($this->at(0))
+			->method('write')
+			->with('', 1);
+
+		$this->Shell->stdout->expects($this->at(1))
+			->method('write')
+			->with('', 2);
+
+		$this->Shell->stdout->expects($this->at(2))
+			->method('write')
+			->with('', 1);
+
+		$this->Shell->stdout->expects($this->at(3))
+			->method('write')
+			->with('', true);
+
+		$this->Shell->stdout->expects($this->at(4))
+			->method('write')
+			->with('', false);
+			
+		$this->Shell->nl();
+		
+		$this->Shell->nl(2);
+		
+		$this->Shell->nl(1);
+		
+		$this->Shell->nl(true);
+		
+		$this->Shell->nl(false);
 	}
 
 /**


### PR DESCRIPTION
Either the code or the documentation should be fixed. 

`Shell::nl()` was earlier returning number of linefeeds while the documentation (http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::nl) says it should be outputting.

For consistency, along with other methods in `Shell`, especially `hr()`, I believe outputting instead of returning would be more appropriate. 
