### PR TITLE
Prevent booleans from being encoded (converted to strings) by h() function

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -225,6 +225,15 @@ class BasicsTest extends CakeTestCase {
 			'n' => '&nbsp;'
 		);
 		$this->assertEquals($expected, $result);
+		
+		// Test that boolean values are not converted to strings
+		$result = h(false);
+		$this->assertFalse($result);
+
+		$arr = array('foo' => false, 'bar' => true);
+		$result = h($arr);
+		$this->assertFalse($result['foo']);
+		$this->assertTrue($result['bar']);
 
 		$obj = new stdClass();
 		$result = h($obj);

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -175,6 +175,8 @@ function h($text, $double = true, $charset = null) {
 		} else {
 			$text = '(object)' . get_class($text);
 		}
+	} elseif (is_bool($text)) {
+		return $text;
 	}
 
 	static $defaultCharset = false;


### PR DESCRIPTION
This patch prevents booleans from being encoded (converted to strings) by the global `h()` function.  New tests included.
### Background

If booleans are encoded, they become strings which can easily cause fatal PHP errors in PHP versions around 5.2.9 and possibly 5.3 also.

```
$a = $this->Article->findById(99);  // potentially returns false
$a = h($a);                         // translates false to empty string
echo $a['Article']['title'];        // Fatal error on PHP 5.2.9 rather than warning
```

PHP 5.4.4 displays a warning when this is attempted (thankfully), but I'm not sure how many other PHP versions are affected by this.
