### PR TITLE
only try to get comparison failure for the appropriate object

### DIFF
--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -249,10 +249,12 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		$testName = get_class($test) . '(' . $test->getName() . ')';
 
 		$actualMsg = $expectedMsg = null;
-		$failure = $message->getComparisonFailure();
-		if (is_object($failure)) {
-			$actualMsg = $message->getComparisonFailure()->getActualAsString();
-			$expectedMsg = $message->getComparisonFailure()->getExpectedAsString();
+		if (method_exists($message, 'comparisonFailure')) {
+			$failure = $message->comparisonFailure();
+			if (is_object($failure)) {
+				$actualMsg = $message->getComparisonFailure()->getActualAsString();
+				$expectedMsg = $message->getComparisonFailure()->getExpectedAsString();
+			}
 		}
 
 		echo "<li class='fail'>\n";


### PR DESCRIPTION
avoid 

```
`Fatal error: Call to undefined method PHPUnit_Framework_AssertionFailedError::getComparisonFailure() in ... on line 252`
```

the $failure object can actually be a `PHPUnit_Framework_AssertionFailedError` instead of Exception. The exception (which extends the error) contains the method, though.

One way to trigger the fatal error seems to be an empty test case:

```
No tests found in class "BoardCategoriesControllerTest"
```
