### PR TITLE
2.3 fix rss test

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -642,8 +642,7 @@ class RssHelperTest extends CakeTestCase {
 			)
 		);
 		$result = $this->Rss->item(null, $item);
-		if (!function_exists('finfo_open') &&
-			(function_exists('mime_content_type') && false === mime_content_type($tmpFile))
+		if (!function_exists('finfo_open') || !function_exists('mime_content_type') || mime_content_type($tmpFile) === false
 		) {
 			$type = false;
 		} else {
@@ -679,6 +678,9 @@ class RssHelperTest extends CakeTestCase {
 			'/category',
 			'/item'
 		);
+		if (!$type) {
+			unset($expected['enclosure']['type']);
+		}
 		$this->assertTags($result, $expected);
 
 		$File->delete();

--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -642,12 +642,12 @@ class RssHelperTest extends CakeTestCase {
 			)
 		);
 		$result = $this->Rss->item(null, $item);
-		if (!function_exists('finfo_open') || !function_exists('mime_content_type') || mime_content_type($tmpFile) === false
-		) {
-			$type = false;
+		if (!function_exists('mime_content_type')) {
+			$type = null;
 		} else {
-			$type = 'text/plain';
+			$type = mime_content_type($tmpFile);
 		}
+		
 		$expected = array(
 			'<item',
 			'<title',
@@ -678,7 +678,7 @@ class RssHelperTest extends CakeTestCase {
 			'/category',
 			'/item'
 		);
-		if (!$type) {
+		if ($type === null) {
 			unset($expected['enclosure']['type']);
 		}
 		$this->assertTags($result, $expected);


### PR DESCRIPTION
fix for windows. the check seems to be the wrong way. at least compared to the one in the rss class itself.
there the value is only set if the method actually exists.
so we need to unset the part in the expected array in the case it does not exist.
