### PR TITLE
at first set file loaded, than load file.

### DIFF
--- a/cake/libs/configure.php
+++ b/cake/libs/configure.php
@@ -1064,8 +1064,8 @@ class App extends Object {
 		}
 		if (file_exists($file)) {
 			if (!$this->return) {
-				require($file);
 				$this->__loaded[$file] = true;
+				require($file);
 			}
 			return true;
 		}


### PR DESCRIPTION
i had trouble with "Cannot redeclare class DboSource". The Problem is that the file is loaded and may the included file also requires that class. In this case the __load function recalls and reload the same file because the loaded flag isnt set.

try include *\cake\libs\model\datasources\dbo_source.php
try include *\cake\libs\model\datasources\dbo_source.php
finsed include *\cake\libs\model\datasources\dbo_source.php
PHP Fatal error:  Cannot redeclare class DboSource in *\cake\libs\model\datasources\dbo_source.php
