### PR TITLE
2.3 doctype unified

### DIFF
--- a/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
@@ -16,7 +16,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<?php echo $this->Html->charset(); ?>

--- a/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
@@ -16,7 +16,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<?php echo $this->Html->charset(); ?>

--- a/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
@@ -16,7 +16,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <?php echo $this->Html->charset(); ?>

--- a/lib/Cake/Test/test_app/View/Layouts/cache_empty_sections.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/cache_empty_sections.ctp
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title><?php echo $title_for_layout; ?></title>

--- a/lib/Cake/Test/test_app/View/Layouts/default.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/default.ctp
@@ -19,7 +19,7 @@ $this->loadHelper('Html');
 
 $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework');
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<?php echo $this->Html->charset(); ?>

--- a/lib/Cake/Test/test_app/View/Layouts/flash.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/flash.ctp
@@ -16,7 +16,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title><?php echo $page_title?></title>

--- a/lib/Cake/TestSuite/templates/header.php
+++ b/lib/Cake/TestSuite/templates/header.php
@@ -17,7 +17,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
A while ago the HtmlHelper method docType was defaulted to HTML5 (- html5: HTML5. Default value.)
For browser related output it makes sense to update the layouts accordingly.
Right now you would get the html5 doctypes for all sites, but on errors and 404s you still get the other one - using the (baked) default templates.

I didn't change the email templates yet - but at some point this might make sense to unify to the new standard, as well. If you think it might make sense to do that right, I can add them. I don't think it would affect the outcome of html emails since the email clients do have issues with the elements used, not the doctype itself (also some clients seem to replace the doctype anyway).
