### PR TITLE
Fixed issue in _validateRouteClass where setting defaultRouteClass back ...

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -182,7 +182,10 @@ class Router {
  * @throws RouterException
  */
 	protected static function _validateRouteClass($routeClass) {
-		if (!class_exists($routeClass) || !is_subclass_of($routeClass, 'CakeRoute')) {
+		if (
+			$routeClass != 'CakeRoute' &&
+			(!class_exists($routeClass) || !is_subclass_of($routeClass, 'CakeRoute'))
+		) {
 			throw new RouterException(__d('cake_dev', 'Route classes must extend CakeRoute'));
 		}
 		return $routeClass;


### PR DESCRIPTION
...to CakeRoute would throw an exception

Ex.

```
Router::defaultRouteClass('MyCustomRoute');
// add some routes
Router::defaultRotueClass('CakeRoute'); // threw an exception
// some more routes
```
