### PR TITLE
Fix failing test with controller task listAll

### DIFF
--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -117,10 +117,10 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$this->Task->connection = 'test';
 		$this->Task->interactive = true;
-		$this->Task->expects($this->at(1))->method('out')->with('1. BakeArticles');
-		$this->Task->expects($this->at(2))->method('out')->with('2. BakeArticlesBakeTags');
-		$this->Task->expects($this->at(3))->method('out')->with('3. BakeComments');
-		$this->Task->expects($this->at(4))->method('out')->with('4. BakeTags');
+		$this->Task->expects($this->at(2))->method('out')->with(' 1. BakeArticles');
+		$this->Task->expects($this->at(3))->method('out')->with(' 2. BakeArticlesBakeTags');
+		$this->Task->expects($this->at(4))->method('out')->with(' 3. BakeComments');
+		$this->Task->expects($this->at(5))->method('out')->with(' 4. BakeTags');
 
 		$expected = array('BakeArticles', 'BakeArticlesBakeTags', 'BakeComments', 'BakeTags');
 		$result = $this->Task->listAll('test');


### PR DESCRIPTION
The failing test:

```
1) ControllerTaskTest::testGetNameInvalidIndex
Expectation failed for method name is equal to <string:err> when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```

This commit fa2a75c3f11d732e63483150f70ed27fc2bdf825 added a `hr()` which calls `out()` once more before and uses sprintf `%2d` which will print a space before single digit numbers.
