### PR TITLE
Added a failing test to testSavePartialFields

### DIFF
--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -17,9 +17,9 @@
  */
 
 /**
- * Represent the transport class of events across the system, it receives a name, and subject and an optional
+ * Represents the transport class of events across the system, it receives a name, and subject and an optional
  * payload. The name can be any string that uniquely identifies the event across the application, while the subject
- * represents the object that the event is applying to.
+ * represents the object that the event applies to.
  *
  * @package Cake.Event
  */

--- a/lib/Cake/Event/CakeEventListener.php
+++ b/lib/Cake/Event/CakeEventListener.php
@@ -18,15 +18,15 @@
 
 /**
  * Objects implementing this interface should declare the `implementedEvents` function
- * to hint the event manager what methods should be called when an event is triggered.
+ * to notify the event manager what methods should be called when an event is triggered.
  *
  * @package Cake.Event
  */
 interface CakeEventListener  {
 
 /**
- * Returns a list of events this object is implementing, when the class is registered
- * in an event manager, each individual method will be associated to the respective event.
+ * Returns a list of events this object is implementing. When the class is registered
+ * in an event manager, each individual method will be associated with the respective event.
  *
  * ## Example:
  *

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -19,9 +19,9 @@
 App::uses('CakeEventListener', 'Event');
 
 /**
- * The event manager is responsible for keeping track of event listeners and pass the correct
- * data to them, and fire them in the correct order, when associated events are triggered. You
- * can create multiple instances of this objects to manage local events or keep a single instance
+ * The event manager is responsible for keeping track of event listeners, passing the correct
+ * data to them, and firing them in the correct order, when associated events are triggered. You
+ * can create multiple instances of this object to manage local events or keep a single instance
  * and pass it around to manage all events in your app.
  *
  * @package Cake.Event
@@ -29,7 +29,7 @@ App::uses('CakeEventListener', 'Event');
 class CakeEventManager {
 
 /**
- * The default priority queue value for new attached listeners
+ * The default priority queue value for new, attached listeners
  *
  * @var int
  */
@@ -50,7 +50,7 @@ class CakeEventManager {
 	protected $_listeners = array();
 
 /**
- * Internal flag to distinguish a common manager from the sigleton
+ * Internal flag to distinguish a common manager from the singleton
  *
  * @var boolean
  */
@@ -62,7 +62,7 @@ class CakeEventManager {
  * other managers were created. Usually for creating hook systems or inter-class
  * communication
  *
- * If called with a first params, it will be set as the globally available instance
+ * If called with the first parameter, it will be set as the globally available instance
  *
  * @param CakeEventManager $manager
  * @return CakeEventManager the global event manager
@@ -83,15 +83,15 @@ class CakeEventManager {
  * Adds a new listener to an event. Listeners
  *
  * @param callback|CakeEventListener $callable PHP valid callback type or instance of CakeEventListener to be called
- * when the event named with $eventKey is triggered. If a CakeEventListener instances is passed, then the `implementedEvents`
+ * when the event named with $eventKey is triggered. If a CakeEventListener instance is passed, then the `implementedEvents`
  * method will be called on the object to register the declared events individually as methods to be managed by this class.
  * It is possible to define multiple event handlers per event name.
  *
- * @param string $eventKey The event unique identifier name to with the callback will be associated. If $callable
+ * @param string $eventKey The event unique identifier name with which the callback will be associated. If $callable
  * is an instance of CakeEventListener this argument will be ignored
  *
  * @param array $options used to set the `priority` and `passParams` flags to the listener.
- * Priorities are handled like queues, and multiple attachments into the same priority queue will be treated in
+ * Priorities are handled like queues, and multiple attachments added to the same priority queue will be treated in
  * the order of insertion. `passParams` means that the event data property will be converted to function arguments
  * when the listener is called. If $called is an instance of CakeEventListener, this parameter will be ignored
  *
@@ -145,7 +145,7 @@ class CakeEventManager {
  * Auxiliary function to extract and return a PHP callback type out of the callable definition
  * from the return value of the `implementedEvents` method on a CakeEventListener
  *
- * @param array $function the array taken from a handler definition for a event
+ * @param array $function the array taken from a handler definition for an event
  * @param CakeEventListener $object The handler object
  * @return callback
  */
@@ -256,7 +256,7 @@ class CakeEventManager {
 	}
 
 /**
- * Returns a list of all listeners for a eventKey in the order they should be called
+ * Returns a list of all listeners for an eventKey in the order they should be called
  *
  * @param string $eventKey
  * @return array

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -552,6 +552,69 @@ class TranslateBehaviorTest extends CakeTestCase {
 			) + $data
 		);
 		$this->assertEquals($expected, $result);
+		
+		$TestModel->locale = 'eng';
+		$data = array(
+			'slug' => 'fifth_translated',
+			'title' => array('eng' => 'Title #5', 'spa' => 'Leyenda #5'),
+		);
+		$TestModel->create($data);
+		$TestModel->save();
+		$TestModel->unbindTranslation();
+		$translations = array('title' => 'Title', 'content' => 'Content');
+		$TestModel->bindTranslation($translations, false);
+		$result = $TestModel->read(null, $TestModel->id);
+		$expected = array(
+			'TranslatedItem' => array(
+				'id' => '5',
+				'translated_article_id' => null,
+				'slug' => 'fifth_translated',
+				'locale' => 'eng',
+				'title' => '',
+				'content' => ''
+			),
+			0 => array(
+				'TranslatedItem__i18n_Title' => 'Title #5',
+				'TranslatedItem__i18n_Content' => ''
+			),
+			'Title' => array(
+				0 => array(
+					'id' => '21',
+					'locale' => 'eng',
+					'model' => 'TranslatedItem',
+					'foreign_key' => '5',
+					'field' => 'title',
+					'content' => 'Title #5'
+				),
+				1 => array(
+					'id' => '22',
+					'locale' => 'spa',
+					'model' => 'TranslatedItem',
+					'foreign_key' => '5',
+					'field' => 'title',
+					'content' => 'Leyenda #5'
+				)
+			),
+			'Content' => array(
+				0 => array(
+					'id' => '23',
+					'locale' => 'eng',
+					'model' => 'TranslatedItem',
+					'foreign_key' => '5',
+					'field' => 'content',
+					'content' => ''
+				),
+				1 => array(
+					'id' => '24',
+					'locale' => 'spa',
+					'model' => 'TranslatedItem',
+					'foreign_key' => '5',
+					'field' => 'content',
+					'content' => ''
+				)
+			)
+		);
+		$this->assertEquals($expected, $result);		
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -2003,28 +2003,28 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * variable to control return of beforeValidate
  *
- * @var string
+ * @var boolean
  */
 	public $beforeValidateReturn = true;
 
 /**
  * variable to control return of beforeSave
  *
- * @var string
+ * @var boolean
  */
 	public $beforeSaveReturn = true;
 
 /**
  * variable to control return of beforeDelete
  *
- * @var string
+ * @var boolean
  */
 	public $beforeDeleteReturn = true;
 
 /**
  * beforeSave callback
  *
- * @return void
+ * @return boolean
  */
 	public function beforeSave($options = array()) {
 		return $this->beforeSaveReturn;
@@ -2033,7 +2033,7 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * beforeValidate callback
  *
- * @return void
+ * @return boolean
  */
 	public function beforeValidate($options = array()) {
 		return $this->beforeValidateReturn;
@@ -2042,7 +2042,7 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * beforeDelete callback
  *
- * @return void
+ * @return boolean
  */
 	public function beforeDelete($cascade = true) {
 		return $this->beforeDeleteReturn;


### PR DESCRIPTION
Added a failing test to the testSavePartialFields method where the title data for two locales creates only one empty content entry instead of two.
