### PR TITLE
fix #2858 RSS helper bug with namedspaced keys

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -717,4 +717,56 @@ class RssHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 	}
 
+	public function testElementNamespaceWithoutPrefix() {
+		$item = array(
+				'creator' => 'Alex',
+			);
+		$attributes = array(
+				'namespace' => 'http://link.com'
+		);
+		$result = $this->Rss->item($attributes, $item);
+		$expected = array(
+			'item' => array(
+					'xmlns' => 'http://link.com'
+			),
+			'creator' => array(
+					'xmlns' => 'http://link.com'
+			),
+			'Alex',
+			'/creator',
+			'/item'
+		);
+		$this->assertTags($result, $expected, true);
+	}
+
+	public function testElementNamespaceWithPrefix() {
+		$item = array(
+				'title'   => 'Title',
+				'creator' => 'Alex'
+			);
+		$attributes = array(
+				'namespace' => array(
+						'prefix' => 'dc',
+						'url' => 'http://link.com'
+				)
+		);
+		$result = $this->Rss->item($attributes, $item);
+		$expected = array(
+			'item' => array(
+					'xmlns:dc' => 'http://link.com'
+			),
+			'title' => array(
+					'xmlns:dc' => 'http://link.com'
+			),
+			'Title',
+			'/title',
+			'creator' => array(
+					'xmlns:dc' => 'http://link.com'
+			),
+			'Alex',
+			'/creator',
+			'/item'
+		);
+		$this->assertTags($result, $expected, true);
+	}
 }

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -256,6 +256,8 @@ class RssHelper extends AppHelper {
 					$attrib = $val;
 					$val = null;
 				break;
+				default:
+					$attrib = $att;
 			}
 			if (!is_null($val) && $escape) {
 				$val = h($val);
@@ -312,7 +314,12 @@ class RssHelper extends AppHelper {
 
 		$xml = '<' . $name;
 		if (!empty($namespace)) {
-			$xml .= ' xmlns:"' . $namespace . '"';
+			$xml .= ' xmlns';
+			if (is_array($namespace)) {
+				$xml .= ':' . $namespace['prefix'];
+				$namespace = $namespace['url'];
+			}
+			$xml .= '="' . $namespace . '"';
 		}
 		$bareName = $name;
 		if (strpos($name, ':') !== false) {
@@ -329,8 +336,10 @@ class RssHelper extends AppHelper {
 		$xml .= '>' . $content . '</' . $name . '>';
 		$elem = Xml::build($xml, array('return' => 'domdocument'));
 		$nodes = $elem->getElementsByTagName($bareName);
-		foreach ($attrib as $key => $value) {
-			$nodes->item(0)->setAttribute($key, $value);
+		if ($attrib) {
+			foreach ($attrib as $key => $value) {
+				$nodes->item(0)->setAttribute($key, $value);
+			}
 		}
 		foreach ($children as $k => $child) {
 			$child = $elem->createElement($name, $child);


### PR DESCRIPTION
allow namespaced keys in rss feed

Makes it possible to add a namespace attribute to all tag elements as discussed in: http://cakephp.lighthouseapp.com/projects/42648/tickets/2858-rss-helper-bug-with-namedspaced-keys#ticket-2858-6
