### PR TITLE
Added test for RSS to allow namespace tags if namespace is specified

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -742,7 +742,8 @@ class RssHelperTest extends CakeTestCase {
 	public function testElementNamespaceWithPrefix() {
 		$item = array(
 				'title'   => 'Title',
-				'creator' => 'Alex'
+				'dc:creator' => 'Alex',
+				'xy:description' => 'descriptive words'
 			);
 		$attributes = array(
 				'namespace' => array(
@@ -760,11 +761,16 @@ class RssHelperTest extends CakeTestCase {
 			),
 			'Title',
 			'/title',
-			'creator' => array(
+			'dc:creator' => array(
 					'xmlns:dc' => 'http://link.com'
 			),
 			'Alex',
-			'/creator',
+			'/dc:creator',
+			'description' => array(
+					'xmlns:dc' => 'http://link.com'
+			),
+			'descriptive words',
+			'/description',
 			'/item'
 		);
 		$this->assertTags($result, $expected, true);


### PR DESCRIPTION
If a namespace prefix is defined it's prefix should not be stripped
from the tag: `<dc:creator>` stays `<dc:creator>`.

Other prefixes are still stripped from the tag name.

This test is missing in 19f0e72d582fba29ade83b11000ba03e0e697f7f
