### PR TITLE
Merge controller properties correctly

### DIFF
--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -197,6 +197,14 @@ class Object {
 					$classProperties[$var] = Hash::normalize($classProperties[$var]);
 					$this->{$var} = Hash::normalize($this->{$var});
 				}
+				foreach ($this->{$var} as $key => $value) {
+					if ($value !== null) {
+						continue;
+					}
+					if (isset($classProperties[$var][$key]) && is_array($classProperties[$var][$key])) {
+						$this->{$var}[$key] = array();
+					}
+				}
 				$this->{$var} = Hash::merge($classProperties[$var], $this->{$var});
 			}
 		}

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -212,8 +212,8 @@ class ControllerMergeVarsTest extends CakeTestCase {
  *
  * @return void
  */
- 	public function testHelperDisabledMerge() {
- 		$Controller = new MergeVariablesController();
+	public function testHelperDisabledMerge() {
+		$Controller = new MergeVariablesController();
 		$Controller->helpers = array('Html' => false, 'Custom', 'Foo' => array('something'));
 		$Controller->constructClasses();
 

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -40,7 +40,7 @@ class MergeVarsAppController extends Controller {
  *
  * @var array
  */
-	public $helpers = array('MergeVar' => array('format' => 'html', 'terse'));
+	public $helpers = array('Html' => array('className' => 'HtmlExt'), 'MergeVar' => array('format' => 'html', 'terse'));
 }
 
 /**
@@ -72,6 +72,13 @@ class MergeVariablesController extends MergeVarsAppController {
  * @var arrays
  */
 	public $uses = array();
+
+/**
+ * helpers
+ *
+ * @var array
+ */
+	public $helpers = array('Html' => array('className' => 'HtmlExtTwo'));
 
 /**
  * parent for mergeVars
@@ -176,7 +183,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$Controller = new MergeVariablesController();
 		$Controller->constructClasses();
 
-		$expected = array('MergeVar' => array('format' => 'html', 'terse'));
+		$expected = array('Html' => array('className' => 'HtmlExtTwo'), 'MergeVar' => array('format' => 'html', 'terse'));
 		$this->assertEquals($expected, $Controller->helpers, 'Duplication of settings occurred. %s');
 	}
 
@@ -188,10 +195,11 @@ class ControllerMergeVarsTest extends CakeTestCase {
  */
 	public function testHelperOrderPrecedence() {
 		$Controller = new MergeVariablesController();
-		$Controller->helpers = array('Custom', 'Foo' => array('something'));
+		$Controller->helpers = array('Html', 'Custom', 'Foo' => array('something'));
 		$Controller->constructClasses();
 
 		$expected = array(
+			'Html' => array('className' => 'HtmlExt'),
 			'MergeVar' => array('format' => 'html', 'terse'),
 			'Custom' => null,
 			'Foo' => array('something')
@@ -218,6 +226,7 @@ class ControllerMergeVarsTest extends CakeTestCase {
 		$this->assertEquals($expected, $Controller->components, 'Components are unexpected.');
 
 		$expected = array(
+			'Html' => array('className' => 'HtmlExt'),
 			'MergeVar' => array('format' => 'html', 'terse'),
 			'Javascript' => null
 		);

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -208,6 +208,25 @@ class ControllerMergeVarsTest extends CakeTestCase {
 	}
 
 /**
+ * Test that merging can be disabled using `'HelperName' => false`
+ *
+ * @return void
+ */
+ 	public function testHelperDisabledMerge() {
+ 		$Controller = new MergeVariablesController();
+		$Controller->helpers = array('Html' => false, 'Custom', 'Foo' => array('something'));
+		$Controller->constructClasses();
+
+		$expected = array(
+			'Html' => false,
+			'MergeVar' => array('format' => 'html', 'terse'),
+			'Custom' => null,
+			'Foo' => array('something')
+		);
+		$this->assertSame($expected, $Controller->helpers, 'Order is incorrect.');
+	}
+
+/**
  * test merging of vars with plugin
  *
  * @return void


### PR DESCRIPTION
fixes ticket #3079

it basically boils down to Hash::merge and how it works.
It needs an (empty) array to properly merge - null doesnt do it.
