### PR TITLE
enable Debugger::exportVar to display protected and private class properties

### DIFF
--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -325,8 +325,35 @@ object(View) {
 	elementCacheSettings => array()
 	int => (int) 2
 	float => (float) 1.333
+	[protected] "_passedVars" => array(
+		(int) 0 => 'viewVars',
+		(int) 1 => 'autoLayout',
+		(int) 2 => 'ext',
+		(int) 3 => 'helpers',
+		(int) 4 => 'view',
+		(int) 5 => 'layout',
+		(int) 6 => 'name',
+		(int) 7 => 'theme',
+		(int) 8 => 'layoutPath',
+		(int) 9 => 'viewPath',
+		(int) 10 => 'request',
+		(int) 11 => 'plugin',
+		(int) 12 => 'passedArgs',
+		(int) 13 => 'cacheAction'
+	)
+	[protected] "_scripts" => array()
+	[protected] "_paths" => array()
+	[protected] "_helpersLoaded" => false
+	[protected] "_parents" => array()
+	[protected] "_current" => null
+	[protected] "_currentType" => ''
+	[protected] "_stack" => array()
+	[protected] "_eventManager" => object(CakeEventManager) {}
+	[protected] "_eventManagerConfigured" => false
+	[private] "__viewFileName" => null
 }
 TEXT;
+debug($result); ob_flush();
 		$this->assertTextEquals($expected, $result);
 
 		$data = array(

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -327,7 +327,7 @@ object(View) {
 	float => (float) 1.333
 
 TEXT;
-		if (strnatcmp(phpversion(),'5.3.0') >= 0) {
+		if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
 			$expected .= <<<TEXT
 	[protected] _passedVars => array(
 		(int) 0 => 'viewVars',

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -325,6 +325,10 @@ object(View) {
 	elementCacheSettings => array()
 	int => (int) 2
 	float => (float) 1.333
+
+TEXT;
+		if (strnatcmp(phpversion(),'5.3.0') >= 0) {
+			$expected .= <<<TEXT
 	[protected] _passedVars => array(
 		(int) 0 => 'viewVars',
 		(int) 1 => 'autoLayout',
@@ -351,8 +355,13 @@ object(View) {
 	[protected] _eventManager => object(CakeEventManager) {}
 	[protected] _eventManagerConfigured => false
 	[private] __viewFileName => null
+
+TEXT;
+		}
+		$expected .= <<<TEXT
 }
 TEXT;
+
 		$this->assertTextEquals($expected, $result);
 
 		$data = array(

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -325,7 +325,7 @@ object(View) {
 	elementCacheSettings => array()
 	int => (int) 2
 	float => (float) 1.333
-	[protected] "_passedVars" => array(
+	[protected] _passedVars => array(
 		(int) 0 => 'viewVars',
 		(int) 1 => 'autoLayout',
 		(int) 2 => 'ext',
@@ -341,16 +341,16 @@ object(View) {
 		(int) 12 => 'passedArgs',
 		(int) 13 => 'cacheAction'
 	)
-	[protected] "_scripts" => array()
-	[protected] "_paths" => array()
-	[protected] "_helpersLoaded" => false
-	[protected] "_parents" => array()
-	[protected] "_current" => null
-	[protected] "_currentType" => ''
-	[protected] "_stack" => array()
-	[protected] "_eventManager" => object(CakeEventManager) {}
-	[protected] "_eventManagerConfigured" => false
-	[private] "__viewFileName" => null
+	[protected] _scripts => array()
+	[protected] _paths => array()
+	[protected] _helpersLoaded => false
+	[protected] _parents => array()
+	[protected] _current => null
+	[protected] _currentType => ''
+	[protected] _stack => array()
+	[protected] _eventManager => object(CakeEventManager) {}
+	[protected] _eventManagerConfigured => false
+	[private] __viewFileName => null
 }
 TEXT;
 		$this->assertTextEquals($expected, $result);

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -353,7 +353,6 @@ object(View) {
 	[private] "__viewFileName" => null
 }
 TEXT;
-debug($result); ob_flush();
 		$this->assertTextEquals($expected, $result);
 
 		$data = array(

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -578,8 +578,8 @@ class Debugger {
 			}
 
 			$ref = new ReflectionObject($var);
-			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);
 
+			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);
 			foreach ($reflectionProperties as $reflectionProperty) {
 				$reflectionProperty->setAccessible(true);
 				$property = $reflectionProperty->getValue($var);
@@ -589,9 +589,7 @@ class Debugger {
 				$props[] = "[protected] $key => " . $value;
 			}
 
-			$ref = new ReflectionObject($var);
 			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PRIVATE);
-
 			foreach ($reflectionProperties as $reflectionProperty) {
 				$reflectionProperty->setAccessible(true);
 				$property = $reflectionProperty->getValue($var);

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -576,6 +576,31 @@ class Debugger {
 				$value = self::_export($value, $depth - 1, $indent);
 				$props[] = "$key => " . $value;
 			}
+
+			$ref = new ReflectionObject($var);
+			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);
+
+			foreach ($reflectionProperties as $reflectionProperty) {
+				$reflectionProperty->setAccessible(true);
+				$property = $reflectionProperty->getValue($var);
+
+				$value = self::_export($property, $depth - 1, $indent);
+				$key = '"' . $reflectionProperty->name . '"';
+				$props[] = "[protected] $key => " . $value;
+			}
+
+			$ref = new ReflectionObject($var);
+			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PRIVATE);
+
+			foreach ($reflectionProperties as $reflectionProperty) {
+				$reflectionProperty->setAccessible(true);
+				$property = $reflectionProperty->getValue($var);
+
+				$value = self::_export($property, $depth - 1, $indent);
+				$key = '"'.$reflectionProperty->name . '"';
+				$props[] = "[private] $key => " . $value;
+			}
+
 			$out .= $break . implode($break, $props) . $end;
 		}
 		$out .= '}';

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -577,26 +577,28 @@ class Debugger {
 				$props[] = "$key => " . $value;
 			}
 
-			$ref = new ReflectionObject($var);
+			if (strnatcmp(phpversion(),'5.3.0') >= 0) {
+				$ref = new ReflectionObject($var);
 
-			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);
-			foreach ($reflectionProperties as $reflectionProperty) {
-				$reflectionProperty->setAccessible(true);
-				$property = $reflectionProperty->getValue($var);
+				$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);
+				foreach ($reflectionProperties as $reflectionProperty) {
+					$reflectionProperty->setAccessible(true);
+					$property = $reflectionProperty->getValue($var);
 
-				$value = self::_export($property, $depth - 1, $indent);
-				$key = $reflectionProperty->name;
-				$props[] = "[protected] $key => " . $value;
-			}
+					$value = self::_export($property, $depth - 1, $indent);
+					$key = $reflectionProperty->name;
+					$props[] = "[protected] $key => " . $value;
+				}
 
-			$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PRIVATE);
-			foreach ($reflectionProperties as $reflectionProperty) {
-				$reflectionProperty->setAccessible(true);
-				$property = $reflectionProperty->getValue($var);
+				$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PRIVATE);
+				foreach ($reflectionProperties as $reflectionProperty) {
+					$reflectionProperty->setAccessible(true);
+					$property = $reflectionProperty->getValue($var);
 
-				$value = self::_export($property, $depth - 1, $indent);
-				$key = $reflectionProperty->name;
-				$props[] = "[private] $key => " . $value;
+					$value = self::_export($property, $depth - 1, $indent);
+					$key = $reflectionProperty->name;
+					$props[] = "[private] $key => " . $value;
+				}
 			}
 
 			$out .= $break . implode($break, $props) . $end;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -585,7 +585,7 @@ class Debugger {
 				$property = $reflectionProperty->getValue($var);
 
 				$value = self::_export($property, $depth - 1, $indent);
-				$key = '"' . $reflectionProperty->name . '"';
+				$key = $reflectionProperty->name;
 				$props[] = "[protected] $key => " . $value;
 			}
 
@@ -597,7 +597,7 @@ class Debugger {
 				$property = $reflectionProperty->getValue($var);
 
 				$value = self::_export($property, $depth - 1, $indent);
-				$key = '"'.$reflectionProperty->name . '"';
+				$key = $reflectionProperty->name;
 				$props[] = "[private] $key => " . $value;
 			}
 

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -577,7 +577,7 @@ class Debugger {
 				$props[] = "$key => " . $value;
 			}
 
-			if (strnatcmp(phpversion(),'5.3.0') >= 0) {
+			if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
 				$ref = new ReflectionObject($var);
 
 				$reflectionProperties = $ref->getProperties(ReflectionProperty::IS_PROTECTED);


### PR DESCRIPTION
enables Debugger::exportVar to display protected and private class properties (similar to print_r debugging)

currently, it does only show public properties (but many useful/interesting ones are protected, though).
but this would be helpful to properly debug. using Reflection this can be solved easily.

this produces quite a similar output to print_r() but will all the safety features like max depth and escaping as well as nice formatting and echoing the type (int, bool).
