### PR TITLE
Prevent PHP notices when App defines their own LOGS and CACHE paths outside TMP

### DIFF
--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -90,12 +90,16 @@ if (!defined('TMP')) {
 /**
  * Path to the logs directory.
  */
+if (!defined('LOGS')) {
 	define('LOGS', TMP . 'logs' . DS);
+}
 
 /**
  * Path to the cache files directory. It can be shared between hosts in a multi-server setup.
  */
+if (!defined('CACHE')) {
 	define('CACHE', TMP . 'cache' . DS);
+}
 
 /**
  * Path to the vendors directory.


### PR DESCRIPTION
Dead simple edit - prevents "PHP Notice:  Constant LOGS already defined" messages appearing in webserver logs when an App defines their own LOGS and CACHE paths outside the TMP path.
