### PR TITLE
Fix cake bake project always finding CakePHP libs in php include_path.

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -82,7 +82,7 @@ class ShellDispatcher {
 		}
 
 		if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-			if(!defined('DS')) {
+			if (!defined('DS')) {
 				define('DS', DIRECTORY_SEPARATOR);
 			}
 

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -82,10 +82,7 @@ class ShellDispatcher {
 		}
 
 		if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-			if (!defined('DS')) {
-				define('DS', DIRECTORY_SEPARATOR);
-			}
-
+			define('DS', DIRECTORY_SEPARATOR);
 			define('CAKE_CORE_INCLUDE_PATH', dirname(dirname(dirname(__FILE__))));
 			define('CAKEPHP_SHELL', true);
 			if (!defined('CORE_PATH')) {

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -82,7 +82,10 @@ class ShellDispatcher {
 		}
 
 		if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-			define('DS', DIRECTORY_SEPARATOR);
+			if(!defined('DS')) {
+				define('DS', DIRECTORY_SEPARATOR);
+			}
+
 			define('CAKE_CORE_INCLUDE_PATH', dirname(dirname(dirname(__FILE__))));
 			define('CAKEPHP_SHELL', true);
 			if (!defined('CORE_PATH')) {

--- a/lib/Cake/Console/cake.php
+++ b/lib/Cake/Console/cake.php
@@ -17,13 +17,13 @@
  * @since         CakePHP(tm) v 1.2.0.5012
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-define('DS', DIRECTORY_SEPARATOR);
-$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
+$ds = DIRECTORY_SEPARATOR;
+$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
 $found = false;
 $paths = explode(PATH_SEPARATOR, ini_get('include_path'));
 
 foreach ($paths as $path) {
-	if (file_exists($path . DS . $dispatcher)) {
+	if (file_exists($path . $ds . $dispatcher)) {
 		$found = $path;
 		break;
 	}
@@ -31,13 +31,13 @@ foreach ($paths as $path) {
 
 if (!$found) {
 	$root = dirname(dirname(dirname(__FILE__)));
-	if (!include $root . DS . $dispatcher) {
+	if (!include $root . $ds . $dispatcher) {
 		trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
 	}
 } else {
-	include $found . DS . $dispatcher;
+	include $found . $ds . $dispatcher;
 }
 
-unset($paths, $path, $found, $dispatcher, $root);
+unset($paths, $path, $found, $dispatcher, $root, $ds);
 
 return ShellDispatcher::run($argv);

--- a/lib/Cake/Console/cake.php
+++ b/lib/Cake/Console/cake.php
@@ -17,25 +17,27 @@
  * @since         CakePHP(tm) v 1.2.0.5012
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-$ds = DIRECTORY_SEPARATOR;
-$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
+define('DS', DIRECTORY_SEPARATOR);
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 $found = false;
 $paths = explode(PATH_SEPARATOR, ini_get('include_path'));
 
 foreach ($paths as $path) {
-	if (file_exists($path . $ds . $dispatcher)) {
+	if (file_exists($path . DS . $dispatcher)) {
 		$found = $path;
+		break;
 	}
 }
 
-if (!$found && function_exists('ini_set')) {
+if (!$found) {
 	$root = dirname(dirname(dirname(__FILE__)));
-	ini_set('include_path', $root . $ds . PATH_SEPARATOR . ini_get('include_path'));
+	if (!include $root . DS . $dispatcher) {
+		trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
+	}
+} else {
+	include $found . DS . $dispatcher;
 }
 
-if (!include $dispatcher) {
-	trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
-}
-unset($paths, $path, $found, $dispatcher, $root, $ds);
+unset($paths, $path, $found, $dispatcher, $root);
 
 return ShellDispatcher::run($argv);


### PR DESCRIPTION
Cake shell was adding the CakePHP libs to php include_path resulting in
producing baked projects without hardcoded CAKE_CORE_INCLUDE_PATH when
hardcoded CAKE_CORE_INCLUDE_PATH is needed.
