### PR TITLE
CakeEmail class does not load the 'default' config unless it's passed to...

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -332,6 +332,8 @@ class CakeEmail {
 
 		if ($config) {
 			$this->config($config);
+		} else {
+			$this->config('default');
 		}
 		if (empty($this->headerCharset)) {
 			$this->headerCharset = $this->charset;


### PR DESCRIPTION
... the constructor - so it's not really a 'default'.  Should it be like this patch, instead?

So currently...
`new CakeEmail();` does not load the default config.
`new CakeEmail('default');` does.

Is this the expected behavior?  And is this COC (convention over configuration) behavior?
