### PR TITLE
Fix setting modelClass with use $this->uses in Controler

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -635,7 +635,9 @@ class Controller extends Object implements CakeEventListener {
 		$this->Components->init($this);
 		if ($this->uses) {
 			$this->uses = (array)$this->uses;
-			list(, $this->modelClass) = pluginSplit(current($this->uses));
+            if (!in_array($this->modelClass, $this->uses)) {
+                list(, $this->modelClass) = pluginSplit(current($this->uses));
+            }
 		}
 		return true;
 	}


### PR DESCRIPTION
After this fix Controller will set $this->modelClass his model by default, not first from $this->uses as before. This behavior looks more logical.
