### PR TITLE
2.3 cake schema

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -127,7 +127,9 @@ class SchemaShell extends AppShell {
 		$this->out(__d('cake_console', 'Generating Schema...'));
 		$options = array();
 		if ($this->params['force']) {
-			$options = array('models' => false);
+			$options['models'] = false;
+		} elseif (!empty($this->params['models'])) {
+			$options['models'] = String::tokenize($this->params['models']);
 		}
 
 		$snapshot = false;
@@ -464,6 +466,10 @@ class SchemaShell extends AppShell {
 			'short' => 's',
 			'help' => __d('cake_console', 'Snapshot number to use/make.')
 		);
+		$models = array(
+			'short' => 'm',
+			'help' => __d('cake_console', 'Specify models as comma separated list.'),
+		);
 		$dry = array(
 			'help' => __d('cake_console', 'Perform a dry run on create and update commands. Queries will be output instead of run.'),
 			'boolean' => true
@@ -489,7 +495,7 @@ class SchemaShell extends AppShell {
 		))->addSubcommand('generate', array(
 			'help' => __d('cake_console', 'Reads from --connection and writes to --path. Generate snapshots with -s'),
 			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force'),
+				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force', 'models'),
 				'arguments' => array(
 					'snapshot' => array('help' => __d('cake_console', 'Generate a snapshot.'))
 				)

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -96,6 +96,7 @@ class SchemaShell extends AppShell {
 				$name = $plugin;
 			}
 		}
+		$name = Inflector::classify($name);
 		$this->Schema = new CakeSchema(compact('name', 'path', 'file', 'connection', 'plugin'));
 	}
 

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -254,11 +254,12 @@ class CakeSchema extends Object {
 					continue;
 				}
 
-				$fulltable = $table = $db->fullTableName($Object, false, false);
-				if ($prefix && strpos($table, $prefix) !== 0) {
+				if (!is_object($Object) || $Object->useTable === false) {
 					continue;
 				}
-				if (!is_object($Object) || $Object->useTable === false) {
+
+				$fulltable = $table = $db->fullTableName($Object, false, false);
+				if ($prefix && strpos($table, $prefix) !== 0) {
 					continue;
 				}
 				if (!in_array($fulltable, $currentTables)) {

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -363,6 +363,41 @@ class SchemaShellTest extends CakeTestCase {
 	}
 
 /**
+ * test generate with specific models
+ *
+ * @return void
+ */
+	public function testGenerateModels() {
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
+		), App::RESET);
+		CakePlugin::load('TestPlugin');
+
+		$this->db->cacheSources = false;
+		$this->Shell->params = array(
+			'plugin' => 'TestPlugin',
+			'connection' => 'test',
+			'models' => 'TestPluginComment',
+			'force' => false,
+			'overwrite' => true
+		);
+		$this->Shell->startup();
+		$this->Shell->Schema->path = TMP . 'tests' . DS;
+
+		$this->Shell->generate();
+		$this->file = new File(TMP . 'tests' . DS . 'schema.php');
+		$contents = $this->file->read();
+
+		$this->assertRegExp('/class TestPluginSchema/', $contents);
+		$this->assertRegExp('/public \$test_plugin_comments/', $contents);
+		$this->assertNotRegExp('/public \$authors/', $contents);
+		$this->assertNotRegExp('/public \$auth_users/', $contents);
+		$this->assertNotRegExp('/public \$posts/', $contents);
+		CakePlugin::unload();
+	}
+
+
+/**
  * Test schema run create with no table args.
  *
  * @return void

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -499,6 +499,35 @@ class SchemaShellTest extends CakeTestCase {
 	}
 
 /**
+ * test that underscored names also result in CamelCased class names
+ *
+ * @return void
+ */
+	public function testName() {
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
+		));
+		CakePlugin::load('TestPlugin');
+		$this->Shell->params = array(
+			'plugin' => 'TestPlugin',
+			'connection' => 'test',
+			'name' => 'custom_name',
+			'force' => false,
+			'overwrite' => true,
+		);
+		$this->Shell->startup();
+		if (file_exists($this->Shell->Schema->path . DS . 'custom_name.php')) {
+			unlink($this->Shell->Schema->path . DS . 'custom_name.php');
+		}
+		$this->Shell->generate();
+
+		$contents = file_get_contents($this->Shell->Schema->path . DS . 'custom_name.php');
+		$this->assertRegExp('/class CustomNameSchema/', $contents);
+		unlink($this->Shell->Schema->path . DS . 'custom_name.php');
+		CakePlugin::unload();
+	}
+
+/**
  * test that using Plugin.name with write.
  *
  * @return void


### PR DESCRIPTION
- corrected uncaught error with a missing table
- removed the 5-level if clauses to a less complex construct (refactoring)
- added option "models" for generate. The CakeSchema is already capable of it but the shell as of now could not provide the information for the schema to only export specific models. this is now also covered included test cases

see http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3101-console-schema-generate-improvements
