### PR TITLE
2.2 resourcesprefix

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -462,36 +462,42 @@ class Router {
  * @return array Array of mapped resources
  */
 	public static function mapResources($controller, $options = array()) {
-		$hasPrefix = isset($options['prefix']);
+		$hasRoutePrefix = isset($options['prefix']);
 		$options = array_merge(array(
 			'prefix' => '/',
 			'id' => self::ID . '|' . self::UUID
 		), $options);
 
-		$prefix = $options['prefix'];
+		$routePrefix = $options['prefix'];
+		$extra = array();
+		foreach (self::prefixes() as $prefix) {
+			if (array_key_exists($prefix, $options)) {
+				$extra[$prefix] = $options[$prefix];
+			}
+		}
 
 		foreach ((array)$controller as $name) {
 			list($plugin, $name) = pluginSplit($name);
-			$urlName = Inflector::underscore($name);
+			$name = Inflector::underscore($name);
 			$plugin = Inflector::underscore($plugin);
-			if ($plugin && !$hasPrefix) {
-				$prefix = '/' . $plugin . '/';
+			if ($plugin && !$hasRoutePrefix) {
+				$routePrefix = '/' . $plugin . '/';
 			}
 
 			foreach (self::$_resourceMap as $params) {
-				$url = $prefix . $urlName . (($params['id']) ? '/:id' : '');
-
-				Router::connect($url,
+				$route = $routePrefix . $name . (($params['id']) ? '/:id' : '');
+				$url = 	array_merge(
+					$extra,
 					array(
 						'plugin' => $plugin,
-						'controller' => $urlName,
+						'controller' => $name,
 						'action' => $params['action'],
 						'[method]' => $params['method']
-					),
-					array('id' => $options['id'], 'pass' => array('id'))
+					)
 				);
+				Router::connect($route, $url, array('id' => $options['id'], 'pass' => array('id')));
 			}
-			self::$_resourceMapped[] = $urlName;
+			self::$_resourceMapped[] = $name;
 		}
 		return self::$_resourceMapped;
 	}

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -457,6 +457,8 @@ class Router {
  *    integer values and UUIDs.
  * - 'prefix' - URL prefix to use for the generated routes.  Defaults to '/'.
  *
+ * For any configured Routing.prefixes you can set extra option key with boolean value
+ *
  * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
  * @param array $options Options to use when generating REST routes
  * @return array Array of mapped resources

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -124,6 +124,24 @@ class RouterTest extends CakeTestCase {
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/name');
 		$this->assertEquals(array('pass' => array('name'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'), $result);
+
+		Configure::write('Routing.prefixes', array('admin'));
+		Router::reload();
+		Router::mapResources('Posts', array('admin' => true));
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$result = Router::parse('/posts');
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'admin_add', '[method]' => 'POST', 'prefix' => 'admin', 'admin' => true), $result);
+
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$result = Router::parse('/posts/1');
+		$this->assertEquals(array('pass' => array('1'), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'admin_edit', 'id' => '1', '[method]' => 'PUT', 'prefix' => 'admin', 'admin' => true), $result);
+
+		Router::reload();
+		Router::mapResources('Posts', array('manager' => true));
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$result = Router::parse('/posts');
+		$this->assertEquals(array('pass' => array(), 'named' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'), $result);
 	}
 
 /**
@@ -164,6 +182,25 @@ class RouterTest extends CakeTestCase {
 			'[method]' => 'GET'
 		);
 		$this->assertEquals($expected, $result);
+
+		Configure::write('Routing.prefixes', array('admin'));
+		Router::reload();
+		$resources = Router::mapResources('TestPlugin.TestPlugin', array('admin' => true));
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$result = Router::parse('/test_plugin/test_plugin');
+		$expected = array(
+			'pass' => array(),
+			'named' => array(),
+			'plugin' => 'test_plugin',
+			'controller' => 'test_plugin',
+			'action' => 'admin_index',
+			'[method]' => 'GET',
+			'admin' => true,
+			'prefix' => 'admin'
+		);
+		$this->assertEquals($expected, $result);
+		$this->assertEquals(array('test_plugin'), $resources);
 	}
 
 /**
@@ -191,6 +228,24 @@ class RouterTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertEquals(array('test_plugin'), $resources);
+
+		Configure::write('Routing.prefixes', array('admin'));
+		Router::reload();
+		Router::mapResources('TestPlugin.TestPlugin', array('prefix' => '/api/', 'admin' => true));
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$result = Router::parse('/api/test_plugin');
+		$expected = array(
+			'pass' => array(),
+			'named' => array(),
+			'plugin' => 'test_plugin',
+			'controller' => 'test_plugin',
+			'action' => 'admin_index',
+			'[method]' => 'GET',
+			'prefix' => 'admin',
+			'admin' => true
+		);
+		$this->assertEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
Enable admin (or other configured routing prefixes) for mapResources()
