### PR TITLE
Js::writeBuffer() incorrectly returns script tag with url to cache file if following 3 conditions are true:

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -351,6 +351,9 @@ class JsHelperTest extends CakeTestCase {
 	public function testWriteScriptsInFile() {
 		$this->skipIf(!is_writable(JS), 'webroot/js is not Writable, script caching test has been skipped.');
 
+		$cache = Configure::read('Cache.disable');
+		Configure::write('Cache.disable', false);
+
 		$this->Js->request->webroot = '/';
 		$this->Js->JsBaseEngine = new TestJsEngineHelper($this->View);
 		$this->Js->buffer('one = 1;');
@@ -364,8 +367,16 @@ class JsHelperTest extends CakeTestCase {
 		$this->assertTrue(file_exists(WWW_ROOT . $filename[1]));
 		$contents = file_get_contents(WWW_ROOT . $filename[1]);
 		$this->assertRegExp('/one\s=\s1;\ntwo\s=\s2;/', $contents);
-
 		@unlink(WWW_ROOT . $filename[1]);
+
+		Configure::write('Cache.disable', true);
+		$this->Js->buffer('one = 1;');
+		$this->Js->buffer('two = 2;');
+		$result = $this->Js->writeBuffer(array('onDomReady' => false, 'cache' => true));
+		$this->assertRegExp('/one\s=\s1;\ntwo\s=\s2;/', $result);
+		$this->assertFalse(file_exists(WWW_ROOT . $filename[1]));
+
+		Configure::write('Cache.disable', $cache);
 	}
 
 /**

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -208,18 +208,19 @@ class JsHelper extends AppHelper {
 		$opts = $options;
 		unset($opts['onDomReady'], $opts['cache'], $opts['clear']);
 
-		if (!$options['cache'] && $options['inline']) {
-			return $this->Html->scriptBlock($script, $opts);
-		}
-
 		if ($options['cache'] && $options['inline']) {
 			$filename = md5($script);
-			if (!file_exists(JS . $filename . '.js')) {
-				cache(str_replace(WWW_ROOT, '', JS) . $filename . '.js', $script, '+999 days', 'public');
+			if (file_exists(JS . $filename . '.js')
+				|| cache(str_replace(WWW_ROOT, '', JS) . $filename . '.js', $script, '+999 days', 'public')
+				) {
+				return $this->Html->script($filename);
 			}
-			return $this->Html->script($filename);
 		}
-		$this->Html->scriptBlock($script, $opts);
+
+		$return = $this->Html->scriptBlock($script, $opts);
+		if ($options['inline']) {
+			return $return;
+		}
 		return null;
 	}
 


### PR DESCRIPTION
1. Js::writeBuffer() is called with `inline` and `cache` options true
2. Configure var Cache.disable is true
3. No cache file for the buffered script exits

So I added check to use file url only if file exists or call to `cache()` succeeded else just return script tag with inline js contents. That's a sensible approach rather than linking to non existent file.
