### PR TITLE
allow calling shells that has the same name as its plugin

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -238,9 +238,13 @@ class ShellDispatcher {
 		App::uses($class, $plugin . 'Console/Command');
 
 		if (!class_exists($class)) {
-			throw new MissingShellException(array(
-				'class' => $class
-			));
+			$plugin = Inflector::camelize($shell);
+			App::uses($class, $plugin . '.Console/Command');
+			if (!class_exists($class)) {
+				throw new MissingShellException(array(
+					'class' => $class
+				));
+			}
 		}
 		$Shell = new $class();
 		$Shell->plugin = trim($plugin, '.');

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -428,6 +428,18 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 		$result = $Dispatcher->getShell('TestPlugin.example');
 		$this->assertInstanceOf('ExampleShell', $result);
+
+		$Dispatcher = new TestShellDispatcher();
+		$result = $Dispatcher->getShell('TestPlugin.TestPlugin');
+		$this->assertInstanceOf('TestPluginShell', $result);
+
+		$Dispatcher = new TestShellDispatcher();
+		$result = $Dispatcher->getShell('TestPlugin');
+		$this->assertInstanceOf('TestPluginShell', $result);
+
+		$Dispatcher = new TestShellDispatcher();
+		$result = $Dispatcher->getShell('test_plugin');
+		$this->assertInstanceOf('TestPluginShell', $result);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/TestPluginShell.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.test_app.Plugin.TestPlugin.Console.Command
+ * @since         CakePHP(tm) v 2.3
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+class TestPluginShell extends Shell {
+
+/**
+ * main method
+ *
+ * @return void
+ */
+	public function main() {
+		$this->out('This is the main method called from TestPlugin.TestPluginShell');
+	}
+}


### PR DESCRIPTION
because:

```
`cake clear_cache all` is much friendlier than
`cake clear_cache.clear_cache all`
```
