### PR TITLE
2.3 containable find list

### DIFF
--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -171,7 +171,7 @@ class ContainableBehavior extends ModelBehavior {
 		}
 
 		if ($this->settings[$Model->alias]['recursive']) {
-			$query['recursive'] = (isset($query['recursive'])) ? $query['recursive'] : $containments['depth'];
+			$query['recursive'] = (isset($query['recursive'])) ? max($query['recursive'], $containments['depth']) : $containments['depth'];
 		}
 
 		$autoFields = ($this->settings[$Model->alias]['autoFields']

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -262,6 +262,30 @@ class ContainableBehaviorTest extends CakeTestCase {
 	}
 
 /**
+ * testContainFindList method
+ *
+ * @return void
+ */
+	public function testContainFindList() {
+		$this->Article->contain('Comment.User');
+		$result = $this->Article->find('list');
+		$expected = array(
+			1 => 'First Article',
+			2 => 'Second Article',
+			3 => 'Third Article'
+		);
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Article->find('list', array('fields'=>array('Article.id', 'User.id'), 'contain'=>array('User')));
+		$expected = array(
+			1 => '1',
+			2 => '3',
+			3 => '1'
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testFindEmbeddedNoBindings method
  *
  * @return void


### PR DESCRIPTION
fixes http://cakephp.lighthouseapp.com/projects/42648/tickets/852-findlist-should-support-joins

I use this fix since 1.3alpha as a core-hack - without any issues so far. would be great if I could drop that now and if it would be handled in the core behavior now :)
