### PR TITLE
2.3 paginatecallback

### DIFF
--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -76,6 +76,7 @@ class JsonViewTest extends CakeTestCase {
 			'View' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'View' . DS)
 		));
 		$Request = new CakeRequest();
+		$Request->params['named'] = array('page' => 2);
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
 		$Controller->name = $Controller->viewPath = 'Posts';
@@ -91,9 +92,10 @@ class JsonViewTest extends CakeTestCase {
 		);
 		$Controller->set('user', $data);
 		$View = new JsonView($Controller);
+		$View->helpers = array('Paginator');
 		$output = $View->render('index');
 
-		$expected = json_encode(array('user' => 'fake', 'list' => array('item1', 'item2')));
+		$expected = json_encode(array('user' => 'fake', 'list' => array('item1', 'item2'), 'paging' => array('page' => 2)));
 		$this->assertSame($expected, $output);
 		$this->assertSame('application/json', $Response->type());
 	}

--- a/lib/Cake/Test/test_app/View/Posts/json/index.ctp
+++ b/lib/Cake/Test/test_app/View/Posts/json/index.ctp
@@ -16,9 +16,12 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+$paging = isset($this->Paginator->options['url']) ? $this->Paginator->options['url'] : null;
+
 $formatted = array(
 	'user' => $user['User']['username'],
-	'list' => array()
+	'list' => array(),
+	'paging' => $paging,
 );
 foreach ($user['Item'] as $item) {
 	$formatted['list'][] = $item['name'];

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -85,13 +85,7 @@ class JsonView extends View {
 			return $this->_serialize($this->viewVars['_serialize']);
 		}
 		if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
-			if (!$this->_helpersLoaded) {
-				$this->loadHelpers();
-			}
-			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($viewFileName)));
-			$this->Blocks->set('content', $this->_render($viewFileName));
-			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($viewFileName)));
-			return $this->Blocks->get('content');
+			return parent::render($view, false);
 		}
 	}
 

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -88,9 +88,10 @@ class JsonView extends View {
 			if (!$this->_helpersLoaded) {
 				$this->loadHelpers();
 			}
-			$content = $this->_render($viewFileName);
-			$this->Blocks->set('content', $content);
-			return $content;
+			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($viewFileName)));
+			$this->Blocks->set('content', $this->_render($viewFileName));
+			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($viewFileName)));
+			return $this->Blocks->get('content');
 		}
 	}
 

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -88,13 +88,7 @@ class XmlView extends View {
 			return $this->_serialize($this->viewVars['_serialize']);
 		}
 		if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
-			if (!$this->_helpersLoaded) {
-				$this->loadHelpers();
-			}
-			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($viewFileName)));
-			$this->Blocks->set('content', (string)$this->_render($viewFileName));
-			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($viewFileName)));
-			return $this->Blocks->get('content');
+			return parent::render($view, false);
 		}
 	}
 

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -91,9 +91,10 @@ class XmlView extends View {
 			if (!$this->_helpersLoaded) {
 				$this->loadHelpers();
 			}
-			$content = $this->_render($viewFileName);
-			$this->Blocks->set('content', (string)$content);
-			return $content;
+			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($viewFileName)));
+			$this->Blocks->set('content', (string)$this->_render($viewFileName));
+			$this->getEventManager()->dispatch(new CakeEvent('View.afterRender', $this, array($viewFileName)));
+			return $this->Blocks->get('content');
 		}
 	}
 


### PR DESCRIPTION
Possible solution to fix this issue:

https://groups.google.com/forum/?fromgroups#!topic/cake-php/4oyq8-3a_Zs

I see a potential edge case BC break here, but the otehr solution woudl be to trigger beforeRender, which i suppose was left out intentionally

The google post requires it for next() method which produces Html, i dont see why that would be needed in json/xml responses, but i think it is common to add navigation urls in the response and without the callback trigger, Paginator->options is not correct.
