### PR TITLE
Add a composer.json (and put cake 3.0 on packagist!?)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "cakephp/cakephp",
+    "description": "The CakePHP framework",
+    "type": "library",
+    "keywords": ["framework"],
+    "homepage": "http://cakephp.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "http://cakephp.lighthouseapp.com/",
+        "forum": "http://ask.cakephp.org/",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/cakephp/"
+    },
+    "require": {
+        "php": ">=5.4"
+    },
+    "autoload": {
+        "psr-0": {
+            "Cake": "lib/Cake/"
+        }
+    },
+    "minimum-stability": "dev",
+    "bin": [
+        "lib/Cake/Console/cake"
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         "source": "https://github.com/cakephp/cakephp/"
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.2"
     },
     "autoload": {
         "psr-0": {
-            "Cake": "lib/Cake/"
+            "Cake": "Cake/"
         }
     },
     "minimum-stability": "dev",
     "bin": [
-        "lib/Cake/Console/cake"
+        "Cake/Console/cake"
     ]
 }


### PR DESCRIPTION
Composer (http://getcomposer.org/) seems to be a great library for
packaging php functionality, I don't see why cake couldn't do so as
well. It could then be submitted to http://packagist.org/ for others
to easily grab and include in php projects.

The structure for this file can be found at
http://getcomposer.org/doc/04-schema.md

Since Cake has a unique directory structure that's designed to
"work out of the box" as well as be able to be separated, deciding
how to 'package' it with composer is not a trivial task.

For the moment it's specified that lib/Cake/ is the root directory
and should work with the PSR-0 convention. I'm not sure how to treat
App/ or plugins/, etc. There could be a few approaches to take.
Symfony is well integrated with composer, and so it could be a package
to take ideas from.

I believe that Cake would want to be used as a library here, with the
./cake script used to generate an application; the bootstrap may need
to be looked at for compatibility/ease of use with this system?

Fortunately composer has some installation customisation features,
which can be found at
http://getcomposer.org/doc/articles/custom-installers.md

Another interesting note is that it has its own windows compatibility
layer for scripts, to enable a linux php script to run from a .bat.
