### PR TITLE
Enable root index.php to get CAKE_CORE_INCLUDE_PATH from PHP 'include_path'

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,7 +36,12 @@ define('WWW_ROOT', ROOT . DS . APP_DIR . DS . WEBROOT_DIR . DS);
  * Full path to the directory containing "cake". Do not add trailing directory separator
  */
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-	define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'lib');
+	if (function_exists('ini_set')) {
+                ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+        }
+	else {
+		define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'lib');
+	}
 }
 
 require APP_DIR . DS . WEBROOT_DIR . DS . 'index.php';

--- a/index.php
+++ b/index.php
@@ -37,9 +37,8 @@ define('WWW_ROOT', ROOT . DS . APP_DIR . DS . WEBROOT_DIR . DS);
  */
 if (!defined('CAKE_CORE_INCLUDE_PATH')) {
 	if (function_exists('ini_set')) {
-                ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
-        }
-	else {
+		ini_set('include_path', ROOT . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+	} else {
 		define('CAKE_CORE_INCLUDE_PATH', ROOT . DS . 'lib');
 	}
 }


### PR DESCRIPTION
Before this path, it was necessary to manually configure the CAKE_CORE_INCLUDE_PATH on the '/index.php' for a shared location Core Lib.

The modification was based on the detection code of the 'webroot/index.php'
