### PR TITLE
avoid duplication in return value when saving habtm

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1745,7 +1745,6 @@ class Model extends Object implements CakeEventListener {
 
 		if ($success && $count > 0) {
 			if (!empty($this->data)) {
-				$success = $this->data;
 				if ($created) {
 					$this->data[$this->alias][$this->primaryKey] = $this->id;
 				}
@@ -1755,7 +1754,7 @@ class Model extends Object implements CakeEventListener {
 				$this->getEventManager()->dispatch($event);
 			}
 			if (!empty($this->data)) {
-				$success = Hash::merge($success, $this->data);
+				$success = $this->data;
 			}
 			$this->data = false;
 			$this->_clearCache();

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -888,6 +888,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Sample->Behaviors->attach('Test', array('beforeSave' => 'off', 'afterSave' => 'test'));
 		$Sample->create();
 		$expected = $record;
+		unset($expected['Sample']['name']);
 		$result = $Sample->save($record);
 		$expected['Sample']['id'] = $Sample->id;
 		$this->assertSame($expected, $result);

--- a/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
+++ b/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
@@ -213,7 +213,6 @@ class ModelCrossSchemaHabtmTest extends BaseModelTest {
 			'Armor' => array(
 				'Armor' => array(
 					1, 2, 3, 4,
-					1, 2, 3, 4,
 				),
 			),
 		);

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -1170,6 +1170,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		$result = $TestModel->save();
 		$this->assertFalse(empty($result));
+		$this->assertEquals($data['Tag'], $result['Tag']);
 
 		$TestModel->unbindModel(array('belongsTo' => array('User'), 'hasMany' => array('Comment')));
 		$result = $TestModel->find('first', array('fields' => array('id', 'user_id', 'title', 'body'), 'conditions' => array('Article.id' => 2)));


### PR DESCRIPTION
Second attempt, now even completely removed the merge, and fixed the tests so that they correcltly assert
