### PR TITLE
Remove legacy test for all actions allowed (*) in startup and tidy code

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -289,13 +289,7 @@ class AuthComponent extends Component {
 		$url = Router::normalize($url);
 		$loginAction = Router::normalize($this->loginAction);
 
-		$allowedActions = $this->allowedActions;
-		$isAllowed = (
-			$this->allowedActions == array('*') ||
-			in_array($action, array_map('strtolower', $allowedActions))
-		);
-
-		if ($loginAction != $url && $isAllowed) {
+		if ($loginAction != $url && in_array($action, array_map('strtolower', $this->allowedActions))) {
 			return true;
 		}
 


### PR DESCRIPTION
The allow('*') was removed here: cakephp/cakephp@841c0c2295b75f220c3da2c9e971cd1d718fdaaa but reference remains in the startup method.

Also, now the code is much thinner I took the opportunity to remove a few unneeded assignments....

My only thought was that it may have been deliberate to explicitly create an "$isAllowed" variable so it was always blatantly obvious in the future? I can change it back if this is preferred :)

(All tests passing)
