### PR TITLE
Fixing typo in view property during unset()

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -919,7 +919,7 @@ class View extends Object {
 
 		include $this->__viewFile;
 
-		unset($this->_viewFile);
+		unset($this->__viewFile);
 		return ob_get_clean();
 	}
 


### PR DESCRIPTION
I caught this typo while going over the View class.
