### PR TITLE
view buffer for FormHelper::postLink()

### DIFF
--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -922,6 +922,48 @@ class ViewTest extends CakeTestCase {
 		$result = $View->renderLayout($content, 'default');
 		$this->assertRegExp('/modified in the afterlife/', $result);
 		$this->assertRegExp('/This is my view output/', $result);
+
+		$content = 'This is my other view output';
+		$result = $View->renderLayout($content);
+		$this->assertRegExp('/modified in the afterlife/', $result);
+		$this->assertRegExp('/This is my other view output/', $result);
+	}
+
+/**
+ * testBuffer method
+ *
+ * @return void
+ */
+	public function testBuffer() {
+		$this->PostsController->helpers = array('Form', 'Html');
+
+		$View = new View($this->PostsController);
+		$result = $View->render('buffer', 'ajax');
+		$this->assertRegExp('/Testing buffer for post links/', $result);
+		$expected = '/\<span class="buttonContainer"\>\s*\<a href="#" onclick="document.post_(.*?).submit\(\); event.returnValue = false; return false;"\>postlink\<\/a\>\s*\<\/span\>/';
+		$this->assertRegExp($expected, $result);
+		$expected = '/\<form action="\/" name="post_(.*?)" id="post_(.*?)" style="display:none;" method="post"\>\<input type="hidden" name="_method" value="POST"\/\>\<\/form\>/';
+		$this->assertRegExp($expected, $result);
+
+		$View = new View($this->PostsController);
+		$result = $View->render('buffer', 'default');
+		$this->assertRegExp('/Testing buffer for post links/', $result);
+		$expected = '/\<span class="buttonContainer"\>\s*\<a href="#" onclick="document.post_(.*?).submit\(\); event.returnValue = false; return false;"\>postlink\<\/a\>\s*\<\/span\>/';
+		$this->assertRegExp($expected, $result);
+		$expected = '/\<form action="\/" name="post_(.*?)" id="post_(.*?)" style="display:none;" method="post"\>\<input type="hidden" name="_method" value="POST"\/\>\<\/form\>/';
+		$this->assertRegExp($expected, $result);
+
+		// test buffered content in layout and view
+		$View = new View($this->PostsController);
+		$result = $View->render('buffer', 'buffer');
+		$this->assertRegExp('/Testing buffer for post links/', $result);
+		$this->assertRegExp('/This is regular text/', $result);
+		$expected = '/\<form>\s*\<a href="#" onclick="document.post_(.*?).submit\(\); event.returnValue = false; return false;"\>postlink2\<\/a\>\s*\<\/form\>/';
+		$this->assertRegExp($expected, $result);
+		$expected = '/\<span class="buttonContainer"\>\s*\<a href="#" onclick="document.post_(.*?).submit\(\); event.returnValue = false; return false;"\>postlink\<\/a\>\s*\<\/span\>/';
+		$this->assertRegExp($expected, $result);
+		$expected = '/\<form action="\/" name="post_(.*?)" id="post_(.*?)" style="display:none;" method="post"\>\<input type="hidden" name="_method" value="POST"\/\>\<\/form\>\s*\<\/div\>\s*<form action="\/" name="post_(.*?)" id="post_(.*?)" style="display:none;" method="post"\>\<input type="hidden" name="_method" value="POST"\/\>\<\/form\>/';
+		$this->assertRegExp($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/View/Layouts/buffer.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/buffer.ctp
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       cake.libs.view.templates.layouts
+ * @since         CakePHP(tm) v 0.10.0.1076
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+?>
+<html>
+<body>
+<p>This is regular text</p>
+<div class="sidebar">
+	<form>
+		<?php echo $this->Form->postLink('postlink2', '/', array()); ?>
+	</form>
+</div>
+<div id="content">
+	<?php echo $content_for_layout; ?>
+</div>
+<?php echo $this->fetch('buffer'); ?>
+</body></html>

--- a/lib/Cake/Test/test_app/View/Posts/buffer.ctp
+++ b/lib/Cake/Test/test_app/View/Posts/buffer.ctp
@@ -1,0 +1,4 @@
+<h3>Testing buffer for post links</h3>
+<span class="buttonContainer">
+	<?php echo $this->Form->postLink('postlink', '/', array()); ?>
+</span>

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1627,8 +1627,8 @@ class FormHelper extends AppHelper {
 		}
 		$options['onclick'] .= ' event.returnValue = false; return false;';
 
-		$out .= $this->Html->link($title, $url, $options);
-		return $out;
+		$this->_View->append('buffer', $out);
+		return $this->Html->link($title, $url, $options);
 	}
 
 /**

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -454,7 +454,7 @@ class View extends Object {
 			$layout = $this->layout;
 		}
 		if ($buffer = $this->Blocks->get('buffer', true)) {
-			$this->Blocks->append('content', "\r\n" . $buffer);
+			$this->Blocks->append('content', $buffer);
 		}
 		if ($layout && $this->autoLayout) {
 			$this->Blocks->set('content', $this->renderLayout('', $layout));

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -453,6 +453,9 @@ class View extends Object {
 		if ($layout === null) {
 			$layout = $this->layout;
 		}
+		if ($buffer = $this->Blocks->get('buffer', true)) {
+			$this->Blocks->append('content', "\r\n" . $buffer);
+		}
 		if ($layout && $this->autoLayout) {
 			$this->Blocks->set('content', $this->renderLayout('', $layout));
 		}
@@ -485,15 +488,14 @@ class View extends Object {
  */
 	public function renderLayout($content, $layout = null) {
 		$layoutFileName = $this->_getLayoutFileName($layout);
-		if (empty($layoutFileName)) {
-			return $this->Blocks->get('content');
-		}
-
-		if (!$this->_helpersLoaded) {
-			$this->loadHelpers();
-		}
 		if (empty($content)) {
 			$content = $this->Blocks->get('content');
+		}
+		if (empty($layoutFileName)) {
+			return $content;
+		}
+		if (!$this->_helpersLoaded) {
+			$this->loadHelpers();
 		}
 		$this->getEventManager()->dispatch(new CakeEvent('View.beforeLayout', $this, array($layoutFileName)));
 

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -119,13 +119,18 @@ class ViewBlock {
  * Get the content for a block.
  *
  * @param string $name Name of the block
+ * @param boolean $clear Whether or not to clear the block after retrieval (default false)
  * @return The block content or '' if the block does not exist.
  */
-	public function get($name) {
+	public function get($name, $clear = false) {
 		if (!isset($this->_blocks[$name])) {
 			return '';
 		}
-		return $this->_blocks[$name];
+		$value = $this->_blocks[$name];
+		if ($clear) {
+			$this->_blocks[$name] = '';
+		}
+		return $value;
 	}
 
 /**


### PR DESCRIPTION
allow View to have a buffer for correct html output in some edge cases.
$this->Form->postLink() for example should not output a form tag inside inline elements like span - only the a tag). also using the above method inside a form would break it currently (form inside form!).

So the buffer method works similar to the js buffer, but will be handled class internally.
The helpers/views only have to write to it. It will automatically be appended to the end of the content block on render.

For the layout you would need to add `<?php echo $this->fetch('buffer'); ?>` manually, though, right before the closing `<body>` tag if you want to use postLink() there. see the test cases for details.

see ticket http://cakephp.lighthouseapp.com/projects/42648/tickets/3149-view-should-have-buffer-for-formhelperpostlink
