### PR TITLE
Ticket 3152 - Email test fails when not running on port 80 

### DIFF
--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1120,7 +1120,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->emailFormat('html');
 		$server = env('SERVER_NAME') ? env('SERVER_NAME') : 'localhost';
 				
-		if (env('SERVER_PORT') != NULL && env('SERVER_PORT') != 80) {
+		if (env('SERVER_PORT') != null && env('SERVER_PORT') != 80) {
 			$server .= ':' . env('SERVER_PORT');
 		}
 				

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1119,8 +1119,8 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->template('image');
 		$this->CakeEmail->emailFormat('html');
 		$server = env('SERVER_NAME') ? env('SERVER_NAME') : 'localhost';
-		
-		if (env('SERVER_PORT') != 80) {
+				
+		if (env('SERVER_PORT') != NULL && env('SERVER_PORT') != 80) {
 			$server .= ':' . env('SERVER_PORT');
 		}
 				

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1118,8 +1118,12 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->config(array('empty'));
 		$this->CakeEmail->template('image');
 		$this->CakeEmail->emailFormat('html');
-
 		$server = env('SERVER_NAME') ? env('SERVER_NAME') : 'localhost';
+		
+		if (env('SERVER_PORT') != 80) {
+			$server .= ':' . env('SERVER_PORT');
+		}
+				
 		$expected = '<img src="http://' . $server . '/img/image.gif" alt="cool image" width="100" height="100" />';
 		$result = $this->CakeEmail->send();
 		$this->assertContains($expected, $result['message']);


### PR DESCRIPTION
What I did

Ran CakeEmailTest::testSendRenderWithImage()

What happened

Failed to match the image because it's looking for localhost/img/image.gif instead of localhost:port/img/image.gif
