### PR TITLE
Schema support for MySQL BIGINTs

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -108,6 +108,7 @@ class Mysql extends DboSource {
 		'primary_key' => array('name' => 'NOT NULL AUTO_INCREMENT'),
 		'string' => array('name' => 'varchar', 'limit' => '255'),
 		'text' => array('name' => 'text'),
+		'biginteger' => array('name' => 'bigint', 'limit' => '20'),
 		'integer' => array('name' => 'int', 'limit' => '11', 'formatter' => 'intval'),
 		'float' => array('name' => 'float', 'formatter' => 'floatval'),
 		'datetime' => array('name' => 'datetime', 'format' => 'Y-m-d H:i:s', 'formatter' => 'date'),
@@ -645,6 +646,9 @@ class Mysql extends DboSource {
 		}
 		if (($col === 'tinyint' && $limit == 1) || $col === 'boolean') {
 			return 'boolean';
+		}
+		if (strpos($col, 'bigint') !== false || $col === 'bigint') {
+			return 'biginteger';
 		}
 		if (strpos($col, 'int') !== false) {
 			return 'integer';

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3068,7 +3068,7 @@ class DboSource extends DataSource {
 		}
 		$out = $this->_buildFieldParameters($out, $column, 'beforeDefault');
 
-		if (isset($column['key']) && $column['key'] === 'primary' && $type === 'integer') {
+		if (isset($column['key']) && $column['key'] === 'primary' && ($type === 'integer' || $type === 'biginteger')) {
 			$out .= ' ' . $this->columns['primary_key']['name'];
 		} elseif (isset($column['key']) && $column['key'] === 'primary') {
 			$out .= ' NOT NULL';

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -268,6 +268,13 @@ class MysqlTest extends CakeTestCase {
 		$this->Dbo->rawQuery('DROP TABLE ' . $name);
 		$this->assertEquals($expected, $result);
 
+		$name = $this->Dbo->fullTableName('bigint');
+		$this->Dbo->rawQuery('CREATE TABLE ' . $name . ' (id bigint(20) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id));');
+		$expected = array('PRIMARY' => array('column' => 'id', 'unique' => 1));
+		$result = $this->Dbo->index('bigint', false);
+		$this->Dbo->rawQuery('DROP TABLE ' . $name);
+		$this->assertEquals($expected, $result);
+
 		$name = $this->Dbo->fullTableName('with_a_key');
 		$this->Dbo->rawQuery('CREATE TABLE ' . $name . ' (id int(11) AUTO_INCREMENT, bool tinyint(1), small_int tinyint(2), primary key(id), KEY `pointless_bool` ( `bool` ));');
 		$expected = array(
@@ -475,6 +482,10 @@ class MysqlTest extends CakeTestCase {
 
 		$result = $this->Dbo->column('int(11) unsigned');
 		$expected = 'integer';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Dbo->column('bigint(20)');
+		$expected = 'biginteger';
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->column('tinyint(1)');


### PR DESCRIPTION
Hi there!

Huge Cake fan here :) In the Cake applications I've been developing, I use BIGINT MySQL columns. However, when a database schema is generated, those columns get converted to INT columns, which unfortunately breaks things if we have values larger than integers stored in the database. This pull request simply adds a type for MySQL's BIGINT.

(tm)
