### PR TITLE
Add foreignKey to whitelist in saveAssociated()

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2266,6 +2266,10 @@ class Model extends Object implements CakeEventListener {
 								$values[$i] = array_merge(array($key => $this->id), $value, array($key => $this->id));
 							}
 						}
+						// add foreignKey to whitelist if not already there
+						if (!in_array($key, $this->{$association}->whitelist)) {
+							$this->{$association}->whitelist[] = $key;
+						}
 						$_return = $this->{$association}->saveMany($values, array_merge($options, array('atomic' => false)));
 						if (in_array(false, $_return, true)) {
 							$validationErrors[$association] = $this->{$association}->validationErrors;


### PR DESCRIPTION
Association's foreignKey doesn't get saved when saving hasMany associations since it's not in the model's whitelist after validation.
This happens if you don't send the foreignKey with the associated records data.
