### PR TITLE
Fixed coding standards

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -970,7 +970,7 @@ class Model extends Object implements EventListener {
 
 				foreach ($this->{$type} as $i => $className) {
 					$className = trim($className);
-					unset ($this->{$type}[$i]);
+					unset($this->{$type}[$i]);
 					$this->{$type}[$className] = array();
 				}
 			}
@@ -980,7 +980,7 @@ class Model extends Object implements EventListener {
 					$plugin = null;
 
 					if (is_numeric($assoc)) {
-						unset ($this->{$type}[$assoc]);
+						unset($this->{$type}[$assoc]);
 						$assoc = $value;
 						$value = array();
 
@@ -1156,7 +1156,7 @@ class Model extends Object implements EventListener {
 
 				foreach ($fieldSet as $fieldName => $fieldValue) {
 					if (isset($this->validationErrors[$fieldName])) {
-						unset ($this->validationErrors[$fieldName]);
+						unset($this->validationErrors[$fieldName]);
 					}
 
 					if ($modelName === $this->alias) {


### PR DESCRIPTION
Functions should be called without space between function’s name and starting bracket.
