### PR TITLE
Fix $readReceipt variable in EmailComponent::send

### DIFF
--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -305,7 +305,7 @@ class EmailComponent extends Component {
 		if (!empty($this->return)) {
 			$lib->returnPath($this->_formatAddresses((array)$this->return));
 		}
-		if (!empty($readReceipt)) {
+		if (!empty($this->readReceipt)) {
 			$lib->readReceipt($this->_formatAddresses((array)$this->readReceipt));
 		}
 


### PR DESCRIPTION
A small typo as `$readReceipt` here will always be empty.
Looks like it should have been `$this->readReceipt` instead.
