### PR TITLE
Remove unused variables and code

### DIFF
--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -318,10 +318,8 @@ class PhpAco {
  * @return void 
  */
 	public function build(array $allow, array $deny = array()) {
-		$stack = array();
 		$this->_tree = array();
 		$tree = array();
-		$root = &$tree;
 
 		foreach ($allow as $dotPath => $aros) {
 			if (is_string($aros)) {

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -557,7 +557,6 @@ class Controller extends Object implements CakeEventListener {
 
 		if ($mergeParent || !empty($pluginController)) {
 			$appVars = get_class_vars($this->_mergeParent);
-			$uses = $appVars['uses'];
 			$merge = array('components', 'helpers');
 			$this->_mergeVars($merge, $this->_mergeParent, true);
 		}

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -185,7 +185,6 @@ class Configure {
  */
 	public static function delete($var = null) {
 		$keys = explode('.', $var);
-		$last = array_pop($keys);
 		self::$_values = Hash::remove(self::$_values, $var);
 	}
 

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -603,7 +603,6 @@ class TranslateBehavior extends ModelBehavior {
 		if (is_string($fields)) {
 			$fields = array($fields);
 		}
-		$RuntimeModel = $this->translateModel($Model);
 		$associations = array();
 
 		foreach ($fields as $key => $value) {

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -271,7 +271,7 @@ class CakeSchema extends Object {
 							unset($currentTables[$key]);
 						}
 						if (!empty($Object->hasAndBelongsToMany)) {
-							foreach ($Object->hasAndBelongsToMany as $Assoc => $assocData) {
+							foreach ($Object->hasAndBelongsToMany as $assocData) {
 								if (isset($assocData['with'])) {
 									$class = $assocData['with'];
 								}
@@ -597,7 +597,7 @@ class CakeSchema extends Object {
 		$db = $Obj->getDataSource();
 		$fields = $Obj->schema(true);
 
-		$columns = $props = array();
+		$columns = array();
 		foreach ($fields as $name => $value) {
 			if ($Obj->primaryKey == $name) {
 				$value['key'] = 'primary';

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -449,7 +449,6 @@ class CakeSession {
  */
 	protected static function _configureSession() {
 		$sessionConfig = Configure::read('Session');
-		$iniSet = function_exists('ini_set');
 
 		if (isset($sessionConfig['defaults'])) {
 			$defaults = self::_defaultConfig($sessionConfig['defaults']);

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -438,7 +438,7 @@ class Postgres extends DboSource {
 			)
 			AND c.oid = i.indrelid AND i.indexrelid = c2.oid
 			ORDER BY i.indisprimary DESC, i.indisunique DESC, c2.relname", false);
-			foreach ($indexes as $i => $info) {
+			foreach ($indexes as $info) {
 				$key = array_pop($info);
 				if ($key['indisprimary']) {
 					$key['relname'] = 'PRIMARY';

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -474,7 +474,7 @@ class Sqlite extends DboSource {
 			if (is_bool($indexes)) {
 				return array();
 			}
-			foreach ($indexes as $i => $info) {
+			foreach ($indexes as $info) {
 				$key = array_pop($info);
 				$keyInfo = $this->query('PRAGMA index_info("' . $key['name'] . '")');
 				foreach ($keyInfo as $keyCol) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1294,9 +1294,9 @@ class DboSource extends DataSource {
 						}
 					}
 					if ($type === 'hasAndBelongsToMany') {
-						$uniqueIds = $merge = array();
+						$merge = array();
 
-						foreach ($fetch as $j => $data) {
+						foreach ($fetch as $data) {
 							if (isset($data[$with]) && $data[$with][$foreignKey] === $row[$modelAlias][$modelPK]) {
 								if ($habtmFieldsCount <= 2) {
 									unset($data[$with]);
@@ -1445,7 +1445,7 @@ class DboSource extends DataSource {
 					$data[$association] = array();
 				}
 			} else {
-				foreach ($merge as $i => $row) {
+				foreach ($merge as $row) {
 					$insert = array();
 					if (count($row) === 1) {
 						$insert = $row[$association];
@@ -2413,7 +2413,7 @@ class DboSource extends DataSource {
 		}
 		$clauses = '/^WHERE\\x20|^GROUP\\x20BY\\x20|^HAVING\\x20|^ORDER\\x20BY\\x20/i';
 
-		if (preg_match($clauses, $conditions, $match)) {
+		if (preg_match($clauses, $conditions)) {
 			$clause = '';
 		}
 		$conditions = $this->_quoteFields($conditions);
@@ -2908,7 +2908,7 @@ class DboSource extends DataSource {
 			$columnMap[$key] = $pdoMap[$type];
 		}
 
-		foreach ($values as $row => $value) {
+		foreach ($values as $value) {
 			$i = 1;
 			foreach ($value as $col => $val) {
 				$statement->bindValue($i, $val, $columnMap[$col]);
@@ -3205,7 +3205,7 @@ class DboSource extends DataSource {
 
 		$isAllFloat = $isAllInt = true;
 		$containsFloat = $containsInt = $containsString = false;
-		foreach ($value as $key => $valElement) {
+		foreach ($value as $valElement) {
 			$valElement = trim($valElement);
 			if (!is_float($valElement) && !preg_match('/^[\d]+\.[\d]+$/', $valElement)) {
 				$isAllFloat = false;

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2363,7 +2363,7 @@ class Model extends Object implements CakeEventListener {
 
 			$updateCounterCache = false;
 			if (!empty($this->belongsTo)) {
-				foreach ($this->belongsTo as $parent => $assoc) {
+				foreach ($this->belongsTo as $assoc) {
 					if (!empty($assoc['counterCache'])) {
 						$updateCounterCache = true;
 						break;
@@ -2449,7 +2449,7 @@ class Model extends Object implements CakeEventListener {
  * @return void
  */
 	protected function _deleteLinks($id) {
-		foreach ($this->hasAndBelongsToMany as $assoc => $data) {
+		foreach ($this->hasAndBelongsToMany as $data) {
 			list($plugin, $joinModel) = pluginSplit($data['with']);
 			$records = $this->{$joinModel}->find('all', array(
 				'conditions' => array($this->{$joinModel}->escapeField($data['foreignKey']) => $id),
@@ -3042,7 +3042,7 @@ class Model extends Object implements CakeEventListener {
 	public function isForeignKey($field) {
 		$foreignKeys = array();
 		if (!empty($this->belongsTo)) {
-			foreach ($this->belongsTo as $assoc => $data) {
+			foreach ($this->belongsTo as $data) {
 				$foreignKeys[] = $data['foreignKey'];
 			}
 		}

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -675,7 +675,7 @@ class CakeRequest implements ArrayAccess {
 	public function accepts($type = null) {
 		$raw = $this->parseAccept();
 		$accept = array();
-		foreach ($raw as $value => $types) {
+		foreach ($raw as $types) {
 			$accept = array_merge($accept, $types);
 		}
 		if ($type === null) {

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -175,7 +175,7 @@ class ClassRegistry {
 					}
 
 					if (!isset($instance)) {
-						trigger_error(__d('cake_dev', '(ClassRegistry::init() could not create instance of %1$s class %2$s ', $class, $type), E_USER_WARNING);
+						trigger_error(__d('cake_dev', '(ClassRegistry::init() could not create instance of %s', $class), E_USER_WARNING);
 						return $false;
 					}
 				}

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -213,7 +213,6 @@ class Debugger {
 		if (empty($line)) {
 			$line = '??';
 		}
-		$path = self::trimPath($file);
 
 		$info = compact('code', 'description', 'file', 'line');
 		if (!in_array($info, $self->errors)) {

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -367,7 +367,7 @@ class Folder {
 			$paths = $this->tree($path);
 
 			foreach ($paths as $type) {
-				foreach ($type as $key => $fullpath) {
+				foreach ($type as $fullpath) {
 					$check = explode(DS, $fullpath);
 					$count = count($check);
 

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -432,7 +432,6 @@ class Hash {
 		}
 		$stack = array();
 
-		$i = 1;
 		while (!empty($needle)) {
 			$key = key($needle);
 			$val = $needle[$key];

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -194,7 +194,7 @@ class FormHelper extends AppHelper {
 
 		if ($key === 'fields') {
 			if (!isset($this->fieldset[$model]['fields'])) {
-				$fields = $this->fieldset[$model]['fields'] = $object->schema();
+				$this->fieldset[$model]['fields'] = $object->schema();
 				foreach ($object->hasAndBelongsToMany as $alias => $assocData) {
 					$this->fieldset[$object->alias]['fields'][$alias] = array('type' => 'multiple');
 				}
@@ -320,7 +320,6 @@ class FormHelper extends AppHelper {
 
 		$key = null;
 		if ($model !== false) {
-			$object = $this->_getModel($model);
 			$key = $this->_introspectModel($model, 'key');
 			$this->setEntity($model, true);
 		}

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -254,7 +254,6 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
 		$options['url'] = $url;
 		$options = $this->_prepareCallbacks('request', $options);
 		if (!empty($options['dataExpression'])) {
-			$callbacks[] = 'data';
 			unset($options['dataExpression']);
 		} elseif (!empty($data)) {
 			$data = $this->object($data);

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -237,7 +237,6 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 		$url = '"' . $this->url($url) . '"';
 		$options = $this->_mapOptions('request', $options);
 		$type = '.Request';
-		$data = null;
 		if (isset($options['type']) && strtolower($options['type']) == 'json') {
 			unset($options['type']);
 		}

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -341,7 +341,7 @@ class RssHelper extends AppHelper {
 				$nodes->item(0)->setAttribute($key, $value);
 			}
 		}
-		foreach ($children as $k => $child) {
+		foreach ($children as $child) {
 			$child = $elem->createElement($name, $child);
 			$nodes->item(0)->appendChild($child);
 		}

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -358,7 +358,6 @@ class TimeHelper extends AppHelper {
  */
 	public function timeAgoInWords($dateTime, $options = array()) {
 		$element = null;
-		$stringDate = '';
 
 		if (is_array($options) && !empty($options['element'])) {
 			$element = array(

--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -101,8 +101,6 @@ class MediaView extends View {
 
 		if ($this->_isActive()) {
 			$extension = strtolower($extension);
-			$chunkSize = 8192;
-			$buffer = '';
 			$fileSize = @filesize($path);
 			$handle = fopen($path, 'rb');
 

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -290,11 +290,6 @@ class View extends Object {
 	protected $_eventManager = null;
 
 /**
- * The view file to be rendered, only used inside _execute()
- */
-	private $__viewFileName = null;
-
-/**
  * Whether the event manager was already configured for this object
  *
  * @var boolean
@@ -856,7 +851,7 @@ class View extends Object {
  */
 	public function loadHelpers() {
 		$helpers = HelperCollection::normalizeObjectArray($this->helpers);
-		foreach ($helpers as $name => $properties) {
+		foreach ($helpers as $properties) {
 			list($plugin, $class) = pluginSplit($properties['class']);
 			$this->{$class} = $this->Helpers->load($properties['class'], $properties['settings']);
 		}


### PR DESCRIPTION
Used [phpmd](http://phpmd.org/) to find unused code. Went through and removed each very carefully by hand. Avoided removing any reported unused vars near `compact()` and `extract()`. Thanks!
