### PR TITLE
remove cookie reading in startup

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -191,9 +191,6 @@ class CookieComponent extends Component {
 		$this->_expire($this->time);
 
 		$this->_values[$this->name] = array();
-		if (isset($_COOKIE[$this->name])) {
-			$this->_values[$this->name] = $this->_decrypt($_COOKIE[$this->name]);
-		}
 	}
 
 /**


### PR DESCRIPTION
read() also handles this, and all methods redaing from _values call read() first

with this line removed you can call Cookie->type('rijndael'); Cookie->read('Key');

With the line in startup, it will already be decrypted with cipher and can only be changed in a beforeFilter()
