### PR TITLE
create fixture table name by imported table name

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -118,7 +118,7 @@ class CakeTestFixture {
 				$db->cacheSources = false;
 				$model->useDbConfig = $import['connection'];
 				$model->name = Inflector::camelize(Inflector::singularize($import['table']));
-				$model->table = $import['table'];
+				$this->table = $model->table = $import['table'];
 				$model->tablePrefix = $db->config['prefix'];
 				$this->fields = $model->schema(true);
 				ClassRegistry::flush();


### PR DESCRIPTION
If imported table name is not according to the terms of cakephp test_suite_tablename will be different from imported table name.So We can't continue the test.
So test_suite_tablename will be the same to imported table name.
