### PR TITLE
enable PluginDot for routeClass parameter

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -304,7 +304,12 @@ class Router {
 		}
 		$routeClass = self::$_routeClass;
 		if (isset($options['routeClass'])) {
-			$routeClass = self::_validateRouteClass($options['routeClass']);
+			if (strpos($options['routeClass'], '.') === false) {
+				$routeClass = $options['routeClass'];
+			} else {
+				list($plugin, $routeClass) = pluginSplit($options['routeClass'], true);
+			}
+			$routeClass = self::_validateRouteClass($routeClass);
 			unset($options['routeClass']);
 		}
 		if ($routeClass == 'RedirectRoute' && isset($defaults['redirect'])) {

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2283,6 +2283,26 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * test using custom route class in PluginDot notation
+ */
+	public function testUsingCustomRouteClassPluginDotSyntax() {
+		App::build(array(
+			'Plugin' => array(
+				CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS
+			)
+		));
+		CakePlugin::load('TestPlugin');
+		App::uses('TestRoute', 'TestPlugin.Routing/Route');
+		$routes = Router::connect(
+			'/:slug',
+			array('controller' => 'posts', 'action' => 'view'),
+			array('routeClass' => 'TestPlugin.TestRoute', 'slug' => '[a-z_-]+')
+		);
+		$this->assertInstanceOf('TestRoute', $routes[0]);
+		CakePlugin::unload('TestPlugin');
+	}
+
+/**
  * test that route classes must extend CakeRoute
  *
  * @expectedException RouterException

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Route/TestRoute.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Route/TestRoute.php
@@ -1,0 +1,7 @@
+<?php
+
+App::uses('CakeRoute', 'Routing/Route');
+
+class TestRoute extends CakeRoute {
+
+}


### PR DESCRIPTION
This is more inline with other usage in models, components etc.

In this version, the path needs to be registered first prior to calling `Router::connect`.
