### PR TITLE
added missing App::uses('Hash', 'Utility');

### DIFF
--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -18,6 +18,7 @@
  */
 
 App::uses('BaseLog', 'Log/Engine');
+App::uses('Hash', 'Utility');
 
 /**
  * File Storage stream for Logging.  Writes logs to different files

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -14,6 +14,7 @@
  */
 
 App::uses('Router', 'Routing');
+App::uses('Hash', 'Utility');
 
 /**
  * Abstract base class for all other Helpers in CakePHP.

--- a/lib/Cake/View/Helper/NumberHelper.php
+++ b/lib/Cake/View/Helper/NumberHelper.php
@@ -21,6 +21,7 @@
 
 App::uses('CakeNumber', 'Utility');
 App::uses('AppHelper', 'View/Helper');
+App::uses('Hash', 'Utility');
 
 /**
  * Number helper library.

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -20,6 +20,7 @@
  */
 
 App::uses('AppHelper', 'View/Helper');
+App::uses('Hash', 'Utility');
 
 /**
  * Text helper library.


### PR DESCRIPTION
added missing App::uses('Hash', 'Utility');

see IRC:
"[17:13:56] <leknoppix> Fatal error: Class 'Hash' not found in /Users/leknoppix/Sites/facturation_musique/lib/Cake/Log/Engine/FileLog.php on line 51"
