### PR TITLE
Added ability to set default view block content

### DIFF
--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -1445,4 +1445,20 @@ TEXT;
 		$end = memory_get_usage();
 		$this->assertLessThanOrEqual($start + 5000, $end);
 	}
+
+/**
+ * tests that a vew block uses default value when not assigned and uses assigned value when it is
+ *
+ * @return void
+ */
+	public function testBlockDefaultValue() {
+		$default = 'Default';
+		$result = $this->View->fetch('title', $default);
+		$this->assertEqual($result, $default);
+
+		$expected = 'My Title';
+		$this->View->assign('title', $expected);
+		$result = $this->View->fetch('title', $default);
+		$this->assertEqual($result, $expected);
+	}
 }

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -1454,11 +1454,11 @@ TEXT;
 	public function testBlockDefaultValue() {
 		$default = 'Default';
 		$result = $this->View->fetch('title', $default);
-		$this->assertEqual($result, $default);
+		$this->assertEquals($default, $result);
 
 		$expected = 'My Title';
 		$this->View->assign('title', $expected);
 		$result = $this->View->fetch('title', $default);
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 }

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -636,11 +636,11 @@ class View extends Object {
  * empty or undefined '' will be returned.
  *
  * @param string $name Name of the block
- * @return The block content or '' if the block does not exist.
+ * @return string The block content or $default if the block does not exist.
  * @see ViewBlock::get()
  */
-	public function fetch($name) {
-		return $this->Blocks->get($name);
+	public function fetch($name, $default = '') {
+		return $this->Blocks->get($name, $default);
 	}
 
 /**

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -119,11 +119,11 @@ class ViewBlock {
  * Get the content for a block.
  *
  * @param string $name Name of the block
- * @return The block content or '' if the block does not exist.
+ * @return string The block content or $default if the block does not exist.
  */
-	public function get($name) {
+	public function get($name, $default = '') {
 		if (!isset($this->_blocks[$name])) {
-			return '';
+			return $default;
 		}
 		return $this->_blocks[$name];
 	}


### PR DESCRIPTION
Use case? I don't really have one. There was a question about it on SO and the change is simple so here it is. It may be useful for others.

SO Question: http://stackoverflow.com/questions/12370833/cakephp-view-template-default-values-for-fetched-content

Instead of the answer given there:

```
$title = $this->fetch('title');
echo !empty($title) ? $title : 'Default';
```

It would become `echo $this->fetch('title', 'Default');`

Not much of a gain, just looks neater IMO.
