### PR TITLE
Adding a check to the object before use

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -146,7 +146,7 @@ class FormHelper extends AppHelper {
 			));
 		} elseif (ClassRegistry::isKeySet($this->defaultModel)) {
 			$defaultObject = ClassRegistry::getObject($this->defaultModel);
-			if (in_array($model, array_keys($defaultObject->getAssociated()), true) && isset($defaultObject->{$model})) {
+			if ($defaultObject && in_array($model, array_keys($defaultObject->getAssociated()), true) && isset($defaultObject->{$model})) {
 				$object = $defaultObject->{$model};
 			}
 		} else {


### PR DESCRIPTION
For some reason that I have not been able to figure out yet the object is
returned as null.  This is causing some exceptions when trying to access
properties that dont exist.

FatalErrorException: "Call to a member function getAssociated() on a non-object"

It has something to do with (I think) Form->create(null) with $uses = ['NonConventionModel'] in the controller

Test still pass with the added check.
