### PR TITLE
skipping the rijndael test if mcrypt_encrypt() is not available

### DIFF
--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -215,6 +215,7 @@ class SecurityTest extends CakeTestCase {
  * @return void
  */
 	public function testRijndael() {
+		$this->skipIf(!function_exists('mcrypt_encrypt'));
 		$txt = 'The quick brown fox jumped over the lazy dog.';
 		$key = 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi';
 


### PR DESCRIPTION
I don't seem to have these libs and get fatal errors.

added `skipIf()` in the tests, not sure if its better to have the checks in the core?
