### PR TITLE
avoiding "Indirect modification of overloaded property $paginate ... no effect"

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -265,6 +265,13 @@ class Controller extends Object implements CakeEventListener {
 	public $methods = array();
 
 /**
+ * The paginate options for this controller
+ *
+ * @var array
+ */
+	public $paginate = array();
+
+/**
  * This controller's primary model class name, the Inflector::singularize()'ed version of
  * the controller's $name property.
  *


### PR DESCRIPTION
After some research I found the issue described as warning in the book:

```
You can run into a situation where assigning a value to a nonexistent property will throw errors:
    $this->paginate['limit'] = 10;
will throw the error “Notice: Indirect modification of overloaded property $paginate has no effect”. 
```

but with this little fix we can make life easier without the notice.
