### PR TITLE
adding query() for CakeRequest

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -759,6 +759,16 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
+ * Provides a read accessor for `$this->query`.  Allows you
+ * to use a syntax similar to `CakeSession` for reading url query data.
+ *
+ * @return mixed The value being read
+ */
+	public function query($name) {
+		return Hash::get($this->query, $name);
+	}
+
+/**
  * Provides a read/write accessor for `$this->data`.  Allows you
  * to use a syntax similar to `CakeSession` for reading post data.
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1697,6 +1697,27 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * test the query() method with arrays passed via $_GET
+ *
+ * @return void
+ */
+	public function testQueryWithArray() {
+		$_GET = array();
+		$_GET['test'] = array('foo', 'bar');
+
+		$request = new CakeRequest();
+
+		$result = $request->query('test');
+		$this->assertEquals(array('foo', 'bar'), $result);
+
+		$result = $request->query('test.1');
+		$this->assertEquals('bar', $result);
+
+		$result = $request->query('test.2');
+		$this->assertNull($result);
+	}
+
+/**
  * test the data() method reading
  *
  * @return void

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1679,6 +1679,24 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * test the query() method
+ *
+ * @return void
+ */
+	public function testQuery() {
+		$_GET = array();
+		$_GET['foo'] = 'bar';
+
+		$request = new CakeRequest();
+
+		$result = $request->query('foo');
+		$this->assertEquals('bar', $result);
+
+		$result = $request->query('imaginary');
+		$this->assertNull($result);
+	}
+
+/**
  * test the data() method reading
  *
  * @return void


### PR DESCRIPTION
@see http://cakephp.lighthouseapp.com/projects/42648/tickets/3111-additional-cakerequest-methods-for-easier-access-to-params-named-pass-url

without pass() and named() for now since there might be some changes in the future to deprecate named() at least.
