### PR TITLE
adding CakeNumber::formatDelta() and fixing issue with format()

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -245,7 +245,7 @@ class ExtractTask extends AppShell {
 		if (empty($this->_translations[$domain][$msgid])) {
 			$this->_translations[$domain][$msgid] = array(
 				'msgid_plural' => false
-			 );
+			);
 		}
 
 		if (isset($details['msgid_plural'])) {

--- a/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
@@ -25,7 +25,7 @@
 	); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0 ):
+if (Configure::read('debug') > 0):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
@@ -22,7 +22,7 @@
 	<?php echo __d('cake', 'An Internal Error Has Occurred.'); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0 ):
+if (Configure::read('debug') > 0):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -389,7 +389,7 @@ class SecurityComponent extends Component {
 			$requireAuth = $this->requireAuth;
 
 			if (in_array($this->request->params['action'], $requireAuth) || $this->requireAuth == array('*')) {
-				if (!isset($controller->request->data['_Token'] )) {
+				if (!isset($controller->request->data['_Token'])) {
 					if (!$this->blackHole($controller, 'auth')) {
 						return null;
 					}

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -1122,7 +1122,7 @@ class Multibyte {
 	public static function checkMultibyte($string) {
 		$length = strlen($string);
 
-		for ($i = 0; $i < $length; $i++ ) {
+		for ($i = 0; $i < $length; $i++) {
 			$value = ord(($string[$i]));
 			if ($value > 128) {
 				return true;

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -184,7 +184,7 @@ class TranslateBehavior extends ModelBehavior {
  */
 	protected function _checkConditions(Model $Model, $query) {
 		$conditionFields = array();
-		if (empty($query['conditions']) || (!empty($query['conditions']) && !is_array($query['conditions'])) ) {
+		if (empty($query['conditions']) || (!empty($query['conditions']) && !is_array($query['conditions']))) {
 			return $conditionFields;
 		}
 		foreach ($query['conditions'] as $col => $val) {

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -599,7 +599,7 @@ class DboSource extends DataSource {
 		} else {
 			if (isset($args[1]) && $args[1] === true) {
 				return $this->fetchAll($args[0], true);
-			} elseif (isset($args[1]) && !is_array($args[1]) ) {
+			} elseif (isset($args[1]) && !is_array($args[1])) {
 				return $this->fetchAll($args[0], false);
 			} elseif (isset($args[1]) && is_array($args[1])) {
 				if (isset($args[2])) {

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1070,7 +1070,7 @@ class CakeResponse {
  * @return int
  */
 	public function length($bytes = null) {
-		if ($bytes !== null ) {
+		if ($bytes !== null) {
 			$this->_headers['Content-Length'] = $bytes;
 		}
 		if (isset($this->_headers['Content-Length'])) {

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -90,6 +90,10 @@ class CakeNumberTest extends CakeTestCase {
 	public function testFormatDelta() {
 		$value = '100100100';
 
+		$result = $this->Number->formatDelta($value);
+		$expected = '+100,100,100.00';
+		$this->assertEquals($expected, $result);
+
 		$result = $this->Number->formatDelta($value, array('before' => '', 'after' => ''));
 		$expected = '+100,100,100.00';
 		$this->assertEquals($expected, $result);

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -70,6 +70,52 @@ class CakeNumberTest extends CakeTestCase {
 		$result = $this->Number->format($value, '-');
 		$expected = '100-100-100';
 		$this->assertEquals($expected, $result);
+
+		$value = 0.00001;
+		$result = $this->Number->format($value, array('places' => 1));
+		$expected = '$0.0';
+		$this->assertEquals($expected, $result);
+
+		$value = -0.00001;
+		$result = $this->Number->format($value, array('places' => 1));
+		$expected = '$0.0';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testFormatDelta method
+ *
+ * @return void
+ */
+	public function testFormatDelta() {
+		$value = '100100100';
+
+		$result = $this->Number->formatDelta($value, array('before' => '', 'after' => ''));
+		$expected = '+100,100,100.00';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->formatDelta($value, array('before' => '[', 'after' => ']'));
+		$expected = '[+100,100,100.00]';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->formatDelta(-$value, array('before' => '[', 'after' => ']'));
+		$expected = '[-100,100,100.00]';
+		$this->assertEquals($expected, $result);
+
+		$value = 0;
+		$result = $this->Number->formatDelta($value, array('places' => 1, 'before' => '[', 'after' => ']'));
+		$expected = '[0.0]';
+		$this->assertEquals($expected, $result);
+
+		$value = 0.0001;
+		$result = $this->Number->formatDelta($value, array('places' => 1, 'before' => '[', 'after' => ']'));
+		$expected = '[0.0]';
+		$this->assertEquals($expected, $result);
+
+		$value = 9876.1234;
+		$result = $this->Number->formatDelta($value, array('places' => 1, 'decimals' => ',', 'thousands' => '.'));
+		$expected = '+9.876,1';
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/View/Errors/error400.ctp
+++ b/lib/Cake/Test/test_app/View/Errors/error400.ctp
@@ -25,7 +25,7 @@
 	); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0 ):
+if (Configure::read('debug') > 0):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/lib/Cake/Test/test_app/View/Errors/error500.ctp
+++ b/lib/Cake/Test/test_app/View/Errors/error500.ctp
@@ -22,7 +22,7 @@
 	<?php echo __d('cake', 'An Internal Error Has Occurred.'); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0 ):
+if (Configure::read('debug') > 0):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -192,6 +192,8 @@ class CakeNumber {
 /**
  * Formats a number into a currency format to show deltas (signed differences in value).
  *
+ * ### Options
+ *
  * - `places` - Number of decimal places to use. ie. 2
  * - `before` - The string to place before whole numbers. ie. '['
  * - `after` - The string to place after decimal numbers. ie. ']'

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -70,13 +70,13 @@ class CakeNumber {
 /**
  * Formats a number with a level of precision.
  *
- * @param float $number A floating point number.
+ * @param float $value A floating point number.
  * @param integer $precision The precision of the returned number.
  * @return float Formatted float.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
  */
-	public static function precision($number, $precision = 3) {
-		return sprintf("%01.{$precision}F", $number);
+	public static function precision($value, $precision = 3) {
+		return sprintf("%01.{$precision}F", $value);
 	}
 
 /**
@@ -135,25 +135,25 @@ class CakeNumber {
 /**
  * Formats a number into a percentage string.
  *
- * @param float $number A floating point number
+ * @param float $value A floating point number
  * @param integer $precision The precision of the returned number
  * @return string Percentage string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toPercentage
  */
-	public static function toPercentage($number, $precision = 2) {
-		return self::precision($number, $precision) . '%';
+	public static function toPercentage($value, $precision = 2) {
+		return self::precision($value, $precision) . '%';
 	}
 
 /**
  * Formats a number into a currency format.
  *
- * @param float $number A floating point number
+ * @param float $value A floating point number
  * @param integer $options if int then places, if string then before, if (,.-) then use it
  *   or array with places and before keys
  * @return string formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
  */
-	public static function format($number, $options = false) {
+	public static function format($value, $options = false) {
 		$places = 0;
 		if (is_int($options)) {
 			$places = $options;
@@ -180,7 +180,8 @@ class CakeNumber {
 			extract($options);
 		}
 
-		$out = $before . self::_numberFormat($number, $places, $decimals, $thousands) . $after;
+		$value = self::_numberFormat($value, $places, '.', '');
+		$out = $before . self::_numberFormat($value, $places, $decimals, $thousands) . $after;
 
 		if ($escape) {
 			return h($out);
@@ -189,33 +190,54 @@ class CakeNumber {
 	}
 
 /**
+ * Formats a number into a currency format to show deltas (signed differences in value).
+ *
+ * - `places` - Number of decimal places to use. ie. 2
+ * - `before` - The string to place before whole numbers. ie. '['
+ * - `after` - The string to place after decimal numbers. ie. ']'
+ * - `thousands` - Thousands separator ie. ','
+ * - `decimals` - Decimal separator symbol ie. '.'
+ *
+ * @param float $value A floating point number
+ * @param array $options
+ * @return string formatted delta
+ */
+	public static function formatDelta($value, $options = array()) {
+		$places = isset($options['places']) ? $options['places'] : 0;
+		$value = self::_numberFormat($value, $places, '.', '');
+		$sign = $value > 0 ? '+' : '';
+		$options['before'] = isset($options['before']) ? $options['before'] . $sign : $sign;
+		return self::format($value, $options);
+	}
+
+/**
  * Alternative number_format() to accommodate multibyte decimals and thousands < PHP 5.4
  *
- * @param float $number
+ * @param float $value
  * @param integer $places
  * @param string $decimals
  * @param string $thousands
  * @return string
  */
-	protected static function _numberFormat($number, $places = 0, $decimals = '.', $thousands = ',') {
+	protected static function _numberFormat($value, $places = 0, $decimals = '.', $thousands = ',') {
 		if (!isset(self::$_numberFormatSupport)) {
 			self::$_numberFormatSupport = version_compare(PHP_VERSION, '5.4.0', '>=');
 		}
 		if (self::$_numberFormatSupport) {
-			return number_format($number, $places, $decimals, $thousands);
+			return number_format($value, $places, $decimals, $thousands);
 		}
-		$number = number_format($number, $places, '.', '');
+		$value = number_format($value, $places, '.', '');
 		$after = '';
-		$foundDecimal = strpos($number, '.');
+		$foundDecimal = strpos($value, '.');
 		if ($foundDecimal !== false) {
-			$after = substr($number, $foundDecimal);
-			$number = substr($number, 0, $foundDecimal);
+			$after = substr($value, $foundDecimal);
+			$value = substr($value, 0, $foundDecimal);
 		}
-		while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $number)) != $number) {
-			$number = $foundThousand;
+		while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $value)) != $value) {
+			$value = $foundThousand;
 		}
-		$number .= $after;
-		return strtr($number, array(' ' => $thousands, '.' => $decimals));
+		$value .= $after;
+		return strtr($value, array(' ' => $thousands, '.' => $decimals));
 	}
 
 /**
@@ -244,14 +266,14 @@ class CakeNumber {
  *   the number will be wrapped with ( and )
  * - `escape` - Should the output be htmlentity escaped? Defaults to true
  *
- * @param float $number
+ * @param float $value
  * @param string $currency Shortcut to default options. Valid values are
  *   'USD', 'EUR', 'GBP', otherwise set at least 'before' and 'after' options.
  * @param array $options
  * @return string Number formatted as a currency.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::currency
  */
-	public static function currency($number, $currency = 'USD', $options = array()) {
+	public static function currency($value, $currency = 'USD', $options = array()) {
 		$default = self::$_currencyDefaults;
 
 		if (isset(self::$_currencies[$currency])) {
@@ -272,14 +294,14 @@ class CakeNumber {
 		$result = $options['before'] = $options['after'] = null;
 
 		$symbolKey = 'whole';
-		if ($number == 0 ) {
-			if ($options['zero'] !== 0 ) {
+		if ($value == 0) {
+			if ($options['zero'] !== 0) {
 				return $options['zero'];
 			}
-		} elseif ($number < 1 && $number > -1 ) {
+		} elseif ($value < 1 && $value > -1) {
 			if ($options['fractionSymbol'] !== false) {
 				$multiply = intval('1' . str_pad('', $options['places'], '0'));
-				$number = $number * $multiply;
+				$value = $value * $multiply;
 				$options['places'] = null;
 				$symbolKey = 'fraction';
 			}
@@ -288,10 +310,10 @@ class CakeNumber {
 		$position = $options[$symbolKey . 'Position'] != 'after' ? 'before' : 'after';
 		$options[$position] = $options[$symbolKey . 'Symbol'];
 
-		$abs = abs($number);
+		$abs = abs($value);
 		$result = self::format($abs, $options);
 
-		if ($number < 0 ) {
+		if ($value < 0) {
 			if ($options['negative'] == '()') {
 				$result = '(' . $result . ')';
 			} else {


### PR DESCRIPTION
corrected version of https://github.com/cakephp/cakephp/pull/771

in some cases you just want to display the values as signed values in the view than first figuring out the sign and passing this on to the format() method.
this is especially useful for outputting differences in values (e.g. "+50 meters since xxxx-xx-xx").

implementing it I found a related issue with format() and almost-zero values. fixed and test cases added.
-0.01 would not show as -0.0 anymore for format() now anymore.

also refactored methods to use a unified $value param instead of different names for the same thing.
