### PR TITLE
Calling Form->input() with 'error'=>'' should trigger field error, but not render error element.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1576,9 +1576,6 @@ class FormHelperTest extends CakeTestCase {
 				'type' => 'password', 'name' => 'data[Contact][password]',
 				'id' => 'ContactPassword', 'class' => 'form-error'
 			),
-			array('div' => array('class' => 'error-message')),
-			array(),
-			'/div',
 			'/div'
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1139,7 +1139,9 @@ class FormHelper extends AppHelper {
 			$errMsg = $this->error($fieldName, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, 'error');
-				$out['error'] = $errMsg;
+				if ($error !== '') {
+					$out['error'] = $errMsg;
+				}
 			}
 		}
 


### PR DESCRIPTION
The idea is to complete [1] and [2] which enabled to trigger element errors (field coloring) but not rendering error messages.

Actually, calling `Form->input()` with:
`'error' => false` prevent any kind of error reporting (field error coloring _and_ error messages)
`'error' => ''` allow field error coloring _and_ render an HTML element with and empty error message

IMO,
`'error' => ''` should allow field error coloring _but_ prevent rendering an HTML element with and empty error message.

[1] 9f23f657558916b55f363ffaa21ac8a3fca9b1b4
[2] ae8dd1c9697f7e9baae4152a30f4a41eb2760493
