### PR TITLE
making messages() and errors() reset themselves by default

### DIFF
--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -767,6 +767,52 @@ class FolderTest extends CakeTestCase {
 	}
 
 /**
+ * test that errors and messages can be resetted
+ *
+ * @return void
+ */
+	public function testReset() {
+		$path = TMP . 'folder_delete_test';
+		mkdir($path);
+		$folder = $path . DS . 'sub';
+		mkdir($folder);
+		$file = $folder . DS . 'file';
+		touch($file);
+		$handle = fopen($file, 'a');
+
+		$Folder = new Folder($folder);
+		$return = $Folder->delete();
+		$this->assertFalse($return);
+
+		$messages = $Folder->messages();
+		$errors = $Folder->errors();
+		$expected = array(
+			$folder . DS . 'file NOT removed',
+			$folder . ' NOT removed',
+		);
+		sort($expected);
+		sort($errors);
+		$this->assertEmpty($messages);
+		$this->assertEquals($expected, $errors);
+
+		fclose($handle);
+
+		$return = $Folder->delete();
+		$this->assertTrue($return);
+
+		$messages = $Folder->messages();
+		$errors = $Folder->errors();
+		$expected = array(
+			$folder . DS . 'file removed',
+			$folder . ' removed',
+		);
+		sort($expected);
+		sort($messages);
+		$this->assertEmpty($errors);
+		$this->assertEquals($expected, $messages);
+	}
+
+/**
  * testDelete method
  *
  * @return void

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -23,7 +23,7 @@ class Folder {
 
 /**
  * Default scheme for Folder::copy
- * Recursively merges subfolders with the same name 
+ * Recursively merges subfolders with the same name
  *
  * @constant MERGE
  */
@@ -740,21 +740,31 @@ class Folder {
 /**
  * get messages from latest method
  *
+ * @param boolean $reset Reset message stack after reading
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::messages
  */
-	public function messages() {
-		return $this->_messages;
+	public function messages($reset = true) {
+		$messages = $this->_messages;
+		if ($reset) {
+			$this->_messages = array();
+		}
+		return $messages;
 	}
 
 /**
  * get error from latest method
  *
+ * @param boolean $reset Reset error stack after reading
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::errors
  */
-	public function errors() {
-		return $this->_errors;
+	public function errors($reset = true) {
+		$errors = $this->_errors;
+		if ($reset) {
+			$this->_errors = array();
+		}
+		return $errors;
 	}
 
 /**


### PR DESCRIPTION
Folder should have a reset method to prevent multiple commands interfering with each other.
right now, a command that throws errors or messages would also affect following commands on the same object.
Allowing the developer to call Folder::delete() between multiple commands removes this issue.

EDIT: now making messages() and errors() reset themselves by default
