### PR TITLE
move charset/App.encoding into CakeResponse

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -94,4 +94,4 @@ if (!empty($failed)) {
 App::uses('Dispatcher', 'Routing');
 
 $Dispatcher = new Dispatcher();
-$Dispatcher->dispatch(new CakeRequest(), new CakeResponse(array('charset' => Configure::read('App.encoding'))));
+$Dispatcher->dispatch(new CakeRequest(), new CakeResponse());

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -98,5 +98,5 @@ App::uses('Dispatcher', 'Routing');
 $Dispatcher = new Dispatcher();
 $Dispatcher->dispatch(
 	new CakeRequest(),
-	new CakeResponse(array('charset' => Configure::read('App.encoding')))
+	new CakeResponse()
 );

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -177,7 +177,7 @@ class CookieComponent extends Component {
 		if ($controller && isset($controller->response)) {
 			$this->_response = $controller->response;
 		} else {
-			$this->_response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
+			$this->_response = new CakeResponse();
 		}
 	}
 

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -146,7 +146,7 @@ class ExceptionRenderer {
 		if (!$request = Router::getRequest(true)) {
 			$request = new CakeRequest();
 		}
-		$response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
+		$response = new CakeResponse();
 
 		if (method_exists($exception, 'responseHeader')) {
 			$response->header($exception->responseHeader());

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -384,9 +384,10 @@ class CakeResponse {
 		if (isset($options['type'])) {
 			$this->type($options['type']);
 		}
-		if (isset($options['charset'])) {
-			$this->charset($options['charset']);
+		if (!isset($options['charset'])) {
+			$options['charset'] = Configure::read('App.encoding');
 		}
+		$this->charset($options['charset']);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Error/TestAppsExceptionRenderer.php
+++ b/lib/Cake/Test/test_app/Error/TestAppsExceptionRenderer.php
@@ -7,7 +7,7 @@ class TestAppsExceptionRenderer extends ExceptionRenderer {
 		if (!$request = Router::getRequest(true)) {
 			$request = new CakeRequest();
 		}
-		$response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
+		$response = new CakeResponse();
 		try {
 			$controller = new TestAppsErrorController($request, $response);
 			$controller->layout = 'banana';

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -302,7 +302,7 @@ class CacheHelper extends AppHelper {
 
 		$file .= '
 				$request = unserialize(base64_decode(\'' . base64_encode(serialize($this->request)) . '\'));
-				$response = new CakeResponse(array("charset" => Configure::read("App.encoding")));
+				$response = new CakeResponse();
 				$controller = new ' . $this->_View->name . 'Controller($request, $response);
 				$controller->plugin = $this->plugin = \'' . $this->_View->plugin . '\';
 				$controller->helpers = $this->helpers = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->helpers)) . '\'));

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -160,7 +160,7 @@ class HtmlHelper extends AppHelper {
 		if (is_object($this->_View->response)) {
 			$this->response = $this->_View->response;
 		} else {
-			$this->response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
+			$this->response = new CakeResponse();
 		}
 		if (!empty($settings['configFile'])) {
 			$this->loadConfig($settings['configFile']);

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -330,7 +330,7 @@ class View extends Object {
 		if (is_object($controller) && isset($controller->response)) {
 			$this->response = $controller->response;
 		} else {
-			$this->response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
+			$this->response = new CakeResponse();
 		}
 		$this->Helpers = new HelperCollection($this);
 		$this->Blocks = new ViewBlock();


### PR DESCRIPTION
Request/Reponse should handle the default for charset itself.

Currently there are places where the CakeResponse object would be created without proper charset setting due to the forgotten param passed on (ExceptionRenderer::_getController() and RedirectRoute::parse() for example). This PR unifies those two different behaviors making them consistent and correct throughout the core and apps.

It is not only cleaner (and less error producing) to do this internally, but also makes creating the object easier and more straight-forward. not only for test cases.
