### PR TITLE
Adding a clearer disclaimer with default routing

### DIFF
--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -40,5 +40,7 @@
 /**
  * Load the CakePHP default routes. Remove this if you do not want to use
  * the built-in default routes.
+ * WARNING: REMOVING THE FOLLOWING LINE WILL DISABLE/BREAK THE DEFAULT CONTROLLER/ACTION ROUTING, 
+ * ie /users/add => UsersController->add()
  */
 	require CAKE . 'Config' . DS . 'routes.php';


### PR DESCRIPTION
I didn't exactly know what "built-in default routes" meant, until I disabled it and struggled for an hour trying to get my controller/action working. =( People who are used to routes.php being fully editable files may out of habit comment or erase this critical line. Most people would not disable controller/action routing.
