### PR TITLE
missing app uses

### DIFF
--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -97,6 +97,7 @@ class CakeTestRunner extends PHPUnit_TextUI_TestRunner {
 		if (class_exists('AppFixtureManager')) {
 			return new AppFixtureManager();
 		}
+		App::uses('CakeFixtureManager', 'TestSuite/Fixture');
 		return new CakeFixtureManager();
 	}
 


### PR DESCRIPTION
I ran into a fatal error in 2.3 - that the class could not be found when testing sth with my own class

```
class MyCakeWebTestCase extends PHPUnit_Extensions_Selenium2TestCase {}
```

adding the app::uses() prevents the fatal error.
