### PR TITLE
Replace Model::read() with Model::find('first') in baked controller

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -349,7 +349,7 @@ class ControllerTask extends BakeTask {
 	public function doHelpers() {
 		return $this->_doPropertyChoices(
 			__d('cake_console', "Would you like this controller to use other helpers\nbesides HtmlHelper and FormHelper?"),
-			__d('cake_console', "Please provide a comma separated list of the other\nhelper names you'd like to use.\nExample: 'Ajax, Javascript, Time'")
+			__d('cake_console', "Please provide a comma separated list of the other\nhelper names you'd like to use.\nExample: 'Text, Js, Time'")
 		);
 	}
 

--- a/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
+++ b/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
@@ -36,11 +36,11 @@
  * @return void
  */
 	public function <?php echo $admin ?>view($id = null) {
-		$this-><?php echo $currentModelName; ?>->id = $id;
-		if (!$this-><?php echo $currentModelName; ?>->exists()) {
+		if (!$this-><?php echo $currentModelName; ?>->exists($id)) {
 			throw new NotFoundException(__('Invalid <?php echo strtolower($singularHumanName); ?>'));
 		}
-		$this->set('<?php echo $singularName; ?>', $this-><?php echo $currentModelName; ?>->read(null, $id));
+		$options = array('conditions' => array('<?php echo $currentModelName; ?>.' . $this-><?php echo $currentModelName; ?>->primaryKey => $id));
+		$this->set('<?php echo $singularName; ?>', $this-><?php echo $currentModelName; ?>->find('first', $options));
 	}
 
 <?php $compact = array(); ?>
@@ -91,8 +91,7 @@
  * @return void
  */
 	public function <?php echo $admin; ?>edit($id = null) {
-		$this-><?php echo $currentModelName; ?>->id = $id;
-		if (!$this-><?php echo $currentModelName; ?>->exists()) {
+		if (!$this-><?php echo $currentModelName; ?>->exists($id)) {
 			throw new NotFoundException(__('Invalid <?php echo strtolower($singularHumanName); ?>'));
 		}
 		if ($this->request->is('post') || $this->request->is('put')) {
@@ -109,7 +108,8 @@
 <?php endif; ?>
 			}
 		} else {
-			$this->request->data = $this-><?php echo $currentModelName; ?>->read(null, $id);
+			$options = array('conditions' => array('<?php echo $currentModelName; ?>.' . $this-><?php echo $currentModelName; ?>->primaryKey => $id));
+			$this->request->data = $this-><?php echo $currentModelName; ?>->find('first', $options);
 		}
 <?php
 		foreach (array('belongsTo', 'hasAndBelongsToMany') as $assoc):

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -191,9 +191,9 @@ class ControllerTaskTest extends CakeTestCase {
  */
 	public function testDoHelpersTrailingSpace() {
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
-		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Javascript, Ajax, CustomOne  '));
+		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Text, Number, CustomOne  '));
 		$result = $this->Task->doHelpers();
-		$expected = array('Javascript', 'Ajax', 'CustomOne');
+		$expected = array('Text', 'Number', 'CustomOne');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -204,9 +204,9 @@ class ControllerTaskTest extends CakeTestCase {
  */
 	public function testDoHelpersTrailingCommas() {
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
-		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Javascript, Ajax, CustomOne, , '));
+		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' Text, Number, CustomOne, , '));
 		$result = $this->Task->doHelpers();
-		$expected = array('Javascript', 'Ajax', 'CustomOne');
+		$expected = array('Text', 'Number', 'CustomOne');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -257,11 +257,11 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testConfirmController() {
 		$controller = 'Posts';
 		$scaffold = false;
-		$helpers = array('Ajax', 'Time');
+		$helpers = array('Js', 'Time');
 		$components = array('Acl', 'Auth');
 
 		$this->Task->expects($this->at(4))->method('out')->with("Controller Name:\n\t$controller");
-		$this->Task->expects($this->at(5))->method('out')->with("Helpers:\n\tAjax, Time");
+		$this->Task->expects($this->at(5))->method('out')->with("Helpers:\n\tJs, Time");
 		$this->Task->expects($this->at(6))->method('out')->with("Components:\n\tAcl, Auth");
 		$this->Task->confirmController($controller, $scaffold, $helpers, $components);
 	}
@@ -272,7 +272,7 @@ class ControllerTaskTest extends CakeTestCase {
  * @return void
  */
 	public function testBake() {
-		$helpers = array('Ajax', 'Time');
+		$helpers = array('Js', 'Time');
 		$components = array('Acl', 'Auth');
 		$this->Task->expects($this->any())->method('createFile')->will($this->returnValue(true));
 
@@ -282,7 +282,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->assertContains(' * @property AuthComponent $Auth', $result);
 		$this->assertContains('class ArticlesController extends AppController', $result);
 		$this->assertContains("public \$components = array('Acl', 'Auth')", $result);
-		$this->assertContains("public \$helpers = array('Ajax', 'Time')", $result);
+		$this->assertContains("public \$helpers = array('Js', 'Time')", $result);
 		$this->assertContains("--actions--", $result);
 
 		$result = $this->Task->bake('Articles', 'scaffold', $helpers, $components);
@@ -350,7 +350,8 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$this->assertContains('function view($id = null)', $result);
 		$this->assertContains("throw new NotFoundException(__('Invalid bake article'));", $result);
-		$this->assertContains("\$this->set('bakeArticle', \$this->BakeArticle->read(null, \$id)", $result);
+		$this->assertContains("\$options = array('conditions' => array('BakeArticle.' . \$this->BakeArticle->primaryKey => \$id));", $result);
+		$this->assertContains("\$this->set('bakeArticle', \$this->BakeArticle->find('first', \$options));", $result);
 
 		$this->assertContains('function add()', $result);
 		$this->assertContains("if (\$this->request->is('post'))", $result);
@@ -389,7 +390,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$this->assertContains('function view($id = null)', $result);
 		$this->assertContains("throw new NotFoundException(__('Invalid bake article'));", $result);
-		$this->assertContains("\$this->set('bakeArticle', \$this->BakeArticle->read(null, \$id)", $result);
+		$this->assertContains("\$this->set('bakeArticle', \$this->BakeArticle->find('first', \$options));", $result);
 
 		$this->assertContains('function add()', $result);
 		$this->assertContains("if (\$this->request->is('post'))", $result);


### PR DESCRIPTION
Because of the use of Model::read() in baked controller newbies often get into a habit of using it everywhere without realizing it populates Model::$data which can affect subsequent calls to model functions.
