### PR TITLE
FormHelper select method api change can produce a fatal due to 1.3 -> 2.* api change

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1365,6 +1365,21 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Test sending non-array as paramter to select method.
+ *
+ * This is related to the method api changing from 1.3 -> 2.*
+ *
+ * @return void
+ */
+	public function testSelectApiChange() {
+		$options = array('1' => 'one', '2' => 'two');
+		// 1.3 syntax (should not throw a fatal error with properly casted third parameter)
+		$this->Form->select('Model.select', $options, null, array('escape' => false));
+		$expected = array('Model.select');
+		$this->assertEquals($expected, $this->Form->fields);
+	}
+
+/**
  * testFormSecuredRadio method
  *
  * @return void

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1801,6 +1801,10 @@ class FormHelper extends AppHelper {
 		$select = array();
 		$style = null;
 		$tag = null;
+		// For 1.3 to 2.* compatibility
+		if ($attributes === null) {
+			$attributes = (array)$attributes;
+		}
 		$attributes += array(
 			'class' => null,
 			'escape' => true,

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1803,7 +1803,7 @@ class FormHelper extends AppHelper {
 		$tag = null;
 		// For 1.3 to 2.* compatibility
 		if ($attributes === null) {
-			$attributes = (array)$attributes;
+			$attributes = array();
 		}
 		$attributes += array(
 			'class' => null,


### PR DESCRIPTION
I was working on migrating a site today from 1.3 to 2.*.

A fatal was occuring when using the `FormHelper::select()` method:

```
Error: Fatal Error (1): Unsupported operand types in [/path/to/my/app/cakephp/lib/Cake/View/Helper/FormHelper.php, line 1809]
```

Since the third parameter in 1.3 used to accept `null` as the default value, just doing a check for null on `$attributes` to prevent the fatal.
