### PR TITLE
Extract LogTrait (3.0)

### DIFF
--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -13,7 +13,8 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 namespace Cake\Core;
-use Cake\Log\Log;
+
+use Cake\Log\LogTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Dispatcher;
@@ -30,6 +31,7 @@ use Cake\Utility\Hash;
  */
 class Object {
 
+	use LogTrait;
 /**
  * constructor, no-op
  *
@@ -152,21 +154,6 @@ class Object {
  */
 	protected function _stop($status = 0) {
 		exit($status);
-	}
-
-/**
- * Convenience method to write a message to Log. See Log::write()
- * for more information on writing to logs.
- *
- * @param string $msg Log message
- * @param integer $type Error type constant. Defined in app/Config/core.php.
- * @return boolean Success of log write
- */
-	public function log($msg, $type = LOG_ERR) {
-		if (!is_string($msg)) {
-			$msg = print_r($msg, true);
-		}
-		return Log::write($type, $msg);
 	}
 
 /**

--- a/lib/Cake/Log/LogTrait.php
+++ b/lib/Cake/Log/LogTrait.php
@@ -13,8 +13,6 @@
  */
 namespace Cake\Log;
 
-use Cake\Log\Log;
-
 /**
  * A trait providing an object short-cut method
  * to logging.

--- a/lib/Cake/Log/LogTrait.php
+++ b/lib/Cake/Log/LogTrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Log;
+
+use Cake\Log\Log;
+
+/**
+ * A trait providing an object short-cut method
+ * to logging.
+ *
+ * @package Cake.Log
+ */
+trait LogTrait {
+
+/**
+ * Convenience method to write a message to Log. See Log::write()
+ * for more information on writing to logs.
+ *
+ * @param string $msg Log message
+ * @param integer $type Error type constant. Defined in app/Config/logging.php.
+ * @return boolean Success of log write
+ */
+	public function log($msg, $type = LOG_ERR) {
+		if (!is_string($msg)) {
+			$msg = print_r($msg, true);
+		}
+		return Log::write($type, $msg);
+	}
+
+}

--- a/lib/Cake/Test/TestCase/Log/LogTraitTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTraitTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Log;
+
+use Cake\Log\Log;
+use Cake\Log\LogTrait;
+use Cake\Log\LogInterface;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for LogTrait
+ *
+ * @package Cake.Test.TestCase.Log
+ */
+class LogTraitTest extends TestCase {
+
+	public function tearDown() {
+		parent::tearDown();
+		Log::drop('trait_test');
+	}
+
+/**
+ * Test log method.
+ *
+ * @return void
+ */
+	public function testLog() {
+		$mock = $this->getMock('Cake\Log\LogInterface');
+		$mock->expects($this->at(0))
+			->method('write')
+			->with('error', 'Testing');
+		
+		$mock->expects($this->at(1))
+			->method('write')
+			->with('debug', print_r(array(1, 2), true));
+
+		Log::engine('trait_test', $mock);
+		$subject = $this->getObjectForTrait('Cake\Log\LogTrait');
+
+		$subject->log('Testing');
+		$subject->log(array(1, 2), 'debug');
+	}
+
+}


### PR DESCRIPTION
Extract the log() method into a trait.  Later on as Object is removed
this trait can be added as needed to other base classes.
