### PR TITLE
2.3 findThreaded with fields should auto-include parent_id

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2888,7 +2888,8 @@ class Model extends Object implements CakeEventListener {
 
 /**
  * In the event of ambiguous results returned (multiple top level results, with different parent_ids)
- * top level results with different parent_ids to the first result will be dropped
+ * top level results with different parent_ids to the first result will be dropped.
+ * If fields are passed as array, the parent_id will automatically be added to it if missing.
  *
  * @param string $state
  * @param mixed $query
@@ -2901,7 +2902,7 @@ class Model extends Object implements CakeEventListener {
 			$parent = $query['parent'];
 		}
 		if ($state === 'before') {
-			if (!empty($query['fields']) && is_array($query['fields']) && !in_array($parent, $query['fields']) &&  !in_array($this->alias . '.' . $parent, $query['fields'])) {
+			if (!empty($query['fields']) && is_array($query['fields']) && !in_array($parent, $query['fields']) && !in_array($this->alias . '.' . $parent, $query['fields'])) {
 				$query['fields'][] = $this->alias . '.' . $parent;
 			}
 			return $query;

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2896,13 +2896,16 @@ class Model extends Object implements CakeEventListener {
  * @return array Threaded results
  */
 	protected function _findThreaded($state, $query, $results = array()) {
+		$parent = 'parent_id';
+		if (isset($query['parent'])) {
+			$parent = $query['parent'];
+		}
 		if ($state === 'before') {
+			if (!empty($query['fields']) && is_array($query['fields']) && !in_array($parent, $query['fields']) &&  !in_array($this->alias . '.' .$parent, $query['fields'])) {
+				$query['fields'][] = $this->alias . '.' .$parent;
+			}
 			return $query;
 		} elseif ($state === 'after') {
-			$parent = 'parent_id';
-			if (isset($query['parent'])) {
-				$parent = $query['parent'];
-			}
 			return Hash::nest($results, array(
 				'idPath' => '{n}.' . $this->alias . '.' . $this->primaryKey,
 				'parentPath' => '{n}.' . $this->alias . '.' . $parent

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2901,8 +2901,8 @@ class Model extends Object implements CakeEventListener {
 			$parent = $query['parent'];
 		}
 		if ($state === 'before') {
-			if (!empty($query['fields']) && is_array($query['fields']) && !in_array($parent, $query['fields']) &&  !in_array($this->alias . '.' .$parent, $query['fields'])) {
-				$query['fields'][] = $this->alias . '.' .$parent;
+			if (!empty($query['fields']) && is_array($query['fields']) && !in_array($parent, $query['fields']) &&  !in_array($this->alias . '.' . $parent, $query['fields'])) {
+				$query['fields'][] = $this->alias . '.' . $parent;
 			}
 			return $query;
 		} elseif ($state === 'after') {

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -3317,6 +3317,80 @@ class ModelReadTest extends BaseModelTest {
 		);
 		$this->assertEquals($expected, $result);
 
+		$result = $TestModel->find('threaded', array(
+			'fields' => array('id', 'name')
+		));
+
+		$expected = array(
+			array(
+				'Category' => array(
+					'id' => '1',
+					'name' => 'Category 1',
+					'parent_id' => '0'
+				),
+				'children' => array(
+					array(
+						'Category' => array(
+							'id' => '2',
+							'name' => 'Category 1.1',
+							'parent_id' => '1'
+						),
+						'children' => array(
+							array('Category' => array(
+								'id' => '7',
+								'name' => 'Category 1.1.1',
+								'parent_id' => '2'),
+								'children' => array()),
+							array('Category' => array(
+								'id' => '8',
+								'name' => 'Category 1.1.2',
+								'parent_id' => '2'),
+								'children' => array()))
+					),
+					array(
+						'Category' => array(
+							'id' => '3',
+							'name' => 'Category 1.2',
+							'parent_id' => '1'
+						),
+						'children' => array()
+					)
+				)
+			),
+			array(
+				'Category' => array(
+					'id' => '4',
+					'name' => 'Category 2',
+					'parent_id' => '0',
+				),
+				'children' => array()
+			),
+			array(
+				'Category' => array(
+					'id' => '5',
+					'name' => 'Category 3',
+					'parent_id' => '0',
+				),
+				'children' => array(
+					array(
+						'Category' => array(
+							'id' => '6',
+							'name' => 'Category 3.1',
+							'parent_id' => '5',
+						),
+						'children' => array()
+					)
+				)
+			)
+		);
+		$this->assertEquals($expected, $result);
+
+		$result = $TestModel->find('threaded', array(
+			'fields' => array($TestModel->alias . '.id', $TestModel->alias . '.name', $TestModel->alias . '.parent_id')
+		));
+
+		$this->assertEquals($expected, $result);
+
 		$result = $TestModel->find('threaded', array('order' => 'id DESC'));
 
 		$expected = array(


### PR DESCRIPTION
see http://cakephp.lighthouseapp.com/projects/42648/tickets/3267-make-tree-behavior-work-with-fields-array-in-options

the documentation should also be updated:

"If you pass fields as a string you always have to manually include the parent_id".
