### PR TITLE
BC mod for saveAll()

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2017,7 +2017,7 @@ class Model extends Object implements CakeEventListener {
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-saveassociated-array-data-null-array-options-array
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-saveall-array-data-null-array-options-array
  */
-	public function saveAll($data, $options = array()) {
+	public function saveAll($data = array(), $options = array()) {
 		$options = array_merge(array('validate' => 'first'), $options);
 		if (Hash::numeric(array_keys($data))) {
 			if ($options['validate'] === 'only') {

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -4726,6 +4726,32 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * test that saveAll still behaves like previous versions (does not necessarily need a first argument)
+ *
+ * @return void
+ */
+	public function testSaveAllWithSet() {
+		$this->loadFixtures('Article', 'Tag', 'Comment', 'User', 'ArticlesTag');
+		$data = array(
+			'Article' => array(
+				'user_id' => 1,
+				'title' => 'Article Has and belongs to Many Tags'
+			),
+			'Tag' => array(
+				'Tag' => array(1, 2)
+			),
+			'Comment' => array(
+				array(
+					'comment' => 'Article comment',
+					'user_id' => 1
+		)));
+		$Article = new Article();
+		$Article->set($data);
+		$result = $Article->saveAll();
+		$this->assertFalse(empty($result));
+	}
+
+/**
  * test that saveAll behaves like plain save() when supplied empty data
  *
  * @link http://cakephp.lighthouseapp.com/projects/42648/tickets/277-test-saveall-with-validation-returns-incorrect-boolean-when-saving-empty-data
@@ -4740,7 +4766,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 
 		$model = new ProductUpdateAll();
-		$result = $model->saveAll(array());
+		$result = $model->saveAll();
 		$this->assertFalse($result);
 	}
 


### PR DESCRIPTION
while upgrading 1.x to 2.2/2.3:

```
$this->OfferRequest->set($this->request->data);
$this->OfferRequest->saveAll();
```

this used to work just fine and would now throw a warning due to missing first argument. which it should not need since we already passed the data in set().
