### PR TITLE
allow ini files to have separators between sections for better readability

### DIFF
--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -173,8 +173,10 @@ class IniReader implements ConfigReaderInterface {
 	public function dump($filename, $data) {
 		$result = array();
 		foreach ($data as $key => $value) {
+			$isSection = false;
 			if ($key[0] != '[') {
 				$result[] = "[$key]";
+				$isSection = true;
 			}
 			if (is_array($value)) {
 				$keyValues = Hash::flatten($value, '.');
@@ -182,8 +184,11 @@ class IniReader implements ConfigReaderInterface {
 					$result[] = "$k = " . $this->_value($v);
 				}
 			}
+			if ($isSection) {
+				$result[] = '';
+			}
 		}
-		$contents = implode("\n", $result);
+		$contents = trim(implode("\n", $result));
 
 		if (substr($filename, -4) !== '.ini') {
 			$filename .= '.ini';

--- a/lib/Cake/Test/Case/Configure/IniReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/IniReaderTest.php
@@ -261,6 +261,7 @@ three.four = value four
 is_null = null
 bool_false = false
 bool_true = true
+
 [Asset]
 timestamp = force
 INI;


### PR DESCRIPTION
currently, the whole file is one list of configurations without the natural space between sections you usually have with ini files in unix.
those make the files easier to read and edit by humans.

so I tried to add separator. it might not have been the best approach so far.
If you got any better ideas, shoot.
I guess, grouping them into "section" arrays before imploding would probably make the code better and less likely to error.
