### PR TITLE
Remove support for asset filters.

### DIFF
--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -48,11 +48,6 @@ class AssetDispatcher extends DispatcherFilter {
 			return;
 		}
 
-		if ($result = $this->_filterAsset($event)) {
-			$event->stopPropagation();
-			return $result;
-		}
-
 		$assetFile = $this->_getAssetFile($url);
 		if ($assetFile === null || !file_exists($assetFile)) {
 			return null;
@@ -70,42 +65,6 @@ class AssetDispatcher extends DispatcherFilter {
 		$ext = array_pop($pathSegments);
 		$this->_deliverAsset($response, $assetFile, $ext);
 		return $response;
-	}
-
-/**
- * Checks if the client is requesting a filtered asset and runs the corresponding
- * filter if any is configured
- *
- * @param Cake\Event\Event $event containing the request and response object
- * @return Cake\Network\Response if the client is requesting a recognized asset, null otherwise
- */
-	protected function _filterAsset($event) {
-		$url = $event->data['request']->url;
-		$response = $event->data['response'];
-		$filters = Configure::read('Asset.filter');
-		$isCss = (
-			strpos($url, 'ccss/') === 0 ||
-			preg_match('#^(theme/([^/]+)/ccss/)|(([^/]+)(?<!css)/ccss)/#i', $url)
-		);
-		$isJs = (
-			strpos($url, 'cjs/') === 0 ||
-			preg_match('#^/((theme/[^/]+)/cjs/)|(([^/]+)(?<!js)/cjs)/#i', $url)
-		);
-
-		if (($isCss && empty($filters['css'])) || ($isJs && empty($filters['js']))) {
-			$response->statusCode(404);
-			return $response;
-		}
-
-		if ($isCss) {
-			include WWW_ROOT . DS . $filters['css'];
-			return $response;
-		}
-
-		if ($isJs) {
-			include WWW_ROOT . DS . $filters['js'];
-			return $response;
-		}
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/TestCase/Routing/DispatcherTest.php
@@ -914,25 +914,6 @@ class DispatcherTest extends TestCase {
 	}
 
 /**
- * test that missing asset processors trigger a 404 with no response body.
- *
- * @return void
- */
-	public function testMissingAssetProcessor404() {
-		$response = $this->getMock('Cake\Network\Response', array('send'));
-		$Dispatcher = new TestDispatcher();
-		Configure::write('Asset.filter', array(
-			'js' => '',
-			'css' => null
-		));
-		Configure::write('Dispatcher.filters', array('AssetDispatcher'));
-
-		$request = new Request('ccss/cake.generic.css');
-		$Dispatcher->dispatch($request, $response);
-		$this->assertEquals('404', $response->statusCode());
-	}
-
-/**
  * Data provider for cached actions.
  *
  * - Test simple views

--- a/lib/Cake/Test/TestCase/Routing/Filter/AssetDispatcherTest.php
+++ b/lib/Cake/Test/TestCase/Routing/Filter/AssetDispatcherTest.php
@@ -34,54 +34,6 @@ class AssetDispatcherTest extends TestCase {
 	}
 
 /**
- * test that asset filters work for theme and plugin assets
- *
- * @return void
- */
-	public function testAssetFilterForThemeAndPlugins() {
-		$filter = new AssetDispatcher();
-		$response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
-		Configure::write('Asset.filter', array(
-			'js' => '',
-			'css' => ''
-		));
-		App::build(array(
-			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/'),
-			'View' => array(CAKE . 'Test/TestApp/View/')
-		), APP::RESET);
-
-		$request = new Request('theme/test_theme/ccss/cake.generic.css');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertSame($response, $filter->beforeDispatch($event));
-		$this->assertTrue($event->isStopped());
-
-		$request = new Request('theme/test_theme/cjs/debug_kit.js');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertSame($response, $filter->beforeDispatch($event));
-		$this->assertTrue($event->isStopped());
-
-		$request = new Request('test_plugin/ccss/cake.generic.css');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertSame($response, $filter->beforeDispatch($event));
-		$this->assertTrue($event->isStopped());
-
-		$request = new Request('test_plugin/cjs/debug_kit.js');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertSame($response, $filter->beforeDispatch($event));
-		$this->assertTrue($event->isStopped());
-
-		$request = new Request('css/ccss/debug_kit.css');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertNull($filter->beforeDispatch($event));
-		$this->assertFalse($event->isStopped());
-
-		$request = new Request('js/cjs/debug_kit.js');
-		$event = new Event('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertNull($filter->beforeDispatch($event));
-		$this->assertFalse($event->isStopped());
-	}
-
-/**
  * Tests that $response->checkNotModified() is called and bypasses
  * file dispatching
  *
@@ -89,10 +41,6 @@ class AssetDispatcherTest extends TestCase {
  */
 	public function testNotModified() {
 		$filter = new AssetDispatcher();
-		Configure::write('Asset.filter', array(
-			'js' => '',
-			'css' => ''
-		));
 		App::build(array(
 			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/'),
 			'View' => array(CAKE . 'Test/TestApp/View/')

--- a/lib/Cake/Test/TestCase/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/HtmlHelperTest.php
@@ -527,8 +527,6 @@ class HtmlHelperTest extends TestCase {
  * @return void
  */
 	public function testCssLink() {
-		Configure::write('Asset.filter.css', false);
-
 		$result = $this->Html->css('screen');
 		$expected = array(
 			'link' => array('rel' => 'stylesheet', 'type' => 'text/css', 'href' => 'preg:/.*css\/screen\.css/')
@@ -560,16 +558,9 @@ class HtmlHelperTest extends TestCase {
 		$expected['link']['href'] = 'preg:/http:\/\/.*\/screen\.css\?1234/';
 		$this->assertTags($result, $expected);
 
-		Configure::write('Asset.filter.css', 'css.php');
-		$result = $this->Html->css('cake.generic');
-		$expected['link']['href'] = 'preg:/.*ccss\/cake\.generic\.css/';
-		$this->assertTags($result, $expected);
-
 		$result = $this->Html->css('//example.com/css/cake.generic.css');
 		$expected['link']['href'] = 'preg:/.*example\.com\/css\/cake\.generic\.css/';
 		$this->assertTags($result, $expected);
-
-		Configure::write('Asset.filter.css', false);
 
 		$result = explode("\n", trim($this->Html->css(array('cake.generic', 'vendor.generic'))));
 		$expected['link']['href'] = 'preg:/.*css\/cake\.generic\.css/';
@@ -599,7 +590,6 @@ class HtmlHelperTest extends TestCase {
  * @return void
  */
 	public function testPluginCssLink() {
-		Configure::write('Asset.filter.css', false);
 		Plugin::load('TestPlugin');
 
 		$result = $this->Html->css('TestPlugin.test_plugin_asset');
@@ -618,13 +608,6 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->css('TestPlugin.test_plugin_asset.css?1234');
 		$expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css\?1234/';
 		$this->assertTags($result, $expected);
-
-		Configure::write('Asset.filter.css', 'css.php');
-		$result = $this->Html->css('TestPlugin.test_plugin_asset');
-		$expected['link']['href'] = 'preg:/.*test_plugin\/ccss\/test_plugin_asset\.css/';
-		$this->assertTags($result, $expected);
-
-		Configure::write('Asset.filter.css', false);
 
 		$result = explode("\n", trim($this->Html->css(array('TestPlugin.test_plugin_asset', 'TestPlugin.vendor.generic'))));
 		$expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css/';
@@ -942,27 +925,6 @@ class HtmlHelperTest extends TestCase {
 
 		$result = $this->Html->script('second_script', array('block' => 'headScripts'));
 		$this->assertNull($result);
-	}
-
-/**
- * Test that Asset.filter.js works.
- *
- * @return void
- */
-	public function testScriptAssetFilter() {
-		Configure::write('Asset.filter.js', 'js.php');
-
-		$result = $this->Html->script('jquery-1.3');
-		$expected = array(
-			'script' => array('type' => 'text/javascript', 'src' => 'cjs/jquery-1.3.js')
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Html->script('//example.com/js/jquery-1.3.js');
-		$expected = array(
-			'script' => array('type' => 'text/javascript', 'src' => '//example.com/js/jquery-1.3.js')
-		);
-		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -435,13 +435,6 @@ class HtmlHelper extends Helper {
 			$url = $path;
 		} else {
 			$url = $this->assetUrl($path, $options + array('pathPrefix' => CSS_URL, 'ext' => '.css'));
-
-			if (Configure::read('Asset.filter.css')) {
-				$pos = strpos($url, CSS_URL);
-				if ($pos !== false) {
-					$url = substr($url, 0, $pos) . 'ccss/' . substr($url, $pos + strlen(CSS_URL));
-				}
-			}
 		}
 
 		if ($rel == 'import') {
@@ -529,10 +522,6 @@ class HtmlHelper extends Helper {
 
 		if (strpos($url, '//') === false) {
 			$url = $this->assetUrl($url, $options + array('pathPrefix' => JS_URL, 'ext' => '.js'));
-
-			if (Configure::read('Asset.filter.js')) {
-				$url = str_replace(JS_URL, 'cjs/', $url);
-			}
 		}
 		$attributes = $this->_parseAttributes($options, array('block', 'once'), ' ');
 		$out = sprintf($this->_tags['javascriptlink'], $url, $attributes);


### PR DESCRIPTION
Remove support for Asset.filter.css and Asset.filter.js.  Both of these
features were never fully implemented by CakePHP.  Asset filtering is
now easily accomplished using the Dispatcher filters/middleware system
as well.

See http://cakephp.lighthouseapp.com/projects/42648/tickets/3279-remove-assetfilter-in-3x
