### PR TITLE
CakeRequest::_processFileData uses Set::insert instead of Hash::insert. ...

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -16,7 +16,6 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-App::uses('Set', 'Utility');
 
 /**
  * A class that helps wrap Request information and particulars about a single request.
@@ -353,7 +352,7 @@ class CakeRequest implements ArrayAccess {
 				$this->_processFileData($newPath, $fields, $field);
 			} else {
 				$newPath .= '.' . $field;
-				$this->data = Set::insert($this->data, $newPath, $fields);
+				$this->data = Hash::insert($this->data, $newPath, $fields);
 			}
 		}
 	}


### PR DESCRIPTION
...And for this, Set class was called.
Set::insert has been replaced Hash::insert completely.
