### PR TITLE
2.3 safe url encode

### DIFF
--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -699,6 +699,36 @@ podeís adquirirla.</span></p>
 	}
 
 /**
+ * test testSafeUrlEncode
+ *
+ * @return void
+ */
+	public function testSafeUrlEncode() {
+		$text = 'abc123';
+		$result = $this->Text->safeUrlEncode($text);
+		$this->assertEquals('YWJjMTIz', $result);
+
+		$text = 'some/problematic+and-not=urlsafe&string';
+		$result = $this->Text->safeUrlEncode($text);
+		$this->assertEquals('c29tZS9wcm9ibGVtYXRpYythbmQtbm90PXVybHNhZmUmc3RyaW5n', $result);
+	}
+
+/**
+ * test testSafeUrlDecode
+ *
+ * @return void
+ */
+	public function testSafeUrlDecode() {
+		$text = 'YWJjMTIz';
+		$result = $this->Text->safeUrlDecode($text);
+		$this->assertEquals('abc123', $result);
+
+		$text = 'c29tZS9wcm9ibGVtYXRpYythbmQtbm90PXVybHNhZmUmc3RyaW5n';
+		$result = $this->Text->safeUrlDecode($text);
+		$this->assertEquals('some/problematic+and-not=urlsafe&string', $result);
+	}
+
+/**
  * testListGeneration method
  *
  * @return void

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -626,6 +626,26 @@ class String {
 	}
 
 /**
+ * Creates a string that is safe to be passed via $_GET query string
+ *
+ * @param string $string Unsafe string
+ * @return string Encoded string
+ */
+	public static function safeUrlEncode($text) {
+		return str_replace(array('/', '='), array('-', '_'), base64_encode($text));
+	}
+
+/**
+ * Decodes a string that has previously been encoded with String::safeUrlEncode()
+ *
+ * @param string $string Safe string
+ * @return string Decoded string
+ */
+	public static function safeUrlDecode($text) {
+		return base64_decode(str_replace(array('-', '_'), array('/', '='), $text));
+	}
+
+/**
  * Creates a comma separated list where the last two items are joined with 'and', forming natural English
  *
  * @param array $list The list to be joined
@@ -641,4 +661,5 @@ class String {
 
 		return array_pop($list);
 	}
+
 }


### PR DESCRIPTION
based on the search plugin, https://groups.google.com/forum/?fromgroups=#!topic/cake-php/5o1Mw-ukGmM and a few more uses cases it seems that neither base64encode nor urlencode can achieve that we can make strings url-compatible as query strings. at least not without quite some overhead.

The problem is that both methods return a string that still can contain harmful characters regarding valid urls.
And another issue is, that most devs are not aware of this. The fact that the search plugin contained this bug with the wrong encoding/decoding for years proves that a unified and well tested core solution for this issue is a possible way to go here.

So it might make sense to provide this in the String class then.
