### PR TITLE
Proposal: Custom Validation Objects

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -277,6 +277,7 @@ class CakeValidationRule {
 		
 		/**
 		 * Allow external validator objects to be used as custom validation rules
+		 * Inspired by: http://goo.gl/8u4FN
 		 * Documentation: http://bit.ly/RXxw43
 		 * 
 		 * It allow to create a custom validator object like:

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -277,7 +277,7 @@ class CakeValidationRule {
 		
 		/**
 		 * Allow external validator objects to be used as custom validation rules
-		 * Inspired by: http://goo.gl/8u4FN
+		 * Documentation: http://bit.ly/RXxw43
 		 * 
 		 * It allow to create a custom validator object like:
 		 *

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -295,14 +295,14 @@ class CakeValidationRule {
 		 * ...
 		 * 
 		 */
-		} elseif (  strpos($this->_rule , '::') ){
+		} elseif (strpos($this->_rule ,'::')) {
 			
 			list($plugin, $class) = pluginSplit($this->_rule);
 			list($className,$method) = explode('::',$class);
 			
 			// Contestualize lazy loading to validation repository even into plugins
 			$location = 'Model/Validation';
-			if ( $plugin ) $location = $plugin.'.'.$location;
+			if ( $plugin ) $location = $plugin . '.' . $location;
 			
 			// Lazy loading and method call
 			App::uses($className, $location);

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -276,11 +276,13 @@ class CakeValidationRule {
 			$this->_valid = call_user_func_array(array('Validation', $this->_rule), $this->_ruleParams);
 		} elseif (strpos($this->_rule ,'::')) {
 			list($plugin, $class) = pluginSplit($this->_rule);
-			list($className,$method) = explode('::',$class);
+			list($className,$method) = explode('::', $class);
 			$location = 'Model/Validation';
 			if ( $plugin ) $location = $plugin . '.' . $location;
 			App::uses($className, $location);
-			if ( class_exists($className) ) $this->_valid = call_user_func_array(array($className, $method), $this->_ruleParams);                
+			if (class_exists($className)) {
+				$this->_valid = call_user_func_array(array($className, $method), $this->_ruleParams);
+			}
 		} elseif (is_string($validator['rule'])) {
 			$this->_valid = preg_match($this->_rule, $data[$field]);
 		} elseif (Configure::read('debug') > 0) {

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -265,8 +265,6 @@ class CakeValidationRule {
 
 		$validator = $this->_getPropertiesArray();
 		$rule = strtolower($this->_rule);
-		
-		
 		if (isset($methods[$rule])) {
 			$this->_ruleParams[] = array_merge($validator, $this->_passedOptions);
 			$this->_ruleParams[0] = array($field => $this->_ruleParams[0]);

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -273,28 +273,6 @@ class CakeValidationRule {
 			$this->_valid = call_user_func_array($methods[$rule], $this->_ruleParams);
 		} elseif (class_exists('Validation') && method_exists('Validation', $this->_rule)) {
 			$this->_valid = call_user_func_array(array('Validation', $this->_rule), $this->_ruleParams);
-		
-		
-		/**
-		 * Allow external validator objects to be used as custom validation rules
-		 * Inspired by: http://goo.gl/8u4FN
-		 * Documentation: http://bit.ly/RXxw43
-		 * 
-		 * It allow to create a custom validator object like:
-		 *
-		 * // App/Model/Validation
-		 * class MyValidator {
-		 *   public static function isReallyInt() {}
-		 * }
-		 *
-		 * // App/Model/Users.php
-		 * ...
-		 * $validate = array(
-		 *   'username' => 'MyValidator::isReallyInt'
-		 *);
-		 * ...
-		 * 
-		 */
 		} elseif (strpos($this->_rule ,'::')) {
 			
 			list($plugin, $class) = pluginSplit($this->_rule);
@@ -311,9 +289,6 @@ class CakeValidationRule {
 		
 		} elseif (is_string($validator['rule'])) {
 			$this->_valid = preg_match($this->_rule, $data[$field]);
-		
-		
-		
 		} elseif (Configure::read('debug') > 0) {
 			trigger_error(__d('cake_dev', 'Could not find validation handler %s for %s', $this->_rule, $field), E_USER_WARNING);
 			return false;

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -257,6 +257,9 @@ class CakeValidationRule {
 /**
  * Dispatches the validation rule to the given validator method
  *
+ * Use "PluginName.ClassName::method" as validation rule name to refer to a custom validator object.
+ * /App/Plugin/Model/Validation/ClassName.php
+ *
  * @return boolean True if the rule could be dispatched, false otherwise
  */
 	public function process($field, &$data, &$methods) {

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -274,7 +274,7 @@ class CakeValidationRule {
 			$this->_valid = call_user_func_array($methods[$rule], $this->_ruleParams);
 		} elseif (class_exists('Validation') && method_exists('Validation', $this->_rule)) {
 			$this->_valid = call_user_func_array(array('Validation', $this->_rule), $this->_ruleParams);
-		} elseif (strpos($this->_rule ,'::')) {
+		} elseif (strpos($this->_rule, '::')) {
 			list($plugin, $class) = pluginSplit($this->_rule);
 			list($className,$method) = explode('::', $class);
 			$location = 'Model/Validation';

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -280,8 +280,10 @@ class CakeValidationRule {
 			$location = 'Model/Validation';
 			if ( $plugin ) $location = $plugin . '.' . $location;
 			App::uses($className, $location);
-			if (class_exists($className)) {
+			if (class_exists($className) && method_exists($className, $method)) {
 				$this->_valid = call_user_func_array(array($className, $method), $this->_ruleParams);
+			} else {
+				$this->_valid = false;
 			}
 		} elseif (is_string($validator['rule'])) {
 			$this->_valid = preg_match($this->_rule, $data[$field]);

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -272,19 +272,12 @@ class CakeValidationRule {
 		} elseif (class_exists('Validation') && method_exists('Validation', $this->_rule)) {
 			$this->_valid = call_user_func_array(array('Validation', $this->_rule), $this->_ruleParams);
 		} elseif (strpos($this->_rule ,'::')) {
-			
 			list($plugin, $class) = pluginSplit($this->_rule);
 			list($className,$method) = explode('::',$class);
-			
-			// Contestualize lazy loading to validation repository even into plugins
 			$location = 'Model/Validation';
 			if ( $plugin ) $location = $plugin . '.' . $location;
-			
-			// Lazy loading and method call
 			App::uses($className, $location);
 			if ( class_exists($className) ) $this->_valid = call_user_func_array(array($className, $method), $this->_ruleParams);                
-			
-		
 		} elseif (is_string($validator['rule'])) {
 			$this->_valid = preg_match($this->_rule, $data[$field]);
 		} elseif (Configure::read('debug') > 0) {


### PR DESCRIPTION
I've packed up a solution to use custom validation rules from outside the model class namespace.

I was inspired by a discussion and code-posting I found here (http://goo.gl/8u4FN) between MarkStory and saleh.

I changed `/lib/Cake/Model/CakeValidationRule.php` adding a code block to `process()` method to search for custom rules into external objects.

I find this solution mandatory to CakePHP letting developers to pack validation rules into their plugins!
I wrote a post to my blog to explain the problem and this solution: http://bit.ly/RXxw43

Bye,
MPeg.
