### PR TITLE
Avoid duplicating RequestHandler component when rendering Errors.

### DIFF
--- a/lib/Cake/Controller/CakeErrorController.php
+++ b/lib/Cake/Controller/CakeErrorController.php
@@ -50,7 +50,11 @@ class CakeErrorController extends AppController {
  */
 	public function __construct($request = null, $response = null) {
 		parent::__construct($request, $response);
-		if (count(Router::extensions())) {
+		if (
+			count(Router::extensions()) &&
+			!array_key_exists('RequestHandler', $this->components) &&
+			!in_array('RequestHandler', $this->components, true)
+		) {
 			$this->components[] = 'RequestHandler';
 		}
 		$this->constructClasses();


### PR DESCRIPTION
If `RequestHandler` component is duplicated, later when calling `CakeErrorController::constructClasses()`:

`CakeErrorController::_mergeControllerVars()` is called to merge components and helpers [1], and `CakeErrorController::_mergeVars()` does the merge because they are different [2]

If the components loaded (for example), looks like:

```
array(
    (int) 0 => 'Session',
    'Auth' => array(
        'authorize' => array(
            (int) 0 => 'Controller'
        ),
        'authenticate' => array(
            (int) 0 => 'Key'
        )
    ),
    (int) 1 => 'RequestHandler'
)
```

they will end up like:

```
array(
    'Session' => null,
    'Auth' => array(
        'authorize' => array(
            (int) 0 => 'Controller',
            (int) 1 => 'Controller'
        ),
        'authenticate' => array(
            (int) 0 => 'Key',
            (int) 1 => 'Key'
        )
    ),
    'RequestHandler' => null
)
```

[1] https://github.com/bar/cakephp/blob/master-cake-error/lib/Cake/Controller/Controller.php#L561
[2] https://github.com/bar/cakephp/blob/master-cake-error/lib/Cake/Core/Object.php#L193
