### PR TITLE
normalize inputs to avoid stripping of whitespaces - except for textarea

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3072,9 +3072,9 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
- * testTextbox method
+ * testNormalize method
  *
- * test textbox element generation
+ * test that whitespaces are normalized for all inputs except textareas (which also understand new line characters)
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3072,6 +3072,23 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testTextbox method
+ *
+ * test textbox element generation
+ *
+ * @return void
+ */
+	public function testNormalize() {
+		$this->Form->request->data['Model']['field'] = "My\nvalue";
+		$result = $this->Form->text('Model.field');
+		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'data[Model][field]', 'value'=>'My value', 'id' => 'ModelField')));
+
+		$this->Form->request->data['Model']['field'] = "My\nvalue";
+		$result = $this->Form->textarea('Model.field');
+		$this->assertTags($result, array('textarea' => array('name' => 'data[Model][field]', 'id' => 'ModelField'), "My\nvalue", '/textarea'));
+	}
+
+/**
  * testDefaultValue method
  *
  * Test default value setting

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -734,8 +734,17 @@ class Helper extends Object {
 			$this->setEntity($field);
 		}
 		$options = (array)$options;
+		$normalize = true;
+		if (isset($options['normalize'])) {
+			$normalize = $options['normalize'];
+			unset($options['normalize']);
+		}
+
 		$options = $this->_name($options);
 		$options = $this->value($options);
+		if (!empty($options['value']) && $normalize) {
+			$options['value'] = str_replace(array("\t", "\r\n", "\n"), ' ', $options['value']);
+		}
 		$options = $this->domId($options);
 		return $options;
 	}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1463,6 +1463,7 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::textarea
  */
 	public function textarea($fieldName, $options = array()) {
+		$options['normalize'] = false;
 		$options = $this->_initInputField($fieldName, $options);
 		$value = null;
 
@@ -2621,6 +2622,8 @@ class FormHelper extends AppHelper {
  * - `secure` - boolean whether or not the field should be added to the security fields.
  *   Disabling the field using the `disabled` option, will also omit the field from being
  *   part of the hashed key.
+ * - `normalize` - boolean whether the content should be normalized regarding whitespaces.
+ *   Since only textareas understand new line characters, this is a good default for all other types.
  *
  * @param string $field Name of the field to initialize options for.
  * @param array $options Array of options to append options into.


### PR DESCRIPTION
Currently, inputs (text, ...) would lose whitespaces other than a "normal space" completely:

If you used `$this->Form->text()`

```
My [newline character]
value
```

(which would be printed "My value" in the view)
would become

```
Myvalue
```

(and therefore "Myvalue" from here on)

in the form. after hitting "save" (without actually modified anything) the whitespace is gone for good.

So for all other types then textareas it makes sense to normalize before setting the value of the input so the form post of the inputs can not destroy the whitespace but normalize it to a normal space.

Since importing or other data mining operations can always store other whitespaces in the DB than just spaces, it is a good default to clean this in the forms without losing vital information (the spacing here).
