### PR TITLE
3.0 app path fixes

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -355,7 +355,7 @@ class App {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::themePath
  */
 	public static function themePath($theme) {
-		$themeDir = 'Themed/' . Inflector::camelize($theme);
+		$themeDir = 'Themed' . DS . Inflector::camelize($theme);
 		foreach (static::$_packages['View'] as $path) {
 			if (is_dir($path . $themeDir)) {
 				return $path . $themeDir . DS;
@@ -500,7 +500,7 @@ class App {
 			$paths[] = CAKE . $package . DS;
 		} else {
 			$pluginPath = static::pluginPath($plugin);
-			$paths[] = $pluginPath . 'Lib/' . $package . DS;
+			$paths[] = $pluginPath . 'Lib' . DS . $package . DS;
 			$paths[] = $pluginPath . $package . DS;
 		}
 
@@ -584,60 +584,60 @@ class App {
 		if (empty(static::$_packageFormat)) {
 			static::$_packageFormat = array(
 				'Model' => array(
-					'%s' . 'Model/'
+					'%s' . 'Model' . DS
 				),
 				'Model/Behavior' => array(
-					'%s' . 'Model/Behavior/'
+					'%s' . 'Model' . DS . 'Behavior' . DS
 				),
 				'Model/Datasource' => array(
-					'%s' . 'Model/Datasource/'
+					'%s' . 'Model' . DS . 'Datasource' . DS
 				),
 				'Model/Datasource/Database' => array(
-					'%s' . 'Model/Datasource/Database/'
+					'%s' . 'Model' . DS . 'Datasource' . DS . 'Database' . DS
 				),
 				'Model/Datasource/Session' => array(
-					'%s' . 'Model/Datasource/Session/'
+					'%s' . 'Model' . DS . 'Datasource' . DS . 'Session' . DS
 				),
 				'Controller' => array(
-					'%s' . 'Controller/'
+					'%s' . 'Controller' . DS
 				),
 				'Controller/Component' => array(
-					'%s' . 'Controller/Component/'
+					'%s' . 'Controller' . DS . 'Component' . DS
 				),
 				'Controller/Component/Auth' => array(
-					'%s' . 'Controller/Component/Auth/'
+					'%s' . 'Controller' . DS . 'Component' . DS . 'Auth' . DS
 				),
 				'Controller/Component/Acl' => array(
-					'%s' . 'Controller/Component/Acl/'
+					'%s' . 'Controller' . DS . 'Component' . DS . 'Acl' . DS
 				),
 				'View' => array(
-					'%s' . 'View/'
+					'%s' . 'View' . DS
 				),
 				'View/Helper' => array(
-					'%s' . 'View/Helper/'
+					'%s' . 'View' . DS . 'Helper' . DS
 				),
 				'Console' => array(
-					'%s' . 'Console/'
+					'%s' . 'Console' . DS
 				),
 				'Console/Command' => array(
-					'%s' . 'Console/Command/'
+					'%s' . 'Console' . DS . 'Command' . DS
 				),
 				'Console/Command/Task' => array(
-					'%s' . 'Console/Command/Task/'
+					'%s' . 'Console' . DS . 'Command' . DS . 'Task' . DS
 				),
 				'Lib' => array(
-					'%s' . 'Lib/'
+					'%s' . 'Lib' . DS
 				),
 				'Locale' => array(
-					'%s' . 'Locale/'
+					'%s' . 'Locale' . DS
 				),
 				'Vendor' => array(
-					'%s' . 'Vendor/',
-					dirname(dirname(CAKE)) . DS . 'vendors/',
+					'%s' . 'Vendor' . DS,
+					dirname(dirname(CAKE)) . DS . 'vendors' . DS,
 				),
 				'Plugin' => array(
-					APP . 'Plugin/',
-					dirname(dirname(CAKE)) . DS . 'plugins/'
+					APP . 'Plugin' . DS,
+					dirname(dirname(CAKE)) . DS . 'plugins' . DS
 				)
 			);
 		}

--- a/lib/Cake/Test/TestCase/Core/AppTest.php
+++ b/lib/Cake/Test/TestCase/Core/AppTest.php
@@ -62,7 +62,7 @@ class AppTest extends TestCase {
 
 		// Test plugin
 		App::build(array(
-			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
+			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS)
 		), App::RESET);
 		Plugin::load('TestPlugin');
 		$this->assertEquals('TestPlugin\Utility\TestPluginEngine', App::classname('TestPlugin.TestPlugin', 'Utility', 'Engine'));
@@ -90,7 +90,7 @@ class AppTest extends TestCase {
 	public function testBuild() {
 		$old = App::path('Model');
 		$expected = array(
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, $old);
 
@@ -98,7 +98,7 @@ class AppTest extends TestCase {
 		$new = App::path('Model');
 		$expected = array(
 			'/path/to/models/',
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, $new);
 
@@ -107,7 +107,7 @@ class AppTest extends TestCase {
 		$new = App::path('Model');
 		$expected = array(
 			'/path/to/models/',
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, $new);
 
@@ -115,7 +115,7 @@ class AppTest extends TestCase {
 		App::build(array('Model' => array('/path/to/models/')), App::APPEND);
 		$new = App::path('Model');
 		$expected = array(
-			APP . 'Model/',
+			APP . 'Model' . DS,
 			'/path/to/models/'
 		);
 		$this->assertEquals($expected, $new);
@@ -127,13 +127,13 @@ class AppTest extends TestCase {
 		), App::APPEND);
 		$new = App::path('Model');
 		$expected = array(
-			APP . 'Model/',
+			APP . 'Model' . DS,
 			'/path/to/models/'
 		);
 		$this->assertEquals($expected, $new);
 		$new = App::path('Controller');
 		$expected = array(
-			APP . 'Controller/',
+			APP . 'Controller' . DS,
 			'/path/to/controllers/'
 		);
 		$this->assertEquals($expected, $new);
@@ -151,7 +151,7 @@ class AppTest extends TestCase {
 	public function testCompatibleBuild() {
 		$old = App::path('Model');
 		$expected = array(
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, $old);
 
@@ -159,56 +159,56 @@ class AppTest extends TestCase {
 
 		$expected = array(
 			'/path/to/models/',
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, App::path('Model'));
 
 		App::build(array('Model/Datasource' => array('/path/to/datasources/')));
 		$expected = array(
 			'/path/to/datasources/',
-			APP . 'Model/Datasource/'
+			APP . 'Model' . DS . 'Datasource' . DS
 		);
 		$this->assertEquals($expected, App::path('Model/Datasource'));
 
 		App::build(array('Model/Behavior' => array('/path/to/behaviors/')));
 		$expected = array(
 			'/path/to/behaviors/',
-			APP . 'Model/Behavior/'
+			APP . 'Model' . DS . 'Behavior' . DS
 		);
 		$this->assertEquals($expected, App::path('Model/Behavior'));
 
 		App::build(array('Controller' => array('/path/to/controllers/')));
 		$expected = array(
 			'/path/to/controllers/',
-			APP . 'Controller/'
+			APP . 'Controller' . DS
 		);
 		$this->assertEquals($expected, App::path('Controller'));
 
 		App::build(array('Controller/Component' => array('/path/to/components/')));
 		$expected = array(
 			'/path/to/components/',
-			APP . 'Controller/Component/'
+			APP . 'Controller' . DS . 'Component' . DS
 		);
 		$this->assertEquals($expected, App::path('Controller/Component'));
 
 		App::build(array('View' => array('/path/to/views/')));
 		$expected = array(
 			'/path/to/views/',
-			APP . 'View/'
+			APP . 'View' . DS
 		);
 		$this->assertEquals($expected, App::path('View'));
 
 		App::build(array('View/Helper' => array('/path/to/helpers/')));
 		$expected = array(
 			'/path/to/helpers/',
-			APP . 'View/Helper/'
+			APP . 'View' . DS . 'Helper' . DS
 		);
 		$this->assertEquals($expected, App::path('View/Helper'));
 
 		App::build(array('Console/Command' => array('/path/to/shells/')));
 		$expected = array(
 			'/path/to/shells/',
-			APP . 'Console/Command/'
+			APP . 'Console' . DS . 'Command' . DS
 		);
 		$this->assertEquals($expected, App::path('Console/Command'));
 
@@ -225,8 +225,8 @@ class AppTest extends TestCase {
 	public function testBuildPackage() {
 		$pluginPaths = array(
 			'/foo/bar',
-			APP . 'Plugin/',
-			dirname(dirname(CAKE)) . DS . 'plugins/'
+			APP . 'Plugin' . DS,
+			dirname(dirname(CAKE)) . DS . 'plugins' . DS
 		);
 		App::build(array(
 			'Plugin' => array(
@@ -241,12 +241,12 @@ class AppTest extends TestCase {
 
 		App::build(array(
 			'Service' => array(
-				'%s' . 'Service/',
+				'%s' . 'Service' . DS
 			),
 		), App::REGISTER);
 
 		$expected = array(
-			APP . 'Service/',
+			APP . 'Service' . DS
 		);
 		$result = App::path('Service');
 		$this->assertEquals($expected, $result);
@@ -273,7 +273,7 @@ class AppTest extends TestCase {
 		Plugin::load('TestPlugin');
 
 		$result = App::path('Vendor', 'TestPlugin');
-		$this->assertEquals($basepath . 'TestPlugin' . DS. 'Vendor' . '/', $result[0]);
+		$this->assertEquals($basepath . 'TestPlugin' . DS. 'Vendor' . DS, $result[0]);
 	}
 
 /**
@@ -284,7 +284,7 @@ class AppTest extends TestCase {
 	public function testBuildWithReset() {
 		$old = App::path('Model');
 		$expected = array(
-			APP . 'Model/'
+			APP . 'Model' . DS
 		);
 		$this->assertEquals($expected, $old);
 
@@ -466,11 +466,11 @@ class AppTest extends TestCase {
 			'View' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS)
 		));
 		$path = App::themePath('test_theme');
-		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . '/' . 'TestTheme' . DS;
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
 		$this->assertEquals($expected, $path);
 
 		$path = App::themePath('TestTheme');
-		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . '/' . 'TestTheme' . DS;
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . DS . 'TestTheme' . DS;
 		$this->assertEquals($expected, $path);
 
 		App::build();

--- a/lib/Cake/Test/TestCase/Core/AppTest.php
+++ b/lib/Cake/Test/TestCase/Core/AppTest.php
@@ -266,14 +266,14 @@ class AppTest extends TestCase {
  * @return void
  */
 	public function testPathWithPlugins() {
-		$basepath = CAKE . 'Test/TestApp/Plugin/';
+		$basepath = CAKE . 'Test' . DS . 'TestApp' . DS. 'Plugin' . DS;
 		App::build(array(
 			'Plugin' => array($basepath),
 		));
 		Plugin::load('TestPlugin');
 
 		$result = App::path('Vendor', 'TestPlugin');
-		$this->assertEquals($basepath . 'TestPlugin/Vendor/', $result[0]);
+		$this->assertEquals($basepath . 'TestPlugin' . DS. 'Vendor' . '/', $result[0]);
 	}
 
 /**
@@ -309,22 +309,22 @@ class AppTest extends TestCase {
  */
 	public function testCore() {
 		$model = App::core('Model');
-		$this->assertEquals(array(CAKE . 'Model/'), $model);
+		$this->assertEquals(array(CAKE . 'Model' . DS), $model);
 
 		$view = App::core('View');
-		$this->assertEquals(array(CAKE . 'View/'), $view);
+		$this->assertEquals(array(CAKE . 'View' . DS), $view);
 
 		$controller = App::core('Controller');
-		$this->assertEquals(array(CAKE . 'Controller/'), $controller);
+		$this->assertEquals(array(CAKE . 'Controller' . DS), $controller);
 
 		$component = App::core('Controller/Component');
-		$this->assertEquals(array(CAKE . 'Controller/Component/'), str_replace('/', DS, $component));
+		$this->assertEquals(array(CAKE . 'Controller' . DS . 'Component' . DS), str_replace('/', DS, $component));
 
 		$auth = App::core('Controller/Component/Auth');
-		$this->assertEquals(array(CAKE . 'Controller/Component/Auth/'), str_replace('/', DS, $auth));
+		$this->assertEquals(array(CAKE . 'Controller' . DS . 'Component' . DS . 'Auth' . DS), str_replace('/', DS, $auth));
 
 		$datasource = App::core('Model/Datasource');
-		$this->assertEquals(array(CAKE . 'Model/Datasource/'), str_replace('/', DS, $datasource));
+		$this->assertEquals(array(CAKE . 'Model' . DS . 'Datasource' . DS), str_replace('/', DS, $datasource));
 	}
 
 /**
@@ -442,16 +442,16 @@ class AppTest extends TestCase {
  */
 	public function testPluginPath() {
 		App::build(array(
-			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
+			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS)
 		));
 		Plugin::load(array('TestPlugin', 'TestPluginTwo'));
 
 		$path = App::pluginPath('TestPlugin');
-		$expected = CAKE . 'Test/TestApp/Plugin/TestPlugin/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS . 'TestPlugin' . DS;
 		$this->assertEquals($expected, $path);
 
 		$path = App::pluginPath('TestPluginTwo');
-		$expected = CAKE . 'Test/TestApp/Plugin/TestPluginTwo/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS;
 		$this->assertEquals($expected, $path);
 		App::build();
 	}
@@ -463,14 +463,14 @@ class AppTest extends TestCase {
  */
 	public function testThemePath() {
 		App::build(array(
-			'View' => array(CAKE . 'Test/TestApp/View/')
+			'View' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS)
 		));
 		$path = App::themePath('test_theme');
-		$expected = CAKE . 'Test/TestApp/View/Themed/TestTheme/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . '/' . 'TestTheme' . DS;
 		$this->assertEquals($expected, $path);
 
 		$path = App::themePath('TestTheme');
-		$expected = CAKE . 'Test/TestApp/View/Themed/TestTheme/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'View' . DS . 'Themed' . '/' . 'TestTheme' . DS;
 		$this->assertEquals($expected, $path);
 
 		App::build();

--- a/lib/Cake/Test/TestCase/Core/PluginTest.php
+++ b/lib/Cake/Test/TestCase/Core/PluginTest.php
@@ -33,7 +33,7 @@ class PluginTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		App::build(array(
-			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
+			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS)
 		), App::RESET);
 		App::objects('Plugin', null, false);
 	}
@@ -58,7 +58,7 @@ class PluginTest extends TestCase {
 		$this->assertEquals('TestPlugin', Plugin::getNamespace('TestPlugin'));
 
 		App::build(array(
-			'Plugin' => array(CAKE . 'Test/TestApp/Plugin2/')
+			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin2' . DS)
 		), App::RESET);
 
 		Plugin::load('TestPluginThree', array('namespace' => 'Company\TestPluginThree'));
@@ -218,10 +218,10 @@ class PluginTest extends TestCase {
  */
 	public function testPath() {
 		Plugin::load(array('TestPlugin', 'TestPluginTwo'));
-		$expected = CAKE . 'Test/TestApp/Plugin/TestPlugin/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS . 'TestPlugin' . DS;
 		$this->assertEquals(Plugin::path('TestPlugin'), $expected);
 
-		$expected = CAKE . 'Test/TestApp/Plugin/TestPluginTwo/';
+		$expected = CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS;
 		$this->assertEquals(Plugin::path('TestPluginTwo'), $expected);
 	}
 

--- a/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
@@ -287,7 +287,7 @@ class DebuggerTest extends TestCase {
 		$this->assertEquals('APP/', Debugger::trimPath(APP));
 		$this->assertEquals('CORE', Debugger::trimPath(CAKE_CORE_INCLUDE_PATH));
 		$this->assertEquals('ROOT', Debugger::trimPath(ROOT));
-		$this->assertEquals('CORE/Cake/', Debugger::trimPath(CAKE));
+		$this->assertEquals('CORE' . DS . 'Cake' . DS, Debugger::trimPath(CAKE));
 		$this->assertEquals('Some/Other/Path', Debugger::trimPath('Some/Other/Path'));
 	}
 

--- a/lib/Cake/Test/TestCase/Utility/FolderTest.php
+++ b/lib/Cake/Test/TestCase/Utility/FolderTest.php
@@ -118,9 +118,9 @@ class FolderTest extends TestCase {
 		$this->assertTrue($result);
 
 		$result = $Folder->realpath('Test/');
-		$this->assertEquals($path . DS . 'Test/', $result);
+		$this->assertEquals($path . DS . 'Test' . DS, $result);
 
-		$result = $Folder->inPath('Test/');
+		$result = $Folder->inPath('Test' . DS);
 		$this->assertTrue($result);
 
 		$result = $Folder->inPath(DS . 'non-existing' . $inside);
@@ -137,7 +137,7 @@ class FolderTest extends TestCase {
  */
 	public function testCreation() {
 		$Folder = new Folder(TMP . 'tests');
-		$result = $Folder->create(TMP . 'tests/first/second/third');
+		$result = $Folder->create(TMP . 'tests' . DS . 'first' . DS . 'second' . DS . 'third');
 		$this->assertTrue($result);
 
 		rmdir(TMP . 'tests/first/second/third');
@@ -145,7 +145,7 @@ class FolderTest extends TestCase {
 		rmdir(TMP . 'tests/first');
 
 		$Folder = new Folder(TMP . 'tests');
-		$result = $Folder->create(TMP . 'tests/first');
+		$result = $Folder->create(TMP . 'tests' . DS . 'first');
 		$this->assertTrue($result);
 		rmdir(TMP . 'tests/first');
 	}
@@ -157,7 +157,7 @@ class FolderTest extends TestCase {
  */
 	public function testCreateWithTrailingDs() {
 		$Folder = new Folder(TMP);
-		$path = TMP . 'tests/trailing/dir/';
+		$path = TMP . 'tests' . DS . 'trailing' . DS . 'dir' . DS;
 		$result = $Folder->create($path);
 		$this->assertTrue($result);
 
@@ -341,11 +341,11 @@ class FolderTest extends TestCase {
  * @return void
  */
 	public function testAddPathElement() {
-		$result = Folder::addPathElement(DS . 'some/dir', 'another_path');
-		$this->assertEquals(DS . 'some/dir/another_path', $result);
+		$result = Folder::addPathElement(DS . 'some' . DS . 'dir', 'another_path');
+		$this->assertEquals(DS . 'some' . DS . 'dir' . DS . 'another_path', $result);
 
-		$result = Folder::addPathElement(DS . 'some/dir/', 'another_path');
-		$this->assertEquals(DS . 'some/dir/another_path', $result);
+		$result = Folder::addPathElement(DS . 'some' . DS . 'dir' . DS, 'another_path');
+		$this->assertEquals(DS . 'some' . DS . 'dir' . DS . 'another_path', $result);
 	}
 
 /**
@@ -467,15 +467,15 @@ class FolderTest extends TestCase {
 			array(
 				$Folder->path,
 				$Folder->path . DS . 'visible_folder',
-				$Folder->path . DS . 'visible_folder/.git',
+				$Folder->path . DS . 'visible_folder' . DS . '.git',
 				$Folder->path . DS . '.svn',
-				$Folder->path . DS . '.svn/inhiddenfolder',
+				$Folder->path . DS . '.svn' . DS . 'inhiddenfolder',
 			),
 			array(
 				$Folder->path . DS . 'not_hidden.txt',
 				$Folder->path . DS . '.hidden.txt',
-				$Folder->path . DS . '.svn/inhiddenfolder/NestedInHiddenFolder.php',
-				$Folder->path . DS . '.svn/InHiddenFolder.php',
+				$Folder->path . DS . '.svn' . DS . 'inhiddenfolder' . DS . 'NestedInHiddenFolder.php',
+				$Folder->path . DS . '.svn' . DS . 'InHiddenFolder.php',
 			),
 		);
 
@@ -599,8 +599,8 @@ class FolderTest extends TestCase {
 		$result = $Folder->inCakePath($path);
 		$this->assertFalse($result);
 
-		$path = DS . 'lib/Cake/Config';
-		$Folder->cd(ROOT . DS . 'lib/Cake/Config');
+		$path = DS . 'lib' . DS . 'Cake' . DS . 'Config';
+		$Folder->cd(ROOT . DS . 'lib' . DS . 'Cake' . DS . 'Config');
 		$result = $Folder->inCakePath($path);
 		$this->assertTrue($result);
 	}
@@ -669,8 +669,8 @@ class FolderTest extends TestCase {
 		$expected = array(
 			CAKE . 'Config/config.php'
 		);
-		$this->assertSame(array_diff($expected, $result), array());
-		$this->assertSame(array_diff($expected, $result), array());
+		$this->assertSame(array(), array_diff($expected, $result));
+		$this->assertSame(array(), array_diff($expected, $result));
 
 		$result = $Folder->findRecursive('(config|woot)\.php', true);
 		$expected = array(
@@ -698,8 +698,8 @@ class FolderTest extends TestCase {
 			TMP . 'testme/my.php',
 			TMP . 'testme/paths.php'
 		);
-		$this->assertSame(array_diff($expected, $result), array());
-		$this->assertSame(array_diff($expected, $result), array());
+		$this->assertSame(array(), array_diff($expected, $result));
+		$this->assertSame(array(), array_diff($expected, $result));
 
 		$result = $Folder->findRecursive('(paths|my)\.php', true);
 		$expected = array(
@@ -820,11 +820,11 @@ class FolderTest extends TestCase {
 
 		$expected = array(
 			$path . DS . 'file_1 removed',
-			$path . DS . 'level_1_1/file_1_1 removed',
-			$path . DS . 'level_1_1/level_2_1/file_2_1 removed',
-			$path . DS . 'level_1_1/level_2_1/file_2_2 removed',
-			$path . DS . 'level_1_1/level_2_1 removed',
-			$path . DS . 'level_1_1/level_2_2 removed',
+			$path . DS . 'level_1_1' . DS . 'file_1_1 removed',
+			$path . DS . 'level_1_1' . DS . 'level_2_1' . DS . 'file_2_1 removed',
+			$path . DS . 'level_1_1' . DS . 'level_2_1' . DS . 'file_2_2 removed',
+			$path . DS . 'level_1_1' . DS . 'level_2_1 removed',
+			$path . DS . 'level_1_1' . DS . 'level_2_2 removed',
 			$path . DS . 'level_1_1 removed',
 			$path . ' removed'
 		);


### PR DESCRIPTION
a lot of tests fail on windows due to harccoded /.
the tests now should run both on windows and unix

but there are still some issues left where there shoud not be '/' in the expected result.
