### PR TITLE
Adding events to the ErrorHandler

### DIFF
--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -99,6 +99,28 @@ App::uses('CakeEvent', 'Event');
 class ErrorHandler {
 
 /**
+ * Instance of the CakeEventManager this error handler is using
+ * to dispatch inner events.
+ *
+ * @var CakeEventManager
+ */
+	protected static $_eventManager = null;
+
+/**
+ * Returns the CakeEventManager manager instance that is handling any callbacks.
+ * You can use this instance to register any new listeners or callbacks to the
+ * error handler events, or create your own events and trigger them at will.
+ *
+ * @return CakeEventManager
+ */
+	public function getEventManager() {
+		if (empty(self::$_eventManager)) {
+			self::$_eventManager = new CakeEventManager();
+		}
+		return self::$_eventManager;
+	}
+
+/**
  * Set as the default exception handler by the CakePHP bootstrap process.
  *
  * This will either use custom exception renderer class if configured,
@@ -110,7 +132,7 @@ class ErrorHandler {
  */
 	public static function handleException(Exception $exception) {
 		$event = new CakeEvent('ErrorHandler.handleException', null, array($exception));
-		CakeEventManager::instance()->dispatch($event);
+		self::getEventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			return $event->result;
@@ -166,7 +188,7 @@ class ErrorHandler {
 		}
 
 		$event = new CakeEvent('ErrorHandler.handleError', null, array($code, $description, $file, $line, $context));
-		CakeEventManager::instance()->dispatch($event);
+		self::getEventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			return $event->result;
@@ -214,7 +236,7 @@ class ErrorHandler {
  */
 	public static function handleFatalError($code, $description, $file, $line) {
 		$event = new CakeEvent('ErrorHandler.handleFatalError', null, array($code, $description, $file, $line));
-		CakeEventManager::instance()->dispatch($event);
+		self::getEventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			return $event->result;

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -323,7 +323,16 @@ class ErrorHandlerTest extends CakeTestCase {
 		$this->assertContains('[FatalErrorException] Something wrong', $log[1], 'message missing.');
 	}
 
-	public function testEvents() {
+/**
+ * test error handler events
+ * These events are tested:
+ * ErrorHandler.handleError
+ * ErrorHandler.handleException
+ * ErrorHandler.handleException
+ *
+ * @return void
+ */
+	public function testErrorHandlerEvents() {
 		CakeEventManager::instance()->attach(new TestErrorHandlerListener());
 
 		$result = ErrorHandler::handleError(E_ERROR, 'Something wrong');

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -20,6 +20,36 @@
 App::uses('ErrorHandler', 'Error');
 App::uses('Controller', 'Controller');
 App::uses('Router', 'Routing');
+App::uses('CakeEventManager', 'Event');
+App::uses('CakeEventListener', 'Event');
+
+class TestErrorHandlerListener implements CakeEventListener {
+/**
+ * Implemented events
+ */
+	public function implementedEvents() {
+		return array(
+			'ErrorHandler.handleException' => 'handleException',
+			'ErrorHandler.handleError' => 'handleError',
+			'ErrorHandler.handleFatalError' => 'handleFatalError');
+	}
+
+	public function handleException($event) {
+		$event->result = 'handleException fired';
+		$event->stopPropagation();
+	}
+
+	public function handleError($event) {
+		$event->result = 'handleError fired';
+		$event->stopPropagation();
+	}
+
+	public function handleFatalError($event) {
+		$event->result = 'handleFatalError fired';
+		$event->stopPropagation();
+	}
+
+}
 
 /**
  * ErrorHandlerTest class
@@ -293,4 +323,16 @@ class ErrorHandlerTest extends CakeTestCase {
 		$this->assertContains('[FatalErrorException] Something wrong', $log[1], 'message missing.');
 	}
 
+	public function testEvents() {
+		CakeEventManager::instance()->attach(new TestErrorHandlerListener());
+
+		$result = ErrorHandler::handleError(E_ERROR, 'Something wrong');
+		$this->assertEqual($result, 'handleError fired');
+
+		$result = ErrorHandler::handleException(new Exception('Something wrong'));
+		$this->assertEqual($result, 'handleException fired');
+
+		$result = ErrorHandler::handleFatalError(E_ERROR, 'Something wrong', __FILE__, __LINE__);
+		$this->assertEqual($result, 'handleFatalError fired');
+	}
 }


### PR DESCRIPTION
Adding events to the error handler. 

This allows it to inject customized actions into the error handling process without the need of extending the existing error handler. In my scenario this would be ideal for reporting fatal error via email for example.

The next step could be to move the existing code into a default ErrorEventListener or something. So far I've just added the events.
