### PR TITLE
Added View::startIfEmpty($name)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist
 .DS_Store
 /tags
+*.swp

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -631,6 +631,17 @@ class View extends Object {
 	}
 
 /**
+ * Start capturing output for a 'block' if it has no content
+ *
+ * @param string $name The name of the block to capture for.
+ * @return void
+ * @see ViewBlock::startIfEmpty()
+ */
+	public function startIfEmpty($name) {
+		return $this->Blocks->startIfEmpty($name);
+	}
+
+/**
  * Append to an existing or new block.  Appending to a new
  * block will create the block.
  *

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -38,6 +38,15 @@ class ViewBlock {
 	protected $_active = array();
 
 /**
+ * Should the currently captured content be discarded on ViewBlock::end()
+ *
+ * @var boolean
+ * @see ViewBlock::end()
+ * @see ViewBlock::startIfEmpty()
+ */
+	protected $_discardActiveBufferOnEnd = false;
+
+/**
  * Start capturing output for a 'block'
  *
  * Blocks allow you to create slots or blocks of dynamic content in the layout.
@@ -55,12 +64,38 @@ class ViewBlock {
 	}
 
 /**
+ * Start capturing output for a 'block' if it is empty
+ *
+ * Blocks allow you to create slots or blocks of dynamic content in the layout.
+ * view files can implement some or all of a layout's slots.
+ *
+ * You can end capturing blocks using View::end().  Blocks can be output
+ * using View::get();
+ *
+ * @param string $name The name of the block to capture for.
+ * @return void
+ * @see ViewBlock::startIfEmpty()
+ */
+	public function startIfEmpty($name) {
+		if (empty($this->_blocks[$name])) {
+			return $this->start($name);
+		}
+		$this->_discardActiveBufferOnEnd = true;
+		ob_start();
+	}
+
+/**
  * End a capturing block. The compliment to ViewBlock::start()
  *
  * @return void
  * @see ViewBlock::start()
  */
 	public function end() {
+		if ($this->_discardActiveBufferOnEnd) {
+			$this->_discardActiveBufferOnEnd = false;
+			ob_end_clean();
+			return;
+		}
 		if (!empty($this->_active)) {
 			$active = end($this->_active);
 			$content = ob_get_clean();


### PR DESCRIPTION
Ticket: #3315

Adds method startIfEmpty to ViewBlock and View allowing the developer to add content to a block only if it has no content from previously rendered Views/Layouts
