### PR TITLE
Added missing App::uses() statement. Closes #3331

### DIFF
--- a/lib/Cake/Controller/CakeErrorController.php
+++ b/lib/Cake/Controller/CakeErrorController.php
@@ -19,6 +19,8 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+App::uses('AppController', 'Controller');
+
 /**
  * Error Handling Controller
  *

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -142,15 +142,14 @@ class ExceptionRenderer {
  * @return Controller
  */
 	protected function _getController($exception) {
+		App::uses('AppController', 'Controller');
 		App::uses('CakeErrorController', 'Controller');
 		if (!$request = Router::getRequest(true)) {
 			$request = new CakeRequest();
 		}
 		$response = new CakeResponse(array('charset' => Configure::read('App.encoding')));
 		try {
-			if (class_exists('AppController')) {
-				$controller = new CakeErrorController($request, $response);
-			}
+			$controller = new CakeErrorController($request, $response);
 		} catch (Exception $e) {
 		}
 		if (empty($controller)) {

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -19,7 +19,6 @@
 
 App::uses('ExceptionRenderer', 'Error');
 App::uses('Controller', 'Controller');
-App::uses('AppController', 'Controller');
 App::uses('Component', 'Controller');
 App::uses('Router', 'Routing');
 


### PR DESCRIPTION
Refs: http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3331-errorexception-not-rendering-correctly

I confirmed with the user lilHermit on IRC that this patch fixes the issue but wanted another set of eyes to review it just in case.
