### PR TITLE
Update checkRequired to use array_key_exists rather than isset

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -163,9 +163,9 @@ class CakeValidationRule {
  */
 	public function checkRequired($field, &$data) {
 		return (
-			(!isset($data[$field]) && $this->isRequired() === true) ||
+			(!array_key_exists($field, $data) && $this->isRequired() === true) ||
 			(
-				isset($data[$field]) && (empty($data[$field]) &&
+				array_key_exists($field, $data) && (empty($data[$field]) &&
 				!is_numeric($data[$field])) && $this->allowEmpty === false
 			)
 		);

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
@@ -171,4 +171,30 @@ class CakeValidationRuleTest extends CakeTestCase {
 		$Rule->isUpdate(true);
 		$this->assertTrue($Rule->isEmptyAllowed());
 	}
+
+/**
+ * Test checkRequired method
+ *
+ * @return void
+ */
+	public function testCheckRequiredWhenRequiredAndAllowEmpty() {
+
+		$Rule = $this->getMock('CakeValidationRule', array('isRequired'));
+		$Rule->expects($this->any())
+			->method('isRequired')
+			->will($this->returnValue(true));
+		$Rule->allowEmpty = true;
+
+		$fieldname = 'field';
+		$data = array(
+			$fieldname => null
+		);
+
+		$this->assertFalse($Rule->checkRequired($fieldname, $data), "A null but present field should not fail requirement check if allowEmpty is true");
+
+		$Rule->allowEmpty = false;
+
+		$this->assertTrue($Rule->checkRequired($fieldname, $data), "A null but present field should fail requirement check if allowEmpty is false");
+
+	}
 }


### PR DESCRIPTION
Not sure if this was intentional, but I found that I could not set a field's validation as:
  required=>true
  allowEmpty=>true
And have it pass validation when the value was present in the data but null.

isset() will return false when the value is null, so I switched this for array_key_exists in CakeValidationRule::checkRequired
