### PR TITLE
XmlView: configure top level element name

### DIFF
--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -64,6 +64,13 @@ class XmlViewTest extends CakeTestCase {
 
 		$expected = Xml::build(array('response' => array('users' => $data)))->asXML();
 		$this->assertSame($expected, $output);
+
+		$Controller->set('_rootNode', 'custom_name');
+		$View = new XmlView($Controller);
+		$output = $View->render(false);
+
+		$expected = Xml::build(array('custom_name' => array('users' => $data)))->asXML();
+		$this->assertSame($expected, $output);
 	}
 
 /**
@@ -79,13 +86,20 @@ class XmlViewTest extends CakeTestCase {
 		$Controller->set($data);
 		$Controller->set('_serialize', array('no', 'user'));
 		$View = new XmlView($Controller);
+		$this->assertSame('application/xml', $Response->type());
 		$output = $View->render(false);
-
 		$expected = array(
 			'response' => array('no' => $data['no'], 'user' => $data['user'])
 		);
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
-		$this->assertSame('application/xml', $Response->type());
+
+		$Controller->set('_rootNode', 'custom_name');
+		$View = new XmlView($Controller);
+		$output = $View->render(false);
+		$expected = array(
+			'custom_name' => array('no' => $data['no'], 'user' => $data['user'])
+		);
+		$this->assertSame(Xml::build($expected)->asXML(), $output);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -35,14 +35,6 @@ class XmlViewTest extends CakeTestCase {
  * @return void
  */
 	public function testRenderWithoutView() {
-		Configure::write('XmlView.RootNodeName', null);
-		$this->__testRenderWithoutView('response');
-
-		Configure::write('XmlView.RootNodeName', 'custom_name');
-		$this->__testRenderWithoutView('custom_name');
-	}
-
-	private function __testRenderWithoutView($rootNodeName) {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
@@ -70,11 +62,17 @@ class XmlViewTest extends CakeTestCase {
 		$View = new XmlView($Controller);
 		$output = $View->render(false);
 
-		$expected = Xml::build(array($rootNodeName => array('users' => $data)))->asXML();
+		$expected = Xml::build(array('response' => array('users' => $data)))->asXML();
+		$this->assertSame($expected, $output);
+
+
+		$Controller->set('_rootElement', 'custom_name');
+		$View = new XmlView($Controller);
+		$output = $View->render(false);
+
+		$expected = Xml::build(array('custom_name' => array('users' => $data)))->asXML();
 		$this->assertSame($expected, $output);
 	}
-
-
 
 /**
  * Test render with an array in _serialize
@@ -82,14 +80,6 @@ class XmlViewTest extends CakeTestCase {
  * @return void
  */
 	public function testRenderWithoutViewMultiple() {
-		Configure::write('XmlView.RootNodeName', null);
-		$this->__testRenderWithoutViewMultiple('response');
-
-		Configure::write('XmlView.RootNodeName', 'custom_name');
-		$this->__testRenderWithoutViewMultiple('custom_name');
-	}
-
-	private function __testRenderWithoutViewMultiple($rootNodeName) {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
@@ -97,13 +87,21 @@ class XmlViewTest extends CakeTestCase {
 		$Controller->set($data);
 		$Controller->set('_serialize', array('no', 'user'));
 		$View = new XmlView($Controller);
+		$this->assertSame('application/xml', $Response->type());
 		$output = $View->render(false);
-
 		$expected = array(
-			$rootNodeName => array('no' => $data['no'], 'user' => $data['user'])
+			'response' => array('no' => $data['no'], 'user' => $data['user'])
 		);
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
-		$this->assertSame('application/xml', $Response->type());
+
+
+		$Controller->set('_rootElement', 'custom_name');
+		$View = new XmlView($Controller);
+		$output = $View->render(false);
+		$expected = array(
+			'custom_name' => array('no' => $data['no'], 'user' => $data['user'])
+		);
+		$this->assertSame(Xml::build($expected)->asXML(), $output);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -66,7 +66,7 @@ class XmlViewTest extends CakeTestCase {
 		$this->assertSame($expected, $output);
 
 
-		$Controller->set('_rootElement', 'custom_name');
+		$Controller->set('_rootNode', 'custom_name');
 		$View = new XmlView($Controller);
 		$output = $View->render(false);
 
@@ -95,7 +95,7 @@ class XmlViewTest extends CakeTestCase {
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
 
 
-		$Controller->set('_rootElement', 'custom_name');
+		$Controller->set('_rootNode', 'custom_name');
 		$View = new XmlView($Controller);
 		$output = $View->render(false);
 		$expected = array(

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -35,6 +35,14 @@ class XmlViewTest extends CakeTestCase {
  * @return void
  */
 	public function testRenderWithoutView() {
+		Configure::write('XmlView.RootNodeName', null);
+		$this->__testRenderWithoutView('response');
+
+		Configure::write('XmlView.RootNodeName', 'custom_name');
+		$this->__testRenderWithoutView('custom_name');
+	}
+
+	private function __testRenderWithoutView($rootNodeName) {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
@@ -62,9 +70,11 @@ class XmlViewTest extends CakeTestCase {
 		$View = new XmlView($Controller);
 		$output = $View->render(false);
 
-		$expected = Xml::build(array('response' => array('users' => $data)))->asXML();
+		$expected = Xml::build(array($rootNodeName => array('users' => $data)))->asXML();
 		$this->assertSame($expected, $output);
 	}
+
+
 
 /**
  * Test render with an array in _serialize
@@ -72,6 +82,14 @@ class XmlViewTest extends CakeTestCase {
  * @return void
  */
 	public function testRenderWithoutViewMultiple() {
+		Configure::write('XmlView.RootNodeName', null);
+		$this->__testRenderWithoutViewMultiple('response');
+
+		Configure::write('XmlView.RootNodeName', 'custom_name');
+		$this->__testRenderWithoutViewMultiple('custom_name');
+	}
+
+	private function __testRenderWithoutViewMultiple($rootNodeName) {
 		$Request = new CakeRequest();
 		$Response = new CakeResponse();
 		$Controller = new Controller($Request, $Response);
@@ -82,7 +100,7 @@ class XmlViewTest extends CakeTestCase {
 		$output = $View->render(false);
 
 		$expected = array(
-			'response' => array('no' => $data['no'], 'user' => $data['user'])
+			$rootNodeName => array('no' => $data['no'], 'user' => $data['user'])
 		);
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
 		$this->assertSame('application/xml', $Response->type());

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -99,15 +99,17 @@ class XmlView extends View {
  * @return string The serialized data
  */
 	protected function _serialize($serialize) {
+		$rootNode = isset($this->viewVars['_rootNode']) ? $this->viewVars['_rootNode'] : 'response';
+
 		if (is_array($serialize)) {
-			$data = array('response' => array());
+			$data = array($rootNode => array());
 			foreach ($serialize as $key) {
-				$data['response'][$key] = $this->viewVars[$key];
+				$data[$rootNode][$key] = $this->viewVars[$key];
 			}
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 			if (is_array($data) && Set::numeric(array_keys($data))) {
-				$data = array('response' => array($serialize => $data));
+				$data = array($rootNode => array($serialize => $data));
 			}
 		}
 		 return Xml::fromArray($data)->asXML();

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -99,17 +99,17 @@ class XmlView extends View {
  * @return string The serialized data
  */
 	protected function _serialize($serialize) {
-		$root = isset($this->viewVars['_rootElement']) ? $this->viewVars['_rootElement'] : 'response';
+		$rootNode = isset($this->viewVars['_rootNode']) ? $this->viewVars['_rootNode'] : 'response';
 
 		if (is_array($serialize)) {
-			$data = array($root => array());
+			$data = array($rootNode => array());
 			foreach ($serialize as $key) {
-				$data[$root][$key] = $this->viewVars[$key];
+				$data[$rootNode][$key] = $this->viewVars[$key];
 			}
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 			if (is_array($data) && Set::numeric(array_keys($data))) {
-				$data = array($root => array($serialize => $data));
+				$data = array($rootNode => array($serialize => $data));
 			}
 		}
 		 return Xml::fromArray($data)->asXML();

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -99,8 +99,7 @@ class XmlView extends View {
  * @return string The serialized data
  */
 	protected function _serialize($serialize) {
-		$root = Configure::read('XmlView.RootNodeName');
-		$root = empty($root) ? 'response' : $root;
+		$root = isset($this->viewVars['_rootElement']) ? $this->viewVars['_rootElement'] : 'response';
 
 		if (is_array($serialize)) {
 			$data = array($root => array());

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -99,15 +99,18 @@ class XmlView extends View {
  * @return string The serialized data
  */
 	protected function _serialize($serialize) {
+		$root = Configure::read('XmlView.RootNodeName');
+		$root = empty($root) ? 'response' : $root;
+
 		if (is_array($serialize)) {
-			$data = array('response' => array());
+			$data = array($root => array());
 			foreach ($serialize as $key) {
-				$data['response'][$key] = $this->viewVars[$key];
+				$data[$root][$key] = $this->viewVars[$key];
 			}
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 			if (is_array($data) && Set::numeric(array_keys($data))) {
-				$data = array('response' => array($serialize => $data));
+				$data = array($root => array($serialize => $data));
 			}
 		}
 		 return Xml::fromArray($data)->asXML();


### PR DESCRIPTION
http://api20.cakephp.org/class/xml-view

XmlView always uses 'request' as the top level element name.  This change allows it to be configured by setting XmlView.RootNodeName.

```
Configure::write('XmlView.RootNodeName', 'custom_name');
```
