### PR TITLE
Revert "Removing unneeded App::uses() call" as it causes ControllerTest to fail.

### DIFF
--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -22,6 +22,7 @@
 App::uses('Debugger', 'Utility');
 App::uses('CakeLog', 'Log');
 App::uses('ExceptionRenderer', 'Error');
+App::uses('AppController', 'Controller');
 
 /**
  *


### PR DESCRIPTION
This reverts commit 0fb4d1d3d8f832f9d25c887dd394e1025a4db046.
