### PR TITLE
Use bytcode sequence for unicode ellipsis

### DIFF
--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -479,7 +479,7 @@ class String {
 		if (isset($options['ending'])) {
 			$default['ellipsis'] = $options['ending'];
 		} elseif (!empty($options['html']) && Configure::read('App.encoding') == 'UTF-8') {
-			$default['ellipsis'] = chr(226);
+			$default['ellipsis'] = "\xE2\x80\xA6";
 		}
 		$options = array_merge($default, $options);
 		extract($options);


### PR DESCRIPTION
The codepoint for "horizontal ellipsis" is 0x2026, which enables a more
robust display of that character on different systems.

With my setup here (Firefox, Linux, Helvetica) ellipsis was not displayed correctly (replaced by a question mark indicating a missing character).

I'm not entirely sure about all that UTF stuff, but this should likely work on most modern systems I guess.
