### PR TITLE
allows to specify the output format of CakeTime::timeAgoInWords

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -157,7 +157,7 @@ class CakeTimeTest extends CakeTestCase {
  * @return void
  */
 	public function testTimeAgoInWordsSpecificFormat($input, $expected) {
-		$result = $this->Time->timeAgoInWords($input, array('time_ago_format' => 'for %s'));
+		$result = $this->Time->timeAgoInWords($input, array('timeAgoFormat' => 'for %s'));
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -38,6 +38,7 @@ class CakeTimeTest extends CakeTestCase {
  * @return void
  */
 	public function setUp() {
+		parent::setUp();
 		$this->Time = new CakeTime();
 		$this->_systemTimezoneIdentifier = date_default_timezone_get();
 	}
@@ -48,6 +49,7 @@ class CakeTimeTest extends CakeTestCase {
  * @return void
  */
 	public function tearDown() {
+		parent::tearDown();
 		unset($this->Time);
 		$this->_restoreSystemTimezone();
 	}
@@ -123,6 +125,42 @@ class CakeTimeTest extends CakeTestCase {
 		$result = $this->Time->timeAgoInWords($input);
 		$this->assertEquals($expected, $result);
 	}
+
+
+/**
+ * provider for timeAgoInWordsSpecificFormat() tests
+ *
+ * @return array
+ */
+	public static function timeAgoSpecificFormatProvider() {
+		return array(
+			array('-12 seconds', 'for 12 seconds'),
+			array('-12 minutes', 'for 12 minutes'),
+			array('-2 hours', 'for 2 hours'),
+			array('-1 day', 'for 1 day'),
+			array('-2 days', 'for 2 days'),
+			array('-2 days -3 hours', 'for 2 days, 3 hours'),
+			array('-1 week', 'for 1 week'),
+			array('-2 weeks -2 days', 'for 2 weeks, 2 days'),
+			array('+1 week', '1 week'),
+			array('+1 week 1 day', '1 week, 1 day'),
+			array('+2 weeks 2 day', '2 weeks, 2 days'),
+			array('2007-9-24', 'on 24/9/07'),
+			array('now', 'just now'),
+		);
+	}
+
+/**
+ * testTimeAgoInWordsSpecificFormat method when a specific format is passed as an option
+ *
+ * @dataProvider timeAgoSpecificFormatProvider
+ * @return void
+ */
+	public function testTimeAgoInWordsSpecificFormat($input, $expected) {
+		$result = $this->Time->timeAgoInWords($input, array('time_ago_format' => 'for %s'));
+		$this->assertEquals($expected, $result);
+	}
+
 
 /**
  * provider for timeAgo with an end date.

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -860,10 +860,9 @@ class CakeTime {
 			if ($timeAgoFormat) {
 				// user format, has already been translated (logically, when setting the 'timeAgoFormat' option)
 				return vsprintf($timeAgoFormat, $relativeDate);
-			} else {
-				// default format, needs to be translated 
-				return __d('cake', '%s ago', $relativeDate);
-			}
+			} 
+			// default format, needs to be translated 
+			return __d('cake', '%s ago', $relativeDate);
 		}
 
 		return $relativeDate;

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -857,7 +857,7 @@ class CakeTime {
 		}
 
 		if (!$backwards) {
-			if($timeAgoFormat) {
+			if ($timeAgoFormat) {
 				// user format, has already been translated (logically, when setting the 'timeAgoFormat' option)
 				return vsprintf($timeAgoFormat, $relativeDate);
 			} else {

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -52,11 +52,12 @@ class CakeTime {
 /**
  * The format to use when formatting a time using `CakeTime::timeAgoInWords()`
  * and the difference is less than `CakeTime::$wordEnd`
+ * false value here means that a default value will be used later
  *
  * @var string
  * @see CakeTime::timeAgoInWords()
  */
-	public static $timeAgoFormat = '%s ago';
+	public static $timeAgoFormat = false;
 
 /**
  * The format to use when formatting a time using `CakeTime::niceShort()`
@@ -856,7 +857,13 @@ class CakeTime {
 		}
 
 		if (!$backwards) {
-			return __d('cake', $timeAgoFormat, $relativeDate);
+			if($timeAgoFormat) {
+				// user format, has already been translated (logically, when setting the 'timeAgoFormat' option)
+				return vsprintf($timeAgoFormat, $relativeDate);
+			} else {
+				// default format, needs to be translated 
+				return __d('cake', '%s ago', $relativeDate);
+			}
 		}
 
 		return $relativeDate;

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -50,6 +50,15 @@ class CakeTime {
 	public static $wordFormat = 'j/n/y';
 
 /**
+ * The format to use when formatting a time using `CakeTime::timeAgoInWords()`
+ * and the difference is less than `CakeTime::$wordEnd`
+ *
+ * @var string
+ * @see CakeTime::timeAgoInWords()
+ */
+	public static $timeAgoFormat = '%s ago';
+
+/**
  * The format to use when formatting a time using `CakeTime::niceShort()`
  * and the difference is between 3 and 7 days
  *
@@ -74,7 +83,7 @@ class CakeTime {
 		'minute' => "minute",
 		'second' => "second",
 	);
-
+	
 /**
  * The end of relative time telling
  *
@@ -690,6 +699,7 @@ class CakeTime {
 		$format = self::$wordFormat;
 		$end = self::$wordEnd;
 		$accuracy = self::$wordAccuracy;
+		$time_ago_format = self::$timeAgoFormat;
 
 		if (is_array($options)) {
 			if (isset($options['timezone'])) {
@@ -715,6 +725,9 @@ class CakeTime {
 				$end = $options['end'];
 			}
 			unset($options['end'], $options['format']);
+			
+			$time_ago_format = isset($options['time_ago_format']) ? $options['time_ago_format'] : self::$timeAgoFormat;
+			
 		} else {
 			$format = $options;
 		}
@@ -844,7 +857,7 @@ class CakeTime {
 		}
 
 		if (!$backwards) {
-			return __d('cake', '%s ago', $relativeDate);
+			return __d('cake', $time_ago_format, $relativeDate);
 		}
 
 		return $relativeDate;

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -699,7 +699,7 @@ class CakeTime {
 		$format = self::$wordFormat;
 		$end = self::$wordEnd;
 		$accuracy = self::$wordAccuracy;
-		$time_ago_format = self::$timeAgoFormat;
+		$timeAgoFormat = self::$timeAgoFormat;
 
 		if (is_array($options)) {
 			if (isset($options['timezone'])) {
@@ -726,8 +726,7 @@ class CakeTime {
 			}
 			unset($options['end'], $options['format']);
 			
-			$time_ago_format = isset($options['time_ago_format']) ? $options['time_ago_format'] : self::$timeAgoFormat;
-			
+			$timeAgoFormat = isset($options['timeAgoFormat']) ? $options['timeAgoFormat'] : self::$timeAgoFormat;
 		} else {
 			$format = $options;
 		}
@@ -857,7 +856,7 @@ class CakeTime {
 		}
 
 		if (!$backwards) {
-			return __d('cake', $time_ago_format, $relativeDate);
+			return __d('cake', $timeAgoFormat, $relativeDate);
 		}
 
 		return $relativeDate;


### PR DESCRIPTION
There's already a _format_ option, but this one was used with the _end_ option,
when there is [a cutoff point to no longer will use words](http://book.cakephp.org/2.0/en/core-utility-libraries/time.html#CakeTime::timeAgoInWords).

Default value remain the same as before : "%s ago"
