### PR TITLE
Add CakeTestCase::getMockForModel convenience method

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -29,6 +29,13 @@ App::uses('CakeHtmlReporter', 'TestSuite/Reporter');
  */
 class CakeTestCaseTest extends CakeTestCase {
 
+/**
+ * fixtures property
+ *
+ * @var array
+ */
+	public $fixtures = array('core.post', 'core.author', 'core.test_plugin_comment');
+
 	public static function setUpBeforeClass() {
 		require_once CAKE . 'Test' . DS . 'Fixture' . DS . 'AssertTagsTestCase.php';
 		require_once CAKE . 'Test' . DS . 'Fixture' . DS . 'FixturizedTestCase.php';
@@ -339,4 +346,48 @@ class CakeTestCaseTest extends CakeTestCase {
 		$this->assertTextNotContains("different\rlines", $stringDirty);
 	}
 
+/**
+ * test getMockForModel()
+ *
+ * @return void
+ */
+	public function testGetMockForModel() {
+
+		$Post = $this->getMockForModel('Post');
+
+		$this->assertInstanceOf('Post', $Post);
+		$this->assertNull($Post->save(array()));
+		$this->assertNull($Post->find('all'));
+		$this->assertEquals('posts', $Post->useTable);
+
+		$Post = $this->getMockForModel('Post', array('save'));
+
+		$this->assertNull($Post->save(array()));
+		$this->assertInternalType('array', $Post->find('all'));
+	}
+
+/**
+ * test getMockForModel() with plugin models
+ *
+ * @return void
+ */
+	public function testGetMockForModelWithPlugin() {
+
+		$TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComment');
+
+		$result = ClassRegistry::init('TestPlugin.TestPluginComment');
+		$this->assertInstanceOf('TestPluginComment', $result);
+
+		$TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComment', array('save'));
+
+		$this->assertInstanceOf('TestPluginComment', $TestPluginComment);
+		$TestPluginComment->expects($this->at(0))
+			->method('save')
+			->will($this->returnValue(true));
+		$TestPluginComment->expects($this->at(1))
+			->method('save')
+			->will($this->returnValue(false));
+		$this->assertTrue($TestPluginComment->save(array()));
+		$this->assertFalse($TestPluginComment->save(array()));
+	}
 }

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -676,4 +676,23 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 	}
 	// @codingStandardsIgnoreStop
 
+/**
+ * Mock a model, maintain fixtures and table association
+ *
+ * @param string $model
+ * @param mixed $methods
+ * @return Model
+ */
+	public function getMockForModel($model, $methods = array(), $config = null) {
+		if (is_null($config)) {
+			$config = ClassRegistry::config('Model');
+		}
+
+		list($plugin, $name) = pluginSplit($model);
+		$config = array_merge((array) $config, array('name' => $name));
+		$mock = $this->getMock($name, $methods, array($config));
+		ClassRegistry::removeObject($name);
+		ClassRegistry::addObject($name, $mock);
+		return $mock;
+	}
 }

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -342,12 +342,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 			if ($methods === true) {
 				$methods = array();
 			}
-			ClassRegistry::init($model);
-			list($plugin, $name) = pluginSplit($model);
-			$config = array_merge((array)$config, array('name' => $model));
-			$_model = $this->getMock($name, $methods, array($config));
-			ClassRegistry::removeObject($name);
-			ClassRegistry::addObject($name, $_model);
+			$this->getMockForModel($model, $methods, $config);
 		}
 
 		foreach ($mocks['components'] as $component => $methods) {


### PR DESCRIPTION
This method provides a convenience to create mocked models that
are still associated with fixtures and the datasource.

Corresponding ticket at [http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3364-feature-request-convenience-method-for-getting-model-mocks]
