### PR TITLE
asserting that tree behavior generates valid sql in recover

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -107,7 +107,7 @@ class TreeBehavior extends ModelBehavior {
  * @return array
  */
 	public function beforeFind(Model $Model, $query) {
-		if ($Model->findQueryType == 'threaded' && !isset($query['parent'])) {
+		if ($Model->findQueryType === 'threaded' && !isset($query['parent'])) {
 			$query['parent'] = $this->settings[$Model->alias]['parent'];
 		}
 		return $query;
@@ -602,7 +602,7 @@ class TreeBehavior extends ModelBehavior {
 		}
 		extract($this->settings[$Model->alias]);
 		$Model->recursive = $recursive;
-		if ($mode == 'parent') {
+		if ($mode === 'parent') {
 			$Model->bindModel(array('belongsTo' => array('VerifyParent' => array(
 				'className' => $Model->name,
 				'foreignKey' => $parent,
@@ -616,13 +616,13 @@ class TreeBehavior extends ModelBehavior {
 			));
 			$Model->unbindModel(array('belongsTo' => array('VerifyParent')));
 			if ($missingParents) {
-				if ($missingParentAction == 'return') {
+				if ($missingParentAction === 'return') {
 					foreach ($missingParents as $id => $display) {
 						$this->errors[]	= 'cannot find the parent for ' . $Model->alias . ' with id ' . $id . '(' . $display . ')';
 					}
 					return false;
-				} elseif ($missingParentAction == 'delete') {
-					$Model->deleteAll(array($Model->primaryKey => array_flip($missingParents)));
+				} elseif ($missingParentAction === 'delete') {
+					$Model->deleteAll(array($Model->alias . '.' . $Model->primaryKey => array_flip($missingParents)));
 				} else {
 					$Model->updateAll(array($parent => $missingParentAction), array($Model->escapeField($Model->primaryKey) => array_flip($missingParents)));
 				}
@@ -986,14 +986,14 @@ class TreeBehavior extends ModelBehavior {
 		extract($this->settings[$Model->alias]);
 		$Model->recursive = $recursive;
 
-		if ($field == 'both') {
+		if ($field === 'both') {
 			$this->_sync($Model, $shift, $dir, $conditions, $created, $left);
 			$field = $right;
 		}
 		if (is_string($conditions)) {
 			$conditions = array($Model->escapeField($field) . " {$conditions}");
 		}
-		if (($scope != '1 = 1' && $scope !== true) && $scope) {
+		if (($scope !== '1 = 1' && $scope !== true) && $scope) {
 			$conditions[] = $scope;
 		}
 		if ($created) {

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -622,9 +622,9 @@ class TreeBehavior extends ModelBehavior {
 					}
 					return false;
 				} elseif ($missingParentAction === 'delete') {
-					$Model->deleteAll(array($Model->alias . '.' . $Model->primaryKey => array_flip($missingParents)));
+					$Model->deleteAll(array($Model->escapeField($Model->primaryKey) => array_flip($missingParents)), false);
 				} else {
-					$Model->updateAll(array($parent => $missingParentAction), array($Model->escapeField($Model->primaryKey) => array_flip($missingParents)));
+					$Model->updateAll(array($Model->escapeField($parent) => $missingParentAction), array($Model->escapeField($Model->primaryKey) => array_flip($missingParents)));
 				}
 			}
 			$count = 1;

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -184,7 +184,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->Behaviors->disable('Tree');
 
 		$this->Tree->save(array('parent_id' => null, 'name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
-		$node1	= $this->Tree->id;
+		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
 		$this->Tree->save(array('parent_id' => null, 'name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
@@ -207,6 +207,65 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$result = $this->Tree->verify();
 		$this->assertTrue($result);
+
+		$result = $this->Tree->find('first', array(
+			'fields' => array('name', $parentField, $leftField, $rightField),
+			'conditions' => array('name' => 'Main'),
+			'recursive' => -1
+		));
+		$expected = array(
+			$modelClass => array(
+				'name' => 'Main',
+				$parentField => null,
+				$leftField => 1,
+				$rightField => 10
+			)
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testRecoverUsingParentModeAndDelete method
+ *
+ * @return void
+ */
+	public function testRecoverUsingParentModeAndDelete() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->Behaviors->disable('Tree');
+
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
+		$node1 = $this->Tree->id;
+
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$node11	= $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$node12	= $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
+		$this->Tree->create();
+		$this->Tree->save(array('parent_id' => null, 'name' => 'Lost', $parentField => 9, $leftField => 0, $rightField => 0));
+
+		$this->Tree->Behaviors->enable('Tree');
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$count = $this->Tree->find('count');
+		$this->assertEquals(6, $count);
+
+		$result = $this->Tree->recover('parent', 'delete');
+		$this->assertTrue($result);
+
+		$result = $this->Tree->verify();
+		$this->assertTrue($result);
+
+		$count = $this->Tree->find('count');
+		$this->assertEquals(5, $count);
 
 		$result = $this->Tree->find('first', array(
 			'fields' => array('name', $parentField, $leftField, $rightField),

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -188,10 +188,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
-		$node11	= $this->Tree->id;
+		$node11 = $this->Tree->id;
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
-		$node12	= $this->Tree->id;
+		$node12 = $this->Tree->id;
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
 		$this->Tree->create();
@@ -239,10 +239,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
-		$node11	= $this->Tree->id;
+		$node11 = $this->Tree->id;
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
-		$node12	= $this->Tree->id;
+		$node12 = $this->Tree->id;
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
 		$this->Tree->create();

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -183,19 +183,19 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree = new $modelClass();
 		$this->Tree->Behaviors->disable('Tree');
 
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
 		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node11	= $this->Tree->id;
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node12	= $this->Tree->id;
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
 
 		$this->Tree->Behaviors->enable('Tree');
 
@@ -234,23 +234,32 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree = new $modelClass();
 		$this->Tree->Behaviors->disable('Tree');
 
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
 		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node11	= $this->Tree->id;
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node12	= $this->Tree->id;
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
 		$this->Tree->create();
-		$this->Tree->save(array('parent_id' => null, 'name' => 'Lost', $parentField => 9, $leftField => 0, $rightField => 0));
+		$this->Tree->save(array('name' => 'Lost', $parentField => 9, $leftField => 0, $rightField => 0));
 
 		$this->Tree->Behaviors->enable('Tree');
+
+		$this->Tree->bindModel(array('belongsTo' => array('Parent' => array(
+			'className' => $this->Tree->name,
+			'foreignKey' => $parentField
+		))));
+		$this->Tree->bindModel(array('hasMany' => array('Child' => array(
+			'className' => $this->Tree->name,
+			'foreignKey' => $parentField
+		))));
 
 		$result = $this->Tree->verify();
 		$this->assertNotSame($result, true);


### PR DESCRIPTION
`$Model->alias . '.' . $Model->primaryKey` should better be used to avoid invalid sql statements

see http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3366-treebehavior-recover-invalid-sql
