### PR TITLE
Allow $options['fieldList'] to be mangled/modified inside beforeValidate().

### DIFF
--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -247,7 +247,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  * @see ModelValidator::validates()
  */
 	public function errors($options = array()) {
-		if (!$this->_triggerBeforeValidate($options)) {
+		if (!$this->_triggerBeforeValidate(&$options)) {
 			return false;
 		}
 		$model = $this->getModel();
@@ -464,7 +464,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  */
 	protected function _triggerBeforeValidate($options = array()) {
 		$model = $this->getModel();
-		$event = new CakeEvent('Model.beforeValidate', $model, array($options));
+		$event = new CakeEvent('Model.beforeValidate', $model, array(&$options));
 		list($event->break, $event->breakOn) = array(true, false);
 		$model->getEventManager()->dispatch($event);
 		if ($event->isStopped()) {


### PR DESCRIPTION
Right now, `ModelValidator::errors()` triggers `ModelValidator::_triggerBeforeValidate()` with a copy of `$options`.

Later, `ModelValidator::_triggerBeforeValidate()` dispatches an event with those options, but if modified inside `Model::beforeValidate()` they are never updated inside `ModelValidator::errors()`, where actual validation occurs.

This is handy when needing to update $fieldList _after_ a `Model::save()` is triggered.
