### PR TITLE
Make phpcs pass

### DIFF
--- a/lib/Cake/Console/Command/ConsoleShell.php
+++ b/lib/Cake/Console/Command/ConsoleShell.php
@@ -238,7 +238,9 @@ class ConsoleShell extends AppShell {
 
 					if ($this->_isValidModel($modelToCheck)) {
 						$findCommand = "\$data = \$this->$command;";
+						//@codingStandardsIgnoreStart
 						@eval($findCommand);
+						//@codingStandardsIgnoreEnd
 
 						if (is_array($data)) {
 							foreach ($data as $idx => $results) {
@@ -294,7 +296,9 @@ class ConsoleShell extends AppShell {
 						list($foo, $data) = explode("->save", $command);
 						$data = preg_replace('/^\(*(array)?\(*(.+?)\)*$/i', '\\2', $data);
 						$saveCommand = "\$this->{$modelToSave}->save(array('{$modelToSave}' => array({$data})));";
+						//@codingStandardsIgnoreStart
 						@eval($saveCommand);
+						//@codingStandardsIgnoreEnd
 						$this->out(__d('cake_console', 'Saved record for %s', $modelToSave));
 					}
 				break;
@@ -304,7 +308,9 @@ class ConsoleShell extends AppShell {
 					if ($this->_isValidModel($modelToCheck)) {
 						// Get the column info for this model
 						$fieldsCommand = "\$data = \$this->{$modelToCheck}->getColumnTypes();";
+						//@codingStandardsIgnoreStart
 						@eval($fieldsCommand);
+						//@codingStandardsIgnoreEnd
 
 						if (is_array($data)) {
 							foreach ($data as $field => $type) {
@@ -326,7 +332,9 @@ class ConsoleShell extends AppShell {
 					$this->out(print_r(Hash::combine(Router::$routes, '{n}.template', '{n}.defaults'), true));
 				break;
 				case (preg_match("/^route\s+(\(.*\))$/i", $command, $tmp) == true):
+					//@codingStandardsIgnoreStart
 					if ($url = eval('return array' . $tmp[1] . ';')) {
+						//@codingStandardsIgnoreEnd
 						$this->out(Router::url($url));
 					}
 				break;
@@ -362,7 +370,9 @@ class ConsoleShell extends AppShell {
 		Router::reload();
 		extract(Router::getNamedExpressions());
 
+		//@codingStandardsIgnoreStart
 		if (!@include APP . 'Config' . DS . 'routes.php') {
+			//@codingStandardsIgnoreEnd
 			return false;
 		}
 		CakePlugin::routes();

--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -78,7 +78,6 @@ class TemplateTask extends AppShell {
 
 		$paths[] = $core;
 
-		// TEMPORARY TODO remove when all paths are DS terminated
 		foreach ($paths as $i => $path) {
 			$paths[$i] = rtrim($path, DS) . DS;
 		}

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -686,7 +686,9 @@ class Shell extends Object {
 	protected function _checkUnitTest() {
 		if (class_exists('PHPUnit_Framework_TestCase')) {
 			return true;
+			//@codingStandardsIgnoreStart
 		} elseif (@include 'PHPUnit' . DS . 'Autoload.php') {
+			//@codingStandardsIgnoreEnd
 			return true;
 		} elseif (App::import('Vendor', 'phpunit', array('file' => 'PHPUnit' . DS . 'Autoload.php'))) {
 			return true;

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -755,7 +755,7 @@ class Controller extends Object implements CakeEventListener {
 			extract($status, EXTR_OVERWRITE);
 		}
 		$event = new CakeEvent('Controller.beforeRedirect', $this, array($url, $status, $exit));
-		//TODO: Remove the following line when the events are fully migrated to the CakeEventManager
+
 		list($event->break, $event->breakOn, $event->collectReturn) = array(true, false, true);
 		$this->getEventManager()->dispatch($event);
 

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -224,9 +224,11 @@ class MissingControllerException extends CakeException {
 
 	protected $_messageTemplate = 'Controller class %s could not be found.';
 
+//@codingStandardsIgnoreStart
 	public function __construct($message, $code = 404) {
 		parent::__construct($message, $code);
 	}
+//@codingStandardsIgnoreEnd
 
 }
 
@@ -240,9 +242,11 @@ class MissingActionException extends CakeException {
 
 	protected $_messageTemplate = 'Action %s::%s() could not be found.';
 
+//@codingStandardsIgnoreStart
 	public function __construct($message, $code = 404) {
 		parent::__construct($message, $code);
 	}
+//@codingStandardsIgnoreEnd
 
 }
 
@@ -256,9 +260,11 @@ class PrivateActionException extends CakeException {
 
 	protected $_messageTemplate = 'Private Action %s::%s() is not directly accessible.';
 
+//@codingStandardsIgnoreStart
 	public function __construct($message, $code = 404, Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
+//@codingStandardsIgnoreEnd
 
 }
 
@@ -572,8 +578,10 @@ class NotImplementedException extends CakeException {
 
 	protected $_messageTemplate = '%s is not implemented.';
 
+//@codingStandardsIgnoreStart
 	public function __construct($message, $code = 501) {
 		parent::__construct($message, $code);
 	}
+//@codingStandardsIgnoreEnd
 
 }

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -987,7 +987,6 @@ class Multibyte {
  * @param string $charset charset to use for encoding. defaults to UTF-8
  * @param string $newline
  * @return string
- * @TODO: add support for 'Q'('Quoted Printable') encoding
  */
 	public static function mimeEncode($string, $charset = null, $newline = "\r\n") {
 		if (!Multibyte::checkMultibyte($string) && strlen($string) < 75) {

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -588,7 +588,6 @@ class TreeBehavior extends ModelBehavior {
  * 'parent' the values of the parent_id field will be used to populate the left and right fields. The missingParentAction
  * parameter only applies to "parent" mode and determines what to do if the parent field contains an id that is not present.
  *
- * @todo Could be written to be faster, *maybe*. Ideally using a subquery and putting all the logic burden on the DB.
  * @param Model $Model Model instance
  * @param string $mode parent or tree
  * @param string|integer $missingParentAction 'return' to do nothing and return, 'delete' to

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -55,7 +55,6 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
 /**
  * Attaches a model object and loads a list of behaviors
  *
- * @todo Make this method a constructor instead..
  * @param string $modelName
  * @param array $behaviors
  * @return void

--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -322,7 +322,6 @@ class DataSource extends Object {
  * @param Model $linkModel Instance of model to replace $__cakeForeignKey__$
  * @param array $stack
  * @return string String of query data with placeholders replaced.
- * @todo Remove and refactor $assocData, ensure uses of the method have the param removed too.
  */
 	public function insertQueryData($query, $data, $association, $assocData, Model $model, Model $linkModel, $stack) {
 		$keys = array('{$__cakeID__$}', '{$__cakeForeignKey__$}');

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -249,7 +249,9 @@ class Sqlite extends DboSource {
 
 		$col = strtolower(str_replace(')', '', $real));
 		$limit = null;
-		@list($col, $limit) = explode('(', $col);
+		if (strpos($col, '(') !== false) {
+			list($col, $limit) = explode('(', $col);
+		}
 
 		if (in_array($col, array('text', 'integer', 'float', 'boolean', 'timestamp', 'date', 'datetime', 'time'))) {
 			return $col;

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -146,7 +146,6 @@ class Permission extends AppModel {
 								return false;
 							case 0:
 								continue;
-							break;
 							case 1:
 								return true;
 						}

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -105,11 +105,13 @@ class CakeSocket {
 			$scheme = 'ssl://';
 		}
 
+		//@codingStandardsIgnoreStart
 		if ($this->config['persistent'] == true) {
 			$this->connection = @pfsockopen($scheme . $this->config['host'], $this->config['port'], $errNum, $errStr, $this->config['timeout']);
 		} else {
 			$this->connection = @fsockopen($scheme . $this->config['host'], $this->config['port'], $errNum, $errStr, $this->config['timeout']);
 		}
+		//@codingStandardsIgnoreEnd
 
 		if (!empty($errNum) || !empty($errStr)) {
 			$this->setLastError($errNum, $errStr);

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -63,9 +63,11 @@ class MailTransport extends AbstractTransport {
  * @return void
  */
 	protected function _mail($to, $subject, $message, $headers, $params = null) {
+		//@codingStandardsIgnoreStart
 		if (!@mail($to, $subject, $message, $headers, $params)) {
 			throw new SocketException(__d('cake_dev', 'Could not send email.'));
 		}
+		//@codingStandardsIgnoreEnd
 	}
 
 }

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -219,16 +219,12 @@ class HttpResponse implements ArrayAccess {
 
 			$chunkSize = 0;
 			$hexLength = 0;
-			$chunkExtensionName = '';
 			$chunkExtensionValue = '';
 			if (isset($match[0])) {
 				$chunkSize = $match[0];
 			}
 			if (isset($match[1])) {
 				$hexLength = $match[1];
-			}
-			if (isset($match[2])) {
-				$chunkExtensionName = $match[2];
 			}
 			if (isset($match[3])) {
 				$chunkExtensionValue = $match[3];
@@ -237,9 +233,6 @@ class HttpResponse implements ArrayAccess {
 			$body = substr($body, strlen($chunkSize));
 			$chunkLength = hexdec($hexLength);
 			$chunk = substr($body, 0, $chunkLength);
-			if (!empty($chunkExtensionName)) {
-				 // @todo See if there are popular chunk extensions we should implement
-			}
 			$decodedBody .= $chunk;
 			if ($chunkLength !== 0) {
 				$body = substr($body, $chunkLength + strlen("\r\n"));
@@ -291,7 +284,6 @@ class HttpResponse implements ArrayAccess {
  *
  * @param array $header Header array containing one ore more 'Set-Cookie' headers.
  * @return mixed Either false on no cookies, or an array of cookies received.
- * @todo Make this 100% RFC 2965 confirm
  */
 	public function parseCookies($header) {
 		$cookieHeader = $this->getHeader('Set-Cookie', $header);
@@ -334,7 +326,6 @@ class HttpResponse implements ArrayAccess {
  * @param string $token Token to unescape
  * @param array $chars
  * @return string Unescaped token
- * @todo Test $chars parameter
  */
 	protected function _unescapeToken($token, $chars = null) {
 		$regex = '/"([' . implode('', $this->_tokenEscapeChars(true, $chars)) . '])"/';
@@ -348,7 +339,6 @@ class HttpResponse implements ArrayAccess {
  * @param boolean $hex true to get them as HEX values, false otherwise
  * @param array $chars
  * @return array Escape chars
- * @todo Test $chars parameter
  */
 	protected function _tokenEscapeChars($hex = true, $chars = null) {
 		if (!empty($chars)) {

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -901,7 +901,6 @@ class HttpSocket extends CakeSocket {
  *
  * @param array $cookies Array of cookies to send with the request.
  * @return string Cookie header string to be sent with the request.
- * @todo Refactor token escape mechanism to be configurable
  */
 	public function buildCookies($cookies) {
 		$header = array();
@@ -917,7 +916,6 @@ class HttpSocket extends CakeSocket {
  * @param string $token Token to escape
  * @param array $chars
  * @return string Escaped token
- * @todo Test $chars parameter
  */
 	protected function _escapeToken($token, $chars = null) {
 		$regex = '/([' . implode('', $this->_tokenEscapeChars(true, $chars)) . '])/';
@@ -931,7 +929,6 @@ class HttpSocket extends CakeSocket {
  * @param boolean $hex true to get them as HEX values, false otherwise
  * @param array $chars
  * @return array Escape chars
- * @todo Test $chars parameter
  */
 	protected function _tokenEscapeChars($hex = true, $chars = null) {
 		if (!empty($chars)) {

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -282,7 +282,9 @@ class BasicsTest extends CakeTestCase {
 
 		$result = cache('basics_test');
 		$this->assertEquals('simple cache write', $result);
-		@unlink(CACHE . 'basics_test');
+		if (file_exists(CACHE . 'basics_test')) {
+			unlink(CACHE . 'basics_test');
+		}
 
 		cache('basics_test', 'expired', '+1 second');
 		sleep(2);
@@ -603,7 +605,9 @@ class BasicsTest extends CakeTestCase {
  * @return void
  */
 	public function testLogError() {
-		@unlink(LOGS . 'error.log');
+		if (file_exists(LOGS . 'error.log')) {
+			unlink(LOGS . 'error.log');
+		}
 
 		// disable stderr output for this test
 		if (CakeLog::stream('stderr')) {

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -111,9 +111,11 @@ class MemcacheEngineTest extends CakeTestCase {
 
 		foreach ($servers as $server) {
 			list($host, $port) = explode(':', $server);
+			//@codingStandardsIgnoreStart
 			if (!@$Memcache->connect($host, $port)) {
 				$available = false;
 			}
+			//@codingStandardsIgnoreEnd
 		}
 
 		$this->skipIf(!$available, 'Need memcache servers at ' . implode(', ', $servers) . ' to run this test.');

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -383,7 +383,9 @@ class ConfigureTest extends CakeTestCase {
 		$result = file_get_contents(TMP . 'config_test.php');
 		$this->assertContains('<?php', $result);
 		$this->assertContains('$config = ', $result);
-		@unlink(TMP . 'config_test.php');
+		if (file_exists(TMP . 'config_test.php')) {
+			unlink(TMP . 'config_test.php');
+		}
 	}
 
 /**
@@ -402,7 +404,9 @@ class ConfigureTest extends CakeTestCase {
 		$this->assertContains('Error', $result);
 		$this->assertNotContains('debug', $result);
 
-		@unlink(TMP . 'config_test.php');
+		if (file_exists(TMP . 'config_test.php')) {
+			unlink(TMP . 'config_test.php');
+		}
 	}
 
 }

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -124,7 +124,9 @@ class ErrorHandlerTest extends CakeTestCase {
 		$this->_restoreError = true;
 
 		ob_start();
+		//@codingStandardsIgnoreStart
 		@include 'invalid.file';
+		//@codingStandardsIgnoreEnd
 		$result = ob_get_clean();
 		$this->assertTrue(empty($result));
 	}
@@ -138,7 +140,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		Configure::write('debug', 0);
 		Configure::write('Error.trace', false);
 		if (file_exists(LOGS . 'debug.log')) {
-			@unlink(LOGS . 'debug.log');
+			unlink(LOGS . 'debug.log');
 		}
 
 		set_error_handler('ErrorHandler::handleError');
@@ -152,7 +154,9 @@ class ErrorHandlerTest extends CakeTestCase {
 			'/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (Notice|Debug): Notice \(8\): Undefined variable:\s+out in \[.+ line \d+\]$/',
 			$result[0]
 		);
-		@unlink(LOGS . 'debug.log');
+		if (file_exists(LOGS . 'debug.log')) {
+			unlink(LOGS . 'debug.log');
+		}
 	}
 
 /**
@@ -164,7 +168,7 @@ class ErrorHandlerTest extends CakeTestCase {
 		Configure::write('debug', 0);
 		Configure::write('Error.trace', true);
 		if (file_exists(LOGS . 'debug.log')) {
-			@unlink(LOGS . 'debug.log');
+			unlink(LOGS . 'debug.log');
 		}
 
 		set_error_handler('ErrorHandler::handleError');
@@ -179,7 +183,9 @@ class ErrorHandlerTest extends CakeTestCase {
 		);
 		$this->assertRegExp('/^Trace:/', $result[1]);
 		$this->assertRegExp('/^ErrorHandlerTest\:\:testHandleErrorLoggingTrace\(\)/', $result[2]);
-		@unlink(LOGS . 'debug.log');
+		if (file_exists(LOGS . 'debug.log')) {
+			unlink(LOGS . 'debug.log');
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -150,7 +150,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertEquals(array('file'), $result);
 
 		if (file_exists(LOGS . 'error.log')) {
-			@unlink(LOGS . 'error.log');
+			unlink(LOGS . 'error.log');
 		}
 		CakeLog::write(LOG_WARNING, 'Test warning');
 		$this->assertTrue(file_exists(LOGS . 'error.log'));

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -66,15 +66,12 @@ class TestBehavior extends ModelBehavior {
 		switch ($settings['beforeFind']) {
 			case 'on':
 				return false;
-			break;
 			case 'test':
 				return null;
-			break;
 			case 'modify':
 				$query['fields'] = array($model->alias . '.id', $model->alias . '.name', $model->alias . '.mytime');
 				$query['recursive'] = -1;
 				return $query;
-			break;
 		}
 	}
 
@@ -94,16 +91,12 @@ class TestBehavior extends ModelBehavior {
 		switch ($settings['afterFind']) {
 			case 'on':
 				return array();
-			break;
 			case 'test':
 				return true;
-			break;
 			case 'test2':
 				return null;
-			break;
 			case 'modify':
 				return Hash::extract($results, "{n}.{$model->alias}");
-			break;
 		}
 	}
 
@@ -121,14 +114,11 @@ class TestBehavior extends ModelBehavior {
 		switch ($settings['beforeSave']) {
 			case 'on':
 				return false;
-			break;
 			case 'test':
 				return true;
-			break;
 			case 'modify':
 				$model->data[$model->alias]['name'] .= ' modified before';
 				return true;
-			break;
 		}
 	}
 
@@ -157,7 +147,6 @@ class TestBehavior extends ModelBehavior {
 			break;
 			case 'test2':
 				return false;
-			break;
 			case 'modify':
 				$model->data[$model->alias]['name'] .= ' ' . $string;
 			break;
@@ -179,18 +168,14 @@ class TestBehavior extends ModelBehavior {
 			case 'on':
 				$model->invalidate('name');
 				return true;
-			break;
 			case 'test':
 				return null;
-			break;
 			case 'whitelist':
 				$this->_addToWhitelist($model, array('name'));
 				return true;
-			break;
 			case 'stop':
 				$model->invalidate('name');
 				return false;
-			break;
 		}
 	}
 
@@ -209,11 +194,9 @@ class TestBehavior extends ModelBehavior {
 		switch ($settings['afterValidate']) {
 			case 'on':
 				return false;
-			break;
 			case 'test':
 				$model->data = array('foo');
 				return true;
-			break;
 		}
 	}
 
@@ -232,17 +215,14 @@ class TestBehavior extends ModelBehavior {
 		switch ($settings['beforeDelete']) {
 			case 'on':
 				return false;
-			break;
 			case 'test':
 				return null;
-			break;
 			case 'test2':
 				echo 'beforeDelete success';
 				if ($cascade) {
 					echo ' (cascading) ';
 				}
 				return true;
-			break;
 		}
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -4054,7 +4054,6 @@ class ModelReadTest extends BaseModelTest {
 /**
  * testFindAllWithConditionInChildQuery
  *
- * @todo external conditions like this are going to need to be revisited at some point
  * @return void
  */
 	public function testFindAllWithConditionInChildQuery() {

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1551,7 +1551,6 @@ class HttpSocketTest extends CakeTestCase {
  * testBuildCookies method
  *
  * @return void
- * @todo Test more scenarios
  */
 	public function testBuildCookies() {
 		$cookies = array(

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1538,7 +1538,6 @@ class RouterTest extends CakeTestCase {
  * test url generation with legacy (1.2) style prefix routes.
  *
  * @return void
- * @todo Remove tests related to legacy style routes.
  * @see testUrlGenerationWithAutoPrefixes
  */
 	public function testUrlGenerationWithLegacyPrefixes() {

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -29,7 +29,9 @@ class JsEncodingObject {
 
 	protected $_title = 'Old thing';
 
+	//@codingStandardsIgnoreStart
 	private $__noshow = 'Never ever';
+	//@codingStandardsIgnoreEnd
 
 }
 
@@ -366,7 +368,9 @@ class JsHelperTest extends CakeTestCase {
 		$this->assertTrue(file_exists(WWW_ROOT . $filename[1]));
 		$contents = file_get_contents(WWW_ROOT . $filename[1]);
 		$this->assertRegExp('/one\s=\s1;\ntwo\s=\s2;/', $contents);
-		@unlink(WWW_ROOT . $filename[1]);
+		if (file_exists(WWW_ROOT . $filename[1])) {
+			unlink(WWW_ROOT . $filename[1]);
+		}
 
 		Configure::write('Cache.disable', true);
 		$this->Js->buffer('one = 1;');

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -279,7 +279,7 @@ class ScaffoldViewTest extends CakeTestCase {
 
 		$this->assertRegExp('/<h2>View Scaffold Mock<\/h2>/', $result);
 		$this->assertRegExp('/<dl>/', $result);
-		//TODO: add specific tests for fields.
+
 		$this->assertRegExp('/<a href="\/scaffold_users\/view\/1">1<\/a>/', $result); //belongsTo links
 		$this->assertRegExp('/<li><a href="\/scaffold_mock\/edit\/1">Edit Scaffold Mock<\/a>\s<\/li>/', $result);
 		$this->assertRegExp('/<a href="\#" onclick="if[^>]*>Delete Scaffold Mock<\/a>\s<\/li>/', $result);
@@ -370,7 +370,7 @@ class ScaffoldViewTest extends CakeTestCase {
 
 		$this->assertRegExp('/<h2>Scaffold Mock<\/h2>/', $result);
 		$this->assertRegExp('/<table cellpadding="0" cellspacing="0">/', $result);
-		//TODO: add testing for table generation
+
 		$this->assertRegExp('/<li><a href="\/admin\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
 
 		Configure::write('Routing.prefixes', $_backAdmin);
@@ -454,7 +454,7 @@ class ScaffoldViewTest extends CakeTestCase {
 
 		$this->assertRegExp('/<h2>Scaffold Mock<\/h2>/', $result);
 		$this->assertRegExp('/<table cellpadding="0" cellspacing="0">/', $result);
-		//TODO: add testing for table generation
+
 		$this->assertRegExp('/<li><a href="\/member\/scaffold_mock\/add">New Scaffold Mock<\/a><\/li>/', $result);
 
 		Configure::write('Routing.prefixes', $_backAdmin);

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -1101,7 +1101,9 @@ class ViewTest extends CakeTestCase {
 
 		$this->assertRegExp('/^some cacheText/', $result);
 
-		@unlink($path);
+		if (file_exists($path)) {
+			unlink($path);
+		}
 	}
 
 /**

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -674,6 +674,6 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 		}
 		return $condition;
 	}
-	// @codingStandardsIgnoreStop
+	// @codingStandardsIgnoreEnd
 
 }

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -82,7 +82,9 @@ class CakeTestSuiteCommand extends PHPUnit_TextUI_Command {
 			$result = $skeleton->generate(true);
 
 			if (!$result['incomplete']) {
+				//@codingStandardsIgnoreStart
 				eval(str_replace(array('<?php', '?>'), '', $result['code']));
+				//@codingStandardsIgnoreEnd
 				$suite = new PHPUnit_Framework_TestSuite(
 					$this->arguments['test'] . 'Test'
 				);

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -173,7 +173,7 @@ abstract class ControllerTestCase extends CakeTestCase {
  *
  * @var boolean
  */
-	private $__dirtyController = false;
+	protected $_dirtyController = false;
 
 /**
  * Used to enable calling ControllerTestCase::testAction() without the testing
@@ -252,7 +252,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 			$this->headers = Router::currentRoute()->response->header();
 			return;
 		}
-		if ($this->__dirtyController) {
+		if ($this->_dirtyController) {
 			$this->controller = null;
 		}
 
@@ -275,7 +275,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 		if (isset($this->controller->View)) {
 			$this->view = $this->controller->View->fetch('__view_no_layout__');
 		}
-		$this->__dirtyController = true;
+		$this->_dirtyController = true;
 		$this->headers = $Dispatch->response->header();
 
 		$_GET = $restore['get'];
@@ -371,7 +371,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 		}
 
 		$_controller->constructClasses();
-		$this->__dirtyController = false;
+		$this->_dirtyController = false;
 
 		$this->controller = $_controller;
 		return $this->controller;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -395,7 +395,10 @@ class Debugger {
 		if (!file_exists($file)) {
 			return array();
 		}
-		$data = @explode("\n", file_get_contents($file));
+		$data = file_get_contents($file);
+		if (!empty($data) && strpos($data, "\n") !== false) {
+			$data = explode("\n", $data);
+		}
 
 		if (empty($data) || !isset($data[$line])) {
 			return;

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -354,7 +354,9 @@ class Folder {
 		}
 
 		if ($recursive === false && is_dir($path)) {
+			//@codingStandardsIgnoreStart
 			if (@chmod($path, intval($mode, 8))) {
+				//@codingStandardsIgnoreEnd
 				$this->_messages[] = __d('cake_dev', '%s changed to %s', $path, $mode);
 				return true;
 			}
@@ -375,7 +377,9 @@ class Folder {
 						continue;
 					}
 
+					//@codingStandardsIgnoreStart
 					if (@chmod($fullpath, intval($mode, 8))) {
+						//@codingStandardsIgnoreEnd
 						$this->_messages[] = __d('cake_dev', '%s changed to %s', $fullpath, $mode);
 					} else {
 						$this->_errors[] = __d('cake_dev', '%s NOT changed to %s', $fullpath, $mode);
@@ -559,13 +563,17 @@ class Folder {
 			foreach ($iterator as $item) {
 				$filePath = $item->getPathname();
 				if ($item->isFile() || $item->isLink()) {
+					//@codingStandardsIgnoreStart
 					if (@unlink($filePath)) {
+						//@codingStandardsIgnoreEnd
 						$this->_messages[] = __d('cake_dev', '%s removed', $filePath);
 					} else {
 						$this->_errors[] = __d('cake_dev', '%s NOT removed', $filePath);
 					}
 				} elseif ($item->isDir() && !$item->isDot()) {
+					//@codingStandardsIgnoreStart
 					if (@rmdir($filePath)) {
+						//@codingStandardsIgnoreEnd
 						$this->_messages[] = __d('cake_dev', '%s removed', $filePath);
 					} else {
 						$this->_errors[] = __d('cake_dev', '%s NOT removed', $filePath);
@@ -575,7 +583,9 @@ class Folder {
 			}
 
 			$path = rtrim($path, DS);
+			//@codingStandardsIgnoreStart
 			if (@rmdir($path)) {
+				//@codingStandardsIgnoreEnd
 				$this->_messages[] = __d('cake_dev', '%s removed', $path);
 			} else {
 				$this->_errors[] = __d('cake_dev', '%s NOT removed', $path);
@@ -629,7 +639,9 @@ class Folder {
 		}
 
 		$exceptions = array_merge(array('.', '..', '.svn'), $options['skip']);
+		//@codingStandardsIgnoreStart
 		if ($handle = @opendir($fromDir)) {
+			//@codingStandardsIgnoreEnd
 			while (false !== ($item = readdir($handle))) {
 				if (!in_array($item, $exceptions)) {
 					$from = Folder::addPathElement($fromDir, $item);

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -103,7 +103,7 @@ abstract class ObjectCollection {
 			if (empty($event->omitSubject)) {
 				$subject = $event->subject();
 			}
-			//TODO: Temporary BC check, while we move all the triggers system into the CakeEventManager
+
 			foreach (array('break', 'breakOn', 'collectReturn', 'modParams') as $opt) {
 				if (isset($event->{$opt})) {
 					$options[$opt] = $event->{$opt};

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -64,7 +64,6 @@ class Security {
  *
  * @param string $authKey Authorization hash
  * @return boolean Success
- * @todo Complete implementation
  */
 	public static function validateAuthKey($authKey) {
 		return true;

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -340,20 +340,26 @@ class Helper extends Object {
 			$filepath = preg_replace('/^' . preg_quote($this->request->webroot, '/') . '/', '', $path);
 			$webrootPath = WWW_ROOT . str_replace('/', DS, $filepath);
 			if (file_exists($webrootPath)) {
+				//@codingStandardsIgnoreStart
 				return $path . '?' . @filemtime($webrootPath);
+				//@codingStandardsIgnoreEnd
 			}
 			$segments = explode('/', ltrim($filepath, '/'));
 			if ($segments[0] === 'theme') {
 				$theme = $segments[1];
 				unset($segments[0], $segments[1]);
 				$themePath = App::themePath($theme) . 'webroot' . DS . implode(DS, $segments);
+				//@codingStandardsIgnoreStart
 				return $path . '?' . @filemtime($themePath);
+				//@codingStandardsIgnoreEnd
 			} else {
 				$plugin = Inflector::camelize($segments[0]);
 				if (CakePlugin::loaded($plugin)) {
 					unset($segments[0]);
 					$pluginPath = CakePlugin::path($plugin) . 'webroot' . DS . implode(DS, $segments);
+					//@codingStandardsIgnoreStart
 					return $path . '?' . @filemtime($pluginPath);
+					//@codingStandardsIgnoreEnd
 				}
 			}
 		}

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -599,7 +599,6 @@ class Helper extends Object {
  * @param string $id The name of the 'id' attribute.
  * @return mixed If $options was an array, an array will be returned with $id set.  If a string
  *   was supplied, a string will be returned.
- * @todo Refactor this method to not have as many input/output options.
  */
 	public function domId($options = null, $id = 'id') {
 		if (is_array($options) && array_key_exists($id, $options) && $options[$id] === null) {
@@ -632,7 +631,6 @@ class Helper extends Object {
  * @param string $key The name of the attribute to be set, defaults to 'name'
  * @return mixed If an array was given for $options, an array with $key set will be returned.
  *   If a string was supplied a string will be returned.
- * @todo Refactor this method to not have as many input/output options.
  */
 	protected function _name($options = array(), $field = null, $key = 'name') {
 		if ($options === null) {
@@ -676,7 +674,6 @@ class Helper extends Object {
  * @param string $key The name of the attribute to be set, defaults to 'value'
  * @return mixed If an array was given for $options, an array with $key set will be returned.
  *   If a string was supplied a string will be returned.
- * @todo Refactor this method to not have as many input/output options.
  */
 	public function value($options = array(), $field = null, $key = 'value') {
 		if ($options === null) {

--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -101,7 +101,9 @@ class MediaView extends View {
 
 		if ($this->_isActive()) {
 			$extension = strtolower($extension);
+			//@codingStandardsIgnoreStart
 			$fileSize = @filesize($path);
+			//@codingStandardsIgnoreEnd
 			$handle = fopen($path, 'rb');
 
 			if ($handle === false) {
@@ -220,7 +222,9 @@ class MediaView extends View {
  * @return boolean
  */
 	protected function _clearBuffer() {
+		//@codingStandardsIgnoreStart
 		return @ob_end_clean();
+		//@codingStandardsIgnoreEnd
 	}
 
 /**
@@ -229,8 +233,10 @@ class MediaView extends View {
  * @return void
  */
 	protected function _flushBuffer() {
+		//@codingStandardsIgnoreStart
 		@flush();
 		@ob_flush();
+		//@codingStandardsIgnoreEnd
 	}
 
 }

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -885,7 +885,7 @@ class View extends Object {
 		$this->getEventManager()->dispatch(new CakeEvent('View.beforeRenderFile', $this, array($viewFile)));
 		$content = $this->_evaluate($viewFile, $data);
 		$afterEvent = new CakeEvent('View.afterRenderFile', $this, array($viewFile, $content));
-		//TODO: For BC puporses, set extra info in the event object. Remove when appropriate
+
 		$afterEvent->modParams = 1;
 		$this->getEventManager()->dispatch($afterEvent);
 		$content = $afterEvent->data[1];

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -562,7 +562,9 @@ class View extends Object {
 
 		if (preg_match('/^<!--cachetime:(\\d+)-->/', $out, $match)) {
 			if (time() >= $match['1']) {
+				//@codingStandardsIgnoreStart
 				@unlink($filename);
+				//@codingStandardsIgnoreEnd
 				unset ($out);
 				return false;
 			} else {

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -311,13 +311,10 @@ function env($key) {
 				$offset = 4;
 			}
 			return substr($filename, 0, -(strlen($name) + $offset));
-			break;
 		case 'PHP_SELF':
 			return str_replace(env('DOCUMENT_ROOT'), '', env('SCRIPT_FILENAME'));
-			break;
 		case 'CGI_MODE':
 			return (PHP_SAPI === 'cgi');
-			break;
 		case 'HTTP_BASE':
 			$host = env('HTTP_HOST');
 			$parts = explode('.', $host);
@@ -357,7 +354,6 @@ function env($key) {
 			}
 			array_shift($parts);
 			return '.' . implode('.', $parts);
-			break;
 	}
 	return null;
 }

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -397,19 +397,27 @@ function cache($path, $data = null, $expires = '+1 day', $target = 'cache') {
 	$filetime = false;
 
 	if (file_exists($filename)) {
+		//@codingStandardsIgnoreStart
 		$filetime = @filemtime($filename);
+		//@codingStandardsIgnoreEnd
 	}
 
 	if ($data === null) {
 		if (file_exists($filename) && $filetime !== false) {
 			if ($filetime + $timediff < $now) {
+				//@codingStandardsIgnoreStart
 				@unlink($filename);
+				//@codingStandardsIgnoreEnd
 			} else {
+				//@codingStandardsIgnoreStart
 				$data = @file_get_contents($filename);
+				//@codingStandardsIgnoreEnd
 			}
 		}
 	} elseif (is_writable(dirname($filename))) {
+		//@codingStandardsIgnoreStart
 		@file_put_contents($filename, $data, LOCK_EX);
+		//@codingStandardsIgnoreEnd
 	}
 	return $data;
 }
@@ -430,7 +438,9 @@ function clearCache($params = null, $type = 'views', $ext = '.php') {
 		$cache = CACHE . $type . DS . $params;
 
 		if (is_file($cache . $ext)) {
+			//@codingStandardsIgnoreStart
 			@unlink($cache . $ext);
+			//@codingStandardsIgnoreEnd
 			return true;
 		} elseif (is_dir($cache)) {
 			$files = glob($cache . '*');
@@ -441,7 +451,9 @@ function clearCache($params = null, $type = 'views', $ext = '.php') {
 
 			foreach ($files as $file) {
 				if (is_file($file) && strrpos($file, DS . 'empty') !== strlen($file) - 6) {
+					//@codingStandardsIgnoreStart
 					@unlink($file);
+					//@codingStandardsIgnoreEnd
 				}
 			}
 			return true;
@@ -462,7 +474,9 @@ function clearCache($params = null, $type = 'views', $ext = '.php') {
 			}
 			foreach ($files as $file) {
 				if (is_file($file) && strrpos($file, DS . 'empty') !== strlen($file) - 6) {
+					//@codingStandardsIgnoreStart
 					@unlink($file);
+					//@codingStandardsIgnoreEnd
 				}
 			}
 			return true;


### PR DESCRIPTION
Added ignores, changed code where possible.
Removed all TODO, i will create lighthouse tickets for all these todos instead.

Once latest changes in cakephp sniff repo will get a new pear release, the remaining errors/warnings will be gone as well., see: https://travis-ci.org/ceeram/cakephp/jobs/3195871

We can then make travis fail when changes introduce new phpcs violations, currently it is allowed to fail and not break the build.
