### PR TITLE
upgrade shell: attempt at making --plugin param actually work.

### DIFF
--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -103,7 +103,7 @@ class UpgradeShell extends AppShell {
 	public function tests() {
 		$this->_paths = array(APP . 'tests' . DS);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']) . 'tests' . DS);
+			$this->_paths = array($this->_pluginPath($this->params['plugin']) . 'tests' . DS);
 		}
 		$patterns = array(
 			array(
@@ -129,7 +129,7 @@ class UpgradeShell extends AppShell {
 		$cwd = getcwd();
 
 		if (!empty($this->params['plugin'])) {
-			chdir(App::pluginPath($this->params['plugin']));
+			chdir($this->_pluginPath($this->params['plugin']));
 		}
 
 		if (is_dir('plugins')) {
@@ -216,7 +216,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_diff(App::path('views'), App::core('views'));
 
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']) . 'views' . DS);
+			$this->_paths = array($this->_pluginPath($this->params['plugin']) . 'views' . DS);
 		}
 
 		$patterns = array();
@@ -230,7 +230,7 @@ class UpgradeShell extends AppShell {
 			CakePlugin::load($plugin);
 			$pluginHelpers = array_merge(
 				$pluginHelpers,
-				App::objects('helper', App::pluginPath($plugin) . DS . 'views' . DS . 'helpers' . DS, false)
+				App::objects('helper', $this->_pluginPath($plugin) . DS . 'views' . DS . 'helpers' . DS, false)
 			);
 		}
 		$helpers = array_merge($pluginHelpers, $helpers);
@@ -261,7 +261,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array($this->_pluginPath($this->params['plugin']));
 		}
 
 		$patterns = array(
@@ -300,7 +300,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array($this->_pluginPath($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -355,7 +355,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_merge($views, $controllers, $components);
 
 		if (!empty($this->params['plugin'])) {
-			$pluginPath = App::pluginPath($this->params['plugin']);
+			$pluginPath = $this->_pluginPath($this->params['plugin']);
 			$this->_paths = array(
 				$pluginPath . 'controllers' . DS,
 				$pluginPath . 'controllers' . DS . 'components' . DS,
@@ -407,7 +407,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array($this->_pluginPath($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -429,7 +429,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array($this->_pluginPath($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -511,7 +511,7 @@ class UpgradeShell extends AppShell {
 	public function components() {
 		$this->_paths = App::Path('Controller/Component');
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = App::Path('Controller/Component', $this->params['plugin']);
+			$this->_paths = $this->_pluginPath($this->params['plugin']) . 'controllers' . DS . 'components' . DS;
 		}
 		$patterns = array(
 			array(
@@ -536,7 +536,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_merge($controllers, $components);
 
 		if (!empty($this->params['plugin'])) {
-			$pluginPath = App::pluginPath($this->params['plugin']);
+			$pluginPath = $this->_pluginPath($this->params['plugin']);
 			$this->_paths = array(
 				$pluginPath . 'controllers' . DS,
 				$pluginPath . 'controllers' . DS . 'components' . DS,
@@ -859,3 +859,4 @@ class UpgradeShell extends AppShell {
 	}
 
 }
+


### PR DESCRIPTION
I am not entirely sure that this is a correct solution.

Current behavior is: when --plugin param is given, individual methods in UpgradeShell will call App::pluginPath() to determine plugin paths. This in turn calls CakePlugin::pluginPaths, which seems not to have been initialized and is probably looking for correctly-named plugins anyway. In either case it returns empty no matter how the files are named.

I replaced the call to App::pluginPath with a call to $this->_pluginPaths() from the Shell class, which also checks CakePlugin, but then defaults to the legacy path when that returns nothing. This method does not actually check whether the files exist, although is_dir is called a couple times in the upgrade shell and will return an error if the directory /plugins/pluginname does not exist.

I'm not sure, due to unfamiliarity with the shell code, how the shell classes are actually supposed to be loading plugins.
