### PR TITLE
2.3 unify object collection

### DIFF
--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -208,7 +208,7 @@ class CakeLog {
 		if (empty(self::$_Collection)) {
 			self::_init();
 		}
-		return self::$_Collection->attached();
+		return self::$_Collection->loaded();
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/TaskCollectionTest.php
+++ b/lib/Cake/Test/Case/Console/TaskCollectionTest.php
@@ -54,8 +54,8 @@ class TaskCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('DbConfigTask', $result);
 		$this->assertInstanceOf('DbConfigTask', $this->Tasks->DbConfig);
 
-		$result = $this->Tasks->attached();
-		$this->assertEquals(array('DbConfig'), $result, 'attached() results are wrong.');
+		$result = $this->Tasks->loaded();
+		$this->assertEquals(array('DbConfig'), $result, 'loaded() results are wrong.');
 	}
 
 /**
@@ -110,14 +110,14 @@ class TaskCollectionTest extends CakeTestCase {
 		$this->Tasks->load('Extract');
 		$this->Tasks->load('DbConfig');
 
-		$result = $this->Tasks->attached();
+		$result = $this->Tasks->loaded();
 		$this->assertEquals(array('Extract', 'DbConfig'), $result, 'loaded tasks is wrong');
 
 		$this->Tasks->unload('DbConfig');
 		$this->assertFalse(isset($this->Tasks->DbConfig));
 		$this->assertTrue(isset($this->Tasks->Extract));
 
-		$result = $this->Tasks->attached();
+		$result = $this->Tasks->loaded();
 		$this->assertEquals(array('Extract'), $result, 'loaded tasks is wrong');
 	}
 

--- a/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
@@ -59,8 +59,8 @@ class ComponentCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('CookieComponent', $result);
 		$this->assertInstanceOf('CookieComponent', $this->Components->Cookie);
 
-		$result = $this->Components->attached();
-		$this->assertEquals(array('Cookie'), $result, 'attached() results are wrong.');
+		$result = $this->Components->loaded();
+		$this->assertEquals(array('Cookie'), $result, 'loaded() results are wrong.');
 
 		$this->assertTrue($this->Components->enabled('Cookie'));
 
@@ -79,8 +79,8 @@ class ComponentCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('CookieAliasComponent', $this->Components->Cookie);
 		$this->assertTrue($this->Components->Cookie->settings['somesetting']);
 
-		$result = $this->Components->attached();
-		$this->assertEquals(array('Cookie'), $result, 'attached() results are wrong.');
+		$result = $this->Components->loaded();
+		$this->assertEquals(array('Cookie'), $result, 'loaded() results are wrong.');
 
 		$this->assertTrue($this->Components->enabled('Cookie'));
 
@@ -93,8 +93,8 @@ class ComponentCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('OtherComponent', $result);
 		$this->assertInstanceOf('OtherComponent', $this->Components->SomeOther);
 
-		$result = $this->Components->attached();
-		$this->assertEquals(array('Cookie', 'SomeOther'), $result, 'attached() results are wrong.');
+		$result = $this->Components->loaded();
+		$this->assertEquals(array('Cookie', 'SomeOther'), $result, 'loaded() results are wrong.');
 		App::build();
 		CakePlugin::unload();
 	}
@@ -148,14 +148,14 @@ class ComponentCollectionTest extends CakeTestCase {
 		$this->Components->load('Cookie');
 		$this->Components->load('Security');
 
-		$result = $this->Components->attached();
+		$result = $this->Components->loaded();
 		$this->assertEquals(array('Cookie', 'Security'), $result, 'loaded components is wrong');
 
 		$this->Components->unload('Cookie');
 		$this->assertFalse(isset($this->Components->Cookie));
 		$this->assertTrue(isset($this->Components->Security));
 
-		$result = $this->Components->attached();
+		$result = $this->Components->loaded();
 		$this->assertEquals(array('Security'), $result, 'loaded components is wrong');
 
 		$result = $this->Components->enabled();

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -440,10 +440,10 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testLoadDisabled() {
 		$Apple = new Apple();
-		$this->assertSame(array(), $Apple->Behaviors->attached());
+		$this->assertSame(array(), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->load('Translate', array('enabled' => false));
-		$this->assertTrue($Apple->Behaviors->attached('Translate'));
+		$this->assertTrue($Apple->Behaviors->loaded('Translate'));
 		$this->assertFalse($Apple->Behaviors->enabled('Translate'));
 	}
 
@@ -452,10 +452,10 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testLoadAlias() {
 		$Apple = new Apple();
-		$this->assertSame(array(), $Apple->Behaviors->attached());
+		$this->assertSame(array(), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->load('Test', array('className' => 'TestAlias', 'somesetting' => true));
-		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
+		$this->assertSame(array('Test'), $Apple->Behaviors->loaded());
 		$this->assertInstanceOf('TestAliasBehavior', $Apple->Behaviors->Test);
 		$this->assertTrue($Apple->Behaviors->Test->settings['Apple']['somesetting']);
 
@@ -468,8 +468,8 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertTrue($Apple->Behaviors->load('SomeOther', array('className' => 'TestPlugin.TestPluginPersisterOne')));
 		$this->assertInstanceOf('TestPluginPersisterOneBehavior', $Apple->Behaviors->SomeOther);
 
-		$result = $Apple->Behaviors->attached();
-		$this->assertEquals(array('Test', 'SomeOther'), $result, 'attached() results are wrong.');
+		$result = $Apple->Behaviors->loaded();
+		$this->assertEquals(array('Test', 'SomeOther'), $result, 'loaded() results are wrong.');
 		App::build();
 		CakePlugin::unload();
 	}
@@ -481,18 +481,18 @@ class BehaviorCollectionTest extends CakeTestCase {
  */
 	public function testBehaviorBinding() {
 		$Apple = new Apple();
-		$this->assertSame(array(), $Apple->Behaviors->attached());
+		$this->assertSame(array(), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->attach('Test', array('key' => 'value'));
-		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
+		$this->assertSame(array('Test'), $Apple->Behaviors->loaded());
 		$this->assertEquals('testbehavior', strtolower(get_class($Apple->Behaviors->Test)));
 		$expected = array('beforeFind' => 'on', 'afterFind' => 'off', 'key' => 'value');
 		$this->assertEquals($expected, $Apple->Behaviors->Test->settings['Apple']);
 		$this->assertEquals(array('Apple'), array_keys($Apple->Behaviors->Test->settings));
 
-		$this->assertSame($Apple->Sample->Behaviors->attached(), array());
+		$this->assertSame($Apple->Sample->Behaviors->loaded(), array());
 		$Apple->Sample->Behaviors->attach('Test', array('key2' => 'value2'));
-		$this->assertSame($Apple->Sample->Behaviors->attached(), array('Test'));
+		$this->assertSame($Apple->Sample->Behaviors->loaded(), array('Test'));
 		$this->assertEquals(array('beforeFind' => 'on', 'afterFind' => 'off', 'key2' => 'value2'), $Apple->Sample->Behaviors->Test->settings['Sample']);
 
 		$this->assertEquals(array('Apple', 'Sample'), array_keys($Apple->Behaviors->Test->settings));
@@ -548,17 +548,17 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEquals(array('Test'), $Apple->Behaviors->attached());
+		$this->assertEquals(array('Test'), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->detach('Plugin.Test');
-		$this->assertEquals(array(), $Apple->Behaviors->attached());
+		$this->assertEquals(array(), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->attach('Plugin.Test');
 		$this->assertTrue(isset($Apple->Behaviors->Test), 'Missing behavior');
-		$this->assertEquals(array('Test'), $Apple->Behaviors->attached());
+		$this->assertEquals(array('Test'), $Apple->Behaviors->loaded());
 
 		$Apple->Behaviors->detach('Test');
-		$this->assertEquals(array(), $Apple->Behaviors->attached());
+		$this->assertEquals(array(), $Apple->Behaviors->loaded());
 	}
 
 /**
@@ -586,7 +586,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');
-		$this->assertSame(array('Test'), $Apple->Behaviors->attached());
+		$this->assertSame(array('Test'), $Apple->Behaviors->loaded());
 		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Sample->Behaviors->attach('Test');
@@ -594,7 +594,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Behaviors->enable('Test');
-		$this->assertSame($Apple->Behaviors->attached('Test'), true);
+		$this->assertSame($Apple->Behaviors->loaded('Test'), true);
 		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -208,11 +208,11 @@ class ModelIntegrationTest extends BaseModelTest {
 	public function testDynamicBehaviorAttachment() {
 		$this->loadFixtures('Apple', 'Sample', 'Author');
 		$TestModel = new Apple();
-		$this->assertEquals(array(), $TestModel->Behaviors->attached());
+		$this->assertEquals(array(), $TestModel->Behaviors->loaded());
 
 		$TestModel->Behaviors->attach('Tree', array('left' => 'left_field', 'right' => 'right_field'));
 		$this->assertTrue(is_object($TestModel->Behaviors->Tree));
-		$this->assertEquals(array('Tree'), $TestModel->Behaviors->attached());
+		$this->assertEquals(array('Tree'), $TestModel->Behaviors->loaded());
 
 		$expected = array(
 			'parent' => 'parent_id',
@@ -227,10 +227,10 @@ class ModelIntegrationTest extends BaseModelTest {
 
 		$TestModel->Behaviors->attach('Tree', array('enabled' => false));
 		$this->assertEquals($expected, $TestModel->Behaviors->Tree->settings['Apple']);
-		$this->assertEquals(array('Tree'), $TestModel->Behaviors->attached());
+		$this->assertEquals(array('Tree'), $TestModel->Behaviors->loaded());
 
 		$TestModel->Behaviors->detach('Tree');
-		$this->assertEquals(array(), $TestModel->Behaviors->attached());
+		$this->assertEquals(array(), $TestModel->Behaviors->loaded());
 		$this->assertFalse(isset($TestModel->Behaviors->Tree));
 	}
 

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -131,8 +131,8 @@ class ObjectCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('FirstGenericObject', $result);
 		$this->assertInstanceOf('FirstGenericObject', $this->Objects->First);
 
-		$result = $this->Objects->attached();
-		$this->assertEquals(array('First'), $result, 'attached() results are wrong.');
+		$result = $this->Objects->loaded();
+		$this->assertEquals(array('First'), $result, 'loaded() results are wrong.');
 
 		$this->assertTrue($this->Objects->enabled('First'));
 
@@ -149,17 +149,17 @@ class ObjectCollectionTest extends CakeTestCase {
 		$this->Objects->load('First');
 		$this->Objects->load('Second');
 
-		$result = $this->Objects->attached();
+		$result = $this->Objects->loaded();
 		$this->assertEquals(array('First', 'Second'), $result, 'loaded objects are wrong');
 
 		$this->Objects->unload('First');
 		$this->assertFalse(isset($this->Objects->First));
 		$this->assertTrue(isset($this->Objects->Second));
 
-		$result = $this->Objects->attached();
+		$result = $this->Objects->loaded();
 		$this->assertEquals(array('Second'), $result, 'loaded objects are wrong');
 
-		$result = $this->Objects->enabled();
+		$result = $this->Objects->loaded();
 		$this->assertEquals(array('Second'), $result, 'enabled objects are wrong');
 	}
 
@@ -171,7 +171,7 @@ class ObjectCollectionTest extends CakeTestCase {
 	public function testSet() {
 		$this->Objects->load('First');
 
-		$result = $this->Objects->attached();
+		$result = $this->Objects->loaded();
 		$this->assertEquals(array('First'), $result, 'loaded objects are wrong');
 
 		$result = $this->Objects->set('First', new SecondGenericObject($this->Objects));

--- a/lib/Cake/Test/Case/View/HelperCollectionTest.php
+++ b/lib/Cake/Test/Case/View/HelperCollectionTest.php
@@ -61,8 +61,8 @@ class HelperCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('HtmlHelper', $result);
 		$this->assertInstanceOf('HtmlHelper', $this->Helpers->Html);
 
-		$result = $this->Helpers->attached();
-		$this->assertEquals(array('Html'), $result, 'attached() results are wrong.');
+		$result = $this->Helpers->loaded();
+		$this->assertEquals(array('Html'), $result, 'loaded() results are wrong.');
 
 		$this->assertTrue($this->Helpers->enabled('Html'));
 	}
@@ -106,8 +106,8 @@ class HelperCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('HtmlAliasHelper', $result);
 		$this->assertInstanceOf('HtmlAliasHelper', $this->Helpers->Html);
 
-		$result = $this->Helpers->attached();
-		$this->assertEquals(array('Html'), $result, 'attached() results are wrong.');
+		$result = $this->Helpers->loaded();
+		$this->assertEquals(array('Html'), $result, 'loaded() results are wrong.');
 
 		$this->assertTrue($this->Helpers->enabled('Html'));
 
@@ -120,8 +120,8 @@ class HelperCollectionTest extends CakeTestCase {
 		$this->assertInstanceOf('OtherHelperHelper', $result);
 		$this->assertInstanceOf('OtherHelperHelper', $this->Helpers->SomeOther);
 
-		$result = $this->Helpers->attached();
-		$this->assertEquals(array('Html', 'SomeOther'), $result, 'attached() results are wrong.');
+		$result = $this->Helpers->loaded();
+		$this->assertEquals(array('Html', 'SomeOther'), $result, 'loaded() results are wrong.');
 		App::build();
 	}
 
@@ -174,14 +174,14 @@ class HelperCollectionTest extends CakeTestCase {
 		$this->Helpers->load('Form');
 		$this->Helpers->load('Html');
 
-		$result = $this->Helpers->attached();
+		$result = $this->Helpers->loaded();
 		$this->assertEquals(array('Form', 'Html'), $result, 'loaded helpers is wrong');
 
 		$this->Helpers->unload('Html');
-		$this->assertNotContains('Html', $this->Helpers->attached());
-		$this->assertContains('Form', $this->Helpers->attached());
+		$this->assertNotContains('Html', $this->Helpers->loaded());
+		$this->assertContains('Form', $this->Helpers->loaded());
 
-		$result = $this->Helpers->attached();
+		$result = $this->Helpers->loaded();
 		$this->assertEquals(array('Form'), $result, 'loaded helpers is wrong');
 	}
 

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -937,7 +937,7 @@ class ViewTest extends CakeTestCase {
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
 
-		$attached = $View->Helpers->attached();
+		$attached = $View->Helpers->loaded();
 		$this->assertEquals(array('Session', 'Html', 'Form', 'Number'), $attached);
 
 		$this->PostsController->helpers = array('Html', 'Form', 'Number', 'TestPlugin.PluggedHelper');
@@ -946,7 +946,7 @@ class ViewTest extends CakeTestCase {
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
 
-		$attached = $View->Helpers->attached();
+		$attached = $View->Helpers->loaded();
 		$expected = array('Html', 'Form', 'Number', 'PluggedHelper');
 		$this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
 	}

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -58,7 +58,7 @@ class ControllerTestDispatcher extends Dispatcher {
 		$this->testController->helpers = array_merge(array('InterceptContent'), $this->testController->helpers);
 		$this->testController->setRequest($request);
 		$this->testController->response = $this->response;
-		foreach ($this->testController->Components->attached() as $component) {
+		foreach ($this->testController->Components->loaded() as $component) {
 			$object = $this->testController->Components->{$component};
 			if (isset($object->response)) {
 				$object->response = $response;

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -267,10 +267,10 @@ abstract class ObjectCollection {
 /**
  * Gets the list of attached objects, or, whether the given object is attached
  *
- * @param string $name Optional.  The name of the behavior to check the status of.  If omitted,
- *   returns an array of currently-attached behaviors
- * @return mixed If $name is specified, returns the boolean status of the corresponding behavior.
- *    Otherwise, returns an array of all attached behaviors.
+ * @param string $name Optional.  The name of the object to check the status of.  If omitted,
+ *   returns an array of currently-attached objects
+ * @return mixed If $name is specified, returns the boolean status of the corresponding object.
+ *    Otherwise, returns an array of all attached objects.
  * @deprecated Use loaded instead.
  */
 	public function attached($name = null) {
@@ -280,10 +280,10 @@ abstract class ObjectCollection {
 /**
  * Gets the list of loaded objects, or, whether the given object is loaded
  *
- * @param string $name Optional.  The name of the behavior to check the status of.  If omitted,
- *   returns an array of currently-loaded behaviors
- * @return mixed If $name is specified, returns the boolean status of the corresponding behavior.
- *    Otherwise, returns an array of all loaded behaviors.
+ * @param string $name Optional.  The name of the object to check the status of.  If omitted,
+ *   returns an array of currently-loaded objects
+ * @return mixed If $name is specified, returns the boolean status of the corresponding object.
+ *    Otherwise, returns an array of all loaded objects.
  */
 	public function loaded($name = null) {
 		if (!empty($name)) {

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -271,6 +271,19 @@ abstract class ObjectCollection {
  *   returns an array of currently-attached behaviors
  * @return mixed If $name is specified, returns the boolean status of the corresponding behavior.
  *    Otherwise, returns an array of all attached behaviors.
+ * @deprecated Use loaded instead.
+ */
+	public function attached($name = null) {
+		return $this->loaded($name);
+	}
+
+/**
+ * Gets the list of loaded objects, or, whether the given object is loaded
+ *
+ * @param string $name Optional.  The name of the behavior to check the status of.  If omitted,
+ *   returns an array of currently-loaded behaviors
+ * @return mixed If $name is specified, returns the boolean status of the corresponding behavior.
+ *    Otherwise, returns an array of all loaded behaviors.
  */
 	public function loaded($name = null) {
 		if (!empty($name)) {

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -272,7 +272,7 @@ abstract class ObjectCollection {
  * @return mixed If $name is specified, returns the boolean status of the corresponding behavior.
  *    Otherwise, returns an array of all attached behaviors.
  */
-	public function attached($name = null) {
+	public function loaded($name = null) {
 		if (!empty($name)) {
 			return isset($this->_loaded[$name]);
 		}


### PR DESCRIPTION
personally I liked attach/detach and attached() better - especially for behaviors.
but since the consensus was to deprecate attach/detach in favor of load/unload we should not keep attached() then either. it is confusing.

so we should deprecate it in favor of loaded().
