### PR TITLE
Update lib/Cake/View/Helper/FormHelper.php

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -955,6 +955,13 @@ class FormHelper extends AppHelper {
 				$options['type'] = 'checkbox';
 			} elseif ($fieldDef = $this->_introspectModel($modelKey, 'fields', $fieldKey)) {
 				$type = $fieldDef['type'];
+				if(substr($type,0,4)=='enum'){
+					$options['options']=explode("','",substr($type,6,strlen($type)-8));
+					if(count($options['options'])<=3)
+						$options['type'] = 'radio';
+					else
+						$options['type'] = 'select';
+				}
 				$primaryKey = $this->fieldset[$modelKey]['key'];
 			}
 


### PR DESCRIPTION
Added support for enum type
Upto 3 constants at enum type system will generate radio buttons for example most commonly used
gender enum('male','female')
for greater the HTML dropdown is applied
