### PR TITLE
add "bases" singular "basis" for prefixed bases

### DIFF
--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -103,6 +103,7 @@ class InflectorTest extends CakeTestCase {
 		$this->assertEquals(Inflector::singularize('colossuses'), 'colossus');
 		$this->assertEquals(Inflector::singularize('diagnoses'), 'diagnosis');
 		$this->assertEquals(Inflector::singularize('bases'), 'basis');
+		$this->assertEquals(Inflector::singularize('price_bases'), 'price_basis');
 		$this->assertEquals(Inflector::singularize('analyses'), 'analysis');
 		$this->assertEquals(Inflector::singularize('curves'), 'curve');
 		$this->assertEquals(Inflector::singularize('cafes'), 'cafe');

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -125,7 +125,7 @@ class Inflector {
 			'/(drive)s$/i' => '\1',
 			'/([^fo])ves$/i' => '\1fe',
 			'/(^analy)ses$/i' => '\1sis',
-			'/(analy|diagno|^ba|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
+			'/(analy|diagno|^ba|\_ba|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => '\1\2sis',
 			'/([ti])a$/i' => '\1um',
 			'/(p)eople$/i' => '\1\2erson',
 			'/(m)en$/i' => '\1an',


### PR DESCRIPTION
inflector seems to fail for prefixed strings and ^.

```
price_bases
```

would become

```
price_base
```

which should be `price_basis`, though.

we should add the _ version, as well, then
