### PR TITLE
fetchVirtualField for Oracle database

### DIFF
--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -410,10 +410,6 @@ class DboSource extends DataSource {
 		if ($this->execute($sql)) {
 			$out = array();
 
-			$first = $this->fetchRow();
-			if ($first != null) {
-				$out[] = $first;
-			}
 			while ($this->hasResult() && $item = $this->fetchResult()) {
 				$this->fetchVirtualField($item);
 				$out[] = $item;


### PR DESCRIPTION
fetchVirtualField is called from fecthRow for the first line and from fecthAll for the following lines

The problem is that the function fetchRow is redefined in db_oracle.php so fetchVirtualField is never call for the first returned line

The solution is to don't call for fetchRow in the fetchAll function of dbo_source.php
