### PR TITLE
Fix behavior of --plugin param in Shell

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -372,7 +372,7 @@ class Shell extends Object {
 		if (!empty($this->params['quiet'])) {
 			$this->_useLogger(false);
 		}
-		if(!empty($this->params['plugin'])){
+		if (!empty($this->params['plugin'])) {
 			CakePlugin::load($this->params['plugin']);
 		}
 		$this->command = $command;

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -372,7 +372,9 @@ class Shell extends Object {
 		if (!empty($this->params['quiet'])) {
 			$this->_useLogger(false);
 		}
-
+        if(!empty($this->params['plugin'])){
+            CakePlugin::load($this->params['plugin']);
+        }
 		$this->command = $command;
 		if (!empty($this->params['help'])) {
 			return $this->_displayHelp($command);

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -372,9 +372,9 @@ class Shell extends Object {
 		if (!empty($this->params['quiet'])) {
 			$this->_useLogger(false);
 		}
-        if(!empty($this->params['plugin'])){
-            CakePlugin::load($this->params['plugin']);
-        }
+		if(!empty($this->params['plugin'])){
+			CakePlugin::load($this->params['plugin']);
+		}
 		$this->command = $command;
 		if (!empty($this->params['help'])) {
 			return $this->_displayHelp($command);


### PR DESCRIPTION
Thought this issue was confined to UpgradeShell. Realized this was incorrect.

Since plugins are not loaded in bootstrap, this seems like a good place to do it. This appears to fix the behavior without other changes.
