### PR TITLE
use CakeSession wrapper in i18n class

### DIFF
--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -23,6 +23,7 @@
 App::uses('CakePlugin', 'Core');
 App::uses('L10n', 'I18n');
 App::uses('Multibyte', 'I18n');
+App::uses('CakeSession', 'Model/Datasource');
 
 /**
  * I18n handles translation of Text and time format strings.
@@ -142,9 +143,10 @@ class I18n {
 		}
 
 		if (empty($language)) {
-			if (!empty($_SESSION['Config']['language'])) {
-				$language = $_SESSION['Config']['language'];
-			} else {
+			if (CakeSession::started()) {
+				$language = CakeSession::read('Config.language');
+			}
+			if (empty($language)) {
 				$language = Configure::read('Config.language');
 			}
 		}


### PR DESCRIPTION
its the only source in the cake core where the session is directly accessed this way.
I think we should not do that here in favor of the wrapper access.
