### PR TITLE
fix ticket 3400: url string with # in it is not routed

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -851,7 +851,7 @@ class Router {
 				$output = self::_handleNoRoute($url);
 			}
 		} else {
-			if (preg_match('/:\/\/|^(javascript|mailto|tel|sms):|\#/i', $url)) {
+			if (preg_match('/:\/\/|^(javascript|mailto|tel|sms):|^\#/i', $url)) {
 				return $url;
 			}
 			if (substr($url, 0, 1) === '/') {

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2540,6 +2540,12 @@ class RouterTest extends CakeTestCase {
 
 		$url = 'sms:012345-678';
 		$this->assertEquals($url, Router::url($url));
+
+		$url = '#here';
+		$this->assertEquals($url, Router::url($url));
+		$url = 'posts/index#here';
+		$expected = FULL_BASE_URL . '/posts/index#here';
+		$this->assertEquals($expected, Router::url($url, true));
 	}
 
 /**


### PR DESCRIPTION
See: http://cakephp.lighthouseapp.com/projects/42648/tickets/3400-url-string-with-in-it-is-not-routed
