### PR TITLE
Avoiding specifying 'maxLimit' too when setting 'limit' greater than def...

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -322,6 +322,11 @@ class PaginatorComponent extends Component {
 		if (isset($this->settings[$alias])) {
 			$defaults = $this->settings[$alias];
 		}
+		if (isset($defaults['limit']) &&
+			(empty($defaults['maxLimit']) || $defaults['limit'] > $defaults['maxLimit'])
+		) {
+			$defaults['maxLimit'] = $defaults['limit'];
+		}
 		return array_merge(
 			array('page' => 1, 'limit' => 20, 'maxLimit' => 100, 'paramType' => 'named'),
 			$defaults

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -821,6 +821,40 @@ class PaginatorComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test mergeOptions with limit > maxLimit in code.
+ *
+ * @return void
+ */
+	public function testMergeOptionsMaxLimit() {
+		$this->Paginator->settings = array(
+			'limit' => 200,
+			'paramType' => 'named',
+		);
+		$result = $this->Paginator->mergeOptions('Post');
+		$expected = array('page' => 1, 'limit' => 200, 'maxLimit' => 200, 'paramType' => 'named');
+		$this->assertEquals($expected, $result);
+
+		$this->Paginator->settings = array(
+			'maxLimit' => 10,
+			'paramType' => 'named',
+		);
+		$result = $this->Paginator->mergeOptions('Post');
+		$expected = array('page' => 1, 'limit' => 20, 'maxLimit' => 10, 'paramType' => 'named');
+		$this->assertEquals($expected, $result);
+
+		$this->request->params['named'] = array(
+			'limit' => 500
+		);
+		$this->Paginator->settings = array(
+			'limit' => 150,
+			'paramType' => 'named',
+		);
+		$result = $this->Paginator->mergeOptions('Post');
+		$expected = array('page' => 1, 'limit' => 500, 'maxLimit' => 150, 'paramType' => 'named');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test that invalid directions are ignored.
  *
  * @return void

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -1311,8 +1311,8 @@ class ControllerTest extends CakeTestCase {
 		$this->assertEquals(array(1, 2, 3), $results);
 
 		$Controller->passedArgs = array();
-		$Controller->paginate = array('limit' => '-1');
-		$this->assertEquals(array('limit' => '-1'), $Controller->paginate);
+		$Controller->paginate = array('limit' => '1');
+		$this->assertEquals(array('limit' => '1'), $Controller->paginate);
 		$Controller->paginate('ControllerPost');
 		$this->assertSame($Controller->params['paging']['ControllerPost']['page'], 1);
 		$this->assertSame($Controller->params['paging']['ControllerPost']['pageCount'], 3);


### PR DESCRIPTION
...ault 'maxLimit' in code.
