### PR TITLE
Added ConfigReaderInterface::dump() and made all readers' dump() method ...

### DIFF
--- a/lib/Cake/Configure/ConfigReaderInterface.php
+++ b/lib/Cake/Configure/ConfigReaderInterface.php
@@ -30,4 +30,13 @@ interface ConfigReaderInterface {
  */
 	public function read($key);
 
+/**
+ * Dumps the configure data into source.
+ *
+ * @param string $key The identifier to write to.
+ * @param array $data The data to dump.
+ * @return boolean True on success or false on failure.
+ */
+	public function dump($key, $data);
+
 }

--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -100,23 +100,8 @@ class IniReader implements ConfigReaderInterface {
 		if (strpos($key, '..') !== false) {
 			throw new ConfigureException(__d('cake_dev', 'Cannot load configuration files with ../ in them.'));
 		}
-		if (substr($key, -8) === '.ini.php') {
-			$key = substr($key, 0, -8);
-			list($plugin, $key) = pluginSplit($key);
-			$key .= '.ini.php';
-		} else {
-			if (substr($key, -4) === '.ini') {
-				$key = substr($key, 0, -4);
-			}
-			list($plugin, $key) = pluginSplit($key);
-			$key .= '.ini';
-		}
 
-		if ($plugin) {
-			$file = App::pluginPath($plugin) . 'Config' . DS . $key;
-		} else {
-			$file = $this->_path . $key;
-		}
+		$file = $this->_getFilePath($key);
 		if (!is_file($file)) {
 			throw new ConfigureException(__d('cake_dev', 'Could not load configuration file: %s', $file));
 		}
@@ -165,23 +150,23 @@ class IniReader implements ConfigReaderInterface {
 /**
  * Dumps the state of Configure data into an ini formatted string.
  *
- * @param string $filename The filename on $this->_path to save into.
- * 	Extension ".ini" will be automatically appended if not included in filename.
+ * @param string $key The identifier to write to. If the key has a . it will be treated
+ *  as a plugin prefix.
  * @param array $data The data to convert to ini file.
  * @return int Bytes saved.
  */
-	public function dump($filename, $data) {
+	public function dump($key, $data) {
 		$result = array();
-		foreach ($data as $key => $value) {
+		foreach ($data as $k => $value) {
 			$isSection = false;
-			if ($key[0] != '[') {
-				$result[] = "[$key]";
+			if ($k[0] != '[') {
+				$result[] = "[$k]";
 				$isSection = true;
 			}
 			if (is_array($value)) {
-				$keyValues = Hash::flatten($value, '.');
-				foreach ($keyValues as $k => $v) {
-					$result[] = "$k = " . $this->_value($v);
+				$kValues = Hash::flatten($value, '.');
+				foreach ($kValues as $k2 => $v) {
+					$result[] = "$k2 = " . $this->_value($v);
 				}
 			}
 			if ($isSection) {
@@ -190,10 +175,8 @@ class IniReader implements ConfigReaderInterface {
 		}
 		$contents = trim(implode("\n", $result));
 
-		if (substr($filename, -4) !== '.ini') {
-			$filename .= '.ini';
-		}
-		return file_put_contents($this->_path . $filename, $contents);
+		$filename = $this->_getFilePath($key);
+		return file_put_contents($filename, $contents);
 	}
 
 /**
@@ -213,6 +196,35 @@ class IniReader implements ConfigReaderInterface {
 			return 'false';
 		}
 		return (string)$val;
+	}
+
+/**
+ * Get file path
+ *
+ * @param string $key The identifier to write to. If the key has a . it will be treated
+ *  as a plugin prefix.
+ * @return string Full file path
+ */
+	protected function _getFilePath($key) {
+		if (substr($key, -8) === '.ini.php') {
+			$key = substr($key, 0, -8);
+			list($plugin, $key) = pluginSplit($key);
+			$key .= '.ini.php';
+		} else {
+			if (substr($key, -4) === '.ini') {
+				$key = substr($key, 0, -4);
+			}
+			list($plugin, $key) = pluginSplit($key);
+			$key .= '.ini';
+		}
+
+		if ($plugin) {
+			$file = App::pluginPath($plugin) . 'Config' . DS . $key;
+		} else {
+			$file = $this->_path . $key;
+		}
+
+		return $file;
 	}
 
 }

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -292,7 +292,7 @@ class Configure {
 	}
 
 /**
- * Dump data currently in Configure into $filename.  The serialization format
+ * Dump data currently in Configure into $key. The serialization format
  * is decided by the config reader attached as $config.  For example, if the
  * 'default' adapter is a PhpReader, the generated file will be a PHP
  * configuration file loadable by the PhpReader.


### PR DESCRIPTION
...support 'Plugin.keyname' format for keys

Refs [3363](http://cakephp.lighthouseapp.com/projects/42648/tickets/3363-configuredump-should-support-plugins)
