### PR TITLE
make View trigger notice if elements are missing.

### DIFF
--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -623,6 +623,29 @@ class ViewTest extends CakeTestCase {
 	}
 
 /**
+ * testElementExists method
+ *
+ * @return void
+ */
+	public function testElementExists() {
+		$result = $this->View->elementExists('test_element');
+		$this->assertTrue($result);
+
+		$result = $this->View->elementExists('TestPlugin.plugin_element');
+		$this->assertTrue($result);
+
+		$result = $this->View->elementExists('non_existent_element');
+		$this->assertFalse($result);
+
+		$result = $this->View->elementExists('TestPlugin.element');
+		$this->assertFalse($result);
+
+		$this->View->plugin = 'TestPlugin';
+		$result = $this->View->elementExists('test_plugin_element');
+		$this->assertTrue($result);
+	}
+
+/**
  * testElement method
  *
  * @return void
@@ -640,21 +663,39 @@ class ViewTest extends CakeTestCase {
 		$result = $this->View->element('TestPlugin.plugin_element');
 		$this->assertEquals('this is the plugin element using params[plugin]', $result);
 
-		$result = $this->View->element('test_plugin.plugin_element');
-		$this->assertRegExp('/Not Found:/', $result);
-		$this->assertRegExp('/test_plugin.plugin_element/', $result);
-
 		$this->View->plugin = 'TestPlugin';
 		$result = $this->View->element('test_plugin_element');
 		$this->assertEquals('this is the test set using View::$plugin plugin element', $result);
+	}
 
+/**
+ * testElementInexistent method
+ *
+ * @expectedException PHPUnit_Framework_Error_Notice
+ * @return void
+ */
+	public function testElementInexistent() {
 		$result = $this->View->element('non_existent_element');
-		$this->assertRegExp('/Not Found:/', $result);
-		$this->assertRegExp('/non_existent_element/', $result);
+	}
 
+/**
+ * testElementInexistent2 method
+ *
+ * @expectedException PHPUnit_Framework_Error_Notice
+ * @return void
+ */
+	public function testElementInexistent2() {
 		$result = $this->View->element('TestPlugin.plugin_element', array(), array('plugin' => 'test_plugin'));
-		$this->assertRegExp('/Not Found:/', $result);
-		$this->assertRegExp('/TestPlugin.plugin_element/', $result);
+	}
+
+/**
+ * testElementInexistent3 method
+ *
+ * @expectedException PHPUnit_Framework_Error_Notice
+ * @return void
+ */
+	public function testElementInexistent3() {
+		$result = $this->View->element('test_plugin.plugin_element');
 	}
 
 /**

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -422,8 +422,8 @@ class View extends Object {
 /**
  * Checks if an element exists
  *
- * @param string $name Name of template file in the/app/View/Elements/ folder,
- *   or `MyPlugin.template` to use the template element from MyPlugin.  If the element
+ * @param string $name Name of template file in the /app/View/Elements/ folder,
+ *   or `MyPlugin.template` to check the template element from MyPlugin.  If the element
  *   is not found in the plugin, the normal view path cascade will be searched.
  * @return boolean Success
  */

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -385,6 +385,7 @@ class View extends Object {
  * - `plugin` - Load an element from a specific plugin.  This option is deprecated, see below.
  * - `callbacks` - Set to true to fire beforeRender and afterRender helper callbacks for this element.
  *   Defaults to false.
+ * - `ignoreMissing` - Used to allow missing elements. Set to true to not trigger notices.
  * @return string Rendered Element
  * @deprecated The `$options['plugin']` is deprecated and will be removed in CakePHP 3.0.  Use
  *   `Plugin.element_name` instead.
@@ -412,11 +413,22 @@ class View extends Object {
 			return $this->_renderElement($file, $data, $options);
 		}
 
-		$file = 'Elements' . DS . $name . $this->ext;
-
-		if (Configure::read('debug') > 0) {
-			return __d('cake_dev', 'Element Not Found: %s', $file);
+		if (empty($options['ignoreMissing'])) {
+			$file = 'Elements' . DS . $name . $this->ext;
+			trigger_error(__d('cake_dev', 'Element Not Found: %s', $file), E_USER_NOTICE);
 		}
+	}
+
+/**
+ * Checks if an element exists
+ *
+ * @param string $name Name of template file in the/app/View/Elements/ folder,
+ *   or `MyPlugin.template` to use the template element from MyPlugin.  If the element
+ *   is not found in the plugin, the normal view path cascade will be searched.
+ * @return boolean Success
+ */
+	public function elementExists($name) {
+		return (bool)$this->_getElementFilename($name);
 	}
 
 /**


### PR DESCRIPTION
this helps to find "silent" errors due to missing files.
currently nobody would notice this since the empty string will be invisible.
but this is obviously bad coding to call non-existent elements.

what do you think?
