### PR TITLE
fix ticket 3429

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -279,8 +279,8 @@ class FixtureTask extends BakeTask {
  * @return string fields definitions
  */
 	protected function _generateSchema($tableInfo) {
-		$schema = $this->_Schema->generateTable('f', $tableInfo);
-		return substr($schema, 13, -2);
+		$schema = trim($this->_Schema->generateTable('f', $tableInfo), "\n");
+		return substr($schema, 13, -1);
 	}
 
 /**


### PR DESCRIPTION
see  http://cakephp.lighthouseapp.com/projects/42648/tickets/3429-baked-schema-has-an-excess-semicolon

i still dont like how  generateTable() creates whitespace noice.
but this fixes the issue anyway.
