### PR TITLE
avoid fatal error

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -569,7 +569,7 @@ class CakeResponse {
  * Buffers the response message to be sent
  * if $content is null the current buffer is returned
  *
- * @param string $content the string message to be sent
+ * @param string|CakeResponse $content the string message to be sent or the CakeResponse object
  * @return string Current message, or buffer if $content param is passed as null
  */
 	public function body($content = null) {

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -570,11 +570,14 @@ class CakeResponse {
  * if $content is null the current buffer is returned
  *
  * @param string $content the string message to be sent
- * @return string current message buffer if $content param is passed as null
+ * @return string Current message, or buffer if $content param is passed as null
  */
 	public function body($content = null) {
 		if (is_null($content)) {
 			return $this->_body;
+		}
+		if (is_object($content) && $content instanceof CakeResponse) {
+			$content = $content->body();
 		}
 		return $this->_body = $content;
 	}


### PR DESCRIPTION
"Fatal error: Maximum function nesting level of '100' reached, aborting! in ...\lib\Cake\Network\CakeResponse.php on line 1127"

I was just modifying the result...

```
....
$res = $this->render('js_base');
if ($someConditionThatIsNotAlwaysTrue) {
    $res = trim(JSMin::minify($res));
}
$this->response->body($res);
....
```

so we should make sure the setter casts to string here.

stacktrace:

1   0.0010  154536  {main}( )   ..\index.php:0
    2   0.0425  1702072 Dispatcher->dispatch( ) ..\index.php:102
    3   1.2384  9203672 CakeResponse->send( )   ..\Dispatcher.php:168
    4   1.2384  9203944 CakeResponse->_setContentLength( )  ..\CakeResponse.php:408
    5   1.2384  9204200 strlen ( )  ..\CakeResponse.php:484
    6   1.2384  9204232 CakeResponse->__toString( ) ..\CakeResponse.php:484
    7   1.2384  9204280 CakeResponse->__toString( ) ..\CakeResponse.php:1127
    8   1.2384  9204312 CakeResponse->__toString( ) ..\CakeResponse.php:1127
    9   1.2384  9204344 CakeResponse->__toString( ) ..\CakeResponse.php:1127
    10  1.2384  9204376 CakeResponse->__toString( ) ..\CakeResponse.php:1127
    ... infinity
