### PR TITLE
no cache for IE8

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -737,7 +737,8 @@ class CakeResponse {
 		$this->header(array(
 			'Expires' => 'Mon, 26 Jul 1997 05:00:00 GMT',
 			'Last-Modified' => gmdate("D, d M Y H:i:s") . " GMT",
-			'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0'
+			'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
+			'Pragma' => 'no-cache',
 		));
 	}
 

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -259,7 +259,8 @@ class CakeResponseTest extends CakeTestCase {
 		$expected = array(
 			'Expires' => 'Mon, 26 Jul 1997 05:00:00 GMT',
 			'Last-Modified' => gmdate("D, d M Y H:i:s") . " GMT",
-			'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0'
+			'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
+			'Pragma' => 'no-cache',
 		);
 		$response->disableCache();
 		$this->assertEquals($expected, $response->header());


### PR DESCRIPTION
somebody must have forgotten to copy the `header("Pragma: no-cache");` from 1.3.
Without it, though, IE8 and possible other IE versions have browser caching issues

see http://www.crydust.be/blog/2009/03/20/ie8-aggressive-caching-fix/

We found the issue upgrading an app from 1.3 to 2.3 and going live with it - customers complained about strange things going on.
