### PR TITLE
ticket 2855 CakeEmail & Transports have ambiguous config behaviors

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1155,7 +1155,7 @@ class CakeEmail {
 			$this->template($config['template'], $layout);
 			unset($config['template']);
 		}
-		$this->transportClass()->config($config);
+		$this->transportClass()->config($this->transportClass()->config() + $config);
 	}
 
 /**

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -70,18 +70,22 @@ class SmtpTransport extends AbstractTransport {
  * Set the configuration
  *
  * @param array $config
- * @return void
+ * @return array Returns configs
  */
-	public function config($config = array()) {
-		$default = array(
-			'host' => 'localhost',
-			'port' => 25,
-			'timeout' => 30,
-			'username' => null,
-			'password' => null,
-			'client' => null
-		);
-		$this->_config = $config + $default;
+	public function config($config = null) {
+		if ($config !== null && is_array($config)) {
+			$default = array(
+				'host' => 'localhost',
+				'port' => 25,
+				'timeout' => 30,
+				'username' => null,
+				'password' => null,
+				'client' => null,
+				'tls' => false
+			);
+			$this->_config = $config + $default;
+		}
+		return $this->_config;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -83,6 +83,7 @@ class EmailConfig {
 		'transport' => 'Debug',
 		'theme' => 'TestTheme',
 		'helpers' => array('Html', 'Form'),
+		'aParamForTransportClass' => 'somevalue'
 	);
 
 }
@@ -703,13 +704,27 @@ class CakeEmailTest extends CakeTestCase {
 	public function testConfig() {
 		$transportClass = $this->CakeEmail->transport('debug')->transportClass();
 
+		$this->CakeEmail->config(array());
+		$this->assertSame($transportClass->config(), array());
+
 		$config = array('test' => 'ok', 'test2' => true);
 		$this->CakeEmail->config($config);
 		$this->assertSame($transportClass->config(), $config);
 		$this->assertSame($this->CakeEmail->config(), $config);
+	}
 
-		$this->CakeEmail->config(array());
-		$this->assertSame($transportClass->config(), array());
+/**
+ * testConfigOverwrite method
+ *
+ * @return void
+ */
+	public function testConfigOverwrite() {
+		$this->CakeEmail->config('test');
+
+		$this->CakeEmail->config(array('subject' => 'test'));
+		$transportClass = $this->CakeEmail->transportClass();
+		$result = $transportClass->config();
+		$this->assertEquals('somevalue', $result['aParamForTransportClass']);
 	}
 
 /**


### PR DESCRIPTION
See http://cakephp.lighthouseapp.com/projects/42648/tickets/2855-cakeemail-transports-have-ambiguous-config-behaviors

This change would pick up the notion that the `CakeEmail` config is overwritten in  `_applyConfig()` with

```
$this->_config += $config;
```

and extend it to the transport class with

```
$this->transportClass()->config() + $config
```

The only problem is that `SmtpTransport::config()` has a slightly different behavior than `AbstractTransport::config()`.
