### PR TITLE
help text from the subcommands is missing on help

### DIFF
--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -82,10 +82,14 @@ class ConsoleInputSubcommand {
 /**
  * Generate the help for this this subcommand.
  *
- * @param integer $width The width to make the name of the subcommand.
+ * @param integer $width The width to make the name of the subcommand if you want to prepend it to the help text.
  * @return string
  */
 	public function help($width = 0) {
+		if ($width === 0) {
+			return $this->_help;
+		}
+
 		$name = $this->_name;
 		if (strlen($name) < $width) {
 			$name = str_pad($name, $width, ' ');

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -517,7 +517,11 @@ class ConsoleOptionParser {
 		) {
 			$subparser = $this->_subcommands[$subcommand]->parser();
 			$subparser->command($this->command() . ' ' . $subparser->command());
-			return $subparser->help(null, $format, $width);
+			$help = $this->_subcommands[$subcommand]->help();
+			if ($help) {
+				$help .= "\n\n";
+			}
+			return $help . $subparser->help(null, $format, $width);
 		}
 		$formatter = new HelpFormatter($this);
 		if ($format == 'text' || $format === true) {

--- a/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
@@ -506,6 +506,8 @@ class ConsoleOptionParserTest extends CakeTestCase {
 
 		$result = $parser->help('method');
 		$expected = <<<TEXT
+This is another command
+
 <info>Usage:</info>
 cake mycommand method [-h] [--connection]
 


### PR DESCRIPTION
currently, when going to

```
cake PluginName.Command subcommand -h
```

you only get the options.

The help text is only displayed on the main `Command -h` and is missing  on the subcommand help.
