### PR TITLE
pluginSplit for a more meaningful notice

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -414,7 +414,9 @@ class View extends Object {
 		}
 
 		if (empty($options['ignoreMissing'])) {
-			$file = 'Elements' . DS . $name . $this->ext;
+			list ($plugin, $name) = pluginSplit($name, true);
+			$name = str_replace('/', DS, $name);
+			$file = $plugin . 'Elements' . DS . $name . $this->ext;
 			trigger_error(__d('cake_dev', 'Element Not Found: %s', $file), E_USER_NOTICE);
 		}
 	}


### PR DESCRIPTION
If you got an element like

```
<?php echo $this->element('PluginName.subfolder/piece'); ?>
```

currently the notice would be

```
Notice (1024): Element Not Found: Elements\PluginName.subfolder/piece.ctp [CORE\Cake\View\View.php, line 418]
```

whereas this would make much more sense:

```
Notice (1024): Element Not Found: PluginName.Elements\subfolder\piece.ctp [CORE\Cake\View\View.php, line 418]
```

fixing both the PluginName (move to the front) and the different DS
