### PR TITLE
Wrapper for counting

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -2180,4 +2180,72 @@ class HashTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * test counting
+ *
+ * @dataProvider countDataProvider
+ */
+	public function testCount($path, $expected) {
+		$array = array(
+			array(
+				'User' => array(
+					'id' => 1,
+					'first_name' => 'sam',
+					'last_name' => 'jones',
+				),
+				'Order' => array(
+					array(
+						'product_id' => 1
+					),
+					array(
+						'product_id' => 2
+					)
+				)
+			),
+			array(
+				'User' => array(
+					'id' => 2,
+					'first_name' => 'bob',
+					'last_name' => 'smith'
+				),
+				'Order' => array(
+					array(
+						'product_id' => 2
+					)
+				)
+			),
+			array(
+				'User' => array(
+					'id' => 3,
+					'first_name' => 'bob',
+					'last_name' => 'jones'
+				),
+				'Order' => array(
+					array(
+						'product_id' => 2
+					),
+					array(
+						'product_id' => 3
+					)
+				)
+			)
+		);
+		$result = Hash::count($array, $path);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function countDataProvider() {
+		return array(
+			array('{n}.User.id', 3),
+			array('{n}.User[first_name=bob]', 2),
+			array('{n}.User[last_name=smith]', 1),
+			array('{n}.Order.{n}[product_id=1]', 1),
+			array('{n}.Order.{n}[product_id=2]', 3),
+			array('{n}.Order.{n}[product_id=3]', 1),
+			array('{n}.Order.{n}[product_id>3]', 0),
+			array('{n}.Order.{n}[product_id<3]', 4),
+			array('{s}.NoMatch.whatever', 0),
+		);
+	}
+
 }

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -141,6 +141,17 @@ class Hash {
 	}
 
 /**
+ *  Wrapper for counting the number of items found
+ *
+ * @param array $data The data to count from.
+ * @param string $path The path to count.
+ * @return integer
+ */
+	public function count(array $data, $path) {
+		return count(self::extract($data, $path));
+	}
+
+/**
  * Check a key against a token.
  *
  * @param string $key The key in the array being searched.


### PR DESCRIPTION
Sometimes you need to do something based on the count of items but do not need
the data in them.

Instead of having to do `count(Hash::extract(...))` all over this is a simple wrapper
to do just that, eg:

```
switch(Hash::count($data, '{n}.Some.path')) {
   case 10: echo $this->element('huge', $data); break;
   case 5: echo $this->element('other', $data); break;
   case 1: echo $this->element('single', $data); break;
   default: echo 'No stuff';
}
```
