### PR TITLE
2.3 FormHelper::radio enhanced options

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3657,6 +3657,51 @@ class FormHelperTest extends CakeTestCase {
 			'/fieldset'
 		);
 		$this->assertTags($result, $expected);
+		
+		$result = $this->Form->radio(
+			'Model.field',
+			array('A' => 'option A', 'B' => 'option B'),
+			array(
+				'beforeOption' => '<img src="/img/%1$s.png" alt="%2$s" />',
+				'afterOption' => '<a href="/option/%1$s">learn more about %2$s</a>'
+			)
+		);
+		$expected = array(
+			'fieldset' => array(),
+			'legend' => array(),
+			'Field',
+			'/legend',
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][field]',
+				'value' => '', 'id' => 'ModelField_'
+			),
+			array('img' => array('src' => '/img/A.png', 'alt' => 'option A')),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => 'A', 'id' => 'ModelFieldA'
+			)),
+			array('label' => array('for' => 'ModelFieldA')),
+			'option A',
+			'/label',
+			array('a' => array('href' => '/option/A')),
+			'learn more about option A',
+			'/a',
+			array('img' => array('src' => '/img/B.png', 'alt' => 'option B')),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => 'B', 'id' => 'ModelFieldB'
+			)),
+			array('label' => array('for' => 'ModelFieldB')),
+			'option B',
+			'/label',
+			array('a' => array('href' => '/option/B')),
+			'learn more about option B',
+			'/a',
+			'/fieldset'
+		);
+		$this->assertTags($result, $expected);
+		
+		
 
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3553,6 +3553,111 @@ class FormHelperTest extends CakeTestCase {
 			'/fieldset'
 		);
 		$this->assertTags($result, $expected);
+
+		$result = $this->Form->radio(
+			'Model.field',
+			array('option A', 'option B'),
+			array('beforeOption' => '<hr />')
+		);
+		$expected = array(
+			'fieldset' => array(),
+			'legend' => array(),
+			'Field',
+			'/legend',
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][field]',
+				'value' => '', 'id' => 'ModelField_'
+			),
+			array('hr' => array()),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '0', 'id' => 'ModelField0'
+			)),
+			array('label' => array('for' => 'ModelField0')),
+			'option A',
+			'/label',
+			array('hr' => array()),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '1', 'id' => 'ModelField1'
+			)),
+			array('label' => array('for' => 'ModelField1')),
+			'option B',
+			'/label',
+			'/fieldset'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->radio(
+			'Model.field',
+			array('option A', 'option B'),
+			array('afterOption' => '<br />')
+		);
+		$expected = array(
+			'fieldset' => array(),
+			'legend' => array(),
+			'Field',
+			'/legend',
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][field]',
+				'value' => '', 'id' => 'ModelField_'
+			),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '0', 'id' => 'ModelField0'
+			)),
+			array('label' => array('for' => 'ModelField0')),
+			'option A',
+			'/label',
+			array('br' => array()),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '1', 'id' => 'ModelField1'
+			)),
+			array('label' => array('for' => 'ModelField1')),
+			'option B',
+			'/label',
+			array('br' => array()),
+			'/fieldset'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->radio(
+			'Model.field',
+			array('option A', 'option B'),
+			array('beforeOption' => '<li>', 'afterOption' => '</li>')
+		);
+		$expected = array(
+			'fieldset' => array(),
+			'legend' => array(),
+			'Field',
+			'/legend',
+			'input' => array(
+				'type' => 'hidden', 'name' => 'data[Model][field]',
+				'value' => '', 'id' => 'ModelField_'
+			),
+			array('li' => array()),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '0', 'id' => 'ModelField0'
+			)),
+			array('label' => array('for' => 'ModelField0')),
+			'option A',
+			'/label',
+			'/li',
+			array('li' => array()),
+			array('input' => array(
+				'type' => 'radio', 'name' => 'data[Model][field]',
+				'value' => '1', 'id' => 'ModelField1'
+			)),
+			array('label' => array('for' => 'ModelField1')),
+			'option B',
+			'/label',
+			'/li',
+			'/fieldset'
+		);
+		$this->assertTags($result, $expected);
+
 	}
 
 /**

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1379,6 +1379,18 @@ class FormHelper extends AppHelper {
 			$disabled = $attributes['disabled'];
 		}
 
+		$beforeOption = null;
+		if (isset($attributes['beforeOption'])) {
+			$beforeOption = $attributes['beforeOption'];
+			unset($attributes['beforeOption']);
+		}
+
+		$afterOption = null;
+		if (isset($attributes['afterOption'])) {
+			$afterOption = $attributes['afterOption'];
+			unset($attributes['afterOption']);
+		}
+		
 		$out = array();
 
 		$hiddenField = isset($attributes['hiddenField']) ? $attributes['hiddenField'] : true;
@@ -1401,10 +1413,10 @@ class FormHelper extends AppHelper {
 				$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
 			}
 			$allOptions = array_merge($attributes, $optionsHere);
-			$out[] = $this->Html->useTag('radio', $attributes['name'], $tagName,
+			$out[] = $beforeOption . $this->Html->useTag('radio', $attributes['name'], $tagName,
 				array_diff_key($allOptions, array('name' => '', 'type' => '', 'id' => '')),
 				$optTitle
-			);
+			) . $afterOption;
 		}
 		$hidden = null;
 

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1332,8 +1332,9 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
 	public function radio($fieldName, $options = array(), $attributes = array()) {
-		$attributes = $this->_initInputField($fieldName, $attributes);
 
+		$attributes = $this->_initInputField($fieldName, $attributes);
+		
 		$showEmpty = $this->_extractOption('empty', $attributes);
 		if ($showEmpty) {
 			$showEmpty = ($showEmpty === true) ? __('empty') : $showEmpty;
@@ -1378,13 +1379,13 @@ class FormHelper extends AppHelper {
 		if (isset($attributes['disabled'])) {
 			$disabled = $attributes['disabled'];
 		}
-
+		
 		$beforeOption = null;
 		if (isset($attributes['beforeOption'])) {
 			$beforeOption = $attributes['beforeOption'];
 			unset($attributes['beforeOption']);
 		}
-
+		
 		$afterOption = null;
 		if (isset($attributes['afterOption'])) {
 			$afterOption = $attributes['afterOption'];
@@ -1410,13 +1411,15 @@ class FormHelper extends AppHelper {
 			);
 
 			if ($label) {
-				$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
+				$optLabel = $this->Html->useTag('label', $tagName, '', $optTitle);
+			} else {
+				$optLabel = $optTitle;
 			}
 			$allOptions = array_merge($attributes, $optionsHere);
-			$out[] = $beforeOption . $this->Html->useTag('radio', $attributes['name'], $tagName,
+			$out[] = sprintf($beforeOption, $optValue, $optTitle) . $this->Html->useTag('radio', $attributes['name'], $tagName,
 				array_diff_key($allOptions, array('name' => '', 'type' => '', 'id' => '')),
-				$optTitle
-			) . $afterOption;
+				$optLabel
+			) . sprintf($afterOption, $optValue, $optTitle);
 		}
 		$hidden = null;
 


### PR DESCRIPTION
- add 'afterOption' and 'beforeOption' options, in order to generate more content witihn a radio set.
  For instance, encapsulate the pair 'label' + 'input' within a 'li'.
- this 2 can uses the options data to generate content, through sprintf format (%1$s will be the key, while %2$s will be the title of the option), for instance adding an 'img' attached to each option.

See unit tests for examples of usage.
I'll update the documentation once these are accepted. 
