### PR TITLE
remove always false statement

### DIFF
--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -109,9 +109,7 @@ class ContainableBehavior extends ModelBehavior {
 		}
 		$noContain = $noContain && empty($contain);
 
-		if (
-			$noContain || empty($contain) || (isset($contain[0]) && $contain[0] === null)
-		) {
+		if ($noContain || empty($contain)) {
 			if ($noContain) {
 				$query['recursive'] = -1;
 			}


### PR DESCRIPTION
Isn't 

```
(isset($contain[0]) && $contain[0] === null) 
```

always false?
