### PR TITLE
Fixes an issue with urls as GET parameters

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -232,7 +232,11 @@ class CakeRequest implements ArrayAccess {
 		} elseif (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '://') === false) {
 			$uri = $_SERVER['REQUEST_URI'];
 		} elseif (isset($_SERVER['REQUEST_URI'])) {
-			$uri = substr($_SERVER['REQUEST_URI'], strlen(FULL_BASE_URL));
+			if (strpos($_SERVER['REQUEST_URI'], '?') !== false && strpos($_SERVER['REQUEST_URI'], '://') > strpos($_SERVER['REQUEST_URI'], '?')) {
+				$uri = $_SERVER['REQUEST_URI'];
+			} else {
+				$uri = substr($_SERVER['REQUEST_URI'], strlen(FULL_BASE_URL));
+			}
 		} elseif (isset($_SERVER['PHP_SELF']) && isset($_SERVER['SCRIPT_NAME'])) {
 			$uri = str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['PHP_SELF']);
 		} elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -136,6 +136,10 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['REQUEST_URI'] = '/tasks/index/page:1/?ts=123456';
 		$request = new CakeRequest();
 		$this->assertEquals('tasks/index/page:1/', $request->url);
+
+		$_SERVER['REQUEST_URI'] = '/some/path?url=http://cakephp.org';
+		$request = new CakeRequest();
+		$this->assertEquals('some/path', $request->url);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -140,6 +140,10 @@ class CakeRequestTest extends CakeTestCase {
 		$_SERVER['REQUEST_URI'] = '/some/path?url=http://cakephp.org';
 		$request = new CakeRequest();
 		$this->assertEquals('some/path', $request->url);
+
+		$_SERVER['REQUEST_URI'] = FULL_BASE_URL.'/other/path?url=http://cakephp.org';
+		$request = new CakeRequest();
+		$this->assertEquals('other/path', $request->url);
 	}
 
 /**


### PR DESCRIPTION
Allow urls as GET parameter: http://domain.com/controller/action?url=http://example.com

Currently the "://" in the $_SERVER['REQUEST'] causes an invalid value for $request->url.
