### PR TITLE
Fix missing controller error

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -249,7 +249,7 @@ class CakeRequest implements ArrayAccess {
 		if (strpos($uri, '?') !== false) {
 			list($uri) = explode('?', $uri, 2);
 		}
-		if (empty($uri) || $uri == '/' || $uri == '//') {
+		if (empty($uri) || $uri == '/' || $uri == '//' || $uri == '/index.php') {
 			return '/';
 		}
 		return $uri;


### PR DESCRIPTION
This fixes the missing "Index.phpController could not be found" error when accessing url `/index.php` and properly loads the site root.
