### PR TITLE
allow missing tmp directories to be autocreated in debug mode

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -298,7 +298,7 @@ class FileEngine extends CacheEngine {
 		$dir = $this->settings['path'] . $groups;
 
 		if (!is_dir($dir)) {
-			mkdir($dir, 0777, true);
+			mkdir($dir, 0664, true);
 		}
 		$path = new SplFileInfo($dir . $key);
 
@@ -331,6 +331,12 @@ class FileEngine extends CacheEngine {
  */
 	protected function _active() {
 		$dir = new SplFileInfo($this->settings['path']);
+		if (Configure::read('debug')) {
+			$path = $dir->getPathname();
+			if (!is_dir($path)) {
+				mkdir($path, 0664, true);
+			}
+		}
 		if ($this->_init && !($dir->isDir() && $dir->isWritable())) {
 			$this->_init = false;
 			trigger_error(__d('cake_dev', '%s is not writable', $this->settings['path']), E_USER_WARNING);

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -61,6 +61,9 @@ class FileLog extends BaseLog {
 		if (!empty($this->_file) && !preg_match('/\.log$/', $this->_file)) {
 			$this->_file .= '.log';
 		}
+		if (Configure::read('debug') && !is_dir($this->_path)) {
+			mkdir($this->_path, 0664, true);
+		}
 	}
 
 /**


### PR DESCRIPTION
allow creating of missing tmp directories in debug (development) mode for cache and log to avoid unnecessary errors thrown

@see http://cakephp.lighthouseapp.com/projects/42648/tickets/885-tmp-cache-folders-autocreation
