### PR TITLE
Fix testClear() case

### DIFF
--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -361,7 +361,7 @@ class MemcacheEngineTest extends CakeTestCase {
 		Cache::write('some_value', 'cache1', 'memcache');
 		$result = Cache::clear(true, 'memcache');
 		$this->assertTrue($result);
-		$this->assertEquals('cache1', Cache::read('some_value', 'memcache'));
+		$this->assertEquals(false, Cache::read('some_value', 'memcache'));
 
 		Cache::write('some_value', 'cache2', 'memcache2');
 		$result = Cache::clear(false, 'memcache');


### PR DESCRIPTION
After clear of memcache config, all keys should be gone. So a read on a key should return false.
