### PR TITLE
Throw exception if requested page number is out of range.

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -122,6 +122,7 @@ class PaginatorComponent extends Component {
  *   on non-indexed, or undesirable columns.
  * @return array Model query results
  * @throws MissingModelException
+ * @throws NotFoundException
  */
 	public function paginate($object = null, $scope = array(), $whitelist = array()) {
 		if (is_array($object)) {
@@ -206,6 +207,7 @@ class PaginatorComponent extends Component {
 			$count = $object->find('count', array_merge($parameters, $extra));
 		}
 		$pageCount = intval(ceil($count / $limit));
+		$requestedPage = $page;
 		$page = max(min($page, $pageCount), 1);
 
 		$paging = array(
@@ -220,6 +222,7 @@ class PaginatorComponent extends Component {
 			'options' => Hash::diff($options, $defaults),
 			'paramType' => $options['paramType']
 		);
+
 		if (!isset($this->Controller->request['paging'])) {
 			$this->Controller->request['paging'] = array();
 		}
@@ -227,6 +230,10 @@ class PaginatorComponent extends Component {
 			(array)$this->Controller->request['paging'],
 			array($object->alias => $paging)
 		);
+
+		if ($requestedPage > $page) {
+			throw new NotFoundException();
+		}
 
 		if (
 			!in_array('Paginator', $this->Controller->helpers) &&

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -872,6 +872,9 @@ class PaginatorComponentTest extends CakeTestCase {
 
 /**
  * Test that a really large page number gets clamped to the max page size.
+ *
+ * @expectedException NotFoundException
+ * @return void
  */
 	public function testOutOfRangePageNumberGetsClamped() {
 		$Controller = new PaginatorTestController($this->request);
@@ -882,21 +885,35 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->constructClasses();
 		$Controller->PaginatorControllerPost->recursive = 0;
 		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(
-			1,
-			$Controller->request->params['paging']['PaginatorControllerPost']['page'],
-			'Super big page number should be capped to max number of pages'
-		);
+	}
 
+/**
+ * testOutOfRangePageNumberAndPageCountZero
+ *
+ * @return void
+ */
+	public function testOutOfRangePageNumberAndPageCountZero() {
+		$Controller = new PaginatorTestController($this->request);
+		$Controller->uses = array('PaginatorControllerPost');
+		$Controller->params['named'] = array(
+			'page' => 3000,
+		);
+		$Controller->constructClasses();
+		$Controller->PaginatorControllerPost->recursive = 0;
 		$Controller->paginate = array(
 			'conditions' => array('PaginatorControllerPost.id >' => 100)
 		);
-		$Controller->Paginator->paginate('PaginatorControllerPost');
-		$this->assertEquals(
-			1,
-			$Controller->request->params['paging']['PaginatorControllerPost']['page'],
-			'Page number should not be 0'
-		);
+		try {
+			$Controller->Paginator->paginate('PaginatorControllerPost');
+		} catch (NotFoundException $e) {
+			$this->assertEquals(
+				1,
+				$Controller->request->params['paging']['PaginatorControllerPost']['page'],
+				'Page number should not be 0'
+			);
+			return;
+		}
+		$this->fail();
 	}
 
 /**


### PR DESCRIPTION
Refs [#3459](http://cakephp.lighthouseapp.com/projects/42648/tickets/3489-paginatorcomponent-problem), [#2929](http://cakephp.lighthouseapp.com/projects/42648/tickets/2929-paginatorhelpernumbers-output-out-of-range-numbers9)
