### PR TITLE
Code cleanup

### DIFF
--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -70,9 +70,7 @@ class PhpReader implements ConfigReaderInterface {
 
 		include $file;
 		if (!isset($config)) {
-			throw new ConfigureException(
-				sprintf(__d('cake_dev', 'No variable $config found in %s'), $file)
-			);
+			throw new ConfigureException(__d('cake_dev', 'No variable $config found in %s', $file));
 		}
 		return $config;
 	}

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -135,7 +135,7 @@ class Component extends Object {
  *
  * @param Controller $controller Controller with components to shutdown
  * @return void
- * @link @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::shutdown
+ * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::shutdown
  */
 	public function shutdown(Controller $controller) {
 	}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2959,7 +2959,7 @@ class DboSource extends DataSource {
 /**
  * Generate a database-native schema for the given Schema object
  *
- * @param Model $schema An instance of a subclass of CakeSchema
+ * @param CakeSchema $schema An instance of a subclass of CakeSchema
  * @param string $tableName Optional. If specified only the table name given will be generated.
  *   Otherwise, all tables defined in the schema are generated.
  * @return string

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -93,7 +93,6 @@ class MemcacheEngineTest extends CakeTestCase {
 			'persistent' => true,
 			'compress' => false,
 			'engine' => 'Memcache',
-			'persistent' => true,
 			'groups' => array()
 		);
 		$this->assertEquals($expecting, $settings);

--- a/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
@@ -155,7 +155,6 @@ class CrudAuthorizeTest extends CakeTestCase {
 			'create' => 'create',
 			'read' => 'read',
 			'index' => 'read',
-			'add' => 'create',
 			'edit' => 'update',
 			'view' => 'read',
 			'delete' => 'delete',

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -1254,7 +1254,7 @@ class ControllerTest extends CakeTestCase {
  * @return void
  */
 	public function testPropertyBackwardsCompatibility() {
-		$request = new CakeRequest('posts/index', null);
+		$request = new CakeRequest('posts/index', false);
 		$request->addParams(array('controller' => 'posts', 'action' => 'index'));
 		$request->data = array('Post' => array('id' => 1));
 		$request->here = '/posts/index';

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1315,7 +1315,7 @@ class RouterTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/view/1.rss');
-		$expected = array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'pass' => array('1'), 'named' => array(), 'ext' => 'rss', 'named' => array());
+		$expected = array('plugin' => null, 'controller' => 'posts', 'action' => 'view', 'pass' => array('1'), 'named' => array(), 'ext' => 'rss');
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/view/1.rss?query=test');


### PR DESCRIPTION
squashed:

Remove unneeded sprintf.
Remove unused param $created in Model::updateCounterCache()
Fix doc blocks.
Remove duplicated keys in tests assertions.
Use boolean value for CakeRequest $parseEnvironment param.
