### PR TITLE
CrudAuthorizeTest::testMapActionsGet/Set fail when having routing-prefixes configured

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -519,6 +519,15 @@ class Router {
 	}
 
 /**
+ * Clears all prefixes used in de connected routes
+ *
+ * @return void
+ */
+	public static function clearPrefixes() {
+		self::$_prefixes = array();
+	}
+
+/**
  * Parses given URL string.  Returns 'routing' parameters for that url.
  *
  * @param string $url URL to be parsed

--- a/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
@@ -33,6 +33,7 @@ class CrudAuthorizeTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('Routing.prefixes', array());
+		Router::clearPrefixes();
 
 		$this->Acl = $this->getMock('AclComponent', array(), array(), '', false);
 		$this->Components = $this->getMock('ComponentCollection');
@@ -131,23 +132,6 @@ class CrudAuthorizeTest extends CakeTestCase {
 			'view' => 'read',
 			'remove' => 'delete'
 		);
-		$prefixes = Router::prefixes();
-		if (!empty($prefixes)) {
-			foreach ($prefixes as $prefix) {
-				$expected = array_merge($expected, array(
-					$prefix . '_index' => 'read',
-					$prefix . '_add' => 'create',
-					$prefix . '_edit' => 'update',
-					$prefix . '_view' => 'read',
-					$prefix . '_remove' => 'delete',
-					$prefix . '_create' => 'create',
-					$prefix . '_read' => 'read',
-					$prefix . '_update' => 'update',
-					$prefix . '_delete' => 'delete'
-				));
-			}
-		}
-
 		$this->assertEquals($expected, $result);
 	}
 
@@ -183,22 +167,6 @@ class CrudAuthorizeTest extends CakeTestCase {
 			'update' => 'update',
 			'random' => 'custom',
 		);
-		$prefixes = Router::prefixes();
-		if (!empty($prefixes)) {
-			foreach ($prefixes as $prefix) {
-				$expected = array_merge($expected, array(
-					$prefix . '_index' => 'read',
-					$prefix . '_add' => 'create',
-					$prefix . '_edit' => 'update',
-					$prefix . '_view' => 'read',
-					$prefix . '_remove' => 'delete',
-					$prefix . '_create' => 'create',
-					$prefix . '_read' => 'read',
-					$prefix . '_update' => 'update',
-					$prefix . '_delete' => 'delete'
-				));
-			}
-		}
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
@@ -131,6 +131,23 @@ class CrudAuthorizeTest extends CakeTestCase {
 			'view' => 'read',
 			'remove' => 'delete'
 		);
+		$prefixes = Router::prefixes();
+		if (!empty($prefixes)) {
+			foreach ($prefixes as $prefix) {
+				$expected = array_merge($expected, array(
+					$prefix . '_index' => 'read',
+					$prefix . '_add' => 'create',
+					$prefix . '_edit' => 'update',
+					$prefix . '_view' => 'read',
+					$prefix . '_remove' => 'delete',
+					$prefix . '_create' => 'create',
+					$prefix . '_read' => 'read',
+					$prefix . '_update' => 'update',
+					$prefix . '_delete' => 'delete'
+				));
+			}
+		}
+
 		$this->assertEquals($expected, $result);
 	}
 
@@ -166,6 +183,22 @@ class CrudAuthorizeTest extends CakeTestCase {
 			'update' => 'update',
 			'random' => 'custom',
 		);
+		$prefixes = Router::prefixes();
+		if (!empty($prefixes)) {
+			foreach ($prefixes as $prefix) {
+				$expected = array_merge($expected, array(
+					$prefix . '_index' => 'read',
+					$prefix . '_add' => 'create',
+					$prefix . '_edit' => 'update',
+					$prefix . '_view' => 'read',
+					$prefix . '_remove' => 'delete',
+					$prefix . '_create' => 'create',
+					$prefix . '_read' => 'read',
+					$prefix . '_update' => 'update',
+					$prefix . '_delete' => 'delete'
+				));
+			}
+		}
 		$this->assertEquals($expected, $result);
 	}
 


### PR DESCRIPTION
CrudAuthorizeTest::testMapActionsGet/Set fail when having routing-prefixes configured, attached patch fixes this. The attached patch also fixes other routing-prefixes than admin_.

1) CrudAuthorizeTest::testMapActionsGet
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'remove' => 'delete'
-    'admin_index' => 'read'
-    'admin_add' => 'create'
-    'admin_edit' => 'update'
-    'admin_view' => 'read'
-    'admin_remove' => 'delete'
-    'admin_create' => 'create'
-    'admin_read' => 'read'
-    'admin_update' => 'update'
-    'admin_delete' => 'delete'
  )

/home/staging/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php:134
/home/staging/lib/Cake/TestSuite/CakeTestCase.php:78
/home/staging/lib/Cake/TestSuite/CakeTestRunner.php:59
/home/staging/lib/Cake/TestSuite/CakeTestSuiteCommand.php:113
/home/staging/lib/Cake/Console/Command/TestShell.php:274
/home/staging/lib/Cake/Console/Command/TestsuiteShell.php:98
/home/staging/lib/Cake/Console/Shell.php:395
/home/staging/lib/Cake/Console/ShellDispatcher.php:201
/home/staging/lib/Cake/Console/ShellDispatcher.php:69

2) CrudAuthorizeTest::testMapActionsSet
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'random' => 'custom'
-    'admin_index' => 'read'
-    'admin_add' => 'create'
-    'admin_edit' => 'update'
-    'admin_view' => 'read'
-    'admin_remove' => 'delete'
-    'admin_create' => 'create'
-    'admin_read' => 'read'
-    'admin_update' => 'update'
-    'admin_delete' => 'delete'
  )

/home/staging/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php:169
/home/staging/lib/Cake/TestSuite/CakeTestCase.php:78
/home/staging/lib/Cake/TestSuite/CakeTestRunner.php:59
/home/staging/lib/Cake/TestSuite/CakeTestSuiteCommand.php:113
/home/staging/lib/Cake/Console/Command/TestShell.php:274
/home/staging/lib/Cake/Console/Command/TestsuiteShell.php:98
/home/staging/lib/Cake/Console/Shell.php:395
/home/staging/lib/Cake/Console/ShellDispatcher.php:201
/home/staging/lib/Cake/Console/ShellDispatcher.php:69
