### PR TITLE
assert that the cache does not silently fail

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -154,20 +154,20 @@ class Cache {
 		$cacheClass = $class . 'Engine';
 		App::uses($cacheClass, $plugin . 'Cache/Engine');
 		if (!class_exists($cacheClass)) {
-			return false;
+			throw new CacheException(__d('cake_dev', 'Cache engine %s is not available.', $name));
 		}
 		$cacheClass = $class . 'Engine';
 		if (!is_subclass_of($cacheClass, 'CacheEngine')) {
 			throw new CacheException(__d('cake_dev', 'Cache engines must use CacheEngine as a base class.'));
 		}
 		self::$_engines[$name] = new $cacheClass();
-		if (self::$_engines[$name]->init($config)) {
-			if (self::$_engines[$name]->settings['probability'] && time() % self::$_engines[$name]->settings['probability'] === 0) {
-				self::$_engines[$name]->gc();
-			}
-			return true;
+		if (!self::$_engines[$name]->init($config)) {
+			throw new CacheException(__d('cake_dev', 'Cache engine %s is not properly configured.', $name));
 		}
-		return false;
+		if (self::$_engines[$name]->settings['probability'] && time() % self::$_engines[$name]->settings['probability'] === 0) {
+			self::$_engines[$name]->gc();
+		}
+		return true;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -65,6 +65,17 @@ class CacheTest extends CakeTestCase {
 	}
 
 /**
+ * testConfigInvalidEngine method
+ *
+ * @expectedException CacheException
+ * @return void
+ */
+	public function testConfigInvalidEngine() {
+		$settings = array('engine' => 'Imaginary');
+		Cache::config('imaginary', $settings);
+	}
+
+/**
  * Check that no fatal errors are issued doing normal things when Cache.disable is true.
  *
  * @return void


### PR DESCRIPTION
could also be just a triggered notice/error, though...
but silently doing nothing is a little bit problematic. especially when using it for sessions you only realize it when not being able to login.
