### PR TITLE
Solution to bug #3080 Hash::flatten endless loop

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -532,6 +532,7 @@ class Hash {
 					$stack[] = array($data, $path);
 				}
 				$data = $element;
+				reset($data);
 				$path .= $key . $separator;
 			} else {
 				$result[$path . $key] = $element;
@@ -539,6 +540,7 @@ class Hash {
 
 			if (empty($data) && !empty($stack)) {
 				list($data, $path) = array_pop($stack);
+				reset($data);
 			}
 		}
 		return $result;


### PR DESCRIPTION
Probably closes ticket #3080 in CakePHP Lighthouse (http://cakephp.lighthouseapp.com/projects/42648/tickets/3080-hashflatten-endless-loop-on-single-0-int-keys).
Hash::flatten has a bug which causes an endless loop when try to flatten an integer key.
Probably the $data array pointer won't reset itself when doing:

``` php
$data = $element
```

and

``` php
list($data, $path) = array_pop($stack)
```

The solution is to reset the pointer after the assignments.

You can test the error with the following array:

<pre>
2013-01-08 11:41:39 Debug: Array
    (
        [AteAccountLogin] => Array
        (
            [id] => 68
            [username] => test
            [is_active] => 0
            [created] => 2012-12-17 09:40:10
            [modified] => 2012-12-17 09:40:10
        )

        [AteAccountProfile] => Array
        (
            [id] => 90
            [email] => test
            [phone] => +39 340 0707596
            [login_id] => 68
            [type] => P
            [company] => None
            [name] => Marco
            [surname] => Tisi
            [country_id] => 109
            [cf] => FAKECF
            [vat] => 012456874
            [cap] => 35030
            [city] => Rovolon
            [address] => Via Mazzini 2/B
            [province] => Padova
            [tos] => 1
            [created] => 2012-12-17 09:40:10
            [modified] => 2013-01-07 16:18:45
            [Country] => Array
                (
                    [id] => 109
                    [iso2] => IT
                    [name] => Italy
                    [long_name] => Italian Republic
                    [iso3] => ITA
                    [numcode] => 380
                    [un_member] => yes
                    [calling_code] => 39
                    [cctld] => .jm
                )

            [AteAccountAddress] => Array
                (
                    [0] => Array
                        (
                            [id] => 7
                            [profile_id] => 90
                            [country_id] => 109
                            [cap] => 35030
                            [city] => Rovolon
                            [address] => Via Mazzini 32/B
                            [province] => Padova
                            [created] => 2012-12-20 12:56:49
                            [modified] => 2013-01-07 16:52:56
                            [Country] => Array
                                (
                                    [id] => 109
                                    [iso2] => IT
                                    [name] => Italy
                                    [long_name] => Italian Republic
                                    [iso3] => ITA
                                    [numcode] => 380
                                    [un_member] => yes
                                    [calling_code] => 39
                                    [cctld] => .jm
                                )

                            [address_string] => Via Mazzini 32/B - 35030 - Rovolon - Padova - Italy
                        )

                    [1] => Array
                        (
                            [id] => 14
                            [profile_id] => 90
                            [country_id] => 109
                            [cap] => 35030
                            [city] => Mestrino
                            [address] => Test
                            [province] => Padova
                            [created] => 2013-01-07 17:03:11
                            [modified] => 2013-01-07 17:03:11
                            [Country] => Array
                                (
                                    [id] => 109
                                    [iso2] => IT
                                    [name] => Italy
                                    [long_name] => Italian Republic
                                    [iso3] => ITA
                                    [numcode] => 380
                                    [un_member] => yes
                                    [calling_code] => 39
                                    [cctld] => .jm
                                )

                            [address_string] => Test - 35030 - Mestrino - Padova - Italy
                        )

                )

        )

    )
</pre>


The endless loop starts when parsing 'AteAccountAddress' key, but if I try to isolate only that children, the bug won't appear.
I tested this with 

PHP 5.4.6-1ubuntu1.1 (cli) (built: Nov 15 2012 01:18:34) 

and 

Server version: Apache/2.2.22 (Ubuntu)
