### PR TITLE
BugFix: saveAll with association hasMany can not be saved

### DIFF
--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -1701,9 +1701,7 @@ class Model extends Overloadable {
 						break;
 						case 'hasMany':
 							if (!$validating) {
-								foreach ($values as $i => $value) {
-									$values[$i][$this->{$type}[$association]['foreignKey']] =  $this->id;
-								}
+								$values[$this->{$type}[$association]['foreignKey']] =  $this->id;
 							}
 
 							$_options = array_merge($options, array('atomic' => false));


### PR DESCRIPTION
When saving new entries with association hasMany, there are the following error:

Cannot use a scalar value as an array
