### PR TITLE
avoid paginate count when no results

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -197,7 +197,9 @@ class PaginatorComponent extends Component {
 		$defaults = $this->getDefaults($object->alias);
 		unset($defaults[0]);
 
-		if ($object->hasMethod('paginateCount')) {
+		if (!$results) {
+			$count = 0;
+		} elseif ($object->hasMethod('paginateCount')) {
 			$count = $object->paginateCount($conditions, $recursive, $extra);
 		} else {
 			$parameters = compact('conditions');

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -140,10 +140,11 @@ class ControllerPaginateModel extends CakeTestModel {
 /**
  * paginate method
  *
- * @return void
+ * @return boolean
  */
 	public function paginate($conditions, $fields, $order, $limit, $page, $recursive, $extra) {
 		$this->extra = $extra;
+		return true;
 	}
 
 /**


### PR DESCRIPTION
In case of no results, i would think the count query is not really needed
