### PR TITLE
Improve messages logged for exceptions

### DIFF
--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -99,6 +99,13 @@ if (isset($filePresent)):
 		$connected = ConnectionManager::getDataSource('default');
 	} catch (Exception $connectionError) {
 		$connected = false;
+		$errorMsg = $connectionError->getMessage();
+		if (method_exists($connectionError, 'getAttributes')) {
+			$attributes = $connectionError->getAttributes();
+			if (isset($errorMsg['message'])) {
+				$errorMsg .= '<br />' . $attributes['message'];
+			}
+		}
 	}
 ?>
 <p>
@@ -111,7 +118,7 @@ if (isset($filePresent)):
 			echo '<span class="notice">';
 				echo __d('cake_dev', 'Cake is NOT able to connect to the database.');
 				echo '<br /><br />';
-				echo $connectionError->getMessage();
+				echo $errorMsg;
 			echo '</span>';
 		endif;
 	?>

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -99,6 +99,13 @@ if (isset($filePresent)):
 		$connected = ConnectionManager::getDataSource('default');
 	} catch (Exception $connectionError) {
 		$connected = false;
+		$errorMsg = $connectionError->getMessage();
+		if (method_exists($connectionError, 'getAttributes')) {
+			$attributes = $connectionError->getAttributes();
+			if (isset($errorMsg['message'])) {
+				$errorMsg .= '<br />' . $attributes['message'];
+			}
+		}
 	}
 ?>
 <p>
@@ -111,7 +118,7 @@ if (isset($filePresent)):
 			echo '<span class="notice">';
 				echo __d('cake_dev', 'Cake is NOT able to connect to the database.');
 				echo '<br /><br />';
-				echo $connectionError->getMessage();
+				echo $errorMsg;
 			echo '</span>';
 		endif;
 	?>

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -137,7 +137,7 @@ class ErrorHandler {
  * @param Exception $exception Exception instance
  * @return string Formatted message
  */
-	protected function _getMessage($exception) {
+	protected static function _getMessage($exception) {
 		$message = sprintf("[%s] %s",
 			get_class($exception),
 			$exception->getMessage()

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -224,7 +224,7 @@ class ErrorHandlerTest extends CakeTestCase {
 
 		$log = file(LOGS . 'error.log');
 		$this->assertRegExp('/\[NotFoundException\] Kaboom!/', $log[0], 'message missing.');
-		$this->assertRegExp('/\#0.*ErrorHandlerTest->testHandleExceptionLog/', $log[1], 'Stack trace missing.');
+		$this->assertRegExp('/\#0.*ErrorHandlerTest->testHandleExceptionLog/', $log[2], 'Stack trace missing.');
 	}
 
 /**


### PR DESCRIPTION
For few exceptions like database exceptions the exception object attributes contain extra info like exact PDO error which can be seen in error views but are not logged. So I added that.
Also added URL in logged messages non CLI requests.
