### PR TITLE
number::currency() zero value issue

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -253,6 +253,18 @@ class CakeNumberTest extends CakeTestCase {
 		$result = $this->Number->currency(0.5, null, array('fractionSymbol' => false, 'fractionPosition' => 'before', 'wholeSymbol' => '$'));
 		$expected = '$0.50';
 		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency(0, 'GBP');
+		$expected = '&#163;0.00';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency(0.00000, 'GBP');
+		$expected = '&#163;0.00';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency('0.00000', 'GBP');
+		$expected = '&#163;0.00';
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -314,6 +314,7 @@ class CakeNumber {
 		$result = $options['before'] = $options['after'] = null;
 
 		$symbolKey = 'whole';
+		$value = (float)$value;
 		if (!$value) {
 			if ($options['zero'] !== 0 ) {
 				return $options['zero'];


### PR DESCRIPTION
Before this change `0.00` and `'0.00'` are treated differently. Floats from the database are returned as the string version while doing calculations will normally end up as floats.

This causes output differences on pages like order totals or invoices where there is a mix of calculated values and database values.

![](http://i.imgur.com/G7VbJ.png)
### Before

```
Number::currency(0.00, 'GBP') -> &#163;0.00
Number::currency('0.00', 'GBP') -> 0p
```
### After

Both versions will return `&#163;0.00` (or whatever 0 is configured to return).

Includes tests and related [ticket](http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3525-cakenumbercurrency-with-zero-value-differs)
