### PR TITLE
Partially revert default niceShortFormat

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -367,6 +367,12 @@ class CakeTimeTest extends CakeTestCase {
 		$time = time() + DAY;
 		$this->assertEquals('Tomorrow, ' . date('H:i', $time), $this->Time->niceShort($time));
 
+		$time = strtotime('+6 days');
+		$this->assertEquals('On ' . date('l F d, H:i', $time), $this->Time->niceShort($time));
+
+		$time = strtotime('-6 days');
+		$this->assertEquals(date('l F d, H:i', $time), $this->Time->niceShort($time));
+
 		date_default_timezone_set('Europe/London');
 		$result = $this->Time->niceShort('2005-01-15 10:00:00', new DateTimeZone('Europe/Brussels'));
 		$this->assertEquals('Jan 15th 2005, 11:00', $result);

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -56,7 +56,7 @@ class CakeTime {
  * @var string
  * @see CakeTime::niceShort()
  */
-	public static $niceShortFormat = '%d/%m, %H:%M';
+	public static $niceShortFormat = '%B %d, %H:%M';
 
 /**
  * The format to use when formatting a time using `CakeTime::timeAgoInWords()`


### PR DESCRIPTION
In 9fa531d6e3a3d0291ea36ccd9f0b9f2ab1d9f11b the default niceShortFormat was changed, which has been interpreted as a regression in #3533.

This change partially reverts the previous change and tries to strike a balance between the old behavior and new.

Refs #3533
