### PR TITLE
Strict in_array for mixed id variable types

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2471,7 +2471,7 @@ class FormHelper extends AppHelper {
 			if ($name !== null) {
 				if (
 					(!$selectedIsArray && !$selectedIsEmpty && (string)$attributes['value'] == (string)$name) ||
-					($selectedIsArray && in_array($name, $attributes['value']))
+					($selectedIsArray && in_array($name, $attributes['value'], true))
 				) {
 					if ($attributes['style'] === 'checkbox') {
 						$htmlOptions['checked'] = true;


### PR DESCRIPTION
Setting the in_array check to strict, as this would return true
incorrectly when and if values are of mixed type.

Issue: http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3545
