### PR TITLE
Accept user-definded datasource when testing

### DIFF
--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -320,6 +320,24 @@ class ClassRegistryTest extends CakeTestCase {
 	}
 
 /**
+ * Tests non override user provided test datasource
+ *
+ */
+	public function testProvideTestDatasource() {
+		ClassRegistry::config(array('testing' => true));
+
+		$testConfig = ConnectionManager::getDataSource('test')->config;
+		ConnectionManager::create('test_doesnotexist', $testConfig);
+
+		$Model = ClassRegistry::init('RegisterArticle');
+		$this->assertEquals('test', $Model->useDbConfig);
+		ClassRegistry::removeObject('RegisterArticle');
+
+		$Model = ClassRegistry::init(array('class' => 'RegisterArticle', 'ds' => 'test_doesnotexist'));
+		$this->assertEquals('test_doesnotexist', $Model->useDbConfig);
+	}
+
+/**
  * Tests that passing the string parameter to init() will return false if the model does not exists
  *
  */

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -151,7 +151,7 @@ class ClassRegistry {
 							}
 						}
 
-						if(!isset($settings['ds']) || empty($settings['ds'])) {
+						if (empty($settings['ds'])) {
 							$settings['ds'] = 'test';
 						}
 					}

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -140,9 +140,8 @@ class ClassRegistry {
 					}
 					$testing = isset($settings['testing']) ? $settings['testing'] : false;
 					if ($testing) {
-						$settings['ds'] = 'test';
 						$defaultProperties = $reflection->getDefaultProperties();
-						if (isset($defaultProperties['useDbConfig'])) {
+						if (isset($defaultProperties['useDbConfig']) && !isset($settings['ds'])) {
 							$useDbConfig = $defaultProperties['useDbConfig'];
 							if (in_array('test_' . $useDbConfig, $availableDs)) {
 								$useDbConfig = 'test_' . $useDbConfig;
@@ -150,6 +149,10 @@ class ClassRegistry {
 							if (strpos($useDbConfig, 'test') === 0) {
 								$settings['ds'] = $useDbConfig;
 							}
+						}
+
+						if(!isset($settings['ds']) || empty($settings['ds'])) {
+							$settings['ds'] = 'test';
 						}
 					}
 					if ($reflection->getConstructor()) {


### PR DESCRIPTION
CakePHP override 'ds' option in ClassRegistry::init when test mode is true.
This change keep user-defined option.

Test case added.
