### PR TITLE
Fixes h() to not return empty string when input string contains invalid code unit sequence.

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -243,7 +243,7 @@ class BasicsTest extends CakeTestCase {
 		$result = h($obj);
 		$this->assertEquals('Body content', $result);
 		
-		$invalidString = file_get_contents(CAKE.'..'.DS.'..'.DS.'app'.DS.'webroot'.DS.'favicon.ico');
+		$invalidString = "An invalid\x80string";
 		$result = h($invalidString);
 		$this->assertNotEmpty($result);
 	}

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -242,6 +242,10 @@ class BasicsTest extends CakeTestCase {
 		$obj = new CakeResponse(array('body' => 'Body content'));
 		$result = h($obj);
 		$this->assertEquals('Body content', $result);
+		
+		$invalidString = file_get_contents(CAKE.'..'.DS.'..'.DS.'app'.DS.'webroot'.DS.'favicon.ico');
+		$result = h($invalidString);
+		$this->assertNotEmpty($result);
 	}
 
 /**

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -189,7 +189,7 @@ function h($text, $double = true, $charset = null) {
 	if (is_string($double)) {
 		$charset = $double;
 	}
-	return htmlspecialchars($text, ENT_QUOTES, ($charset) ? $charset : $defaultCharset, $double);
+	return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, ($charset) ? $charset : $defaultCharset, $double);
 }
 
 /**


### PR DESCRIPTION
Caught me by surprise when I passed an object containing some invalid code unit sequence (binary data) to `debug()` but it returned me an empty string, even though there are plaintext properties (which I was interested in).

Even for normal usage, I think `h()` should not return a result that's far too different from the original input, especially when there are other valid plantext characters.
