### PR TITLE
Using Set::merge better than array_merge

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -936,7 +936,7 @@ class FormHelper extends AppHelper {
 	public function input($fieldName, $options = array()) {
 		$this->setEntity($fieldName);
 
-		$options = array_merge(
+		$options = Set::merge(
 			array('before' => null, 'between' => null, 'after' => null, 'format' => null),
 			$this->_inputDefaults,
 			$options


### PR DESCRIPTION
With array_merge inputDefaults overwritten if I set sub-array options.

For example: I want to change all form input error message from div to label and change the class name from error-message to error, this can happen by set value to Form::create(Null, array('inputDefaults' => array()))
But what if I want to set custom attr for each field in the form??
