### PR TITLE
Don't set "required" attribute for checkboxes (unless explicitly specifi...

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -128,6 +128,7 @@ class Contact extends CakeTestModel {
 			'rule_on_create' => array('rule' => array('maxLength', 50), 'on' => 'create'),
 			'rule_on_update' => array('rule' => array('between', 1, 50), 'on' => 'update'),
 		),
+		'boolean_field' => array('rule' => 'boolean')
 	);
 
 /**
@@ -7276,6 +7277,28 @@ class FormHelperTest extends CakeTestCase {
 				'id' => 'ContactIamrequiredalways',
 				'required' => 'required'
 			),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('Contact.boolean_field', array('type' => 'checkbox'));
+		$expected = array(
+			'div' => array('class' => 'input checkbox required'),
+			array('input' => array(
+				'type' => 'hidden',
+				'name' => 'data[Contact][boolean_field]',
+				'id' => 'ContactBooleanField_',
+				'value' => '0'
+			)),
+			array('input' => array(
+				'type' => 'checkbox',
+				'name' => 'data[Contact][boolean_field]',
+				'value' => '1',
+				'id' => 'ContactBooleanField'
+			)),
+			'label' => array('for' => 'ContactBooleanField'),
+			'Boolean Field',
+			'/label',
 			'/div'
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1379,9 +1379,10 @@ class FormHelper extends AppHelper {
 			unset($options['default']);
 		}
 
+		$options += array('required' => false);
 		$options = $this->_initInputField($fieldName, $options) + array('hiddenField' => true);
 		$value = current($this->value($valueOptions));
-		$output = "";
+		$output = '';
 
 		if (empty($options['value'])) {
 			$options['value'] = 1;


### PR DESCRIPTION
...ed).

Adding it prevents user from submitting form with checkbox unchecked when the "boolean" validation rule is specified for the field.
Closes #3560
