### PR TITLE
Fixes h() to not return empty string when input contains invalid code unit sequence. Fixes #3561

### DIFF
--- a/lib/Cake/Test/TestCase/BasicsTest.php
+++ b/lib/Cake/Test/TestCase/BasicsTest.php
@@ -207,6 +207,10 @@ class BasicsTest extends TestCase {
 		$string = '<foo> & &nbsp;';
 		$result = h($string, 'UTF-8');
 		$this->assertEquals('&lt;foo&gt; &amp; &amp;nbsp;', $result);
+		
+		$string = "An invalid\x80string";
+		$result = h($string);
+		$this->assertContains('string', $result);
 
 		$arr = array('<foo>', '&nbsp;');
 		$result = h($arr);
@@ -231,6 +235,11 @@ class BasicsTest extends TestCase {
 			'n' => '&nbsp;'
 		);
 		$this->assertEquals($expected, $result);
+		
+		$arr = array('invalid' => "\x99An invalid\x80string", 'good' => 'Good string');
+		$result = h($arr);
+		$this->assertContains('An invalid', $result['invalid']);
+		$this->assertEquals('Good string', $result['good']);
 
 		// Test that boolean values are not converted to strings
 		$result = h(false);

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -197,7 +197,7 @@ if (!function_exists('h')) {
 		if (is_string($double)) {
 			$charset = $double;
 		}
-		return htmlspecialchars($text, ENT_QUOTES, ($charset) ? $charset : $defaultCharset, $double);
+		return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, ($charset) ? $charset : $defaultCharset, $double);
 	}
 
 }


### PR DESCRIPTION
Resubmitting #1080 for 3.0.
