### PR TITLE
Fix Hash::sort() 'natural' type fallback on PHP < 5.4

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -1118,6 +1118,28 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Test that sort() with 'natural' type will fallback to 'regular' as SORT_NATURAL is introduced in PHP 5.4
+ *
+ * @return void
+ */
+	public function testSortNaturalFallbackToRegular() {
+		if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+			$this->markTestSkipped('Skipping SORT_NATURAL fallback test on PHP >= 5.4');
+		}
+
+		$a = array(
+			0 => array('Person' => array('name' => 'Jeff')),
+			1 => array('Shirt' => array('color' => 'black'))
+		);
+		$b = array(
+			0 => array('Shirt' => array('color' => 'black')),
+			1 => array('Person' => array('name' => 'Jeff')),
+		);
+		$sorted = Hash::sort($a, '{n}.Person.name', 'asc', 'natural');
+		$this->assertEquals($sorted, $b);
+	}
+
+/**
  * test sorting with out of order keys.
  *
  * @return void

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -732,10 +732,11 @@ class Hash {
  *
  * ## Sort types
  *
- * - `numeric` Sort by numeric value.
- * - `regular` Sort by numeric value.
- * - `string` Sort by numeric value.
- * - `natural` Sort by natural order. Requires PHP 5.4 or greater.
+ * - `regular` For regular sorting (don't change types)
+ * - `numeric` Compare values numerically
+ * - `string` Compare values as strings
+ * - `natural` Compare items as strings using "natural ordering" in a human friendly way.
+ *   Will sort foo10 below foo2 as an example. Requires PHP 5.4 or greater or it will fallback to 'regular'
  *
  * @param array $data An array of data to sort
  * @param string $path A Set-compatible path to the array value
@@ -769,7 +770,7 @@ class Hash {
 		$dir = strtolower($dir);
 		$type = strtolower($type);
 		if ($type == 'natural' && version_compare(PHP_VERSION, '5.4.0', '<')) {
-			$type == 'regular';
+			$type = 'regular';
 		}
 		if ($dir === 'asc') {
 			$dir = SORT_ASC;


### PR DESCRIPTION
This commit also change the method behavior. I tested this on PHP 5.3 where

```
Hash::sort($a, '{n}.Person.name', 'asc', 'natural');
```

throws notice and warning and result is not sorted at all.
