### PR TITLE
Added "tel" and "email" input type guessing.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1826,12 +1826,12 @@ class FormHelperTest extends CakeTestCase {
 
 		$result = $this->Form->input('Contact.email', array('id' => 'custom'));
 		$expected = array(
-			'div' => array('class' => 'input text'),
+			'div' => array('class' => 'input email'),
 			'label' => array('for' => 'custom'),
 			'Email',
 			'/label',
 			array('input' => array(
-				'type' => 'text', 'name' => 'data[Contact][email]',
+				'type' => 'email', 'name' => 'data[Contact][email]',
 				'id' => 'custom', 'maxlength' => 255
 			)),
 			'/div'
@@ -1845,7 +1845,7 @@ class FormHelperTest extends CakeTestCase {
 			'Email',
 			'/label',
 			array('input' => array(
-				'type' => 'text', 'name' => 'data[Contact][email]',
+				'type' => 'email', 'name' => 'data[Contact][email]',
 				'id' => 'ContactEmail', 'maxlength' => 255
 			)),
 			'/div'
@@ -1920,12 +1920,12 @@ class FormHelperTest extends CakeTestCase {
 		$this->Form->request->data = array('Contact' => array('phone' => 'Hello & World > weird chars'));
 		$result = $this->Form->input('Contact.phone');
 		$expected = array(
-			'div' => array('class' => 'input text'),
+			'div' => array('class' => 'input tel'),
 			'label' => array('for' => 'ContactPhone'),
 			'Phone',
 			'/label',
 			array('input' => array(
-				'type' => 'text', 'name' => 'data[Contact][phone]',
+				'type' => 'tel', 'name' => 'data[Contact][phone]',
 				'value' => 'Hello &amp; World &gt; weird chars',
 				'id' => 'ContactPhone', 'maxlength' => 255
 			)),
@@ -2808,9 +2808,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',
@@ -2833,9 +2833,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',
@@ -2863,9 +2863,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',
@@ -2889,9 +2889,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',
@@ -2922,9 +2922,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',
@@ -2952,9 +2952,9 @@ class FormHelperTest extends CakeTestCase {
 			'input' => array('type' => 'hidden', 'name' => 'data[Contact][id]', 'id' => 'ContactId'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input email')),
 			'*/div',
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input tel')),
 			'*/div',
 			array('div' => array('class' => 'input password')),
 			'*/div',

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1129,6 +1129,10 @@ class FormHelper extends AppHelper {
 			$options['type'] = 'select';
 		} elseif (in_array($fieldKey, array('psword', 'passwd', 'password'))) {
 			$options['type'] = 'password';
+		} elseif (in_array($fieldKey, array('tel', 'telephone', 'phone'))) {
+			$options['type'] = 'tel';
+		} elseif ($fieldKey === 'email') {
+			$options['type'] = 'email';
 		} elseif (isset($options['checked'])) {
 			$options['type'] = 'checkbox';
 		} elseif ($fieldDef = $this->_introspectModel($modelKey, 'fields', $fieldKey)) {
@@ -1235,7 +1239,9 @@ class FormHelper extends AppHelper {
 			is_scalar($fieldDef['length']) &&
 			$options['type'] !== 'select'
 		);
-		if ($autoLength && $options['type'] == 'text') {
+		if ($autoLength &&
+			in_array($options['type'], array('text', 'email', 'tel', 'url'))
+		) {
 			$options['maxlength'] = $fieldDef['length'];
 		}
 		if ($autoLength && $fieldDef['type'] == 'float') {


### PR DESCRIPTION
Refs [#3557](http://cakephp.lighthouseapp.com/projects/42648/tickets/3557-input-typeemail-for-email-fields)

I am on the fence regarding using "url" type guessing as it does validation for absolute url which might not always be desirable. I believe it's common usage to not require end users to enter absolute urls.
