### PR TITLE
Renamed AuthComponent::redirect() to AuthComponent::redirectUrl().

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -623,6 +623,17 @@ class AuthComponent extends Component {
 	}
 
 /**
+ * Backwards compatible alias for AuthComponent::redirectUrl()
+ *
+ * @param string|array $url Optional URL to write as the login redirect URL.
+ * @return string Redirect URL
+ * @deprecated 2.3 Use AuthComponent::redirectUrl() instead
+ */
+	public function redirect($url = null) {
+		return $this->redirectUrl($url);
+	}
+
+/**
  * If no parameter is passed, gets the authentication redirect URL. Pass a url in to
  * set the destination a user should be redirected to upon logging in. Will fallback to
  * AuthComponent::$loginRedirect if there is no stored redirect value.
@@ -630,7 +641,7 @@ class AuthComponent extends Component {
  * @param string|array $url Optional URL to write as the login redirect URL.
  * @return string Redirect URL
  */
-	public function redirect($url = null) {
+	public function redirectUrl($url = null) {
 		if (!is_null($url)) {
 			$redir = $url;
 			$this->Session->write('Auth.redirect', $redir);

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -758,7 +758,7 @@ class AuthComponentTest extends CakeTestCase {
 		);
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize($this->Auth->loginRedirect);
-		$this->assertEquals($expected, $this->Auth->redirect());
+		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
 		$this->Auth->Session->delete('Auth');
 
@@ -797,7 +797,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginRedirect = false;
 		$this->Auth->startup($this->Controller);
 		$expected = Router::normalize('/admin');
-		$this->assertEquals($expected, $this->Auth->redirect());
+		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
 		// Ticket #4750
 		// Named Parameters
@@ -1263,7 +1263,7 @@ class AuthComponentTest extends CakeTestCase {
  */
 	public function testRedirectSet() {
 		$value = array('controller' => 'users', 'action' => 'home');
-		$result = $this->Auth->redirect($value);
+		$result = $this->Auth->redirectUrl($value);
 		$this->assertEquals('/users/home', $result);
 		$this->assertEquals($value, $this->Auth->Session->read('Auth.redirect'));
 	}
@@ -1277,7 +1277,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginAction = array('controller' => 'users', 'action' => 'login');
 		$this->Auth->Session->write('Auth.redirect', '/users/home');
 
-		$result = $this->Auth->redirect();
+		$result = $this->Auth->redirectUrl();
 		$this->assertEquals('/users/home', $result);
 		$this->assertFalse($this->Auth->Session->check('Auth.redirect'));
 	}
@@ -1293,7 +1293,7 @@ class AuthComponentTest extends CakeTestCase {
 		$this->Auth->loginRedirect = array('controller' => 'users', 'action' => 'home');
 		$this->Auth->Session->write('Auth.redirect', array('controller' => 'users', 'action' => 'login'));
 
-		$result = $this->Auth->redirect();
+		$result = $this->Auth->redirectUrl();
 		$this->assertEquals('/users/home', $result);
 		$this->assertFalse($this->Auth->Session->check('Auth.redirect'));
 	}


### PR DESCRIPTION
Closes [#3268](http://cakephp.lighthouseapp.com/projects/42648/tickets/3268-renaming-authcomponentredirect-to-redirecturl)
