### PR TITLE
3.0 - Add shortcut accessors for `json` and `xml` to Network\Http\Response

### DIFF
--- a/lib/Cake/Network/Http/Response.php
+++ b/lib/Cake/Network/Http/Response.php
@@ -325,12 +325,12 @@ class Response extends Message {
  * @return null|SimpleXML
  */
 	protected function _getXml() {
-		try {
-			$data = new \SimpleXMLElement($this->_body);
-		} catch (Exception $e) {
-			return null;
+		$restore = libxml_use_internal_errors();
+		$data = simplexml_load_string($this->_body);
+		if ($data) {
+			return $data;
 		}
-		return $data;
+		return null;
 	}
 
 /**

--- a/lib/Cake/Network/Http/Response.php
+++ b/lib/Cake/Network/Http/Response.php
@@ -49,6 +49,20 @@ use Cake\Network\Http\Message;
  *
  * `$content = $response->body;`
  *
+ * If your response body is in XML or JSON you can use
+ * special content type specific accessors to read the decoded data.
+ * JSON data will be returned as arrays, while XML data will be returned
+ * as SimpleXML nodes:
+ *
+ * {{{
+ * // Get as xml
+ * $content = $response->xml
+ * // Get as json
+ * $content = $response->json
+ * }}}
+ *
+ * If the response cannot be decoded, null will be returned.
+ *
  * ### Check the status code
  *
  * You can access the response status code using:
@@ -84,7 +98,9 @@ class Response extends Message {
 		'cookies' => '_cookies',
 		'headers' => '_headers',
 		'body' => '_body',
-		'code' => '_code'
+		'code' => '_code',
+		'json' => '_getJson',
+		'xml' => '_getXml'
 	];
 
 /**
@@ -291,6 +307,33 @@ class Response extends Message {
 	}
 
 /**
+ * Get the response body as JSON decoded data.
+ *
+ * @return null|array
+ */
+	protected function _getJson() {
+		$data = json_decode($this->_body, true);
+		if ($data) {
+			return $data;
+		}
+		return null;
+	}
+
+/**
+ * Get the response body as XML decoded data.
+ *
+ * @return null|SimpleXML
+ */
+	protected function _getXml() {
+		try {
+			$data = new \SimpleXMLElement($this->_body);
+		} catch (Exception $e) {
+			return null;
+		}
+		return $data;
+	}
+
+/**
  * Read values as properties.
  *
  * @param string $name
@@ -301,6 +344,9 @@ class Response extends Message {
 			return false;
 		}
 		$key = $this->_exposedProperties[$name];
+		if (substr($key, 0, 4) == '_get') {
+			return $this->{$key}();
+		}
 		return $this->{$key};
 	}
 
@@ -315,6 +361,10 @@ class Response extends Message {
 			return false;
 		}
 		$key = $this->_exposedProperties[$name];
+		if (substr($key, 0, 4) == '_get') {
+			$val = $this->{$key}();
+			return $val !== null;
+		}
 		return isset($this->$key);
 	}
 

--- a/lib/Cake/Test/TestCase/Network/Http/ResponseTest.php
+++ b/lib/Cake/Test/TestCase/Network/Http/ResponseTest.php
@@ -73,6 +73,38 @@ class ResponseTest extends TestCase {
 	}
 
 /**
+ * Test accessor for json
+ *
+ * @return void
+ */
+	public function testBodyJson() {
+		$data = [
+			'property' => 'value'
+		];
+		$encoded = json_encode($data);
+		$response = new Response([], $encoded);
+		$this->assertTrue(isset($response->json));
+		$this->assertEquals($data['property'], $response->json['property']);
+	}
+
+/**
+ * Test accessor for xml
+ *
+ * @return void
+ */
+	public function testBodyXml() {
+		$data = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<test>Test</test>
+</root>
+XML;
+		$response = new Response([], $data);
+		$this->assertTrue(isset($response->xml));
+		$this->assertEquals('Test', (string)$response->xml->test);
+	}
+
+/**
  * Test isOk()
  *
  * @return void

--- a/lib/Cake/Test/TestCase/Network/Http/ResponseTest.php
+++ b/lib/Cake/Test/TestCase/Network/Http/ResponseTest.php
@@ -85,6 +85,10 @@ class ResponseTest extends TestCase {
 		$response = new Response([], $encoded);
 		$this->assertTrue(isset($response->json));
 		$this->assertEquals($data['property'], $response->json['property']);
+
+		$data = '';
+		$response = new Response([], $data);
+		$this->assertFalse(isset($response->json));
 	}
 
 /**
@@ -102,6 +106,10 @@ XML;
 		$response = new Response([], $data);
 		$this->assertTrue(isset($response->xml));
 		$this->assertEquals('Test', (string)$response->xml->test);
+
+		$data = '';
+		$response = new Response([], $data);
+		$this->assertFalse(isset($response->xml));
 	}
 
 /**


### PR DESCRIPTION
This makes reading/dealing with xml & json easier. It also leaves room to add other commonly used data types in the future if necessary.
