### PR TITLE
FormHelper->inputs() does not work with form created with Plugin syntax,...

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2633,6 +2633,45 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testFormInputsPlugin method
+ *
+ * test correct results from form::inputs() with Plugin
+ *
+ * @return void
+ */
+    public function testFormInputsPlugin() {
+        $this->loadFixtures('Post');
+        App::build(array(
+            'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
+        ));
+        CakePlugin::load('TestPlugin');
+        $this->Form->request['models'] = array('TestPluginPost' => array('plugin' => 'TestPlugin', 'className' => 'TestPluginPost'));
+        $this->Form->create('TestPlugin.Post');
+        $result = $this->Form->inputs();
+        $expected = array(
+            'fieldset' => array(),
+            'legend' => array(),
+            'New Test Plugin Post',
+            '/legend',
+            'input' => array('type' => 'hidden', 'name' => 'data[TestPluginPost][id]', 'id' => 'TestPluginPostId'),
+            array('div' => array('class' => 'input select')),
+            '*/div',
+            array('div' => array('class' => 'input text')),
+            '*/div',
+            array('div' => array('class' => 'input textarea')),
+            '*/div',
+            array('div' => array('class' => 'input text')),
+            '*/div',
+            array('div' => array('class' => 'input datetime')),
+            '*/div',
+            array('div' => array('class' => 'input datetime')),
+            '*/div',
+            '/fieldset'
+        );
+        $this->assertTags($result, $expected);
+    }
+
+/**
  * test that input() and a non standard primary key makes a hidden input by default.
  *
  * @return void

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2639,37 +2639,37 @@ class FormHelperTest extends CakeTestCase {
  *
  * @return void
  */
-    public function testFormInputsPlugin() {
-        $this->loadFixtures('Post');
-        App::build(array(
-            'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
-        ));
-        CakePlugin::load('TestPlugin');
-        $this->Form->request['models'] = array('TestPluginPost' => array('plugin' => 'TestPlugin', 'className' => 'TestPluginPost'));
-        $this->Form->create('TestPlugin.Post');
-        $result = $this->Form->inputs();
-        $expected = array(
-            'fieldset' => array(),
-            'legend' => array(),
-            'New Test Plugin Post',
-            '/legend',
-            'input' => array('type' => 'hidden', 'name' => 'data[TestPluginPost][id]', 'id' => 'TestPluginPostId'),
-            array('div' => array('class' => 'input select')),
-            '*/div',
-            array('div' => array('class' => 'input text')),
-            '*/div',
-            array('div' => array('class' => 'input textarea')),
-            '*/div',
-            array('div' => array('class' => 'input text')),
-            '*/div',
-            array('div' => array('class' => 'input datetime')),
-            '*/div',
-            array('div' => array('class' => 'input datetime')),
-            '*/div',
-            '/fieldset'
-        );
-        $this->assertTags($result, $expected);
-    }
+	public function testFormInputsPlugin() {
+		$this->loadFixtures('Post');
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
+		));
+		CakePlugin::load('TestPlugin');
+		$this->Form->request['models'] = array('TestPluginPost' => array('plugin' => 'TestPlugin', 'className' => 'TestPluginPost'));
+		$this->Form->create('TestPlugin.Post');
+		$result = $this->Form->inputs();
+		$expected = array(
+			'fieldset' => array(),
+			'legend' => array(),
+			'New Test Plugin Post',
+			'/legend',
+			'input' => array('type' => 'hidden', 'name' => 'data[TestPluginPost][id]', 'id' => 'TestPluginPostId'),
+			array('div' => array('class' => 'input select')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input textarea')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input datetime')),
+			'*/div',
+			array('div' => array('class' => 'input datetime')),
+			'*/div',
+			'/fieldset'
+		);
+		$this->assertTags($result, $expected);
+	}
 
 /**
  * test that input() and a non standard primary key makes a hidden input by default.

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -329,8 +329,11 @@ class FormHelper extends AppHelper {
 
 		$key = null;
 		if ($model !== false) {
-			$key = $this->_introspectModel($model, 'key');
-			$this->setEntity($model, true);
+            if (strpos($model, '.') !== false) {
+                $model = str_replace('.', '', $model);
+            }
+            $key = $this->_introspectModel($model, 'key');
+            $this->setEntity($model, true);
 		}
 
 		if ($model !== false && $key) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -329,11 +329,11 @@ class FormHelper extends AppHelper {
 
 		$key = null;
 		if ($model !== false) {
-            if (strpos($model, '.') !== false) {
-                $model = str_replace('.', '', $model);
-            }
-            $key = $this->_introspectModel($model, 'key');
-            $this->setEntity($model, true);
+			if (strpos($model, '.') !== false) {
+				$model = str_replace('.', '', $model);
+			}
+			$key = $this->_introspectModel($model, 'key');
+			$this->setEntity($model, true);
 		}
 
 		if ($model !== false && $key) {


### PR DESCRIPTION
Ticket [#3571](http://cakephp.lighthouseapp.com/projects/42648/tickets/3571-formhelper-inputs-does-not-work-with-form-created-with-plugin-syntax)

I`m not sure if the tests were well written, please let me know anything so I can improve...
