### PR TITLE
Fix CrudAuthorizeTest, added Router::reload() in setUp

### DIFF
--- a/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
@@ -33,6 +33,7 @@ class CrudAuthorizeTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('Routing.prefixes', array());
+		Router::reload();
 
 		$this->Acl = $this->getMock('AclComponent', array(), array(), '', false);
 		$this->Components = $this->getMock('ComponentCollection');


### PR DESCRIPTION
When having router-prefixes set the
 Configure::write('Routing.prefixes', array());
clears it but a Router::reload() is required for prefixes to take effect
