### PR TITLE
fix a CakeRequest bug, query strings which contain http protocols cause $this->url error

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -229,7 +229,7 @@ class CakeRequest implements ArrayAccess {
 	protected function _url() {
 		if (!empty($_SERVER['PATH_INFO'])) {
 			return $_SERVER['PATH_INFO'];
-		} elseif (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '://') === false) {
+		} elseif (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], FULL_BASE_URL) !== 0) {
 			$uri = $_SERVER['REQUEST_URI'];
 		} elseif (isset($_SERVER['REQUEST_URI'])) {
 			$qPosition = strpos($_SERVER['REQUEST_URI'], '?');

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -147,6 +147,17 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test that querystrings which contain full url are handled correctly.
+ *
+ * @return void
+ */
+    public function testQueryStringContainProtocol(){
+        $_SERVER['REQUEST_URI'] = '/some/path?redirect=http://yourdomain.com/';
+        $request = new CakeRequest();
+        $this->assertEquals('some/path', $request->url);
+    }
+
+/**
  * test addParams() method
  *
  * @return void


### PR DESCRIPTION
``` php
$_SERVER['REQUEST_URI'] = '/some/path?redirect=http://yourdomain.com/';
$request = new CakeRequest();
echo $request->url;
// this will print 'p://yourdomain.com/', which should be 'some/path'
```
