### PR TITLE
fix a DboDataSource buildJoinStatement bug that table prefix is appended to subquery

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1691,7 +1691,7 @@ class DboSource extends DataSource {
 		if (!empty($data['conditions'])) {
 			$data['conditions'] = trim($this->conditions($data['conditions'], true, false));
 		}
-		if (!empty($data['table']) && (!is_string($data['table']) || strpos($data['table'], '(') !== 0)){
+		if (!empty($data['table']) && (!is_string($data['table']) || strpos($data['table'], '(') !== 0)) {
 			$data['table'] = $this->fullTableName($data['table']);
 		}
 		return $this->renderJoinStatement($data);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1691,9 +1691,8 @@ class DboSource extends DataSource {
 		if (!empty($data['conditions'])) {
 			$data['conditions'] = trim($this->conditions($data['conditions'], true, false));
 		}
-		if (!empty($data['table'])) {
-			$schema = !(is_string($data['table']) && strpos($data['table'], '(') === 0);
-			$data['table'] = $this->fullTableName($data['table'], true, $schema);
+		if (!empty($data['table']) && (!is_string($data['table']) || strpos($data['table'], '(') !== 0)){
+			$data['table'] = $this->fullTableName($data['table']);
 		}
 		return $this->renderJoinStatement($data);
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1122,6 +1122,42 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * data provider for testBuildJoinStatementWithTablePrefix
+ *
+ * @return array
+ */
+	public static function joinStatementsWithPrefix($schema) {
+		return array(
+			array(array(
+				'type' => 'LEFT',
+				'alias' => 'PostsTag',
+				'table' => 'posts_tags',
+				'conditions' => array('PostsTag.post_id = Post.id')
+			), 'LEFT JOIN pre_posts_tags AS PostsTag ON (PostsTag.post_id = Post.id)'),
+				array(array(
+					'type' => 'LEFT',
+					'alias' => 'Stock',
+					'table' => '(SELECT Stock.article_id, sum(quantite) quantite FROM stocks AS Stock GROUP BY Stock.article_id)',
+					'conditions' => 'Stock.article_id = Article.id'
+				), 'LEFT JOIN (SELECT Stock.article_id, sum(quantite) quantite FROM stocks AS Stock GROUP BY Stock.article_id) AS Stock ON (Stock.article_id = Article.id)')
+			);
+	}
+
+/**
+ * Test buildJoinStatement()
+ * ensure that prefix is not added when table value is a subquery
+ *
+ * @dataProvider joinStatementsWithPrefix
+ * @return void
+ */
+	public function testBuildJoinStatementWithTablePrefix($join, $expected) {
+		$db = new DboTestSource;
+		$db->config['prefix'] = 'pre_';
+		$result = $db->buildJoinStatement($join);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test conditionKeysToString()
  *
  * @return void


### PR DESCRIPTION
when table is a subquery string, it is not necessary at all to call fullTableName, this will avoid both schema and table prefix appended to it

fix ticket [#3579](http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3579)
