### PR TITLE
Changed params for HtmlHelper::css() to be consistent with HtmlHelper::s...

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -549,7 +549,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected);
 
 		CakePlugin::load('TestPlugin');
-		$result = $this->Html->css('TestPlugin.style', null, array('plugin' => false));
+		$result = $this->Html->css('TestPlugin.style', array('plugin' => false));
 		$expected['link']['href'] = 'preg:/.*css\/TestPlugin\.style\.css/';
 		$this->assertTags($result, $expected);
 		CakePlugin::unload('TestPlugin');
@@ -595,6 +595,49 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->View->expects($this->at(1))
 			->method('append')
 			->with('css', $this->matchesRegularExpression('/more_css_in_head.css/'));
+
+		$result = $this->Html->css('css_in_head', array('inline' => false));
+		$this->assertNull($result);
+
+		$result = $this->Html->css('more_css_in_head', array('inline' => false));
+		$this->assertNull($result);
+
+		$result = $this->Html->css('screen', array('rel' => 'import'));
+		$expected = array(
+			'style' => array('type' => 'text/css'),
+			'preg:/@import url\(.*css\/screen\.css\);/',
+			'/style'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test css link BC usage
+ *
+ * @return void
+ */
+	public function testCssLinkBC() {
+		Configure::write('Asset.filter.css', false);
+
+		CakePlugin::load('TestPlugin');
+		$result = $this->Html->css('TestPlugin.style', null, array('plugin' => false));
+		$expected = array(
+			'link' => array(
+				'rel' => 'stylesheet',
+				'type' => 'text/css',
+				'href' => 'preg:/.*css\/TestPlugin\.style\.css/'
+			)
+		);
+		$this->assertTags($result, $expected);
+		CakePlugin::unload('TestPlugin');
+
+		$result = $this->Html->css('screen', 'import');
+		$expected = array(
+			'style' => array('type' => 'text/css'),
+			'preg:/@import url\(.*css\/screen\.css\);/',
+			'/style'
+		);
+		$this->assertTags($result, $expected);
 
 		$result = $this->Html->css('css_in_head', null, array('inline' => false));
 		$this->assertNull($result);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -384,30 +384,42 @@ class HtmlHelper extends AppHelper {
  *
  * Add the stylesheet to the `$scripts_for_layout` layout var:
  *
- * `$this->Html->css('styles.css', null, array('inline' => false));`
+ * `$this->Html->css('styles.css', array('inline' => false));`
  *
  * Add the stylesheet to a custom block:
  *
- * `$this->Html->css('styles.css', null, array('block' => 'layoutCss'));`
+ * `$this->Html->css('styles.css', array('block' => 'layoutCss'));`
  *
  * ### Options
  *
  * - `inline` If set to false, the generated tag will be appended to the 'css' block,
  *   and included in the `$scripts_for_layout` layout variable. Defaults to true.
- * - `block` Set the name of the block link/style tag will be appended to. This overrides the `inline`
- *   option.
+ * - `block` Set the name of the block link/style tag will be appended to.
+ *   This overrides the `inline` option.
  * - `plugin` False value will prevent parsing path as a plugin
+ * - `rel` Defaults to 'stylesheet'. If equal to 'import' the stylesheet will be imported.
  *
  * @param string|array $path The name of a CSS style sheet or an array containing names of
  *   CSS stylesheets. If `$path` is prefixed with '/', the path will be relative to the webroot
  *   of your application. Otherwise, the path will be relative to your CSS path, usually webroot/css.
- * @param string $rel Rel attribute. Defaults to "stylesheet". If equal to 'import' the stylesheet will be imported.
- * @param array $options Array of HTML attributes.
+ * @param array $options Array of options and HTML arguments.
  * @return string CSS <link /> or <style /> tag, depending on the type of link.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::css
  */
-	public function css($path, $rel = null, $options = array()) {
-		$options += array('block' => null, 'inline' => true);
+	public function css($path, $options = array()) {
+		if (!is_array($options)) {
+			$rel = $options;
+			$options = array();
+			if ($rel) {
+				$options['rel'] = $rel;
+			}
+			if (func_num_args() > 2) {
+				$options = func_get_arg(2) + $options;
+			}
+			unset($rel);
+		}
+
+		$options += array('block' => null, 'inline' => true, 'rel' => 'stylesheet');
 		if (!$options['inline'] && empty($options['block'])) {
 			$options['block'] = __FUNCTION__;
 		}
@@ -416,7 +428,7 @@ class HtmlHelper extends AppHelper {
 		if (is_array($path)) {
 			$out = '';
 			foreach ($path as $i) {
-				$out .= "\n\t" . $this->css($i, $rel, $options);
+				$out .= "\n\t" . $this->css($i, $options);
 			}
 			if (empty($options['block'])) {
 				return $out . "\n";
@@ -437,13 +449,19 @@ class HtmlHelper extends AppHelper {
 			}
 		}
 
-		if ($rel == 'import') {
-			$out = sprintf($this->_tags['style'], $this->_parseAttributes($options, array('inline', 'block'), '', ' '), '@import url(' . $url . ');');
+		if ($options['rel'] == 'import') {
+			$out = sprintf(
+				$this->_tags['style'],
+				$this->_parseAttributes($options, array('rel', 'block'), '', ' '),
+				'@import url(' . $url . ');'
+			);
 		} else {
-			if (!$rel) {
-				$rel = 'stylesheet';
-			}
-			$out = sprintf($this->_tags['css'], $rel, $url, $this->_parseAttributes($options, array('inline', 'block'), '', ' '));
+			$out = sprintf(
+				$this->_tags['css'],
+				$options['rel'],
+				$url,
+				$this->_parseAttributes($options, array('rel', 'block'), '', ' ')
+			);
 		}
 
 		if (empty($options['block'])) {


### PR DESCRIPTION
...cript().

Closes [#3593](http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3593-reduce-arguments-in-htmlhelpercss)
