### PR TITLE
Added a note about plugin assets not working without url rewrite 

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -92,7 +92,9 @@
  * /app/.htaccess
  * /app/webroot/.htaccess
  *
- * And uncomment the App.baseUrl below:
+ * And uncomment the App.baseUrl below. But keep in mind
+ * that plugin assets such as images, CSS and Javascript files 
+ * will not without url rewriting!
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -246,7 +246,7 @@
  *
  * Note: 'default' and other application caches should be configured in app/Config/bootstrap.php.
  *       Please check the comments in boostrap.php for more info on the cache engines available
- *       and their setttings.
+ *       and their settings.
  */
 $engine = 'File';
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -95,6 +95,12 @@
  * And uncomment the App.baseUrl below. But keep in mind
  * that plugin assets such as images, CSS and Javascript files 
  * will not work without url rewriting!
+ * To work around this issue you should either symlink or copy 
+ * the plugin assets into you app's webroot directory. This is 
+ * ecommended even when you are using mod_rewrite. Handling static 
+ * assets through the Dispatcher is incredibly inefficient and 
+ * included primarily as a development convenience - and 
+ * thus not recommended for production applications.
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -97,7 +97,7 @@
  * will not work without url rewriting!
  * To work around this issue you should either symlink or copy 
  * the plugin assets into you app's webroot directory. This is 
- * ecommended even when you are using mod_rewrite. Handling static 
+ * recommended even when you are using mod_rewrite. Handling static
  * assets through the Dispatcher is incredibly inefficient and 
  * included primarily as a development convenience - and 
  * thus not recommended for production applications.

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -94,7 +94,7 @@
  *
  * And uncomment the App.baseUrl below. But keep in mind
  * that plugin assets such as images, CSS and Javascript files 
- * will not without url rewriting!
+ * will not work without url rewriting!
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -92,7 +92,15 @@
  * /app/.htaccess
  * /app/webroot/.htaccess
  *
- * And uncomment the App.baseUrl below:
+ * And uncomment the App.baseUrl below. But keep in mind
+ * that plugin assets such as images, CSS and Javascript files 
+ * will not work without url rewriting!
+ * To work around this issue you should either symlink or copy 
+ * the plugin assets into you app's webroot directory. This is 
+ * recommended even when you are using mod_rewrite. Handling static
+ * assets through the Dispatcher is incredibly inefficient and 
+ * included primarily as a development convenience - and 
+ * thus not recommended for production applications.
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 
@@ -246,7 +254,7 @@
  *
  * Note: 'default' and other application caches should be configured in app/Config/bootstrap.php.
  *       Please check the comments in boostrap.php for more info on the cache engines available
- *       and their setttings.
+ *       and their settings.
  */
 $engine = 'File';
 

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -92,7 +92,9 @@
  * /app/.htaccess
  * /app/webroot/.htaccess
  *
- * And uncomment the App.baseUrl below:
+  * And uncomment the App.baseUrl below. But keep in mind
+ * that plugin assets such as images, CSS and Javascript files 
+ * will not work without url rewriting!
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -92,12 +92,12 @@
  * /app/.htaccess
  * /app/webroot/.htaccess
  *
-  * And uncomment the App.baseUrl below. But keep in mind
+ * And uncomment the App.baseUrl below. But keep in mind
  * that plugin assets such as images, CSS and Javascript files 
  * will not work without url rewriting!
  * To work around this issue you should either symlink or copy 
  * the plugin assets into you app's webroot directory. This is 
- * ecommended even when you are using mod_rewrite. Handling static 
+ * recommended even when you are using mod_rewrite. Handling static
  * assets through the Dispatcher is incredibly inefficient and 
  * included primarily as a development convenience - and 
  * thus not recommended for production applications.

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -95,6 +95,12 @@
   * And uncomment the App.baseUrl below. But keep in mind
  * that plugin assets such as images, CSS and Javascript files 
  * will not work without url rewriting!
+ * To work around this issue you should either symlink or copy 
+ * the plugin assets into you app's webroot directory. This is 
+ * ecommended even when you are using mod_rewrite. Handling static 
+ * assets through the Dispatcher is incredibly inefficient and 
+ * included primarily as a development convenience - and 
+ * thus not recommended for production applications.
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -307,7 +307,7 @@
  *
  * Note: 'default' and other application caches should be configured in app/Config/bootstrap.php.
  *       Please check the comments in boostrap.php for more info on the cache engines available
- *       and their setttings.
+ *       and their settings.
  */
 $engine = 'File';
 

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -92,7 +92,15 @@
  * /app/.htaccess
  * /app/webroot/.htaccess
  *
- * And uncomment the App.baseUrl below:
+ * And uncomment the App.baseUrl below. But keep in mind
+ * that plugin assets such as images, CSS and Javascript files 
+ * will not work without url rewriting!
+ * To work around this issue you should either symlink or copy 
+ * the plugin assets into you app's webroot directory. This is 
+ * recommended even when you are using mod_rewrite. Handling static
+ * assets through the Dispatcher is incredibly inefficient and 
+ * included primarily as a development convenience - and 
+ * thus not recommended for production applications.
  */
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 
@@ -307,7 +315,7 @@
  *
  * Note: 'default' and other application caches should be configured in app/Config/bootstrap.php.
  *       Please check the comments in boostrap.php for more info on the cache engines available
- *       and their setttings.
+ *       and their settings.
  */
 $engine = 'File';
 


### PR DESCRIPTION
http://cakephp.lighthouseapp.com/projects/42880/tickets/25-i-installed-but-dont-see-the-images-and-css-of-debugkit

--> "Plugin assets do not work without url rewriting, this is in the documentation for CakePHP itself. I guess it could be repeated for this and every other plugin."

--> "I could have sworn it was with the Plugin Assets section, but apparently its not there. Perhaps its just something I know from experience."

see also:
http://cakephp.lighthouseapp.com/projects/42648/tickets/1755-plugin-webroot-without-mod_rewrite-problem

http://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/500-plugin-css-directories-bug#ticket-500-8
