### PR TITLE
3.0 - First pass at making Email\Email use Multipart classes.

### DIFF
--- a/lib/Cake/Network/Http/FormData/Part.php
+++ b/lib/Cake/Network/Http/FormData/Part.php
@@ -58,6 +58,20 @@ class Part {
 	protected $_filename;
 
 /**
+ * The encoding used in this part.
+ *
+ * @var string
+ */
+	protected $_transferEncoding;
+
+/**
+ * The contentId for the part
+ *
+ * @var string
+ */
+	protected $_contentId;
+
+/**
  * Constructor
  *
  * @param string $name The name of the data.
@@ -72,7 +86,39 @@ class Part {
 	}
 
 /**
+ * Get/set the disposition type
+ *
+ * By passing in `false` you can disable the disposition
+ * header from being added.
+ *
+ * @param null|string $disposition Use null to get/string to set.
+ * @return mixed
+ */
+	public function disposition($disposition = null) {
+		if ($disposition === null) {
+			return $this->_disposition;
+		}
+		$this->_disposition = $disposition;
+	}
+
+/**
+ * Get/set the contentId for a part.
+ *
+ * @param null|string $id The content id.
+ * @return mixed.
+ */
+	public function contentId($id = null) {
+		if ($id === null) {
+			return $this->_contentId = $id;
+		}
+		$this->_contentId = $id;
+	}
+
+/**
  * Get/set the filename.
+ *
+ * Setting the filname to `false` will exclude it from the
+ * generated output.
  *
  * @param null|string $filename Use null to get/string to set.
  * @return mixed
@@ -98,6 +144,21 @@ class Part {
 	}
 
 /**
+ * Set the transfer-encoding for multipart.
+ *
+ * Useful when content bodies are in encodings like base64.
+ *
+ * @param null|string $type The type of encoding the value has.
+ * @return mixed
+ */
+	public function transferEncoding($type) {
+		if ($type === null) {
+			return $this->_transferEncoding;
+		}
+		$this->_transferEncoding = $type;
+	}
+
+/**
  * Convert the part into a string.
  *
  * Creates a string suitable for use in HTTP requests.
@@ -106,13 +167,24 @@ class Part {
  */
 	public function __toString() {
 		$out = '';
-		$out .= sprintf('Content-Disposition: %s; name="%s"', $this->_disposition, $this->_name);
-		if ($this->_filename) {
-			$out .= '; filename="' . $this->_filename . '"';
+		if ($this->_disposition) {
+			$out .= 'Content-Disposition: ' . $this->_disposition;
+			if ($this->_name) {
+				$out .= '; name="' . $this->_name . '"';
+			}
+			if ($this->_filename) {
+				$out .= '; filename="' . $this->_filename . '"';
+			}
+			$out .= "\r\n";
 		}
-		$out .= "\r\n";
 		if ($this->_type) {
 			$out .= 'Content-Type: ' . $this->_type . "\r\n";
+		}
+		if ($this->_transferEncoding) {
+			$out .= 'Content-Transfer-Encoding: ' . $this->_transferEncoding . "\r\n";
+		}
+		if ($this->_contentId) {
+			$out .= 'Content-ID: <' . $this->_contentId . ">\r\n";
 		}
 		$out .= "\r\n";
 		$out .= (string)$this->_value;

--- a/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
+++ b/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
@@ -848,9 +848,10 @@ class EmailTest extends TestCase {
 			"\r\n" .
 			"\r\n" .
 			"--$boundary\r\n" .
+			"Content-Disposition: attachment; filename=\"basics.php\"\r\n" .
 			"Content-Type: application/octet-stream\r\n" .
 			"Content-Transfer-Encoding: base64\r\n" .
-			"Content-Disposition: attachment; filename=\"basics.php\"\r\n\r\n";
+			"\r\n";
 		$this->assertContains($expected, $result['message']);
 	}
 
@@ -892,9 +893,10 @@ class EmailTest extends TestCase {
 			"--alt-{$boundary}--\r\n" .
 			"\r\n" .
 			"--$boundary\r\n" .
+			"Content-Disposition: attachment; filename=\"VERSION.txt\"\r\n" .
 			"Content-Type: application/octet-stream\r\n" .
 			"Content-Transfer-Encoding: base64\r\n" .
-			"Content-Disposition: attachment; filename=\"VERSION.txt\"\r\n\r\n";
+			"\r\n";
 		$this->assertContains($expected, $result['message']);
 	}
 
@@ -944,10 +946,11 @@ class EmailTest extends TestCase {
 			"--alt-{$boundary}--\r\n" .
 			"\r\n" .
 			"--rel-$boundary\r\n" .
+			"Content-Disposition: inline; filename=\"cake.png\"\r\n" .
 			"Content-Type: application/octet-stream\r\n" .
 			"Content-Transfer-Encoding: base64\r\n" .
 			"Content-ID: <abc123>\r\n" .
-			"Content-Disposition: inline; filename=\"cake.png\"\r\n\r\n";
+			"\r\n";
 		$this->assertContains($expected, $result['message']);
 		$this->assertContains('--rel-' . $boundary . '--', $result['message']);
 		$this->assertContains('--' . $boundary . '--', $result['message']);
@@ -1280,19 +1283,32 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->config(array());
 		$this->CakeEmail->attachments(array(CAKE . 'basics.php'));
 		$result = $this->CakeEmail->send('body');
-		$this->assertContains("Content-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"basics.php\"", $result['message']);
+		$expected = "Content-Disposition: attachment; filename=\"basics.php\"\r\n" .
+			"Content-Type: application/octet-stream\r\n" .
+			"Content-Transfer-Encoding: base64\r\n";
+		$this->assertContains($expected, $result['message']);
 
 		$this->CakeEmail->attachments(array('my.file.txt' => CAKE . 'basics.php'));
 		$result = $this->CakeEmail->send('body');
-		$this->assertContains("Content-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"my.file.txt\"", $result['message']);
+		$expected = "Content-Disposition: attachment; filename=\"my.file.txt\"\r\n" .
+			"Content-Type: application/octet-stream\r\n" .
+			"Content-Transfer-Encoding: base64\r\n";
+		$this->assertContains($expected, $result['message']);
 
 		$this->CakeEmail->attachments(array('file.txt' => array('file' => CAKE . 'basics.php', 'mimetype' => 'text/plain')));
 		$result = $this->CakeEmail->send('body');
-		$this->assertContains("Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"file.txt\"", $result['message']);
+		$expected = "Content-Disposition: attachment; filename=\"file.txt\"\r\n" .
+			"Content-Type: text/plain\r\n" .
+			"Content-Transfer-Encoding: base64\r\n";
+		$this->assertContains($expected, $result['message']);
 
 		$this->CakeEmail->attachments(array('file2.txt' => array('file' => CAKE . 'basics.php', 'mimetype' => 'text/plain', 'contentId' => 'a1b1c1')));
 		$result = $this->CakeEmail->send('body');
-		$this->assertContains("Content-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\nContent-ID: <a1b1c1>\r\nContent-Disposition: inline; filename=\"file2.txt\"", $result['message']);
+		$expected = "Content-Disposition: inline; filename=\"file2.txt\"\r\n" .
+			"Content-Type: text/plain\r\n" .
+			"Content-Transfer-Encoding: base64\r\n" .
+			"Content-ID: <a1b1c1>\r\n";
+		$this->assertContains($expected, $result['message']);
 	}
 
 /**


### PR DESCRIPTION
There is still work to be done around a more generic multipart builder, but I think that might require a separate Mime building sub-package.  I'm not sure how far down that road we might want to go.  If people think its worthwhile, or would lead to cleaner internals I can see how hard it would be to build a simple multipart message generator. Parsing messages is more difficult and something I don't think we really need in CakePHP.
