### PR TITLE
Add CakeRequest::param()

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -806,6 +806,20 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
+ * Safely access the values in $this->params.
+ *
+ * @param string $name The name of the parameter to get.
+ * @return mixed The value of the provided parameter. Will
+ *   return false if the parameter doesn't exist or is falsey.
+ */
+	public function param($name) {
+		if (!isset($this->params[$name])) {
+			return false;
+		}
+		return $this->params[$name];
+	}
+
+/**
  * Read data from `php://input`. Useful when interacting with XML or JSON
  * request body content.
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1769,6 +1769,26 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test using param()
+ *
+ * @return void
+ */
+	public function testReadingParams() {
+		$request = new CakeRequest();
+		$request->addParams(array(
+			'controller' => 'posts',
+			'admin' => true,
+			'truthy' => 1,
+			'zero' => '0',
+		));
+		$this->assertFalse($request->param('not_set'));
+		$this->assertTrue($request->param('admin'));
+		$this->assertEquals(1, $request->param('truthy'));
+		$this->assertEquals('posts', $request->param('controller'));
+		$this->assertEquals('0', $request->param('zero'));
+	}
+
+/**
  * test the data() method reading
  *
  * @return void


### PR DESCRIPTION
This method gives a read accessor to the data in $request->params. It removes the need to use isset() and empty(). I felt like this would be a useful method when I had to write 

``` php
if (!empty($this->request->param['admin'])) {
...
}
```

Which would just be:

``` php
if ($this->request->param('admin')) {
...
}
```

After this change.  This method also completes the `data()` and `query()` cycle of methods.
