### PR TITLE
Breaking out the find so that it can be easily overloaded for caching

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2678,39 +2678,42 @@ class Model extends Object implements CakeEventListener {
  * @link http://book.cakephp.org/2.0/en/models/retrieving-your-data.html
  */
 	public function find($type = 'first', $query = array()) {
-		$query = $this->_beforeFind($type, $query);
+		$this->findQueryType = $type;
+		$this->id = $this->getID();
+
+		$query = $this->buildQuery($type, $query);
 		if (is_null($query)) {
 			return null;
 		}
 
-		return $this->_afterFind($type, $query);
+		return $this->_readDataSource($type, $query);
 	}
 
 /**
- * Before running a find
+ * Read from the datasource
+ *
+ * Model::_readDataSource() is used by all find() calls to read from the data source and can be overloaded to allow
+ * caching of datasource calls.
  * 
- * @param string $type the find type to run
- * @param array $query the finds query params
+ * {{{
+ * protected function _readDataSource($type, $query) {
+ * 		$cacheName = md5(json_encode($query));
+ * 		$cache = Cache::read($cacheName, 'cache-config-name');
+ * 		if ($cache !== false) {
+ * 			return $cache;
+ * 		}
+ *
+ * 		$results = parent::_readDataSource($type, $query);
+ * 		Cache::write($cacheName, $results, 'cache-config-name');
+ * 		return $results;
+ * }
+ * }}}
  * 
- * @return array|null
+ * @param string $type Type of find operation (all / first / count / neighbors / list / threaded)
+ * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
+ * @return array
  */
-	protected function _beforeFind($type, $query) {
-		$this->findQueryType = $type;
-		$this->id = $this->getID();
-
-		return $this->buildQuery($type, $query);
-	}
-
-/**
- * After running a find
- * 
- * @param string $type the find type to run
- * @param array $query the finds query params
- * @param array $results they results from the find
- * 
- * @return array|null
- */
-	protected function _afterFind($type, $query) {
+	protected function _readDataSource($type, $query) {
 		$results = $this->getDataSource()->read($this, $query);
 		$this->resetAssociations();
 
@@ -2727,7 +2730,6 @@ class Model extends Object implements CakeEventListener {
 		if ($this->findMethods[$type] === true) {
 			return $this->{'_find' . ucfirst($type)}('after', $query, $results);
 		}
-
 	}
 
 /**

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2678,14 +2678,39 @@ class Model extends Object implements CakeEventListener {
  * @link http://book.cakephp.org/2.0/en/models/retrieving-your-data.html
  */
 	public function find($type = 'first', $query = array()) {
-		$this->findQueryType = $type;
-		$this->id = $this->getID();
-
-		$query = $this->buildQuery($type, $query);
+		$query = $this->_beforeFind($type, $query);
 		if (is_null($query)) {
 			return null;
 		}
 
+		return $this->_afterFind($type, $query);
+	}
+
+/**
+ * Before running a find
+ * 
+ * @param string $type the find type to run
+ * @param array $query the finds query params
+ * 
+ * @return array|null
+ */
+	protected function _beforeFind($type, $query) {
+		$this->findQueryType = $type;
+		$this->id = $this->getID();
+
+		return $this->buildQuery($type, $query);
+	}
+
+/**
+ * After running a find
+ * 
+ * @param string $type the find type to run
+ * @param array $query the finds query params
+ * @param array $results they results from the find
+ * 
+ * @return array|null
+ */
+	protected function _afterFind($type, $query) {
 		$results = $this->getDataSource()->read($this, $query);
 		$this->resetAssociations();
 
@@ -2702,6 +2727,7 @@ class Model extends Object implements CakeEventListener {
 		if ($this->findMethods[$type] === true) {
 			return $this->{'_find' . ucfirst($type)}('after', $query, $results);
 		}
+
 	}
 
 /**


### PR DESCRIPTION
Before this commit you have to do some hacks to cache model finds easily. When using custom find methods like `find('foo')` => `_findFoo(...)` it is common for the method to adjust the query params.

Trying to cache a query using a hash of the query params :

```
/** Overloaded find() */
function find($type, $query) {
    $query = $this->_beforeFind($query); // $query gets modified by custom finds
    $cacheKey = $type . '_' . md5(selialize($query));

    $cache = Cache::read($cachKey, 'my_cache');
    if ($cacheKey !== false) {
        return $cache;
    }

    $results = $this->_afterFind($type, $query); // chance to cache the results
    Cache::write($cacheKey, $results, 'my_cache');

    return $results;
}
```

Before this commit you either have to completely overload find and rewrite it in the AppModel or call the before to get the modified `$query` and let cake run the before again.
