### PR TITLE
Strict comparison for strings where applicable

### DIFF
--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -106,10 +106,10 @@ class MemcacheEngine extends CacheEngine {
  * @return array Array containing host, port
  */
 	protected function _parseServerString($server) {
-		if ($server[0] == 'u') {
+		if ($server[0] === 'u') {
 			return array($server, 0);
 		}
-		if (substr($server, 0, 1) == '[') {
+		if (substr($server, 0, 1) === '[') {
 			$position = strpos($server, ']:');
 			if ($position !== false) {
 				$position++;

--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -160,7 +160,7 @@ class IniReader implements ConfigReaderInterface {
 		$result = array();
 		foreach ($data as $k => $value) {
 			$isSection = false;
-			if ($k[0] != '[') {
+			if ($k[0] !== '[') {
 				$result[] = "[$k]";
 				$isSection = true;
 			}

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -122,14 +122,14 @@ class AclShell extends AppShell {
 		$class = ucfirst($this->args[0]);
 		$parent = $this->parseIdentifier($this->args[1]);
 
-		if (!empty($parent) && $parent != '/' && $parent != 'root') {
+		if (!empty($parent) && $parent !== '/' && $parent !== 'root') {
 			$parent = $this->_getNodeId($class, $parent);
 		} else {
 			$parent = null;
 		}
 
 		$data = $this->parseIdentifier($this->args[2]);
-		if (is_string($data) && $data != '/') {
+		if (is_string($data) && $data !== '/') {
 			$data = array('alias' => $data);
 		} elseif (is_string($data)) {
 			$this->error(__d('cake_console', '/ can not be used as an alias!') . __d('cake_console', "	/ is the root, please supply a sub alias"));
@@ -604,7 +604,7 @@ class AclShell extends AppShell {
 		}
 		$vars = array();
 		$class = ucwords($type);
-		$vars['secondary_id'] = (strtolower($class) == 'aro') ? 'foreign_key' : 'object_id';
+		$vars['secondary_id'] = (strtolower($class) === 'aro') ? 'foreign_key' : 'object_id';
 		$vars['data_name'] = $type;
 		$vars['table_name'] = $type . 's';
 		$vars['class'] = $class;

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -66,7 +66,7 @@ class ControllerTask extends BakeTask {
 			if (!isset($this->connection)) {
 				$this->connection = 'default';
 			}
-			if (strtolower($this->args[0]) == 'all') {
+			if (strtolower($this->args[0]) === 'all') {
 				return $this->all();
 			}
 
@@ -162,13 +162,13 @@ class ControllerTask extends BakeTask {
 		}
 		$doItInteractive = $this->in(implode("\n", $question), array('y', 'n'), 'y');
 
-		if (strtolower($doItInteractive) == 'y') {
+		if (strtolower($doItInteractive) === 'y') {
 			$this->interactive = true;
 			$useDynamicScaffold = $this->in(
 				__d('cake_console', "Would you like to use dynamic scaffolding?"), array('y', 'n'), 'n'
 			);
 
-			if (strtolower($useDynamicScaffold) == 'y') {
+			if (strtolower($useDynamicScaffold) === 'y') {
 				$wannaBakeCrud = 'n';
 				$actions = 'scaffold';
 			} else {
@@ -185,12 +185,12 @@ class ControllerTask extends BakeTask {
 			list($wannaBakeCrud, $wannaBakeAdminCrud) = $this->_askAboutMethods();
 		}
 
-		if (strtolower($wannaBakeCrud) == 'y') {
-			$actions = $this->bakeActions($controllerName, null, strtolower($wannaUseSession) == 'y');
+		if (strtolower($wannaBakeCrud) === 'y') {
+			$actions = $this->bakeActions($controllerName, null, strtolower($wannaUseSession) === 'y');
 		}
-		if (strtolower($wannaBakeAdminCrud) == 'y') {
+		if (strtolower($wannaBakeAdminCrud) === 'y') {
 			$admin = $this->Project->getPrefix();
-			$actions .= $this->bakeActions($controllerName, $admin, strtolower($wannaUseSession) == 'y');
+			$actions .= $this->bakeActions($controllerName, $admin, strtolower($wannaUseSession) === 'y');
 		}
 
 		$baked = false;
@@ -198,7 +198,7 @@ class ControllerTask extends BakeTask {
 			$this->confirmController($controllerName, $useDynamicScaffold, $helpers, $components);
 			$looksGood = $this->in(__d('cake_console', 'Look okay?'), array('y','n'), 'y');
 
-			if (strtolower($looksGood) == 'y') {
+			if (strtolower($looksGood) === 'y') {
 				$baked = $this->bake($controllerName, $actions, $helpers, $components);
 				if ($baked && $this->_checkUnitTest()) {
 					$this->bakeTest($controllerName);
@@ -229,7 +229,7 @@ class ControllerTask extends BakeTask {
 		$this->hr();
 		$this->out(__d('cake_console', "Controller Name:\n\t%s", $controllerName));
 
-		if (strtolower($useDynamicScaffold) == 'y') {
+		if (strtolower($useDynamicScaffold) === 'y') {
 			$this->out("public \$scaffold;");
 		}
 
@@ -386,7 +386,7 @@ class ControllerTask extends BakeTask {
 	protected function _doPropertyChoices($prompt, $example) {
 		$proceed = $this->in($prompt, array('y','n'), 'n');
 		$property = array();
-		if (strtolower($proceed) == 'y') {
+		if (strtolower($proceed) === 'y') {
 			$propertyList = $this->in($example);
 			$propertyListTrimmed = str_replace(' ', '', $propertyList);
 			$property = explode(',', $propertyListTrimmed);

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -110,7 +110,7 @@ class DbConfigTask extends AppShell {
 			$datasource = $this->in(__d('cake_console', 'Datasource:'), array('Mysql', 'Postgres', 'Sqlite', 'Sqlserver'), 'Mysql');
 
 			$persistent = $this->in(__d('cake_console', 'Persistent Connection?'), array('y', 'n'), 'n');
-			if (strtolower($persistent) == 'n') {
+			if (strtolower($persistent) === 'n') {
 				$persistent = 'false';
 			} else {
 				$persistent = 'true';
@@ -126,7 +126,7 @@ class DbConfigTask extends AppShell {
 				$port = $this->in(__d('cake_console', 'Port?'), null, 'n');
 			}
 
-			if (strtolower($port) == 'n') {
+			if (strtolower($port) === 'n') {
 				$port = null;
 			}
 
@@ -142,7 +142,7 @@ class DbConfigTask extends AppShell {
 
 				if (!$password) {
 					$blank = $this->in(__d('cake_console', 'The password you supplied was empty. Use an empty password?'), array('y', 'n'), 'n');
-					if ($blank == 'y') {
+					if ($blank === 'y') {
 						$blankPassword = true;
 					}
 				}
@@ -157,7 +157,7 @@ class DbConfigTask extends AppShell {
 			while (!$prefix) {
 				$prefix = $this->in(__d('cake_console', 'Table Prefix?'), null, 'n');
 			}
-			if (strtolower($prefix) == 'n') {
+			if (strtolower($prefix) === 'n') {
 				$prefix = null;
 			}
 
@@ -165,17 +165,17 @@ class DbConfigTask extends AppShell {
 			while (!$encoding) {
 				$encoding = $this->in(__d('cake_console', 'Table encoding?'), null, 'n');
 			}
-			if (strtolower($encoding) == 'n') {
+			if (strtolower($encoding) === 'n') {
 				$encoding = null;
 			}
 
 			$schema = '';
-			if ($datasource == 'postgres') {
+			if ($datasource === 'postgres') {
 				while (!$schema) {
 					$schema = $this->in(__d('cake_console', 'Table schema?'), null, 'n');
 				}
 			}
-			if (strtolower($schema) == 'n') {
+			if (strtolower($schema) === 'n') {
 				$schema = null;
 			}
 
@@ -188,7 +188,7 @@ class DbConfigTask extends AppShell {
 			$dbConfigs[] = $config;
 			$doneYet = $this->in(__d('cake_console', 'Do you wish to add another database configuration?'), null, 'n');
 
-			if (strtolower($doneYet == 'n')) {
+			if (strtolower($doneYet === 'n')) {
 				$done = true;
 			}
 		}
@@ -239,7 +239,7 @@ class DbConfigTask extends AppShell {
 		$this->hr();
 		$looksGood = $this->in(__d('cake_console', 'Look okay?'), array('y', 'n'), 'y');
 
-		if (strtolower($looksGood) == 'y') {
+		if (strtolower($looksGood) === 'y') {
 			return $config;
 		}
 		return false;

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -388,14 +388,14 @@ class ExtractTask extends AppShell {
 			}
 
 			list($type, $string, $line) = $countToken;
-			if (($type == T_STRING) && ($string == $functionName) && ($firstParenthesis == '(')) {
+			if (($type == T_STRING) && ($string == $functionName) && ($firstParenthesis === '(')) {
 				$position = $count;
 				$depth = 0;
 
 				while (!$depth) {
-					if ($this->_tokens[$position] == '(') {
+					if ($this->_tokens[$position] === '(') {
 						$depth++;
-					} elseif ($this->_tokens[$position] == ')') {
+					} elseif ($this->_tokens[$position] === ')') {
 						$depth--;
 					}
 					$position++;
@@ -537,7 +537,7 @@ class ExtractTask extends AppShell {
 				}
 
 				$this->_store($domain, $header, $sentence);
-				if ($domain != 'default' && $this->_merge) {
+				if ($domain !== 'default' && $this->_merge) {
 					$this->_store('default', $header, $sentence);
 				}
 			}
@@ -640,11 +640,11 @@ class ExtractTask extends AppShell {
 	protected function _getStrings(&$position, $target) {
 		$strings = array();
 		$count = count($strings);
-		while ($count < $target && ($this->_tokens[$position] == ',' || $this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING)) {
+		while ($count < $target && ($this->_tokens[$position] === ',' || $this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING)) {
 			$count = count($strings);
-			if ($this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING && $this->_tokens[$position + 1] == '.') {
+			if ($this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING && $this->_tokens[$position + 1] === '.') {
 				$string = '';
-				while ($this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING || $this->_tokens[$position] == '.') {
+				while ($this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING || $this->_tokens[$position] === '.') {
 					if ($this->_tokens[$position][0] == T_CONSTANT_ENCAPSED_STRING) {
 						$string .= $this->_formatString($this->_tokens[$position][1]);
 					}
@@ -668,7 +668,7 @@ class ExtractTask extends AppShell {
 	protected function _formatString($string) {
 		$quote = substr($string, 0, 1);
 		$string = substr($string, 1, -1);
-		if ($quote == '"') {
+		if ($quote === '"') {
 			$string = stripcslashes($string);
 		} else {
 			$string = strtr($string, array("\\'" => "'", "\\\\" => "\\"));
@@ -697,11 +697,11 @@ class ExtractTask extends AppShell {
 				$this->out($this->_tokens[$count][1], false);
 			} else {
 				$this->out($this->_tokens[$count], false);
-				if ($this->_tokens[$count] == '(') {
+				if ($this->_tokens[$count] === '(') {
 					$parenthesis++;
 				}
 
-				if ($this->_tokens[$count] == ')') {
+				if ($this->_tokens[$count] === ')') {
 					$parenthesis--;
 				}
 			}

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -107,7 +107,7 @@ class FixtureTask extends BakeTask {
 			if (!isset($this->connection)) {
 				$this->connection = 'default';
 			}
-			if (strtolower($this->args[0]) == 'all') {
+			if (strtolower($this->args[0]) === 'all') {
 				return $this->all();
 			}
 			$model = $this->_modelName($this->args[0]);
@@ -159,17 +159,17 @@ class FixtureTask extends BakeTask {
 	public function importOptions($modelName) {
 		$options = array();
 		$doSchema = $this->in(__d('cake_console', 'Would you like to import schema for this fixture?'), array('y', 'n'), 'n');
-		if ($doSchema == 'y') {
+		if ($doSchema === 'y') {
 			$options['schema'] = $modelName;
 		}
 		$doRecords = $this->in(__d('cake_console', 'Would you like to use record importing for this fixture?'), array('y', 'n'), 'n');
-		if ($doRecords == 'y') {
+		if ($doRecords === 'y') {
 			$options['records'] = true;
 		}
-		if ($doRecords == 'n') {
+		if ($doRecords === 'n') {
 			$prompt = __d('cake_console', "Would you like to build this fixture with data from %s's table?", $modelName);
 			$fromTable = $this->in($prompt, array('y', 'n'), 'n');
-			if (strtolower($fromTable) == 'y') {
+			if (strtolower($fromTable) === 'y') {
 				$options['fromTable'] = true;
 			}
 		}
@@ -203,7 +203,7 @@ class FixtureTask extends BakeTask {
 			if (isset($importOptions['records'])) {
 				$importBits[] = "'records' => true";
 			}
-			if ($this->connection != 'default') {
+			if ($this->connection !== 'default') {
 				$importBits[] .= "'connection' => '{$this->connection}'";
 			}
 			if (!empty($importBits)) {
@@ -307,7 +307,7 @@ class FixtureTask extends BakeTask {
 					case 'string':
 					case 'binary':
 						$isPrimaryUuid = (
-							isset($fieldInfo['key']) && strtolower($fieldInfo['key']) == 'primary' &&
+							isset($fieldInfo['key']) && strtolower($fieldInfo['key']) === 'primary' &&
 							isset($fieldInfo['length']) && $fieldInfo['length'] == 36
 						);
 						if ($isPrimaryUuid) {

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -98,7 +98,7 @@ class ModelTask extends BakeTask {
 			if (!isset($this->connection)) {
 				$this->connection = 'default';
 			}
-			if (strtolower($this->args[0]) == 'all') {
+			if (strtolower($this->args[0]) === 'all') {
 				return $this->all();
 			}
 			$model = $this->_modelName($this->args[0]);
@@ -150,7 +150,7 @@ class ModelTask extends BakeTask {
 		$object = new Model(array('name' => $className, 'table' => $table, 'ds' => $this->connection));
 		$fields = $object->schema(true);
 		foreach ($fields as $name => $field) {
-			if (isset($field['key']) && $field['key'] == 'primary') {
+			if (isset($field['key']) && $field['key'] === 'primary') {
 				$object->primaryKey = $name;
 				break;
 			}
@@ -209,7 +209,7 @@ class ModelTask extends BakeTask {
 		if (!in_array($useTable, $this->_tables)) {
 			$prompt = __d('cake_console', "The table %s doesn't exist or could not be automatically detected\ncontinue anyway?", $useTable);
 			$continue = $this->in($prompt, array('y', 'n'));
-			if (strtolower($continue) == 'n') {
+			if (strtolower($continue) === 'n') {
 				return false;
 			}
 		}
@@ -235,13 +235,13 @@ class ModelTask extends BakeTask {
 
 			$prompt = __d('cake_console', "Would you like to supply validation criteria \nfor the fields in your model?");
 			$wannaDoValidation = $this->in($prompt, array('y','n'), 'y');
-			if (array_search($useTable, $this->_tables) !== false && strtolower($wannaDoValidation) == 'y') {
+			if (array_search($useTable, $this->_tables) !== false && strtolower($wannaDoValidation) === 'y') {
 				$validate = $this->doValidation($tempModel);
 			}
 
 			$prompt = __d('cake_console', "Would you like to define model associations\n(hasMany, hasOne, belongsTo, etc.)?");
 			$wannaDoAssoc = $this->in($prompt, array('y','n'), 'y');
-			if (strtolower($wannaDoAssoc) == 'y') {
+			if (strtolower($wannaDoAssoc) === 'y') {
 				$associations = $this->doAssociations($tempModel);
 			}
 		}
@@ -258,7 +258,7 @@ class ModelTask extends BakeTask {
 		if ($fullTableName !== Inflector::tableize($currentModelName)) {
 			$this->out(__d('cake_console', 'DB Table:   %s', $fullTableName));
 		}
-		if ($primaryKey != 'id') {
+		if ($primaryKey !== 'id') {
 			$this->out(__d('cake_console', 'Primary Key: %s', $primaryKey));
 		}
 		if (!empty($validate)) {
@@ -275,7 +275,7 @@ class ModelTask extends BakeTask {
 		$this->hr();
 		$looksGood = $this->in(__d('cake_console', 'Look okay?'), array('y', 'n'), 'y');
 
-		if (strtolower($looksGood) == 'y') {
+		if (strtolower($looksGood) === 'y') {
 			$vars = compact('associations', 'validate', 'primaryKey', 'useTable', 'displayField');
 			$vars['useDbConfig'] = $this->connection;
 			if ($this->bake($currentModelName, $vars)) {
@@ -315,7 +315,7 @@ class ModelTask extends BakeTask {
 	public function findPrimaryKey($fields) {
 		$name = 'id';
 		foreach ($fields as $name => $field) {
-			if (isset($field['key']) && $field['key'] == 'primary') {
+			if (isset($field['key']) && $field['key'] === 'primary') {
 				break;
 			}
 		}
@@ -332,7 +332,7 @@ class ModelTask extends BakeTask {
 		$fieldNames = array_keys($fields);
 		$prompt = __d('cake_console', "A displayField could not be automatically detected\nwould you like to choose one?");
 		$continue = $this->in($prompt, array('y', 'n'));
-		if (strtolower($continue) == 'n') {
+		if (strtolower($continue) === 'n') {
 			return false;
 		}
 		$prompt = __d('cake_console', 'Choose a field from the options above:');
@@ -379,7 +379,7 @@ class ModelTask extends BakeTask {
 		sort($options);
 		$default = 1;
 		foreach ($options as $option) {
-			if ($option{0} != '_') {
+			if ($option{0} !== '_') {
 				$choices[$default] = strtolower($option);
 				$default++;
 			}
@@ -402,7 +402,7 @@ class ModelTask extends BakeTask {
 		$validate = $alreadyChosen = array();
 
 		$anotherValidator = 'y';
-		while ($anotherValidator == 'y') {
+		while ($anotherValidator === 'y') {
 			if ($this->interactive) {
 				$this->out();
 				$this->out(__d('cake_console', 'Field: <info>%s</info>', $fieldName));
@@ -428,25 +428,25 @@ class ModelTask extends BakeTask {
 			$methods = array_flip($this->_validations);
 			$guess = $defaultChoice;
 			if ($metaData['null'] != 1 && !in_array($fieldName, array($primaryKey, 'created', 'modified', 'updated'))) {
-				if ($fieldName == 'email') {
+				if ($fieldName === 'email') {
 					$guess = $methods['email'];
-				} elseif ($metaData['type'] == 'string' && $metaData['length'] == 36) {
+				} elseif ($metaData['type'] === 'string' && $metaData['length'] == 36) {
 					$guess = $methods['uuid'];
-				} elseif ($metaData['type'] == 'string') {
+				} elseif ($metaData['type'] === 'string') {
 					$guess = $methods['notempty'];
-				} elseif ($metaData['type'] == 'text') {
+				} elseif ($metaData['type'] === 'text') {
 					$guess = $methods['notempty'];
-				} elseif ($metaData['type'] == 'integer') {
+				} elseif ($metaData['type'] === 'integer') {
 					$guess = $methods['numeric'];
-				} elseif ($metaData['type'] == 'boolean') {
+				} elseif ($metaData['type'] === 'boolean') {
 					$guess = $methods['boolean'];
-				} elseif ($metaData['type'] == 'date') {
+				} elseif ($metaData['type'] === 'date') {
 					$guess = $methods['date'];
-				} elseif ($metaData['type'] == 'time') {
+				} elseif ($metaData['type'] === 'time') {
 					$guess = $methods['time'];
-				} elseif ($metaData['type'] == 'datetime') {
+				} elseif ($metaData['type'] === 'datetime') {
 					$guess = $methods['datetime'];
-				} elseif ($metaData['type'] == 'inet') {
+				} elseif ($metaData['type'] === 'inet') {
 					$guess = $methods['ip'];
 				}
 			}
@@ -549,14 +549,14 @@ class ModelTask extends BakeTask {
 		$fieldNames = array_keys($model->schema(true));
 		foreach ($fieldNames as $fieldName) {
 			$offset = strpos($fieldName, '_id');
-			if ($fieldName != $model->primaryKey && $fieldName != 'parent_id' && $offset !== false) {
+			if ($fieldName != $model->primaryKey && $fieldName !== 'parent_id' && $offset !== false) {
 				$tmpModelName = $this->_modelNameFromKey($fieldName);
 				$associations['belongsTo'][] = array(
 					'alias' => $tmpModelName,
 					'className' => $tmpModelName,
 					'foreignKey' => $fieldName,
 				);
-			} elseif ($fieldName == 'parent_id') {
+			} elseif ($fieldName === 'parent_id') {
 				$associations['belongsTo'][] = array(
 					'alias' => 'Parent' . $model->name,
 					'className' => $model->name,
@@ -593,7 +593,7 @@ class ModelTask extends BakeTask {
 						'className' => $tempOtherModel->name,
 						'foreignKey' => $fieldName
 					);
-				} elseif ($otherTable == $model->table && $fieldName == 'parent_id') {
+				} elseif ($otherTable == $model->table && $fieldName === 'parent_id') {
 					$assoc = array(
 						'alias' => 'Child' . $model->name,
 						'className' => $model->name,
@@ -659,7 +659,7 @@ class ModelTask extends BakeTask {
 
 					if ('n' == strtolower($response)) {
 						unset($associations[$type][$i]);
-					} elseif ($type == 'hasMany') {
+					} elseif ($type === 'hasMany') {
 						unset($associations['hasOne'][$i]);
 					}
 				}
@@ -755,7 +755,7 @@ class ModelTask extends BakeTask {
 			$tempOtherModel = new Model(array('table' => $otherTable, 'ds' => $this->connection));
 			$modelFieldsTemp = $tempOtherModel->schema(true);
 			foreach ($modelFieldsTemp as $fieldName => $field) {
-				if ($field['type'] == 'integer' || $field['type'] == 'string') {
+				if ($field['type'] === 'integer' || $field['type'] === 'string') {
 					$possible[$otherTable][] = $fieldName;
 				}
 			}
@@ -877,7 +877,7 @@ class ModelTask extends BakeTask {
 				$this->out(__d('cake_console', "Given your model named '%s',\nCake would expect a database table named '%s'", $modelName, $fullTableName));
 				$tableIsGood = $this->in(__d('cake_console', 'Do you want to use this table?'), array('y', 'n'), 'y');
 			}
-			if (strtolower($tableIsGood) == 'n') {
+			if (strtolower($tableIsGood) === 'n') {
 				$useTable = $this->in(__d('cake_console', 'What is the name of the table?'));
 			}
 		}

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -107,7 +107,7 @@ class PluginTask extends AppShell {
 
 		$looksGood = $this->in(__d('cake_console', 'Look okay?'), array('y', 'n', 'q'), 'y');
 
-		if (strtolower($looksGood) == 'y') {
+		if (strtolower($looksGood) === 'y') {
 			$Folder = new Folder($this->path . $plugin);
 			$directories = array(
 				'Config' . DS . 'Schema',

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -198,7 +198,7 @@ class TestTask extends BakeTask {
 		}
 		$keys[] = 'q';
 		$selection = $this->in(__d('cake_console', 'Enter the type of object to bake a test for or (q)uit'), $keys, 'q');
-		if ($selection == 'q') {
+		if ($selection === 'q') {
 			return $this->_stop();
 		}
 		$types = array_keys($this->classTypes);
@@ -281,7 +281,7 @@ class TestTask extends BakeTask {
 		ClassRegistry::flush();
 		App::import($type, $class);
 		$class = $this->getRealClassName($type, $class);
-		if (strtolower($type) == 'model') {
+		if (strtolower($type) === 'model') {
 			$instance = ClassRegistry::init($class);
 		} else {
 			$instance = new $class();
@@ -298,7 +298,7 @@ class TestTask extends BakeTask {
  * @return string Real classname
  */
 	public function getRealClassName($type, $class) {
-		if (strtolower($type) == 'model' || empty($this->classTypes[$type])) {
+		if (strtolower($type) === 'model' || empty($this->classTypes[$type])) {
 			return $class;
 		}
 
@@ -358,7 +358,7 @@ class TestTask extends BakeTask {
 		$thisMethods = array_diff($classMethods, $parentMethods);
 		$out = array();
 		foreach ($thisMethods as $method) {
-			if (substr($method, 0, 1) != '_' && $method != strtolower($className)) {
+			if (substr($method, 0, 1) !== '_' && $method != strtolower($className)) {
 				$out[] = $method;
 			}
 		}
@@ -397,7 +397,7 @@ class TestTask extends BakeTask {
 			if (!isset($this->_fixtures[$className])) {
 				$this->_processModel($subject->{$alias});
 			}
-			if ($type == 'hasAndBelongsToMany') {
+			if ($type === 'hasAndBelongsToMany') {
 				if (!empty($subject->hasAndBelongsToMany[$alias]['with'])) {
 					list(, $joinModel) = pluginSplit($subject->hasAndBelongsToMany[$alias]['with']);
 				} else {
@@ -454,7 +454,7 @@ class TestTask extends BakeTask {
 	public function getUserFixtures() {
 		$proceed = $this->in(__d('cake_console', 'Bake could not detect fixtures, would you like to add some?'), array('y', 'n'), 'n');
 		$fixtures = array();
-		if (strtolower($proceed) == 'y') {
+		if (strtolower($proceed) === 'y') {
 			$fixtureList = $this->in(__d('cake_console', "Please provide a comma separated list of the fixtures names you'd like to use.\nExample: 'app.comment, app.post, plugin.forums.post'"));
 			$fixtureListTrimmed = str_replace(' ', '', $fixtureList);
 			$fixtures = explode(',', $fixtureListTrimmed);
@@ -472,7 +472,7 @@ class TestTask extends BakeTask {
  */
 	public function hasMockClass($type) {
 		$type = strtolower($type);
-		return $type == 'controller';
+		return $type === 'controller';
 	}
 
 /**
@@ -486,17 +486,17 @@ class TestTask extends BakeTask {
 	public function generateConstructor($type, $fullClassName, $plugin) {
 		$type = strtolower($type);
 		$pre = $construct = $post = '';
-		if ($type == 'model') {
+		if ($type === 'model') {
 			$construct = "ClassRegistry::init('{$plugin}$fullClassName');\n";
 		}
-		if ($type == 'behavior') {
+		if ($type === 'behavior') {
 			$construct = "new $fullClassName();\n";
 		}
-		if ($type == 'helper') {
+		if ($type === 'helper') {
 			$pre = "\$View = new View();\n";
 			$construct = "new {$fullClassName}(\$View);\n";
 		}
-		if ($type == 'component') {
+		if ($type === 'component') {
 			$pre = "\$Collection = new ComponentCollection();\n";
 			$construct = "new {$fullClassName}(\$Collection);\n";
 		}
@@ -514,11 +514,11 @@ class TestTask extends BakeTask {
 	public function generateUses($type, $realType, $className) {
 		$uses = array();
 		$type = strtolower($type);
-		if ($type == 'component') {
+		if ($type === 'component') {
 			$uses[] = array('ComponentCollection', 'Controller');
 			$uses[] = array('Component', 'Controller');
 		}
-		if ($type == 'helper') {
+		if ($type === 'helper') {
 			$uses[] = array('View', 'View');
 			$uses[] = array('Helper', 'View');
 		}

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -100,7 +100,7 @@ class ViewTask extends BakeTask {
 		$this->controllerName = $this->_controllerName($this->args[0]);
 
 		$this->Project->interactive = false;
-		if (strtolower($this->args[0]) == 'all') {
+		if (strtolower($this->args[0]) === 'all') {
 			return $this->all();
 		}
 
@@ -211,7 +211,7 @@ class ViewTask extends BakeTask {
 		$prompt = __d('cake_console', "Would you like bake to build your views interactively?\nWarning: Choosing no will overwrite %s views if it exist.", $this->controllerName);
 		$interactive = $this->in($prompt, array('y', 'n'), 'n');
 
-		if (strtolower($interactive) == 'n') {
+		if (strtolower($interactive) === 'n') {
 			$this->interactive = false;
 		}
 
@@ -220,13 +220,13 @@ class ViewTask extends BakeTask {
 
 		$wannaDoAdmin = $this->in(__d('cake_console', "Would you like to create the views for admin routing?"), array('y', 'n'), 'n');
 
-		if (strtolower($wannaDoScaffold) == 'y' || strtolower($wannaDoAdmin) == 'y') {
+		if (strtolower($wannaDoScaffold) === 'y' || strtolower($wannaDoAdmin) === 'y') {
 			$vars = $this->_loadController();
-			if (strtolower($wannaDoScaffold) == 'y') {
+			if (strtolower($wannaDoScaffold) === 'y') {
 				$actions = $this->scaffoldActions;
 				$this->bakeActions($actions, $vars);
 			}
-			if (strtolower($wannaDoAdmin) == 'y') {
+			if (strtolower($wannaDoAdmin) === 'y') {
 				$admin = $this->Project->getPrefix();
 				$regularActions = $this->scaffoldActions;
 				$adminActions = array();
@@ -332,7 +332,7 @@ class ViewTask extends BakeTask {
 		$this->out(__d('cake_console', 'Path:            %s', $this->getPath() . $this->controllerName . DS . Inflector::underscore($action) . ".ctp"));
 		$this->hr();
 		$looksGood = $this->in(__d('cake_console', 'Look okay?'), array('y', 'n'), 'y');
-		if (strtolower($looksGood) == 'y') {
+		if (strtolower($looksGood) === 'y') {
 			$this->bake($action, ' ');
 			$this->_stop();
 		} else {

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -326,7 +326,7 @@ class TestShell extends Shell {
 				break;
 			}
 
-			if ($choice == 'q') {
+			if ($choice === 'q') {
 				break;
 			}
 		}

--- a/lib/Cake/Console/Command/TestsuiteShell.php
+++ b/lib/Cake/Console/Command/TestsuiteShell.php
@@ -67,11 +67,11 @@ class TestsuiteShell extends TestShell {
 
 		$category = $this->args[0];
 
-		if ($category == 'core') {
+		if ($category === 'core') {
 			$params['core'] = true;
-		} elseif ($category == 'app') {
+		} elseif ($category === 'app') {
 			$params['app'] = true;
-		} elseif ($category != 'core') {
+		} elseif ($category !== 'core') {
 			$params['plugin'] = $category;
 		}
 

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -470,9 +470,9 @@ class ConsoleOptionParser {
 		$params = $args = array();
 		$this->_tokens = $argv;
 		while (($token = array_shift($this->_tokens)) !== null) {
-			if (substr($token, 0, 2) == '--') {
+			if (substr($token, 0, 2) === '--') {
 				$params = $this->_parseLongOption($token, $params);
-			} elseif (substr($token, 0, 1) == '-') {
+			} elseif (substr($token, 0, 1) === '-') {
 				$params = $this->_parseShortOption($token, $params);
 			} else {
 				$args = $this->_parseArg($token, $args);
@@ -521,9 +521,9 @@ class ConsoleOptionParser {
 			return $subparser->help(null, $format, $width);
 		}
 		$formatter = new HelpFormatter($this);
-		if ($format == 'text' || $format === true) {
+		if ($format === 'text' || $format === true) {
 			return $formatter->text($width);
-		} elseif ($format == 'xml') {
+		} elseif ($format === 'xml') {
 			return $formatter->xml();
 		}
 	}

--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -153,7 +153,7 @@ class ConsoleOutput {
 	public function __construct($stream = 'php://stdout') {
 		$this->_output = fopen($stream, 'w');
 
-		if (DS == '\\' && !(bool)env('ANSICON')) {
+		if (DS === '\\' && !(bool)env('ANSICON')) {
 			$this->_outputAs = self::PLAIN;
 		}
 	}

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -290,7 +290,7 @@ class Shell extends Object {
 			if (!$method->isPublic() || substr($name, 0, 1) === '_') {
 				return false;
 			}
-			if ($method->getDeclaringClass()->name == 'Shell') {
+			if ($method->getDeclaringClass()->name === 'Shell') {
 				return false;
 			}
 			return true;
@@ -403,7 +403,7 @@ class Shell extends Object {
  */
 	protected function _displayHelp($command) {
 		$format = 'text';
-		if (!empty($this->args[0]) && $this->args[0] == 'xml') {
+		if (!empty($this->args[0]) && $this->args[0] === 'xml') {
 			$format = 'xml';
 			$this->stdout->outputAs(ConsoleOutput::RAW);
 		} else {
@@ -654,10 +654,10 @@ class Shell extends Object {
 			$this->out(__d('cake_console', '<warning>File `%s` exists</warning>', $path));
 			$key = $this->in(__d('cake_console', 'Do you want to overwrite?'), array('y', 'n', 'q'), 'n');
 
-			if (strtolower($key) == 'q') {
+			if (strtolower($key) === 'q') {
 				$this->out(__d('cake_console', '<error>Quitting</error>.'), 2);
 				$this->_stop();
-			} elseif (strtolower($key) != 'y') {
+			} elseif (strtolower($key) !== 'y') {
 				$this->out(__d('cake_console', 'Skip `%s`', $path), 2);
 				return false;
 			}
@@ -695,7 +695,7 @@ class Shell extends Object {
 
 		$prompt = __d('cake_console', 'PHPUnit is not installed. Do you want to bake unit test files anyway?');
 		$unitTest = $this->in($prompt, array('y', 'n'), 'y');
-		$result = strtolower($unitTest) == 'y' || strtolower($unitTest) == 'yes';
+		$result = strtolower($unitTest) === 'y' || strtolower($unitTest) === 'yes';
 
 		if ($result) {
 			$this->out();

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -201,7 +201,7 @@ class ShellDispatcher {
 		}
 		$methods = array_diff(get_class_methods($Shell), get_class_methods('Shell'));
 		$added = in_array($command, $methods);
-		$private = $command[0] == '_' && method_exists($Shell, $command);
+		$private = $command[0] === '_' && method_exists($Shell, $command);
 
 		if (!$private) {
 			if ($added) {
@@ -288,7 +288,7 @@ class ShellDispatcher {
 			}
 		}
 
-		if ($params['app'][0] == '/' || preg_match('/([a-z])(:)/i', $params['app'], $matches)) {
+		if ($params['app'][0] === '/' || preg_match('/([a-z])(:)/i', $params['app'], $matches)) {
 			$params['root'] = dirname($params['app']);
 		} elseif (strpos($params['app'], '/')) {
 			$params['root'] .= '/' . dirname($params['app']);

--- a/lib/Cake/Console/Templates/default/classes/model.ctp
+++ b/lib/Cake/Console/Templates/default/classes/model.ctp
@@ -38,7 +38,7 @@ foreach (array('hasOne', 'belongsTo', 'hasMany', 'hasAndBelongsToMany') as $asso
  */
 class <?php echo $name ?> extends <?php echo $plugin; ?>AppModel {
 
-<?php if ($useDbConfig != 'default'): ?>
+<?php if ($useDbConfig !== 'default'): ?>
 /**
  * Use database config
  *

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -77,7 +77,7 @@ if (!defined('WWW_ROOT')) {
 }
 
 // for built-in server
-if (php_sapi_name() == 'cli-server') {
+if (php_sapi_name() === 'cli-server') {
 	if ($_SERVER['REQUEST_URI'] !== '/' && file_exists(WWW_ROOT . $_SERVER['REQUEST_URI'])) {
 		return false;
 	}

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -23,7 +23,7 @@ App::uses('BaseAuthorize', 'Controller/Component/Auth');
  * {{{
  *	public function isAuthorized($user) {
  *		if (!empty($this->request->params['admin'])) {
- *			return $user['role'] == 'admin';
+ *			return $user['role'] === 'admin';
  *		}
  *		return !empty($user);
  *	}

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -188,7 +188,7 @@ class DigestAuthenticate extends BaseAuthenticate {
 		$digest = env('PHP_AUTH_DIGEST');
 		if (empty($digest) && function_exists('apache_request_headers')) {
 			$headers = apache_request_headers();
-			if (!empty($headers['Authorization']) && substr($headers['Authorization'], 0, 7) == 'Digest ') {
+			if (!empty($headers['Authorization']) && substr($headers['Authorization'], 0, 7) === 'Digest ') {
 				$digest = substr($headers['Authorization'], 7);
 			}
 		}
@@ -205,7 +205,7 @@ class DigestAuthenticate extends BaseAuthenticate {
  * @return array An array of digest authentication headers
  */
 	public function parseAuthData($digest) {
-		if (substr($digest, 0, 7) == 'Digest ') {
+		if (substr($digest, 0, 7) === 'Digest ') {
 			$digest = substr($digest, 7);
 		}
 		$keys = $match = array();

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -130,7 +130,7 @@ class RequestHandlerComponent extends Component {
 		if (isset($this->request->params['ext'])) {
 			$this->ext = $this->request->params['ext'];
 		}
-		if (empty($this->ext) || $this->ext == 'html') {
+		if (empty($this->ext) || $this->ext === 'html') {
 			$this->_setExtension();
 		}
 		$this->params = $controller->params;
@@ -590,7 +590,7 @@ class RequestHandlerComponent extends Component {
 		}
 		$options = array_merge($defaults, $options);
 
-		if ($type == 'ajax') {
+		if ($type === 'ajax') {
 			$controller->layout = $this->ajaxLayout;
 			return $this->respondAs('html', $options);
 		}

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -963,7 +963,7 @@ class Controller extends Object implements CakeEventListener {
 		}
 
 		$referer = $this->request->referer($local);
-		if ($referer == '/' && $default) {
+		if ($referer === '/' && $default) {
 			return Router::url($default, true);
 		}
 		return $referer;
@@ -1048,13 +1048,13 @@ class Controller extends Object implements CakeEventListener {
 				if ($fieldOp === 'LIKE') {
 					$key = $key . ' LIKE';
 					$value = '%' . $value . '%';
-				} elseif ($fieldOp && $fieldOp != '=') {
+				} elseif ($fieldOp && $fieldOp !== '=') {
 					$key = $key . ' ' . $fieldOp;
 				}
 				$cond[$key] = $value;
 			}
 		}
-		if ($bool && strtoupper($bool) != 'AND') {
+		if ($bool && strtoupper($bool) !== 'AND') {
 			$cond = array($bool => $cond);
 		}
 		return $cond;

--- a/lib/Cake/Controller/Scaffold.php
+++ b/lib/Cake/Controller/Scaffold.php
@@ -227,7 +227,7 @@ class Scaffold {
 		}
 
 		if ($this->controller->beforeScaffold($action)) {
-			if ($action == 'edit') {
+			if ($action === 'edit') {
 				if (isset($request->params['pass'][0])) {
 					$this->ScaffoldModel->id = $request['pass'][0];
 				}
@@ -237,7 +237,7 @@ class Scaffold {
 			}
 
 			if (!empty($request->data)) {
-				if ($action == 'create') {
+				if ($action === 'create') {
 					$this->ScaffoldModel->create();
 				}
 
@@ -443,7 +443,7 @@ class Scaffold {
 				$associations[$type][$assocKey]['controller'] =
 					Inflector::pluralize(Inflector::underscore($model));
 
-				if ($type == 'hasAndBelongsToMany') {
+				if ($type === 'hasAndBelongsToMany') {
 					$associations[$type][$assocKey]['with'] = $assocData['with'];
 				}
 			}

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -433,7 +433,7 @@ class App {
 			$type = 'plugins';
 		}
 
-		if ($type == 'plugins') {
+		if ($type === 'plugins') {
 			$extension = '/.*/';
 			$includeDirectories = true;
 		}
@@ -637,11 +637,11 @@ class App {
 			return self::_loadClass($name, $plugin, $type, $originalType, $parent);
 		}
 
-		if ($originalType == 'file' && !empty($file)) {
+		if ($originalType === 'file' && !empty($file)) {
 			return self::_loadFile($name, $plugin, $search, $file, $return);
 		}
 
-		if ($originalType == 'vendor') {
+		if ($originalType === 'vendor') {
 			return self::_loadVendor($name, $plugin, $file, $ext);
 		}
 
@@ -660,7 +660,7 @@ class App {
  * @return boolean true indicating the successful load and existence of the class
  */
 	protected static function _loadClass($name, $plugin, $type, $originalType, $parent) {
-		if ($type == 'Console/Command' && $name == 'Shell') {
+		if ($type === 'Console/Command' && $name === 'Shell') {
 			$type = 'Console';
 		} elseif (isset(self::$types[$originalType]['suffix'])) {
 			$suffix = self::$types[$originalType]['suffix'];

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -149,7 +149,7 @@ class ErrorHandler {
 				$message .= "\nException Attributes: " . var_export($exception->getAttributes(), true);
 			}
 		}
-		if (php_sapi_name() != 'cli') {
+		if (php_sapi_name() !== 'cli') {
 			$request = Router::getRequest();
 			if ($request) {
 				$message .= "\nRequest URL: " . $request->here();

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -104,7 +104,7 @@ class ExceptionRenderer {
 
 		if ($exception instanceof CakeException && !$methodExists) {
 			$method = '_cakeError';
-			if (empty($template) || $template == 'internalError') {
+			if (empty($template) || $template === 'internalError') {
 				$template = 'error500';
 			}
 		} elseif ($exception instanceof PDOException) {
@@ -119,7 +119,7 @@ class ExceptionRenderer {
 		}
 
 		$isNotDebug = !Configure::read('debug');
-		if ($isNotDebug && $method == '_cakeError') {
+		if ($isNotDebug && $method === '_cakeError') {
 			$method = 'error400';
 		}
 		if ($isNotDebug && $code == 500) {

--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -174,7 +174,7 @@ class I18n {
 			Cache::write($_this->domain, $_this->_domains[$domain][$_this->_lang], '_cake_core_');
 		}
 
-		if ($_this->category == 'LC_TIME') {
+		if ($_this->category === 'LC_TIME') {
 			return $_this->_translateTime($singular, $domain);
 		}
 
@@ -410,7 +410,7 @@ class I18n {
 			$header = unpack("L1magic/L1version/L1count/L1o_msg/L1o_trn", $header);
 			extract($header);
 
-			if ((dechex($magic) == '950412de' || dechex($magic) == 'ffffffff950412de') && !$version) {
+			if ((dechex($magic) === '950412de' || dechex($magic) === 'ffffffff950412de') && !$version) {
 				for ($n = 0; $n < $count; $n++) {
 					$r = unpack("L1len/L1offs", substr($data, $o_msg + $n * 8, 8));
 					$msgid = substr($data, $r["offs"], $r["len"]);

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -750,7 +750,7 @@ class Multibyte {
 
 		$length = 75 - strlen($start) - strlen($end);
 		$length = $length - ($length % 4);
-		if ($charset == 'UTF-8') {
+		if ($charset === 'UTF-8') {
 			$parts = array();
 			$maxchars = floor(($length * 3) / 4);
 			$stringLength = strlen($string);

--- a/lib/Cake/Log/Engine/ConsoleLog.php
+++ b/lib/Cake/Log/Engine/ConsoleLog.php
@@ -50,7 +50,7 @@ class ConsoleLog extends BaseLog {
  */
 	public function __construct($config = array()) {
 		parent::__construct($config);
-		if (DS == '\\' && !(bool)env('ANSICON')) {
+		if (DS === '\\' && !(bool)env('ANSICON')) {
 			$outputAs = ConsoleOutput::PLAIN;
 		} else {
 			$outputAs = ConsoleOutput::COLOR;

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -76,7 +76,7 @@ class FileLog extends BaseLog {
 
 		if (!empty($this->_file)) {
 			$filename = $this->_path . $this->_file;
-		} elseif ($type == 'error' || $type == 'warning') {
+		} elseif ($type === 'error' || $type === 'warning') {
 			$filename = $this->_path . 'error.log';
 		} elseif (in_array($type, $debugTypes)) {
 			$filename = $this->_path . 'debug.log';

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -200,7 +200,7 @@ class ContainableBehavior extends ModelBehavior {
 
 		if (!empty($mandatory[$Model->alias])) {
 			foreach ($mandatory[$Model->alias] as $field) {
-				if ($field == '--primaryKey--') {
+				if ($field === '--primaryKey--') {
 					$field = $Model->primaryKey;
 				} elseif (preg_match('/^.+\.\-\-[^-]+\-\-$/', $field)) {
 					list($modelName, $field) = explode('.', $field);
@@ -307,7 +307,7 @@ class ContainableBehavior extends ModelBehavior {
 				if (!$optionKey && is_string($key) && preg_match('/^[a-z(]/', $key) && (!isset($Model->{$key}) || !is_object($Model->{$key}))) {
 					$option = 'fields';
 					$val = array($key);
-					if ($key{0} == '(') {
+					if ($key{0} === '(') {
 						$val = preg_split('/\s*,\s*/', substr($key, 1, -1));
 					} elseif (preg_match('/ASC|DESC$/', $key)) {
 						$option = 'order';
@@ -374,9 +374,9 @@ class ContainableBehavior extends ModelBehavior {
 			foreach ($map as $parent => $children) {
 				foreach ($children as $type => $bindings) {
 					foreach ($bindings as $dependency) {
-						if ($type == 'hasAndBelongsToMany') {
+						if ($type === 'hasAndBelongsToMany') {
 							$fields[$parent][] = '--primaryKey--';
-						} elseif ($type == 'belongsTo') {
+						} elseif ($type === 'belongsTo') {
 							$fields[$parent][] = $dependency . '.--primaryKey--';
 						}
 					}

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -160,7 +160,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
 		foreach ($methods as $m) {
 			if (!isset($parentMethods[$m])) {
 				$methodAllowed = (
-					$m[0] != '_' && !array_key_exists($m, $this->_methods) &&
+					$m[0] !== '_' && !array_key_exists($m, $this->_methods) &&
 					!in_array($m, $callbacks)
 				);
 				if ($methodAllowed) {

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -227,7 +227,7 @@ class CakeSchema extends Object {
 			foreach ($models as $model) {
 				$importModel = $model;
 				$plugin = null;
-				if ($model == 'AppModel') {
+				if ($model === 'AppModel') {
 					continue;
 				}
 
@@ -412,7 +412,7 @@ class CakeSchema extends Object {
 		if (is_array($fields)) {
 			$cols = array();
 			foreach ($fields as $field => $value) {
-				if ($field != 'indexes' && $field != 'tableParameters') {
+				if ($field !== 'indexes' && $field !== 'tableParameters') {
 					if (is_string($value)) {
 						$type = $value;
 						$value = array('type' => $type);
@@ -420,14 +420,14 @@ class CakeSchema extends Object {
 					$col = "\t\t'{$field}' => array('type' => '" . $value['type'] . "', ";
 					unset($value['type']);
 					$col .= implode(', ', $this->_values($value));
-				} elseif ($field == 'indexes') {
+				} elseif ($field === 'indexes') {
 					$col = "\t\t'indexes' => array(\n\t\t\t";
 					$props = array();
 					foreach ((array)$value as $key => $index) {
 						$props[] = "'{$key}' => array(" . implode(', ', $this->_values($index)) . ")";
 					}
 					$col .= implode(",\n\t\t\t", $props) . "\n\t\t";
-				} elseif ($field == 'tableParameters') {
+				} elseif ($field === 'tableParameters') {
 					$col = "\t\t'tableParameters' => array(";
 					$props = array();
 					foreach ((array)$value as $key => $param) {
@@ -472,7 +472,7 @@ class CakeSchema extends Object {
 		}
 		$tables = array();
 		foreach ($new as $table => $fields) {
-			if ($table == 'missing') {
+			if ($table === 'missing') {
 				continue;
 			}
 			if (!array_key_exists($table, $old)) {

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -199,10 +199,10 @@ class Postgres extends DboSource {
 			foreach ($cols as $c) {
 				$type = $c->type;
 				if (!empty($c->oct_length) && $c->char_length === null) {
-					if ($c->type == 'character varying') {
+					if ($c->type === 'character varying') {
 						$length = null;
 						$type = 'text';
-					} elseif ($c->type == 'uuid') {
+					} elseif ($c->type === 'uuid') {
 						$length = 36;
 					} else {
 						$length = intval($c->oct_length);
@@ -217,7 +217,7 @@ class Postgres extends DboSource {
 				}
 				$fields[$c->name] = array(
 					'type' => $this->column($type),
-					'null' => ($c->null == 'NO' ? false : true),
+					'null' => ($c->null === 'NO' ? false : true),
 					'default' => preg_replace(
 						"/^'(.*)'$/",
 						"$1",
@@ -234,7 +234,7 @@ class Postgres extends DboSource {
 					}
 				}
 				if (
-					$fields[$c->name]['default'] == 'NULL' ||
+					$fields[$c->name]['default'] === 'NULL' ||
 					preg_match('/nextval\([\'"]?([\w.]+)/', $c->default, $seq)
 				) {
 					$fields[$c->name]['default'] = null;
@@ -247,7 +247,7 @@ class Postgres extends DboSource {
 						$this->_sequenceMap[$table][$c->name] = $sequenceName;
 					}
 				}
-				if ($fields[$c->name]['type'] == 'boolean' && !empty($fields[$c->name]['default'])) {
+				if ($fields[$c->name]['type'] === 'boolean' && !empty($fields[$c->name]['default'])) {
 					$fields[$c->name]['default'] = constant($fields[$c->name]['default']);
 				}
 			}
@@ -382,7 +382,7 @@ class Postgres extends DboSource {
 			$result = array();
 			for ($i = 0; $i < $count; $i++) {
 				if (!preg_match('/^.+\\(.*\\)/', $fields[$i]) && !preg_match('/\s+AS\s+/', $fields[$i])) {
-					if (substr($fields[$i], -1) == '*') {
+					if (substr($fields[$i], -1) === '*') {
 						if (strpos($fields[$i], '.') !== false && $fields[$i] != $alias . '.*') {
 							$build = explode('.', $fields[$i]);
 							$AssociatedModel = $model->{$build[0]};
@@ -576,7 +576,7 @@ class Postgres extends DboSource {
 		if (isset($indexes['drop'])) {
 			foreach ($indexes['drop'] as $name => $value) {
 				$out = 'DROP ';
-				if ($name == 'PRIMARY') {
+				if ($name === 'PRIMARY') {
 					continue;
 				} else {
 					$out .= 'INDEX ' . $name;
@@ -587,7 +587,7 @@ class Postgres extends DboSource {
 		if (isset($indexes['add'])) {
 			foreach ($indexes['add'] as $name => $value) {
 				$out = 'CREATE ';
-				if ($name == 'PRIMARY') {
+				if ($name === 'PRIMARY') {
 					continue;
 				} else {
 					if (!empty($value['unique'])) {
@@ -663,11 +663,11 @@ class Postgres extends DboSource {
 				return 'datetime';
 			case (strpos($col, 'time') === 0):
 				return 'time';
-			case ($col == 'bigint'):
+			case ($col === 'bigint'):
 				return 'biginteger';
-			case (strpos($col, 'int') !== false && $col != 'interval'):
+			case (strpos($col, 'int') !== false && $col !== 'interval'):
 				return 'integer';
-			case (strpos($col, 'char') !== false || $col == 'uuid'):
+			case (strpos($col, 'char') !== false || $col === 'uuid'):
 				return 'string';
 			case (strpos($col, 'text') !== false):
 				return 'text';
@@ -693,7 +693,7 @@ class Postgres extends DboSource {
 		if (strpos($col, '(') !== false) {
 			list($col, $limit) = explode('(', $col);
 		}
-		if ($col == 'uuid') {
+		if ($col === 'uuid') {
 			return 36;
 		}
 		if ($limit) {
@@ -852,7 +852,7 @@ class Postgres extends DboSource {
 				$out = str_replace('DEFAULT DEFAULT', 'DEFAULT NULL', $out);
 			} elseif (in_array($column['type'], array('integer', 'float'))) {
 				$out = str_replace('DEFAULT DEFAULT', 'DEFAULT 0', $out);
-			} elseif ($column['type'] == 'boolean') {
+			} elseif ($column['type'] === 'boolean') {
 				$out = str_replace('DEFAULT DEFAULT', 'DEFAULT FALSE', $out);
 			}
 		}
@@ -872,7 +872,7 @@ class Postgres extends DboSource {
 			return array();
 		}
 		foreach ($indexes as $name => $value) {
-			if ($name == 'PRIMARY') {
+			if ($name === 'PRIMARY') {
 				$out = 'PRIMARY KEY  (' . $this->name($value['column']) . ')';
 			} else {
 				$out = 'CREATE ';

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -357,7 +357,7 @@ class Sqlite extends DboSource {
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
 				$resultRow[$table][$column] = $row[$col];
-				if ($type == 'boolean' && !is_null($row[$col])) {
+				if ($type === 'boolean' && !is_null($row[$col])) {
 					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
 				}
 			}
@@ -412,7 +412,7 @@ class Sqlite extends DboSource {
 			return null;
 		}
 
-		if (isset($column['key']) && $column['key'] == 'primary' && $type == 'integer') {
+		if (isset($column['key']) && $column['key'] === 'primary' && $type === 'integer') {
 			return $this->name($name) . ' ' . $this->columns['primary_key']['name'];
 		}
 		return parent::buildColumn($column);
@@ -456,7 +456,7 @@ class Sqlite extends DboSource {
 
 		foreach ($indexes as $name => $value) {
 
-			if ($name == 'PRIMARY') {
+			if ($name === 'PRIMARY') {
 				continue;
 			}
 			$out = 'CREATE ';

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -227,7 +227,7 @@ class Sqlserver extends DboSource {
 				$this->value($fields[$field]['default'], $fields[$field]['type']);
 			}
 
-			if ($fields[$field]['key'] !== false && $fields[$field]['type'] == 'integer') {
+			if ($fields[$field]['key'] !== false && $fields[$field]['type'] === 'integer') {
 				$fields[$field]['length'] = 11;
 			} elseif ($fields[$field]['key'] === false) {
 				unset($fields[$field]['key']);
@@ -235,7 +235,7 @@ class Sqlserver extends DboSource {
 			if (in_array($fields[$field]['type'], array('date', 'time', 'datetime', 'timestamp'))) {
 				$fields[$field]['length'] = null;
 			}
-			if ($fields[$field]['type'] == 'float' && !empty($column->Size)) {
+			if ($fields[$field]['type'] === 'float' && !empty($column->Size)) {
 				$fields[$field]['length'] = $fields[$field]['length'] . ',' . $column->Size;
 			}
 		}
@@ -271,7 +271,7 @@ class Sqlserver extends DboSource {
 				}
 
 				if (!preg_match('/\s+AS\s+/i', $fields[$i])) {
-					if (substr($fields[$i], -1) == '*') {
+					if (substr($fields[$i], -1) === '*') {
 						if (strpos($fields[$i], '.') !== false && $fields[$i] != $alias . '.*') {
 							$build = explode('.', $fields[$i]);
 							$AssociatedModel = $model->{$build[0]};
@@ -299,7 +299,7 @@ class Sqlserver extends DboSource {
 						$fieldName = $this->name($name);
 						$fieldAlias = $this->name($alias);
 					}
-					if ($model->getColumnType($fields[$i]) == 'datetime') {
+					if ($model->getColumnType($fields[$i]) === 'datetime') {
 						$fieldName = "CONVERT(VARCHAR(20), {$fieldName}, 20)";
 					}
 					$fields[$i] = "{$fieldName} AS {$fieldAlias}";
@@ -402,13 +402,13 @@ class Sqlserver extends DboSource {
 			$col = $real->Type;
 		}
 
-		if ($col == 'datetime2') {
+		if ($col === 'datetime2') {
 			return 'datetime';
 		}
 		if (in_array($col, array('date', 'time', 'datetime', 'timestamp'))) {
 			return $col;
 		}
-		if ($col == 'bit') {
+		if ($col === 'bit') {
 			return 'boolean';
 		}
 		if (strpos($col, 'bigint') !== false) {
@@ -426,7 +426,7 @@ class Sqlserver extends DboSource {
 		if (strpos($col, 'text') !== false) {
 			return 'text';
 		}
-		if (strpos($col, 'binary') !== false || $col == 'image') {
+		if (strpos($col, 'binary') !== false || $col === 'image') {
 			return 'binary';
 		}
 		if (in_array($col, array('float', 'real', 'decimal', 'numeric'))) {
@@ -481,7 +481,7 @@ class Sqlserver extends DboSource {
 			} else {
 				$map = array(0, $name);
 			}
-			$map[] = ($column['sqlsrv:decl_type'] == 'bit') ? 'boolean' : $column['native_type'];
+			$map[] = ($column['sqlsrv:decl_type'] === 'bit') ? 'boolean' : $column['native_type'];
 			$this->map[$index++] = $map;
 		}
 	}
@@ -683,7 +683,7 @@ class Sqlserver extends DboSource {
 		$join = array();
 
 		foreach ($indexes as $name => $value) {
-			if ($name == 'PRIMARY') {
+			if ($name === 'PRIMARY') {
 				$join[] = 'PRIMARY KEY (' . $this->name($value['column']) . ')';
 			} elseif (isset($value['unique']) && $value['unique']) {
 				$out = "ALTER TABLE {$table} ADD CONSTRAINT {$name} UNIQUE";
@@ -709,7 +709,7 @@ class Sqlserver extends DboSource {
 	protected function _getPrimaryKey($model) {
 		$schema = $this->describe($model);
 		foreach ($schema as $field => $props) {
-			if (isset($props['key']) && $props['key'] == 'primary') {
+			if (isset($props['key']) && $props['key'] === 'primary') {
 				return $field;
 			}
 		}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -323,9 +323,9 @@ class DboSource extends DataSource {
 				$data, array_fill(0, count($data), $column)
 			);
 		} elseif (is_object($data) && isset($data->type, $data->value)) {
-			if ($data->type == 'identifier') {
+			if ($data->type === 'identifier') {
 				return $this->name($data->value);
-			} elseif ($data->type == 'expression') {
+			} elseif ($data->type === 'expression') {
 				return $data->value;
 			}
 		} elseif (in_array($data, array('{$__cakeID__$}', '{$__cakeForeignKey__$}'), true)) {
@@ -899,7 +899,7 @@ class DboSource extends DataSource {
 		if (empty($log['log'])) {
 			return;
 		}
-		if (PHP_SAPI != 'cli') {
+		if (PHP_SAPI !== 'cli') {
 			$controller = null;
 			$View = new View($controller, false);
 			$View->set('logs', array($this->configKeyName => $log));
@@ -1878,7 +1878,7 @@ class DboSource extends DataSource {
 
 			if ($quoteValues) {
 				$update .= $this->value($value, $model->getColumnType($field));
-			} elseif ($model->getColumnType($field) == 'boolean' && (is_int($value) || is_bool($value))) {
+			} elseif ($model->getColumnType($field) === 'boolean' && (is_int($value) || is_bool($value))) {
 				$update .= $this->boolean($value, true);
 			} elseif (!$alias) {
 				$update .= str_replace($quotedAlias . '.', '', str_replace(

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -818,7 +818,7 @@ class Model extends Object implements CakeEventListener {
 				$className = empty($this->__backAssociation[$type][$name]['className']) ?
 					$name : $this->__backAssociation[$type][$name]['className'];
 				break;
-			} elseif ($type == 'hasAndBelongsToMany') {
+			} elseif ($type === 'hasAndBelongsToMany') {
 				foreach ($this->{$type} as $k => $relation) {
 					if (empty($relation['with'])) {
 						continue;
@@ -1061,7 +1061,7 @@ class Model extends Object implements CakeEventListener {
 					break;
 
 					case 'foreignKey':
-						$data = (($type == 'belongsTo') ? Inflector::underscore($assocKey) : Inflector::singularize($this->table)) . '_id';
+						$data = (($type === 'belongsTo') ? Inflector::underscore($assocKey) : Inflector::singularize($this->table)) . '_id';
 					break;
 
 					case 'associationForeignKey':
@@ -1262,7 +1262,7 @@ class Model extends Object implements CakeEventListener {
 		if (isset($data['hour']) && isset($data['meridian']) && $data['hour'] == 12 && 'am' == $data['meridian']) {
 			$data['hour'] = '00';
 		}
-		if ($type == 'time') {
+		if ($type === 'time') {
 			foreach ($timeFields as $key => $val) {
 				if (!isset($data[$val]) || $data[$val] === '0' || $data[$val] === '00') {
 					$data[$val] = '00';
@@ -1277,9 +1277,9 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
-		if ($type == 'datetime' || $type == 'timestamp' || $type == 'date') {
+		if ($type === 'datetime' || $type === 'timestamp' || $type === 'date') {
 			foreach ($dateFields as $key => $val) {
-				if ($val == 'hour' || $val == 'min' || $val == 'sec') {
+				if ($val === 'hour' || $val === 'min' || $val === 'sec') {
 					if (!isset($data[$val]) || $data[$val] === '0' || $data[$val] === '00') {
 						$data[$val] = '00';
 					} else {

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -100,7 +100,7 @@ class Permission extends AppModel {
 			return false;
 		}
 
-		if ($action != '*' && !in_array('_' . $action, $permKeys)) {
+		if ($action !== '*' && !in_array('_' . $action, $permKeys)) {
 			trigger_error(__d('cake_dev', "ACO permissions key %s does not exist in DbAcl::check()", $action), E_USER_NOTICE);
 			return false;
 		}
@@ -126,7 +126,7 @@ class Permission extends AppModel {
 			} else {
 				$perms = Hash::extract($perms, '{n}.' . $this->alias);
 				foreach ($perms as $perm) {
-					if ($action == '*') {
+					if ($action === '*') {
 
 						foreach ($permKeys as $key) {
 							if (!empty($perm)) {

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -194,7 +194,7 @@ class CakeValidationRule {
  */
 	public function skip() {
 		if (!empty($this->on)) {
-			if ($this->on == 'create' && $this->isUpdate() || $this->on == 'update' && !$this->isUpdate()) {
+			if ($this->on === 'create' && $this->isUpdate() || $this->on === 'update' && !$this->isUpdate()) {
 				return true;
 			}
 		}

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -134,7 +134,7 @@ class CakeRequest implements ArrayAccess {
 		if (empty($url)) {
 			$url = $this->_url();
 		}
-		if ($url[0] == '/') {
+		if ($url[0] === '/') {
 			$url = substr($url, 1);
 		}
 		$this->url = $url;
@@ -255,7 +255,7 @@ class CakeRequest implements ArrayAccess {
 		if (strpos($uri, '?') !== false) {
 			list($uri) = explode('?', $uri, 2);
 		}
-		if (empty($uri) || $uri == '/' || $uri == '//' || $uri == '/index.php') {
+		if (empty($uri) || $uri === '/' || $uri === '//' || $uri === '/index.php') {
 			return '/';
 		}
 		return $uri;
@@ -412,7 +412,7 @@ class CakeRequest implements ArrayAccess {
 		if (!empty($ref) && !empty($base)) {
 			if ($local && strpos($ref, $base) === 0) {
 				$ref = substr($ref, strlen($base));
-				if ($ref[0] != '/') {
+				if ($ref[0] !== '/') {
 					$ref = '/' . $ref;
 				}
 				return $ref;
@@ -893,10 +893,10 @@ class CakeRequest implements ArrayAccess {
 		if (isset($this->params[$name])) {
 			return $this->params[$name];
 		}
-		if ($name == 'url') {
+		if ($name === 'url') {
 			return $this->query;
 		}
-		if ($name == 'data') {
+		if ($name === 'data') {
 			return $this->data;
 		}
 		return null;

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -135,7 +135,7 @@ class CakeSocket {
 		}
 
 		$scheme = null;
-		if (isset($this->config['request']['uri']) && $this->config['request']['uri']['scheme'] == 'https') {
+		if (isset($this->config['request']['uri']) && $this->config['request']['uri']['scheme'] === 'https') {
 			$scheme = 'ssl://';
 		}
 

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1512,7 +1512,7 @@ class CakeEmail {
  */
 	protected function _getTypes() {
 		$types = array($this->_emailFormat);
-		if ($this->_emailFormat == 'both') {
+		if ($this->_emailFormat === 'both') {
 			$types = array('html', 'text');
 		}
 		return $types;

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -545,7 +545,7 @@ class HttpSocket extends CakeSocket {
 			if (is_array($port)) {
 				$port = $port[0];
 			}
-			if ($url{0} == '/') {
+			if ($url{0} === '/') {
 				$url = $this->config['request']['uri']['host'] . ':' . $port . $url;
 			}
 			if (!preg_match('/^.+:\/\/|\*|^\//', $url)) {
@@ -867,7 +867,7 @@ class HttpSocket extends CakeSocket {
 
 		if (is_string($request)) {
 			$isValid = preg_match("/(.+) (.+) (.+)\r\n/U", $request, $match);
-			if (!$this->quirksMode && (!$isValid || ($match[2] == '*' && !in_array($match[3], $asteriskMethods)))) {
+			if (!$this->quirksMode && (!$isValid || ($match[2] === '*' && !in_array($match[3], $asteriskMethods)))) {
 				throw new SocketException(__d('cake_dev', 'HttpSocket::_buildRequestLine - Passed an invalid request line string. Activate quirks mode to do this.'));
 			}
 			return $request;
@@ -918,7 +918,7 @@ class HttpSocket extends CakeSocket {
 
 		$returnHeader = '';
 		foreach ($header as $field => $contents) {
-			if (is_array($contents) && $mode == 'standard') {
+			if (is_array($contents) && $mode === 'standard') {
 				$contents = implode(',', $contents);
 			}
 			foreach ((array)$contents as $content) {

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -191,7 +191,7 @@ class Router {
  */
 	protected static function _validateRouteClass($routeClass) {
 		if (
-			$routeClass != 'CakeRoute' &&
+			$routeClass !== 'CakeRoute' &&
 			(!class_exists($routeClass) || !is_subclass_of($routeClass, 'CakeRoute'))
 		) {
 			throw new RouterException(__d('cake_dev', 'Route classes must extend CakeRoute'));
@@ -332,7 +332,7 @@ class Router {
 			$routeClass = self::_validateRouteClass($routeClass);
 			unset($options['routeClass']);
 		}
-		if ($routeClass == 'RedirectRoute' && isset($defaults['redirect'])) {
+		if ($routeClass === 'RedirectRoute' && isset($defaults['redirect'])) {
 			$defaults = $defaults['redirect'];
 		}
 		self::$routes[] = new $routeClass($route, $defaults, $options);
@@ -715,7 +715,7 @@ class Router {
 			return;
 		}
 		foreach (self::$_initialState as $key => $val) {
-			if ($key != '_initialState') {
+			if ($key !== '_initialState') {
 				self::${$key} = $val;
 			}
 		}
@@ -1001,7 +1001,7 @@ class Router {
 
 		$out .= $addition;
 
-		if (isset($out[0]) && $out[0] != '?') {
+		if (isset($out[0]) && $out[0] !== '?') {
 			$out = '?' . $out;
 		}
 		return $out;

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -767,7 +767,7 @@ EXPECTED;
 '<div>this-is-a-test</div>'
 ###########################
 EXPECTED;
-		if (php_sapi_name() == 'cli') {
+		if (php_sapi_name() === 'cli') {
 			$expected = sprintf($expectedText, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 17);
 		} else {
 			$expected = sprintf($expectedHtml, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 19);
@@ -791,7 +791,7 @@ EXPECTED;
 '<div>this-is-a-test</div>'
 ###########################
 EXPECTED;
-		if (php_sapi_name() == 'cli') {
+		if (php_sapi_name() === 'cli') {
 			$expected = sprintf($expectedText, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 17);
 		} else {
 			$expected = sprintf($expectedHtml, str_replace(CAKE_CORE_INCLUDE_PATH, '', __FILE__), __LINE__ - 19);

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -228,7 +228,7 @@ class CacheTest extends CakeTestCase {
 			'duration' => 3600,
 			'probability' => 100,
 			'engine' => 'File',
-			'isWindows' => DIRECTORY_SEPARATOR == '\\',
+			'isWindows' => DIRECTORY_SEPARATOR === '\\',
 			'mask' => 0664,
 			'groups' => array()
 		);

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -504,12 +504,12 @@ class DbAclTest extends CakeTestCase {
 				$perms = '';
 				foreach ($rights as $right) {
 					if ($this->Acl->check($aro, $aco, $right)) {
-						if ($right == '*') {
+						if ($right === '*') {
 							$perms .= '****';
 							break;
 						}
 						$perms .= $right[0];
-					} elseif ($right != '*') {
+					} elseif ($right !== '*') {
 						$perms .= ' ';
 					}
 				}

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -107,7 +107,7 @@ class PaginatorControllerPost extends CakeTestModel {
  * @return void
  */
 	public function find($conditions = null, $fields = array(), $order = null, $recursive = null) {
-		if ($conditions == 'popular') {
+		if ($conditions === 'popular') {
 			$conditions = array($this->name . '.' . $this->primaryKey . ' > ' => '1');
 			$options = Hash::merge($fields, compact('conditions'));
 			return parent::find('all', $options);
@@ -278,7 +278,7 @@ class PaginatorCustomPost extends CakeTestModel {
  * @return array
  */
 	protected function _findTotals($state, $query, $results = array()) {
-		if ($state == 'before') {
+		if ($state === 'before') {
 			$query['fields'] = array('author_id');
 			$this->virtualFields['total_posts'] = "COUNT({$this->alias}.id)";
 			$query['fields'][] = 'total_posts';
@@ -296,7 +296,7 @@ class PaginatorCustomPost extends CakeTestModel {
  * @return array
  */
 	protected function _findTotalsOperation($state, $query, $results = array()) {
-		if ($state == 'before') {
+		if ($state === 'before') {
 			if (!empty($query['operation']) && $query['operation'] === 'count') {
 				unset($query['limit']);
 				$query['recursive'] = -1;

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -103,7 +103,7 @@ class ControllerPost extends CakeTestModel {
  * @return void
  */
 	public function find($type = 'first', $options = array()) {
-		if ($type == 'popular') {
+		if ($type === 'popular') {
 			$conditions = array($this->name . '.' . $this->primaryKey . ' > ' => '1');
 			$options = Hash::merge($options, compact('conditions'));
 			return parent::find('all', $options);

--- a/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
@@ -124,7 +124,7 @@ class ConsoleLogTest extends CakeTestCase {
 		TestCakeLog::config('test_console_log', array(
 			'engine' => 'TestConsoleLog',
 			));
-		if (DS == '\\' && !(bool)env('ANSICON')) {
+		if (DS === '\\' && !(bool)env('ANSICON')) {
 			$expected = ConsoleOutput::PLAIN;
 		} else {
 			$expected = ConsoleOutput::COLOR;

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -193,9 +193,9 @@ class DbAroUserTest extends CakeTestModel {
  * @return void
  */
 	public function bindNode($ref = null) {
-		if (Configure::read('DbAclbindMode') == 'string') {
+		if (Configure::read('DbAclbindMode') === 'string') {
 			return 'ROOT/admins/Gandalf';
-		} elseif (Configure::read('DbAclbindMode') == 'array') {
+		} elseif (Configure::read('DbAclbindMode') === 'array') {
 			return array('DbAroTest' => array('DbAroTest.model' => 'AuthUser', 'DbAroTest.foreign_key' => 2));
 		}
 	}

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -61,7 +61,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function beforeFind(Model $model, $query) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['beforeFind']) || $settings['beforeFind'] == 'off') {
+		if (!isset($settings['beforeFind']) || $settings['beforeFind'] === 'off') {
 			return parent::beforeFind($model, $query);
 		}
 		switch ($settings['beforeFind']) {
@@ -86,7 +86,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function afterFind(Model $model, $results, $primary) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['afterFind']) || $settings['afterFind'] == 'off') {
+		if (!isset($settings['afterFind']) || $settings['afterFind'] === 'off') {
 			return parent::afterFind($model, $results, $primary);
 		}
 		switch ($settings['afterFind']) {
@@ -109,7 +109,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function beforeSave(Model $model) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['beforeSave']) || $settings['beforeSave'] == 'off') {
+		if (!isset($settings['beforeSave']) || $settings['beforeSave'] === 'off') {
 			return parent::beforeSave($model);
 		}
 		switch ($settings['beforeSave']) {
@@ -132,7 +132,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function afterSave(Model $model, $created) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['afterSave']) || $settings['afterSave'] == 'off') {
+		if (!isset($settings['afterSave']) || $settings['afterSave'] === 'off') {
 			return parent::afterSave($model, $created);
 		}
 		$string = 'modified after';
@@ -162,7 +162,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function beforeValidate(Model $model) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['validate']) || $settings['validate'] == 'off') {
+		if (!isset($settings['validate']) || $settings['validate'] === 'off') {
 			return parent::beforeValidate($model);
 		}
 		switch ($settings['validate']) {
@@ -189,7 +189,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function afterValidate(Model $model) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['afterValidate']) || $settings['afterValidate'] == 'off') {
+		if (!isset($settings['afterValidate']) || $settings['afterValidate'] === 'off') {
 			return parent::afterValidate($model);
 		}
 		switch ($settings['afterValidate']) {
@@ -210,7 +210,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function beforeDelete(Model $model, $cascade = true) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['beforeDelete']) || $settings['beforeDelete'] == 'off') {
+		if (!isset($settings['beforeDelete']) || $settings['beforeDelete'] === 'off') {
 			return parent::beforeDelete($model, $cascade);
 		}
 		switch ($settings['beforeDelete']) {
@@ -235,7 +235,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function afterDelete(Model $model) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['afterDelete']) || $settings['afterDelete'] == 'off') {
+		if (!isset($settings['afterDelete']) || $settings['afterDelete'] === 'off') {
 			return parent::afterDelete($model);
 		}
 		switch ($settings['afterDelete']) {
@@ -253,7 +253,7 @@ class TestBehavior extends ModelBehavior {
  */
 	public function onError(Model $model, $error) {
 		$settings = $this->settings[$model->alias];
-		if (!isset($settings['onError']) || $settings['onError'] == 'off') {
+		if (!isset($settings['onError']) || $settings['onError'] === 'off') {
 			return parent::onError($model, $error);
 		}
 		echo "onError trigger success";

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -1131,7 +1131,7 @@ class MysqlTest extends CakeTestCase {
 				$linkModel = $this->Model->Category2->{$assoc};
 				$external = isset($assocData['external']);
 
-				if ($this->Model->Category2->alias == $linkModel->alias && $type != 'hasAndBelongsToMany' && $type != 'hasMany') {
+				if ($this->Model->Category2->alias == $linkModel->alias && $type !== 'hasAndBelongsToMany' && $type !== 'hasMany') {
 					$result = $this->Dbo->generateAssociationQuery($this->Model->Category2, $linkModel, $type, $assoc, $assocData, $queryData, $external, $null);
 					$this->assertFalse(empty($result));
 				} else {

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -2574,7 +2574,7 @@ class NumberTree extends CakeTestModel {
 			$this->create($data);
 
 			if ($hierarchal) {
-				if ($this->name == 'UnconventionalTree') {
+				if ($this->name === 'UnconventionalTree') {
 					$data[$this->name]['join'] = $parentId;
 				} else {
 					$data[$this->name]['parent_id'] = $parentId;

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -29,7 +29,7 @@ class TestCakeRequest extends CakeRequest {
 		if (empty($url)) {
 			$url = $this->_url();
 		}
-		if ($url[0] == '/') {
+		if ($url[0] === '/') {
 			$url = substr($url, 1);
 		}
 		$this->url = $url;

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -376,7 +376,7 @@ class SomePostsController extends AppController {
  * @return void
  */
 	public function beforeFilter() {
-		if ($this->params['action'] == 'index') {
+		if ($this->params['action'] === 'index') {
 			$this->params['action'] = 'view';
 		} else {
 			$this->params['action'] = 'change';
@@ -1666,7 +1666,7 @@ class DispatcherTest extends CakeTestCase {
  */
 	protected function _cachePath($here) {
 		$path = $here;
-		if ($here == '/') {
+		if ($here === '/') {
 			$path = 'home';
 		}
 		$path = strtolower(Inflector::slug($path));

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -57,7 +57,7 @@ class RouterTest extends CakeTestCase {
  * @return void
  */
 	public function testFullBaseURL() {
-		$skip = PHP_SAPI == 'cli';
+		$skip = PHP_SAPI === 'cli';
 		if ($skip) {
 			$this->markTestSkipped('Cannot validate base urls in CLI');
 		}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -303,7 +303,7 @@ class FileTest extends CakeTestCase {
  */
 	public function testPrepare() {
 		$string = "some\nvery\ncool\r\nteststring here\n\n\nfor\r\r\n\n\r\n\nhere";
-		if (DS == '\\') {
+		if (DS === '\\') {
 			$expected = "some\r\nvery\r\ncool\r\nteststring here\r\n\r\n\r\n";
 			$expected .= "for\r\n\r\n\r\n\r\n\r\nhere";
 		} else {

--- a/lib/Cake/Test/test_app/Lib/Cache/Engine/TestAppCacheEngine.php
+++ b/lib/Cake/Test/test_app/Lib/Cache/Engine/TestAppCacheEngine.php
@@ -20,7 +20,7 @@
 class TestAppCacheEngine extends CacheEngine {
 
 	public function write($key, $value, $duration) {
-		if ($key == 'fail') {
+		if ($key === 'fail') {
 			return false;
 		}
 	}

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -380,7 +380,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 				$tags = (string)$tags;
 			}
 			$i++;
-			if (is_string($tags) && $tags{0} == '<') {
+			if (is_string($tags) && $tags{0} === '<') {
 				$tags = array(substr($tags, 1) => array());
 			} elseif (is_string($tags)) {
 				$tagsTrimmed = preg_replace('/\s+/m', '', $tags);
@@ -388,7 +388,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 				if (preg_match('/^\*?\//', $tags, $match) && $tagsTrimmed !== '//') {
 					$prefix = array(null, null);
 
-					if ($match[0] == '*/') {
+					if ($match[0] === '*/') {
 						$prefix = array('Anything, ', '.*?');
 					}
 					$regex[] = array(

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -186,7 +186,7 @@ abstract class ControllerTestCase extends CakeTestCase {
  * @throws BadMethodCallException when you call methods that don't exist.
  */
 	public function __call($name, $arguments) {
-		if ($name == 'testAction') {
+		if ($name === 'testAction') {
 			return call_user_func_array(array($this, '_testAction'), $arguments);
 		}
 		throw new BadMethodCallException("Method '{$name}' does not exist.");
@@ -226,7 +226,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 
 		$_SERVER['REQUEST_METHOD'] = strtoupper($options['method']);
 		if (is_array($options['data'])) {
-			if (strtoupper($options['method']) == 'GET') {
+			if (strtoupper($options['method']) === 'GET') {
 				$_GET = $options['data'];
 				$_POST = array();
 			} else {
@@ -263,7 +263,7 @@ abstract class ControllerTestCase extends CakeTestCase {
 			$this->generate($plugin . Inflector::camelize($request->params['controller']));
 		}
 		$params = array();
-		if ($options['return'] == 'result') {
+		if ($options['return'] === 'result') {
 			$params['return'] = 1;
 			$params['bare'] = 1;
 			$params['requested'] = 1;

--- a/lib/Cake/TestSuite/Coverage/HtmlCoverageReport.php
+++ b/lib/Cake/TestSuite/Coverage/HtmlCoverageReport.php
@@ -157,14 +157,14 @@ HTML;
 		<script type="text/javascript">
 		function coverage_show_hide(selector) {
 			var element = document.getElementById(selector);
-			element.style.display = (element.style.display == 'none') ? '' : 'none';
+			element.style.display = (element.style.display === 'none') ? '' : 'none';
 		}
 		function coverage_toggle_all() {
 			var divs = document.querySelectorAll('div.coverage-container');
 			var i = divs.length;
 			while (i--) {
 				if (divs[i] && divs[i].className.indexOf('primary') == -1) {
-					divs[i].style.display = (divs[i].style.display == 'none') ? '' : 'none';
+					divs[i].style.display = (divs[i].style.display === 'none') ? '' : 'none';
 				}
 			}
 		}
@@ -183,7 +183,7 @@ HTML;
 		$filename = basename($filename);
 		list($file, $ext) = explode('.', $filename);
 		$display = in_array($file, $this->_testNames) ? 'block' : 'none';
-		$primary = $display == 'block' ? 'primary' : '';
+		$primary = $display === 'block' ? 'primary' : '';
 		return <<<HTML
 	<div class="coverage-container $primary" style="display:$display;">
 	<h4>

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -134,7 +134,7 @@ class CakeNumber {
 			return $size * pow(1024, $i + 1);
 		}
 
-		if (substr($size, -1) == 'B' && ctype_digit(substr($size, 0, -1))) {
+		if (substr($size, -1) === 'B' && ctype_digit(substr($size, 0, -1))) {
 			$size = substr($size, 0, -1);
 			return (int)$size;
 		}
@@ -329,14 +329,14 @@ class CakeNumber {
 			}
 		}
 
-		$position = $options[$symbolKey . 'Position'] != 'after' ? 'before' : 'after';
+		$position = $options[$symbolKey . 'Position'] !== 'after' ? 'before' : 'after';
 		$options[$position] = $options[$symbolKey . 'Symbol'];
 
 		$abs = abs($value);
 		$result = self::format($abs, $options);
 
 		if ($value < 0) {
-			if ($options['negative'] == '()') {
+			if ($options['negative'] === '()') {
 				$result = '(' . $result . ')';
 			} else {
 				$result = $options['negative'] . $result;

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -165,7 +165,7 @@ class CakeTime {
 				break;
 			case 'c':
 				$format = __dc('cake', 'd_t_fmt', 5);
-				if ($format != 'd_t_fmt') {
+				if ($format !== 'd_t_fmt') {
 					return self::convertSpecifiers($format, self::$_time);
 				}
 				break;
@@ -206,12 +206,12 @@ class CakeTime {
 				$format = __dc('cake', 'am_pm', 5);
 				if (is_array($format)) {
 					$meridiem = $format[$meridiem];
-					return ($specifier[1] == 'P') ? strtolower($meridiem) : strtoupper($meridiem);
+					return ($specifier[1] === 'P') ? strtolower($meridiem) : strtoupper($meridiem);
 				}
 				break;
 			case 'r':
 				$complete = __dc('cake', 't_fmt_ampm', 5);
-				if ($complete != 't_fmt_ampm') {
+				if ($complete !== 't_fmt_ampm') {
 					return str_replace('%p', self::_translateSpecifier(array('%p', 'p')), $complete);
 				}
 				break;
@@ -225,13 +225,13 @@ class CakeTime {
 				return ($weekDay = date('w', self::$_time)) ? $weekDay : 7;
 			case 'x':
 				$format = __dc('cake', 'd_fmt', 5);
-				if ($format != 'd_fmt') {
+				if ($format !== 'd_fmt') {
 					return self::convertSpecifiers($format, self::$_time);
 				}
 				break;
 			case 'X':
 				$format = __dc('cake', 't_fmt', 5);
-				if ($format != 't_fmt') {
+				if ($format !== 't_fmt') {
 					return self::convertSpecifiers($format, self::$_time);
 				}
 				break;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -257,7 +257,7 @@ class Debugger {
 		);
 		echo $self->outputError($data);
 
-		if ($error == 'Fatal Error') {
+		if ($error === 'Fatal Error') {
 			exit();
 		}
 		return true;
@@ -326,9 +326,9 @@ class Debugger {
 			if (in_array($signature, $options['exclude'])) {
 				continue;
 			}
-			if ($options['format'] == 'points' && $trace['file'] != '[internal]') {
+			if ($options['format'] === 'points' && $trace['file'] !== '[internal]') {
 				$back[] = array('file' => $trace['file'], 'line' => $trace['line']);
-			} elseif ($options['format'] == 'array') {
+			} elseif ($options['format'] === 'array') {
 				$back[] = $trace;
 			} else {
 				if (isset($self->_templates[$options['format']]['traceLine'])) {
@@ -343,7 +343,7 @@ class Debugger {
 			}
 		}
 
-		if ($options['format'] == 'array' || $options['format'] == 'points') {
+		if ($options['format'] === 'array' || $options['format'] === 'points') {
 			return $back;
 		}
 		return implode("\n", $back);
@@ -847,7 +847,7 @@ class Debugger {
  * @return void
  */
 	public static function checkSecurityKeys() {
-		if (Configure::read('Security.salt') == 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi') {
+		if (Configure::read('Security.salt') === 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi') {
 			trigger_error(__d('cake_dev', 'Please change the value of \'Security.salt\' in app/Config/core.php to a salt value specific to your application'), E_USER_NOTICE);
 		}
 

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -212,7 +212,7 @@ class File {
  */
 	public static function prepare($data, $forceWindows = false) {
 		$lineBreak = "\n";
-		if (DIRECTORY_SEPARATOR == '\\' || $forceWindows === true) {
+		if (DIRECTORY_SEPARATOR === '\\' || $forceWindows === true) {
 			$lineBreak = "\r\n";
 		}
 		return strtr($data, array("\r\n" => $lineBreak, "\n" => $lineBreak, "\r" => $lineBreak));

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -267,7 +267,7 @@ class Folder {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isWindowsPath
  */
 	public static function isWindowsPath($path) {
-		return (preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) == '\\\\');
+		return (preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) === '\\\\');
 	}
 
 /**
@@ -278,7 +278,7 @@ class Folder {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isAbsolute
  */
 	public static function isAbsolute($path) {
-		return !empty($path) && ($path[0] === '/' || preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) == '\\\\');
+		return !empty($path) && ($path[0] === '/' || preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) === '\\\\');
 	}
 
 /**
@@ -460,7 +460,7 @@ class Folder {
 		foreach ($iterator as $itemPath => $fsIterator) {
 			if ($skipHidden) {
 				$subPathName = $fsIterator->getSubPathname();
-				if ($subPathName{0} == '.' || strpos($subPathName, DS . '.') !== false) {
+				if ($subPathName{0} === '.' || strpos($subPathName, DS . '.') !== false) {
 					continue;
 				}
 			}

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -770,7 +770,7 @@ class Hash {
 
 		$dir = strtolower($dir);
 		$type = strtolower($type);
-		if ($type == 'natural' && version_compare(PHP_VERSION, '5.4.0', '<')) {
+		if ($type === 'natural' && version_compare(PHP_VERSION, '5.4.0', '<')) {
 			$type = 'regular';
 		}
 		if ($dir === 'asc') {

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -271,7 +271,7 @@ class Inflector {
 			return;
 		}
 		foreach (self::$_initialState as $key => $val) {
-			if ($key != '_initialState') {
+			if ($key !== '_initialState') {
 				self::${$key} = $val;
 			}
 		}

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -120,14 +120,14 @@ class Security {
 			$string = $salt . $string;
 		}
 
-		if (!$type || $type == 'sha1') {
+		if (!$type || $type === 'sha1') {
 			if (function_exists('sha1')) {
 				return sha1($string);
 			}
 			$type = 'sha256';
 		}
 
-		if ($type == 'sha256' && function_exists('mhash')) {
+		if ($type === 'sha256' && function_exists('mhash')) {
 			return bin2hex(mhash(MHASH_SHA256, $string));
 		}
 

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -477,7 +477,7 @@ class String {
 		);
 		if (isset($options['ending'])) {
 			$default['ellipsis'] = $options['ending'];
-		} elseif (!empty($options['html']) && Configure::read('App.encoding') == 'UTF-8') {
+		} elseif (!empty($options['html']) && Configure::read('App.encoding') === 'UTF-8') {
 			$default['ellipsis'] = "\xe2\x80\xa6";
 		}
 		$options = array_merge($default, $options);

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -182,7 +182,7 @@ class Validation {
 					return self::luhn($check, $deep);
 				}
 			}
-		} elseif ($type == 'all') {
+		} elseif ($type === 'all') {
 			foreach ($cards['all'] as $value) {
 				$regex = $value;
 
@@ -529,7 +529,7 @@ class Validation {
  */
 	public static function money($check, $symbolPosition = 'left') {
 		$money = '(?!0,?\d)(?:\d{1,3}(?:([, .])\d{3})?(?:\1\d{3})*|(?:\d+))((?!\1)[,.]\d{2})?';
-		if ($symbolPosition == 'right') {
+		if ($symbolPosition === 'right') {
 			$regex = '/^' . $money . '(?<!\x{00a2})\p{Sc}?$/u';
 		} else {
 			$regex = '/^(?!\x{00a2})\p{Sc}?' . $money . '$/u';

--- a/lib/Cake/View/Elements/exception_stack_trace.ctp
+++ b/lib/Cake/View/Elements/exception_stack_trace.ctp
@@ -69,7 +69,7 @@ App::uses('Debugger', 'Utility');
 <script type="text/javascript">
 function traceToggle(event, id) {
 	var el = document.getElementById(id);
-	el.style.display = (el.style.display == 'block') ? 'none' : 'block';
+	el.style.display = (el.style.display === 'block') ? 'none' : 'block';
 	event.preventDefault();
 	return false;
 }

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -355,7 +355,7 @@ class Helper extends Object {
 
 /**
  * Adds a timestamp to a file based resource based on the value of `Asset.timestamp` in
- * Configure. If Asset.timestamp is true and debug > 0, or Asset.timestamp == 'force'
+ * Configure. If Asset.timestamp is true and debug > 0, or Asset.timestamp === 'force'
  * a timestamp will be added.
  *
  * @param string $path The file path to timestamp, the path must be inside WWW_ROOT

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -127,7 +127,7 @@ class CacheHelper extends AppHelper {
 				}
 			}
 
-			if (!isset($index) && $this->request->params['action'] == 'index') {
+			if (!isset($index) && $this->request->params['action'] === 'index') {
 				$index = 'index';
 			}
 

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -793,7 +793,7 @@ class FormHelper extends AppHelper {
 			} else {
 				$text = $fieldName;
 			}
-			if (substr($text, -3) == '_id') {
+			if (substr($text, -3) === '_id') {
 				$text = substr($text, 0, -3);
 			}
 			$text = __(Inflector::humanize(Inflector::underscore($text)));
@@ -993,7 +993,7 @@ class FormHelper extends AppHelper {
 		unset($options['type'], $options['before'], $options['between'], $options['after'], $options['format']);
 
 		$out['error'] = null;
-		if ($type != 'hidden' && $error !== false) {
+		if ($type !== 'hidden' && $error !== false) {
 			$errMsg = $this->error($fieldName, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, 'error');
@@ -1192,13 +1192,13 @@ class FormHelper extends AppHelper {
  * @return array
  */
 	protected function _getFormat($options) {
-		if ($options['type'] == 'hidden') {
+		if ($options['type'] === 'hidden') {
 			return array('input');
 		}
 		if (is_array($options['format']) && in_array('input', $options['format'])) {
 			return $options['format'];
 		}
-		if ($options['type'] == 'checkbox') {
+		if ($options['type'] === 'checkbox') {
 			return array('before', 'input', 'between', 'label', 'after', 'error');
 		}
 		return array('before', 'label', 'between', 'input', 'after', 'error');
@@ -1246,7 +1246,7 @@ class FormHelper extends AppHelper {
 		) {
 			$options['maxlength'] = $fieldDef['length'];
 		}
-		if ($autoLength && $fieldDef['type'] == 'float') {
+		if ($autoLength && $fieldDef['type'] === 'float') {
 			$options['maxlength'] = array_sum(explode(',', $fieldDef['length'])) + 1;
 		}
 		return $options;
@@ -2053,7 +2053,7 @@ class FormHelper extends AppHelper {
 			)
 		));
 
-		$template = ($style == 'checkbox') ? 'checkboxmultipleend' : 'selectend';
+		$template = ($style === 'checkbox') ? 'checkboxmultipleend' : 'selectend';
 		$select[] = $this->Html->useTag($template);
 		return implode("\n", $select);
 	}
@@ -2503,14 +2503,14 @@ class FormHelper extends AppHelper {
 		if (!empty($timeFormat)) {
 			$time = explode(':', $days[1]);
 
-			if ($time[0] >= '12' && $timeFormat == '12') {
+			if ($time[0] >= '12' && $timeFormat === '12') {
 				$meridian = 'pm';
-			} elseif ($time[0] == '00' && $timeFormat == '12') {
+			} elseif ($time[0] === '00' && $timeFormat === '12') {
 				$time[0] = 12;
 			} elseif ($time[0] >= 12) {
 				$meridian = 'pm';
 			}
-			if ($time[0] == 0 && $timeFormat == '12') {
+			if ($time[0] == 0 && $timeFormat === '12') {
 				$time[0] = 12;
 			}
 			$hour = $min = null;
@@ -2531,7 +2531,7 @@ class FormHelper extends AppHelper {
  * @return array
  */
 	protected function _name($options = array(), $field = null, $key = 'name') {
-		if ($this->requestType == 'get') {
+		if ($this->requestType === 'get') {
 			if ($options === null) {
 				$options = array();
 			} elseif (is_string($options)) {
@@ -2767,7 +2767,7 @@ class FormHelper extends AppHelper {
 				for ($i = $min; $i <= $max; $i++) {
 					$data[$i] = $i;
 				}
-				if ($options['order'] != 'asc') {
+				if ($options['order'] !== 'asc') {
 					$data = array_reverse($data, true);
 				}
 			break;

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -438,7 +438,7 @@ class HtmlHelper extends AppHelper {
 			}
 		}
 
-		if ($rel == 'import') {
+		if ($rel === 'import') {
 			$out = sprintf($this->_tags['style'], $this->_parseAttributes($options, array('inline', 'block'), '', ' '), '@import url(' . $url . ');');
 		} else {
 			if (!$rel) {

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -150,7 +150,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
  * @return JqueryEngineHelper instance of $this. Allows chained methods.
  */
 	public function get($selector) {
-		if ($selector == 'window' || $selector == 'document') {
+		if ($selector === 'window' || $selector === 'document') {
 			$this->selection = $this->jQueryObject . '(' . $selector . ')';
 		} else {
 			$this->selection = $this->jQueryObject . '("' . $selector . '")';
@@ -227,7 +227,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
 		switch ($name) {
 			case 'slideIn':
 			case 'slideOut':
-				$name = ($name == 'slideIn') ? 'slideDown' : 'slideUp';
+				$name = ($name === 'slideIn') ? 'slideDown' : 'slideUp';
 			case 'hide':
 			case 'show':
 			case 'fadeIn':

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -122,7 +122,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
  */
 	public function get($selector) {
 		$this->_multipleSelection = false;
-		if ($selector == 'window' || $selector == 'document') {
+		if ($selector === 'window' || $selector === 'document') {
 			$this->selection = "$(" . $selector . ")";
 			return $this;
 		}
@@ -195,9 +195,9 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
 	public function effect($name, $options = array()) {
 		$speed = null;
 		if (isset($options['speed']) && in_array($options['speed'], array('fast', 'slow'))) {
-			if ($options['speed'] == 'fast') {
+			if ($options['speed'] === 'fast') {
 				$speed = '"short"';
-			} elseif ($options['speed'] == 'slow') {
+			} elseif ($options['speed'] === 'slow') {
 				$speed = '"long"';
 			}
 		}
@@ -239,7 +239,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
 		$options = $this->_mapOptions('request', $options);
 		$type = $data = null;
 		if (isset($options['type']) || isset($options['update'])) {
-			if (isset($options['type']) && strtolower($options['type']) == 'json') {
+			if (isset($options['type']) && strtolower($options['type']) === 'json') {
 				$type = '.JSON';
 			}
 			if (isset($options['update'])) {

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -237,7 +237,7 @@ class PaginatorHelper extends AppHelper {
 			$dir = strtolower(current($params['order']));
 		}
 
-		if ($dir == 'desc') {
+		if ($dir === 'desc') {
 			return 'desc';
 		}
 		return 'asc';
@@ -426,7 +426,7 @@ class PaginatorHelper extends AppHelper {
  * @return array converted url params.
  */
 	protected function _convertUrlKeys($url, $type) {
-		if ($type == 'named') {
+		if ($type === 'named') {
 			return $url;
 		}
 		if (!isset($url['?'])) {
@@ -479,7 +479,7 @@ class PaginatorHelper extends AppHelper {
 
 		if ($this->{$check}($model)) {
 			$url = array_merge(
-				array('page' => $paging['page'] + ($which == 'Prev' ? $step * -1 : $step)),
+				array('page' => $paging['page'] + ($which === 'Prev' ? $step * -1 : $step)),
 				$url
 			);
 			if ($tag === false) {

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -120,7 +120,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
  */
 	public function get($selector) {
 		$this->_multiple = false;
-		if ($selector == 'window' || $selector == 'document') {
+		if ($selector === 'window' || $selector === 'document') {
 			$this->selection = "$(" . $selector . ")";
 			return $this;
 		}
@@ -196,9 +196,9 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 		$effect = '';
 		$optionString = null;
 		if (isset($options['speed'])) {
-			if ($options['speed'] == 'fast') {
+			if ($options['speed'] === 'fast') {
 				$options['duration'] = 0.5;
-			} elseif ($options['speed'] == 'slow') {
+			} elseif ($options['speed'] === 'slow') {
 				$options['duration'] = 2;
 			} else {
 				$options['duration'] = 1;
@@ -215,12 +215,12 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 			break;
 			case 'slideIn':
 			case 'slideOut':
-				$name = ($name == 'slideIn') ? 'slideDown' : 'slideUp';
+				$name = ($name === 'slideIn') ? 'slideDown' : 'slideUp';
 				$effect = 'Effect.' . $name . '(' . $this->selection . $optionString . ');';
 			break;
 			case 'fadeIn':
 			case 'fadeOut':
-				$name = ($name == 'fadeIn') ? 'appear' : 'fade';
+				$name = ($name === 'fadeIn') ? 'appear' : 'fade';
 				$effect = $this->selection . '.' . $name . '(' . substr($optionString, 2) . ');';
 			break;
 		}
@@ -239,7 +239,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
 		$url = '"' . $url . '"';
 		$options = $this->_mapOptions('request', $options);
 		$type = '.Request';
-		if (isset($options['type']) && strtolower($options['type']) == 'json') {
+		if (isset($options['type']) && strtolower($options['type']) === 'json') {
 			unset($options['type']);
 		}
 		if (isset($options['update'])) {

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -138,7 +138,7 @@ class RssHelper extends AppHelper {
 		foreach ($elements as $elem => $data) {
 			$attributes = array();
 			if (is_array($data)) {
-				if (strtolower($elem) == 'cloud') {
+				if (strtolower($elem) === 'cloud') {
 					$attributes = $data;
 					$data = array();
 				} elseif (isset($data['attrib']) && is_array($data['attrib'])) {

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -129,7 +129,7 @@ class SessionHelper extends AppHelper {
 				$flash = array_merge($flash, $attrs);
 			}
 
-			if ($flash['element'] == 'default') {
+			if ($flash['element'] === 'default') {
 				$class = 'message';
 				if (!empty($flash['params']['class'])) {
 					$class = $flash['params']['class'];

--- a/lib/Cake/View/ScaffoldView.php
+++ b/lib/Cake/View/ScaffoldView.php
@@ -52,7 +52,7 @@ class ScaffoldView extends ThemeView {
 			}
 		}
 
-		if ($name === 'add' || $name == 'edit') {
+		if ($name === 'add' || $name === 'edit') {
 			$name = 'form';
 		}
 

--- a/lib/Cake/View/Scaffolds/form.ctp
+++ b/lib/Cake/View/Scaffolds/form.ctp
@@ -27,7 +27,7 @@
 <div class="actions">
 	<h3><?php echo __d('cake', 'Actions'); ?></h3>
 	<ul>
-<?php if ($this->request->action != 'add'): ?>
+<?php if ($this->request->action !== 'add'): ?>
 		<li><?php echo $this->Form->postLink(
 			__d('cake', 'Delete'),
 			array('action' => 'delete', $this->Form->value($modelClass . '.' . $primaryKey)),

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -550,7 +550,7 @@ class View extends Object {
 		ob_start();
 		include ($filename);
 
-		if (Configure::read('debug') > 0 && $this->layout != 'xml') {
+		if (Configure::read('debug') > 0 && $this->layout !== 'xml') {
 			echo "<!-- Cached Render Time: " . round(microtime(true) - $timeStart, 4) . "s -->";
 		}
 		$out = ob_get_clean();

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -97,7 +97,7 @@ HTML;
 ###########################
 TEXT;
 			$template = $html;
-			if (php_sapi_name() == 'cli' || $showHtml === false) {
+			if (php_sapi_name() === 'cli' || $showHtml === false) {
 				$template = $text;
 				if ($showFrom) {
 					$lineInfo = sprintf('%s (line %s)', $file, $line);
@@ -141,7 +141,7 @@ if (!function_exists('sortByKey')) {
 			$sa[$key] = $val[$sortby];
 		}
 
-		if ($order == 'asc') {
+		if ($order === 'asc') {
 			asort($sa, $type);
 		} else {
 			arsort($sa, $type);


### PR DESCRIPTION
Make == to === and != to !== where applicable.
In light of the recent bugs and issues regarding too lose checks it would be wise to further improve the core where strict comparison can be used.
There are many flaws in using too lose comparison.

The rule should be: As strict as possible. Especially for strings.
