### PR TITLE
help text from the subcommands is missing on help

### DIFF
--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -84,7 +84,7 @@ class ConsoleInputSubcommand {
  * Generate the help for this this subcommand.
  *
  * @param integer $width The width to make the name of the subcommand if you want to prepend it to the help text.
- + @param integer $maxWidth The maximal width the help text should be wrapped with.
+ + @param integer $maxWidth The maximum width the help text should be wrapped with.
  * @return string
  */
 	public function help($width = 0, $maxWidth = 0) {

--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -83,10 +83,14 @@ class ConsoleInputSubcommand {
 /**
  * Generate the help for this this subcommand.
  *
- * @param integer $width The width to make the name of the subcommand.
+ * @param integer $width The width to make the name of the subcommand if you want to prepend it to the help text.
  * @return string
  */
 	public function help($width = 0) {
+		if ($width === 0) {
+			return $this->_help;
+		}
+
 		$name = $this->_name;
 		if (strlen($name) < $width) {
 			$name = str_pad($name, $width, ' ');

--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -84,18 +84,28 @@ class ConsoleInputSubcommand {
  * Generate the help for this this subcommand.
  *
  * @param integer $width The width to make the name of the subcommand if you want to prepend it to the help text.
+ + @param integer $maxWidth The maximal width the help text should be wrapped with.
  * @return string
  */
-	public function help($width = 0) {
-		if ($width === 0) {
-			return $this->_help;
-		}
-
+	public function help($width = 0, $maxWidth = 0) {
 		$name = $this->_name;
+		if ($width === 0) {
+			$name = '';
+		}
 		if (strlen($name) < $width) {
 			$name = str_pad($name, $width, ' ');
 		}
-		return $name . $this->_help;
+		if ($name) {
+			$name .= ' ';
+		}
+
+		$out[] = String::wrap($this->_help, array(
+			'width' => $maxWidth,
+			'indent' => str_repeat(' ', strlen($name)),
+			'indentAt' => 1
+		));
+
+		return $name . implode("\n", $out);
 	}
 
 /**

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -518,7 +518,7 @@ class ConsoleOptionParser {
 		) {
 			$subparser = $this->_subcommands[$subcommand]->parser();
 			$subparser->command($this->command() . ' ' . $subparser->command());
-			$help = $this->_subcommands[$subcommand]->help(null, $format, $width);
+			$help = $this->_subcommands[$subcommand]->help(1, $width);
 			if ($help) {
 				$help .= "\n\n";
 			}

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -518,7 +518,7 @@ class ConsoleOptionParser {
 		) {
 			$subparser = $this->_subcommands[$subcommand]->parser();
 			$subparser->command($this->command() . ' ' . $subparser->command());
-			$help = $this->_subcommands[$subcommand]->help();
+			$help = $this->_subcommands[$subcommand]->help(null, $format, $width);
 			if ($help) {
 				$help .= "\n\n";
 			}

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -518,7 +518,11 @@ class ConsoleOptionParser {
 		) {
 			$subparser = $this->_subcommands[$subcommand]->parser();
 			$subparser->command($this->command() . ' ' . $subparser->command());
-			return $subparser->help(null, $format, $width);
+			$help = $this->_subcommands[$subcommand]->help();
+			if ($help) {
+				$help .= "\n\n";
+			}
+			return $help . $subparser->help(null, $format, $width);
 		}
 		$formatter = new HelpFormatter($this);
 		if ($format == 'text' || $format === true) {

--- a/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
@@ -519,6 +519,8 @@ class ConsoleOptionParserTest extends CakeTestCase {
 
 		$result = $parser->help('method');
 		$expected = <<<TEXT
+This is another command
+
 <info>Usage:</info>
 cake mycommand method [-h] [--connection]
 

--- a/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
@@ -512,14 +512,15 @@ class ConsoleOptionParserTest extends CakeTestCase {
 
 		$parser = new ConsoleOptionParser('mycommand', false);
 		$parser->addSubcommand('method', array(
-				'help' => 'This is another command',
+				'help' => 'This is another very long command help text to check if the sub commands also display their help when they are supposed to do so.',
 				'parser' => $subParser
 			))
 			->addOption('test', array('help' => 'A test option.'));
 
 		$result = $parser->help('method');
 		$expected = <<<TEXT
-This is another command
+method This is another very long command help text to check if the sub commands
+       also display their help when they are supposed to do so.
 
 <info>Usage:</info>
 cake mycommand method [-h] [--connection]


### PR DESCRIPTION
2.4 target of previous PR #1021
