### PR TITLE
Add the new logging scopes to both CakeEmail and Object.

### DIFF
--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -151,13 +151,13 @@ class Object {
  * @param integer $type Error type constant. Defined in app/Config/core.php.
  * @return boolean Success of log write
  */
-	public function log($msg, $type = LOG_ERR) {
-		App::uses('CakeLog', 'Log');
-		if (!is_string($msg)) {
-			$msg = print_r($msg, true);
-		}
-		return CakeLog::write($type, $msg);
-	}
+  public function log($msg, $type = LOG_ERR, $scope = null) {
+    if (!is_string($msg)) {
+      $msg = print_r($msg, true);
+    }
+
+    return CakeLog::write($type, $msg, $scope);
+  }
 
 /**
  * Allows setting of multiple properties of the object in a single line of code. Will only set

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -151,13 +151,14 @@ class Object {
  * @param integer $type Error type constant. Defined in app/Config/core.php.
  * @return boolean Success of log write
  */
-  public function log($msg, $type = LOG_ERR, $scope = null) {
-    if (!is_string($msg)) {
-      $msg = print_r($msg, true);
-    }
+	public function log($msg, $type = LOG_ERR, $scope = null) {
+		App::uses('CakeLog', 'Log');
+		if (!is_string($msg)) {
+			$msg = print_r($msg, true);
+		}
 
-    return CakeLog::write($type, $msg, $scope);
-  }
+		return CakeLog::write($type, $msg, $scope);
+	}
 
 /**
  * Allows setting of multiple properties of the object in a single line of code. Will only set

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -15,6 +15,7 @@
  */
 
 App::uses('Set', 'Utility');
+App::uses('CakeLog', 'Log');
 
 /**
  * Object class provides a few generic methods used in several subclasses.
@@ -152,7 +153,6 @@ class Object {
  * @return boolean Success of log write
  */
 	public function log($msg, $type = LOG_ERR, $scope = null) {
-		App::uses('CakeLog', 'Log');
 		if (!is_string($msg)) {
 			$msg = print_r($msg, true);
 		}

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1066,7 +1066,7 @@ class CakeEmail {
 		$contents = $this->transportClass()->send($this);
 		if (!empty($this->_config['log'])) {
 			$level = LOG_DEBUG;
-			$scope = null;
+			$scope = 'email';
 			if ($this->_config['log'] !== true) {
 				if (!is_array($this->_config['log'])) {
 					$this->_config['log'] = array('level' => $this->_config['log']);

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1066,10 +1066,15 @@ class CakeEmail {
 		$contents = $this->transportClass()->send($this);
 		if (!empty($this->_config['log'])) {
 			$level = LOG_DEBUG;
+			$scope = null;
 			if ($this->_config['log'] !== true) {
-				$level = $this->_config['log'];
+				if (!is_array($this->_config['log'])) {
+					$this->_config['log'] = array('level' => $this->_config['log']);
+				}
+				$this->_config['log'] = array_merge(compact('level', 'scope'), $this->_config['log']);
+				extract($this->_config['log']);
 			}
-			CakeLog::write($level, PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message']);
+			CakeLog::write($level, PHP_EOL . $contents['headers'] . PHP_EOL . $contents['message'], $scope);
 		}
 		return $contents;
 	}

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1014,6 +1014,35 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
+ * testSendWithLogAndScope method
+ *
+ * @return void
+ */
+	public function testSendWithLogAndScope() {
+		CakeLog::config('email', array(
+			'engine' => 'FileLog',
+			'path' => TMP,
+			'types' => array('cake_test_emails'),
+			'scopes' => array('email')
+		));
+		CakeLog::drop('default');
+		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->to('me@cakephp.org');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->subject('My title');
+		$this->CakeEmail->config(array('log' => array('level' => 'cake_test_emails', 'scope' => 'email')));
+		$result = $this->CakeEmail->send("Logging This");
+
+		App::uses('File', 'Utility');
+		$File = new File(TMP . 'cake_test_emails.log');
+		$log = $File->read();
+		$this->assertTrue(strpos($log, $result['headers']) !== false);
+		$this->assertTrue(strpos($log, $result['message']) !== false);
+		$File->delete();
+		CakeLog::drop('email');
+	}
+
+/**
  * testSendRender method
  *
  * @return void


### PR DESCRIPTION
Scopes are great but when you pamper us with nice features, it's obvious we're going to want even more ;)

This adds the new scopes feature in `CakeLog` to the `Object::log()` and `CakeEmail::send()`.

Tiny contribution, but I hope it will make it to the core.
