### PR TITLE
Prevent response object being set as response body

### DIFF
--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -192,7 +192,9 @@ class Dispatcher implements CakeEventListener {
 
 		if ($render && $controller->autoRender) {
 			$response = $controller->render();
-		} elseif ($response->body() === null) {
+		} elseif (!($result instanceof CakeResponse) &&
+			$response->body() === null
+		) {
 			$response->body($result);
 		}
 		$controller->shutdownProcess();

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -208,6 +208,16 @@ class SomePagesController extends AppController {
 		return new CakeResponse(array('body' => 'new response'));
 	}
 
+/**
+ * Test file sending
+ *
+ * @return CakeResponse
+ */
+	public function sendfile() {
+		$this->response->file(CAKE . 'Test' . DS . 'test_app' . DS . 'Vendor' . DS . 'css' . DS . 'test_asset.css');
+		return $this->response;
+	}
+
 }
 
 /**
@@ -864,6 +874,40 @@ class DispatcherTest extends CakeTestCase {
 		$result = ob_get_clean();
 
 		$this->assertEquals('new response', $result);
+	}
+
+/**
+ * testDispatchActionSendsFile
+ *
+ * @return void
+ */
+	public function testDispatchActionSendsFile() {
+		Router::connect('/:controller/:action');
+		$Dispatcher = new Dispatcher();
+		$request = new CakeRequest('some_pages/sendfile');
+		$response = $this->getMock('CakeResponse', array(
+			'header',
+			'type',
+			'download',
+			'_sendHeader',
+			'_setContentType',
+			'_isActive',
+			'_clearBuffer',
+			'_flushBuffer'
+		));
+
+		$response->expects($this->never())
+			->method('body');
+
+		$response->expects($this->exactly(1))
+			->method('_isActive')
+			->will($this->returnValue(true));
+
+		ob_start();
+		$Dispatcher->dispatch($request, $response);
+		$result = ob_get_clean();
+
+		$this->assertEquals("/* this is the test asset css file */\n", $result);
 	}
 
 /**


### PR DESCRIPTION
While fixing earlier I just did `!is_object($result)` instead of `!($result instanceof CakeResponse)` but that broke lot of tests, for eg. `ObjectTest::testRequestActionParamParseAndPass()`.

Apparently when using requestAction a CakeRequest instance gets set as response body. I find that pretty strange. The docblock for `CakeReponse::body()` is incorrect in that case as it says the `$content` argument should be a string.
