### PR TITLE
Removed the error control operator from "ocilogon" and "ociplogon".

### DIFF
--- a/cake/libs/model/datasources/dbo/dbo_oracle.php
+++ b/cake/libs/model/datasources/dbo/dbo_oracle.php
@@ -173,9 +173,9 @@ class DboOracle extends DboSource {
 		$config['charset'] = !empty($config['charset']) ? $config['charset'] : null;
 
 		if (!$config['persistent']) {
-			$this->connection = @ocilogon($config['login'], $config['password'], $config['database'], $config['charset']);
+			$this->connection = ocilogon($config['login'], $config['password'], $config['database'], $config['charset']);
 		} else {
-			$this->connection = @ociplogon($config['login'], $config['password'], $config['database'], $config['charset']);
+			$this->connection = ociplogon($config['login'], $config['password'], $config['database'], $config['charset']);
 		}
 
 		if ($this->connection) {


### PR DESCRIPTION
To avoid "white screen" when the OCI8 extension is not enabled.
