### PR TITLE
Configure load with keys similar to dump including BC

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -276,23 +276,25 @@ class Configure {
  * @throws ConfigureException Will throw any exceptions the reader raises.
  */
 	public static function load($key, $config = 'default', $options = array()) {
-		$merge = true;
-		$keys = array();
+		$defaults = array(
+			'merge' => true,
+			'keys' => array()
+		);
 		if (!is_array($options)) {
 			$options = array('merge' => $options);
 		}
-		extract($options);
+		$options += $defaults;
 
 		$reader = self::_getReader($config);
 		if (!$reader) {
 			return false;
 		}
 		$values = $reader->read($key);
-		if (!empty($keys)) {
-			$values = array_intersect_key($values, array_flip($keys));
+		if (!empty($options['keys'])) {
+			$values = array_intersect_key($values, array_flip($options['keys']));
 		}
 
-		if ($merge) {
+		if ($options['merge']) {
 			$keys = array_keys($values);
 			foreach ($keys as $key) {
 				if (($c = self::read($key)) && is_array($values[$key]) && is_array($c)) {

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -271,7 +271,7 @@ class Configure {
  * @param array options (or boolean $merge for BC)
  * - boolean $merge If config files should be merged instead of simply overridden
  * - array $keys The name of the top-level keys you want to dump.
- *   This allows you save only some data stored in Configure.
+ *   This allows you to load only some data stored in the config file.
  * @return mixed false if file not found, void if load successful.
  * @throws ConfigureException Will throw any exceptions the reader raises.
  */
@@ -325,7 +325,7 @@ class Configure {
  *   This could be a filename or a cache key depending on the adapter being used.
  * @param string $config The name of the configured adapter to dump data with.
  * @param array $keys The name of the top-level keys you want to dump.
- *   This allows you save only some data stored in Configure.
+ *   This allows you to save only some data stored in Configure.
  * @return boolean success
  * @throws ConfigureException if the adapter does not implement a `dump` method.
  */

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -302,6 +302,45 @@ class ConfigureTest extends CakeTestCase {
 	}
 
 /**
+ * Test loading only some of the data.
+ *
+ * @return
+ */
+	public function testLoadPartial() {
+		Configure::config('test', new PhpReader(CAKE . 'Test' . DS . 'test_app' . DS . 'Config' . DS));
+
+		$result = Configure::load('var_test2', 'test', array('keys' => array('Deep')));
+		$this->assertTrue($result);
+
+		$this->assertNull(Configure::read('Read'));
+		$this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'));
+		$this->assertEquals('buried2', Configure::read('Deep.Second.SecondDeepest'));
+	}
+
+/**
+ * Test loading only some of the data without merging.
+ *
+ * @return
+ */
+	public function testLoadPartialNoMerge() {
+		Configure::config('test', new PhpReader(CAKE . 'Test' . DS . 'test_app' . DS . 'Config' . DS));
+
+		$result = Configure::load('var_test', 'test', array('keys' => array('Deep')));
+		$this->assertTrue($result);
+		$this->assertNull(Configure::read('Read'));
+
+ 		$expected = array('Deeper' => array('Deepest' => 'buried'));
+		$this->assertEquals($expected, Configure::read('Deep'));
+
+		$result = Configure::load('var_test2', 'test', array('merge' => false, 'keys' => array('Deep')));
+		$this->assertTrue($result);
+
+		$this->assertNull(Configure::read('Read'));
+		$this->assertEquals('buried2', Configure::read('Deep.Second.SecondDeepest'));
+		$this->assertNull(Configure::read('Deep.Deeper.Deepest'));
+	}
+
+/**
  * testLoad method
  *
  * @return void

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -309,6 +309,10 @@ class ConfigureTest extends CakeTestCase {
 	public function testLoadPartial() {
 		Configure::config('test', new PhpReader(CAKE . 'Test' . DS . 'test_app' . DS . 'Config' . DS));
 
+		$result = Configure::load('var_test', 'test', array('keys' => array('Deep')));
+		$this->assertTrue($result);
+		$this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'));
+
 		$result = Configure::load('var_test2', 'test', array('keys' => array('Deep')));
 		$this->assertTrue($result);
 


### PR DESCRIPTION
Allow load to work as dump already does, loading only a subset.
