### PR TITLE
3.0 - Move set() into a trait

### DIFF
--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -20,6 +20,7 @@ namespace Cake\Console\Command\Task;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Utility\Folder;
+use Cake\Utility\ViewVarsTrait;
 
 /**
  * Template Task can generate templated output Used in other Tasks.
@@ -29,12 +30,7 @@ use Cake\Utility\Folder;
  */
 class TemplateTask extends Shell {
 
-/**
- * variables to add to template scope
- *
- * @var array
- */
-	public $templateVars = array();
+	use ViewVarsTrait;
 
 /**
  * Paths to look for templates on.
@@ -106,31 +102,6 @@ class TemplateTask extends Shell {
 	}
 
 /**
- * Set variable values to the template scope
- *
- * @param string|array $one A string or an array of data.
- * @param string|array $two Value in case $one is a string (which then works as the key).
- *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
- * @return void
- */
-	public function set($one, $two = null) {
-		if (is_array($one)) {
-			if (is_array($two)) {
-				$data = array_combine($one, $two);
-			} else {
-				$data = $one;
-			}
-		} else {
-			$data = array($one => $two);
-		}
-
-		if (!$data) {
-			return false;
-		}
-		$this->templateVars = $data + $this->templateVars;
-	}
-
-/**
  * Runs the template
  *
  * @param string $directory directory / type of thing you want
@@ -148,7 +119,7 @@ class TemplateTask extends Shell {
 		$themePath = $this->getThemePath();
 		$templateFile = $this->_findTemplate($themePath, $directory, $filename);
 		if ($templateFile) {
-			extract($this->templateVars);
+			extract($this->viewVars);
 			ob_start();
 			ob_implicit_flush(0);
 			include $templateFile;

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -28,6 +28,7 @@ use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
+use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
 
 /**
@@ -66,6 +67,7 @@ class Controller extends Object implements EventListener {
 
 	use MergeVariablesTrait;
 	use RequestActionTrait;
+	use ViewVarsTrait;
 
 /**
  * The name of this controller. Controller names are plural, named after the model they manipulate.
@@ -773,28 +775,6 @@ class Controller extends Object implements EventListener {
  */
 	public function header($status) {
 		$this->response->header($status);
-	}
-
-/**
- * Saves a variable for use inside a view template.
- *
- * @param string|array $one A string or an array of data.
- * @param string|array $two Value in case $one is a string (which then works as the key).
- *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
- * @return void
- * @link http://book.cakephp.org/2.0/en/controllers.html#interacting-with-views
- */
-	public function set($one, $two = null) {
-		if (is_array($one)) {
-			if (is_array($two)) {
-				$data = array_combine($one, $two);
-			} else {
-				$data = $one;
-			}
-		} else {
-			$data = array($one => $two);
-		}
-		$this->viewVars = $data + $this->viewVars;
 	}
 
 /**

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -148,13 +148,6 @@ class Controller extends Object implements EventListener {
 	public $layoutPath = null;
 
 /**
- * Contains variables to be handed to the view.
- *
- * @var array
- */
-	public $viewVars = array();
-
-/**
  * The name of the view file to render. The name specified
  * is the filename in /app/View/<SubFolder> without the .ctp extension.
  *

--- a/lib/Cake/Test/TestCase/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/Task/ControllerTaskTest.php
@@ -319,8 +319,8 @@ class ControllerTaskTest extends TestCase {
 		$result = $this->Task->bake('Articles', '--actions--', array(), array(), array());
 
 		$this->assertContains("App::uses('ControllerTestAppController', 'ControllerTest.Controller');", $result);
-		$this->assertEquals('ControllerTest', $this->Task->Template->templateVars['plugin']);
-		$this->assertEquals('ControllerTest.', $this->Task->Template->templateVars['pluginPath']);
+		$this->assertEquals('ControllerTest', $this->Task->Template->viewVars['plugin']);
+		$this->assertEquals('ControllerTest.', $this->Task->Template->viewVars['pluginPath']);
 
 		Plugin::unload();
 	}

--- a/lib/Cake/Test/TestCase/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/Task/TemplateTaskTest.php
@@ -65,20 +65,20 @@ class TemplateTaskTest extends TestCase {
  */
 	public function testSet() {
 		$this->Task->set('one', 'two');
-		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEquals('two', $this->Task->templateVars['one']);
+		$this->assertTrue(isset($this->Task->viewVars['one']));
+		$this->assertEquals('two', $this->Task->viewVars['one']);
 
 		$this->Task->set(array('one' => 'three', 'four' => 'five'));
-		$this->assertTrue(isset($this->Task->templateVars['one']));
-		$this->assertEquals('three', $this->Task->templateVars['one']);
-		$this->assertTrue(isset($this->Task->templateVars['four']));
-		$this->assertEquals('five', $this->Task->templateVars['four']);
+		$this->assertTrue(isset($this->Task->viewVars['one']));
+		$this->assertEquals('three', $this->Task->viewVars['one']);
+		$this->assertTrue(isset($this->Task->viewVars['four']));
+		$this->assertEquals('five', $this->Task->viewVars['four']);
 
-		$this->Task->templateVars = array();
+		$this->Task->viewVars = array();
 		$this->Task->set(array(3 => 'three', 4 => 'four'));
 		$this->Task->set(array(1 => 'one', 2 => 'two'));
 		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($expected, $this->Task->templateVars);
+		$this->assertEquals($expected, $this->Task->viewVars);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/Task/TemplateTaskTest.php
@@ -59,29 +59,6 @@ class TemplateTaskTest extends TestCase {
 	}
 
 /**
- * test that set sets variables
- *
- * @return void
- */
-	public function testSet() {
-		$this->Task->set('one', 'two');
-		$this->assertTrue(isset($this->Task->viewVars['one']));
-		$this->assertEquals('two', $this->Task->viewVars['one']);
-
-		$this->Task->set(array('one' => 'three', 'four' => 'five'));
-		$this->assertTrue(isset($this->Task->viewVars['one']));
-		$this->assertEquals('three', $this->Task->viewVars['one']);
-		$this->assertTrue(isset($this->Task->viewVars['four']));
-		$this->assertEquals('five', $this->Task->viewVars['four']);
-
-		$this->Task->viewVars = array();
-		$this->Task->set(array(3 => 'three', 4 => 'four'));
-		$this->Task->set(array(1 => 'one', 2 => 'two'));
-		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($expected, $this->Task->viewVars);
-	}
-
-/**
  * test finding themes installed in
  *
  * @return void

--- a/lib/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -320,48 +320,6 @@ class ControllerTest extends TestCase {
 	}
 
 /**
- * testControllerSet method
- *
- * @return void
- */
-	public function testControllerSet() {
-		$request = new Request('controller_posts/index');
-		$Controller = new Controller($request);
-
-		$Controller->set('variable_with_underscores', null);
-		$this->assertTrue(array_key_exists('variable_with_underscores', $Controller->viewVars));
-
-		$Controller->viewVars = array();
-		$viewVars = array('ModelName' => array('id' => 1, 'name' => 'value'));
-		$Controller->set($viewVars);
-		$this->assertTrue(array_key_exists('ModelName', $Controller->viewVars));
-
-		$Controller->viewVars = array();
-		$Controller->set('variable_with_underscores', 'value');
-		$this->assertTrue(array_key_exists('variable_with_underscores', $Controller->viewVars));
-
-		$Controller->viewVars = array();
-		$viewVars = array('ModelName' => 'name');
-		$Controller->set($viewVars);
-		$this->assertTrue(array_key_exists('ModelName', $Controller->viewVars));
-
-		$Controller->set('title', 'someTitle');
-		$this->assertSame($Controller->viewVars['title'], 'someTitle');
-		$this->assertTrue(empty($Controller->pageTitle));
-
-		$Controller->viewVars = array();
-		$expected = array('ModelName' => 'name', 'ModelName2' => 'name2');
-		$Controller->set(array('ModelName', 'ModelName2'), array('name', 'name2'));
-		$this->assertSame($expected, $Controller->viewVars);
-
-		$Controller->viewVars = array();
-		$Controller->set(array(3 => 'three', 4 => 'four'));
-		$Controller->set(array(1 => 'one', 2 => 'two'));
-		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($expected, $Controller->viewVars);
-	}
-
-/**
  * testRender method
  *
  * @return void

--- a/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
@@ -322,7 +322,6 @@ object(Cake\View\View) {
 		(int) 1 => 'Form'
 	)
 	viewPath => ''
-	viewVars => array()
 	view => null
 	layout => 'default'
 	layoutPath => null
@@ -338,6 +337,7 @@ object(Cake\View\View) {
 	response => object(Cake\Network\Response) {}
 	elementCache => 'default'
 	elementCacheSettings => array()
+	viewVars => array()
 	int => (int) 2
 	float => (float) 1.333
 	[protected] _passedVars => array(

--- a/lib/Cake/Test/TestCase/Utility/ViewVarsTraitTest.php
+++ b/lib/Cake/Test/TestCase/Utility/ViewVarsTraitTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\ViewVarsTrait;
+
+/**
+ * ViewVarsTrait test case
+ *
+ * @package Cake.Test.TestCase.Utility
+ */
+class ViewVarsTraitTest extends TestCase {
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		$this->subject = $this->getObjectForTrait('Cake\Utility\ViewVarsTrait');
+	}
+
+/**
+ * Test set() with one param.
+ *
+ * @return void
+ */
+	public function testSetOneParam() {
+		$data = ['test' => 'val', 'foo' => 'bar'];
+		$this->subject->set($data);
+		$this->assertEquals($data, $this->subject->viewVars);
+
+		$update = ['test' => 'updated'];
+		$this->subject->set($update);
+		$this->assertEquals('updated', $this->subject->viewVars['test']);
+	}
+
+/**
+ * test set() with 2 params
+ *
+ * @return void
+ */
+	public function testSetTwoParam() {
+		$this->subject->set('testing', 'value');
+		$this->assertEquals(['testing' => 'value'], $this->subject->viewVars);
+	}
+
+/**
+ * test set() with 2 params in combine mode
+ *
+ * @return void
+ */
+	public function testSetTwoParamCombind() {
+		$keys = ['one', 'key'];
+		$vals = ['two', 'val'];
+		$this->subject->set($keys, $vals);
+
+		$expected = ['one' => 'two', 'key' => 'val'];
+		$this->assertEquals($expected, $this->subject->viewVars);
+	}
+
+}

--- a/lib/Cake/Test/TestCase/View/ViewTest.php
+++ b/lib/Cake/Test/TestCase/View/ViewTest.php
@@ -1187,37 +1187,6 @@ class ViewTest extends TestCase {
 	}
 
 /**
- * testSet method
- *
- * @return void
- */
-	public function testSet() {
-		$View = new TestView($this->PostsController);
-		$View->viewVars = array();
-		$View->set('somekey', 'someValue');
-		$this->assertSame($View->viewVars, array('somekey' => 'someValue'));
-		$this->assertSame($View->getVars(), array('somekey'));
-
-		$View->viewVars = array();
-		$keys = array('key1', 'key2');
-		$values = array('value1', 'value2');
-		$View->set($keys, $values);
-		$this->assertSame($View->viewVars, array('key1' => 'value1', 'key2' => 'value2'));
-		$this->assertSame($View->getVars(), array('key1', 'key2'));
-		$this->assertSame($View->getVar('key1'), 'value1');
-		$this->assertNull($View->getVar('key3'));
-
-		$View->set(array('key3' => 'value3'));
-		$this->assertSame($View->getVar('key3'), 'value3');
-
-		$View->viewVars = array();
-		$View->set(array(3 => 'three', 4 => 'four'));
-		$View->set(array(1 => 'one', 2 => 'two'));
-		$expected = array(3 => 'three', 4 => 'four', 1 => 'one', 2 => 'two');
-		$this->assertEquals($expected, $View->viewVars);
-	}
-
-/**
  * testBadExt method
  *
  * @expectedException Cake\Error\MissingViewException

--- a/lib/Cake/Utility/SetContextTrait.php
+++ b/lib/Cake/Utility/SetContextTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Utility;
+
+/**
+ * Provides the set() method for collecting context.
+ *
+ * Once collected context data can be passed to another object.
+ * This is done in Controller, TemplateTask and View for example.
+ *
+ * @package Cake.Utility
+ */
+trait SetContextTrait {
+
+/**
+ * Saves a variable for use inside a template.
+ *
+ * @param string|array $one A string or an array of data.
+ * @param string|array $two Value in case $one is a string (which then works as the key).
+ *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
+ * @return void
+ * @link http://book.cakephp.org/2.0/en/controllers.html#interacting-with-views
+ */
+	public function set($one, $two = null) {
+		if (is_array($one)) {
+			if (is_array($two)) {
+				$data = array_combine($one, $two);
+			} else {
+				$data = $one;
+			}
+		} else {
+			$data = array($one => $two);
+		}
+		$this->viewVars = $data + $this->viewVars;
+	}
+
+}

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2013, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c), Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -6,7 +6,7 @@
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright 2005-2013, Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
@@ -37,7 +37,6 @@ trait ViewVarsTrait {
  * @param string|array $val Value in case $name is a string (which then works as the key).
  *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
  * @return void
- * @link http://book.cakephp.org/2.0/en/controllers.html#interacting-with-views
  */
 	public function set($name, $val = null) {
 		if (is_array($name)) {

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -28,7 +28,7 @@ trait ViewVarsTrait {
  *
  * @var array
  */
-	public $viewVars = array();
+	public $viewVars = [];
 
 /**
  * Saves a variable for use inside a template.
@@ -47,7 +47,7 @@ trait ViewVarsTrait {
 				$data = $one;
 			}
 		} else {
-			$data = array($one => $two);
+			$data = [$one => $two];
 		}
 		$this->viewVars = $data + $this->viewVars;
 	}

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -33,21 +33,21 @@ trait ViewVarsTrait {
 /**
  * Saves a variable for use inside a template.
  *
- * @param string|array $one A string or an array of data.
- * @param string|array $two Value in case $one is a string (which then works as the key).
- *   Unused if $one is an associative array, otherwise serves as the values to $one's keys.
+ * @param string|array $name A string or an array of data.
+ * @param string|array $val Value in case $name is a string (which then works as the key).
+ *   Unused if $name is an associative array, otherwise serves as the values to $name's keys.
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#interacting-with-views
  */
-	public function set($one, $two = null) {
-		if (is_array($one)) {
-			if (is_array($two)) {
-				$data = array_combine($one, $two);
+	public function set($name, $val = null) {
+		if (is_array($name)) {
+			if (is_array($val)) {
+				$data = array_combine($name, $val);
 			} else {
-				$data = $one;
+				$data = $name;
 			}
 		} else {
-			$data = [$one => $two];
+			$data = [$name => $val];
 		}
 		$this->viewVars = $data + $this->viewVars;
 	}

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -23,6 +23,11 @@ namespace Cake\Utility;
  */
 trait ViewVarsTrait {
 
+/**
+ * Variables for the view
+ *
+ * @var array
+ */
 	public $viewVars = array();
 
 /**

--- a/lib/Cake/Utility/ViewVarsTrait.php
+++ b/lib/Cake/Utility/ViewVarsTrait.php
@@ -14,14 +14,16 @@
 namespace Cake\Utility;
 
 /**
- * Provides the set() method for collecting context.
+ * Provides the set() method for collecting template context.
  *
  * Once collected context data can be passed to another object.
  * This is done in Controller, TemplateTask and View for example.
  *
  * @package Cake.Utility
  */
-trait SetContextTrait {
+trait ViewVarsTrait {
+
+	public $viewVars = array();
 
 /**
  * Saves a variable for use inside a template.

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -120,13 +120,6 @@ class View extends Object {
 	public $viewPath = null;
 
 /**
- * Variables for the view
- *
- * @var array
- */
-	public $viewVars = array();
-
-/**
  * Name of view to use with this View.
  *
  * @var string

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -33,6 +33,7 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\ObjectCollection;
+use Cake\Utility\ViewVarsTrait;
 
 /**
  * View, the V in the MVC triad. View interacts with Helpers and view variables passed
@@ -66,6 +67,7 @@ use Cake\Utility\ObjectCollection;
 class View extends Object {
 
 	use RequestActionTrait;
+	use ViewVarsTrait;
 
 /**
  * Helpers collection
@@ -795,32 +797,6 @@ class View extends Object {
 		}
 		$this->uuids[] = $hash;
 		return $hash;
-	}
-
-/**
- * Allows a template or element to set a variable that will be available in
- * a layout or other element. Analogous to Controller::set().
- *
- * @param string|array $one A string or an array of data.
- * @param string|array $two Value in case $one is a string (which then works as the key).
- *    Unused if $one is an associative array, otherwise serves as the values to $one's keys.
- * @return void
- */
-	public function set($one, $two = null) {
-		$data = null;
-		if (is_array($one)) {
-			if (is_array($two)) {
-				$data = array_combine($one, $two);
-			} else {
-				$data = $one;
-			}
-		} else {
-			$data = array($one => $two);
-		}
-		if (!$data) {
-			return false;
-		}
-		$this->viewVars = $data + $this->viewVars;
 	}
 
 /**


### PR DESCRIPTION
This method is copy + pasted 3 times in the code. Extract it out into a trait. I have it in Cake\Utility right now as its used in View, Controller and Console packages as well, so Utility seemed like a reasonable place to put it.
