### PR TITLE
Fix non-array join query data

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1093,7 +1093,7 @@ class DboSource extends DataSource {
 
 		if ($model->recursive > -1) {
 			$joined = array();
-			if (isset($queryData['joins'][0]['alias'])) {
+			if (isset($queryData['joins'][0]) && is_array($queryData['joins'][0]) && isset($queryData['joins'][0]['alias'])) {
 				$joined[$model->alias] = (array)Hash::extract($queryData['joins'], '{n}.alias');
 			}
 			foreach ($_associations as $type) {


### PR DESCRIPTION
If a join is given as string (eg a join of a select statement) php evaluates
isset($queryData['joins'][0]['alias']) incorrect to true.  The fix checks if
$queryData['joins'][0] is set and is an array before checking the array key
'alias'.
