### PR TITLE
Fix an issue which gives gibberish error message when gzip is enabled.

### DIFF
--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -227,7 +227,7 @@ class ErrorHandler {
 		}
 
 		if (ob_get_level()) {
-			ob_clean();
+			ob_end_clean();
 		}
 
 		if (Configure::read('debug')) {


### PR DESCRIPTION
In my case `ob_get_level()` returns `2` and resulted in gibberish output when app contains fatal error.

Traced it to this. Guessing it is related to gzip or `ob_gzhandler`.

Before the fix:
![Screen Shot 2013-02-26 at 12 25 59 AM](https://f.cloud.github.com/assets/280505/192608/19518620-7f68-11e2-861e-87d979865c01.png)

After:
![Screen Shot 2013-02-26 at 12 25 51 AM](https://f.cloud.github.com/assets/280505/192610/206509aa-7f68-11e2-89db-7808a44dab18.png)
