### PR TITLE
CREATE instead of ALTER

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -365,17 +365,16 @@ class SchemaShell extends AppShell {
 
 		if (empty($table)) {
 			foreach ($compare as $table => $changes) {
-				// Table does not exist in DB, creates it !
-				if(isset($compare[$table]['create'])){
+				if (isset($compare[$table]['create'])) {
 					$contents[$table] = $db->createSchema($Schema, $table);
 				} else {
 					$contents[$table] = $db->alterSchema(array($table => $compare[$table]), $table);
 				}
 			}
 		} elseif (isset($compare[$table])) {
-			if(isset($compare[$table]['create'])){
+			if (isset($compare[$table]['create'])) {
 				$contents[$table] = $db->createSchema($Schema, $table);
-			}else {
+			} else {
 				$contents[$table] = $db->alterSchema(array($table => $compare[$table]), $table);
 			}
 		}

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -365,10 +365,19 @@ class SchemaShell extends AppShell {
 
 		if (empty($table)) {
 			foreach ($compare as $table => $changes) {
-				$contents[$table] = $db->alterSchema(array($table => $changes), $table);
+				// Table does not exist in DB, creates it !
+				if(isset($compare[$table]['create'])){
+					$contents[$table] = $db->createSchema($Schema, $table);
+				} else {
+					$contents[$table] = $db->alterSchema(array($table => $compare[$table]), $table);
+				}
 			}
 		} elseif (isset($compare[$table])) {
-			$contents[$table] = $db->alterSchema(array($table => $compare[$table]), $table);
+			if(isset($compare[$table]['create'])){
+				$contents[$table] = $db->createSchema($Schema, $table);
+			}else {
+				$contents[$table] = $db->alterSchema(array($table => $compare[$table]), $table);
+			}
 		}
 
 		if (empty($contents)) {

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -476,7 +476,8 @@ class CakeSchema extends Object {
 				continue;
 			}
 			if (!array_key_exists($table, $old)) {
-				$tables[$table]['add'] = $fields;
+				// It is a new table
+				$tables[$table]['create'] = $fields;
 			} else {
 				$diff = $this->_arrayDiffAssoc($fields, $old[$table]);
 				if (!empty($diff)) {

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -476,7 +476,6 @@ class CakeSchema extends Object {
 				continue;
 			}
 			if (!array_key_exists($table, $old)) {
-				// It is a new table
 				$tables[$table]['create'] = $fields;
 			} else {
 				$diff = $this->_arrayDiffAssoc($fields, $old[$table]);

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -79,6 +79,14 @@ class SchemaShellTestSchema extends CakeSchema {
 		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 	);
+
+	public $newone = array(
+		'id' => array('type' => 'integer', 'null' => false, 'default' => 0, 'key' => 'primary'),
+		'testit' => array('type' => 'string', 'null' => false, 'default' => 'Title'),
+		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
+	);
 }
 
 /**
@@ -478,6 +486,34 @@ class SchemaShellTest extends CakeTestCase {
 			->method('_run')
 			->with($this->arrayHasKey('articles'), 'update', $this->isInstanceOf('CakeSchema'));
 
+		$this->Shell->update();
+	}
+
+	/**
+	 * test run update with a table arg. and checks that a CREATE statement is issued
+	 * table creation
+	 * @return void
+	 */
+	public function testUpdateWithTableCreate() {
+		$this->Shell = $this->getMock(
+			'SchemaShell',
+			array('in', 'out', 'hr', 'createFile', 'error', 'err', '_stop', '_run'),
+			array(&$this->Dispatcher)
+		);
+	
+		$this->Shell->params = array(
+			'connection' => 'test',
+			'force' => true
+		);
+		$this->Shell->args = array('SchemaShellTest', 'newone');
+		$this->Shell->startup();
+		$this->Shell->expects($this->any())
+		->method('in')
+		->will($this->returnValue('y'));
+		$r = $this->Shell->expects($this->once())
+		->method('_run')
+		->with($this->arrayHasKey('newone'), 'update', $this->isInstanceOf('CakeSchema'));
+	
 		$this->Shell->update();
 	}
 

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -508,11 +508,11 @@ class SchemaShellTest extends CakeTestCase {
 		$this->Shell->args = array('SchemaShellTest', 'newone');
 		$this->Shell->startup();
 		$this->Shell->expects($this->any())
-		->method('in')
-		->will($this->returnValue('y'));
+			->method('in')
+			->will($this->returnValue('y'));
 		$r = $this->Shell->expects($this->once())
-		->method('_run')
-		->with($this->arrayHasKey('newone'), 'update', $this->isInstanceOf('CakeSchema'));
+			->method('_run')
+			->with($this->arrayHasKey('newone'), 'update', $this->isInstanceOf('CakeSchema'));
 	
 		$this->Shell->update();
 	}

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -865,13 +865,13 @@ class CakeSchemaTest extends CakeTestCase {
 		$compare = $New->compare($this->Schema, $tables);
 		$expected = array(
 			'ratings' => array(
-				'add' => array(
+				'create' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
-					'foreign_key' => array('type' => 'integer', 'null' => false, 'default' => null, 'after' => 'id'),
-					'model' => array('type' => 'varchar', 'null' => false, 'default' => null, 'after' => 'foreign_key'),
-					'value' => array('type' => 'float', 'null' => false, 'length' => '5,2', 'default' => null, 'after' => 'model'),
-					'created' => array('type' => 'datetime', 'null' => false, 'default' => null, 'after' => 'value'),
-					'modified' => array('type' => 'datetime', 'null' => false, 'default' => null, 'after' => 'created'),
+					'foreign_key' => array('type' => 'integer', 'null' => false, 'default' => null),
+					'model' => array('type' => 'varchar', 'null' => false, 'default' => null),
+					'value' => array('type' => 'float', 'null' => false, 'length' => '5,2', 'default' => null),
+					'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
+					'modified' => array('type' => 'datetime', 'null' => false, 'default' => null),
 					'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
 					'tableParameters' => array('charset' => 'latin1', 'collate' => 'latin1_swedish_ci', 'engine' => 'MyISAM')
 				)


### PR DESCRIPTION
When modifying and adding tables to schema.php I feel frustrated non-existing tables in the database issues ALTER TABLE with all fields.

This is a PR where tables in the schema.php and absent from the database issue a valid CREATE table with the exact same code used by schema create or schema dump.

BEFORE:

``` sql
ALTER TABLE "public"."newone" 
    ALTER COLUMN "id" TYPE  serial ,
    ALTER COLUMN "id"  SET NOT NULL,
    ALTER COLUMN "id"  SET DEFAULT 0,
...
```

AFTER:

``` sql
CREATE TABLE "public"."newone" (
    "id" serial NOT NULL,
...
```

Cheers,
Rémi
