### PR TITLE
Keep default=false for boolean columns

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -626,7 +626,7 @@ class CakeSchema extends Object {
 				unset($value['limit']);
 			}
 
-			if (isset($value['default']) && ($value['default'] === '' || ($value['default'] === false && $value['type'] != 'boolean'))) {
+			if (isset($value['default']) && ($value['default'] === '' || ($value['default'] === false && $value['type'] !== 'boolean'))) {
 				unset($value['default']);
 			}
 			if (empty($value['length'])) {

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -626,7 +626,7 @@ class CakeSchema extends Object {
 				unset($value['limit']);
 			}
 
-			if (isset($value['default']) && ($value['default'] === '' || $value['default'] === false)) {
+			if (isset($value['default']) && ($value['default'] === '' || ($value['default'] === false && $value['type'] != 'boolean'))) {
 				unset($value['default']);
 			}
 			if (empty($value['length'])) {


### PR DESCRIPTION
A little improvement to a corner case. I have a boolean field with default to false.

In my schema.php I have :

``` php
array('type' => 'boolean', 'default' => false)
```

From the database, before this patch it reads :

``` php
array('type' => 'boolean')
```

So when I use schema update, I have a change whereas there isn't any.

This PR fixes it.

Hope it makes sense,
Rémi
