### PR TITLE
 datestyle setting for Postgres driver

### DIFF
--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -52,6 +52,9 @@
  *
  * unix_socket =>
  * For MySQL to connect via socket specify the `unix_socket` parameter instead of `host` and `port`
+ * 
+ * datestyle =>
+ * For Postgres specifies how date and timestamps will be formatted in results
  */
 class DATABASE_CONFIG {
 

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -129,6 +129,9 @@ class Postgres extends DboSource {
 			if (!empty($config['schema'])) {
 				$this->_execute('SET search_path TO ' . $config['schema']);
 			}
+			if (!empty($config['datestyle'])) {
+				$this->_execute("SET datestyle TO " . $config['datestyle']);
+			}
 		} catch (PDOException $e) {
 			throw new MissingConnectionException(array(
 				'class' => get_class($this),

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -1003,4 +1003,17 @@ class PostgresTest extends CakeTestCase {
 		$this->assertTrue($new['currval'] > $original['nextval'], 'Sequence did not update');
 	}
 
+	public function testDatestyleSetting() {
+		Configure::write('Cache.disable', true);
+		$this->Dbo = ConnectionManager::getDataSource('test');
+		$this->skipIf(!($this->Dbo instanceof Postgres));
+
+		$config2 = $this->Dbo->config;
+		$config2['datestyle'] = 'sql, dmy';
+		ConnectionManager::create('test2', $config2);
+		$this->Dbo2 = new Postgres($config2, true);
+		$expected = array(array('r' => date('d/m/Y')));
+		$r = $this->Dbo2->fetchRow('SELECT now()::date AS "r"');
+		$this->assertEquals($expected, $r);
+	}
 }


### PR DESCRIPTION
Allows to specify how dates will output from queries. Very useful when you don't have access to postgres configuration and don't want to put some PHP logic to deal with it.
