### PR TITLE
mask setting for FileLog

### DIFF
--- a/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
@@ -81,4 +81,20 @@ class FileLogTest extends CakeTestCase {
 		unlink($path . 'error.log');
 	}
 
+	/**
+	 * test using the mask setting to write logs with special permissions.
+	 *
+	 * @return void
+	 */
+	public function testMaskSetting() {
+		$mask = 0666;
+		if (file_exists(LOGS . 'error.log')) {
+			unlink(LOGS . 'error.log');
+		}
+	
+		$log = new FileLog(compact('mask'));
+		$log->write('warning', 'Test warning');
+		$this->assertTrue(file_exists(LOGS . 'error.log'));
+		unlink(LOGS . 'error.log');
+	}
 }


### PR DESCRIPTION
Useful when log rotation is done with a different user than the web daemon or to use the console with a different user
