### PR TITLE
Documentation link API for Configure::read()

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -160,7 +160,7 @@ class Configure {
  * Configure::read('Name.key'); will return only the value of Configure::Name[key]
  * }}}
  *
- * @linkhttp://book.cakephp.org/2.0/en/development/configuration.html#Configure::read
+ * @link http://book.cakephp.org/2.0/en/development/configuration.html#Configure::read
  * @param string $var Variable to obtain. Use '.' to access array elements.
  * @return mixed value stored in configure, or null.
  */


### PR DESCRIPTION
The link to the book page was parsed incorrectly because a space is missing.

See: http://api.cakephp.org/2.3/class-Configure.html#_read
