### PR TITLE
SchemaShell: Implement "exclude" parameter

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -152,6 +152,13 @@ class SchemaShell extends AppShell {
 
 		Configure::write('Cache.disable', $cacheDisable);
 
+		if (!empty($this->params['exclude']) && !empty($content)) {
+			$excluded = String::tokenize($this->params['exclude']);
+			foreach ($excluded as $table) {
+				unset($content['tables'][$table]);
+			}
+		}
+
 		if ($snapshot === true) {
 			$fileName = rtrim($this->params['file'], '.php');
 			$Folder = new Folder($this->Schema->path);
@@ -479,6 +486,9 @@ class SchemaShell extends AppShell {
 		$write = array(
 			'help' => __d('cake_console', 'Write the dumped SQL to a file.')
 		);
+		$exclude = array(
+			'help' => __d('cake_console', 'Tables to exclude as comma separated list.')
+		);
 
 		$parser = parent::getOptionParser();
 		$parser->description(
@@ -492,7 +502,7 @@ class SchemaShell extends AppShell {
 		))->addSubcommand('generate', array(
 			'help' => __d('cake_console', 'Reads from --connection and writes to --path. Generate snapshots with -s'),
 			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force', 'models'),
+				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force', 'models', 'exclude'),
 				'arguments' => array(
 					'snapshot' => array('help' => __d('cake_console', 'Generate a snapshot.'))
 				)

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -398,6 +398,30 @@ class SchemaShellTest extends CakeTestCase {
 	}
 
 /**
+ * test generate with excluded tables
+ *
+ * @return void
+ */
+	public function testGenerateExclude() {
+		$this->db->cacheSources = false;
+		$this->Shell->params = array(
+			'force' => false,
+			'overwrite' => true,
+			'exclude' => 'acos,aros'
+		);
+		$this->Shell->startup();
+		$this->Shell->Schema->path = TMP . 'tests' . DS;
+
+		$this->Shell->generate();
+		$this->file = new File(TMP . 'tests' . DS . 'schema.php');
+		$contents = $this->file->read();
+
+		$this->assertNotRegExp('/public \$aros = array\(/', $contents);
+		$this->assertNotRegExp('/public \$acos = array\(/', $contents);
+		$this->assertRegExp('/public \$aros_acos = array\(/', $contents);
+	}
+
+/**
  * Test schema run create with no table args.
  *
  * @return void


### PR DESCRIPTION
Allows for passing a list of tables to ignore when generating schemas.
Closes #3652.
