### PR TITLE
Fixed issue with including including PHPUnit's Autoload script.

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestSuiteDispatcherTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestSuiteDispatcherTest.php
@@ -1,0 +1,38 @@
+<?php
+
+class CakeTestSuiteDispatcherTest extends CakeTestCase {
+
+  public function setUp() {
+    $this->vendors = App::path('vendors');
+    $this->includePath = ini_get('include_path');
+  }
+
+  public function tearDown() {
+    App::build(array('Vendor' => $this->vendors), App::RESET);
+    ini_set('include_path', $this->includePath);
+  }
+
+  protected function clearPaths() {
+    App::build(array('Vendor' => array('junk')), App::RESET);
+    ini_set('include_path', 'junk');
+  }
+
+  public function testLoadTestFramework() {
+    $dispatcher = new CakeTestSuiteDispatcher();
+
+    $this->assertTrue($dispatcher->loadTestFramework());
+
+    $this->clearPaths();
+
+    $exception = null;
+
+    try {
+      $dispatcher->loadTestFramework();
+    } catch(Exception $ex) {
+      $exception = $ex;
+    }
+
+    $this->assertEquals(get_class($exception), "PHPUnit_Framework_Error_Warning");
+  }
+
+}

--- a/lib/Cake/Test/Case/TestSuite/CakeTestSuiteDispatcherTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestSuiteDispatcherTest.php
@@ -1,0 +1,28 @@
+<?php
+
+class CakeTestSuiteDispatcherTest extends CakeTestCase {
+
+  protected function clearPaths() {
+    App::build(array('Vendor' => array('junk')), App::RESET);
+    ini_set('include_path', 'junk');
+  }
+
+  public function testLoadTestFramework() {
+    $dispatcher = new CakeTestSuiteDispatcher();
+
+    $this->assertTrue($dispatcher->loadTestFramework());
+
+    $this->clearPaths();
+
+    $exception = null;
+
+    try {
+      $dispatcher->loadTestFramework();
+    } catch(Exception $ex) {
+      $exception = $ex;
+    }
+
+    $this->assertEquals(get_class($exception), "PHPUnit_Framework_Error_Warning");
+  }
+
+}

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -138,13 +138,14 @@ class CakeTestSuiteDispatcher {
  */
 	public function loadTestFramework() {
 		foreach (App::path('vendors') as $vendor) {
-			if (is_dir($vendor . 'PHPUnit')) {
+      $vendor = rtrim($vendor, DS);
+			if (is_dir($vendor . DS . 'PHPUnit')) {
 				ini_set('include_path', $vendor . PATH_SEPARATOR . ini_get('include_path'));
 				break;
 			}
 		}
 
-		return include 'PHPUnit' . DS . 'Autoload.php';
+		return (include('PHPUnit' . DS . 'Autoload.php')) !== false;
 	}
 
 /**


### PR DESCRIPTION
This pull request makes two small changes to CakeTestSuiteDispatcher::loadTestFramework().

First, it resolves any issues with vendor paths ending with a DS character by stripping the character from the end of the vendor path and only adding it where necessary.

Second, it now returns TRUE or FALSE instead of the return value from PHPUnit/Autoload.php.  PHPUnit/Autoload.php returns NULL when included successfully, which causes the result to be treated as a false value in CakeTestSuiteDispatcher::_checkPHPUnit().
