### PR TITLE
Allow behaviors to be added for baked models

### DIFF
--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -164,7 +164,7 @@ class ModelTask extends BakeTask {
  * @param array $options Array of options to use for the selections. indexes must start at 0
  * @param string $prompt Prompt to use for options list.
  * @param integer $default The default option for the given prompt.
- * @return integer result of user choice.
+ * @return integer Result of user choice.
  */
 	public function inOptions($options, $prompt = null, $default = null) {
 		$valid = false;
@@ -347,7 +347,7 @@ class ModelTask extends BakeTask {
  * @return array $validate Array of user selected validations.
  */
 	public function doValidation($model) {
-		if (!is_object($model)) {
+		if (!$model instanceof Model) {
 			return false;
 		}
 		$fields = $model->schema();
@@ -490,10 +490,10 @@ class ModelTask extends BakeTask {
  * Handles associations
  *
  * @param Model $model
- * @return array $associations
+ * @return array Associations
  */
 	public function doAssociations($model) {
-		if (!is_object($model)) {
+		if (!$model instanceof Model) {
 			return false;
 		}
 		if ($this->interactive === true) {
@@ -539,11 +539,35 @@ class ModelTask extends BakeTask {
 	}
 
 /**
+ * Handles behaviors
+ *
+ * @param Model $model
+ * @return array Behaviors
+ */
+	public function doActsAs($model) {
+		if (!$model instanceof Model) {
+			return false;
+		}
+		$behaviors = array();
+		$fields = $model->schema(true);
+		if (empty($fields)) {
+			return array();
+		}
+
+		if (isset($fields['lft']) && $fields['lft']['type'] === 'integer' &&
+			isset($fields['rght']) && $fields['rght']['type'] === 'integer' &&
+			isset($fields['parent_id'])) {
+			$behaviors[] = 'Tree';
+		}
+		return $behaviors;
+	}
+
+/**
  * Find belongsTo relations and add them to the associations list.
  *
  * @param Model $model Model instance of model being generated.
  * @param array $associations Array of in progress associations
- * @return array $associations with belongsTo added in.
+ * @return array Associations with belongsTo added in.
  */
 	public function findBelongsTo(Model $model, $associations) {
 		$fieldNames = array_keys($model->schema(true));
@@ -572,7 +596,7 @@ class ModelTask extends BakeTask {
  *
  * @param Model $model Model instance being generated
  * @param array $associations Array of in progress associations
- * @return array $associations with hasOne and hasMany added in.
+ * @return array Associations with hasOne and hasMany added in.
  */
 	public function findHasOneAndMany(Model $model, $associations) {
 		$foreignKey = $this->_modelKey($model->name);
@@ -615,7 +639,7 @@ class ModelTask extends BakeTask {
  *
  * @param Model $model Model instance being generated
  * @param array $associations Array of in-progress associations
- * @return array $associations with hasAndBelongsToMany added in.
+ * @return array Associations with hasAndBelongsToMany added in.
  */
 	public function findHasAndBelongsToMany(Model $model, $associations) {
 		$foreignKey = $this->_modelKey($model->name);
@@ -747,7 +771,7 @@ class ModelTask extends BakeTask {
 /**
  * Finds all possible keys to use on custom associations.
  *
- * @return array array of tables and possible keys
+ * @return array Array of tables and possible keys
  */
 	protected function _generatePossibleKeys() {
 		$possible = array();
@@ -771,11 +795,12 @@ class ModelTask extends BakeTask {
  * @return string
  */
 	public function bake($name, $data = array()) {
-		if (is_object($name)) {
+		if ($name instanceof Model) {
 			if (!$data) {
 				$data = array();
 				$data['associations'] = $this->doAssociations($name);
 				$data['validate'] = $this->doValidation($name);
+				$data['actsAs'] = $this->doActsAs($name);
 			}
 			$data['primaryKey'] = $name->primaryKey;
 			$data['useTable'] = $name->table;
@@ -784,8 +809,10 @@ class ModelTask extends BakeTask {
 		} else {
 			$data['name'] = $name;
 		}
+
 		$defaults = array(
 			'associations' => array(),
+			'actsAs' => array(),
 			'validate' => array(),
 			'primaryKey' => 'id',
 			'useTable' => null,
@@ -920,7 +947,7 @@ class ModelTask extends BakeTask {
  * Forces the user to specify the model he wants to bake, and returns the selected model name.
  *
  * @param string $useDbConfig Database config name
- * @return string the model name
+ * @return string The model name
  */
 	public function getName($useDbConfig = null) {
 		$this->listAll($useDbConfig);

--- a/lib/Cake/Console/Templates/default/classes/model.ctp
+++ b/lib/Cake/Console/Templates/default/classes/model.ctp
@@ -74,6 +74,16 @@ if ($displayField): ?>
 
 <?php endif;
 
+if (!empty($actsAs)): ?>
+/**
+ * Behaviors
+ *
+ * @var array
+ */
+	public $actsAs = array(<?php echo "\n\t"; foreach ($actsAs as $behavior): echo "\t"; var_export($behavior); echo ",\n\t"; endforeach; ?>);
+
+<?php endif;
+
 if (!empty($validate)):
 	echo "/**\n * Validation rules\n *\n * @var array\n */\n";
 	echo "\tpublic \$validate = array(\n";

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -42,7 +42,7 @@ class ModelTaskTest extends CakeTestCase {
  */
 	public $fixtures = array(
 		'core.bake_article', 'core.bake_comment', 'core.bake_articles_bake_tag',
-		'core.bake_tag', 'core.category_thread'
+		'core.bake_tag', 'core.category_thread', 'core.number_tree'
 	);
 
 /**
@@ -624,6 +624,20 @@ class ModelTaskTest extends CakeTestCase {
 	}
 
 /**
+ * test non interactive doActsAs
+ *
+ * @return void
+ */
+	public function testDoActsAs() {
+		$this->Task->connection = 'test';
+		$this->Task->interactive = false;
+		$model = new Model(array('ds' => 'test', 'name' => 'NumberTree'));
+		$result = $this->Task->doActsAs($model);
+
+		$this->assertEquals(array('Tree'), $result);
+	}
+
+/**
  * Ensure that the fixture object is correctly called.
  *
  * @return void
@@ -837,6 +851,27 @@ STRINGEND;
 	}
 
 /**
+ * test bake() for models with behaviors
+ *
+ * @return void
+ */
+	public function testBakeWithBehaviors() {
+		$result = $this->Task->bake('NumberTree', array('actsAs' => array('Tree', 'PluginName.Sluggable')));
+		$expected = <<<TEXT
+/**
+ * Behaviors
+ *
+ * @var array
+ */
+	public \$actsAs = array(
+		'Tree',
+		'PluginName.Sluggable',
+	);
+TEXT;
+		$this->assertTextContains($expected, $result);
+	}
+
+/**
  * test that execute passes runs bake depending with named model.
  *
  * @return void
@@ -987,7 +1022,7 @@ STRINGEND;
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('ModelTask',
-			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'doAssociations', 'doValidation', 'createFile'),
+			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'doAssociations', 'doValidation', 'doActsAs', 'createFile'),
 			array($out, $out, $in)
 		);
 		$this->_setupOtherMocks();
@@ -1001,6 +1036,7 @@ STRINGEND;
 		$this->Task->expects($this->once())->method('_getModelObject')->will($this->returnValue($object));
 		$this->Task->expects($this->once())->method('doAssociations')->will($this->returnValue(array()));
 		$this->Task->expects($this->once())->method('doValidation')->will($this->returnValue(array()));
+		$this->Task->expects($this->once())->method('doActsAs')->will($this->returnValue(array()));
 
 		$filename = '/my/path/BakeOdd.php';
 		$this->Task->expects($this->once())->method('createFile')
@@ -1042,7 +1078,7 @@ STRINGEND;
 		$out = $this->getMock('ConsoleOutput', array(), array(), '', false);
 		$in = $this->getMock('ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('ModelTask',
-			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'doAssociations', 'doValidation', 'createFile'),
+			array('in', 'err', '_stop', '_checkUnitTest', 'getAllTables', '_getModelObject', 'doAssociations', 'doValidation', 'doActsAs', 'createFile'),
 			array($out, $out, $in)
 		);
 		$this->_setupOtherMocks();
@@ -1056,6 +1092,7 @@ STRINGEND;
 		$this->Task->expects($this->once())->method('_getModelObject')->will($this->returnValue($object));
 		$this->Task->expects($this->once())->method('doAssociations')->will($this->returnValue(array()));
 		$this->Task->expects($this->once())->method('doValidation')->will($this->returnValue(array()));
+		$this->Task->expects($this->once())->method('doActsAs')->will($this->returnValue(array()));
 
 		$filename = '/my/path/BakeOdd.php';
 		$this->Task->expects($this->once())->method('createFile')


### PR DESCRIPTION
If you bake a tree model (actsAs Tree) and you got lft/rgt/parent fields bake should be able to auto-detect this.

Derived from tryouts back in 2011 - see https://cakephp.lighthouseapp.com/projects/42648/tickets/1781-plugin-information-gets-lost-during-baking

Can then be further enhanced to also support plugin behaviors (Sluggable for slugged field etc). This can than done via custom bake task that extends the core task and just overwrites the method. Easy to extend and enhance in user land code.
