### PR TITLE
Move 'Auth.redirect' session value clearing from AuthComponent::shutdown...

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -608,7 +608,7 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Log a user out. 
+ * Log a user out.
  *
  * Returns the login action to redirect to. Triggers the logout() method of
  * all the authenticate objects, so they can perform custom logout logic.
@@ -680,6 +680,7 @@ class AuthComponent extends Component {
 
 		$user = $this->user();
 		if ($user) {
+			$this->Session->delete('Auth.redirect');
 			return true;
 		}
 		return false;
@@ -789,18 +790,6 @@ class AuthComponent extends Component {
  */
 	public static function password($password) {
 		return Security::hash($password, null, true);
-	}
-
-/**
- * Component shutdown. If user is logged in, wipe out redirect.
- *
- * @param Controller $controller Instantiating controller
- * @return void
- */
-	public function shutdown(Controller $controller) {
-		if ($this->loggedIn()) {
-			$this->Session->delete('Auth.redirect');
-		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -1109,20 +1109,6 @@ class AuthComponentTest extends CakeTestCase {
 	}
 
 /**
- * Tests that shutdown destroys the redirect session var
- *
- * @return void
- */
-	public function testShutDown() {
-		$this->Auth->Session->write('Auth.User', 'not empty');
-		$this->Auth->Session->write('Auth.redirect', 'foo');
-		$this->Controller->Auth->loggedIn(true);
-
-		$this->Controller->Auth->shutdown($this->Controller);
-		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
-	}
-
-/**
  * test $settings in Controller::$components
  *
  * @return void


### PR DESCRIPTION
...() to prevent unnecessary session start.

Refs [#3702](https://cakephp.lighthouseapp.com/projects/42648/tickets/3702-AuthComponent-still-starts-the-session-on-an-allowed-action)
