### PR TITLE
Fix incorrect default meridian in FormHelper::dateTime()

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2383,14 +2383,14 @@ class FormHelper extends AppHelper {
 				$current->setDate($year, $month, $day);
 			}
 			if ($hour !== null) {
-				if ($timeFormat == '12') {
+				if ($timeFormat === '12') {
 					$hour = date('H', strtotime("$hour:$min $meridian"));
 				}
 				$current->setTime($hour, $min);
 			}
 			$change = (round($min * (1 / $interval)) * $interval) - $min;
 			$current->modify($change > 0 ? "+$change minutes" : "$change minutes");
-			$format = ($timeFormat == '12') ? 'Y m d h i a' : 'Y m d H i a';
+			$format = ($timeFormat === '12') ? 'Y m d h i a' : 'Y m d H i a';
 			$newTime = explode(' ', $current->format($format));
 			list($year, $month, $day, $hour, $min, $meridian) = $newTime;
 		}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2383,11 +2383,16 @@ class FormHelper extends AppHelper {
 				$current->setDate($year, $month, $day);
 			}
 			if ($hour !== null) {
+				if ($timeFormat == '12') {
+					$hour = date('H', strtotime("$hour:$min $meridian"));
+				}
 				$current->setTime($hour, $min);
 			}
 			$change = (round($min * (1 / $interval)) * $interval) - $min;
 			$current->modify($change > 0 ? "+$change minutes" : "$change minutes");
 			$newTime = explode(' ', $current->format('Y m d H i a'));
+			$format = ($timeFormat == '12') ? 'Y m d h i a' : 'Y m d H i a';
+			$newTime = explode(' ', $current->format($format));
 			list($year, $month, $day, $hour, $min, $meridian) = $newTime;
 		}
 

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2390,7 +2390,6 @@ class FormHelper extends AppHelper {
 			}
 			$change = (round($min * (1 / $interval)) * $interval) - $min;
 			$current->modify($change > 0 ? "+$change minutes" : "$change minutes");
-			$newTime = explode(' ', $current->format('Y m d H i a'));
 			$format = ($timeFormat == '12') ? 'Y m d h i a' : 'Y m d H i a';
 			$newTime = explode(' ', $current->format($format));
 			list($year, $month, $day, $hour, $min, $meridian) = $newTime;


### PR DESCRIPTION
Prevent the default meridian from being changed from 'pm' to 'am' when the default time is in a 12-hour format between 1:00pm and 11:59pm and both a minute interval and default minute value are specified.
