### PR TITLE
Fix bug where differing key-ordering in the first and last records in a fixture would cause mis-inserted rows

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -436,6 +436,10 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$this->insertMulti['table'] = $table;
 		$this->insertMulti['fields'] = $fields;
 		$this->insertMulti['values'] = $values;
+		$this->insertMulti['fields_values'] = array();
+		foreach($values as $record) {
+			$this->insertMulti['fields_values'][] = array_combine($fields, $record);
+		}
 		return true;
 	}
 
@@ -454,13 +458,31 @@ class CakeTestFixtureTest extends CakeTestCase {
 		$this->assertTrue($this->criticDb->fullDebug);
 		$this->assertTrue($return);
 		$this->assertEquals('strings', $this->insertMulti['table']);
-		$this->assertEquals(array('email', 'name', 'age'), $this->insertMulti['fields']);
+		$this->assertEquals(array('name', 'email', 'age'), array_values($this->insertMulti['fields']));
 		$expected = array(
 			array('Mark Doe', 'mark.doe@email.com', null),
 			array('John Doe', 'john.doe@email.com', 20),
 			array('Jane Doe', 'jane.doe@email.com', 30),
 		);
 		$this->assertEquals($expected, $this->insertMulti['values']);
+		$expected = array(
+			array(
+				'name' => 'Mark Doe', 
+				'email' => 'mark.doe@email.com', 
+				'age' => null
+			),
+			array(
+				'name' => 'John Doe', 
+				'email' => 'john.doe@email.com', 
+				'age' => 20
+			),
+			array(
+				'name' => 'Jane Doe', 
+				'email' => 'jane.doe@email.com', 
+				'age' => 30
+			),
+		);
+		$this->assertEquals($expected, $this->insertMulti['fields_values']);
 	}
 
 /**

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -277,7 +277,6 @@ class CakeTestFixture {
 				$fields = array_unique($fields);
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-					$fields = array_keys($record);
 					$values[] = array_values(array_merge($default, $record));
 				}
 				$nested = $db->useNestedTransactions;


### PR DESCRIPTION
Before my change, the field order was effectively taken from the last record in the fixture, but the values were ordered according to the array_unique call in insert(), whose order is (primarily) determined by the first record in the fixture.  If these two orders differed, values and keys were mismatched, causing either faulty data inserts or failed inserts due to constraints.

Removing this line fixes it, because the ordering of $fields remains as taken from array that is used to create $default, which is what determines the ordering of $values, so the ordering remains consistent.  Looking at the code and with my testing, I don't see any reason $fields needs to be taken from the last record, so this shouldn't have any adverse effects, but I am not familiar enough with the Cake core to say for sure.

The StringsTestFixture actually already had this case, but passed the broken behavior - that test actually asserts that the keys are ('email','name','age'), and then asserts that the values are in a different order!  I updated that test to test for the new order, and also added an assert (and some code to the insertCallback) to test that the correct values get matched to the correct keys.

You can also test this by swapping the first two elements in the first or last record of any existing fixture - I used the Comments fixture - and running one of the Model tests.

Again, I'm not familiar enough with all of Cake to be entirely confident in these changes, but I believe my changes are safe and should fit well.

I can also submit a pull request from my 2.3 branch, which has the changes applied there as well, since that's what we're using in production.
