### PR TITLE
Improvement to Validator::uuid

### DIFF
--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -776,7 +776,7 @@ class Validation {
  * @return boolean Success
  */
 	public static function uuid($check) {
-		$regex = '/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i';
+		$regex = '/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$/';
 		return self::_check($check, $regex);
 	}
 


### PR DESCRIPTION
Properly matches version digit and variant digit, based on RFC4122
