### PR TITLE
Fixed bug with Friendly forwarding

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -310,7 +310,7 @@ class AuthComponent extends Component {
 
 		if ($loginAction == $url) {
 			if (empty($request->data)) {
-				if (!$this->Session->check('Auth.redirect') && !$this->loginRedirect && env('HTTP_REFERER')) {
+				if (!$this->Session->check('Auth.redirect') && env('HTTP_REFERER')) {
 					$this->Session->write('Auth.redirect', $controller->referer(null, true));
 				}
 			}


### PR DESCRIPTION
When a AuthComponent::$loginRedirect is set, the 'Auth.redirect' session variable does not get set to the REFERER even though $loginRedirect is supposed to be a fallback if _no_ REFERER was set
