### PR TITLE
remove redundant updated in favor of modified

### DIFF
--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -429,7 +429,7 @@ class ModelTask extends BakeTask {
 			$prompt = __d('cake_console', "... or enter in a valid regex validation string.\n");
 			$methods = array_flip($this->_validations);
 			$guess = $defaultChoice;
-			if ($metaData['null'] != 1 && !in_array($fieldName, array($primaryKey, 'created', 'modified', 'updated'))) {
+			if ($metaData['null'] != 1 && !in_array($fieldName, array($primaryKey, 'created', 'modified'))) {
 				if ($fieldName === 'email') {
 					$guess = $methods['email'];
 				} elseif ($metaData['type'] === 'string' && $metaData['length'] == 36) {

--- a/lib/Cake/Console/Templates/default/views/form.ctp
+++ b/lib/Cake/Console/Templates/default/views/form.ctp
@@ -27,7 +27,7 @@ use Cake\Utility\Inflector;
 		foreach ($fields as $field) {
 			if (strpos($action, 'add') !== false && $field == $primaryKey) {
 				continue;
-			} elseif (!in_array($field, array('created', 'modified', 'updated'))) {
+			} elseif (!in_array($field, array('created', 'modified'))) {
 				echo "\t\techo \$this->Form->input('{$field}');\n";
 			}
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1637,12 +1637,12 @@ class Model extends Object implements EventListener {
 		}
 		$this->set($data);
 
-		if (empty($this->data) && !$this->hasField(array('created', 'updated', 'modified'))) {
+		if (empty($this->data) && !$this->hasField(array('created', 'modified'))) {
 			$this->whitelist = $_whitelist;
 			return false;
 		}
 
-		foreach (array('created', 'updated', 'modified') as $field) {
+		foreach (array('created', 'modified') as $field) {
 			$keyPresentAndEmpty = (
 				isset($this->data[$this->alias]) &&
 				array_key_exists($field, $this->data[$this->alias]) &&
@@ -1654,7 +1654,7 @@ class Model extends Object implements EventListener {
 		}
 
 		$exists = $this->exists();
-		$dateFields = array('modified', 'updated');
+		$dateFields = array('modified');
 
 		if (!$exists) {
 			$dateFields[] = 'created';
@@ -1708,7 +1708,7 @@ class Model extends Object implements EventListener {
 				$joined[$n] = $v;
 			} else {
 				if ($n === $this->alias) {
-					foreach (array('created', 'updated', 'modified') as $field) {
+					foreach (array('created', 'modified') as $field) {
 						if (array_key_exists($field, $v) && empty($v[$field])) {
 							unset($v[$field]);
 						}
@@ -2710,7 +2710,7 @@ class Model extends Object implements EventListener {
  *
  * Model::_readDataSource() is used by all find() calls to read from the data source and can be overloaded to allow
  * caching of datasource calls.
- * 
+ *
  * {{{
  * protected function _readDataSource($type, $query) {
  * 		$cacheName = md5(json_encode($query));
@@ -2724,7 +2724,7 @@ class Model extends Object implements EventListener {
  * 		return $results;
  * }
  * }}}
- * 
+ *
  * @param string $type Type of find operation (all / first / count / neighbors / list / threaded)
  * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
  * @return array

--- a/lib/Cake/Test/Fixture/AdvertisementFixture.php
+++ b/lib/Cake/Test/Fixture/AdvertisementFixture.php
@@ -44,7 +44,7 @@ class AdvertisementFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'title' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -53,7 +53,7 @@ class AdvertisementFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('title' => 'First Ad', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('title' => 'Second Ad', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31')
+		array('title' => 'First Ad', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('title' => 'Second Ad', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/AnotherArticleFixture.php
+++ b/lib/Cake/Test/Fixture/AnotherArticleFixture.php
@@ -44,7 +44,7 @@ class AnotherArticleFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'title' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -53,8 +53,8 @@ class AnotherArticleFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('title' => 'First Article', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('title' => 'Second Article', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('title' => 'Third Article', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('title' => 'First Article', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('title' => 'Second Article', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('title' => 'Third Article', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/ArmorFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorFixture.php
@@ -53,7 +53,7 @@ class ArmorFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
@@ -55,7 +55,7 @@ class ArmorsPlayerFixture extends TestFixture {
 		'armor_id' => array('type' => 'integer', 'null' => false),
 		'broken' => array('type' => 'boolean', 'null' => false, 'default' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
@@ -47,7 +47,7 @@ class ArticleFeaturedFixture extends TestFixture {
 		'body' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,8 +56,8 @@ class ArticleFeaturedFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/ArticleFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFixture.php
@@ -47,7 +47,7 @@ class ArticleFixture extends TestFixture {
 		'body' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,9 +56,9 @@ class ArticleFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 
 }

--- a/lib/Cake/Test/Fixture/AttachmentFixture.php
+++ b/lib/Cake/Test/Fixture/AttachmentFixture.php
@@ -45,7 +45,7 @@ class AttachmentFixture extends TestFixture {
 		'comment_id' => array('type' => 'integer', 'null' => false),
 		'attachment' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,6 +54,6 @@ class AttachmentFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('comment_id' => 5, 'attachment' => 'attachment.zip', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31')
+		array('comment_id' => 5, 'attachment' => 'attachment.zip', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
@@ -45,7 +45,7 @@ class AuthUserCustomFieldFixture extends TestFixture {
 		'email' => array('type' => 'string', 'null' => false),
 		'password' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,11 +54,11 @@ class AuthUserCustomFieldFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('email' => 'mariano@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('email' => 'nate@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('email' => 'larry@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'),
-		array('email' => 'garrett@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
-		array('email' => 'chartjes@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
+		array('email' => 'mariano@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('email' => 'nate@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('email' => 'larry@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'),
+		array('email' => 'garrett@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
+		array('email' => 'chartjes@example.com', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
 
 	);
 }

--- a/lib/Cake/Test/Fixture/AuthUserFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserFixture.php
@@ -45,7 +45,7 @@ class AuthUserFixture extends TestFixture {
 		'username' => array('type' => 'string', 'null' => false),
 		'password' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,11 +54,11 @@ class AuthUserFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('username' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('username' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('username' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'),
-		array('username' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
-		array('username' => 'chartjes', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
+		array('username' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('username' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('username' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'),
+		array('username' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
+		array('username' => 'chartjes', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
 
 	);
 }

--- a/lib/Cake/Test/Fixture/AuthorFixture.php
+++ b/lib/Cake/Test/Fixture/AuthorFixture.php
@@ -45,7 +45,7 @@ class AuthorFixture extends TestFixture {
 		'user' => array('type' => 'string', 'default' => null),
 		'password' => array('type' => 'string', 'default' => null),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,9 +54,9 @@ class AuthorFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'),
-		array('user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
+		array('user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'),
+		array('user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/BakeArticleFixture.php
+++ b/lib/Cake/Test/Fixture/BakeArticleFixture.php
@@ -47,7 +47,7 @@ class BakeArticleFixture extends TestFixture {
 		'body' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/BakeCommentFixture.php
+++ b/lib/Cake/Test/Fixture/BakeCommentFixture.php
@@ -47,7 +47,7 @@ class BakeCommentFixture extends TestFixture {
 		'comment' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/BakeTagFixture.php
+++ b/lib/Cake/Test/Fixture/BakeTagFixture.php
@@ -44,7 +44,7 @@ class BakeTagFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'tag' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/CallbackFixture.php
+++ b/lib/Cake/Test/Fixture/CallbackFixture.php
@@ -45,7 +45,7 @@ class CallbackFixture extends TestFixture {
 		'user' => array('type' => 'string', 'null' => false),
 		'password' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,8 +54,8 @@ class CallbackFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user' => 'user1', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('user' => 'user2', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'),
-		array('user' => 'user3', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
+		array('user' => 'user1', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('user' => 'user2', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'),
+		array('user' => 'user3', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/CategoryFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryFixture.php
@@ -45,7 +45,7 @@ class CategoryFixture extends TestFixture {
 		'parent_id' => array('type' => 'integer', 'null' => false),
 		'name' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,13 +54,13 @@ class CategoryFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('parent_id' => 0, 'name' => 'Category 1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 1, 'name' => 'Category 1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 1, 'name' => 'Category 1.2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 0, 'name' => 'Category 2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 0, 'name' => 'Category 3', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 5, 'name' => 'Category 3.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 2, 'name' => 'Category 1.1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 2, 'name' => 'Category 1.1.2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
+		array('parent_id' => 0, 'name' => 'Category 1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 1, 'name' => 'Category 1.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 1, 'name' => 'Category 1.2', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 0, 'name' => 'Category 2', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 0, 'name' => 'Category 3', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 5, 'name' => 'Category 3.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 2, 'name' => 'Category 1.1.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 2, 'name' => 'Category 1.1.2', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/CategoryThreadFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryThreadFixture.php
@@ -45,7 +45,7 @@ class CategoryThreadFixture extends TestFixture {
 		'parent_id' => array('type' => 'integer', 'null' => false),
 		'name' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,12 +54,12 @@ class CategoryThreadFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('parent_id' => 0, 'name' => 'Category 1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 1, 'name' => 'Category 1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 2, 'name' => 'Category 1.1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 3, 'name' => 'Category 1.1.2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 4, 'name' => 'Category 1.1.1.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 5, 'name' => 'Category 2', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'),
-		array('parent_id' => 6, 'name' => 'Category 2.1', 'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31')
+		array('parent_id' => 0, 'name' => 'Category 1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 1, 'name' => 'Category 1.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 2, 'name' => 'Category 1.1.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 3, 'name' => 'Category 1.1.2', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 4, 'name' => 'Category 1.1.1.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 5, 'name' => 'Category 2', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'),
+		array('parent_id' => 6, 'name' => 'Category 2.1', 'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/CommentFixture.php
+++ b/lib/Cake/Test/Fixture/CommentFixture.php
@@ -47,7 +47,7 @@ class CommentFixture extends TestFixture {
 		'comment' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,11 +56,11 @@ class CommentFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31'),
-		array('article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'),
-		array('article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'),
-		array('article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article', 'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'),
-		array('article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article', 'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'),
-		array('article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article', 'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31')
+		array('article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31'),
+		array('article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'),
+		array('article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'),
+		array('article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article', 'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'),
+		array('article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article', 'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'),
+		array('article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article', 'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/DataTestFixture.php
+++ b/lib/Cake/Test/Fixture/DataTestFixture.php
@@ -45,7 +45,7 @@ class DataTestFixture extends TestFixture {
 		'count' => array('type' => 'integer', 'default' => 0),
 		'float' => array('type' => 'float', 'default' => 0),
 		'created' => array('type' => 'datetime', 'default' => null),
-		'updated' => array('type' => 'datetime', 'default' => null)
+		'modified' => array('type' => 'datetime', 'default' => null)
 	);
 
 /**
@@ -58,7 +58,7 @@ class DataTestFixture extends TestFixture {
 			'count' => 2,
 			'float' => 2.4,
 			'created' => '2010-09-06 12:28:00',
-			'updated' => '2010-09-06 12:28:00'
+			'modified' => '2010-09-06 12:28:00'
 		)
 	);
 }

--- a/lib/Cake/Test/Fixture/DomainFixture.php
+++ b/lib/Cake/Test/Fixture/DomainFixture.php
@@ -46,7 +46,7 @@ class DomainFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'domain' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,12 +56,12 @@ class DomainFixture extends TestFixture {
  * @access public
  */
 	public $records = array(
-		array('domain' => 'cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('domain' => 'book.cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('domain' => 'api.cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('domain' => 'mark-story.com', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('domain' => 'tinadurocher.com', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('domain' => 'chavik.com', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
-		array('domain' => 'xintesa.com', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+		array('domain' => 'cakephp.org', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('domain' => 'book.cakephp.org', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('domain' => 'api.cakephp.org', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('domain' => 'mark-story.com', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('domain' => 'tinadurocher.com', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('domain' => 'chavik.com', 'created' => '2001-02-03 00:01:02', 'modified' => '2007-03-17 01:22:31'),
+		array('domain' => 'xintesa.com', 'created' => '2001-02-03 00:01:02', 'modified' => '2007-03-17 01:22:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/DomainsSiteFixture.php
+++ b/lib/Cake/Test/Fixture/DomainsSiteFixture.php
@@ -48,7 +48,7 @@ class DomainsSiteFixture extends TestFixture {
 		'site_id' => array('type' => 'integer', 'null' => false),
 		'active' => array('type' => 'boolean', 'null' => false, 'default' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime',
+		'modified' => 'datetime',
 	);
 
 /**
@@ -58,11 +58,11 @@ class DomainsSiteFixture extends TestFixture {
  * @access public
  */
 	public $records = array(
-		array('site_id' => 1, 'domain_id' => 1, 'active' => true, 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('site_id' => 1, 'domain_id' => 2, 'active' => true, 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('site_id' => 2, 'domain_id' => 4, 'active' => true, 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('site_id' => 2, 'domain_id' => 5, 'active' => true, 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('site_id' => 3, 'domain_id' => 6, 'active' => true, 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
-		array('site_id' => 3, 'domain_id' => 7, 'active' => false, 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+		array('site_id' => 1, 'domain_id' => 1, 'active' => true, 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('site_id' => 1, 'domain_id' => 2, 'active' => true, 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('site_id' => 2, 'domain_id' => 4, 'active' => true, 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('site_id' => 2, 'domain_id' => 5, 'active' => true, 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('site_id' => 3, 'domain_id' => 6, 'active' => true, 'created' => '2001-02-03 00:01:02', 'modified' => '2007-03-17 01:22:31'),
+		array('site_id' => 3, 'domain_id' => 7, 'active' => false, 'created' => '2001-02-03 00:01:02', 'modified' => '2007-03-17 01:22:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/FeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/FeaturedFixture.php
@@ -47,7 +47,7 @@ class FeaturedFixture extends TestFixture {
 		'published_date' => 'datetime',
 		'end_date' => 'datetime',
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,7 +56,7 @@ class FeaturedFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23', 'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23', 'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
+		array('article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23', 'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23', 'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/HomeFixture.php
+++ b/lib/Cake/Test/Fixture/HomeFixture.php
@@ -46,7 +46,7 @@ class HomeFixture extends TestFixture {
 		'advertisement_id' => array('type' => 'integer', 'null' => false),
 		'title' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -55,7 +55,7 @@ class HomeFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('another_article_id' => 1, 'advertisement_id' => 1, 'title' => 'First Home', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('another_article_id' => 3, 'advertisement_id' => 1, 'title' => 'Second Home', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31')
+		array('another_article_id' => 1, 'advertisement_id' => 1, 'title' => 'First Home', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('another_article_id' => 3, 'advertisement_id' => 1, 'title' => 'Second Home', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinABFixture.php
+++ b/lib/Cake/Test/Fixture/JoinABFixture.php
@@ -46,7 +46,7 @@ class JoinABFixture extends TestFixture {
 		'join_b_id' => array('type' => 'integer', 'default' => null),
 		'other' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -55,8 +55,8 @@ class JoinABFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('join_a_id' => 1, 'join_b_id' => 2, 'other' => 'Data for Join A 1 Join B 2', 'created' => '2008-01-03 10:56:33', 'updated' => '2008-01-03 10:56:33'),
-		array('join_a_id' => 2, 'join_b_id' => 3, 'other' => 'Data for Join A 2 Join B 3', 'created' => '2008-01-03 10:56:34', 'updated' => '2008-01-03 10:56:34'),
-		array('join_a_id' => 3, 'join_b_id' => 1, 'other' => 'Data for Join A 3 Join B 1', 'created' => '2008-01-03 10:56:35', 'updated' => '2008-01-03 10:56:35')
+		array('join_a_id' => 1, 'join_b_id' => 2, 'other' => 'Data for Join A 1 Join B 2', 'created' => '2008-01-03 10:56:33', 'modified' => '2008-01-03 10:56:33'),
+		array('join_a_id' => 2, 'join_b_id' => 3, 'other' => 'Data for Join A 2 Join B 3', 'created' => '2008-01-03 10:56:34', 'modified' => '2008-01-03 10:56:34'),
+		array('join_a_id' => 3, 'join_b_id' => 1, 'other' => 'Data for Join A 3 Join B 1', 'created' => '2008-01-03 10:56:35', 'modified' => '2008-01-03 10:56:35')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinACFixture.php
+++ b/lib/Cake/Test/Fixture/JoinACFixture.php
@@ -46,7 +46,7 @@ class JoinACFixture extends TestFixture {
 		'join_c_id' => array('type' => 'integer', 'default' => null),
 		'other' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -55,8 +55,8 @@ class JoinACFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('join_a_id' => 1, 'join_c_id' => 2, 'other' => 'Data for Join A 1 Join C 2', 'created' => '2008-01-03 10:57:22', 'updated' => '2008-01-03 10:57:22'),
-		array('join_a_id' => 2, 'join_c_id' => 3, 'other' => 'Data for Join A 2 Join C 3', 'created' => '2008-01-03 10:57:23', 'updated' => '2008-01-03 10:57:23'),
-		array('join_a_id' => 3, 'join_c_id' => 1, 'other' => 'Data for Join A 3 Join C 1', 'created' => '2008-01-03 10:57:24', 'updated' => '2008-01-03 10:57:24')
+		array('join_a_id' => 1, 'join_c_id' => 2, 'other' => 'Data for Join A 1 Join C 2', 'created' => '2008-01-03 10:57:22', 'modified' => '2008-01-03 10:57:22'),
+		array('join_a_id' => 2, 'join_c_id' => 3, 'other' => 'Data for Join A 2 Join C 3', 'created' => '2008-01-03 10:57:23', 'modified' => '2008-01-03 10:57:23'),
+		array('join_a_id' => 3, 'join_c_id' => 1, 'other' => 'Data for Join A 3 Join C 1', 'created' => '2008-01-03 10:57:24', 'modified' => '2008-01-03 10:57:24')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinAFixture.php
+++ b/lib/Cake/Test/Fixture/JoinAFixture.php
@@ -45,7 +45,7 @@ class JoinAFixture extends TestFixture {
 		'name' => array('type' => 'string', 'default' => ''),
 		'body' => array('type' => 'text'),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -54,8 +54,8 @@ class JoinAFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('name' => 'Join A 1', 'body' => 'Join A 1 Body', 'created' => '2008-01-03 10:54:23', 'updated' => '2008-01-03 10:54:23'),
-		array('name' => 'Join A 2', 'body' => 'Join A 2 Body', 'created' => '2008-01-03 10:54:24', 'updated' => '2008-01-03 10:54:24'),
-		array('name' => 'Join A 3', 'body' => 'Join A 2 Body', 'created' => '2008-01-03 10:54:25', 'updated' => '2008-01-03 10:54:24')
+		array('name' => 'Join A 1', 'body' => 'Join A 1 Body', 'created' => '2008-01-03 10:54:23', 'modified' => '2008-01-03 10:54:23'),
+		array('name' => 'Join A 2', 'body' => 'Join A 2 Body', 'created' => '2008-01-03 10:54:24', 'modified' => '2008-01-03 10:54:24'),
+		array('name' => 'Join A 3', 'body' => 'Join A 2 Body', 'created' => '2008-01-03 10:54:25', 'modified' => '2008-01-03 10:54:24')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinBFixture.php
+++ b/lib/Cake/Test/Fixture/JoinBFixture.php
@@ -44,7 +44,7 @@ class JoinBFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -53,8 +53,8 @@ class JoinBFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('name' => 'Join B 1', 'created' => '2008-01-03 10:55:01', 'updated' => '2008-01-03 10:55:01'),
-		array('name' => 'Join B 2', 'created' => '2008-01-03 10:55:02', 'updated' => '2008-01-03 10:55:02'),
-		array('name' => 'Join B 3', 'created' => '2008-01-03 10:55:03', 'updated' => '2008-01-03 10:55:03')
+		array('name' => 'Join B 1', 'created' => '2008-01-03 10:55:01', 'modified' => '2008-01-03 10:55:01'),
+		array('name' => 'Join B 2', 'created' => '2008-01-03 10:55:02', 'modified' => '2008-01-03 10:55:02'),
+		array('name' => 'Join B 3', 'created' => '2008-01-03 10:55:03', 'modified' => '2008-01-03 10:55:03')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinCFixture.php
+++ b/lib/Cake/Test/Fixture/JoinCFixture.php
@@ -44,7 +44,7 @@ class JoinCFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -53,8 +53,8 @@ class JoinCFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('name' => 'Join C 1', 'created' => '2008-01-03 10:56:11', 'updated' => '2008-01-03 10:56:11'),
-		array('name' => 'Join C 2', 'created' => '2008-01-03 10:56:12', 'updated' => '2008-01-03 10:56:12'),
-		array('name' => 'Join C 3', 'created' => '2008-01-03 10:56:13', 'updated' => '2008-01-03 10:56:13')
+		array('name' => 'Join C 1', 'created' => '2008-01-03 10:56:11', 'modified' => '2008-01-03 10:56:11'),
+		array('name' => 'Join C 2', 'created' => '2008-01-03 10:56:12', 'modified' => '2008-01-03 10:56:12'),
+		array('name' => 'Join C 3', 'created' => '2008-01-03 10:56:13', 'modified' => '2008-01-03 10:56:13')
 	);
 }

--- a/lib/Cake/Test/Fixture/JoinThingFixture.php
+++ b/lib/Cake/Test/Fixture/JoinThingFixture.php
@@ -46,7 +46,7 @@ class JoinThingFixture extends TestFixture {
 		'something_else_id' => array('type' => 'integer', 'default' => null),
 		'doomed' => array('type' => 'boolean', 'default' => '0'),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -55,8 +55,8 @@ class JoinThingFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('something_id' => 1, 'something_else_id' => 2, 'doomed' => '1', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('something_id' => 2, 'something_else_id' => 3, 'doomed' => '0', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('something_id' => 3, 'something_else_id' => 1, 'doomed' => '1', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('something_id' => 1, 'something_else_id' => 2, 'doomed' => '1', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('something_id' => 2, 'something_else_id' => 3, 'doomed' => '0', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('something_id' => 3, 'something_else_id' => 1, 'doomed' => '1', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/NumericArticleFixture.php
+++ b/lib/Cake/Test/Fixture/NumericArticleFixture.php
@@ -44,7 +44,7 @@ class NumericArticleFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'title' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -53,7 +53,7 @@ class NumericArticleFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('title' => 'First Article', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('title' => '12345abcde', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
+		array('title' => 'First Article', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('title' => '12345abcde', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/PlayerFixture.php
+++ b/lib/Cake/Test/Fixture/PlayerFixture.php
@@ -44,7 +44,7 @@ class PlayerFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**

--- a/lib/Cake/Test/Fixture/PostFixture.php
+++ b/lib/Cake/Test/Fixture/PostFixture.php
@@ -47,7 +47,7 @@ class PostFixture extends TestFixture {
 		'body' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,8 +56,8 @@ class PostFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('author_id' => 1, 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('author_id' => 3, 'title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('author_id' => 1, 'title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('author_id' => 1, 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('author_id' => 3, 'title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('author_id' => 1, 'title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/SiteFixture.php
+++ b/lib/Cake/Test/Fixture/SiteFixture.php
@@ -46,7 +46,7 @@ class SiteFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,8 +56,8 @@ class SiteFixture extends TestFixture {
  * @access public
  */
 	public $records = array(
-		array('name' => 'cakephp', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('name' => 'Mark Story\'s sites', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('name' => 'rchavik sites', 'created' => '2001-02-03 00:01:02', 'updated' => '2007-03-17 01:22:31'),
+		array('name' => 'cakephp', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('name' => 'Mark Story\'s sites', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('name' => 'rchavik sites', 'created' => '2001-02-03 00:01:02', 'modified' => '2007-03-17 01:22:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/SomethingElseFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingElseFixture.php
@@ -46,7 +46,7 @@ class SomethingElseFixture extends TestFixture {
 		'body' => array('type' => 'text'),
 		'published' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -55,8 +55,8 @@ class SomethingElseFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/SomethingFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingFixture.php
@@ -46,7 +46,7 @@ class SomethingFixture extends TestFixture {
 		'body' => array('type' => 'text'),
 		'published' => array('type' => 'string', 'default' => ''),
 		'created' => array('type' => 'datetime', 'null' => true),
-		'updated' => array('type' => 'datetime', 'null' => true)
+		'modified' => array('type' => 'datetime', 'null' => true)
 	);
 
 /**
@@ -55,8 +55,8 @@ class SomethingFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('title' => 'Third Post', 'body' => 'Third Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/TagFixture.php
+++ b/lib/Cake/Test/Fixture/TagFixture.php
@@ -44,7 +44,7 @@ class TagFixture extends TestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'tag' => array('type' => 'string', 'null' => false),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -53,8 +53,8 @@ class TagFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-		array('tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'updated' => '2007-03-18 12:26:31'),
-		array('tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'updated' => '2007-03-18 12:28:31')
+		array('tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+		array('tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'modified' => '2007-03-18 12:26:31'),
+		array('tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'modified' => '2007-03-18 12:28:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
@@ -47,7 +47,7 @@ class TestPluginArticleFixture extends TestFixture {
 		'body' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,8 +56,8 @@ class TestPluginArticleFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user_id' => 1, 'title' => 'First Plugin Article', 'body' => 'First Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:39:23', 'updated' => '2008-09-24 10:41:31'),
-		array('user_id' => 3, 'title' => 'Second Plugin Article', 'body' => 'Second Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:41:23', 'updated' => '2008-09-24 10:43:31'),
-		array('user_id' => 1, 'title' => 'Third Plugin Article', 'body' => 'Third Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:43:23', 'updated' => '2008-09-24 10:45:31')
+		array('user_id' => 1, 'title' => 'First Plugin Article', 'body' => 'First Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:39:23', 'modified' => '2008-09-24 10:41:31'),
+		array('user_id' => 3, 'title' => 'Second Plugin Article', 'body' => 'Second Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:41:23', 'modified' => '2008-09-24 10:43:31'),
+		array('user_id' => 1, 'title' => 'Third Plugin Article', 'body' => 'Third Plugin Article Body', 'published' => 'Y', 'created' => '2008-09-24 10:43:23', 'modified' => '2008-09-24 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
@@ -47,7 +47,7 @@ class TestPluginCommentFixture extends TestFixture {
 		'comment' => 'text',
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -56,11 +56,11 @@ class TestPluginCommentFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:45:23', 'updated' => '2008-09-24 10:47:31'),
-		array('id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:47:23', 'updated' => '2008-09-24 10:49:31'),
-		array('id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:49:23', 'updated' => '2008-09-24 10:51:31'),
-		array('id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Plugin Article', 'published' => 'N', 'created' => '2008-09-24 10:51:23', 'updated' => '2008-09-24 10:53:31'),
-		array('id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:53:23', 'updated' => '2008-09-24 10:55:31'),
-		array('id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:55:23', 'updated' => '2008-09-24 10:57:31')
+		array('id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:45:23', 'modified' => '2008-09-24 10:47:31'),
+		array('id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:47:23', 'modified' => '2008-09-24 10:49:31'),
+		array('id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:49:23', 'modified' => '2008-09-24 10:51:31'),
+		array('id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Plugin Article', 'published' => 'N', 'created' => '2008-09-24 10:51:23', 'modified' => '2008-09-24 10:53:31'),
+		array('id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:53:23', 'modified' => '2008-09-24 10:55:31'),
+		array('id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Plugin Article', 'published' => 'Y', 'created' => '2008-09-24 10:55:23', 'modified' => '2008-09-24 10:57:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
@@ -45,7 +45,7 @@ class TranslatedArticleFixture extends TestFixture {
 		'user_id' => array('type' => 'integer', 'null' => false),
 		'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,8 +54,8 @@ class TranslatedArticleFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('id' => 1, 'user_id' => 1, 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-		array('id' => 2, 'user_id' => 3, 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-		array('id' => 3, 'user_id' => 1, 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31')
+		array('id' => 1, 'user_id' => 1, 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+		array('id' => 2, 'user_id' => 3, 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+		array('id' => 3, 'user_id' => 1, 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31')
 	);
 }

--- a/lib/Cake/Test/Fixture/UserFixture.php
+++ b/lib/Cake/Test/Fixture/UserFixture.php
@@ -45,7 +45,7 @@ class UserFixture extends TestFixture {
 		'user' => array('type' => 'string', 'null' => true),
 		'password' => array('type' => 'string', 'null' => true),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,9 +54,9 @@ class UserFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
-		array('user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'),
-		array('user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'),
-		array('user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'),
+		array('user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
+		array('user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'),
+		array('user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'),
+		array('user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'),
 	);
 }

--- a/lib/Cake/Test/Fixture/UuidFixture.php
+++ b/lib/Cake/Test/Fixture/UuidFixture.php
@@ -45,7 +45,7 @@ class UuidFixture extends TestFixture {
 		'title' => 'string',
 		'count' => array('type' => 'integer', 'default' => 0),
 		'created' => 'datetime',
-		'updated' => 'datetime'
+		'modified' => 'datetime'
 	);
 
 /**
@@ -54,9 +54,9 @@ class UuidFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('id' => '47c36f9c-bc00-4d17-9626-4e183ca6822b', 'title' => 'Unique record 1', 'count' => 2, 'created' => '2008-03-13 01:16:23', 'updated' => '2008-03-13 01:18:31'),
-		array('id' => '47c36f9c-f2b0-43f5-b3f7-4e183ca6822b', 'title' => 'Unique record 2', 'count' => 4, 'created' => '2008-03-13 01:18:24', 'updated' => '2008-03-13 01:20:32'),
-		array('id' => '47c36f9c-0ffc-4084-9b03-4e183ca6822b', 'title' => 'Unique record 3', 'count' => 5, 'created' => '2008-03-13 01:20:25', 'updated' => '2008-03-13 01:22:33'),
-		array('id' => '47c36f9c-2578-4c2e-aeab-4e183ca6822b', 'title' => 'Unique record 4', 'count' => 3, 'created' => '2008-03-13 01:22:26', 'updated' => '2008-03-13 01:24:34'),
+		array('id' => '47c36f9c-bc00-4d17-9626-4e183ca6822b', 'title' => 'Unique record 1', 'count' => 2, 'created' => '2008-03-13 01:16:23', 'modified' => '2008-03-13 01:18:31'),
+		array('id' => '47c36f9c-f2b0-43f5-b3f7-4e183ca6822b', 'title' => 'Unique record 2', 'count' => 4, 'created' => '2008-03-13 01:18:24', 'modified' => '2008-03-13 01:20:32'),
+		array('id' => '47c36f9c-0ffc-4084-9b03-4e183ca6822b', 'title' => 'Unique record 3', 'count' => 5, 'created' => '2008-03-13 01:20:25', 'modified' => '2008-03-13 01:22:33'),
+		array('id' => '47c36f9c-2578-4c2e-aeab-4e183ca6822b', 'title' => 'Unique record 4', 'count' => 3, 'created' => '2008-03-13 01:22:26', 'modified' => '2008-03-13 01:24:34'),
 	);
 }

--- a/lib/Cake/Test/TestCase/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/SchemaShellTest.php
@@ -62,7 +62,7 @@ class SchemaShellTestSchema extends Schema {
 		'comment' => array('type' => 'text', 'null' => false, 'default' => null),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 	);
 
@@ -79,7 +79,7 @@ class SchemaShellTestSchema extends Schema {
 		'summary' => array('type' => 'text', 'null' => true),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'Y', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 	);
 }

--- a/lib/Cake/Test/TestCase/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -165,7 +165,7 @@ class BasicAuthenticateTest extends TestCase {
 			'id' => 1,
 			'user' => 'mariano',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		);
 		$this->assertEquals($expected, $result);
 	}

--- a/lib/Cake/Test/TestCase/Controller/Component/Auth/BlowfishAuthenticateTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/Auth/BlowfishAuthenticateTest.php
@@ -153,7 +153,7 @@ class BlowfishAuthenticateTest extends TestCase {
 			'id' => 1,
 			'user' => 'mariano',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31',
+			'modified' => '2007-03-17 01:18:31',
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -206,8 +206,8 @@ class BlowfishAuthenticateTest extends TestCase {
 			'username' => 'gwoo',
 			'created' => '2007-03-17 01:16:23'
 		);
-		$this->assertEquals(static::date(), $result['updated']);
-		unset($result['updated']);
+		$this->assertEquals(static::date(), $result['modified']);
+		unset($result['modified']);
 		$this->assertEquals($expected, $result);
 		Plugin::unload();
 	}

--- a/lib/Cake/Test/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -186,7 +186,7 @@ DIGEST;
 			'id' => 1,
 			'user' => 'mariano',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		);
 		$this->assertEquals($expected, $result);
 	}

--- a/lib/Cake/Test/TestCase/Controller/Component/Auth/FormAuthenticateTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/Auth/FormAuthenticateTest.php
@@ -151,7 +151,7 @@ class FormAuthenticateTest extends TestCase {
 			'id' => 1,
 			'user' => 'mariano',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -205,8 +205,8 @@ class FormAuthenticateTest extends TestCase {
 			'username' => 'gwoo',
 			'created' => '2007-03-17 01:16:23'
 		);
-		$this->assertEquals(static::date(), $result['updated']);
-		unset($result['updated']);
+		$this->assertEquals(static::date(), $result['modified']);
+		unset($result['modified']);
 		$this->assertEquals($expected, $result);
 		Plugin::unload();
 	}

--- a/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
@@ -982,7 +982,7 @@ class AuthComponentTest extends TestCase {
 			'username' => 'mariano',
 			'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		);
 		$this->assertTrue($this->Auth->login($user));
 		$this->assertTrue($this->Auth->loggedIn());

--- a/lib/Cake/Test/TestCase/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ScaffoldTest.php
@@ -215,7 +215,7 @@ class ScaffoldTest extends TestCase {
 		$this->assertEquals('title', $result['displayField']);
 		$this->assertEquals('scaffoldMock', $result['singularVar']);
 		$this->assertEquals('scaffoldMock', $result['pluralVar']);
-		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated'), $result['scaffoldFields']);
+		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'modified'), $result['scaffoldFields']);
 		$this->assertArrayHasKey('plugin', $result['associations']['belongsTo']['User']);
 	}
 
@@ -303,7 +303,7 @@ class ScaffoldTest extends TestCase {
 		$this->assertContains('name="ScaffoldTag[ScaffoldTag]"', $result);
 
 		$result = $Scaffold->controller->viewVars;
-		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'updated', 'ScaffoldTag'), $result['scaffoldFields']);
+		$this->assertEquals(array('id', 'user_id', 'title', 'body', 'published', 'created', 'modified', 'ScaffoldTag'), $result['scaffoldFields']);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/TestCase/Model/Behavior/ContainableBehaviorTest.php
@@ -206,12 +206,12 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$this->assertTrue(Set::matches('/Comment/comment', $r));
 		$this->assertFalse(Set::matches('/Comment/updated', $r));
 
-		$r = $this->Article->find('all', array('contain' => array('Comment' => array('fields' => array('comment', 'updated')))));
+		$r = $this->Article->find('all', array('contain' => array('Comment' => array('fields' => array('comment', 'modified')))));
 		$this->assertFalse(Set::matches('/Comment/created', $r));
 		$this->assertTrue(Set::matches('/Comment/comment', $r));
 		$this->assertTrue(Set::matches('/Comment/updated', $r));
 
-		$r = $this->Article->find('all', array('contain' => array('Comment' => array('comment', 'updated'))));
+		$r = $this->Article->find('all', array('contain' => array('Comment' => array('comment', 'modified'))));
 		$this->assertFalse(Set::matches('/Comment/created', $r));
 		$this->assertTrue(Set::matches('/Comment/comment', $r));
 		$this->assertTrue(Set::matches('/Comment/updated', $r));
@@ -310,15 +310,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 		$expected = array(
 			array('Article' => array(
 				'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-				'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)),
 			array('Article' => array(
 				'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-				'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+				'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 			)),
 			array('Article' => array(
 				'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-				'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+				'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 			))
 		);
 		$this->assertEquals($expected, $result);
@@ -336,31 +336,31 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
@@ -372,59 +372,59 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 					)
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31'
 					)
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array()
 			)
@@ -443,31 +443,31 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
@@ -478,59 +478,59 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 					)
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31'
 					)
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array()
 			)
@@ -550,39 +550,39 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 						'User' => array(
 							'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+							'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 						)
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 						'User' => array(
 							'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+							'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 						)
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					)
 				)
@@ -590,23 +590,23 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 						'User' => array(
 							'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+							'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 						)
 					)
 				)
@@ -614,7 +614,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'Comment' => array()
 			)
@@ -627,19 +627,19 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				)
@@ -647,15 +647,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					)
 				)
@@ -663,19 +663,19 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				)
@@ -689,33 +689,33 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					),
 					'Comment' => array(
 						array(
 							'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 						),
 						array(
 							'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						),
 						array(
 							'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 						)
 					)
 				)
@@ -723,15 +723,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					),
 					'Comment' => array()
@@ -740,33 +740,33 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					),
 					'Comment' => array(
 						array(
 							'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 						),
 						array(
 							'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						),
 						array(
 							'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 						)
 					)
 				)
@@ -780,100 +780,100 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 						'Attachment' => array()
 					)
 				),
 				'Tag' => array(
-					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => 2, 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'updated' => '2007-03-18 12:26:31')
+					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => 2, 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'modified' => '2007-03-18 12:26:31')
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					)
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 						'Attachment' => array(
 							'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-							'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						)
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 						'Attachment' => array()
 					)
 				),
 				'Tag' => array(
-					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => 3, 'tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'updated' => '2007-03-18 12:28:31')
+					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => 3, 'tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'modified' => '2007-03-18 12:28:31')
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				),
@@ -895,39 +895,39 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 						'User' => array(
 							'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+							'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 						)
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 						'User' => array(
 							'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+							'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 						)
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					)
 				)
@@ -935,23 +935,23 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 						'User' => array(
 							'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+							'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 						)
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 						'User' => array(
 							'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-							'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+							'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 						)
 					)
 				)
@@ -959,7 +959,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'Comment' => array()
 			)
@@ -971,19 +971,19 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				)
@@ -991,15 +991,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					)
 				)
@@ -1007,19 +1007,19 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				)
@@ -1032,33 +1032,33 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					),
 					'Comment' => array(
 						array(
 							'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 						),
 						array(
 							'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						),
 						array(
 							'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 						)
 					)
 				)
@@ -1066,15 +1066,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					),
 					'Comment' => array()
@@ -1083,33 +1083,33 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					),
 					'Comment' => array(
 						array(
 							'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31'
 						),
 						array(
 							'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						),
 						array(
 							'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31'
 						)
 					)
 				)
@@ -1122,100 +1122,100 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'Article' => array(
 					'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				),
 				'Comment' => array(
 					array(
 						'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 						'Attachment' => array()
 					),
 					array(
 						'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+						'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 						'Attachment' => array()
 					)
 				),
 				'Tag' => array(
-					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => 2, 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'updated' => '2007-03-18 12:26:31')
+					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => 2, 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'modified' => '2007-03-18 12:26:31')
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31',
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31',
 					'ArticleFeatured' => array(
 						array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 						)
 					)
 				),
 				'Comment' => array(
 					array(
 						'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 						'Attachment' => array(
 							'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-							'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+							'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 						)
 					),
 					array(
 						'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 						'Attachment' => array()
 					)
 				),
 				'Tag' => array(
-					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => 3, 'tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'updated' => '2007-03-18 12:28:31')
+					array('id' => 1, 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => 3, 'tag' => 'tag3', 'created' => '2007-03-18 12:26:23', 'modified' => '2007-03-18 12:28:31')
 				)
 			),
 			array(
 				'Article' => array(
 					'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+					'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'ArticleFeatured' => array(
 						array(
 							'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+							'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 						)
 					)
 				),
@@ -1238,24 +1238,24 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array()
 					)
 				)
@@ -1263,25 +1263,25 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					)
@@ -1290,7 +1290,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -1303,54 +1303,54 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							)
@@ -1358,7 +1358,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -1367,46 +1367,46 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array()
 							)
@@ -1417,7 +1417,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -1430,56 +1430,56 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Attachment' => array()
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -1488,7 +1488,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -1496,38 +1496,38 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Attachment' => array()
 							)
 						)
@@ -1537,7 +1537,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -1557,24 +1557,24 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array()
 					)
 				)
@@ -1582,25 +1582,25 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					)
@@ -1609,7 +1609,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -1621,54 +1621,54 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							)
@@ -1676,7 +1676,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -1685,46 +1685,46 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array()
 							)
@@ -1735,7 +1735,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -1747,56 +1747,56 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Attachment' => array()
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -1805,7 +1805,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -1813,38 +1813,38 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Attachment' => array()
 							)
 						)
@@ -1854,7 +1854,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -1874,15 +1874,15 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'name' => 'Category 1'
 							)
@@ -1890,7 +1890,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array()
 					)
 				)
@@ -1898,22 +1898,22 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'name' => 'Category 1'
 							)
@@ -1924,7 +1924,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -1985,7 +1985,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
@@ -2006,14 +2006,14 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
@@ -2030,7 +2030,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2055,7 +2055,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array(
 					'User' => array(
 						'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-						'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+						'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 					),
 					'ArticleFeatured' => array(
 						array(
@@ -2076,14 +2076,14 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array(
 					'User' => array(
 						'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-						'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+						'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 					),
 					'ArticleFeatured' => array()
 				),
 				array(
 					'User' => array(
 						'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-						'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+						'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 					),
 					'ArticleFeatured' => array(
 						array(
@@ -2100,7 +2100,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 				array(
 					'User' => array(
 						'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-						'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+						'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 					),
 					'ArticleFeatured' => array()
 				)
@@ -2121,24 +2121,24 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array()
 					)
 				)
@@ -2146,25 +2146,25 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					)
@@ -2173,7 +2173,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2188,54 +2188,54 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							)
@@ -2243,7 +2243,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -2252,46 +2252,46 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array()
 							)
@@ -2302,7 +2302,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2317,56 +2317,56 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Attachment' => array()
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -2375,7 +2375,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -2383,38 +2383,38 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Attachment' => array()
 							)
 						)
@@ -2424,7 +2424,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -2444,24 +2444,24 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array()
 					)
 				)
@@ -2469,25 +2469,25 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						)
 					)
@@ -2496,7 +2496,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2519,54 +2519,54 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							)
@@ -2574,7 +2574,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -2583,46 +2583,46 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array()
 							)
@@ -2633,7 +2633,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2656,54 +2656,54 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Article' => array(
 									'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 								),
 								'Attachment' => array()
 							)
@@ -2711,7 +2711,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -2720,46 +2720,46 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'ArticleFeatured' => array()
 			),
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Article' => array(
 									'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+									'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 								),
 								'Attachment' => array()
 							)
@@ -2770,7 +2770,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'ArticleFeatured' => array()
 			)
@@ -2793,56 +2793,56 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 1, 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 1, 'user_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 						'Featured' => array(
 							'id' => 1, 'article_featured_id' => 1, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 1, 'article_id' => 1, 'user_id' => 2, 'comment' => 'First Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 2, 'article_id' => 1, 'user_id' => 4, 'comment' => 'Second Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 3, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Third Comment for First Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'updated' => '2007-03-18 10:51:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:49:23', 'modified' => '2007-03-18 10:51:31',
 								'Attachment' => array()
 							),
 							array(
 								'id' => 4, 'article_id' => 1, 'user_id' => 1, 'comment' => 'Fourth Comment for First Article',
-								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31',
+								'published' => 'N', 'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31',
 								'Attachment' => array()
 							)
 						)
 					),
 					array(
 						'id' => 3, 'user_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31',
 						'Featured' => array(),
 						'Comment' => array()
 					)
@@ -2851,7 +2851,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 2, 'user' => 'nate', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:18:23', 'updated' => '2007-03-17 01:20:31'
+					'created' => '2007-03-17 01:18:23', 'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()
@@ -2859,38 +2859,38 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 3, 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31'
+					'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31'
 				),
 				'Article' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'
 					)
 				),
 				'ArticleFeatured' => array(
 					array(
 						'id' => 2, 'user_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body',
-						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31',
+						'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31',
 						'Featured' => array(
 							'id' => 2, 'article_featured_id' => 2, 'category_id' => 1, 'published_date' => '2007-03-31 10:39:23',
-							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31',
+							'end_date' => '2007-05-15 10:39:23', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31',
 							'Category' => array(
 								'id' => 1, 'parent_id' => 0, 'name' => 'Category 1',
-								'created' => '2007-03-18 15:30:23', 'updated' => '2007-03-18 15:32:31'
+								'created' => '2007-03-18 15:30:23', 'modified' => '2007-03-18 15:32:31'
 							)
 						),
 						'Comment' => array(
 							array(
 								'id' => 5, 'article_id' => 2, 'user_id' => 1, 'comment' => 'First Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'updated' => '2007-03-18 10:55:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:53:23', 'modified' => '2007-03-18 10:55:31',
 								'Attachment' => array(
 									'id' => 1, 'comment_id' => 5, 'attachment' => 'attachment.zip',
-									'created' => '2007-03-18 10:51:23', 'updated' => '2007-03-18 10:53:31'
+									'created' => '2007-03-18 10:51:23', 'modified' => '2007-03-18 10:53:31'
 								)
 							),
 							array(
 								'id' => 6, 'article_id' => 2, 'user_id' => 2, 'comment' => 'Second Comment for Second Article',
-								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'updated' => '2007-03-18 10:57:31',
+								'published' => 'Y', 'created' => '2007-03-18 10:55:23', 'modified' => '2007-03-18 10:57:31',
 								'Attachment' => array()
 							)
 						)
@@ -2900,7 +2900,7 @@ class ContainableBehaviorTest extends CakeTestCase {
 			array(
 				'User' => array(
 					'id' => 4, 'user' => 'garrett', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-					'created' => '2007-03-17 01:22:23', 'updated' => '2007-03-17 01:24:31'
+					'created' => '2007-03-17 01:22:23', 'modified' => '2007-03-17 01:24:31'
 				),
 				'Article' => array(),
 				'ArticleFeatured' => array()

--- a/lib/Cake/Test/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -1036,7 +1036,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'user_id' => 1,
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31',
+				'modified' => '2007-03-18 10:41:31',
 				'locale' => 'eng',
 				'title' => 'Title (eng) #1',
 				'body' => 'Body (eng) #1'
@@ -1046,7 +1046,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'user' => 'mariano',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:16:23',
-				'updated' => '2007-03-17 01:18:31'
+				'modified' => '2007-03-17 01:18:31'
 			),
 			'TranslatedItem' => array(
 				array(
@@ -1076,7 +1076,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 					'user_id' => 1,
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31',
+					'modified' => '2007-03-18 10:41:31',
 					'locale' => 'eng',
 					'title' => 'Title (eng) #1',
 					'body' => 'Body (eng) #1'
@@ -1088,7 +1088,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 					'user_id' => 3,
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31',
+					'modified' => '2007-03-18 10:43:31',
 					'locale' => 'eng',
 					'title' => 'Title (eng) #2',
 					'body' => 'Body (eng) #2'
@@ -1100,7 +1100,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 					'user_id' => 1,
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31',
+					'modified' => '2007-03-18 10:45:31',
 					'locale' => 'eng',
 					'title' => 'Title (eng) #3',
 					'body' => 'Body (eng) #3'
@@ -1118,7 +1118,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 				'user_id' => 1,
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31',
+				'modified' => '2007-03-18 10:41:31',
 				'locale' => 'eng',
 				'title' => 'Title (eng) #1',
 				'body' => 'Body (eng) #1'

--- a/lib/Cake/Test/TestCase/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/Database/MysqlTest.php
@@ -2662,7 +2662,7 @@ class MysqlTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, array(), false);
-		$expected = array('id', 'client_id', 'name', 'login', 'passwd', 'addr_1', 'addr_2', 'zip_code', 'city', 'country', 'phone', 'fax', 'url', 'email', 'comments', 'last_login', 'created', 'updated');
+		$expected = array('id', 'client_id', 'name', 'login', 'passwd', 'addr_1', 'addr_2', 'zip_code', 'city', 'country', 'phone', 'fax', 'url', 'email', 'comments', 'last_login', 'created', 'modified');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Dbo->fields($this->Model, null, 'COUNT(*)');

--- a/lib/Cake/Test/TestCase/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/Database/PostgresTest.php
@@ -144,7 +144,7 @@ class PostgresTestModel extends Model {
 			'comments' => array('type' => 'text', 'null' => '1', 'default' => '', 'length' => ''),
 			'last_login' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
 			'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-			'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+			'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 		);
 	}
 
@@ -182,7 +182,7 @@ class PostgresClientTestModel extends Model {
 			'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 			'email' => array('type' => 'string', 'null' => '1', 'default' => '', 'length' => '155'),
 			'created' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
-			'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+			'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 		);
 	}
 
@@ -633,7 +633,7 @@ class PostgresTest extends TestCase {
 				'body' => array('type' => 'text'),
 				'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 				'created' => array('type' => 'datetime'),
-				'updated' => array('type' => 'datetime'),
+				'modified' => array('type' => 'datetime'),
 			)
 		));
 		$this->Dbo->query($this->Dbo->createSchema($Old));
@@ -648,7 +648,7 @@ class PostgresTest extends TestCase {
 				'body' => array('type' => 'string', 'length' => 500),
 				'status' => array('type' => 'integer', 'length' => 3, 'default' => 1),
 				'created' => array('type' => 'datetime'),
-				'updated' => array('type' => 'datetime'),
+				'modified' => array('type' => 'datetime'),
 			)
 		));
 		$this->Dbo->query($this->Dbo->alterSchema($New->compare($Old), 'alter_posts'));
@@ -674,7 +674,7 @@ class PostgresTest extends TestCase {
 				'body' => array('type' => 'text'),
 				'published' => array('type' => 'string', 'length' => 1, 'default' => 'N'),
 				'created' => array('type' => 'datetime'),
-				'updated' => array('type' => 'datetime'),
+				'modified' => array('type' => 'datetime'),
 			)
 		));
 		$result = $this->Dbo->alterSchema($New->compare($Old), 'alter_posts');

--- a/lib/Cake/Test/TestCase/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/Database/SqliteTest.php
@@ -313,7 +313,7 @@ class SqliteTest extends TestCase {
 				'default' => null,
 				'length' => null,
 			),
-			'updated' => array(
+			'modified' => array(
 				'type' => 'datetime',
 				'null' => true,
 				'default' => null,

--- a/lib/Cake/Test/TestCase/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/Database/SqlserverTest.php
@@ -156,7 +156,7 @@ class SqlserverTestModel extends TestModel {
 		'comments' => array('type' => 'text', 'null' => '1', 'default' => '', 'length' => ''),
 		'last_login' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 /**
@@ -216,7 +216,7 @@ class SqlserverClientTestModel extends TestModel {
 		'name'		=> array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'email'		=> array('type' => 'string', 'null' => '1', 'default' => '', 'length' => '155'),
 		'created'	=> array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated'	=> array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified'	=> array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 }
 

--- a/lib/Cake/Test/TestCase/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/DboSourceTest.php
@@ -196,21 +196,21 @@ class DboSourceTest extends TestCase {
 		$data = array('Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
 				'body' => 'First Article Body', 'published' => 'Y',
-				'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 		));
 		$merge = array('Topic' => array(array(
 			'id' => '1', 'topic' => 'Topic', 'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		)));
 		$expected = array(
 			'Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
 				'body' => 'First Article Body', 'published' => 'Y',
-				'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Topic' => array(
 				'id' => '1', 'topic' => 'Topic', 'created' => '2007-03-17 01:16:23',
-				'updated' => '2007-03-17 01:18:31'
+				'modified' => '2007-03-17 01:18:31'
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Topic', 'hasOne');
@@ -219,21 +219,21 @@ class DboSourceTest extends TestCase {
 		$data = array('Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
 				'body' => 'First Article Body', 'published' => 'Y',
-				'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 		));
 		$merge = array('User2' => array(array(
 			'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
-			'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+			'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 		)));
 
 		$expected = array(
 			'Article2' => array(
 				'id' => '1', 'user_id' => '1', 'title' => 'First Article',
 				'body' => 'First Article Body', 'published' => 'Y',
-				'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'User2' => array(
-				'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+				'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 			)
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'User2', 'belongsTo');
@@ -241,13 +241,13 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article2' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(array('Comment' => false));
 		$expected = array(
 			'Article2' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Comment' => array()
 		);
@@ -256,31 +256,31 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(
 			array(
 				'Comment' => array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Comment' => array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
 		$expected = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Comment' => array(
 				array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
@@ -289,42 +289,42 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(
 			array(
 				'Comment' => array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'User2' => array(
-					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Comment' => array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'User2' => array(
-					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
 		$expected = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Comment' => array(
 				array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'User2' => array(
-						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 					)
 				),
 				array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'User2' => array(
-						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 					)
 				)
 			)
@@ -334,16 +334,16 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(
 			array(
 				'Comment' => array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'User2' => array(
-					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Tag' => array(
 					array('id' => 1, 'tag' => 'Tag 1'),
@@ -352,23 +352,23 @@ class DboSourceTest extends TestCase {
 			),
 			array(
 				'Comment' => array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'User2' => array(
-					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				'Tag' => array()
 			)
 		);
 		$expected = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Comment' => array(
 				array(
-					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'id' => '1', 'comment' => 'Comment 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'User2' => array(
-						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 					),
 					'Tag' => array(
 						array('id' => 1, 'tag' => 'Tag 1'),
@@ -376,9 +376,9 @@ class DboSourceTest extends TestCase {
 					)
 				),
 				array(
-					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31',
+					'id' => '2', 'comment' => 'Comment 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31',
 					'User2' => array(
-						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+						'id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 					),
 					'Tag' => array()
 				)
@@ -389,39 +389,39 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(
 			array(
 				'Tag' => array(
-					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Tag' => array(
-					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Tag' => array(
-					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
 		$expected = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
 			'Tag' => array(
 				array(
-					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				array(
-					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				),
 				array(
-					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
@@ -430,31 +430,31 @@ class DboSourceTest extends TestCase {
 
 		$data = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			)
 		);
 		$merge = array(
 			array(
 				'Tag' => array(
-					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Tag' => array(
-					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '2', 'tag' => 'Tag 2', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			),
 			array(
 				'Tag' => array(
-					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'
+					'id' => '3', 'tag' => 'Tag 3', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'
 				)
 			)
 		);
 		$expected = array(
 			'Article' => array(
-				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'
+				'id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'
 			),
-			'Tag' => array('id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31')
+			'Tag' => array('id' => '1', 'tag' => 'Tag 1', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31')
 		);
 		$this->testDb->mergeAssociation($data, $merge, 'Tag', 'hasOne');
 		$this->assertEquals($expected, $data);

--- a/lib/Cake/Test/TestCase/Model/ModelCrossSchemaHabtmTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelCrossSchemaHabtmTest.php
@@ -218,7 +218,7 @@ class ModelCrossSchemaHabtmTest extends BaseModelTest {
 			),
 		);
 		unset($result['Player']['created']);
-		unset($result['Player']['updated']);
+		unset($result['Player']['modified']);
 		$this->assertEquals($expected, $result);
 
 		$spongebob = $Player->find('all', array(

--- a/lib/Cake/Test/TestCase/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelIntegrationTest.php
@@ -302,14 +302,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(
 					array(
@@ -319,7 +319,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '2',
@@ -328,7 +328,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 					),
 					array(
 						'id' => '3',
@@ -337,7 +337,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -346,20 +346,20 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 				)),
 				'Tag' => array(
 					array(
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '2',
 						'tag' => 'tag2',
 						'created' => '2007-03-18 12:24:23',
-						'updated' => '2007-03-18 12:26:31'
+						'modified' => '2007-03-18 12:26:31'
 			))),
 			array(
 				'Article' => array(
@@ -369,14 +369,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => '3',
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 				),
 				'Comment' => array(
 					array(
@@ -386,7 +386,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 					),
 					array(
 						'id' => '6',
@@ -395,20 +395,20 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 				)),
 				'Tag' => array(
 					array(
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '3',
 						'tag' => 'tag3',
 						'created' => '2007-03-18 12:26:23',
-						'updated' => '2007-03-18 12:28:31'
+						'modified' => '2007-03-18 12:28:31'
 			))),
 			array(
 				'Article' => array(
@@ -418,14 +418,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(),
 				'Tag' => array()
@@ -472,14 +472,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'First Comment for First Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:45:23',
-					'updated' => '2007-03-18 10:47:31'
+					'modified' => '2007-03-18 10:47:31'
 				),
 				'User' => array(
 					'id' => '2',
 					'user' => 'nate',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:18:23',
-					'updated' => '2007-03-17 01:20:31'
+					'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(
 					'id' => '1',
@@ -488,7 +488,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 			)),
 			array(
 				'Comment' => array(
@@ -498,14 +498,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'Second Comment for First Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:47:23',
-					'updated' => '2007-03-18 10:49:31'
+					'modified' => '2007-03-18 10:49:31'
 				),
 				'User' => array(
 					'id' => '4',
 					'user' => 'garrett',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:22:23',
-					'updated' => '2007-03-17 01:24:31'
+					'modified' => '2007-03-17 01:24:31'
 				),
 				'Article' => array(
 					'id' => '1',
@@ -514,7 +514,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 			)),
 			array(
 				'Comment' => array(
@@ -524,14 +524,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'Third Comment for First Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:49:23',
-					'updated' => '2007-03-18 10:51:31'
+					'modified' => '2007-03-18 10:51:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					'id' => '1',
@@ -540,7 +540,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 			)),
 			array(
 				'Comment' => array(
@@ -550,14 +550,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'Fourth Comment for First Article',
 					'published' => 'N',
 					'created' => '2007-03-18 10:51:23',
-					'updated' => '2007-03-18 10:53:31'
+					'modified' => '2007-03-18 10:53:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					'id' => '1',
@@ -566,7 +566,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 			)),
 			array(
 				'Comment' => array(
@@ -576,14 +576,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'First Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:53:23',
-					'updated' => '2007-03-18 10:55:31'
+					'modified' => '2007-03-18 10:55:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Article' => array(
 					'id' => '2',
@@ -592,7 +592,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 			)),
 			array(
 				'Comment' => array(
@@ -602,14 +602,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'comment' => 'Second Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:55:23',
-					'updated' => '2007-03-18 10:57:31'
+					'modified' => '2007-03-18 10:57:31'
 				),
 				'User' => array(
 					'id' => '2',
 					'user' => 'nate',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:18:23',
-					'updated' => '2007-03-17 01:20:31'
+					'modified' => '2007-03-17 01:20:31'
 				),
 				'Article' => array(
 					'id' => '2',
@@ -618,7 +618,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 		)));
 		$this->assertEquals($expected, $TestModel->Comment->find('all'));
 	}
@@ -706,8 +706,8 @@ class ModelIntegrationTest extends BaseModelTest {
 		// tests that record is still identical prior to removal
 		$Site->id = 1;
 		$results = $Site->read();
-		unset($results['Domain'][0]['DomainsSite']['updated']);
-		unset($activated['DomainsSite']['updated']);
+		unset($results['Domain'][0]['DomainsSite']['modified']);
+		unset($activated['DomainsSite']['modified']);
 		$this->assertEquals($activated['DomainsSite'], $results['Domain'][0]['DomainsSite']);
 	}
 
@@ -893,7 +893,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$Post = new Post();
 
 		$result = $Post->schema();
-		$columns = array('id', 'author_id', 'title', 'body', 'published', 'created', 'updated');
+		$columns = array('id', 'author_id', 'title', 'body', 'published', 'created', 'modified');
 		$this->assertEquals($columns, array_keys($result));
 
 		$types = array('integer', 'integer', 'string', 'text', 'string', 'datetime', 'datetime');
@@ -1325,14 +1325,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Plugin Article Body',
 					'published' => 'Y',
 					'created' => '2008-09-24 10:39:23',
-					'updated' => '2008-09-24 10:41:31'
+					'modified' => '2008-09-24 10:41:31'
 				),
 				'User' => array(
 					'id' => 1,
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'TestPluginComment' => array(
 					array(
@@ -1342,7 +1342,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for First Plugin Article',
 						'published' => 'Y',
 						'created' => '2008-09-24 10:45:23',
-						'updated' => '2008-09-24 10:47:31'
+						'modified' => '2008-09-24 10:47:31'
 					),
 					array(
 						'id' => 2,
@@ -1351,7 +1351,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Plugin Article',
 						'published' => 'Y',
 						'created' => '2008-09-24 10:47:23',
-						'updated' => '2008-09-24 10:49:31'
+						'modified' => '2008-09-24 10:49:31'
 					),
 					array(
 						'id' => 3,
@@ -1360,7 +1360,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Plugin Article',
 						'published' => 'Y',
 						'created' => '2008-09-24 10:49:23',
-						'updated' => '2008-09-24 10:51:31'
+						'modified' => '2008-09-24 10:51:31'
 					),
 					array(
 						'id' => 4,
@@ -1369,7 +1369,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Plugin Article',
 						'published' => 'N',
 						'created' => '2008-09-24 10:51:23',
-						'updated' => '2008-09-24 10:53:31'
+						'modified' => '2008-09-24 10:53:31'
 			))),
 			array(
 				'TestPluginArticle' => array(
@@ -1379,14 +1379,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Plugin Article Body',
 					'published' => 'Y',
 					'created' => '2008-09-24 10:41:23',
-					'updated' => '2008-09-24 10:43:31'
+					'modified' => '2008-09-24 10:43:31'
 				),
 				'User' => array(
 					'id' => 3,
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 				),
 				'TestPluginComment' => array(
 					array(
@@ -1396,7 +1396,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Plugin Article',
 						'published' => 'Y',
 						'created' => '2008-09-24 10:53:23',
-						'updated' => '2008-09-24 10:55:31'
+						'modified' => '2008-09-24 10:55:31'
 					),
 					array(
 						'id' => 6,
@@ -1405,7 +1405,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Plugin Article',
 						'published' => 'Y',
 						'created' => '2008-09-24 10:55:23',
-						'updated' => '2008-09-24 10:57:31'
+						'modified' => '2008-09-24 10:57:31'
 			))),
 			array(
 				'TestPluginArticle' => array(
@@ -1415,14 +1415,14 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Plugin Article Body',
 					'published' => 'Y',
 					'created' => '2008-09-24 10:43:23',
-					'updated' => '2008-09-24 10:45:31'
+					'modified' => '2008-09-24 10:45:31'
 				),
 				'User' => array(
 					'id' => 1,
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'TestPluginComment' => array()
 		));
@@ -1642,7 +1642,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		$model = new Test();
 		$this->assertEquals('integer', $model->getColumnType('id'));
 		$this->assertEquals('text', $model->getColumnType('notes'));
-		$this->assertEquals('datetime', $model->getColumnType('updated'));
+		$this->assertEquals('datetime', $model->getColumnType('modified'));
 		$this->assertEquals(null, $model->getColumnType('unknown'));
 
 		$model = new Article();
@@ -1709,7 +1709,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'Something' => array(
 					array(
@@ -1718,14 +1718,14 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'Third Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:43:23',
-						'updated' => '2007-03-18 10:45:31',
+						'modified' => '2007-03-18 10:45:31',
 						'JoinThing' => array(
 							'id' => '3',
 							'something_id' => '3',
 							'something_else_id' => '1',
 							'doomed' => true,
 							'created' => '2007-03-18 10:43:23',
-							'updated' => '2007-03-18 10:45:31'
+							'modified' => '2007-03-18 10:45:31'
 			)))),
 			array(
 				'SomethingElse' => array(
@@ -1734,7 +1734,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'Something' => array(
 					array(
@@ -1743,14 +1743,14 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'First Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:39:23',
-						'updated' => '2007-03-18 10:41:31',
+						'modified' => '2007-03-18 10:41:31',
 						'JoinThing' => array(
 							'id' => '1',
 							'something_id' => '1',
 							'something_else_id' => '2',
 							'doomed' => true,
 							'created' => '2007-03-18 10:39:23',
-							'updated' => '2007-03-18 10:41:31'
+							'modified' => '2007-03-18 10:41:31'
 			)))),
 			array(
 				'SomethingElse' => array(
@@ -1759,7 +1759,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'Something' => array(
 					array(
@@ -1768,14 +1768,14 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'Second Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:41:23',
-						'updated' => '2007-03-18 10:43:31',
+						'modified' => '2007-03-18 10:43:31',
 						'JoinThing' => array(
 							'id' => '2',
 							'something_id' => '2',
 							'something_else_id' => '3',
 							'doomed' => false,
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 		)))));
 		$this->assertEquals($expected, $result);
 
@@ -1788,7 +1788,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'SomethingElse' => array(
 					array(
@@ -1797,7 +1797,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'Second Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:41:23',
-						'updated' => '2007-03-18 10:43:31',
+						'modified' => '2007-03-18 10:43:31',
 						'JoinThing' => array(
 							'doomed' => true,
 							'something_id' => '1',
@@ -1810,7 +1810,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'SomethingElse' => array(
 					array(
@@ -1819,7 +1819,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'Third Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:43:23',
-						'updated' => '2007-03-18 10:45:31',
+						'modified' => '2007-03-18 10:45:31',
 						'JoinThing' => array(
 							'doomed' => false,
 							'something_id' => '2',
@@ -1832,7 +1832,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'SomethingElse' => array(
 					array(
@@ -1841,7 +1841,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'body' => 'First Post Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:39:23',
-						'updated' => '2007-03-18 10:41:31',
+						'modified' => '2007-03-18 10:41:31',
 						'JoinThing' => array(
 							'doomed' => true,
 							'something_id' => '3',
@@ -1857,7 +1857,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'body' => 'First Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			),
 			'SomethingElse' => array(
 				array(
@@ -1866,7 +1866,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31',
+					'modified' => '2007-03-18 10:43:31',
 					'JoinThing' => array(
 						'doomed' => true,
 						'something_id' => '1',
@@ -1907,7 +1907,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31',
+					'modified' => '2007-03-18 10:41:31',
 					'JoinThing' => array(
 						'doomed' => true,
 						'something_id' => '1',
@@ -1920,7 +1920,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31',
+					'modified' => '2007-03-18 10:43:31',
 					'JoinThing' => array(
 						'doomed' => true,
 						'something_id' => '1',
@@ -1933,7 +1933,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31',
+					'modified' => '2007-03-18 10:45:31',
 					'JoinThing' => array(
 						'doomed' => false,
 						'something_id' => '1',
@@ -1941,8 +1941,8 @@ class ModelIntegrationTest extends BaseModelTest {
 					)
 				)
 			);
-		$this->assertEquals(static::date(), $result['Something']['updated']);
-		unset($result['Something']['updated']);
+		$this->assertEquals(static::date(), $result['Something']['modified']);
+		unset($result['Something']['modified']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -2079,7 +2079,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'Comment' => array(
 					array(
@@ -2089,7 +2089,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -2098,7 +2098,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'Article' => array(
@@ -2108,7 +2108,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'Comment' => array(
 					array(
@@ -2118,7 +2118,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -2127,7 +2127,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'Article' => array(
@@ -2137,7 +2137,7 @@ class ModelIntegrationTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'Comment' => array(
 					array(
@@ -2147,7 +2147,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -2156,7 +2156,7 @@ class ModelIntegrationTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -2215,7 +2215,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'default' => null,
 				'length' => null
 			),
-			'updated' => array(
+			'modified' => array(
 				'type' => 'datetime',
 				'null' => true,
 				'default' => null,

--- a/lib/Cake/Test/TestCase/Model/ModelReadTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelReadTest.php
@@ -65,7 +65,7 @@ class ModelReadTest extends BaseModelTest {
 				'something_else_id' => 2,
 				'doomed' => '0',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			)
 		);
 
@@ -3147,7 +3147,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => '0',
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3156,7 +3156,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '1',
 							'name' => 'Category 1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array(
 							array('Category' => array(
@@ -3164,14 +3164,14 @@ class ModelReadTest extends BaseModelTest {
 								'parent_id' => '2',
 								'name' => 'Category 1.1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()),
 							array('Category' => array(
 								'id' => '8',
 								'parent_id' => '2',
 								'name' => 'Category 1.1.2',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()))
 					),
 					array(
@@ -3180,7 +3180,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '1',
 							'name' => 'Category 1.2',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					)
@@ -3192,7 +3192,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => '0',
 					'name' => 'Category 2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array()
 			),
@@ -3202,7 +3202,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => '0',
 					'name' => 'Category 3',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3211,7 +3211,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '5',
 							'name' => 'Category 3.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					)
@@ -3231,7 +3231,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => '0',
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3240,7 +3240,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '1',
 							'name' => 'Category 1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array(
 							array('Category' => array(
@@ -3248,14 +3248,14 @@ class ModelReadTest extends BaseModelTest {
 								'parent_id' => '2',
 								'name' => 'Category 1.1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()),
 							array('Category' => array(
 								'id' => '8',
 								'parent_id' => '2',
 								'name' => 'Category 1.1.2',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()))
 					),
 					array(
@@ -3264,7 +3264,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '1',
 							'name' => 'Category 1.2',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					)
@@ -3350,7 +3350,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 0,
 					'name' => 'Category 3',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3359,7 +3359,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => 5,
 							'name' => 'Category 3.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					)
@@ -3371,7 +3371,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 0,
 					'name' => 'Category 2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array()
 			),
@@ -3381,7 +3381,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 0,
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3390,7 +3390,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => 1,
 							'name' => 'Category 1.2',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					),
@@ -3400,7 +3400,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => 1,
 							'name' => 'Category 1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array(
 							array('Category' => array(
@@ -3408,14 +3408,14 @@ class ModelReadTest extends BaseModelTest {
 								'parent_id' => '2',
 								'name' => 'Category 1.1.2',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()),
 							array('Category' => array(
 								'id' => '7',
 								'parent_id' => '2',
 								'name' => 'Category 1.1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()))
 					)
 				)
@@ -3433,7 +3433,7 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => '0',
 					'name' => 'Category 3',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'children' => array(
 					array(
@@ -3442,7 +3442,7 @@ class ModelReadTest extends BaseModelTest {
 							'parent_id' => '5',
 							'name' => 'Category 3.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31'
+							'modified' => '2007-03-18 15:32:31'
 						),
 						'children' => array()
 					)
@@ -3461,21 +3461,21 @@ class ModelReadTest extends BaseModelTest {
 						'parent_id' => '1',
 						'name' => 'Category 1.1',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31'),
+						'modified' => '2007-03-18 15:32:31'),
 						'children' => array(
 							array('Category' => array(
 								'id' => '7',
 								'parent_id' => '2',
 								'name' => 'Category 1.1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()),
 							array('Category' => array(
 								'id' => '8',
 								'parent_id' => '2',
 								'name' => 'Category 1.1.2',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31'),
+								'modified' => '2007-03-18 15:32:31'),
 								'children' => array()))));
 		$this->assertEquals($expected, $result);
 
@@ -3661,7 +3661,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				)
 			)
 		);
@@ -3678,7 +3678,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				)
 			),
 			'next' => array(
@@ -3689,7 +3689,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				)
 			)
 		);
@@ -3706,7 +3706,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				)
 			),
 			'next' => null
@@ -4135,7 +4135,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				)
 			),
 			array(
@@ -4146,7 +4146,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				)
 			)
 		);
@@ -4170,7 +4170,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				)
 			),
 			array(
@@ -4181,7 +4181,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				)
 			),
 			array(
@@ -4192,7 +4192,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				)
 			)
 		);
@@ -4243,7 +4243,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -4252,7 +4252,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 					),
 					array(
 						'id' => '5',
@@ -4261,7 +4261,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 			))),
 			array(
 				'User' => array(
@@ -4276,7 +4276,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -4285,7 +4285,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'User' => array(
@@ -4307,7 +4307,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -4338,7 +4338,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -4347,7 +4347,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 					),
 					array(
 						'id' => '5',
@@ -4356,7 +4356,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 			))),
 			array(
 				'User' => array(
@@ -4371,7 +4371,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -4380,7 +4380,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'User' => array(
@@ -4402,7 +4402,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -4460,7 +4460,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -4469,7 +4469,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 					),
 					array(
 						'id' => '5',
@@ -4478,7 +4478,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 			))),
 			array(
 				'User' => array(
@@ -4493,7 +4493,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -4502,7 +4502,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'User' => array(
@@ -4525,7 +4525,7 @@ class ModelReadTest extends BaseModelTest {
 						'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 		))));
 		$this->assertEquals($expected, $result);
 
@@ -4570,7 +4570,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '5',
@@ -4579,7 +4579,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 			))),
 			array(
 				'User' => array(
@@ -4594,7 +4594,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -4603,7 +4603,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'User' => array(
@@ -4625,7 +4625,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -4729,7 +4729,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -4738,7 +4738,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 					),
 					array(
 						'id' => '5',
@@ -4747,7 +4747,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31'
+						'modified' => '2007-03-18 10:55:31'
 			))),
 			array(
 				'User' => array(
@@ -4762,7 +4762,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '6',
@@ -4771,7 +4771,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31'
+						'modified' => '2007-03-18 10:57:31'
 			))),
 			array(
 				'User' => array(
@@ -4793,7 +4793,7 @@ class ModelReadTest extends BaseModelTest {
 							'comment' => 'Second Comment for First Article',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:47:23',
-							'updated' => '2007-03-18 10:49:31'
+							'modified' => '2007-03-18 10:49:31'
 		))));
 		$this->assertEquals($expected, $result);
 
@@ -4820,7 +4820,7 @@ class ModelReadTest extends BaseModelTest {
 						'body' => 'First Article Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:39:23',
-						'updated' => '2007-03-18 10:41:31'
+						'modified' => '2007-03-18 10:41:31'
 					),
 					array(
 						'id' => 3,
@@ -4829,7 +4829,7 @@ class ModelReadTest extends BaseModelTest {
 						'body' => 'Third Article Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:43:23',
-						'updated' => '2007-03-18 10:45:31'
+						'modified' => '2007-03-18 10:45:31'
 			))),
 			array(
 				'User' => array(
@@ -4851,7 +4851,7 @@ class ModelReadTest extends BaseModelTest {
 						'body' => 'Second Article Body',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:41:23',
-						'updated' => '2007-03-18 10:43:31'
+						'modified' => '2007-03-18 10:43:31'
 			))),
 			array(
 				'User' => array(
@@ -5004,14 +5004,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'Author' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31',
+					'modified' => '2007-03-17 01:18:31',
 					'test' => 'working'
 			)),
 			array(
@@ -5022,14 +5022,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'Author' => array(
 					'id' => '3',
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31',
+					'modified' => '2007-03-17 01:22:31',
 					'test' => 'working'
 			)),
 			array(
@@ -5040,14 +5040,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'Author' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31',
+					'modified' => '2007-03-17 01:18:31',
 					'test' => 'working'
 		)));
 		$this->assertEquals($expected, $result);
@@ -5073,7 +5073,7 @@ class ModelReadTest extends BaseModelTest {
 			'comment' => 'First Comment for First Article',
 			'published' => 'Y',
 			'created' => '2007-03-18 10:45:23',
-			'updated' => '2007-03-18 10:47:31',
+			'modified' => '2007-03-18 10:47:31',
 			'callback' => 'Fire'
 		);
 		$this->assertEquals($expected, $result[0]['Post'][0]['Comment'][0]);
@@ -5159,14 +5159,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'Author' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 			)),
 			array(
 				'Post' => array(
@@ -5176,14 +5176,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'Author' => array(
 					'id' => '3',
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 			)),
 			array(
 				'Post' => array(
@@ -5193,14 +5193,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'Author' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 		)));
 		$this->assertEquals($expected, $result);
 		unset($TestModel);
@@ -5226,7 +5226,7 @@ class ModelReadTest extends BaseModelTest {
 			'comment' => 'First Comment for First Article',
 			'published' => 'Y',
 			'created' => '2007-03-18 10:45:23',
-			'updated' => '2007-03-18 10:47:31'
+			'modified' => '2007-03-18 10:47:31'
 		);
 		$this->assertEquals($expected, $result[0]['Post'][0]['Comment'][0]);
 	}
@@ -5436,14 +5436,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'Author' => array(
 					'id' => 1,
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31',
+					'modified' => '2007-03-17 01:18:31',
 					'test' => 'working'
 				),
 				'Tag' => array(
@@ -5451,13 +5451,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '2',
 						'tag' => 'tag2',
 						'created' => '2007-03-18 12:24:23',
-						'updated' => '2007-03-18 12:26:31'
+						'modified' => '2007-03-18 12:26:31'
 			))),
 			array(
 				'Post' => array(
@@ -5467,14 +5467,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'Author' => array(
 					'id' => 3,
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31',
+					'modified' => '2007-03-17 01:22:31',
 					'test' => 'working'
 				),
 				'Tag' => array(
@@ -5482,13 +5482,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 						),
 					array(
 						'id' => '3',
 						'tag' => 'tag3',
 						'created' => '2007-03-18 12:26:23',
-						'updated' => '2007-03-18 12:28:31'
+						'modified' => '2007-03-18 12:28:31'
 			))),
 			array(
 				'Post' => array(
@@ -5498,14 +5498,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'Author' => array(
 					'id' => 1,
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31',
+					'modified' => '2007-03-17 01:18:31',
 					'test' => 'working'
 				),
 				'Tag' => array()
@@ -5580,14 +5580,14 @@ class ModelReadTest extends BaseModelTest {
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			),
 			'User' => array(
 				'id' => '3',
 				'user' => 'larry',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:20:23',
-				'updated' => '2007-03-17 01:22:31'
+				'modified' => '2007-03-17 01:22:31'
 			),
 			'Comment' => array(
 				array(
@@ -5597,7 +5597,7 @@ class ModelReadTest extends BaseModelTest {
 					'comment' => 'First Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:53:23',
-					'updated' => '2007-03-18 10:55:31'
+					'modified' => '2007-03-18 10:55:31'
 				),
 				array(
 					'id' => '6',
@@ -5606,20 +5606,20 @@ class ModelReadTest extends BaseModelTest {
 					'comment' => 'Second Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:55:23',
-					'updated' => '2007-03-18 10:57:31'
+					'modified' => '2007-03-18 10:57:31'
 			)),
 			'Tag' => array(
 				array(
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 
 		$this->assertEquals($expected, $result);
@@ -5768,13 +5768,13 @@ class ModelReadTest extends BaseModelTest {
 					'advertisement_id' => '1',
 					'title' => 'First Home',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'AnotherArticle' => array(
 					'id' => '1',
 					'title' => 'First Article',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31',
+					'modified' => '2007-03-18 10:41:31',
 					'Home' => array(
 						array(
 							'id' => '1',
@@ -5782,13 +5782,13 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'First Home',
 							'created' => '2007-03-18 10:39:23',
-							'updated' => '2007-03-18 10:41:31'
+							'modified' => '2007-03-18 10:41:31'
 				))),
 				'Advertisement' => array(
 					'id' => '1',
 					'title' => 'First Ad',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31',
+					'modified' => '2007-03-18 10:41:31',
 					'Home' => array(
 						array(
 							'id' => '1',
@@ -5796,7 +5796,7 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'First Home',
 							'created' => '2007-03-18 10:39:23',
-							'updated' => '2007-03-18 10:41:31'
+							'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => '2',
@@ -5804,7 +5804,7 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'Second Home',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 			)))),
 			array(
 				'Home' => array(
@@ -5813,13 +5813,13 @@ class ModelReadTest extends BaseModelTest {
 					'advertisement_id' => '1',
 					'title' => 'Second Home',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'AnotherArticle' => array(
 					'id' => '3',
 					'title' => 'Third Article',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31',
+					'modified' => '2007-03-18 10:45:31',
 					'Home' => array(
 						array(
 							'id' => '2',
@@ -5827,13 +5827,13 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'Second Home',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 				))),
 				'Advertisement' => array(
 					'id' => '1',
 					'title' => 'First Ad',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31',
+					'modified' => '2007-03-18 10:41:31',
 					'Home' => array(
 						array(
 							'id' => '1',
@@ -5841,7 +5841,7 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'First Home',
 							'created' => '2007-03-18 10:39:23',
-							'updated' => '2007-03-18 10:41:31'
+							'modified' => '2007-03-18 10:41:31'
 						),
 						array(
 							'id' => '2',
@@ -5849,7 +5849,7 @@ class ModelReadTest extends BaseModelTest {
 							'advertisement_id' => '1',
 							'title' => 'Second Home',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 		)))));
 
 		$this->assertEquals($expected, $result);
@@ -5945,44 +5945,44 @@ class ModelReadTest extends BaseModelTest {
 				'parent_id' => 6,
 				'name' => 'Category 2.1',
 				'created' => '2007-03-18 15:30:23',
-				'updated' => '2007-03-18 15:32:31'
+				'modified' => '2007-03-18 15:32:31'
 			),
 			'ParentCategory' => array(
 				'id' => 6,
 				'parent_id' => 5,
 				'name' => 'Category 2',
 				'created' => '2007-03-18 15:30:23',
-				'updated' => '2007-03-18 15:32:31',
+				'modified' => '2007-03-18 15:32:31',
 				'ParentCategory' => array(
 					'id' => 5,
 					'parent_id' => 4,
 					'name' => 'Category 1.1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 4,
 						'parent_id' => 3,
 						'name' => 'Category 1.1.2',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 3,
 							'parent_id' => 2,
 							'name' => 'Category 1.1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 2,
 								'parent_id' => 1,
 								'name' => 'Category 1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 								'ParentCategory' => array(
 									'id' => 1,
 									'parent_id' => 0,
 									'name' => 'Category 1',
 									'created' => '2007-03-18 15:30:23',
-									'updated' => '2007-03-18 15:32:31'
+									'modified' => '2007-03-18 15:32:31'
 		)))))));
 
 		$this->db->fullDebug = $fullDebug;
@@ -6009,44 +6009,44 @@ class ModelReadTest extends BaseModelTest {
 				'parent_id' => 6,
 				'name' => 'Category 2.1',
 				'created' => '2007-03-18 15:30:23',
-				'updated' => '2007-03-18 15:32:31'
+				'modified' => '2007-03-18 15:32:31'
 			),
 			'ParentCategory' => array(
 				'id' => 6,
 				'parent_id' => 5,
 				'name' => 'Category 2',
 				'created' => '2007-03-18 15:30:23',
-				'updated' => '2007-03-18 15:32:31',
+				'modified' => '2007-03-18 15:32:31',
 				'ParentCategory' => array(
 					'id' => 5,
 					'parent_id' => 4,
 					'name' => 'Category 1.1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 4,
 						'parent_id' => 3,
 						'name' => 'Category 1.1.2',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 3,
 							'parent_id' => 2,
 							'name' => 'Category 1.1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 2,
 								'parent_id' => 1,
 								'name' => 'Category 1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 								'ParentCategory' => array(
 									'id' => 1,
 									'parent_id' => 0,
 									'name' => 'Category 1',
 									'created' => '2007-03-18 15:30:23',
-									'updated' => '2007-03-18 15:32:31'
+									'modified' => '2007-03-18 15:32:31'
 		)))))));
 
 		$this->db->fullDebug = $fullDebug;
@@ -6073,14 +6073,14 @@ class ModelReadTest extends BaseModelTest {
 				'parent_id' => 0,
 				'name' => 'Category 1',
 				'created' => '2007-03-18 15:30:23',
-				'updated' => '2007-03-18 15:32:31'
+				'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => null,
 					'parent_id' => null,
 					'name' => null,
 					'created' => null,
-					'updated' => null,
+					'modified' => null,
 					'ParentCategory' => array()
 			)),
 			array(
@@ -6089,14 +6089,14 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 1,
 					'name' => 'Category 1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 1,
 					'parent_id' => 0,
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array()
 				)),
 			array(
@@ -6105,20 +6105,20 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 2,
 					'name' => 'Category 1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 2,
 					'parent_id' => 1,
 					'name' => 'Category 1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 1,
 						'parent_id' => 0,
 						'name' => 'Category 1',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array()
 			))),
 			array(
@@ -6127,26 +6127,26 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 3,
 					'name' => 'Category 1.1.2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 3,
 					'parent_id' => 2,
 					'name' => 'Category 1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 2,
 						'parent_id' => 1,
 						'name' => 'Category 1.1',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 1,
 							'parent_id' => 0,
 							'name' => 'Category 1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array()
 			)))),
 			array(
@@ -6155,32 +6155,32 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 4,
 					'name' => 'Category 1.1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 4,
 					'parent_id' => 3,
 					'name' => 'Category 1.1.2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 3,
 						'parent_id' => 2,
 						'name' => 'Category 1.1.1',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 2,
 							'parent_id' => 1,
 							'name' => 'Category 1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 1,
 								'parent_id' => 0,
 								'name' => 'Category 1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 								'ParentCategory' => array()
 			))))),
 			array(
@@ -6189,38 +6189,38 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 5,
 					'name' => 'Category 2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 5,
 					'parent_id' => 4,
 					'name' => 'Category 1.1.1.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 4,
 						'parent_id' => 3,
 						'name' => 'Category 1.1.2',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 3,
 							'parent_id' => 2,
 							'name' => 'Category 1.1.1',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 2,
 								'parent_id' => 1,
 								'name' => 'Category 1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 								'ParentCategory' => array(
 									'id' => 1,
 									'parent_id' => 0,
 									'name' => 'Category 1',
 									'created' => '2007-03-18 15:30:23',
-									'updated' => '2007-03-18 15:32:31',
+									'modified' => '2007-03-18 15:32:31',
 									'ParentCategory' => array()
 			)))))),
 			array(
@@ -6229,44 +6229,44 @@ class ModelReadTest extends BaseModelTest {
 					'parent_id' => 6,
 					'name' => 'Category 2.1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				),
 				'ParentCategory' => array(
 					'id' => 6,
 					'parent_id' => 5,
 					'name' => 'Category 2',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31',
+					'modified' => '2007-03-18 15:32:31',
 					'ParentCategory' => array(
 						'id' => 5,
 						'parent_id' => 4,
 						'name' => 'Category 1.1.1.1',
 						'created' => '2007-03-18 15:30:23',
-						'updated' => '2007-03-18 15:32:31',
+						'modified' => '2007-03-18 15:32:31',
 						'ParentCategory' => array(
 							'id' => 4,
 							'parent_id' => 3,
 							'name' => 'Category 1.1.2',
 							'created' => '2007-03-18 15:30:23',
-							'updated' => '2007-03-18 15:32:31',
+							'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 3,
 								'parent_id' => 2,
 								'name' => 'Category 1.1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 							'ParentCategory' => array(
 								'id' => 2,
 								'parent_id' => 1,
 								'name' => 'Category 1.1',
 								'created' => '2007-03-18 15:30:23',
-								'updated' => '2007-03-18 15:32:31',
+								'modified' => '2007-03-18 15:32:31',
 								'ParentCategory' => array(
 									'id' => 1,
 									'parent_id' => 0,
 									'name' => 'Category 1',
 									'created' => '2007-03-18 15:30:23',
-									'updated' => '2007-03-18 15:32:31'
+									'modified' => '2007-03-18 15:32:31'
 		))))))));
 
 		$this->db->fullDebug = $fullDebug;
@@ -6338,7 +6338,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 			)),
 			array(
 				'User' => array(
@@ -6346,7 +6346,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'nate',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:18:23',
-					'updated' => '2007-03-17 01:20:31'
+					'modified' => '2007-03-17 01:20:31'
 			)),
 			array(
 				'User' => array(
@@ -6354,7 +6354,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 			)),
 			array(
 				'User' => array(
@@ -6362,7 +6362,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'garrett',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:22:23',
-					'updated' => '2007-03-17 01:24:31'
+					'modified' => '2007-03-17 01:24:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6374,7 +6374,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 			)),
 			array(
 				'User' => array(
@@ -6382,7 +6382,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'garrett',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:22:23',
-					'updated' => '2007-03-17 01:24:31'
+					'modified' => '2007-03-17 01:24:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6396,7 +6396,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 			)),
 			array(
 				'User' => array(
@@ -6404,7 +6404,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'garrett',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:22:23',
-					'updated' => '2007-03-17 01:24:31'
+					'modified' => '2007-03-17 01:24:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6423,7 +6423,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 			)),
 			array(
 				'User' => array(
@@ -6431,7 +6431,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'nate',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:18:23',
-					'updated' => '2007-03-17 01:20:31'
+					'modified' => '2007-03-17 01:20:31'
 			)),
 			array(
 				'User' => array(
@@ -6439,7 +6439,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 			)),
 			array(
 				'User' => array(
@@ -6447,7 +6447,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'garrett',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:22:23',
-					'updated' => '2007-03-17 01:24:31'
+					'modified' => '2007-03-17 01:24:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6484,7 +6484,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 			)),
 			array(
 				'User' => array(
@@ -6492,7 +6492,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'nate',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:18:23',
-					'updated' => '2007-03-17 01:20:31'
+					'modified' => '2007-03-17 01:20:31'
 			)),
 			array(
 				'User' => array(
@@ -6500,7 +6500,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6516,7 +6516,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 			)),
 			array(
 				'User' => array(
@@ -6524,7 +6524,7 @@ class ModelReadTest extends BaseModelTest {
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -6539,7 +6539,7 @@ class ModelReadTest extends BaseModelTest {
 						'user' => 'garrett',
 						'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 						'created' => '2007-03-17 01:22:23',
-						'updated' => '2007-03-17 01:24:31'
+						'modified' => '2007-03-17 01:24:31'
 			)));
 			$this->assertEquals($expected, $result);
 
@@ -6612,7 +6612,7 @@ class ModelReadTest extends BaseModelTest {
 				'body' => 'First Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			),
 			2 => array(
 				'id' => 2,
@@ -6621,7 +6621,7 @@ class ModelReadTest extends BaseModelTest {
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			),
 			3 => array(
 				'id' => 3,
@@ -6630,7 +6630,7 @@ class ModelReadTest extends BaseModelTest {
 				'body' => 'Third Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'modified' => '2007-03-18 10:45:31'
 		));
 
 		$this->assertEquals($expected, $result);
@@ -6650,7 +6650,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				3 => array(
 					'id' => 3,
@@ -6659,7 +6659,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				)),
 			3 => array(
 				2 => array(
@@ -6669,7 +6669,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 		)));
 
 		$this->assertEquals($expected, $result);
@@ -6994,7 +6994,7 @@ class ModelReadTest extends BaseModelTest {
 				'user' => 'mariano',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:16:23',
-				'updated' => '2007-03-17 01:18:31'
+				'modified' => '2007-03-17 01:18:31'
 		));
 		$this->assertEquals($expected, $result);
 
@@ -7004,7 +7004,7 @@ class ModelReadTest extends BaseModelTest {
 			'user' => 'mariano',
 			'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 			'created' => '2007-03-17 01:16:23',
-			'updated' => '2007-03-17 01:18:31'
+			'modified' => '2007-03-17 01:18:31'
 		));
 		$this->assertEquals($expected, $result);
 	}
@@ -7029,7 +7029,7 @@ class ModelReadTest extends BaseModelTest {
 				'user' => 'nate',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:18:23',
-				'updated' => '2007-03-17 01:20:31'
+				'modified' => '2007-03-17 01:20:31'
 		));
 		$this->assertEquals($expected, $result);
 
@@ -7040,7 +7040,7 @@ class ModelReadTest extends BaseModelTest {
 				'user' => 'nate',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:18:23',
-				'updated' => '2007-03-17 01:20:31'
+				'modified' => '2007-03-17 01:20:31'
 		));
 		$this->assertEquals($expected, $result);
 
@@ -7075,7 +7075,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				array(
 					'id' => '3',
@@ -7084,7 +7084,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 		)));
 		$this->assertEquals($expected, $result);
 	}
@@ -7131,7 +7131,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				array(
 					'id' => '3',
@@ -7140,7 +7140,7 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -7159,13 +7159,13 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31',
+					'modified' => '2007-03-18 10:43:31',
 					'User' => array(
 						'id' => '3',
 						'user' => 'larry',
 						'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 						'created' => '2007-03-17 01:20:23',
-						'updated' => '2007-03-17 01:22:31'
+						'modified' => '2007-03-17 01:22:31'
 					),
 					'Comment' => array(
 						array(
@@ -7175,7 +7175,7 @@ class ModelReadTest extends BaseModelTest {
 							'comment' => 'First Comment for Second Article',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:53:23',
-							'updated' => '2007-03-18 10:55:31'
+							'modified' => '2007-03-18 10:55:31'
 						),
 						array(
 							'id' => '6',
@@ -7184,20 +7184,20 @@ class ModelReadTest extends BaseModelTest {
 							'comment' => 'Second Comment for Second Article',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:55:23',
-							'updated' => '2007-03-18 10:57:31'
+							'modified' => '2007-03-18 10:57:31'
 					)),
 					'Tag' => array(
 						array(
 							'id' => '1',
 							'tag' => 'tag1',
 							'created' => '2007-03-18 12:22:23',
-							'updated' => '2007-03-18 12:24:31'
+							'modified' => '2007-03-18 12:24:31'
 						),
 						array(
 							'id' => '3',
 							'tag' => 'tag3',
 							'created' => '2007-03-18 12:26:23',
-							'updated' => '2007-03-18 12:28:31'
+							'modified' => '2007-03-18 12:28:31'
 		)))));
 		$this->assertEquals($expected, $result);
 	}
@@ -7227,14 +7227,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(
 					array(
@@ -7244,7 +7244,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '2',
@@ -7253,7 +7253,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 					),
 					array(
 						'id' => '3',
@@ -7262,7 +7262,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Third Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:49:23',
-						'updated' => '2007-03-18 10:51:31'
+						'modified' => '2007-03-18 10:51:31'
 					),
 					array(
 						'id' => '4',
@@ -7271,7 +7271,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Fourth Comment for First Article',
 						'published' => 'N',
 						'created' => '2007-03-18 10:51:23',
-						'updated' => '2007-03-18 10:53:31'
+						'modified' => '2007-03-18 10:53:31'
 					)
 				),
 				'Tag' => array(
@@ -7279,13 +7279,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '2',
 						'tag' => 'tag2',
 						'created' => '2007-03-18 12:24:23',
-						'updated' => '2007-03-18 12:26:31'
+						'modified' => '2007-03-18 12:26:31'
 			))),
 			array(
 				'Article' => array(
@@ -7295,14 +7295,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(),
 				'Tag' => array()
@@ -7325,14 +7325,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => '3',
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 				),
 				'Comment' => array(
 					array(
@@ -7342,7 +7342,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31',
+						'modified' => '2007-03-18 10:55:31',
 						'Article' => array(
 							'id' => '2',
 							'user_id' => '3',
@@ -7350,21 +7350,21 @@ class ModelReadTest extends BaseModelTest {
 							'body' => 'Second Article Body',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 						),
 						'User' => array(
 							'id' => '1',
 							'user' => 'mariano',
 							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 							'created' => '2007-03-17 01:16:23',
-							'updated' => '2007-03-17 01:18:31'
+							'modified' => '2007-03-17 01:18:31'
 						),
 						'Attachment' => array(
 							'id' => '1',
 							'comment_id' => 5,
 							'attachment' => 'attachment.zip',
 							'created' => '2007-03-18 10:51:23',
-							'updated' => '2007-03-18 10:53:31'
+							'modified' => '2007-03-18 10:53:31'
 						)
 					),
 					array(
@@ -7374,7 +7374,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:55:23',
-						'updated' => '2007-03-18 10:57:31',
+						'modified' => '2007-03-18 10:57:31',
 						'Article' => array(
 							'id' => '2',
 							'user_id' => '3',
@@ -7382,14 +7382,14 @@ class ModelReadTest extends BaseModelTest {
 							'body' => 'Second Article Body',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 						),
 						'User' => array(
 							'id' => '2',
 							'user' => 'nate',
 							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 							'created' => '2007-03-17 01:18:23',
-							'updated' => '2007-03-17 01:20:31'
+							'modified' => '2007-03-17 01:20:31'
 						),
 						'Attachment' => array()
 					)
@@ -7399,13 +7399,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '3',
 						'tag' => 'tag3',
 						'created' => '2007-03-18 12:26:23',
-						'updated' => '2007-03-18 12:28:31'
+						'modified' => '2007-03-18 12:28:31'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -7441,7 +7441,7 @@ class ModelReadTest extends BaseModelTest {
 					'published_date' => '2007-03-31 10:39:23',
 					'end_date' => '2007-05-15 10:39:23',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'ArticleFeatured' => array(
 					'id' => '1',
@@ -7453,7 +7453,7 @@ class ModelReadTest extends BaseModelTest {
 						'user' => 'mariano',
 						'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 						'created' => '2007-03-17 01:16:23',
-						'updated' => '2007-03-17 01:18:31'
+						'modified' => '2007-03-17 01:18:31'
 					),
 					'Category' => array(),
 					'Featured' => array(
@@ -7463,14 +7463,14 @@ class ModelReadTest extends BaseModelTest {
 						'published_date' => '2007-03-31 10:39:23',
 						'end_date' => '2007-05-15 10:39:23',
 						'created' => '2007-03-18 10:39:23',
-						'updated' => '2007-03-18 10:41:31'
+						'modified' => '2007-03-18 10:41:31'
 				)),
 				'Category' => array(
 					'id' => '1',
 					'parent_id' => '0',
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 				)),
 			array(
 				'Featured' => array(
@@ -7480,7 +7480,7 @@ class ModelReadTest extends BaseModelTest {
 					'published_date' => '2007-03-31 10:39:23',
 					'end_date' => '2007-05-15 10:39:23',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'ArticleFeatured' => array(
 					'id' => '2',
@@ -7492,7 +7492,7 @@ class ModelReadTest extends BaseModelTest {
 						'user' => 'larry',
 						'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 						'created' => '2007-03-17 01:20:23',
-						'updated' => '2007-03-17 01:22:31'
+						'modified' => '2007-03-17 01:22:31'
 					),
 					'Category' => array(),
 					'Featured' => array(
@@ -7502,14 +7502,14 @@ class ModelReadTest extends BaseModelTest {
 						'published_date' => '2007-03-31 10:39:23',
 						'end_date' => '2007-05-15 10:39:23',
 						'created' => '2007-03-18 10:39:23',
-						'updated' => '2007-03-18 10:41:31'
+						'modified' => '2007-03-18 10:41:31'
 				)),
 				'Category' => array(
 					'id' => '1',
 					'parent_id' => '0',
 					'name' => 'Category 1',
 					'created' => '2007-03-18 15:30:23',
-					'updated' => '2007-03-18 15:32:31'
+					'modified' => '2007-03-18 15:32:31'
 		)));
 		$this->assertEquals($expected, $result);
 	}
@@ -7537,14 +7537,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'First Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:39:23',
-					'updated' => '2007-03-18 10:41:31'
+					'modified' => '2007-03-18 10:41:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(
 					array(
@@ -7554,7 +7554,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:45:23',
-						'updated' => '2007-03-18 10:47:31'
+						'modified' => '2007-03-18 10:47:31'
 					),
 					array(
 						'id' => '2',
@@ -7563,7 +7563,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'Second Comment for First Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:47:23',
-						'updated' => '2007-03-18 10:49:31'
+						'modified' => '2007-03-18 10:49:31'
 					),
 				),
 				'Tag' => array(
@@ -7571,13 +7571,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '2',
 						'tag' => 'tag2',
 						'created' => '2007-03-18 12:24:23',
-						'updated' => '2007-03-18 12:26:31'
+						'modified' => '2007-03-18 12:26:31'
 			))),
 			array(
 				'Article' => array(
@@ -7587,14 +7587,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Third Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				),
 				'User' => array(
 					'id' => '1',
 					'user' => 'mariano',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:16:23',
-					'updated' => '2007-03-17 01:18:31'
+					'modified' => '2007-03-17 01:18:31'
 				),
 				'Comment' => array(),
 				'Tag' => array()
@@ -7618,14 +7618,14 @@ class ModelReadTest extends BaseModelTest {
 					'body' => 'Second Article Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:41:23',
-					'updated' => '2007-03-18 10:43:31'
+					'modified' => '2007-03-18 10:43:31'
 				),
 				'User' => array(
 					'id' => '3',
 					'user' => 'larry',
 					'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 					'created' => '2007-03-17 01:20:23',
-					'updated' => '2007-03-17 01:22:31'
+					'modified' => '2007-03-17 01:22:31'
 				),
 				'Comment' => array(
 					array(
@@ -7635,7 +7635,7 @@ class ModelReadTest extends BaseModelTest {
 						'comment' => 'First Comment for Second Article',
 						'published' => 'Y',
 						'created' => '2007-03-18 10:53:23',
-						'updated' => '2007-03-18 10:55:31',
+						'modified' => '2007-03-18 10:55:31',
 						'Article' => array(
 							'id' => '2',
 							'user_id' => '3',
@@ -7643,21 +7643,21 @@ class ModelReadTest extends BaseModelTest {
 							'body' => 'Second Article Body',
 							'published' => 'Y',
 							'created' => '2007-03-18 10:41:23',
-							'updated' => '2007-03-18 10:43:31'
+							'modified' => '2007-03-18 10:43:31'
 						),
 						'User' => array(
 							'id' => '1',
 							'user' => 'mariano',
 							'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 							'created' => '2007-03-17 01:16:23',
-							'updated' => '2007-03-17 01:18:31'
+							'modified' => '2007-03-17 01:18:31'
 						),
 						'Attachment' => array(
 							'id' => '1',
 							'comment_id' => 5,
 							'attachment' => 'attachment.zip',
 							'created' => '2007-03-18 10:51:23',
-							'updated' => '2007-03-18 10:53:31'
+							'modified' => '2007-03-18 10:53:31'
 						)
 					)
 				),
@@ -7666,13 +7666,13 @@ class ModelReadTest extends BaseModelTest {
 						'id' => '1',
 						'tag' => 'tag1',
 						'created' => '2007-03-18 12:22:23',
-						'updated' => '2007-03-18 12:24:31'
+						'modified' => '2007-03-18 12:24:31'
 					),
 					array(
 						'id' => '3',
 						'tag' => 'tag3',
 						'created' => '2007-03-18 12:26:23',
-						'updated' => '2007-03-18 12:28:31'
+						'modified' => '2007-03-18 12:28:31'
 					)
 				)
 			)

--- a/lib/Cake/Test/TestCase/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelValidationTest.php
@@ -2048,7 +2048,7 @@ class ModelValidationTest extends BaseModelTest {
 				'created' => '2007-03-18 10:39:23'
 			),
 		);
-		unset($result['Article']['updated']);
+		unset($result['Article']['modified']);
 		$this->assertEquals($expected['Article'], $result['Article']);
 
 		$data = array(
@@ -2067,7 +2067,7 @@ class ModelValidationTest extends BaseModelTest {
 			'conditions' => array('Article.id' => 1)
 		));
 		$expected['Article']['title'] = 'First Article (modified)';
-		unset($result['Article']['updated']);
+		unset($result['Article']['modified']);
 		$this->assertEquals($expected['Article'], $result['Article']);
 	}
 

--- a/lib/Cake/Test/TestCase/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelWriteTest.php
@@ -61,7 +61,7 @@ class ModelWriteTest extends BaseModelTest {
 				'join_b_id' => 2,
 				'other' => 'Data for Join A 1 Join B 2',
 				'created' => '2008-01-03 10:56:33',
-				'updated' => '2008-01-03 10:56:33'
+				'modified' => '2008-01-03 10:56:33'
 		));
 		$this->assertEquals($expected, $result);
 
@@ -71,7 +71,7 @@ class ModelWriteTest extends BaseModelTest {
 			'join_b_id' => 1,
 			'other' => 'Data for Join A 1 Join B 1',
 			'created' => '2008-01-03 10:56:44',
-			'updated' => '2008-01-03 10:56:44'
+			'modified' => '2008-01-03 10:56:44'
 		);
 		$result = $TestModel->JoinAsJoinB->save($data);
 		$lastInsertId = $TestModel->JoinAsJoinB->getLastInsertID();
@@ -87,7 +87,7 @@ class ModelWriteTest extends BaseModelTest {
 				'join_b_id' => 2,
 				'other' => 'Data for Join A 1 Join B 2',
 				'created' => '2008-01-03 10:56:33',
-				'updated' => '2008-01-03 10:56:33'
+				'modified' => '2008-01-03 10:56:33'
 		));
 		$this->assertEquals($expected, $result);
 
@@ -170,7 +170,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save(array('title' => 'Test record'));
 		$result = $TestModel->findByTitle('Test record');
 		$this->assertEquals(
-			array('id', 'title', 'count', 'created', 'updated'),
+			array('id', 'title', 'count', 'created', 'modified'),
 			array_keys($result['Uuid'])
 		);
 		$this->assertEquals(36, strlen($result['Uuid']['id']));
@@ -192,7 +192,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel->save(array('title' => 'Test record', 'id' => null));
 		$result = $TestModel->findByTitle('Test record');
 		$this->assertEquals(
-			array('id', 'title', 'count', 'created', 'updated'),
+			array('id', 'title', 'count', 'created', 'modified'),
 			array_keys($result['Uuid'])
 		);
 		$this->assertEquals(36, strlen($result['Uuid']['id']));
@@ -440,7 +440,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->db->query('ALTER TABLE ' . $this->db->fullTableName('category_threads') . ' ADD ' . $column);
 		$this->db->flushMethodCache();
 		$Category = new CategoryThread();
-		$result = $Category->updateAll(array('CategoryThread.name' => "'updated'"), array('CategoryThread.parent_id' => 5));
+		$result = $Category->updateAll(array('CategoryThread.name' => "'modified'"), array('CategoryThread.parent_id' => 5));
 		$this->assertFalse(empty($result));
 
 		$Category = new CategoryThread();
@@ -782,7 +782,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'New Article',
 				'body' => 'New Article Body',
 				'created' => '2007-03-18 14:55:23',
-				'updated' => '2007-03-18 14:57:31'
+				'modified' => '2007-03-18 14:57:31'
 			),
 			'Tag' => array('Tag' => array(1, 3))
 		);
@@ -800,14 +800,14 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'New Article Body',
 				'published' => 'N',
 				'created' => '2007-03-18 14:55:23',
-				'updated' => '2007-03-18 14:57:31'
+				'modified' => '2007-03-18 14:57:31'
 			),
 			'User' => array(
 				'id' => '2',
 				'user' => 'nate',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:18:23',
-				'updated' => '2007-03-17 01:20:31'
+				'modified' => '2007-03-17 01:20:31'
 			),
 			'Comment' => array(),
 			'Tag' => array(
@@ -815,13 +815,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -831,7 +831,7 @@ class ModelWriteTest extends BaseModelTest {
 			'comment' => 'Comment New Article',
 			'published' => 'Y',
 			'created' => '2007-03-18 14:57:23',
-			'updated' => '2007-03-18 14:59:31'
+			'modified' => '2007-03-18 14:59:31'
 		));
 		$result = $TestModel->Comment->create() && $TestModel->Comment->save($data);
 		$this->assertFalse(empty($result));
@@ -840,7 +840,7 @@ class ModelWriteTest extends BaseModelTest {
 			'comment_id' => '7',
 			'attachment' => 'newattachment.zip',
 			'created' => '2007-03-18 15:02:23',
-			'updated' => '2007-03-18 15:04:31'
+			'modified' => '2007-03-18 15:04:31'
 		));
 		$result = $TestModel->Comment->Attachment->save($data);
 		$this->assertFalse(empty($result));
@@ -855,14 +855,14 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'New Article Body',
 				'published' => 'N',
 				'created' => '2007-03-18 14:55:23',
-				'updated' => '2007-03-18 14:57:31'
+				'modified' => '2007-03-18 14:57:31'
 			),
 			'User' => array(
 				'id' => '2',
 				'user' => 'nate',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:18:23',
-				'updated' => '2007-03-17 01:20:31'
+				'modified' => '2007-03-17 01:20:31'
 			),
 			'Comment' => array(
 				array(
@@ -872,7 +872,7 @@ class ModelWriteTest extends BaseModelTest {
 					'comment' => 'Comment New Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 14:57:23',
-					'updated' => '2007-03-18 14:59:31',
+					'modified' => '2007-03-18 14:59:31',
 					'Article' => array(
 						'id' => '4',
 						'user_id' => '2',
@@ -880,34 +880,34 @@ class ModelWriteTest extends BaseModelTest {
 						'body' => 'New Article Body',
 						'published' => 'N',
 						'created' => '2007-03-18 14:55:23',
-						'updated' => '2007-03-18 14:57:31'
+						'modified' => '2007-03-18 14:57:31'
 					),
 					'User' => array(
 						'id' => '1',
 						'user' => 'mariano',
 						'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 						'created' => '2007-03-17 01:16:23',
-						'updated' => '2007-03-17 01:18:31'
+						'modified' => '2007-03-17 01:18:31'
 					),
 					'Attachment' => array(
 						'id' => '2',
 						'comment_id' => '7',
 						'attachment' => 'newattachment.zip',
 						'created' => '2007-03-18 15:02:23',
-						'updated' => '2007-03-18 15:04:31'
+						'modified' => '2007-03-18 15:04:31'
 			))),
 			'Tag' => array(
 				array(
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 
 		$this->assertEquals($expected, $result);
@@ -1166,14 +1166,14 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			),
 			'User' => array(
 				'id' => '3',
 				'user' => 'larry',
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf99',
 				'created' => '2007-03-17 01:20:23',
-				'updated' => '2007-03-17 01:22:31'
+				'modified' => '2007-03-17 01:22:31'
 			),
 			'Comment' => array(
 				array(
@@ -1183,7 +1183,7 @@ class ModelWriteTest extends BaseModelTest {
 					'comment' => 'First Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:53:23',
-					'updated' => '2007-03-18 10:55:31'
+					'modified' => '2007-03-18 10:55:31'
 				),
 				array(
 					'id' => '6',
@@ -1192,20 +1192,20 @@ class ModelWriteTest extends BaseModelTest {
 					'comment' => 'Second Comment for Second Article',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:55:23',
-					'updated' => '2007-03-18 10:57:31'
+					'modified' => '2007-03-18 10:57:31'
 			)),
 			'Tag' => array(
 				array(
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 				)
 			)
 		);
@@ -1239,13 +1239,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1273,13 +1273,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1308,19 +1308,19 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1378,13 +1378,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1418,13 +1418,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1458,13 +1458,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				)
 			)
 		);
@@ -1500,13 +1500,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 				)
 			)
 		);
@@ -1542,13 +1542,13 @@ class ModelWriteTest extends BaseModelTest {
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1559,7 +1559,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'New Article With Tags and fieldList',
 				'body' => 'New Article Body with Tags and fieldList',
 				'created' => '2007-03-18 14:55:23',
-				'updated' => '2007-03-18 14:57:31'
+				'modified' => '2007-03-18 14:57:31'
 			),
 			'Tag' => array(
 				'Tag' => array(1, 2, 3)
@@ -1582,26 +1582,26 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => '',
 				'published' => 'N',
 				'created' => '',
-				'updated' => ''
+				'modified' => ''
 			),
 			'Tag' => array(
 				0 => array(
 					'id' => 1,
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				1 => array(
 					'id' => 2,
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				),
 				2 => array(
 					'id' => 3,
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 		)));
 		$this->assertEquals($expected, $result);
 
@@ -1648,20 +1648,20 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			),
 			'Tag' => array(
 				array(
 					'id' => '1',
 					'tag' => 'tag1',
 					'created' => '2007-03-18 12:22:23',
-					'updated' => '2007-03-18 12:24:31'
+					'modified' => '2007-03-18 12:24:31'
 				),
 				array(
 					'id' => '3',
 					'tag' => 'tag3',
 					'created' => '2007-03-18 12:26:23',
-					'updated' => '2007-03-18 12:28:31'
+					'modified' => '2007-03-18 12:28:31'
 				)
 			)
 		);
@@ -1680,14 +1680,14 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => static::date()
+				'modified' => static::date()
 			),
 			'Tag' => array(
 				array(
 					'id' => '2',
 					'tag' => 'tag2',
 					'created' => '2007-03-18 12:24:23',
-					'updated' => '2007-03-18 12:26:31'
+					'modified' => '2007-03-18 12:26:31'
 				)
 			)
 		);
@@ -1800,13 +1800,13 @@ class ModelWriteTest extends BaseModelTest {
 						'id' => 2,
 						'tag' => 'tag2',
 						'created' => '2007-03-18 12:24:23',
-						'updated' => '2007-03-18 12:26:31'
+						'modified' => '2007-03-18 12:26:31'
 					),
 					array(
 						'id' => 3,
 						'tag' => 'tag3',
 						'created' => '2007-03-18 12:26:23',
-						'updated' => '2007-03-18 12:28:31'
+						'modified' => '2007-03-18 12:28:31'
 			))),
 			array(
 				'Story' => array(
@@ -1971,7 +1971,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $TestModel->save();
 		$this->assertTrue(isset($result['Author']['created']));
-		$this->assertTrue(isset($result['Author']['updated']));
+		$this->assertTrue(isset($result['Author']['modified']));
 		$this->assertEquals(1, $TestModel->find('count'));
 	}
 
@@ -2034,7 +2034,7 @@ class ModelWriteTest extends BaseModelTest {
 			'title' => 'My article',
 			'body' => 'Some text',
 			'created' => '1970-01-01 00:00:00',
-			'updated' => '1970-01-01 12:00:00',
+			'modified' => '1970-01-01 12:00:00',
 			'modified' => '1970-01-01 12:00:00'
 		);
 
@@ -2047,7 +2047,7 @@ class ModelWriteTest extends BaseModelTest {
 				'title' => 'My article',
 				'body' => 'Some text',
 				'created' => '1970-01-01 00:00:00',
-				'updated' => '1970-01-01 12:00:00',
+				'modified' => '1970-01-01 12:00:00',
 				'modified' => '1970-01-01 12:00:00'
 		));
 		$this->assertEquals($expected, $result);
@@ -2056,7 +2056,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->create(array(
 			'Article' => array_diff_key($data, array(
 				'created' => true,
-				'updated' => true,
+				'modified' => true,
 				'modified' => true
 		))), true);
 		$expected = array(
@@ -2579,35 +2579,35 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'Join A 1',
 				'body' => 'Join A 1 Body',
 				'created' => '2008-01-03 10:54:23',
-				'updated' => '2008-01-03 10:54:23'
+				'modified' => '2008-01-03 10:54:23'
 			),
 			'JoinB' => array(
 				0 => array(
 					'id' => 2,
 					'name' => 'Join B 2',
 					'created' => '2008-01-03 10:55:02',
-					'updated' => '2008-01-03 10:55:02',
+					'modified' => '2008-01-03 10:55:02',
 					'JoinAsJoinB' => array(
 						'id' => 1,
 						'join_a_id' => 1,
 						'join_b_id' => 2,
 						'other' => 'Data for Join A 1 Join B 2',
 						'created' => '2008-01-03 10:56:33',
-						'updated' => '2008-01-03 10:56:33'
+						'modified' => '2008-01-03 10:56:33'
 			))),
 			'JoinC' => array(
 				0 => array(
 					'id' => 2,
 					'name' => 'Join C 2',
 					'created' => '2008-01-03 10:56:12',
-					'updated' => '2008-01-03 10:56:12',
+					'modified' => '2008-01-03 10:56:12',
 					'JoinAsJoinC' => array(
 						'id' => 1,
 						'join_a_id' => 1,
 						'join_c_id' => 2,
 						'other' => 'Data for Join A 1 Join C 2',
 						'created' => '2008-01-03 10:57:22',
-						'updated' => '2008-01-03 10:57:22'
+						'modified' => '2008-01-03 10:57:22'
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -2617,7 +2617,7 @@ class ModelWriteTest extends BaseModelTest {
 			'JoinA' => array(
 				'id' => '1',
 				'name' => 'New name for Join A 1',
-				'updated' => static::date()
+				'modified' => static::date()
 			),
 			'JoinB' => array(
 				array(
@@ -2625,7 +2625,7 @@ class ModelWriteTest extends BaseModelTest {
 					'join_b_id' => 2,
 					'other' => 'New data for Join A 1 Join B 2',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 			)),
 			'JoinC' => array(
 				array(
@@ -2633,7 +2633,7 @@ class ModelWriteTest extends BaseModelTest {
 					'join_c_id' => 2,
 					'other' => 'New data for Join A 1 Join C 2',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 		)));
 
 		$TestModel->set($data);
@@ -2646,35 +2646,35 @@ class ModelWriteTest extends BaseModelTest {
 				'name' => 'New name for Join A 1',
 				'body' => 'Join A 1 Body',
 				'created' => '2008-01-03 10:54:23',
-				'updated' => static::date()
+				'modified' => static::date()
 			),
 			'JoinB' => array(
 				0 => array(
 					'id' => 2,
 					'name' => 'Join B 2',
 					'created' => '2008-01-03 10:55:02',
-					'updated' => '2008-01-03 10:55:02',
+					'modified' => '2008-01-03 10:55:02',
 					'JoinAsJoinB' => array(
 						'id' => 1,
 						'join_a_id' => 1,
 						'join_b_id' => 2,
 						'other' => 'New data for Join A 1 Join B 2',
 						'created' => static::date(),
-						'updated' => static::date()
+						'modified' => static::date()
 			))),
 			'JoinC' => array(
 				0 => array(
 					'id' => 2,
 					'name' => 'Join C 2',
 					'created' => '2008-01-03 10:56:12',
-					'updated' => '2008-01-03 10:56:12',
+					'modified' => '2008-01-03 10:56:12',
 					'JoinAsJoinC' => array(
 						'id' => 1,
 						'join_a_id' => 1,
 						'join_c_id' => 2,
 						'other' => 'New data for Join A 1 Join C 2',
 						'created' => static::date(),
-						'updated' => static::date()
+						'modified' => static::date()
 		))));
 
 		$this->assertEquals($expected, $result);
@@ -2719,11 +2719,11 @@ class ModelWriteTest extends BaseModelTest {
 				'test' => 'working'
 		));
 		$this->assertEquals(static::date(), $result[3]['Post']['created']);
-		$this->assertEquals(static::date(), $result[3]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[3]['Author']['created']);
-		$this->assertEquals(static::date(), $result[3]['Author']['updated']);
-		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
-		unset($result[3]['Author']['created'], $result[3]['Author']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Author']['modified']);
+		unset($result[3]['Post']['created'], $result[3]['Post']['modified']);
+		unset($result[3]['Author']['created'], $result[3]['Author']['modified']);
 		$this->assertEquals($expected, $result[3]);
 		$this->assertEquals(4, count($result));
 
@@ -2767,11 +2767,11 @@ class ModelWriteTest extends BaseModelTest {
 					'published' => 'N'
 		)));
 		$this->assertEquals(static::date(), $result[0]['Post']['created']);
-		$this->assertEquals(static::date(), $result[0]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[0]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[1]['Post']['created']);
-		$this->assertEquals(static::date(), $result[1]['Post']['updated']);
-		unset($result[0]['Post']['created'], $result[0]['Post']['updated']);
-		unset($result[1]['Post']['created'], $result[1]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[1]['Post']['modified']);
+		unset($result[0]['Post']['created'], $result[0]['Post']['modified']);
+		unset($result[1]['Post']['created'], $result[1]['Post']['modified']);
 		$this->assertEquals($expected, $result);
 
 		$TestModel = new Comment();
@@ -2796,8 +2796,8 @@ class ModelWriteTest extends BaseModelTest {
 			'published' => 'Y'
 		);
 		$this->assertEquals(static::date(), $result[6]['Comment']['created']);
-		$this->assertEquals(static::date(), $result[6]['Comment']['updated']);
-		unset($result[6]['Comment']['created'], $result[6]['Comment']['updated']);
+		$this->assertEquals(static::date(), $result[6]['Comment']['modified']);
+		unset($result[6]['Comment']['created'], $result[6]['Comment']['modified']);
 		$this->assertEquals($expected, $result[6]['Comment']);
 
 		$expected = array(
@@ -2806,8 +2806,8 @@ class ModelWriteTest extends BaseModelTest {
 			'attachment' => 'some_file.tgz'
 		);
 		$this->assertEquals(static::date(), $result[6]['Attachment']['created']);
-		$this->assertEquals(static::date(), $result[6]['Attachment']['updated']);
-		unset($result[6]['Attachment']['created'], $result[6]['Attachment']['updated']);
+		$this->assertEquals(static::date(), $result[6]['Attachment']['modified']);
+		unset($result[6]['Attachment']['created'], $result[6]['Attachment']['modified']);
 		$this->assertEquals($expected, $result[6]['Attachment']);
 	}
 
@@ -3191,10 +3191,10 @@ class ModelWriteTest extends BaseModelTest {
 				'published' => 'Y',
 			)
 		);
-		unset($result['Attachment']['created'], $result['Attachment']['updated']);
+		unset($result['Attachment']['created'], $result['Attachment']['modified']);
 		$this->assertEquals($expected['Attachment'], $result['Attachment']);
 
-		unset($result['Comment']['created'], $result['Comment']['updated']);
+		unset($result['Comment']['created'], $result['Comment']['modified']);
 		$this->assertEquals($expected['Comment'], $result['Comment']);
 
 		$result = $TestModel->findById($result['Comment']['article_id']);
@@ -3222,9 +3222,9 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		);
 		unset(
-			$result['Article']['created'], $result['Article']['updated'],
-			$result['User']['created'], $result['User']['updated'],
-			$result['Comment'][0]['created'], $result['Comment'][0]['updated']
+			$result['Article']['created'], $result['Article']['modified'],
+			$result['User']['created'], $result['User']['modified'],
+			$result['Comment'][0]['created'], $result['Comment'][0]['modified']
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -3694,10 +3694,10 @@ class ModelWriteTest extends BaseModelTest {
 				'published' => 'Y',
 			)
 		);
-		unset($result['Attachment']['created'], $result['Attachment']['updated']);
+		unset($result['Attachment']['created'], $result['Attachment']['modified']);
 		$this->assertEquals($expected['Attachment'], $result['Attachment']);
 
-		unset($result['Comment']['created'], $result['Comment']['updated']);
+		unset($result['Comment']['created'], $result['Comment']['modified']);
 		$this->assertEquals($expected['Comment'], $result['Comment']);
 	}
 
@@ -4146,7 +4146,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'First Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			)),
 			array('Post' => array(
 				'id' => '2',
@@ -4155,7 +4155,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			)),
 			array('Post' => array(
 				'id' => '3',
@@ -4164,7 +4164,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Third Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'modified' => '2007-03-18 10:45:31'
 		)));
 
 		if (count($result) != 3) {
@@ -4177,7 +4177,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => null,
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 			));
 
 			$expected[] = array(
@@ -4188,7 +4188,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => null,
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 			));
 
 			$this->assertEquals($expected, $result);
@@ -4214,7 +4214,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'First Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			)),
 			array('Post' => array(
 				'id' => '2',
@@ -4223,7 +4223,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			)),
 			array('Post' => array(
 				'id' => '3',
@@ -4232,7 +4232,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Third Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'modified' => '2007-03-18 10:45:31'
 		)));
 
 		if (count($result) != 3) {
@@ -4245,7 +4245,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 			));
 
 			$expected[] = array(
@@ -4256,7 +4256,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 			));
 		}
 		$this->assertEquals($expected, $result);
@@ -4371,7 +4371,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 			)),
 			array(
 				'Post' => array(
@@ -4381,12 +4381,12 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Fourth post body',
 					'published' => 'N'
 		)));
-		$this->assertEquals(static::date(), $result[0]['Post']['updated']);
-		$this->assertEquals(static::date(), $result[1]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[0]['Post']['modified']);
+		$this->assertEquals(static::date(), $result[1]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[3]['Post']['created']);
-		$this->assertEquals(static::date(), $result[3]['Post']['updated']);
-		unset($result[0]['Post']['updated'], $result[1]['Post']['updated']);
-		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Post']['modified']);
+		unset($result[0]['Post']['modified'], $result[1]['Post']['modified']);
+		unset($result[3]['Post']['created'], $result[3]['Post']['modified']);
 		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
@@ -4461,7 +4461,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 				)
 			),
 			array(
@@ -4475,13 +4475,13 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		);
 
-		$this->assertEquals(static::date(), $result[0]['Post']['updated']);
-		$this->assertEquals(static::date(), $result[1]['Post']['updated']);
-		$this->assertEquals(static::date(), $result[3]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[0]['Post']['modified']);
+		$this->assertEquals(static::date(), $result[1]['Post']['modified']);
+		$this->assertEquals(static::date(), $result[3]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[3]['Post']['created']);
 		unset(
-			$result[0]['Post']['updated'], $result[1]['Post']['updated'],
-			$result[3]['Post']['updated'], $result[3]['Post']['created']
+			$result[0]['Post']['modified'], $result[1]['Post']['modified'],
+			$result[3]['Post']['modified'], $result[3]['Post']['created']
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertEquals($errors, $TestModel->validationErrors);
@@ -4502,8 +4502,8 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
 		unset(
-			$result[0]['Post']['updated'], $result[1]['Post']['updated'],
-			$result[3]['Post']['updated'], $result[3]['Post']['created']
+			$result[0]['Post']['modified'], $result[1]['Post']['modified'],
+			$result[3]['Post']['modified'], $result[3]['Post']['created']
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertEquals($errors, $TestModel->validationErrors);
@@ -4859,13 +4859,13 @@ class ModelWriteTest extends BaseModelTest {
 				'password' => '5f4dcc3b5aa765d61d8327deb882cf90',
 				'test' => 'working'
 		));
-		$this->assertEquals(static::date(), $result[3]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[3]['Post']['created']);
 		$this->assertEquals(static::date(), $result[3]['Author']['created']);
-		$this->assertEquals(static::date(), $result[3]['Author']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Author']['modified']);
 		unset(
-			$result[3]['Post']['updated'], $result[3]['Post']['created'],
-			$result[3]['Author']['updated'], $result[3]['Author']['created']
+			$result[3]['Post']['modified'], $result[3]['Post']['created'],
+			$result[3]['Author']['modified'], $result[3]['Author']['created']
 		);
 		$this->assertEquals($expected, $result[3]);
 		$this->assertEquals(4, count($result));
@@ -4891,9 +4891,9 @@ class ModelWriteTest extends BaseModelTest {
 			'comment' => 'New comment with attachment',
 			'published' => 'Y'
 		);
-		$this->assertEquals(static::date(), $result[6]['Comment']['updated']);
+		$this->assertEquals(static::date(), $result[6]['Comment']['modified']);
 		$this->assertEquals(static::date(), $result[6]['Comment']['created']);
-		unset($result[6]['Comment']['updated'], $result[6]['Comment']['created']);
+		unset($result[6]['Comment']['modified'], $result[6]['Comment']['created']);
 		$this->assertEquals($expected, $result[6]['Comment']);
 
 		$expected = array(
@@ -4901,9 +4901,9 @@ class ModelWriteTest extends BaseModelTest {
 			'comment_id' => '7',
 			'attachment' => 'some_file.tgz'
 		);
-		$this->assertEquals(static::date(), $result[6]['Attachment']['updated']);
+		$this->assertEquals(static::date(), $result[6]['Attachment']['modified']);
 		$this->assertEquals(static::date(), $result[6]['Attachment']['created']);
-		unset($result[6]['Attachment']['updated'], $result[6]['Attachment']['created']);
+		unset($result[6]['Attachment']['modified'], $result[6]['Attachment']['created']);
 		$this->assertEquals($expected, $result[6]['Attachment']);
 	}
 
@@ -5002,12 +5002,12 @@ class ModelWriteTest extends BaseModelTest {
 				)
 			)
 		);
-		$this->assertEquals(static::date(), $result[0]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[0]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[0]['Post']['created']);
-		$this->assertEquals(static::date(), $result[1]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[1]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[1]['Post']['created']);
-		unset($result[0]['Post']['updated'], $result[0]['Post']['created']);
-		unset($result[1]['Post']['updated'], $result[1]['Post']['created']);
+		unset($result[0]['Post']['modified'], $result[0]['Post']['created']);
+		unset($result[1]['Post']['modified'], $result[1]['Post']['created']);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -5574,7 +5574,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'First Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			)),
 			array('Post' => array(
 				'id' => '2',
@@ -5583,7 +5583,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			)),
 			array('Post' => array(
 				'id' => '3',
@@ -5592,7 +5592,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Third Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'modified' => '2007-03-18 10:45:31'
 		)));
 
 		if (count($result) != 3) {
@@ -5616,11 +5616,11 @@ class ModelWriteTest extends BaseModelTest {
 			));
 
 			$this->assertEquals(static::date(), $result[3]['Post']['created']);
-			$this->assertEquals(static::date(), $result[3]['Post']['updated']);
+			$this->assertEquals(static::date(), $result[3]['Post']['modified']);
 			$this->assertEquals(static::date(), $result[4]['Post']['created']);
-			$this->assertEquals(static::date(), $result[4]['Post']['updated']);
-			unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
-			unset($result[4]['Post']['created'], $result[4]['Post']['updated']);
+			$this->assertEquals(static::date(), $result[4]['Post']['modified']);
+			unset($result[3]['Post']['created'], $result[3]['Post']['modified']);
+			unset($result[4]['Post']['created'], $result[4]['Post']['modified']);
 			$this->assertEquals($expected, $result);
 			// Skip the rest of the transactional tests
 			return;
@@ -5644,7 +5644,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'First Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'modified' => '2007-03-18 10:41:31'
 			)),
 			array('Post' => array(
 				'id' => '2',
@@ -5653,7 +5653,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Second Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'modified' => '2007-03-18 10:43:31'
 			)),
 			array('Post' => array(
 				'id' => '3',
@@ -5662,7 +5662,7 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => 'Third Post Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'modified' => '2007-03-18 10:45:31'
 		)));
 
 		if (count($result) != 3) {
@@ -5685,11 +5685,11 @@ class ModelWriteTest extends BaseModelTest {
 					'published' => 'N'
 			));
 			$this->assertEquals(static::date(), $result[3]['Post']['created']);
-			$this->assertEquals(static::date(), $result[3]['Post']['updated']);
+			$this->assertEquals(static::date(), $result[3]['Post']['modified']);
 			$this->assertEquals(static::date(), $result[4]['Post']['created']);
-			$this->assertEquals(static::date(), $result[4]['Post']['updated']);
-			unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
-			unset($result[4]['Post']['created'], $result[4]['Post']['updated']);
+			$this->assertEquals(static::date(), $result[4]['Post']['modified']);
+			unset($result[3]['Post']['created'], $result[3]['Post']['modified']);
+			unset($result[4]['Post']['created'], $result[4]['Post']['modified']);
 		}
 		$this->assertEquals($expected, $result);
 
@@ -5805,7 +5805,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => 'Third Post Body',
 					'published' => 'Y',
 					'created' => '2007-03-18 10:43:23',
-					'updated' => '2007-03-18 10:45:31'
+					'modified' => '2007-03-18 10:45:31'
 			)),
 			array(
 				'Post' => array(
@@ -5818,12 +5818,12 @@ class ModelWriteTest extends BaseModelTest {
 			)
 		);
 
-		$this->assertEquals(static::date(), $result[0]['Post']['updated']);
-		$this->assertEquals(static::date(), $result[1]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[0]['Post']['modified']);
+		$this->assertEquals(static::date(), $result[1]['Post']['modified']);
 		$this->assertEquals(static::date(), $result[3]['Post']['created']);
-		$this->assertEquals(static::date(), $result[3]['Post']['updated']);
-		unset($result[0]['Post']['updated'], $result[1]['Post']['updated']);
-		unset($result[3]['Post']['created'], $result[3]['Post']['updated']);
+		$this->assertEquals(static::date(), $result[3]['Post']['modified']);
+		unset($result[0]['Post']['modified'], $result[1]['Post']['modified']);
+		unset($result[3]['Post']['created'], $result[3]['Post']['modified']);
 		$this->assertEquals($expected, $result);
 
 		$TestModel->validate = array('title' => 'notEmpty', 'author_id' => 'numeric');
@@ -6545,14 +6545,14 @@ class ModelWriteTest extends BaseModelTest {
 				'body' => null,
 				'published' => 'N',
 				'created' => static::date(),
-				'updated' => static::date(),
+				'modified' => static::date(),
 			),
 			'Author' => array (
 				'id' => '5',
 				'user' => 'bob',
 				'password' => null,
 				'created' => static::date(),
-				'updated' => static::date(),
+				'modified' => static::date(),
 				'test' => 'working',
 			),
 		);
@@ -6590,7 +6590,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => '',
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 				)
 			),
 			array(
@@ -6601,7 +6601,7 @@ class ModelWriteTest extends BaseModelTest {
 					'body' => '',
 					'published' => 'N',
 					'created' => static::date(),
-					'updated' => static::date()
+					'modified' => static::date()
 				)
 			)
 		);

--- a/lib/Cake/Test/TestCase/Model/SchemaTest.php
+++ b/lib/Cake/Test/TestCase/Model/SchemaTest.php
@@ -60,7 +60,7 @@ class MyAppSchema extends Schema {
 		'comment' => array('type' => 'text', 'null' => false, 'default' => null),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 	);
 
@@ -77,7 +77,7 @@ class MyAppSchema extends Schema {
 		'summary' => array('type' => 'text', 'null' => true),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'Y', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 	);
 
@@ -147,7 +147,7 @@ class TestAppSchema extends Schema {
 		'comment' => array('type' => 'text', 'null' => true, 'default' => null),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 		'tableParameters' => array(),
 	);
@@ -164,7 +164,7 @@ class TestAppSchema extends Schema {
 		'body' => array('type' => 'text', 'null' => true, 'default' => null),
 		'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 		'tableParameters' => array(),
 	);
@@ -190,7 +190,7 @@ class TestAppSchema extends Schema {
 		'id' => array('type' => 'integer', 'null' => false, 'default' => 0, 'key' => 'primary'),
 		'tag' => array('type' => 'string', 'null' => false),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-		'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 		'tableParameters' => array()
 	);
@@ -762,7 +762,7 @@ class SchemaTest extends TestCase {
 			'body' => array('type' => 'text', 'null' => true, 'default' => null),
 			'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 			'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-			'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+			'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 			'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => true)),
 		);
 		$result = $this->Schema->generateTable('posts', $posts);
@@ -775,7 +775,7 @@ class SchemaTest extends TestCase {
 			'body' => array('type' => 'text', 'null' => true, 'default' => null),
 			'published' => array('type' => 'string', 'null' => true, 'default' => 'N', 'length' => 1),
 			'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
-			'updated' => array('type' => 'datetime', 'null' => true, 'default' => null),
+			'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 			'indexes' => array(
 				'PRIMARY' => array('column' => 'id', 'unique' => true),
 				'MyFtIndex' => array('column' => array('title', 'body'), 'type' => 'fulltext')

--- a/lib/Cake/Test/TestCase/Model/models.php
+++ b/lib/Cake/Test/TestCase/Model/models.php
@@ -92,7 +92,7 @@ class Test extends CakeTestModel {
 		'email' => array('type' => 'string', 'null' => '1', 'default' => '', 'length' => '155'),
 		'notes' => array('type' => 'text', 'null' => '1', 'default' => 'write some notes here', 'length' => ''),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 }
@@ -136,7 +136,7 @@ class TestAlias extends CakeTestModel {
 		'email' => array('type' => 'string', 'null' => '1', 'default' => '', 'length' => '155'),
 		'notes' => array('type' => 'text', 'null' => '1', 'default' => 'write some notes here', 'length' => ''),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 }
 
@@ -3571,7 +3571,7 @@ class TestModel extends CakeTestModel {
 		'comments' => array('type' => 'text', 'null' => '1', 'default' => '', 'length' => '155'),
 		'last_login' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 /**
@@ -3722,7 +3722,7 @@ class TestModel4 extends CakeTestModel {
 				'id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -3835,7 +3835,7 @@ class TestModel5 extends CakeTestModel {
 				'test_model4_id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -3895,7 +3895,7 @@ class TestModel6 extends CakeTestModel {
 				'test_model5_id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -3942,7 +3942,7 @@ class TestModel7 extends CakeTestModel {
 				'id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -4003,7 +4003,7 @@ class TestModel8 extends CakeTestModel {
 				'test_model9_id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '8'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -4064,7 +4064,7 @@ class TestModel9 extends CakeTestModel {
 				'test_model8_id' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => '11'),
 				'name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 				'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-				'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+				'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 			);
 		}
 		return $this->_schema;
@@ -4729,7 +4729,7 @@ class MysqlTestModel extends Model {
 			'comments' => array('type' => 'text', 'null' => '1', 'default' => '', 'length' => ''),
 			'last_login' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => ''),
 			'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-			'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+			'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 		);
 	}
 

--- a/lib/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
+++ b/lib/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
@@ -315,7 +315,7 @@ class TestFixtureTest extends TestCase {
 			'body',
 			'published',
 			'created',
-			'updated',
+			'modified',
 		];
 		$this->assertEquals($expected, array_keys($Fixture->fields));
 
@@ -346,7 +346,7 @@ class TestFixtureTest extends TestCase {
 			'body',
 			'published',
 			'created',
-			'updated',
+			'modified',
 		];
 		$this->assertEquals($expected, array_keys($Fixture->fields));
 		$this->assertFalse(empty($Fixture->records[0]), 'No records loaded on importing fixture.');

--- a/lib/Cake/Test/TestCase/Utility/SetTest.php
+++ b/lib/Cake/Test/TestCase/Utility/SetTest.php
@@ -117,20 +117,20 @@ class SetTest extends TestCase {
 
 		$data = array(
 			array(
-				'Article' => array('id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(
-					array('id' => '1', 'article_id' => '1', 'user_id' => '2', 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31'),
-					array('id' => '2', 'article_id' => '1', 'user_id' => '4', 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'),
+					array('id' => '1', 'article_id' => '1', 'user_id' => '2', 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31'),
+					array('id' => '2', 'article_id' => '1', 'user_id' => '4', 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'),
 				),
 				'Tag' => array(
-					array('id' => '1', 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => '2', 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'updated' => '2007-03-18 12:26:31')
+					array('id' => '1', 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => '2', 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'modified' => '2007-03-18 12:26:31')
 				)
 			),
 			array(
-				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'),
-				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'),
+				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(),
 				'Tag' => array()
 			)
@@ -399,15 +399,15 @@ class SetTest extends TestCase {
 	public function testExtract() {
 		$a = array(
 			array(
-				'Article' => array('id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '1', 'user_id' => '1', 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+				'User' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(
-					array('id' => '1', 'article_id' => '1', 'user_id' => '2', 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'updated' => '2007-03-18 10:47:31'),
-					array('id' => '2', 'article_id' => '1', 'user_id' => '4', 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'),
+					array('id' => '1', 'article_id' => '1', 'user_id' => '2', 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:45:23', 'modified' => '2007-03-18 10:47:31'),
+					array('id' => '2', 'article_id' => '1', 'user_id' => '4', 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'),
 				),
 				'Tag' => array(
-					array('id' => '1', 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'updated' => '2007-03-18 12:24:31'),
-					array('id' => '2', 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'updated' => '2007-03-18 12:26:31')
+					array('id' => '1', 'tag' => 'tag1', 'created' => '2007-03-18 12:22:23', 'modified' => '2007-03-18 12:24:31'),
+					array('id' => '2', 'tag' => 'tag2', 'created' => '2007-03-18 12:24:23', 'modified' => '2007-03-18 12:26:31')
 				),
 				'Deep' => array(
 					'Nesting' => array(
@@ -421,26 +421,26 @@ class SetTest extends TestCase {
 				)
 			),
 			array(
-				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'),
-				'User' => array('id' => '2', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'),
+				'User' => array('id' => '2', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(),
 				'Tag' => array()
 			),
 			array(
-				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'),
-				'User' => array('id' => '3', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'),
+				'User' => array('id' => '3', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(),
 				'Tag' => array()
 			),
 			array(
-				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'),
-				'User' => array('id' => '4', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'),
+				'User' => array('id' => '4', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(),
 				'Tag' => array()
 			),
 			array(
-				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'updated' => '2007-03-18 10:45:31'),
-				'User' => array('id' => '5', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),
+				'Article' => array('id' => '3', 'user_id' => '1', 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y', 'created' => '2007-03-18 10:43:23', 'modified' => '2007-03-18 10:45:31'),
+				'User' => array('id' => '5', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31'),
 				'Comment' => array(),
 				'Tag' => array()
 			)
@@ -2116,8 +2116,8 @@ class SetTest extends TestCase {
 						'Icon' => array('id' => 851),
 						'Profile' => array('name' => 'Some Name', 'address' => 'Some Address'),
 						'Comment' => array(
-								array('id' => 1, 'article_id' => 1, 'user_id' => 1, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'),
-								array('id' => 2, 'article_id' => 1, 'user_id' => 2, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'))));
+								array('id' => 1, 'article_id' => 1, 'user_id' => 1, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'),
+								array('id' => 2, 'article_id' => 1, 'user_id' => 2, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'))));
 
 		$class = new \stdClass;
 		$class->User = new \stdClass;
@@ -2152,8 +2152,8 @@ class SetTest extends TestCase {
 						'Icon' => array('id' => 851),
 						'Profile' => array('name' => 'Some Name', 'address' => 'Some Address'),
 						'Comment' => array(
-								array('id' => 1, 'article_id' => 1, 'user_id' => 1, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'),
-								array('id' => 2, 'article_id' => 1, 'user_id' => 2, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'updated' => '2007-03-18 10:49:31'))));
+								array('id' => 1, 'article_id' => 1, 'user_id' => 1, 'comment' => 'First Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'),
+								array('id' => 2, 'article_id' => 1, 'user_id' => 2, 'comment' => 'Second Comment for First Article', 'published' => 'Y', 'created' => '2007-03-18 10:47:23', 'modified' => '2007-03-18 10:49:31'))));
 
 		// @codingStandardsIgnoreStart
 		$class = new \stdClass;
@@ -2368,7 +2368,7 @@ class SetTest extends TestCase {
 					'cookies' => array('PHPSESSID' => "dde9896ad24595998161ffaf9e0dbe2d"),
 					'redirect' => '',
 					'created' => "1195055503",
-					'updated' => "1195055503",
+					'modified' => "1195055503",
 				)
 			),
 			array(
@@ -2395,7 +2395,7 @@ class SetTest extends TestCase {
 					'cookies' => array('PHPSESSID' => "dde9896ad24595998161ffaf9e0dbe2d"),
 					'redirect' => '',
 					'created' => "1195055503",
-					'updated' => "1195055503",
+					'modified' => "1195055503",
 				),
 			)
 		);
@@ -2421,7 +2421,7 @@ class SetTest extends TestCase {
 					'get_vars' => '',
 					'redirect' => '',
 					'created' => "1195055503",
-					'updated' => "1195055503",
+					'modified' => "1195055503",
 				)
 			),
 			array(
@@ -2432,7 +2432,7 @@ class SetTest extends TestCase {
 					'get_vars' => '',
 					'redirect' => '',
 					'created' => "1195055503",
-					'updated' => "1195055503",
+					'modified' => "1195055503",
 				),
 			)
 		);
@@ -2471,12 +2471,12 @@ class SetTest extends TestCase {
 	public function testNestedMappedData() {
 		$result = Set::map(array(
 				array(
-					'Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-					'Author' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31', 'test' => 'working'),
+					'Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+					'Author' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31', 'test' => 'working'),
 				)
 				, array(
-					'Post' => array('id' => '2', 'author_id' => '3', 'title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'updated' => '2007-03-18 10:43:31'),
-					'Author' => array('id' => '3', 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'updated' => '2007-03-17 01:22:31', 'test' => 'working'),
+					'Post' => array('id' => '2', 'author_id' => '3', 'title' => 'Second Post', 'body' => 'Second Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:41:23', 'modified' => '2007-03-18 10:43:31'),
+					'Author' => array('id' => '3', 'user' => 'larry', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:20:23', 'modified' => '2007-03-17 01:22:31', 'test' => 'working'),
 				)
 			));
 
@@ -2528,8 +2528,8 @@ class SetTest extends TestCase {
 
 		$result = Set::map(
 			array(
-				'Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'updated' => '2007-03-18 10:41:31'),
-				'Author' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31', 'test' => 'working'),
+				'Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post', 'body' => 'First Post Body', 'published' => 'Y', 'created' => '2007-03-18 10:39:23', 'modified' => '2007-03-18 10:41:31'),
+				'Author' => array('id' => '1', 'user' => 'mariano', 'password' => '5f4dcc3b5aa765d61d8327deb882cf99', 'created' => '2007-03-17 01:16:23', 'modified' => '2007-03-17 01:18:31', 'test' => 'working'),
 			)
 		);
 		// @codingStandardsIgnoreStart

--- a/lib/Cake/Test/TestCase/Utility/ViewVarsTraitTest.php
+++ b/lib/Cake/Test/TestCase/Utility/ViewVarsTraitTest.php
@@ -42,9 +42,9 @@ class ViewVarsTraitTest extends TestCase {
 		$this->subject->set($data);
 		$this->assertEquals($data, $this->subject->viewVars);
 
-		$update = ['test' => 'updated'];
+		$update = ['test' => 'modified'];
 		$this->subject->set($update);
-		$this->assertEquals('updated', $this->subject->viewVars['test']);
+		$this->assertEquals('modified', $this->subject->viewVars['test']);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/FormHelperTest.php
@@ -72,7 +72,7 @@ class Contact extends TestModel {
 		'password' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'published' => array('type' => 'date', 'null' => true, 'default' => null, 'length' => null),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null),
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null),
 		'age' => array('type' => 'integer', 'null' => '', 'default' => '', 'length' => null)
 	);
 
@@ -278,7 +278,7 @@ class UserForm extends TestModel {
 		'something' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
 		'active' => array('type' => 'boolean', 'null' => false, 'default' => false),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 }
 
@@ -373,7 +373,7 @@ class ValidateUser extends TestModel {
 		'email' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'balance' => array('type' => 'float', 'null' => false, 'length' => '5,2'),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 /**
@@ -414,7 +414,7 @@ class ValidateProfile extends TestModel {
 		'full_name' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'city' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 /**
@@ -476,7 +476,7 @@ class ValidateItem extends TestModel {
 			'type' => 'string', 'null' => '', 'default' => '', 'length' => '255'
 		),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
-		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
+		'modified' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
 
 /**
@@ -5631,12 +5631,12 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDatetimeWithDefault() {
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
+		$result = $this->Form->dateTime('Contact.modified', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
 
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array(
+		$result = $this->Form->dateTime('Contact.modified', 'DMY', '12', array(
 			'default' => '2009-06-01 11:15:30'
 		));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
@@ -5650,7 +5650,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeWithBogusData() {
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
+		$result = $this->Form->dateTime('Contact.modified', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
 		$this->assertNotRegExp('/selected="selected">\d/', $result);
 	}
 
@@ -5703,38 +5703,38 @@ class FormHelperTest extends TestCase {
 	public function testFormDateTimeMulti() {
 		extract($this->dateRegex);
 
-		$result = $this->Form->dateTime('Contact.1.updated');
+		$result = $this->Form->dateTime('Contact.1.modified');
 		$expected = array(
-			array('select' => array('name' => 'Contact[1][updated][day]', 'id' => 'Contact1UpdatedDay')),
+			array('select' => array('name' => 'Contact[1][modified][day]', 'id' => 'Contact1ModifiedDay')),
 			$daysRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[1][updated][month]', 'id' => 'Contact1UpdatedMonth')),
+			array('select' => array('name' => 'Contact[1][modified][month]', 'id' => 'Contact1ModifiedMonth')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[1][updated][year]', 'id' => 'Contact1UpdatedYear')),
+			array('select' => array('name' => 'Contact[1][modified][year]', 'id' => 'Contact1ModifiedYear')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[1][updated][hour]', 'id' => 'Contact1UpdatedHour')),
+			array('select' => array('name' => 'Contact[1][modified][hour]', 'id' => 'Contact1ModifiedHour')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[1][updated][min]', 'id' => 'Contact1UpdatedMin')),
+			array('select' => array('name' => 'Contact[1][modified][min]', 'id' => 'Contact1ModifiedMin')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[1][updated][meridian]', 'id' => 'Contact1UpdatedMeridian')),
+			array('select' => array('name' => 'Contact[1][modified][meridian]', 'id' => 'Contact1ModifiedMeridian')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5742,38 +5742,38 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->dateTime('Contact.2.updated');
+		$result = $this->Form->dateTime('Contact.2.modified');
 		$expected = array(
-			array('select' => array('name' => 'Contact[2][updated][day]', 'id' => 'Contact2UpdatedDay')),
+			array('select' => array('name' => 'Contact[2][modified][day]', 'id' => 'Contact2ModifiedDay')),
 			$daysRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[2][updated][month]', 'id' => 'Contact2UpdatedMonth')),
+			array('select' => array('name' => 'Contact[2][modified][month]', 'id' => 'Contact2ModifiedMonth')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[2][updated][year]', 'id' => 'Contact2UpdatedYear')),
+			array('select' => array('name' => 'Contact[2][modified][year]', 'id' => 'Contact2ModifiedYear')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[2][updated][hour]', 'id' => 'Contact2UpdatedHour')),
+			array('select' => array('name' => 'Contact[2][modified][hour]', 'id' => 'Contact2ModifiedHour')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[2][updated][min]', 'id' => 'Contact2UpdatedMin')),
+			array('select' => array('name' => 'Contact[2][modified][min]', 'id' => 'Contact2ModifiedMin')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[2][updated][meridian]', 'id' => 'Contact2UpdatedMeridian')),
+			array('select' => array('name' => 'Contact[2][modified][meridian]', 'id' => 'Contact2ModifiedMeridian')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -7802,13 +7802,13 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->input('Contact.updated', array('div' => false));
+		$result = $this->Form->input('Contact.modified', array('div' => false));
 		$expected = array(
-			'label' => array('for' => 'ContactUpdatedMonth'),
-			'Updated',
+			'label' => array('for' => 'ContactModifiedMonth'),
+			'Modified',
 			'/label',
 			array('select' => array(
-				'name' => 'Contact[updated][month]', 'id' => 'ContactUpdatedMonth'
+				'name' => 'Contact[modified][month]', 'id' => 'ContactModifiedMonth'
 			)),
 			$monthsRegex,
 			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
@@ -7817,7 +7817,7 @@ class FormHelperTest extends TestCase {
 			'*/select',
 			'-',
 			array('select' => array(
-				'name' => 'Contact[updated][day]', 'id' => 'ContactUpdatedDay'
+				'name' => 'Contact[modified][day]', 'id' => 'ContactModifiedDay'
 			)),
 			$daysRegex,
 			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
@@ -7826,7 +7826,7 @@ class FormHelperTest extends TestCase {
 			'*/select',
 			'-',
 			array('select' => array(
-				'name' => 'Contact[updated][year]', 'id' => 'ContactUpdatedYear'
+				'name' => 'Contact[modified][year]', 'id' => 'ContactModifiedYear'
 			)),
 			$yearsRegex,
 			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),

--- a/lib/Cake/View/Scaffolds/form.ctp
+++ b/lib/Cake/View/Scaffolds/form.ctp
@@ -21,7 +21,7 @@ use Cake\Utility\Inflector;
 <div class="<?php echo $pluralVar; ?> form">
 <?php
 	echo $this->Form->create();
-	echo $this->Form->inputs($scaffoldFields, array('created', 'modified', 'updated'));
+	echo $this->Form->inputs($scaffoldFields, array('created', 'modified'));
 	echo $this->Form->end(__d('cake', 'Submit'));
 ?>
 </div>


### PR DESCRIPTION
First step is removing the overhead of two magic fields doing the same thing.
Will also be closer to the documentation at http://book.cakephp.org/2.0/en/models/saving-your-data.html#using-created-and-modified

As a second step we could then either form a customizable

```
public $createdField
public $modifiedField
```

attribute for each model (similar to `displayField`), or form it a trait of some kind.

see https://cakephp.lighthouseapp.com/projects/42648/tickets/2870-magic-datetime-fields-should-be-reduced-to-created-and-modified-aliasing
