### PR TITLE
correct and unify country codes for validation

### DIFF
--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -618,6 +618,8 @@ class Validation {
 			switch ($country) {
 				case 'us':
 				case 'ca':
+				// deprecated three-letter-code
+				case 'can':
 				case 'all':
 					// includes all NANPA members.
 					// see http://en.wikipedia.org/wiki/North_American_Numbering_Plan#List_of_NANPA_countries_and_territories

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -617,8 +617,8 @@ class Validation {
 		if (is_null($regex)) {
 			switch ($country) {
 				case 'us':
+				case 'ca':
 				case 'all':
-				case 'can':
 					// includes all NANPA members.
 					// see http://en.wikipedia.org/wiki/North_American_Numbering_Plan#List_of_NANPA_countries_and_territories
 					$regex = '/^(?:\+?1)?[-. ]?\\(?[2-9][0-8][0-9]\\)?[-. ]?[2-9][0-9]{2}[-. ]?[0-9]{4}$/';


### PR DESCRIPTION
As in postal() `ca` is the correct (2 letter iso) country code for Canada, so this should be corrected in phone() accordingly.

I will then also update the 2.4 docs:
https://github.com/dereuromark/docs/compare/cakephp:2.4...dereuromark:2.4-validation
