### PR TITLE
fix line length for templated emails

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -319,8 +319,8 @@ class CakeEmail {
 
 /**
  * Constructor
- * @param array|string $config Array of configs, or string to load configs from email.php
  *
+ * @param array|string $config Array of configs, or string to load configs from email.php
  */
 	public function __construct($config = null) {
 		$this->_appCharset = Configure::read('App.encoding');
@@ -1565,6 +1565,12 @@ class CakeEmail {
 			$render = $View->render($template, $layout);
 			$render = str_replace(array("\r\n", "\r"), "\n", $render);
 			$rendered[$type] = $this->_encodeString($render, $this->charset);
+		}
+
+		foreach ($rendered as $type => $content) {
+			$rendered[$type] = $this->_wrap($content);
+			$rendered[$type] = implode("\n", $rendered[$type]);
+			$rendered[$type] = rtrim($rendered[$type], "\n");
 		}
 		return $rendered;
 	}

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1082,6 +1082,30 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
+ * testSendRenderWithHTML method and assert line length is kept below the required limit
+ *
+ * @return void
+ */
+	public function testSendRenderWithHTML() {
+		$this->CakeEmail->reset();
+		$this->CakeEmail->transport('debug');
+
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
+		$this->CakeEmail->subject('My title');
+		$this->CakeEmail->config(array('empty'));
+		$this->CakeEmail->emailFormat('html');
+		$this->CakeEmail->template('html', 'default');
+		$result = $this->CakeEmail->send();
+
+		$this->assertTextContains('<h1>HTML Ipsum Presents</h1>', $result['message']);
+		$lines = explode("\n", $result['message']);
+		foreach ($lines as $line) {
+			$this->assertTrue(strlen($line) <= CakeEmail::LINE_LENGTH_MUST);
+		}
+	}
+
+/**
  * testSendRenderWithVars method
  *
  * @return void

--- a/lib/Cake/Test/test_app/View/Emails/html/html.ctp
+++ b/lib/Cake/Test/test_app/View/Emails/html/html.ctp
@@ -1,0 +1,8 @@
+<h1>HTML Ipsum Presents</h1><p><strong>Pellentesque habitant morbi tristique</strong> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. <em>Aenean ultricies mi vitae est.</em> Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, <code>commodo vitae</code>, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. <a href="#">Donec non enim</a> in turpis pulvinar facilisis. Ut felis.</p><h2>Header Level 2</h2><ol><li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li>Aliquam tincidunt mauris eu risus.</li></ol><blockquote><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus magna. Cras in mi at felis aliquet congue. Ut a est eget ligula molestie gravida. Curabitur massa. Donec eleifend, libero at sagittis mollis, tellus est malesuada tellus, at luctus turpis elit sit amet quam. Vivamus pretium ornare est.</p></blockquote><h3>Header Level 3</h3><ul><li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li><li>Aliquam tincidunt mauris eu risus.</li></ul>
+<pre><code>
+#header h1 a {
+	display: block;
+	width: 300px;
+	height: 80px;
+}</code></pre>
+<p>Some more <b>Bold</b> test.</p>


### PR DESCRIPTION
One possible solution to the invalid line length issue of templated emails.
Or should this go into 2.4?

see https://cakephp.lighthouseapp.com/projects/42648/tickets/3712-CakeEmail-creates-invalid-templated-emails
