### PR TITLE
Allow creating of missing tmp directories in debug (development) mode

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -299,7 +299,7 @@ class FileEngine extends CacheEngine {
 		$dir = $this->settings['path'] . $groups;
 
 		if (!is_dir($dir)) {
-			mkdir($dir, 0777, true);
+			mkdir($dir, 0775, true);
 		}
 		$path = new SplFileInfo($dir . $key);
 
@@ -332,6 +332,12 @@ class FileEngine extends CacheEngine {
  */
 	protected function _active() {
 		$dir = new SplFileInfo($this->settings['path']);
+		if (Configure::read('debug')) {
+			$path = $dir->getPathname();
+			if (!is_dir($path)) {
+				mkdir($path, 0775, true);
+			}
+		}
 		if ($this->_init && !($dir->isDir() && $dir->isWritable())) {
 			$this->_init = false;
 			trigger_error(__d('cake_dev', '%s is not writable', $this->settings['path']), E_USER_WARNING);

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -104,6 +104,10 @@ class FileLog extends BaseLog {
 		if (!empty($config['path'])) {
 			$this->_path = $config['path'];
 		}
+		if (Configure::read('debug') && !is_dir($this->_path)) {
+			mkdir($this->_path, 0775, true);
+		}
+
 		if (!empty($config['file'])) {
 			$this->_file = $config['file'];
 			if (substr($this->_file, -4) !== '.log') {

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -132,6 +132,10 @@ class CacheTest extends CakeTestCase {
  * @return void
  */
 	public function testInvalidConfig() {
+		// In debug mode it would auto create the folder.
+		$debug = Configure::read('debug');
+		Configure::write('debug', 0);
+
 		Cache::config('invalid', array(
 			'engine' => 'File',
 			'duration' => '+1 year',
@@ -141,6 +145,8 @@ class CacheTest extends CakeTestCase {
 			'random' => 'wii'
 		));
 		Cache::read('Test', 'invalid');
+
+		Configure::write('debug', $debug);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -338,20 +338,19 @@ class FileEngineTest extends CakeTestCase {
 	}
 
 /**
- * check that FileEngine generates an error when a configured Path does not exist.
+ * check that FileEngine does not generate an error when a configured Path does not exist in debug mode.
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
-	public function testErrorWhenPathDoesNotExist() {
-		$this->skipIf(is_dir(TMP . 'tests' . DS . 'file_failure'), 'Cannot run test directory exists.');
+	public function testPathDoesNotExist() {
+		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
 
-		Cache::config('failure', array(
+		Cache::config('autocreate', array(
 			'engine' => 'File',
-			'path' => TMP . 'tests' . DS . 'file_failure'
+			'path' => TMP . 'tests' . DS . 'autocreate'
 		));
 
-		Cache::drop('failure');
+		Cache::drop('autocreate');
 	}
 
 /**


### PR DESCRIPTION
Allow creating of missing tmp directories in debug (development) mode for cache and log to avoid unnecessary errors thrown.
