### PR TITLE
Add missing App::uses() to avoid fatal error

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -17,6 +17,7 @@
  * @since         CakePHP(tm) v 1.2.0.6001
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+App::uses('Inflector', 'Utility');
 
 /**
  * App is responsible for path management, class location and class loading.


### PR DESCRIPTION
fixes
http://stackoverflow.com/questions/15663276/class-inflector-not-found-after-installing-uploader-4-plugin-to-cakephp-using
