### PR TITLE
Add a bit of backwards compatibility for specifying auth in the config

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -323,6 +323,8 @@ class HttpSocket extends CakeSocket {
 
 		if (isset($this->request['uri']['user'], $this->request['uri']['pass'])) {
 			$this->configAuth('Basic', $this->request['uri']['user'], $this->request['uri']['pass']);
+		} elseif (isset($this->request['auth'], $this->request['auth']['method'], $this->request['auth']['user'], $this->request['auth']['pass'])) {
+			$this->configAuth($this->request['auth']['method'], $this->request['auth']['user'], $this->request['auth']['pass']);
 		}
 		$this->_setAuth();
 		$this->request['auth'] = $this->_auth;

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1065,6 +1065,19 @@ class HttpSocketTest extends CakeTestCase {
 		$socket->configAuth('Test', 'mark', 'passwd');
 		$socket->get('http://example.com/test');
 		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Test mark.passwd') !== false);
+
+		$socket->configAuth(false);
+		$socket->request(array(
+			'method' => 'GET',
+			'uri' => 'http://example.com/test',
+			'auth' => array(
+				'method'=>'Basic',
+				'user' => 'joel',
+				'pass' => 'hunter2'
+			)
+		));
+		$this->assertEquals($socket->request['auth'],array('Basic' => array('user' => 'joel', 'pass' => 'hunter2')));
+		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic am9lbDpodW50ZXIy') !== false);
 	}
 
 /**


### PR DESCRIPTION
The doc example still shows the ability to pass auth as follows:

```
<?php
public $request = array(
    'method' => 'GET',
    'uri' => 'http://example.com',
    'auth' => array(
        'method' => 'Basic',
        'user' => null,
        'pass' => null
    ),
);
?>
```

But this configuration fails due to restructuring of HttpSocket.  One could simply update the documentation, but it seems fairly straightforward to add a couple lines to maintain backwards compatibility.

I've simply added a check similar to the one that checks for 'user' and 'pass' in the uri component to check for this format of auth specification, and added tests to ensure it's working.

I understand if CakePHP doesn't want to be terribly concerned with backwards compatibility at this point, in which case the documentation should be updated.
