### PR TITLE
Form Helper: Override auto-hidden primaryKey field with option hiddenField => false

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1153,7 +1153,7 @@ class FormHelper extends AppHelper {
 			} elseif (isset($map[$type])) {
 				$options['type'] = $map[$type];
 			}
-			if ($fieldKey == $primaryKey && $options['hiddenField'] !== false) {
+			if ($fieldKey == $primaryKey && (isset($options['hiddenField']) && $options['hiddenField'] !== false)) {	
 				$options['type'] = 'hidden';
 			}
 			if (

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1153,7 +1153,7 @@ class FormHelper extends AppHelper {
 			} elseif (isset($map[$type])) {
 				$options['type'] = $map[$type];
 			}
-			if ($fieldKey == $primaryKey && (isset($options['hiddenField']) && $options['hiddenField'] !== false)) {	
+			if ($fieldKey == $primaryKey && (!isset($options['hiddenField']) || $options['hiddenField'] !== false)) {
 				$options['type'] = 'hidden';
 			}
 			if (

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1153,7 +1153,7 @@ class FormHelper extends AppHelper {
 			} elseif (isset($map[$type])) {
 				$options['type'] = $map[$type];
 			}
-			if ($fieldKey == $primaryKey) {
+			if ($fieldKey == $primaryKey && false !== $options['hiddenField']) {
 				$options['type'] = 'hidden';
 			}
 			if (

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1153,7 +1153,7 @@ class FormHelper extends AppHelper {
 			} elseif (isset($map[$type])) {
 				$options['type'] = $map[$type];
 			}
-			if ($fieldKey == $primaryKey && false !== $options['hiddenField']) {
+			if ($fieldKey == $primaryKey && $options['hiddenField'] !== false) {
 				$options['type'] = 'hidden';
 			}
 			if (


### PR DESCRIPTION
Reported in lighthouse

https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3728-FormHelper-ignores-hiddenField-option-for-primaryKey
