### PR TITLE
Improve CakeRequest::is()

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -466,14 +466,21 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
- * Check whether or not a Request is a certain type. Uses the built in detection rules
- * as well as additional rules defined with CakeRequest::addDetector(). Any detector can be called
+ * Check whether or not a Request is a certain type.
+ *
+ * Uses the built in detection rules as well as additional rules
+ * defined with CakeRequest::addDetector(). Any detector can be called
  * as `is($type)` or `is$Type()`.
  *
- * @param string $type The type of request you want to check.
+ * @param string|array $type The type of request you want to check. If an array
+ *   this method will return true if the request matches any type.
  * @return boolean Whether or not the request is the type you are checking.
  */
 	public function is($type) {
+		if (is_array($type)) {
+			$result = array_map(array($this, 'is'), $type);
+			return count(array_filter($result)) > 0;
+		}
 		$type = strtolower($type);
 		if (!isset($this->_detectors[$type])) {
 			return false;

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -510,6 +510,22 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
+ * Check that a request matches all the given types.
+ *
+ * Allows you to test multiple types and union the results.
+ * See CakeRequest::is() for how to add additional types and the
+ * built-in types.
+ *
+ * @param array $types The types to check.
+ * @return boolean Success.
+ * @see CakeRequest::is()
+ */
+	public function isAll(array $types) {
+		$result = array_filter(array_map(array($this, 'is'), $types));
+		return count($result) === count($types);
+	}
+
+/**
  * Add a new detector to the list of detectors that a request can use.
  * There are several different formats and types of detectors that can be set.
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -724,6 +724,24 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test is() with multiple types.
+ *
+ * @return void
+ */
+	public function testIsMultiple() {
+		$request = new CakeRequest('some/path');
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$this->assertTrue($request->is(array('get', 'post')));
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->assertTrue($request->is(array('get', 'post')));
+
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$this->assertFalse($request->is(array('get', 'post')));
+	}
+
+/**
  * test the method() method.
  *
  * @return void

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -742,6 +742,22 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test isAll()
+ *
+ * @return void
+ */
+	public function testIsAll() {
+		$request = new CakeRequest('some/path');
+
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$this->assertTrue($request->isAll(array('ajax', 'get')));
+		$this->assertFalse($request->isAll(array('post', 'get')));
+		$this->assertFalse($request->isAll(array('ajax', 'post')));
+	}
+
+/**
  * test the method() method.
  *
  * @return void


### PR DESCRIPTION
Add ability to do OR and AND operations on multiple types. In the past checking multiple types required multiple method calls, these new changes let the end developer do both types of checks with one method call. Related to [3714](https://cakephp.lighthouseapp.com/projects/42648/tickets/3714)
