### PR TITLE
Added validation rule for French postal codes

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2112,6 +2112,10 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::postal('1111', null, 'it'));
 		$this->assertTrue(Validation::postal('13089', null, 'it'));
 
+		$this->assertFalse(Validation::postal('111', null, 'fr'));
+		$this->assertFalse(Validation::postal('1111', null, 'fr'));
+		$this->assertTrue(Validation::postal('13089', null, 'fr'));
+
 		$this->assertFalse(Validation::postal('111', null, 'uk'));
 		$this->assertFalse(Validation::postal('1111', null, 'uk'));
 		$this->assertFalse(Validation::postal('AZA 0AB', null, 'uk'));

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -652,6 +652,7 @@ class Validation {
 					break;
 				case 'it':
 				case 'de':
+				case 'fr':
 					$regex = '/^[0-9]{5}$/i';
 					break;
 				case 'be':


### PR DESCRIPTION
French postal codes can be validated the same way as Italian or German ones.
