### PR TITLE
This fixes an issue where attempting to use "!=" in a condition with an array with only a single element generates invalid SQL.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2495,7 +2495,11 @@ class DboSource extends DataSource {
 					if ($keys === array_values($keys)) {
 						$count = count($value);
 						if ($count === 1 && !preg_match("/\s+NOT$/", $key)) {
-							$data = $this->_quoteFields($key) . ' = (';
+							$data = $this->_quoteFields($key);
+							if(!preg_match("/\s+!=$/", $key)) {
+								$data .= ' =';
+							}
+							$data .= ' (';
 							if ($quoteValues) {
 								if (is_object($model)) {
 									$columnType = $model->getColumnType($key);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2496,7 +2496,7 @@ class DboSource extends DataSource {
 						$count = count($value);
 						if ($count === 1 && !preg_match("/\s+NOT$/", $key)) {
 							$data = $this->_quoteFields($key);
-							if(!preg_match("/\s+!=$/", $key)) {
+							if (!preg_match('/\s+!=$/', $key)) {
 								$data .= ' =';
 							}
 							$data .= ' (';

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7944,7 +7944,7 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
- * test that checks for error when != condition passed in key and a 1 element array value
+ * test to assert that != in key together with a single element array will work
  *
  * @return void
  */

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -7944,6 +7944,27 @@ class ModelReadTest extends BaseModelTest {
 	}
 
 /**
+ * test that checks for error when != condition passed in key and a 1 element array value
+ *
+ * @return void
+ */
+	public function testNotEqualsInArrayWithOneValue() {
+		$this->loadFixtures('Article');
+		$Article = new Article();
+		$Article->recursive = -1;
+
+		$result = $Article->find(
+			'all',
+			array(
+				'conditions' => array(
+					'Article.id !=' => array(1)
+				)
+			)
+		);
+		$this->assertTrue(is_array($result) && !empty($result));
+	}	
+
+/**
  * test custom find method
  *
  * @return void


### PR DESCRIPTION
Example:
$condition['Model.id !='] = array(1, 2); //Generates `Model`.`id` NOT IN (1, 2) as expected

$condition['Model.id !='] = array(1); //Generates `Model`.`id` != = (1) which is invalid SQL

Patch will cause the above to generate `Model`.`id` != (1);
