### PR TITLE
remove copyrights from bake templates

### DIFF
--- a/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 /*

--- a/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 /**

--- a/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 /*

--- a/lib/Cake/Console/Templates/skel/Config/acl.ini.php
+++ b/lib/Cake/Console/Templates/skel/Config/acl.ini.php
@@ -5,17 +5,9 @@
 ; *
 ; * PHP 5
 ; *
-; * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
-; * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
-; *
-; *  Licensed under The MIT License
-; *  Redistributions of files must retain the above copyright notice.
-; *
-; * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 ; * @link          http://cakephp.org CakePHP(tm) Project
 ; * @package       app.Config
 ; * @since         CakePHP(tm) v 0.10.0.1076
-; * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
 ; */
 
 ; acl.ini.php - Cake ACL Configuration

--- a/lib/Cake/Console/Templates/skel/Config/acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/acl.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 2.1
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 /**

--- a/lib/Cake/Console/Templates/skel/Config/bootstrap.php
+++ b/lib/Cake/Console/Templates/skel/Config/bootstrap.php
@@ -10,18 +10,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.10.8.2117
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 // Setup a 'default' cache configuration for use in the application.

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 /**

--- a/lib/Cake/Console/Templates/skel/Config/database.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/database.php.default
@@ -14,7 +14,7 @@
  * You can specify multiple configurations for production, development and testing.
  *
  * datasource => The name of a supported datasource; valid options are as follows:
- *		Database/Mysql 		- MySQL 4 & 5,
+ *		Database/Mysql		- MySQL 4 & 5,
  *		Database/Sqlite		- SQLite (PHP5 only),
  *		Database/Postgres	- PostgreSQL 7 and higher,
  *		Database/Sqlserver	- Microsoft SQL Server 2005 and higher

--- a/lib/Cake/Console/Templates/skel/Config/database.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/database.php.default
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * Database configuration class.
  * You can specify multiple configurations for production, development and testing.

--- a/lib/Cake/Console/Templates/skel/Config/email.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/email.php.default
@@ -14,7 +14,7 @@
  * You can specify multiple configurations for production, development and testing.
  *
  * transport => The name of a supported transport; valid options are as follows:
- *		Mail 		- Send using PHP mail function
+ *		Mail		- Send using PHP mail function
  *		Smtp		- Send using SMTP
  *		Debug		- Do not send the email, just return the result
  *

--- a/lib/Cake/Console/Templates/skel/Config/email.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/email.php.default
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 2.0.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  *
  * Email configuration class.
  * You can specify multiple configurations for production, development and testing.

--- a/lib/Cake/Console/Templates/skel/Config/routes.php
+++ b/lib/Cake/Console/Templates/skel/Config/routes.php
@@ -8,18 +8,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 /**
  * Here, we are connecting '/' (base path) to controller called 'Pages',

--- a/lib/Cake/Console/Templates/skel/Console/Command/AppShell.php
+++ b/lib/Cake/Console/Templates/skel/Console/Command/AppShell.php
@@ -4,17 +4,8 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 2.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 App::uses('Shell', 'Console');

--- a/lib/Cake/Console/Templates/skel/Console/cake.bat
+++ b/lib/Cake/Console/Templates/skel/Console/cake.bat
@@ -9,11 +9,11 @@
 :: Licensed under The MIT License
 :: Redistributions of files must retain the above copyright notice.
 ::
-:: @copyright		Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
-:: @link		http://cakephp.org CakePHP(tm) Project
-:: @package   	app.Console
-:: @since		CakePHP(tm) v 2.0
-:: @license		MIT License (http://www.opensource.org/licenses/mit-license.php)
+:: @copyright   Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+:: @link        http://cakephp.org CakePHP(tm) Project
+:: @package     app.Console
+:: @since       CakePHP(tm) v 2.0
+:: @license     MIT License (http://www.opensource.org/licenses/mit-license.php)
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/lib/Cake/Console/Templates/skel/Console/cake.php
+++ b/lib/Cake/Console/Templates/skel/Console/cake.php
@@ -12,11 +12,11 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://cakephp.org CakePHP(tm) Project
- * @package       app.Console
- * @since         CakePHP(tm) v 2.0
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @copyright   Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link        http://cakephp.org CakePHP(tm) Project
+ * @package     app.Console
+ * @since       CakePHP(tm) v 2.0
+ * @license     MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 $ds = DIRECTORY_SEPARATOR;
 $dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';

--- a/lib/Cake/Console/Templates/skel/Controller/AppController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/AppController.php
@@ -7,18 +7,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Controller
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 App::uses('Controller', 'Controller');
 

--- a/lib/Cake/Console/Templates/skel/Controller/PagesController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/PagesController.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Controller
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 App::uses('AppController', 'Controller');
 

--- a/lib/Cake/Console/Templates/skel/Model/AppModel.php
+++ b/lib/Cake/Console/Templates/skel/Model/AppModel.php
@@ -7,18 +7,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Model
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 App::uses('Model', 'Model');

--- a/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
 <h2><?php echo $name; ?></h2>

--- a/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
 <h2><?php echo $name; ?></h2>

--- a/lib/Cake/Console/Templates/skel/View/Helper/AppHelper.php
+++ b/lib/Cake/Console/Templates/skel/View/Helper/AppHelper.php
@@ -7,18 +7,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Helper
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 App::uses('Helper', 'View');
 

--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts.Email.html
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">

--- a/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
 <?php echo $this->fetch('content'); ?>

--- a/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework');

--- a/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
 $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework');

--- a/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 ?>
 <!DOCTYPE html>

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -3,18 +3,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Pages
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 if (!Configure::read('debug')):
 	throw new NotFoundException();

--- a/lib/Cake/Console/Templates/skel/index.php
+++ b/lib/Cake/Console/Templates/skel/index.php
@@ -2,17 +2,8 @@
 /**
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app
  * @since         CakePHP(tm) v 0.10.0.1076
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 require 'webroot' . DIRECTORY_SEPARATOR . 'index.php';

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -6,18 +6,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.webroot
  * @since         CakePHP(tm) v 0.2.9
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 /**
  * Use the DS to separate the directories in other defines

--- a/lib/Cake/Console/Templates/skel/webroot/test.php
+++ b/lib/Cake/Console/Templates/skel/webroot/test.php
@@ -4,18 +4,9 @@
  *
  * PHP 5
  *
- * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
- * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- *
- * Licensed under The MIT License
- * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html
  * @package       app.webroot
  * @since         CakePHP(tm) v 1.2.0.4433
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 set_time_limit(0);
 ini_set('display_errors', 1);


### PR DESCRIPTION
Leaving `link`, `package`, and `since` in the templates. However, I think both `link` and `since` should be be deleted, and only `package` should be left in templates.

What you think?
