### PR TITLE
Add test for time input with interval on first hour of the day

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2347,6 +2347,16 @@ class FormHelperTest extends CakeTestCase {
 		$this->assertContains('<option value="04" selected="selected">4</option>', $result);
 		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
 		$this->assertContains('<option value="pm" selected="selected">pm</option>', $result);
+
+		$result = $this->Form->input('Model.start_time', array(
+			'type' => 'time',
+			'timeFormat' => '12',
+			'interval' => 10,
+			'selected' => '2013-05-19 00:33:00'
+		));
+		$this->assertContains('<option value="12" selected="selected">12</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertContains('<option value="am" selected="selected">am</option>', $result);
 	}
 
 /**


### PR DESCRIPTION
This test proves incorrect behavior of FormHelper::datetime() selecting `pm` instead of `am` with (10 minutes) 'interval' option, on the first hour of the day:
2013-05-19 00:33:00 is selected as 12:30 pm

I've tried to fix this without any luck...
