### PR TITLE
Second parameter of ClassRegistry::init() is a boolean, not a string

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -539,7 +539,7 @@ class TranslateBehavior extends ModelBehavior {
 				$className = $Model->translateModel;
 			}
 
-			$this->runtime[$Model->alias]['model'] = ClassRegistry::init($className, 'Model');
+			$this->runtime[$Model->alias]['model'] = ClassRegistry::init($className);
 		}
 		if (!empty($Model->translateTable) && $Model->translateTable !== $this->runtime[$Model->alias]['model']->useTable) {
 			$this->runtime[$Model->alias]['model']->setSource($Model->translateTable);


### PR DESCRIPTION
Invalid call to ClassRegistry::init() in TranslateBehaviour
Some legacy code from CakePHP 1.3. ClassRegistry::init() used to take a type argument.
