### PR TITLE
Second parameter of ClassRegistry::init() is a boolean, not a string

### DIFF
--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -73,7 +73,7 @@ class ClassRegistry {
  * Examples
  * Simple Use: Get a Post model instance ```ClassRegistry::init('Post');```
  *
- * Expanded: ```array('class' => 'ClassName', 'alias' => 'AliasNameStoredInTheRegistry', 'type' => 'Model');```
+ * Expanded: ```array('class' => 'ClassName', 'alias' => 'AliasNameStoredInTheRegistry');```
  *
  * Model Classes can accept optional ```array('id' => $id, 'table' => $table, 'ds' => $ds, 'alias' => $alias);```
  *


### PR DESCRIPTION
Invalid call to ClassRegistry::init() in TranslateBehaviour
Some legacy code from CakePHP 1.3. ClassRegistry::init() used to take a type argument.
