### PR TITLE
No use of type key in ClassRegistry::init()

### DIFF
--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -73,7 +73,7 @@ class ClassRegistry {
  * Examples
  * Simple Use: Get a Post model instance ```ClassRegistry::init('Post');```
  *
- * Expanded: ```array('class' => 'ClassName', 'alias' => 'AliasNameStoredInTheRegistry', 'type' => 'Model');```
+ * Expanded: ```array('class' => 'ClassName', 'alias' => 'AliasNameStoredInTheRegistry');```
  *
  * Model Classes can accept optional ```array('id' => $id, 'table' => $table, 'ds' => $ds, 'alias' => $alias);```
  *


### PR DESCRIPTION
This seems to be legacy documentation from CakePHP 1.3
