### PR TITLE
Added missing HTTP Status 505 to CakeResponse

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -71,7 +71,8 @@ class CakeResponse {
 		501 => 'Not Implemented',
 		502 => 'Bad Gateway',
 		503 => 'Service Unavailable',
-		504 => 'Gateway Time-out'
+		504 => 'Gateway Time-out',
+		505 => 'Unsupported Version'
 	);
 
 /**


### PR DESCRIPTION
Just a quick fix to add HTTP Status 505 (Unsupported Version) to CakeResponse.
