### PR TITLE
fix currentRoute() when $_currentRoute is empty, return false

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -1093,7 +1093,8 @@ class Router {
  * @return CakeRoute Matching route object.
  */
 	public static function currentRoute() {
-		return self::$_currentRoute[count(self::$_currentRoute) - 1];
+		$count = count(self::$_currentRoute) - 1;
+		return ($count >= 0) ? self::$_currentRoute[$count] : false;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2162,6 +2162,16 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * testCurrentRouteWhenNonExistentRoute
+ *
+ * @return void
+ */
+	public function testCurrentRouteWhenNonExistentRoute() {
+		$route = Router::currentRoute();
+		$this->assertFalse($route);
+	}
+
+/**
  * testCurrentRoute
  *
  * This test needs some improvement and actual requestAction() usage


### PR DESCRIPTION
fix currentRoute() when $_currentRoute is empty, return false.
for example : conflict with DebugKit , when not defined any route
![error](https://f.cloud.github.com/assets/174688/428959/e6781316-ae2b-11e2-9b29-7fbcb0901969.png)
