### PR TITLE
Add Cache::groups() to retrieve group->config maps

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -52,6 +52,13 @@ class Cache {
 	protected static $_config = array();
 
 /**
+ * Group to Config mapping
+ *
+ * @var array
+ */
+	protected static $_groups = array();
+
+/**
  * Whether to reset the settings with the next call to Cache::set();
  *
  * @var array
@@ -128,6 +135,14 @@ class Cache {
 
 		if (empty(self::$_config[$name]['engine'])) {
 			return false;
+		}
+
+		if (!empty(self::$_config[$name]['groups'])) {
+			foreach (self::$_config[$name]['groups'] as $group) {
+				self::$_groups[$group][] = $name;
+				sort(self::$_groups[$group]);
+				self::$_groups[$group] = array_unique(self::$_groups[$group]);
+			}
 		}
 
 		$engine = self::$_config[$name]['engine'];
@@ -496,6 +511,36 @@ class Cache {
 			return self::$_engines[$name]->settings();
 		}
 		return array();
+	}
+
+/**
+ * Retrieve group names to config mapping.
+ *
+ * {{{
+ *	Cache::config('daily', array(
+ *		'duration' => '1 day', 'groups' => array('posts')
+ *	));
+ *	Cache::config('weekly', array(
+ *		'duration' => '1 week', 'groups' => array('posts', 'archive')
+ *	));
+ *	$configs = Cache::groupConfigs('posts');
+ * }}}
+ *
+ * $config will equal to `array('posts' => array('daily', 'weekly'))`
+ *
+ * @param string $group group name or null to retrieve all group mappings
+ * @return array map of group and all configuration that has the same group
+ * @throws CacheException
+ */
+	public static function groupConfigs($group = null) {
+		if ($group == null) {
+			return self::$_groups;
+		}
+		if (isset(self::$_groups[$group])) {
+			return array($group => self::$_groups[$group]);
+		} else {
+			throw new CacheException(__d('cake_dev', 'Invalid cache group %s', $group));
+		}
 	}
 
 }

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -48,6 +48,9 @@ class CacheTest extends CakeTestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
+		Cache::drop('latest');
+		Cache::drop('page');
+		Cache::drop('archive');
 		Configure::write('Cache.disable', $this->_cacheDisable);
 		Cache::config('default', $this->_defaultCacheConfig['settings']);
 	}
@@ -235,6 +238,67 @@ class CacheTest extends CakeTestCase {
 		$this->assertEquals($expected, Cache::settings('sessions'));
 
 		Cache::config('sessions', $_cacheConfigSessions['settings']);
+	}
+
+/**
+ * testGroupConfigs method
+ */
+	public function testGroupConfigs() {
+		Cache::config('latest', array(
+			'duration' => 300,
+			'engine' => 'File',
+			'groups' => array(
+				'posts', 'comments',
+			),
+		));
+
+		$expected = array(
+			'posts' => array('latest'),
+			'comments' => array('latest'),
+		);
+		$result = Cache::groupConfigs();
+		$this->assertEquals($expected, $result);
+
+		$result = Cache::groupConfigs('posts');
+		$this->assertEquals(array('posts' => array('latest')), $result);
+
+		Cache::config('page', array(
+			'duration' => 86400,
+			'engine' => 'File',
+			'groups' => array(
+				'posts', 'archive'
+			),
+		));
+
+		$result = Cache::groupConfigs();
+		$expected = array(
+			'posts' => array('latest', 'page'),
+			'comments' => array('latest'),
+			'archive' => array('page'),
+		);
+		$this->assertEquals($expected, $result);
+
+		$result = Cache::groupConfigs('archive');
+		$this->assertEquals(array('archive' => array('page')), $result);
+
+		Cache::config('archive', array(
+			'duration' => 86400 * 30,
+			'engine' => 'File',
+			'groups' => array(
+				'posts', 'archive', 'comments',
+			),
+		));
+
+		$result = Cache::groupConfigs('archive');
+		$this->assertEquals(array('archive' => array('archive', 'page')), $result);
+	}
+
+/**
+ * testGroupConfigsThrowsException method
+ * @expectedException CacheException
+ */
+	public function testGroupConfigsThrowsException() {
+		Cache::groupConfigs('bogus');
 	}
 
 /**


### PR DESCRIPTION
Please don't merge yet. Looking for feedback.

I'm also thinking of allowing on-the-fly addition of group to existing config.  Perhaps via a new API: `Cache::groupAdd($config, $groupName)`.

Comments?
