### PR TITLE
fix select hours for 0/12

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2207,7 +2207,7 @@ class FormHelper extends AppHelper {
 		if ($attributes['value'] > 12 && !$format24Hours) {
 			$attributes['value'] -= 12;
 		}
-		if ($attributes['value'] === '00' && !$format24Hours) {
+		if (($attributes['value'] === 0 || $attributes['value'] === '00') && !$format24Hours) {
 			$attributes['value'] = 12;
 		}
 


### PR DESCRIPTION
for hour 12 (e.g. local time 14 at UTC+2) the tests fail as `-= 12` casts to 0 and the `=== '00'` check is not triggered.

see http://ci.cakephp.org/job/CakePHP%202.3%20-%20MySQL/993/ etc
