### PR TITLE
Should autoLink escape ampersands?

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -147,6 +147,11 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'This is a test text with URL <a href="http://www.cakephp.org" class="link" id="MyLink">http://www.cakephp.org</a>';
 		$result = $this->Text->autoLink($text, array('class' => 'link', 'id' => 'MyLink'));
 		$this->assertEquals($expected, $result);
+
+		$text = 'This is a test text with URL http://www.cakephp.org?product_id=666&foo=bar&something=breaking';
+		$expected = 'This is a test text with URL <a href="http://www.cakephp.org?product_id=666&foo=bar&something=breaking" class="link" id="MyLink">http://www.cakephp.org?product_id=666&foo=bar&something=breaking</a>';
+		$result = $this->Text->autoLink($text, array('class' => 'link', 'id' => 'MyLink'));
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -162,6 +167,11 @@ class TextHelperTest extends CakeTestCase {
 
 		$text = 'This is a <b>test</b> text with URL http://www.cakephp.org';
 		$expected = 'This is a <b>test</b> text with URL <a href="http://www.cakephp.org">http://www.cakephp.org</a>';
+		$result = $this->Text->autoLink($text, array('escape' => false));
+		$this->assertEquals($expected, $result);
+
+		$text = 'This is a <b>test</b> text with URL http://www.cakephp.org?page=5433&section=foobar';
+		$expected = 'This is a <b>test</b> text with URL <a href="http://www.cakephp.org?page=5433&section=foobar">http://www.cakephp.org?page=5433&section=foobar</a>';
 		$result = $this->Text->autoLink($text, array('escape' => false));
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
Text::autoLink appears to escape ampersands in URLs. (Added to test case to demonstrate).

```
1) TextHelperTest::testAutoLink
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'This is a test text with URL <a href="http://www.cakephp.org?product_id=666&foo=bar&something=breaking" class="link" id="MyLink">http://www.cakephp.org?product_id=666&foo=bar&something=breaking</a>'
+'This is a test text with URL <a href="http://www.cakephp.org" class="link" id="MyLink">http://www.cakephp.org</a>?product_id=666&amp;foo=bar&amp;something=breaking'

/Users/robmcvey/Projects/cakephp/lib/Cake/Test/Case/View/Helper/TextHelperTest.php:154
```

If a URL has GET params, should autoLink remove these? The anchor text of the link will display as "&amp;" and the URL itself won't won't.

Happy to fix, or if this is indeed the desired behaviour (for a reason I can't think of!) please close.

Keep up the good work, fellas! 
