### PR TITLE
Patched CakeResponse's MapType() to increase performance by reducing hun...

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -717,9 +717,7 @@ class CakeResponse {
 		}
 
 		foreach ($this->_mimeTypes as $alias => $types) {
-			if (is_array($types) && in_array($ctype, $types)) {
-				return $alias;
-			} elseif (is_string($types) && $types == $ctype) {
+			if (in_array($ctype, (array)$types)) {
 				return $alias;
 			}
 		}


### PR DESCRIPTION
I have been doing so profiling to see why some of my requests were taking more processing time than i would like, and i found one of the bottlenecks to be on CakeResponse's mapType() method.
After discussing with rchavik on IRC about it, he came with this nice casting approach which saves around a thousand is_array() and is_string() system calls.

This screenshot shows that the method is about twice as fast now: http://i.imgur.com/ooAMwJC.png

// Diego
