### PR TITLE
add schema param and skip interactive prompts if unnecessary

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -83,8 +83,12 @@ class FixtureTask extends BakeTask {
 		))->addOption('plugin', array(
 			'help' => __d('cake_console', 'CamelCased name of the plugin to bake fixtures for.'),
 			'short' => 'p',
+		))->addOption('schema', array(
+			'help' => __d('cake_console', 'Importing schema for fixtures rather than hardcoding it.'),
+			'short' => 's',
+			'boolean' => true
 		))->addOption('records', array(
-			'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10'),
+			'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10.'),
 			'short' => 'r',
 			'boolean' => true
 		))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
@@ -124,9 +128,14 @@ class FixtureTask extends BakeTask {
 		$this->interactive = false;
 		$this->Model->interactive = false;
 		$tables = $this->Model->listAll($this->connection, false);
+
 		foreach ($tables as $table) {
 			$model = $this->_modelName($table);
-			$this->bake($model);
+			$importOptions = array();
+			if (!empty($this->params['schema'])) {
+				$importOptions['schema'] = $model;
+			}
+			$this->bake($model, false, $importOptions);
 		}
 	}
 
@@ -158,11 +167,20 @@ class FixtureTask extends BakeTask {
  */
 	public function importOptions($modelName) {
 		$options = array();
-		$doSchema = $this->in(__d('cake_console', 'Would you like to import schema for this fixture?'), array('y', 'n'), 'n');
-		if ($doSchema === 'y') {
+
+		if (!empty($this->params['schema'])) {
 			$options['schema'] = $modelName;
+		} else {
+			$doSchema = $this->in(__d('cake_console', 'Would you like to import schema for this fixture?'), array('y', 'n'), 'n');
+			if ($doSchema === 'y') {
+				$options['schema'] = $modelName;
+			}
 		}
-		$doRecords = $this->in(__d('cake_console', 'Would you like to use record importing for this fixture?'), array('y', 'n'), 'n');
+		if (!empty($this->params['records'])) {
+			$doRecords = 'y';
+		} else {
+			$doRecords = $this->in(__d('cake_console', 'Would you like to use record importing for this fixture?'), array('y', 'n'), 'n');
+		}
 		if ($doRecords === 'y') {
 			$options['records'] = true;
 		}

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -124,6 +124,48 @@ class FixtureTaskTest extends CakeTestCase {
 	}
 
 /**
+ * test importOptions with overwriting command line options.
+ *
+ * @return void
+ */
+	public function testImportOptionsWithCommandLineOptions() {
+		$this->Task->params = array('schema' => true, 'records' => true);
+
+		$result = $this->Task->importOptions('Article');
+		$expected = array('schema' => 'Article', 'records' => true);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test importOptions with schema.
+ *
+ * @return void
+ */
+	public function testImportOptionsWithSchema() {
+		$this->Task->params = array('schema' => true);
+		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
+		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue('n'));
+
+		$result = $this->Task->importOptions('Article');
+		$expected = array('schema' => 'Article');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test importOptions with records.
+ *
+ * @return void
+ */
+	public function testImportOptionsWithRecords() {
+		$this->Task->params = array('records' => true);
+		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('n'));
+
+		$result = $this->Task->importOptions('Article');
+		$expected = array('records' => true);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test importOptions choosing from Table.
  *
  * @return void
@@ -267,6 +309,32 @@ class FixtureTaskTest extends CakeTestCase {
 		$filename = '/my/path/CommentFixture.php';
 		$this->Task->expects($this->at(1))->method('createFile')
 			->with($filename, $this->stringContains("'comment' => 'First Comment for First Article'"));
+		$this->Task->expects($this->exactly(2))->method('createFile');
+
+		$this->Task->all();
+	}
+
+/**
+ * test using all() with -schema
+ *
+ * @return void
+ */
+	public function testAllWithSchemaImport() {
+		$this->Task->connection = 'test';
+		$this->Task->path = '/my/path/';
+		$this->Task->args = array('all');
+		$this->Task->params = array('schema' => true);
+
+		$this->Task->Model->expects($this->any())->method('listAll')
+			->will($this->returnValue(array('Articles', 'comments')));
+
+		$filename = '/my/path/ArticleFixture.php';
+		$this->Task->expects($this->at(0))->method('createFile')
+			->with($filename, $this->stringContains('public $import = array(\'model\' => \'Article\''));
+
+		$filename = '/my/path/CommentFixture.php';
+		$this->Task->expects($this->at(1))->method('createFile')
+			->with($filename, $this->stringContains('public $import = array(\'model\' => \'Comment\''));
 		$this->Task->expects($this->exactly(2))->method('createFile');
 
 		$this->Task->all();


### PR DESCRIPTION
Improvements for schema baking.

-s / --schema option added to allow baking all fixtures with noninteractive "all" while using schema import.

I also removed the interactive prompts for records or schema if already passed in as command line arguments as this is then unnecessary.
