### PR TITLE
3.0 Add support for fixed length strings.

### DIFF
--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -18,6 +18,9 @@ namespace Cake\Database\Schema;
 
 use Cake\Database\Schema\Table;
 
+/**
+ * Schema dialect/support for MySQL
+ */
 class MysqlSchema {
 
 /**
@@ -78,33 +81,33 @@ class MysqlSchema {
 		}
 
 		if (in_array($col, array('date', 'time', 'datetime', 'timestamp'))) {
-			return [$col, null];
+			return ['type' => $col, 'length' => null];
 		}
 		if (($col === 'tinyint' && $length === 1) || $col === 'boolean') {
-			return ['boolean', null];
+			return ['type' => 'boolean', 'length' => null];
 		}
 		if (strpos($col, 'bigint') !== false || $col === 'bigint') {
-			return ['biginteger', $length];
+			return ['type' => 'biginteger', 'length' => $length];
 		}
 		if (strpos($col, 'int') !== false) {
-			return ['integer', $length];
+			return ['type' => 'integer', 'length' => $length];
 		}
 		if (strpos($col, 'char') !== false || $col === 'tinytext') {
-			return ['string', $length];
+			return ['type' => 'string', 'length' => $length];
 		}
 		if (strpos($col, 'text') !== false) {
-			return ['text', $length];
+			return ['type' => 'text', 'length' => $length];
 		}
 		if (strpos($col, 'blob') !== false || $col === 'binary') {
-			return ['binary', $length];
+			return ['type' => 'binary', 'length' => $length];
 		}
 		if (strpos($col, 'float') !== false || strpos($col, 'double') !== false) {
-			return ['float', $length];
+			return ['type' => 'float', 'length' => $length];
 		}
 		if (strpos($col, 'decimal') !== false) {
-			return ['decimal', null];
+			return ['type' => 'decimal', 'length' => null];
 		}
-		return ['text', null];
+		return ['type' => 'text', 'length' => null];
 	}
 
 /**
@@ -116,12 +119,10 @@ class MysqlSchema {
  * @return void
  */
 	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
-		list($type, $length) = $this->convertColumn($row['Type']);
-		$field = [
-			'type' => $type,
+		$field = $this->convertColumn($row['Type']);
+		$field += [
 			'null' => $row['Null'] === 'YES' ? true : false,
 			'default' => $row['Default'],
-			'length' => $length,
 		];
 		foreach ($fieldParams as $key => $metadata) {
 			if (!empty($row[$metadata['column']])) {

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -66,7 +66,7 @@ class MysqlSchema {
  * The returned type will be a type that Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @return array List of (type, length)
+ * @return array Array of column information.
  */
 	public function convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
@@ -91,6 +91,9 @@ class MysqlSchema {
 		}
 		if (strpos($col, 'int') !== false) {
 			return ['type' => 'integer', 'length' => $length];
+		}
+		if ($col === 'char') {
+			return ['type' => 'string', 'fixed' => true, 'length' => $length];
 		}
 		if (strpos($col, 'char') !== false || $col === 'tinytext') {
 			return ['type' => 'string', 'length' => $length];

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -108,7 +108,7 @@ class PostgresSchema {
 			return ['type' => 'string', 'length' => 39];
 		}
 		if ($col === 'uuid') {
-			return ['type' => 'string', 'length' => 36];
+			return ['type' => 'string', 'fixed' => true, 'length' => 36];
 		}
 		if ($col === 'char' || $col === 'character') {
 			return ['type' => 'string', 'fixed' => true, 'length' => $length];

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -74,51 +74,51 @@ class PostgresSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @return array List of (type, length)
+ * @return array Array of column information.
  */
 	public function convertColumn($column) {
 		$col = strtolower($column);
 		if (in_array($col, array('date', 'time', 'boolean'))) {
-			return [$col, null];
+			return ['type' =>$col, 'length' => null];
 		}
 		if (strpos($col, 'timestamp') !== false) {
-			return ['datetime', null];
+			return ['type' => 'datetime', 'length' => null];
 		}
 		if ($col === 'serial' || $col === 'integer') {
-			return ['integer', 10];
+			return ['type' => 'integer', 'length' => 10];
 		}
 		if ($col === 'bigserial' || $col === 'bigint') {
-			return ['biginteger', 20];
+			return ['type' => 'biginteger', 'length' => 20];
 		}
 		if ($col === 'smallint') {
-			return ['integer', 5];
+			return ['type' => 'integer', 'length' => 5];
 		}
 		if ($col === 'inet') {
-			return ['string', 39];
+			return ['type' => 'string', 'length' => 39];
 		}
 		if ($col === 'uuid') {
-			return ['string', 36];
+			return ['type' => 'string', 'length' => 36];
 		}
 		if (strpos($col, 'char') !== false) {
-			return ['string', null];
+			return ['type' => 'string', 'length' => null];
 		}
 		if (strpos($col, 'text') !== false) {
-			return ['text', null];
+			return ['type' => 'text', 'length' => null];
 		}
 		if ($col === 'bytea') {
-			return ['binary', null];
+			return ['type' => 'binary', 'length' => null];
 		}
 		if ($col === 'real' || strpos($col, 'double') !== false) {
-			return ['float', null];
+			return ['type' => 'float', 'length' => null];
 		}
 		if (
 			strpos($col, 'numeric') !== false ||
 			strpos($col, 'money') !== false ||
 			strpos($col, 'decimal') !== false
 		) {
-			return ['decimal', null];
+			return ['type' => 'decimal', 'length' => null];
 		}
-		return ['text', null];
+		return ['type' => 'text', 'length' => null];
 	}
 
 /**
@@ -143,9 +143,9 @@ class PostgresSchema {
  * @return void
  */
 	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
-		list($type, $length) = $this->convertColumn($row['type']);
+		$field = $this->convertColumn($row['type']);
 
-		if ($type === 'boolean') {
+		if ($field['type'] === 'boolean') {
 			if ($row['default'] === 'true') {
 				$row['default'] = 1;
 			}
@@ -154,12 +154,11 @@ class PostgresSchema {
 			}
 		}
 
-		$field = [
-			'type' => $type,
+		$field += [
 			'null' => $row['null'] === 'YES' ? true : false,
 			'default' => $row['default'],
-			'length' => $row['char_length'] ?: $length,
 		];
+		$field['length'] = $row['char_length'] ?: $field['length'];
 		foreach ($fieldParams as $key => $metadata) {
 			if (!empty($row[$metadata['column']])) {
 				$field[$key] = $row[$metadata['column']];

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -71,6 +71,9 @@ class SqliteSchema {
 		if (strpos($col, 'int') !== false) {
 			return ['type' => 'integer', 'length' => $length];
 		}
+		if ($col === 'char') {
+			return ['type' => 'string', 'fixed' => true, 'length' => $length];
+		}
 		if (strpos($col, 'char') !== false) {
 			return ['type' => 'string', 'length' => $length];
 		}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -39,7 +39,7 @@ class SqliteSchema {
  *
  * @param string $column The column type + length
  * @throws Cake\Error\Exception
- * @return array List of (type, length)
+ * @return array Array of column information.
  */
 	public function convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
@@ -53,31 +53,31 @@ class SqliteSchema {
 		}
 
 		if ($col === 'bigint') {
-			return ['biginteger', $length];
+			return ['type' => 'biginteger', 'length' => $length];
 		}
 		if (in_array($col, ['blob', 'clob'])) {
-			return ['binary', null];
+			return ['type' => 'binary', 'length' => null];
 		}
 		if (in_array($col, ['date', 'time', 'timestamp', 'datetime'])) {
-			return [$col, null];
+			return ['type' => $col, 'length' => null];
 		}
 		if (strpos($col, 'decimal') !== false) {
-			return ['decimal', null];
+			return ['type' => 'decimal', 'length' => null];
 		}
 
 		if (strpos($col, 'boolean') !== false) {
-			return ['boolean', null];
+			return ['type' => 'boolean', 'length' => null];
 		}
 		if (strpos($col, 'int') !== false) {
-			return ['integer', $length];
+			return ['type' => 'integer', 'length' => $length];
 		}
 		if (strpos($col, 'char') !== false) {
-			return ['string', $length];
+			return ['type' => 'string', 'length' => $length];
 		}
 		if (in_array($col, ['float', 'real', 'double'])) {
-			return ['float', null];
+			return ['type' => 'float', 'length' => null];
 		}
-		return ['text', null];
+		return ['type' => 'text', 'length' => null];
 	}
 
 /**
@@ -118,12 +118,10 @@ class SqliteSchema {
  * @param array $fieldParams Additional field parameters to parse.
  */
 	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
-		list($type, $length) = $this->convertColumn($row['type']);
-		$field = [
-			'type' => $type,
+		$field = $this->convertColumn($row['type']);
+		$field += [
 			'null' => !$row['notnull'],
 			'default' => $row['dflt_value'] === null ? null : trim($row['dflt_value'], "'"),
-			'length' => $length,
 		];
 		if ($row['pk'] == true) {
 			$field['null'] = false;

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -47,63 +47,63 @@ class MysqlSchemaTest extends TestCase {
 		return [
 			[
 				'DATETIME',
-				['datetime', null]
+				['type' => 'datetime', 'length' => null]
 			],
 			[
 				'DATE',
-				['date', null]
+				['type' =>  'date', 'length' => null]
 			],
 			[
 				'TIME',
-				['time', null]
+				['type' => 'time', 'length' => null]
 			],
 			[
 				'TINYINT(1)',
-				['boolean', null]
+				['type' => 'boolean', 'length' => null]
 			],
 			[
 				'TINYINT(2)',
-				['integer', 2]
+				['type' => 'integer', 'length' => 2]
 			],
 			[
 				'INTEGER(11)',
-				['integer', 11]
+				['type' => 'integer', 'length' => 11]
 			],
 			[
 				'BIGINT',
-				['biginteger', null]
+				['type' => 'biginteger', 'length' => null]
 			],
 			[
 				'VARCHAR(255)',
-				['string', 255]
+				['type' => 'string', 'length' => 255]
 			],
 			[
 				'CHAR(25)',
-				['string', 25]
+				['type' => 'string', 'length' => 25]
 			],
 			[
 				'TINYTEXT',
-				['string', null]
+				['type' => 'string', 'length' => null]
 			],
 			[
 				'BLOB',
-				['binary', null]
+				['type' => 'binary', 'length' => null]
 			],
 			[
 				'MEDIUMBLOB',
-				['binary', null]
+				['type' => 'binary', 'length' => null]
 			],
 			[
 				'FLOAT',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'DOUBLE',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'DECIMAL(11,2)',
-				['decimal', null]
+				['type' => 'decimal', 'length' => null]
 			],
 		];
 	}

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -79,7 +79,7 @@ class MysqlSchemaTest extends TestCase {
 			],
 			[
 				'CHAR(25)',
-				['type' => 'string', 'length' => 25]
+				['type' => 'string', 'length' => 25, 'fixed' => true]
 			],
 			[
 				'TINYTEXT',

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -82,91 +82,91 @@ SQL;
 		return [
 			[
 				'TIMESTAMP',
-				['datetime', null]
+				['type' => 'datetime', 'length' => null]
 			],
 			[
 				'TIMESTAMP WITHOUT TIME ZONE',
-				['datetime', null]
+				['type' => 'datetime', 'length' => null]
 			],
 			[
 				'DATE',
-				['date', null]
+				['type' => 'date', 'length' => null]
 			],
 			[
 				'TIME',
-				['time', null]
+				['type' => 'time', 'length' => null]
 			],
 			[
 				'SMALLINT',
-				['integer', 5]
+				['type' => 'integer', 'length' => 5]
 			],
 			[
 				'INTEGER',
-				['integer', 10]
+				['type' => 'integer', 'length' => 10]
 			],
 			[
 				'SERIAL',
-				['integer', 10]
+				['type' => 'integer', 'length' => 10]
 			],
 			[
 				'BIGINT',
-				['biginteger', 20]
+				['type' => 'biginteger', 'length' => 20]
 			],
 			[
 				'NUMERIC',
-				['decimal', null]
+				['type' => 'decimal', 'length' => null]
 			],
 			[
 				'DECIMAL(10,2)',
-				['decimal', null]
+				['type' => 'decimal', 'length' => null]
 			],
 			[
 				'MONEY',
-				['decimal', null]
+				['type' => 'decimal', 'length' => null]
 			],
 			[
 				'VARCHAR',
-				['string', null]
+				['type' => 'string', 'length' => null]
 			],
 			[
 				'CHARACTER VARYING',
-				['string', null]
+				['type' => 'string', 'length' => null]
 			],
 			[
 				'CHAR',
-				['string', null]
+				['type' => 'string', 'length' => null]
 			],
 			[
 				'UUID',
-				['string', 36]
+				['type' => 'string', 'length' => 36]
 			],
 			[
 				'CHARACTER',
-				['string', null]
+				['type' => 'string', 'length' => null]
 			],
 			[
 				'INET',
-				['string', 39]
+				['type' => 'string', 'length' => 39]
 			],
 			[
 				'TEXT',
-				['text', null]
+				['type' => 'text', 'length' => null]
 			],
 			[
 				'BYTEA',
-				['binary', null]
+				['type' => 'binary', 'length' => null]
 			],
 			[
 				'REAL',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'DOUBLE PRECISION',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'BIGSERIAL',
-				['biginteger', 20]
+				['type' => 'biginteger', 'length' => 20]
 			],
 		];
 	}

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -129,20 +129,28 @@ SQL;
 				['type' => 'string', 'length' => null]
 			],
 			[
+				'VARCHAR(10)',
+				['type' => 'string', 'length' => 10]
+			],
+			[
 				'CHARACTER VARYING',
 				['type' => 'string', 'length' => null]
 			],
 			[
-				'CHAR',
-				['type' => 'string', 'length' => null]
+				'CHARACTER VARYING(10)',
+				['type' => 'string', 'length' => 10]
+			],
+			[
+				'CHAR(10)',
+				['type' => 'string', 'fixed' => true, 'length' => 10]
+			],
+			[
+				'CHARACTER(10)',
+				['type' => 'string', 'fixed' => true, 'length' => 10]
 			],
 			[
 				'UUID',
 				['type' => 'string', 'length' => 36]
-			],
-			[
-				'CHARACTER',
-				['type' => 'string', 'length' => null]
 			],
 			[
 				'INET',

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -47,63 +47,63 @@ class SqliteSchemaTest extends TestCase {
 		return [
 			[
 				'DATETIME',
-				['datetime', null]
+				['type' => 'datetime', 'length' => null]
 			],
 			[
 				'DATE',
-				['date', null]
+				['type' => 'date', 'length' => null]
 			],
 			[
 				'TIME',
-				['time', null]
+				['type' => 'time', 'length' => null]
 			],
 			[
 				'BOOLEAN',
-				['boolean', null]
+				['type' => 'boolean', 'length' => null]
 			],
 			[
 				'BIGINT',
-				['biginteger', null]
+				['type' => 'biginteger', 'length' => null]
 			],
 			[
 				'VARCHAR(255)',
-				['string', 255]
+				['type' => 'string', 'length' => 255]
 			],
 			[
 				'CHAR(25)',
-				['string', 25]
+				['type' => 'string', 'length' => 25]
 			],
 			[
 				'BLOB',
-				['binary', null]
+				['type' => 'binary', 'length' => null]
 			],
 			[
 				'INTEGER(11)',
-				['integer', 11]
+				['type' => 'integer', 'length' => 11]
 			],
 			[
 				'TINYINT(5)',
-				['integer', 5]
+				['type' => 'integer', 'length' => 5]
 			],
 			[
 				'MEDIUMINT(10)',
-				['integer', 10]
+				['type' => 'integer', 'length' => 10]
 			],
 			[
 				'FLOAT',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'DOUBLE',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'REAL',
-				['float', null]
+				['type' => 'float', 'length' => null]
 			],
 			[
 				'DECIMAL(11,2)',
-				['decimal', null]
+				['type' => 'decimal', 'length' => null]
 			],
 		];
 	}

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -71,7 +71,7 @@ class SqliteSchemaTest extends TestCase {
 			],
 			[
 				'CHAR(25)',
-				['type' => 'string', 'length' => 25]
+				['type' => 'string', 'fixed' => true, 'length' => 25]
 			],
 			[
 				'BLOB',


### PR DESCRIPTION
This flag is useful for indicating the difference between varchar + char fields. In some databases (mysql) the performance characteristics between char & varchar are important.

Having fixed length strings also enables us to better preserve schema details when generating fixtures and reflecting schema.
