### PR TITLE
Loooong page numbers in pagination component (SQL error?)

### DIFF
--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -890,6 +890,24 @@ class PaginatorComponentTest extends CakeTestCase {
 	}
 
 /**
+ * Test that a really REALLY large page number gets clamped to the max page size.
+ * 
+ *
+ * @expectedException NotFoundException
+ * @return void
+ */
+	public function testOutOfVeryBigRangePageNumberGetsClamped() {
+		$Controller = new PaginatorTestController($this->request);
+		$Controller->uses = array('PaginatorControllerPost');
+		$Controller->params['named'] = array(
+			'page' => 3000000000000000000000000,
+		);
+		$Controller->constructClasses();
+		$Controller->PaginatorControllerPost->recursive = 0;
+		$Controller->Paginator->paginate('PaginatorControllerPost');
+	}	
+
+/**
  * testOutOfRangePageNumberAndPageCountZero
  *
  * @return void


### PR DESCRIPTION
Found the following error, with corresponding access log entry:

<b>app/tmp/error.log</b>

```
2013-05-02 09:25:29 Error: [PDOException] SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '5.5340232221129E+19, 6' at line 1
#0 /var/www/httpdocs/lib/Cake/Model/Datasource/DboSource.php(460): PDOStatement->execute(Array)
#1 /var/www/httpdocs/lib/Cake/Model/Datasource/DboSource.php(426): DboSource->_execute('SELECT `Job`.`i...', Array)
#2 /var/www/httpdocs/lib/Cake/Model/Datasource/DboSource.php(670): DboSource->execute('SELECT `Job`.`i...', Array, Array)
#3 /var/www/httpdocs/lib/Cake/Model/Datasource/DboSource.php(1081): DboSource->fetchAll('SELECT `Job`.`i...', false)
#4 /var/www/httpdocs/lib/Cake/Model/Model.php(2696): DboSource->read(Object(Job), Array)
#5 /var/www/httpdocs/lib/Cake/Controller/Component/PaginatorComponent.php(196): Model->find('all', Array)
#6 /var/www/httpdocs/lib/Cake/Controller/Controller.php(1074): PaginatorComponent->paginate('Job', Array, Array)
#7 /var/www/httpdocs/app/Controller/JobsController.php(326): Controller->paginate('Job')
#8 [internal function]: JobsController->index()
#9 /var/www/httpdocs/lib/Cake/Controller/Controller.php(486): ReflectionMethod->invokeArgs(Object(JobsController), Array)
#10 /var/www/httpdocs/lib/Cake/Routing/Dispatcher.php(187): Controller->invokeAction(Object(CakeRequest))
#11 /var/www/httpdocs/lib/Cake/Routing/Dispatcher.php(162): Dispatcher->_invoke(Object(JobsController), Object(CakeRequest), Object(CakeResponse))
#12 /var/www/httpdocs/app/webroot/index.php(96): Dispatcher->dispatch(Object(CakeRequest), Object(CakeResponse))
```

<b>access.log</b>

```
80.176.141.230 - - [01/May/2013:17:57:17 +0100] "GET /jobs/index/page:30000000000000000000000000000000 HTTP/1.1" 200
```

This should throw a NotFound exception the same as any other request for a page number that does not exist. 

<b>Box info</b>

```
PHP 5.4.6-1ubuntu1.2 (cli) (built: Mar 11 2013 14:57:54) 
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.4.0, Copyright (c) 1998-2012 Zend Technologies

mysql  Ver 14.14 Distrib 5.5.29, for debian-linux-gnu (x86_64) using readline 6.2
```
