### PR TITLE
Ensure session is not invalidated after reading/deleting non-existent key.

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -250,7 +250,6 @@ class CakeSession {
 			self::_overwrite($_SESSION, Hash::remove($_SESSION, $name));
 			return !self::check($name);
 		}
-		self::_setError(2, __d('cake_dev', "%s doesn't exist", $name));
 		return false;
 	}
 
@@ -370,7 +369,6 @@ class CakeSession {
 		if (isset($result)) {
 			return $result;
 		}
-		self::_setError(2, "$name doesn't exist");
 		return null;
 	}
 

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -348,21 +348,6 @@ class CakeSessionTest extends CakeTestCase {
 	}
 
 /**
- * testError method
- *
- * @return void
- */
-	public function testError() {
-		TestCakeSession::read('Does.not.exist');
-		$result = TestCakeSession::error();
-		$this->assertEquals("Does.not.exist doesn't exist", $result);
-
-		TestCakeSession::delete('Failing.delete');
-		$result = TestCakeSession::error();
-		$this->assertEquals("Failing.delete doesn't exist", $result);
-	}
-
-/**
  * testDel method
  *
  * @return void


### PR DESCRIPTION
Hack to fix [#3813](https://cakephp.lighthouseapp.com/projects/42648/tickets/3813-bug-in-i18n-when-reading-language-from-session)
