### PR TITLE
Add pluralize method to the Core TextHelper

### DIFF
--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -279,4 +279,19 @@ class TextHelper extends AppHelper {
 		return $this->_engine->toList($list, $and, $separator);
 	}
 
+/**
+ * Give the plural form of a word
+ * depending on $count. Usefull when displaying
+ * the number of comment associate to a post for example
+ *
+ * @param string $word Word to pluralize
+ * @param integer $count The amout of $word
+ * @return string Modified string
+ */
+	public function pluralize($word, $count){
+		if( $count > 1 ){
+			return $count . ' ' . Inflector::pluralize( $word );
+		}
+		return $count . ' ' . $word;
+	}
 }


### PR DESCRIPTION
Pluralize method helps to write and manipulate word depending on number. Will be really usefull when displaying for example, the number of comment associate to a post. 
Inspired from RubyOnRails pluralize helper method
