### PR TITLE
3.0 - Re-factor connection handling logic

### DIFF
--- a/lib/Cake/Database/Driver.php
+++ b/lib/Cake/Database/Driver.php
@@ -23,22 +23,47 @@ use \Cake\Database\SqlDialectTrait;
  * Represents a database diver containing all specificities for
  * a database engine including its SQL dialect
  *
- **/
+ */
 abstract class Driver {
+
+/**
+ * Configuration data.
+ *
+ * @var array
+ */
+	protected $_config;
+
+/**
+ * Base configuration that is merged into the user
+ * supplied configuration data.
+ *
+ * @var array
+ */
+	protected $_baseConfig = [];
+
+/**
+ * Constructor
+ *
+ * @param array $config The configuration for the driver.
+ * @return void
+ */
+	public function __construct($config = []) {
+		$config += $this->_baseConfig;
+		$this->_config = $config;
+	}
 
 /**
  * Establishes a connection to the database server
  *
- * @param array $config configuration to be used for creating connection
  * @return boolean true con success
- **/
-	public abstract function connect(array $config);
+ */
+	public abstract function connect();
 
 /**
  * Disconnects from database server
  *
  * @return void
- **/
+ */
 	public abstract function disconnect();
 
 /**
@@ -46,14 +71,14 @@ abstract class Driver {
  * If first argument is passed,
  *
  * @return void
- **/
+ */
 	public abstract function connection($connection = null);
 
 /**
  * Returns whether php is able to use this driver for connecting to database
  *
  * @return boolean true if it is valid to use this driver
- **/
+ */
 	public abstract function enabled();
 
 /**
@@ -61,28 +86,28 @@ abstract class Driver {
  *
  * @param string $sql
  * @return Cake\Database\Statement
- **/
+ */
 	public abstract function prepare($sql);
 
 /**
  * Starts a transaction
  *
  * @return boolean true on success, false otherwise
- **/
+ */
 	public abstract function beginTransaction();
 
 /**
  * Commits a transaction
  *
  * @return boolean true on success, false otherwise
- **/
+ */
 	public abstract function commitTransaction();
 
 /**
  * Rollsback a transaction
  *
  * @return boolean true on success, false otherwise
- **/
+ */
 	public abstract function rollbackTransaction();
 
 /**
@@ -105,7 +130,7 @@ abstract class Driver {
  * Checks if the driver supports quoting
  *
  * @return boolean
- **/
+ */
 	public function supportsQuoting() {
 		return true;
 	}
@@ -115,9 +140,27 @@ abstract class Driver {
  *
  * @param string $table table name or sequence to get last insert value from
  * @return string|integer
- **/
+ */
 	public function lastInsertId($table = null) {
 		return $this->_connection->lastInsertId($table);
+	}
+
+/**
+ * Check whether or not the driver is connected.
+ *
+ * @return boolean
+ */
+	public function isConnected() {
+		return $this->_connection !== null;
+	}
+
+/**
+ * Destructor
+ *
+ * @return void
+ */
+	public function __destruct() {
+		$this->_connection = null;
 	}
 
 }

--- a/lib/Cake/Database/Driver/Mysql.php
+++ b/lib/Cake/Database/Driver/Mysql.php
@@ -46,11 +46,13 @@ class Mysql extends \Cake\Database\Driver {
 /**
  * Establishes a connection to the database server
  *
- * @param array $config configuration to be used for creating connection
  * @return boolean true on success
  */
-	public function connect(array $config) {
-		$config += $this->_baseConfig;
+	public function connect() {
+		if ($this->_connection) {
+			return true;
+		}
+		$config = $this->_config;
 
 		if ($config['timezone'] === 'UTC') {
 			$config['timezone'] = '+0:00';

--- a/lib/Cake/Database/Driver/PDODriverTrait.php
+++ b/lib/Cake/Database/Driver/PDODriverTrait.php
@@ -23,6 +23,13 @@ use PDO;
 trait PDODriverTrait {
 
 /**
+ * Instance of PDO.
+ *
+ * @var \PDO
+ */
+	protected $_connection;
+
+/**
  * Establishes a connection to the databse server
  *
  * @param array $config configuration to be used for creating connection
@@ -69,7 +76,8 @@ trait PDODriverTrait {
  * @return Cake\Database\Statement
  */
 	public function prepare($sql) {
-		$statement = $this->connection()->prepare($sql);
+		$this->connect();
+		$statement = $this->_connection->prepare($sql);
 		return new PDOStatement($statement, $this);
 	}
 
@@ -79,7 +87,8 @@ trait PDODriverTrait {
  * @return boolean true on success, false otherwise
  */
 	public function beginTransaction() {
-		return $this->connection()->beginTransaction();
+		$this->connect();
+		return $this->_connection->beginTransaction();
 	}
 
 /**
@@ -88,7 +97,8 @@ trait PDODriverTrait {
  * @return boolean true on success, false otherwise
  */
 	public function commitTransaction() {
-		return $this->connection()->commit();
+		$this->connect();
+		return $this->_connection->commit();
 	}
 
 /**
@@ -97,7 +107,8 @@ trait PDODriverTrait {
  * @return boolean true on success, false otherwise
  */
 	public function rollbackTransaction() {
-		return $this->connection()->rollback();
+		$this->connect();
+		return $this->_connection->rollback();
 	}
 
 /**
@@ -106,7 +117,8 @@ trait PDODriverTrait {
  * @return string
  */
 	public function quote($value, $type) {
-		return $this->connection()->quote($value, $type);
+		$this->connect();
+		return $this->_connection->quote($value, $type);
 	}
 
 /**
@@ -116,7 +128,8 @@ trait PDODriverTrait {
  * @return string|integer
  */
 	public function lastInsertId($table = null) {
-		return $this->connection()->lastInsertId();
+		$this->connect();
+		return $this->_connection->lastInsertId();
 	}
 
 /**
@@ -125,7 +138,8 @@ trait PDODriverTrait {
  * @return boolean
  */
 	public function supportsQuoting() {
-		return $this->connection()->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
+		$this->connect();
+		return $this->_connection->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'odbc';
 	}
 
 }

--- a/lib/Cake/Database/Driver/Postgres.php
+++ b/lib/Cake/Database/Driver/Postgres.php
@@ -49,11 +49,13 @@ class Postgres extends \Cake\Database\Driver {
 /**
  * Establishes a connection to the databse server
  *
- * @param array $config configuration to be used for creating connection
  * @return boolean true on success
  */
-	public function connect(array $config) {
-		$config += $this->_baseConfig;
+	public function connect() {
+		if ($this->_connection) {
+			return true;
+		}
+		$config = $this->_config;
 		$config['flags'] += [
 			PDO::ATTR_PERSISTENT => $config['persistent'],
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
@@ -64,7 +66,7 @@ class Postgres extends \Cake\Database\Driver {
 		}
 
 		$this->_connect($config);
-		$connection = $this->connection();
+		$this->_connection = $connection = $this->connection();
 		if (!empty($config['encoding'])) {
 			$this->setEncoding($config['encoding']);
 		}
@@ -88,7 +90,6 @@ class Postgres extends \Cake\Database\Driver {
  *
  * @return boolean true if it is valid to use this driver
  */
-
 	public function enabled() {
 		return in_array('pgsql', PDO::getAvailableDrivers());
 	}
@@ -99,8 +100,8 @@ class Postgres extends \Cake\Database\Driver {
  * @return void
  */
 	public function setEncoding($encoding) {
-		$connection = $this->connection();
-		$connection->exec('SET NAMES ' . $connection->quote($encoding));
+		$this->connect();
+		$this->_connection->exec('SET NAMES ' . $this->_connection->quote($encoding));
 	}
 
 /**
@@ -110,8 +111,8 @@ class Postgres extends \Cake\Database\Driver {
  * @return void
  */
 	public function setSchema($schema) {
-		$connection = $this->connection();
-		$connection->exec('SET search_path TO ' . $connection->quote($schema));
+		$this->connect();
+		$this->_connection->exec('SET search_path TO ' . $this->_connection->quote($schema));
 	}
 
 }

--- a/lib/Cake/Database/Driver/Sqlite.php
+++ b/lib/Cake/Database/Driver/Sqlite.php
@@ -33,6 +33,8 @@ class Sqlite extends \Cake\Database\Driver {
  */
 	protected $_baseConfig = [
 		'persistent' => false,
+		'login' => null,
+		'password' => null,
 		'database' => ':memory:',
 		'encoding' => 'utf8',
 		'flags' => [],
@@ -43,11 +45,13 @@ class Sqlite extends \Cake\Database\Driver {
 /**
  * Establishes a connection to the databse server
  *
- * @param array $config configuration to be used for creating connection
  * @return boolean true on success
  */
-	public function connect(array $config) {
-		$config += $this->_baseConfig + ['login' => null, 'password' => null];
+	public function connect() {
+		if ($this->_connection) {
+			return true;
+		}
+		$config = $this->_config;
 		$config['flags'] += [
 			PDO::ATTR_PERSISTENT => $config['persistent'],
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
@@ -64,7 +68,6 @@ class Sqlite extends \Cake\Database\Driver {
 				$this->connection()->exec($command);
 			}
 		}
-
 		return true;
 	}
 
@@ -85,7 +88,8 @@ class Sqlite extends \Cake\Database\Driver {
  * @return Cake\Database\Statement
  */
 	public function prepare($sql) {
-		$statement = $this->connection()->prepare($sql);
+		$this->connect();
+		$statement = $this->_connection->prepare($sql);
 		return new SqliteStatement(new PDOStatement($statement, $this), $this);
 	}
 

--- a/lib/Cake/Test/TestCase/Database/Driver/MysqlTest.php
+++ b/lib/Cake/Test/TestCase/Database/Driver/MysqlTest.php
@@ -77,7 +77,6 @@ class MysqlTest extends TestCase {
  * @return void
  */
 	public function testConnectionConfigCustom() {
-		$driver = $this->getMock('Cake\Database\Driver\Mysql', ['_connect']);
 		$config = [
 			'persistent' => false,
 			'host' => 'foo',
@@ -90,7 +89,11 @@ class MysqlTest extends TestCase {
 			'timezone' => 'Antartica',
 			'init' => ['Execute this', 'this too']
 		];
-
+		$driver = $this->getMock(
+			'Cake\Database\Driver\Mysql',
+			['_connect'],
+			[$config]
+		);
 		$expected = $config;
 		$expected['dsn'] = 'mysql:host=foo;port=3440;dbname=bar;charset=a-language';
 		$expected['init'][] = "SET time_zone = 'Antartica'";
@@ -102,7 +105,7 @@ class MysqlTest extends TestCase {
 		];
 		$driver->expects($this->once())->method('_connect')
 			->with($expected);
-		$driver->connect($config);
+		$driver->connect();
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
+++ b/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
@@ -74,7 +74,7 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 		$driver->expects($this->any())->method('connection')
 			->will($this->returnValue($connection));
 
-		$driver->connect([]);
+		$driver->connect();
 	}
 
 /**
@@ -83,7 +83,6 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testConnectionConfigCustom() {
-		$driver = $this->getMock('Cake\Database\driver\Postgres', ['_connect', 'connection']);
 		$config = [
 			'persistent' => false,
 			'host' => 'foo',
@@ -97,6 +96,11 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 			'schema' => 'fooblic',
 			'init' => ['Execute this', 'this too']
 		];
+		$driver = $this->getMock(
+			'Cake\Database\driver\Postgres',
+			['_connect', 'connection'],
+			[$config]
+		);
 
 		$expected = $config;
 		$expected['dsn'] = 'pgsql:host=foo;port=3440;dbname=bar';
@@ -121,12 +125,14 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 		$connection->expects($this->at(7))->method('exec')->with('SET timezone = Antartica');
 		$connection->expects($this->exactly(5))->method('exec');
 
+		$driver->connection($connection);
 		$driver->expects($this->once())->method('_connect')
 			->with($expected);
+
 		$driver->expects($this->any())->method('connection')
 			->will($this->returnValue($connection));
 
-		$driver->connect($config);
+		$driver->connect();
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Database/Driver/SqliteTest.php
+++ b/lib/Cake/Test/TestCase/Database/Driver/SqliteTest.php
@@ -61,7 +61,6 @@ class SqliteTest extends TestCase {
  * @return void
  */
 	public function testConnectionConfigCustom() {
-		$driver = $this->getMock('Cake\Database\driver\Sqlite', ['_connect', 'connection']);
 		$config = [
 			'persistent' => true,
 			'host' => 'foo',
@@ -70,6 +69,11 @@ class SqliteTest extends TestCase {
 			'encoding' => 'a-language',
 			'init' => ['Execute this', 'this too']
 		];
+		$driver = $this->getMock(
+			'Cake\Database\driver\Sqlite',
+			['_connect', 'connection'],
+			[$config]
+		);
 
 		$expected = $config;
 		$expected += ['login' => null, 'password' => null];

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -150,7 +150,7 @@ SQL;
 			],
 			[
 				'UUID',
-				['type' => 'string', 'length' => 36]
+				['type' => 'string', 'fixed' => true, 'length' => 36]
 			],
 			[
 				'INET',


### PR DESCRIPTION
This allows classes that only access the driver (like schema platforms)  to have access to lazy connection features. I think this also makes the drivers better encapsulate their behavior. Before some of the connected/connection logic was in the connection class which I think will slowly become the datasource class, or a wrapper for the various SQL based datasources at the very least.
