### PR TITLE
resolve unnecessary naming conflict in SQL dump output

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -902,7 +902,7 @@ class DboSource extends DataSource {
 		if (PHP_SAPI !== 'cli') {
 			$controller = null;
 			$View = new View($controller, false);
-			$View->set('logs', array($this->configKeyName => $log));
+			$View->set('sqlLogs', array($this->configKeyName => $log));
 			echo $View->element('sql_dump', array('_forced_from_dbo_' => true));
 		} else {
 			foreach ($log['log'] as $k => $i) {

--- a/lib/Cake/View/Elements/sql_dump.ctp
+++ b/lib/Cake/View/Elements/sql_dump.ctp
@@ -20,22 +20,22 @@
 if (!class_exists('ConnectionManager') || Configure::read('debug') < 2) {
 	return false;
 }
-$noLogs = !isset($logs);
+$noLogs = !isset($sqlLogs);
 if ($noLogs):
 	$sources = ConnectionManager::sourceList();
 
-	$logs = array();
+	$sqlLogs = array();
 	foreach ($sources as $source):
 		$db = ConnectionManager::getDataSource($source);
 		if (!method_exists($db, 'getLog')):
 			continue;
 		endif;
-		$logs[$source] = $db->getLog();
+		$sqlLogs[$source] = $db->getLog();
 	endforeach;
 endif;
 
 if ($noLogs || isset($_forced_from_dbo_)):
-	foreach ($logs as $source => $logInfo):
+	foreach ($sqlLogs as $source => $logInfo):
 		$text = $logInfo['count'] > 1 ? 'queries' : 'query';
 		printf(
 			'<table class="cake-sql-log" id="cakeSqlLog_%s" summary="Cake SQL Log" cellspacing="0">',
@@ -71,5 +71,5 @@ if ($noLogs || isset($_forced_from_dbo_)):
 	<?php
 	endforeach;
 else:
-	echo '<p>Encountered unexpected $logs cannot generate SQL log</p>';
+	echo '<p>Encountered unexpected $sqlLogs cannot generate SQL log</p>';
 endif;


### PR DESCRIPTION
If you pass $logs - or have a log model + controller:

```
Encountered unexpected $logs cannot generate SQL log
```

$logs is to generic to be used in the element IMO. This change resolves this unnecessary naming conflict.
