### PR TITLE
Fix bug in Xml::_toArray Method

### DIFF
--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -644,6 +644,16 @@ XML;
 			)
 		);
 		$this->assertEquals($expected, Xml::toArray($obj));
+
+		$xml = '<tag type="myType">0</tag>';
+		$obj = Xml::build($xml);
+		$expected = array(
+			'tag' => array(
+				'@type' => 'myType',
+				'@' => 0
+			)
+		);
+		$this->assertEquals($expected, Xml::toArray($obj));
 	}
 
 /**

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -360,7 +360,7 @@ class Xml {
 		$asString = trim((string)$xml);
 		if (empty($data)) {
 			$data = $asString;
-		} elseif (!empty($asString)) {
+		} elseif (strlen($asString) > 0) {
 			$data['@'] = $asString;
 		}
 


### PR DESCRIPTION
# Hi !
# Problem :

Method : Xml::_toArray();

Example : 

``` php
debug(Xml::toArray(Xml::build('<tag type="myType">0</tag>')));
```

Output is :

```
array(
    'tag' => array(
        '@type' => 'myType'
    )
)
```

That must be :

```
array(
    'tag' => array(
        '@type' => 'myType',
        '@' => 0
    )
)
```
# Why ?

When a tag has an attribute, Xml::_toArray() test if the value isn't empty, but the string `0` is considered as empty !

``` php
$asString = trim((string)$xml);
if (empty($data)) {
    $data = $asString;
} elseif (!empty($asString)) {
    $data['@'] = $asString;
}
```
# Solution :

Check if the string is equals to the string `0`.

``` php
$asString = trim((string)$xml);
if (empty($data)) {
    $data = $asString;
} elseif (!empty($asString) || $asString === '0') {
    $data['@'] = $asString;
}
```
