### PR TITLE
Prevent autoload when checking for the existence of HttpException

### DIFF
--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -63,7 +63,7 @@ class CakeBaseException extends RuntimeException {
  *
  * @package       Cake.Error
  */
-if (!class_exists('HttpException')) {
+if (!class_exists('HttpException', false)) {
 	class HttpException extends CakeBaseException {
 	}
 }


### PR DESCRIPTION
The class_exists() check has been added in https://github.com/cakephp/cakephp/commit/4f29f58a5e9689adda104d77edf2c0cfe5101cd1#L1R28 to prevent a side effect with a PECL extension.

However if an autoloader such as the Composer one is loaded, it will try to require this `exceptions.php` file again:

```
    'HttpException' => $vendorDir . '/pear-pear.cakephp.org/CakePHP/Cake/Error/exceptions.php',
```

this will result in a "Fatal error:  Cannot redeclare class CakeBaseException"

I have not find a cleaner way to prevent this error and cannot think of another side effect this change could have.
