### PR TITLE
index.php is not an appropriate router for the built in webserver

### DIFF
--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -126,11 +126,10 @@ class ServerShell extends AppShell {
 			return;
 		}
 
-		$command = sprintf("php -S %s:%d -t %s %s",
+		$command = sprintf("php -S %s:%d -t %s",
 			$this->_host,
 			$this->_port,
-			$this->_documentRoot,
-			WWW_ROOT . '/index.php'
+			$this->_documentRoot
 		);
 
 		$port = ($this->_port == self::DEFAULT_PORT) ? '' : ':' . $this->_port;


### PR DESCRIPTION
Currently the built in web server cannot serve static assets with a query string due to the configured router. It serve's HTML instead. Additionally the 'router' will return 200 for non-existent files.

e.g. 

``` bash
$ ./app/Console/cake server -p 8080
# In another terminal
$ curl --head http://localhost:8080/img/cake.icon.png
HTTP/1.1 200 OK
Host: localhost:8080
Connection: close
Content-Type: image/png
Content-Length: 943
$ curl --head http://localhost:8080/img/cake.icon.png?
HTTP/1.1 200 OK
Host: localhost:8080
Connection: close
X-Powered-By: PHP/5.4.14
Content-type: text/html
$ curl --head http://localhost:8080/img/NO_FILE
HTTP/1.1 200 OK
Host: localhost:8080
Connection: close
X-Powered-By: PHP/5.4.14
Content-type: text/html
```

Removing the explicitly defined router resolves this. After applying patch, query strings and 404's work:

``` bash
$ curl --head http://localhost:8080/img/cake.icon.png?
HTTP/1.1 200 OK
Host: localhost:8080
Connection: close
Content-Type: image/png
Content-Length: 943
$ curl --head http://localhost:8080/img/NO_FILE
HTTP/1.1 404 Not Found
Host: localhost:8080
Connection: close
Content-Type: text/html; charset=UTF-8
Content-Length: 366
```
