### PR TITLE
$this->modelClass needs to be correct prior to the components init() 

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -632,11 +632,11 @@ class Controller extends Object implements CakeEventListener {
  */
 	public function constructClasses() {
 		$this->_mergeControllerVars();
-		$this->Components->init($this);
 		if ($this->uses) {
 			$this->uses = (array)$this->uses;
 			list(, $this->modelClass) = pluginSplit(current($this->uses));
 		}
+		$this->Components->init($this);
 		return true;
 	}
 

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -360,6 +360,13 @@ class TestComponent extends Object {
 
 class Test2Component extends TestComponent {
 
+	public $model;
+
+	public function __construct(ComponentCollection $collection, $settings) {
+		$this->controller = $collection->getController();
+		$this->model = $this->controller->modelClass;
+	}
+
 	public function beforeRender(Controller $controller) {
 		return false;
 	}
@@ -524,6 +531,22 @@ class ControllerTest extends CakeTestCase {
 
 		$this->assertTrue(isset($Controller->TestPluginPost));
 		$this->assertTrue(is_a($Controller->TestPluginPost, 'TestPluginPost'));
+	}
+
+/**
+ * testConstructClassesWithComponents method
+ *
+ * @return void
+ */
+	public function testConstructClassesWithComponents() {
+		$Controller = new TestPluginController(new CakeRequest(), new CakeResponse());
+		$Controller->uses = array('NameTest');
+		$Controller->components[] = 'Test2';
+
+		$Controller->constructClasses();
+		$this->assertEquals('NameTest', $Controller->Test2->model);
+		$this->assertEquals('Name', $Controller->NameTest->name);
+		$this->assertEquals('Name', $Controller->NameTest->alias);
 	}
 
 /**


### PR DESCRIPTION
$this->modelClass needs to be correct prior to the components init() call if the component itself accesses the model, lazyloading would try to load the wrong model otherwise.
