### PR TITLE
Utilize File utility to base64 encode email attachments

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1385,7 +1385,8 @@ class CakeEmail {
  * @return string File contents in base64 encoding
  */
 	protected function _readFile($file) {
-		return File::readAndBase64Encode($file);
+		$f = new File($file);
+		return $f->readBase64();
 	}
 
 /**

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1386,7 +1386,7 @@ class CakeEmail {
  */
 	protected function _readFile($path) {
 		$File = new File($path);
-		return $File->readBase64();
+		return chunk_split(base64_encode($File->read()));
 	}
 
 /**

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1381,12 +1381,12 @@ class CakeEmail {
 /**
  * Read the file contents and return a base64 version of the file contents.
  *
- * @param string $file The file to read.
+ * @param string $path The absolute path to the file to read.
  * @return string File contents in base64 encoding
  */
-	protected function _readFile($file) {
-		$f = new File($file);
-		return $f->readBase64();
+	protected function _readFile($path) {
+		$File = new File($path);
+		return $File->readBase64();
 	}
 
 /**

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -21,6 +21,7 @@
 App::uses('Validation', 'Utility');
 App::uses('Multibyte', 'I18n');
 App::uses('AbstractTransport', 'Network/Email');
+App::uses('File', 'Utility');
 App::uses('String', 'Utility');
 App::uses('View', 'View');
 App::import('I18n', 'Multibyte');
@@ -1359,7 +1360,7 @@ class CakeEmail {
 			if (!empty($fileInfo['contentId'])) {
 				continue;
 			}
-			$data = $this->readFile($fileInfo['file']);
+			$data = $this->_readFile($fileInfo['file']);
 
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];
@@ -1383,12 +1384,8 @@ class CakeEmail {
  * @param string $file The file to read.
  * @return string File contents in base64 encoding
  */
-	public function readFile($file) {
-		$handle = fopen($file, 'rb');
-		$data = fread($handle, filesize($file));
-		$data = chunk_split(base64_encode($data));
-		fclose($handle);
-		return $data;
+	protected function _readFile($file) {
+		return File::readAndBase64Encode($file);
 	}
 
 /**
@@ -1407,7 +1404,7 @@ class CakeEmail {
 			if (empty($fileInfo['contentId'])) {
 				continue;
 			}
-			$data = $this->readFile($fileInfo['file']);
+			$data = $this->_readFile($fileInfo['file']);
 
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1359,7 +1359,7 @@ class CakeEmail {
 			if (!empty($fileInfo['contentId'])) {
 				continue;
 			}
-			$data = $this->_readFile($fileInfo['file']);
+			$data = $this->readFile($fileInfo['file']);
 
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];
@@ -1383,7 +1383,7 @@ class CakeEmail {
  * @param string $file The file to read.
  * @return string File contents in base64 encoding
  */
-	protected function _readFile($file) {
+	public function readFile($file) {
 		$handle = fopen($file, 'rb');
 		$data = fread($handle, filesize($file));
 		$data = chunk_split(base64_encode($data));
@@ -1407,7 +1407,7 @@ class CakeEmail {
 			if (empty($fileInfo['contentId'])) {
 				continue;
 			}
-			$data = $this->_readFile($fileInfo['file']);
+			$data = $this->readFile($fileInfo['file']);
 
 			$msg[] = '--' . $boundary;
 			$msg[] = 'Content-Type: ' . $fileInfo['mimetype'];

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -181,6 +181,21 @@ class File {
 	}
 
 /**
+ * Read the file contents and return a base64 version of the file contents.
+ *
+ * @param string $file The file to read.
+ * @return string File contents in base64 encoding
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readAndBase64Encode
+ */
+	public static function readAndBase64Encode($file) {
+		$handle = fopen($file, 'rb');
+		$data = fread($handle, filesize($file));
+		$data = chunk_split(base64_encode($data));
+		fclose($handle);
+		return $data;
+	}
+
+/**
  * Sets or gets the offset for the currently opened file.
  *
  * @param integer|boolean $offset The $offset in bytes to seek. If set to false then the current offset is returned.

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -185,7 +185,7 @@ class File {
  * The string is split into smaller chunks to match RFC 2045 semantics.
  *
  * @return string File contents in base64 encoding
- * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readAndBase64Encode
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readBase64
  */
 	public function readBase64() {
 		return chunk_split(base64_encode($this->read()));

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -181,18 +181,13 @@ class File {
 	}
 
 /**
- * Read the file contents and return a base64 version of the file contents.
+ * Return the contents of this File as a base64 version of the file contents.
  *
- * @param string $file The file to read.
  * @return string File contents in base64 encoding
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readAndBase64Encode
  */
-	public static function readAndBase64Encode($file) {
-		$handle = fopen($file, 'rb');
-		$data = fread($handle, filesize($file));
-		$data = chunk_split(base64_encode($data));
-		fclose($handle);
-		return $data;
+	public function readBase64() {
+		return chunk_split(base64_encode($this->read()));
 	}
 
 /**

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -182,6 +182,7 @@ class File {
 
 /**
  * Return the contents of this File as a base64 version of the file contents.
+ * The string is split into smaller chunks to match RFC 2045 semantics.
  *
  * @return string File contents in base64 encoding
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readAndBase64Encode

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -181,17 +181,6 @@ class File {
 	}
 
 /**
- * Return the contents of this File as a base64 version of the file contents.
- * The string is split into smaller chunks to match RFC 2045 semantics.
- *
- * @return string File contents in base64 encoding
- * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::readBase64
- */
-	public function readBase64() {
-		return chunk_split(base64_encode($this->read()));
-	}
-
-/**
  * Sets or gets the offset for the currently opened file.
  *
  * @param integer|boolean $offset The $offset in bytes to seek. If set to false then the current offset is returned.


### PR DESCRIPTION
I needed this method while building a Transport, and found it better to move this method out of the CakeEmail class and into the File utility, so it could be re-used.
