### PR TITLE
CakeEmail::_wrap does not operate correctly by the character string of specific Japanese. 

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1253,7 +1253,7 @@ class CakeEmail {
 				$formatted[] = '';
 				continue;
 			}
-			if (!preg_match('/\<[a-z]/i', $line)) {
+			if (!preg_match('/<[a-z]+.+>/i', $line)) {
 				$formatted = array_merge(
 					$formatted,
 					explode("\n", wordwrap($line, $wrapLength, "\n"))

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1623,7 +1623,7 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 	public function testWrapLongLine() {
-		$message = '<a href="http://cakephp.org">' . str_repeat('1234567890', 100) . "</a>";
+		$message = '<a href="http://cakephp.org">' . str_repeat('x', CakeEmail::LINE_LENGTH_MUST) . "</a>";
 
 		$this->CakeEmail->reset();
 		$this->CakeEmail->transport('Debug');
@@ -1632,7 +1632,27 @@ class CakeEmailTest extends CakeTestCase {
 		$this->CakeEmail->subject('Wordwrap Test');
 		$this->CakeEmail->config(array('empty'));
 		$result = $this->CakeEmail->send($message);
-		$expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('1234567890', 100) . "\r\n</a>\r\n\r\n";
+		$expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('x', CakeEmail::LINE_LENGTH_MUST) . "\r\n</a>\r\n\r\n";
+		$this->assertEquals($expected, $result['message']);
+	}
+
+	public function testWrapIncludeTag() {
+		$message = '<a href="http://cakephp.org">CakePHP</a>';
+
+		$this->CakeEmail->reset();
+		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->to('cake@cakephp.org');
+		$this->CakeEmail->subject('Wordwrap Test');
+		$this->CakeEmail->config(array('empty'));
+		$result = $this->CakeEmail->send($message);
+		$expected = "{$message}\r\n\r\n";
+		$this->assertEquals($expected, $result['message']);
+
+		$message = 'foo<bar';
+
+		$result = $this->CakeEmail->send($message);
+		$expected = "{$message}\r\n\r\n";
 		$this->assertEquals($expected, $result['message']);
 	}
 

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1622,6 +1622,38 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertContains('ってテーブルを作ってやってたらう', $result['message']);
 	}
 
+	public function testWrapLongLine() {
+		$message = '<a href="http://cakephp.org">' . str_repeat('1234567890', 100) . "</a>";
+
+		$this->CakeEmail->reset();
+		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->to('cake@cakephp.org');
+		$this->CakeEmail->subject('Wordwrap Test');
+		$this->CakeEmail->config(array('empty'));
+		$result = $this->CakeEmail->send($message);
+		$expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('1234567890', 100) . "\r\n</a>\r\n\r\n";
+		$this->assertEquals($expected, $result['message']);
+	}
+
+	public function testWrapForJapaneseEncoding() {
+		$this->skipIf(!function_exists('mb_convert_encoding'));
+
+		$message = mb_convert_encoding('受け付けました', 'iso-2022-jp', 'UTF-8');
+
+		$this->CakeEmail->reset();
+		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->from('cake@cakephp.org');
+		$this->CakeEmail->to('cake@cakephp.org');
+		$this->CakeEmail->subject('Wordwrap Test');
+		$this->CakeEmail->config(array('empty'));
+		$this->CakeEmail->charset('iso-2022-jp');
+		$this->CakeEmail->headerCharset('iso-2022-jp');
+		$result = $this->CakeEmail->send($message);
+		$expected = "{$message}\r\n\r\n";
+		$this->assertEquals($expected, $result['message']);
+	}
+
 /**
  * Tests that the body is encoded using the configured charset
  *


### PR DESCRIPTION
The assembly of the message was not correctly completed in specific Japanese.

Character string with the pattern "<u" exists when encoding is ISO-2022-JP.
