### PR TITLE
code is not translatable and should not be part of translation strings

### DIFF
--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -404,15 +404,19 @@ class ProjectTask extends AppShell {
 		}
 		if ($this->interactive) {
 			$this->hr();
-			$this->out(__d('cake_console', 'You need to enable Configure::write(\'Routing.prefixes\', array(\'admin\')) in /app/Config/core.php to use prefix routing.'));
+			$this->out(__d('cake_console', 'You need to enable %s in %s to use prefix routing.',
+					'Configure::write(\'Routing.prefixes\', array(\'admin\'))',
+					'/app/Config/core.php'));
 			$this->out(__d('cake_console', 'What would you like the prefix route to be?'));
-			$this->out(__d('cake_console', 'Example: www.example.com/admin/controller'));
+			$this->out(__d('cake_console', 'Example: %s', 'www.example.com/admin/controller'));
 			while (!$admin) {
 				$admin = $this->in(__d('cake_console', 'Enter a routing prefix:'), null, 'admin');
 			}
 			if ($this->cakeAdmin($admin) !== true) {
-				$this->out(__d('cake_console', '<error>Unable to write to</error> /app/Config/core.php.'));
-				$this->out(__d('cake_console', 'You need to enable Configure::write(\'Routing.prefixes\', array(\'admin\')) in /app/Config/core.php to use prefix routing.'));
+				$this->out(__d('cake_console', '<error>Unable to write to</error> %s.', '/app/Config/core.php'));
+				$this->out(__d('cake_console', 'You need to enable %s in %s to use prefix routing.',
+					'Configure::write(\'Routing.prefixes\', array(\'admin\'))',
+					'/app/Config/core.php'));
 				$this->_stop();
 			}
 			return $admin . '_';


### PR DESCRIPTION
Using code/paths in translation strings only creates noise and increases the risk of errors in the translation as there is no real value in having them in the translation string itself.

There are probably more places, but I wanted to get some opinions first.
