### PR TITLE
Proposed new timezone method for FormHelper

### DIFF
--- a/lib/Cake/Test/TestCase/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/FormHelperTest.php
@@ -5186,6 +5186,20 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+	
+
+
+/**
+* testTimeZoneSelect method
+*
+* Test for proposed new Form::timezone() option 
+*
+* @return void
+*/	
+	public function testTimeZoneSelect() {
+		$this->markTestIncomplete("Test for proposed new Form::timezone() option");
+	}
+	
 
 /**
  * testCheckbox method

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2069,6 +2069,34 @@ class FormHelper extends Helper {
 		$select[] = $this->Html->useTag($template);
 		return implode("\n", $select);
 	}
+	
+/**
+ * Returns a formatted SELECT element for choosing local timezone
+ *
+ * ### Attributes:
+ *
+ * - `showParents` - If included in the array and set to true, an additional option element
+ *   will be added for the parent of each option group. You can set an option with the same name
+ *   and it's key will be used for the value of the option.
+ * - `multiple` - show a multiple select box. If set to 'checkbox' multiple checkboxes will be
+ *   created instead.
+ * - `empty` - If true, the empty select option is shown. If a string,
+ *   that string is displayed as the empty element.
+ * - `escape` - If true contents of options will be HTML entity encoded. Defaults to true.
+ * - `value` The selected value of the input.
+ * - `class` - When using multiple = checkbox the classname to apply to the divs. Defaults to 'checkbox'.
+ * - `disabled` - Control the disabled attribute. When creating a select box, set to true to disable the
+ *   select box. When creating checkboxes, `true` will disable all checkboxes. You can also set disabled
+ *   to a list of values you want to disable when creating checkboxes.
+ *
+ * @param string $fieldName Name attribute of the timezone SELECT
+ * @param array $attributes The HTML attributes of the timezone select element.
+ * @return string Formatted SELECT element to choose world timezone
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
+ */
+	public function timezone($fieldName, $attributes = array()) {	
+		return $this->select($fieldName, array(), $attributes = array());
+	}	
 
 /**
  * Returns a SELECT element for days.


### PR DESCRIPTION
### Some background

Every implementation I've seen of a drop down list of timezones has been very poor in terms of UX. The select is easy to use, but the lists I've seen presented, although correct, are not often clear for your average user. 

For a developer it's easy to just offer a select input of UTC offsets or timezone identifiers, but to 95% of real World web users this is confusing, do people <b>really</b> know how many hours ahead or behind of UTC they are? Is it daylight saving or standard? 

At work, we have had a headache with users choosing the wrong timezone, and in our app these times are actually deadlines, so when a user does this wrong it's a real pain. 

So we created a helper. Basically, if offers a 2-tier select with the top level being the Country. Everyone knows what Country they are in (right? :smile: )

![screen shot 2013-05-17 at 15 29 03](https://f.cloud.github.com/assets/222958/518764/f47df39c-bf04-11e2-83f8-0446c2f83235.png)
![screen shot 2013-05-17 at 15 28 36](https://f.cloud.github.com/assets/222958/518772/09751bb8-bf05-11e2-9543-b0d9709e8ab6.png)

The second tier offers a list of the possible timeszones in that Country, along with the local time for each. This makes the choice for users much easier if they don't know what GMT or UTC is.

Could be a nice option for the FormHelper! Thoughts?
