### PR TITLE
3.0 - Postgres schema create + refactoring

### DIFF
--- a/lib/Cake/Database/Schema/Collection.php
+++ b/lib/Cake/Database/Schema/Collection.php
@@ -89,7 +89,10 @@ class Collection {
 		}
 
 		$table = new Table($name);
-		$fieldParams = $this->_dialect->extraSchemaColumns();
+		$fieldParams = [];
+		if (method_exists($this->_dialect, 'extraSchemaColumn')) {
+			$fieldParams = $this->_dialect->extraSchemaColumns();
+		}
 		foreach ($statement->fetchAll('assoc') as $row) {
 			$this->_dialect->convertFieldDescription($table, $row, $fieldParams);
 		}

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -256,14 +256,15 @@ class MysqlSchema {
 		return $out;
 	}
 
+
 /**
- * Generate the SQL fragment for a single index in MySQL
+ * Generate the SQL fragments for defining table constraints.
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
-	public function indexSql(Table $table, $name) {
+	public function constraintSql(Table $table, $name) {
 		$data = $table->index($name);
 		if ($data['type'] === Table::INDEX_PRIMARY) {
 			$columns = array_map(
@@ -293,6 +294,17 @@ class MysqlSchema {
 			}
 		}
 		return $out . ' (' . implode(', ', $columns) . ')';
+	}
+
+/**
+ * Generate the SQL fragment for a single index in MySQL
+ *
+ * @param Cake\Database\Schema\Table $table The table object the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	public function indexSql(Table $table, $name) {
+		return '';
 	}
 
 }

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -171,7 +171,7 @@ class MysqlSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param string $table The name of the table.
+ * @param Table $table Table instance
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
@@ -179,7 +179,7 @@ class MysqlSchema {
  */
 	public function createTableSql($table, $columns, $constraints, $indexes) {
 		$content = implode(",\n", array_merge($columns, $constraints, $indexes));
-		return [sprintf("CREATE TABLE `%s` (\n%s\n);", $table, $content)];
+		return [sprintf("CREATE TABLE `%s` (\n%s\n)", $table->name(), $content)];
 	}
 
 /**

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -20,7 +20,7 @@ use Cake\Database\Schema\Table;
 use Cake\Error;
 
 /**
- * Schema dialect/support for MySQL
+ * Schema management/reflection features for MySQL
  */
 class MysqlSchema {
 
@@ -35,6 +35,7 @@ class MysqlSchema {
  * Constructor
  *
  * @param Cake\Database\Driver $driver The driver to use.
+ * @return void
  */
 	public function __construct($driver) {
 		$this->_driver = $driver;

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -171,11 +171,11 @@ class MysqlSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param Table $table Table instance
+ * @param Cake\Database\Schema\Table $table Table instance
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
- * @return array A complete CREATE TABLE statement(s)
+ * @return array Complete CREATE TABLE statement(s)
  */
 	public function createTableSql($table, $columns, $constraints, $indexes) {
 		$content = implode(",\n", array_merge($columns, $constraints, $indexes));

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -279,17 +279,7 @@ class MysqlSchema {
 			$out = 'UNIQUE KEY ';
 		}
 		$out .= $this->_driver->quoteIdentifier($name);
-
-		$columns = array_map(
-			[$this->_driver, 'quoteIdentifier'],
-			$data['columns']
-		);
-		foreach ($data['columns'] as $i => $column) {
-			if (isset($data['length'][$column])) {
-				$columns[$i] .= sprintf('(%d)', $data['length'][$column]);
-			}
-		}
-		return $out . ' (' . implode(', ', $columns) . ')';
+		return $this->_keySql($out, $data);
 	}
 
 /**
@@ -308,7 +298,17 @@ class MysqlSchema {
 			$out = 'FULLTEXT KEY ';
 		}
 		$out .= $this->_driver->quoteIdentifier($name);
+		return $this->_keySql($out, $data);
+	}
 
+/**
+ * Helper method for generating key SQL snippets.
+ *
+ * @param string $prefix The key prefix
+ * @param array $data Key data.
+ * @return string
+ */
+	protected function _keySql($prefix, $data) {
 		$columns = array_map(
 			[$this->_driver, 'quoteIdentifier'],
 			$data['columns']
@@ -318,7 +318,7 @@ class MysqlSchema {
 				$columns[$i] .= sprintf('(%d)', $data['length'][$column]);
 			}
 		}
-		return $out . ' (' . implode(', ', $columns) . ')';
+		return $prefix . ' (' . implode(', ', $columns) . ')';
 	}
 
 }

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -304,13 +304,13 @@ class PostgresSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param string $table The name of the table.
+ * @param Cake\Database\Schema\Table $table Table instance.
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
- * @return string A complete CREATE TABLE statement
+ * @return string Complete CREATE TABLE statement
  */
-	public function createTableSql($table, $columns, $constraints, $indexes) {
+	public function createTableSql(Table $table, $columns, $constraints, $indexes) {
 		$content = array_merge($columns, $constraints);
 		$content = implode(",\n", array_filter($content));
 		$tableName = $this->_driver->quoteIdentifier($table->name());

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -259,17 +259,24 @@ class PostgresSchema {
 	}
 
 /**
- * Generate the SQL fragment for a single index.
- *
- * Handles creating index types that can be defined in a table create
- * statement. Primary keys + unique constraints are handled here.
- * Other index types are handled in indexSql().
+ * Generate the SQL fragment for a single index
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
 	public function indexSql(Table $table, $name) {
+		return '';
+	}
+
+/**
+ * Generate the SQL fragment for a single constraint
+ *
+ * @param Cake\Database\Schema\Table $table The table object the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	public function constraintSql(Table $table, $name) {
 		$data = $table->index($name);
 		$out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
 		if ($data['type'] === Table::INDEX_PRIMARY) {

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -261,12 +261,28 @@ class PostgresSchema {
 /**
  * Generate the SQL fragment for a single index.
  *
+ * Handles creating index types that can be defined in a table create
+ * statement. Primary keys + unique constraints are handled here.
+ * Other index types are handled in indexSql().
+ *
  * @param Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
 	public function indexSql(Table $table, $name) {
 		$data = $table->index($name);
+		$out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
+		if ($data['type'] === Table::INDEX_PRIMARY) {
+			$out = 'PRIMARY KEY ';
+		}
+		if ($data['type'] === Table::INDEX_UNIQUE) {
+			$out .= ' UNIQUE ';
+		}
+		$columns = array_map(
+			[$this->_driver, 'quoteIdentifier'],
+			$data['columns']
+		);
+		return $out . '(' . implode(', ', $columns) . ')';
 	}
 
 /**

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -313,10 +313,21 @@ class PostgresSchema {
 	public function createTableSql($table, $columns, $constraints, $indexes) {
 		$content = array_merge($columns, $constraints);
 		$content = implode(",\n", array_filter($content));
+		$tableName = $this->_driver->quoteIdentifier($table->name());
 		$out = [];
-		$out[] = sprintf("CREATE TABLE \"%s\" (\n%s\n)", $table, $content);
+		$out[] = sprintf("CREATE TABLE %s (\n%s\n)", $tableName, $content);
 		foreach ($indexes as $index) {
 			$out[] = $index;
+		}
+		foreach ($table->columns() as $column) {
+			$columnData = $table->column($column);
+			if (isset($columnData['comment'])) {
+				$out[] = sprintf('COMMENT ON COLUMN %s.%s IS %s',
+					$tableName,
+					$this->_driver->quoteIdentifier($column),
+					$this->_driver->schemaValue($columnData['comment'])
+				);
+			}
 		}
 		return $out;
 	}

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -19,6 +19,9 @@ namespace Cake\Database\Schema;
 use Cake\Database\Schema\Table;
 use Cake\Error;
 
+/**
+ * Schema management/reflection features for Postgres.
+ */
 class PostgresSchema {
 
 /**
@@ -28,6 +31,12 @@ class PostgresSchema {
  */
 	protected $_driver;
 
+/**
+ * Constructor
+ *
+ * @param Cake\Database\Driver\Postgres $driver Driver to use.
+ * @return void
+ */
 	public function __construct($driver) {
 		$this->_driver = $driver;
 	}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -254,11 +254,11 @@ class SqliteSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param Table $table Table instance
+ * @param Table $table Cake\Database\Schema\Table instance
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
- * @return array A complete CREATE TABLE statement(s)S
+ * @return array Complete CREATE TABLE statement(s)S
  */
 	public function createTableSql($table, $columns, $constraints, $indexes) {
 		$lines = array_merge($columns, $constraints);

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -19,6 +19,9 @@ namespace Cake\Database\Schema;
 use Cake\Database\Schema\Table;
 use Cake\Error;
 
+/**
+ * Schema management/reflection features for Sqlite
+ */
 class SqliteSchema {
 
 /**
@@ -28,6 +31,12 @@ class SqliteSchema {
  */
 	protected $_driver;
 
+/**
+ * Constructor
+ *
+ * @param Cake\Database\Driver\Sqlite $driver Driver to use.
+ * @return void
+ */
 	public function __construct($driver) {
 		$this->_driver = $driver;
 	}
@@ -103,15 +112,6 @@ class SqliteSchema {
  */
 	public function describeTableSql($table) {
 		return ["PRAGMA table_info(" . $this->_driver->quoteIdentifier($table) . ")", []];
-	}
-
-/**
- * Additional metadata columns in table descriptions.
- *
- * @return array
- */
-	public function extraSchemaColumns() {
-		return [];
 	}
 
 /**
@@ -197,7 +197,7 @@ class SqliteSchema {
 	}
 
 /**
- * Generate the SQL fragment for a single index in MySQL
+ * Generate the SQL fragment for a single index.
  *
  * Note integer primary keys will return ''. This is intentional as Sqlite requires
  * that integer primary keys be defined in the column definition.

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -197,7 +197,7 @@ class SqliteSchema {
 	}
 
 /**
- * Generate the SQL fragment for a single index.
+ * Generate the SQL fragments for defining table constraints.
  *
  * Note integer primary keys will return ''. This is intentional as Sqlite requires
  * that integer primary keys be defined in the column definition.
@@ -206,18 +206,15 @@ class SqliteSchema {
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
-	public function indexSql(Table $table, $name) {
+	public function constraintSql(Table $table, $name) {
 		$data = $table->index($name);
-
 		if (
 			count($data['columns']) === 1 &&
 			$table->column($data['columns'][0])['type'] === 'integer'
 		) {
 			return '';
 		}
-
-		$out = 'CONSTRAINT ';
-		$out .= $this->_driver->quoteIdentifier($name);
+		$out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
 		if ($data['type'] === Table::INDEX_PRIMARY) {
 			$out .= ' PRIMARY KEY';
 		}
@@ -229,6 +226,17 @@ class SqliteSchema {
 			$data['columns']
 		);
 		return $out . ' (' . implode(', ', $columns) . ')';
+	}
+
+/**
+ * Generate the SQL fragment for a single index.
+ *
+ * @param Cake\Database\Schema\Table $table The table object the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	public function indexSql(Table $table, $name) {
+		return '';
 	}
 
 /**

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -254,7 +254,7 @@ class SqliteSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param string $table The name of the table.
+ * @param Table $table Table instance
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
@@ -263,10 +263,10 @@ class SqliteSchema {
 	public function createTableSql($table, $columns, $constraints, $indexes) {
 		$lines = array_merge($columns, $constraints);
 		$content = implode(",\n", array_filter($lines));
-		$table = sprintf("CREATE TABLE \"%s\" (\n%s\n);", $table, $content);
+		$table = sprintf("CREATE TABLE \"%s\" (\n%s\n)", $table->name(), $content);
 		$out = [$table];
 		foreach ($indexes as $index) {
-			$out[] = $index . ";";
+			$out[] = $index;
 		}
 		return $out;
 	}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -214,18 +214,21 @@ class SqliteSchema {
 		) {
 			return '';
 		}
-		$out = 'CONSTRAINT ' . $this->_driver->quoteIdentifier($name);
 		if ($data['type'] === Table::CONSTRAINT_PRIMARY) {
-			$out .= ' PRIMARY KEY';
+			$type = 'PRIMARY KEY';
 		}
 		if ($data['type'] === Table::CONSTRAINT_UNIQUE) {
-			$out .= ' UNIQUE';
+			$type = 'UNIQUE';
 		}
 		$columns = array_map(
 			[$this->_driver, 'quoteIdentifier'],
 			$data['columns']
 		);
-		return $out . ' (' . implode(', ', $columns) . ')';
+		return sprintf('CONSTRAINT %s %s (%s)',
+			$this->_driver->quoteIdentifier($name),
+			$type,
+			implode(', ', $columns)
+		);
 	}
 
 /**

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -129,6 +129,15 @@ class Table {
 	}
 
 /**
+ * Get the name of the table.
+ *
+ * @return string
+ */
+	public function name() {
+		return $this->_table;
+	}
+
+/**
  * Add a column to the table.
  *
  * ### Attributes

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -336,9 +336,9 @@ class Table {
  */
 	public function createTableSql(Connection $connection) {
 		$dialect = $connection->driver()->schemaDialect();
-		$lines = $constraints = $indexes = [];
+		$columns = $constraints = $indexes = [];
 		foreach (array_keys($this->_columns) as $name) {
-			$lines[] = $dialect->columnSql($this, $name);
+			$columns[] = $dialect->columnSql($this, $name);
 		}
 		foreach (array_keys($this->_constraints) as $name) {
 			$constraints[] = $dialect->constraintSql($this, $name);
@@ -346,7 +346,7 @@ class Table {
 		foreach (array_keys($this->_indexes) as $name) {
 			$indexes[] = $dialect->indexSql($this, $name);
 		}
-		return $dialect->createTableSql($this->_table, $lines, $constraints, $indexes);
+		return $dialect->createTableSql($this, $columns, $constraints, $indexes);
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -552,7 +552,7 @@ CREATE TABLE `posts` (
 `body` TEXT,
 `created` DATETIME,
 PRIMARY KEY (`id`)
-);
+)
 SQL;
 		$result = $table->createTableSql($connection);
 		$this->assertCount(1, $result);

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -415,16 +415,6 @@ SQL;
 				'UNIQUE KEY `unique_idx` (`title`, `author_id`)'
 			],
 			[
-				'key_key',
-				['type' => 'index', 'columns' => ['author_id']],
-				'KEY `key_key` (`author_id`)'
-			],
-			[
-				'full_text',
-				['type' => 'fulltext', 'columns' => ['title']],
-				'FULLTEXT KEY `full_text` (`title`)'
-			],
-			[
 				'length_idx',
 				[
 					'type' => 'unique',
@@ -450,9 +440,48 @@ SQL;
 			'length' => 255
 		])->addColumn('author_id', [
 			'type' => 'integer',
-		])->addIndex($name, $data);
+		])->addConstraint($name, $data);
 
 		$this->assertEquals($expected, $schema->constraintSql($table, $name));
+	}
+
+/**
+ * Test provider for indexSql()
+ *
+ * @return array
+ */
+	public static function indexSqlProvider() {
+		return [
+			[
+				'key_key',
+				['type' => 'index', 'columns' => ['author_id']],
+				'KEY `key_key` (`author_id`)'
+			],
+			[
+				'full_text',
+				['type' => 'fulltext', 'columns' => ['title']],
+				'FULLTEXT KEY `full_text` (`title`)'
+			],
+		];
+	}
+
+/**
+ * Test the indexSql method.
+ *
+ * @dataProvider indexSqlProvider
+ */
+	public function testIndexSql($name, $data, $expected) {
+		$driver = $this->_getMockedDriver();
+		$schema = new MysqlSchema($driver);
+
+		$table = (new Table('articles'))->addColumn('title', [
+			'type' => 'string',
+			'length' => 255
+		])->addColumn('author_id', [
+			'type' => 'integer',
+		])->addIndex($name, $data);
+
+		$this->assertEquals($expected, $schema->indexSql($table, $name));
 	}
 
 /**
@@ -469,7 +498,7 @@ SQL;
 				'type' => 'integer',
 				'null' => false
 			])
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);
@@ -481,7 +510,7 @@ SQL;
 				'type' => 'biginteger',
 				'null' => false
 			])
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);
@@ -511,7 +540,7 @@ SQL;
 			])
 			->addColumn('body', ['type' => 'text'])
 			->addColumn('created', 'datetime')
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);
@@ -526,7 +555,8 @@ PRIMARY KEY (`id`)
 );
 SQL;
 		$result = $table->createTableSql($connection);
-		$this->assertEquals($expected, $result);
+		$this->assertCount(1, $result);
+		$this->assertEquals($expected, $result[0]);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -398,11 +398,11 @@ SQL;
 	}
 
 /**
- * Provide data for testing indexSql
+ * Provide data for testing constraintSql
  *
  * @return array
  */
-	public static function indexSqlProvider() {
+	public static function constraintSqlProvider() {
 		return [
 			[
 				'primary',
@@ -437,11 +437,11 @@ SQL;
 	}
 
 /**
- * Test the indexSql method.
+ * Test the constraintSql method.
  *
- * @dataProvider indexSqlProvider
+ * @dataProvider constraintSqlProvider
  */
-	public function testIndexSql($name, $data, $expected) {
+	public function testConstraintSql($name, $data, $expected) {
 		$driver = $this->_getMockedDriver();
 		$schema = new MysqlSchema($driver);
 
@@ -452,7 +452,7 @@ SQL;
 			'type' => 'integer',
 		])->addIndex($name, $data);
 
-		$this->assertEquals($expected, $schema->indexSql($table, $name));
+		$this->assertEquals($expected, $schema->constraintSql($table, $name));
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -444,7 +444,7 @@ SQL;
 				'type' => 'integer',
 				'null' => false
 			])
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);
@@ -486,7 +486,7 @@ SQL;
 			'length' => 255
 		])->addColumn('author_id', [
 			'type' => 'integer',
-		])->addIndex($name, $data);
+		])->addConstraint($name, $data);
 
 		$this->assertEquals($expected, $schema->constraintSql($table, $name));
 	}
@@ -512,9 +512,13 @@ SQL;
 			])
 			->addColumn('body', ['type' => 'text'])
 			->addColumn('created', 'datetime')
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
-				'columns' => ['id']
+				'columns' => ['id'],
+			])
+			->addIndex('title_idx', [
+				'type' => 'index',
+				'columns' => ['title'],
 			]);
 
 		$expected = <<<SQL
@@ -524,10 +528,16 @@ CREATE TABLE "articles" (
 "body" TEXT,
 "created" TIMESTAMP,
 PRIMARY KEY ("id")
-);
+)
 SQL;
 		$result = $table->createTableSql($connection);
-		$this->assertEquals($expected, $result);
+
+		$this->assertCount(2, $result);
+		$this->assertEquals($expected, $result[0]);
+		$this->assertEquals(
+			'CREATE INDEX "title_idx" ON "atricles" ("title")',
+			$result[1]
+		);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -453,11 +453,11 @@ SQL;
 	}
 
 /**
- * Provide data for testing indexSql
+ * Provide data for testing constraintSql
  *
  * @return array
  */
-	public static function indexSqlProvider() {
+	public static function constraintSqlProvider() {
 		return [
 			[
 				'primary',
@@ -475,9 +475,9 @@ SQL;
 /**
  * Test the indexSql method.
  *
- * @dataProvider indexSqlProvider
+ * @dataProvider constraintSqlProvider
  */
-	public function testIndexSql($name, $data, $expected) {
+	public function testConstraintSql($name, $data, $expected) {
 		$driver = $this->_getMockedDriver();
 		$schema = new PostgresSchema($driver);
 
@@ -488,7 +488,7 @@ SQL;
 			'type' => 'integer',
 		])->addIndex($name, $data);
 
-		$this->assertEquals($expected, $schema->indexSql($table, $name));
+		$this->assertEquals($expected, $schema->constraintSql($table, $name));
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -462,7 +462,7 @@ SQL;
 			[
 				'primary',
 				['type' => 'primary', 'columns' => ['title']],
-				'CONSTRAINT "primary" PRIMARY KEY ("title")'
+				'PRIMARY KEY ("title")'
 			],
 			[
 				'unique_idx',
@@ -522,7 +522,8 @@ CREATE TABLE "articles" (
 "id" SERIAL,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
-"created" TIMESTAMP
+"created" TIMESTAMP,
+PRIMARY KEY ("id")
 );
 SQL;
 		$result = $table->createTableSql($connection);

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -509,6 +509,7 @@ SQL;
 			->addColumn('title', [
 				'type' => 'string',
 				'null' => false,
+				'comment' => 'This is the title',
 			])
 			->addColumn('body', ['type' => 'text'])
 			->addColumn('created', 'datetime')
@@ -532,11 +533,15 @@ PRIMARY KEY ("id")
 SQL;
 		$result = $table->createTableSql($connection);
 
-		$this->assertCount(2, $result);
+		$this->assertCount(3, $result);
 		$this->assertEquals($expected, $result[0]);
 		$this->assertEquals(
-			'CREATE INDEX "title_idx" ON "atricles" ("title")',
+			'CREATE INDEX "title_idx" ON "articles" ("title")',
 			$result[1]
+		);
+		$this->assertEquals(
+			'COMMENT ON COLUMN "articles"."title" IS "This is the title"',
+			$result[2]
 		);
 	}
 

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -20,6 +20,7 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\PostgresSchema;
+use Cake\Database\Schema\Table;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -289,4 +290,265 @@ SQL;
 			$this->assertEquals($definition, $result->column($field));
 		}
 	}
+
+/**
+ * Column provider for creating column sql
+ *
+ * @return array
+ */
+	public static function columnSqlProvider() {
+		return [
+			// strings
+			[
+				'title',
+				['type' => 'string', 'length' => 25, 'null' => false],
+				'"title" VARCHAR(25) NOT NULL'
+			],
+			[
+				'title',
+				['type' => 'string', 'length' => 25, 'null' => true, 'default' => 'ignored'],
+				'"title" VARCHAR(25) DEFAULT NULL'
+			],
+			[
+				'id',
+				['type' => 'string', 'length' => 32, 'fixed' => true, 'null' => false],
+				'"id" CHAR(32) NOT NULL'
+			],
+			[
+				'id',
+				['type' => 'string', 'length' => 36, 'fixed' => true, 'null' => false],
+				'"id" UUID NOT NULL'
+			],
+			[
+				'role',
+				['type' => 'string', 'length' => 10, 'null' => false, 'default' => 'admin'],
+				'"role" VARCHAR(10) NOT NULL DEFAULT "admin"'
+			],
+			[
+				'title',
+				['type' => 'string'],
+				'"title" VARCHAR'
+			],
+			// Text
+			[
+				'body',
+				['type' => 'text', 'null' => false],
+				'"body" TEXT NOT NULL'
+			],
+			// Integers
+			[
+				'post_id',
+				['type' => 'integer', 'length' => 11],
+				'"post_id" INTEGER'
+			],
+			[
+				'post_id',
+				['type' => 'biginteger', 'length' => 20],
+				'"post_id" BIGINT'
+			],
+			// Decimal
+			[
+				'value',
+				['type' => 'decimal'],
+				'"value" DECIMAL'
+			],
+			[
+				'value',
+				['type' => 'decimal', 'length' => 11],
+				'"value" DECIMAL(11,0)'
+			],
+			[
+				'value',
+				['type' => 'decimal', 'length' => 12, 'precision' => 5],
+				'"value" DECIMAL(12,5)'
+			],
+			// Float
+			[
+				'value',
+				['type' => 'float'],
+				'"value" FLOAT'
+			],
+			[
+				'value',
+				['type' => 'float', 'length' => 11, 'precision' => 3],
+				'"value" FLOAT(3)'
+			],
+			// Binary
+			[
+				'img',
+				['type' => 'binary'],
+				'"img" BYTEA'
+			],
+			// Boolean
+			[
+				'checked',
+				['type' => 'boolean', 'default' => false],
+				'"checked" BOOLEAN DEFAULT FALSE'
+			],
+			[
+				'checked',
+				['type' => 'boolean', 'default' => true, 'null' => false],
+				'"checked" BOOLEAN NOT NULL DEFAULT TRUE'
+			],
+			// datetimes
+			[
+				'created',
+				['type' => 'datetime'],
+				'"created" TIMESTAMP'
+			],
+			// Date & Time
+			[
+				'start_date',
+				['type' => 'date'],
+				'"start_date" DATE'
+			],
+			[
+				'start_time',
+				['type' => 'time'],
+				'"start_time" TIME'
+			],
+			// timestamps
+			[
+				'created',
+				['type' => 'timestamp', 'null' => true],
+				'"created" TIMESTAMP DEFAULT NULL'
+			],
+		];
+	}
+
+/**
+ * Test generating column definitions
+ *
+ * @dataProvider columnSqlProvider
+ * @return void
+ */
+	public function testColumnSql($name, $data, $expected) {
+		$driver = $this->_getMockedDriver();
+		$schema = new PostgresSchema($driver);
+
+		$table = (new Table('articles'))->addColumn($name, $data);
+		$this->assertEquals($expected, $schema->columnSql($table, $name));
+	}
+
+/**
+ * Test generating a column that is a primary key.
+ *
+ * @return void
+ */
+	public function testColumnSqlPrimaryKey() {
+		$driver = $this->_getMockedDriver();
+		$schema = new PostgresSchema($driver);
+
+		$table = new Table('articles');
+		$table->addColumn('id', [
+				'type' => 'integer',
+				'null' => false
+			])
+			->addIndex('primary', [
+				'type' => 'primary',
+				'columns' => ['id']
+			]);
+		$result = $schema->columnSql($table, 'id');
+		$this->assertEquals($result, '"id" SERIAL');
+	}
+
+/**
+ * Provide data for testing indexSql
+ *
+ * @return array
+ */
+	public static function indexSqlProvider() {
+		return [
+			[
+				'primary',
+				['type' => 'primary', 'columns' => ['title']],
+				'CONSTRAINT "primary" PRIMARY KEY ("title")'
+			],
+			[
+				'unique_idx',
+				['type' => 'unique', 'columns' => ['title', 'author_id']],
+				'CONSTRAINT "unique_idx" UNIQUE ("title", "author_id")'
+			],
+		];
+	}
+
+/**
+ * Test the indexSql method.
+ *
+ * @dataProvider indexSqlProvider
+ */
+	public function testIndexSql($name, $data, $expected) {
+		$driver = $this->_getMockedDriver();
+		$schema = new PostgresSchema($driver);
+
+		$table = (new Table('articles'))->addColumn('title', [
+			'type' => 'string',
+			'length' => 255
+		])->addColumn('author_id', [
+			'type' => 'integer',
+		])->addIndex($name, $data);
+
+		$this->assertEquals($expected, $schema->indexSql($table, $name));
+	}
+
+/**
+ * Integration test for converting a Schema\Table into MySQL table creates.
+ *
+ * @return void
+ */
+	public function testCreateTableSql() {
+		$driver = $this->_getMockedDriver();
+		$connection = $this->getMock('Cake\Database\Connection', array(), array(), '', false);
+		$connection->expects($this->any())->method('driver')
+			->will($this->returnValue($driver));
+
+		$table = (new Table('articles'))->addColumn('id', [
+				'type' => 'integer',
+				'null' => false
+			])
+			->addColumn('title', [
+				'type' => 'string',
+				'null' => false,
+			])
+			->addColumn('body', ['type' => 'text'])
+			->addColumn('created', 'datetime')
+			->addIndex('primary', [
+				'type' => 'primary',
+				'columns' => ['id']
+			]);
+
+		$expected = <<<SQL
+CREATE TABLE "articles" (
+"id" SERIAL,
+"title" VARCHAR NOT NULL,
+"body" TEXT,
+"created" TIMESTAMP
+);
+SQL;
+		$result = $table->createTableSql($connection);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Get a schema instance with a mocked driver/pdo instances
+ *
+ * @return Driver
+ */
+	protected function _getMockedDriver() {
+		$driver = new \Cake\Database\Driver\Postgres();
+		$mock = $this->getMock('FakePdo', ['quote', 'quoteIdentifier']);
+		$mock->expects($this->any())
+			->method('quote')
+			->will($this->returnCallback(function ($value) {
+				return '"' . $value . '"';
+			}));
+		$mock->expects($this->any())
+			->method('quoteIdentifier')
+			->will($this->returnCallback(function ($value) {
+				return '"' . $value . '"';
+			}));
+		$driver->connection($mock);
+		return $driver;
+	}
+
 }

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -397,16 +397,16 @@ SQL;
 		$result = $schema->columnSql($table, 'id');
 		$this->assertEquals($result, '"id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT');
 
-		$result = $schema->indexSql($table, 'primary');
+		$result = $schema->constraintSql($table, 'primary');
 		$this->assertEquals('', $result, 'Integer primary keys are special in sqlite.');
 	}
 
 /**
- * Provide data for testing indexSql
+ * Provide data for testing constraintSql
  *
  * @return array
  */
-	public static function indexSqlProvider() {
+	public static function constraintSqlProvider() {
 		return [
 			[
 				'primary',
@@ -422,11 +422,11 @@ SQL;
 	}
 
 /**
- * Test the indexSql method.
+ * Test the constraintSql method.
  *
- * @dataProvider indexSqlProvider
+ * @dataProvider constraintSqlProvider
  */
-	public function testIndexSql($name, $data, $expected) {
+	public function testConstraintSql($name, $data, $expected) {
 		$driver = $this->_getMockedDriver();
 		$schema = new SqliteSchema($driver);
 
@@ -437,7 +437,7 @@ SQL;
 			'type' => 'integer',
 		])->addIndex($name, $data);
 
-		$this->assertEquals($expected, $schema->indexSql($table, $name));
+		$this->assertEquals($expected, $schema->constraintSql($table, $name));
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -481,7 +481,7 @@ SQL;
 /**
  * Get a schema instance with a mocked driver/pdo instances
  *
- * @return MysqlSchema
+ * @return Driver
  */
 	protected function _getMockedDriver() {
 		$driver = new \Cake\Database\Driver\Sqlite();

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -510,13 +510,13 @@ CREATE TABLE "articles" (
 "title" VARCHAR NOT NULL,
 "body" TEXT,
 "created" DATETIME
-);
+)
 SQL;
 		$result = $table->createTableSql($connection);
 		$this->assertCount(2, $result);
 		$this->assertEquals($expected, $result[0]);
 		$this->assertEquals(
-			'CREATE INDEX "title_idx" ON "articles" ("title");',
+			'CREATE INDEX "title_idx" ON "articles" ("title")',
 			$result[1]
 		);
 	}

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -390,7 +390,7 @@ SQL;
 				'type' => 'integer',
 				'null' => false
 			])
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);
@@ -435,9 +435,43 @@ SQL;
 			'length' => 255
 		])->addColumn('author_id', [
 			'type' => 'integer',
-		])->addIndex($name, $data);
+		])->addConstraint($name, $data);
 
 		$this->assertEquals($expected, $schema->constraintSql($table, $name));
+	}
+
+/**
+ * Provide data for testing indexSql
+ *
+ * @return array
+ */
+	public static function indexSqlProvider() {
+		return [
+			[
+				'author_idx',
+				['type' => 'index', 'columns' => ['title', 'author_id']],
+				'CREATE INDEX "author_idx" ON "articles" ("title", "author_id")'
+			],
+		];
+	}
+
+/**
+ * Test the indexSql method.
+ *
+ * @dataProvider indexSqlProvider
+ */
+	public function testIndexSql($name, $data, $expected) {
+		$driver = $this->_getMockedDriver();
+		$schema = new SqliteSchema($driver);
+
+		$table = (new Table('articles'))->addColumn('title', [
+			'type' => 'string',
+			'length' => 255
+		])->addColumn('author_id', [
+			'type' => 'integer',
+		])->addIndex($name, $data);
+
+		$this->assertEquals($expected, $schema->indexSql($table, $name));
 	}
 
 /**
@@ -461,9 +495,13 @@ SQL;
 			])
 			->addColumn('body', ['type' => 'text'])
 			->addColumn('created', 'datetime')
-			->addIndex('primary', [
+			->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
+			])
+			->addIndex('title_idx', [
+				'type' => 'index',
+				'columns' => ['title']
 			]);
 
 		$expected = <<<SQL
@@ -475,7 +513,12 @@ CREATE TABLE "articles" (
 );
 SQL;
 		$result = $table->createTableSql($connection);
-		$this->assertEquals($expected, $result);
+		$this->assertCount(2, $result);
+		$this->assertEquals($expected, $result[0]);
+		$this->assertEquals(
+			'CREATE INDEX "title_idx" ON "articles" ("title");',
+			$result[1]
+		);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
@@ -202,10 +202,10 @@ class TableTest extends TestCase {
 		$table->addColumn('id', 'integer')
 			->addColumn('title', 'string')
 			->addColumn('author_id', 'integer')
-			->addIndex('author_idx', [
+			->addConstraint('author_idx', [
 				'columns' => ['author_id'],
 				'type' => 'unique'
-			])->addIndex('primary', [
+			])->addConstraint('primary', [
 				'type' => 'primary',
 				'columns' => ['id']
 			]);

--- a/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
@@ -88,21 +88,53 @@ class TableTest extends TestCase {
 	}
 
 /**
+ * Test adding an constraint.
+ *
+ * @return void
+ */
+	public function testAddConstraint() {
+		$table = new Table('articles');
+		$table->addColumn('id', [
+			'type' => 'integer'
+		]);
+		$result = $table->addConstraint('primary', [
+			'type' => 'primary',
+			'columns' => ['id']
+		]);
+		$this->assertSame($result, $table);
+		$this->assertEquals(['primary'], $table->constraints());
+	}
+
+/**
+ * Test that an exception is raised when constraintes
+ * are added for fields that do not exist.
+ *
+ * @expectedException Cake\Error\Exception
+ * @return void
+ */
+	public function testAddConstraintErrorWhenFieldIsMissing() {
+		$table = new Table('articles');
+		$table->addConstraint('author_idx', [
+			'columns' => ['author_id']
+		]);
+	}
+
+/**
  * Test adding an index.
  *
  * @return void
  */
 	public function testAddIndex() {
 		$table = new Table('articles');
-		$table->addColumn('id', [
-			'type' => 'integer'
+		$table->addColumn('title', [
+			'type' => 'string'
 		]);
-		$result = $table->addIndex('primary', [
-			'type' => 'primary',
-			'columns' => ['id']
+		$result = $table->addIndex('faster', [
+			'type' => 'index',
+			'columns' => ['title']
 		]);
 		$this->assertSame($result, $table);
-		$this->assertEquals(['primary'], $table->indexes());
+		$this->assertEquals(['faster'], $table->indexes());
 	}
 
 /**
@@ -147,15 +179,15 @@ class TableTest extends TestCase {
 			->addColumn('author_id', 'integer');
 
 		$table->addIndex('author_idx', [
-			'columns' => ['author_id'],
-			'type' => 'unique'
-			])->addIndex('primary', [
-				'type' => 'primary',
-				'columns' => ['id']
+				'columns' => ['author_id'],
+				'type' => 'index'
+			])->addIndex('texty', [
+				'type' => 'fulltext',
+				'columns' => ['title']
 			]);
 
 		$this->assertEquals(
-			['author_idx', 'primary'],
+			['author_idx', 'texty'],
 			$table->indexes()
 		);
 	}


### PR DESCRIPTION
This change implements basic table create support for postgres. I also had to modify a bunch of guts to make things work smoothly.
- Tables now separate indexes + constraints. This is mostly because both SQLite and Postgres handle them as very different things. I wondered if it might make sense to store them internally as separate things but only expose one set of methods. I'm open to changing back to only having the _index_ methods.
- Parameters + return values were updated to afford index + comment creation in postgres + sqlite.

Let me know what you think. After this is fixing up Fixtures so they can create tables again :smile:
