### PR TITLE
make HtmlHelper::tag() just return the $text content with no wrapping tag when $name === false

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1697,6 +1697,12 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->tag(false, '<em>stuff</em>');
 		$this->assertEquals($result, '<em>stuff</em>');
+
+		$result = $this->Html->tag(null, '<em>stuff</em>');
+		$this->assertEquals($result, '<em>stuff</em>');
+
+		$result = $this->Html->tag('', '<em>stuff</em>');
+		$this->assertEquals($result, '<em>stuff</em>');
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1694,6 +1694,9 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->tag('div', '<text>', array('class' => 'class-name', 'escape' => true));
 		$this->assertTags($result, array('div' => array('class' => 'class-name'), '&lt;text&gt;', '/div'));
+
+		$result = $this->Html->tag(false, '<em>stuff</em>');
+		$this->assertEquals($result, '<em>stuff</em>');
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -896,6 +896,9 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::tag
  */
 	public function tag($name, $text = null, $options = array()) {
+		if ($name === false) {
+			return $text;
+		}
 		if (is_array($options) && isset($options['escape']) && $options['escape']) {
 			$text = h($text);
 			unset($options['escape']);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -896,7 +896,7 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::tag
  */
 	public function tag($name, $text = null, $options = array()) {
-		if ($name === false) {
+		if (empty($name)) {
 			return $text;
 		}
 		if (is_array($options) && isset($options['escape']) && $options['escape']) {


### PR DESCRIPTION
If `$name === false` then there shouldn't be a wrapping tag.
