### PR TITLE
Ensure passing empty array to SmtpTransport::config() does not reset exi...

### DIFF
--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -71,9 +71,12 @@ class SmtpTransport extends AbstractTransport {
  * Set the configuration
  *
  * @param array $config
- * @return void
+ * @return array Returns configs
  */
-	public function config($config = array()) {
+	public function config($config = null) {
+		if ($config === null) {
+			return $this->_config;
+		}
 		$default = array(
 			'host' => 'localhost',
 			'port' => 25,
@@ -83,7 +86,8 @@ class SmtpTransport extends AbstractTransport {
 			'client' => null,
 			'tls' => false
 		);
-		$this->_config = $config + $default;
+		$this->_config = empty($config) ? $this->_config + $default : $config + $default;
+		return $this->_config;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -327,4 +327,21 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->SmtpTransport->disconnect();
 	}
 
+/**
+ * testEmptyConfigArray method
+ *
+ * @return void
+ */
+	public function testEmptyConfigArray() {
+		$expected = $this->SmtpTransport->config(array(
+			'client' => 'myhost.com',
+			'port' => 666
+		));
+
+		$this->assertEquals(666, $expected['port']);
+
+		$result = $this->SmtpTransport->config(array());
+		$this->assertEquals($expected, $result);
+	}
+
 }


### PR DESCRIPTION
...sting config.

Synced args and return value with AbstractTransport::config().

Fixes [#3840](https://cakephp.lighthouseapp.com/projects/42648/tickets/3840-cakeemail-config-and-config-at-transport-level#ticket-3840-5)
