### PR TITLE
Fix: Incorrect model being used as Controller::$modelClass

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -634,7 +634,7 @@ class Controller extends Object implements CakeEventListener {
 		$this->_mergeControllerVars();
 		if ($this->uses) {
 			$this->uses = (array)$this->uses;
-			list(, $this->modelClass) = pluginSplit(current($this->uses));
+			list(, $this->modelClass) = pluginSplit(reset($this->uses));
 		}
 		$this->Components->init($this);
 		return true;

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -250,4 +250,17 @@ class ControllerMergeVarsTest extends CakeTestCase {
 
 		$this->assertFalse(isset($Controller->Session));
 	}
+
+/**
+ * Ensure that $modelClass is correct even when Controller::$uses
+ * has been iterated, eg: by a Component, or event handlers.
+ */
+	public function testMergeVarsModelClass() {
+		$Controller = new MergeVariablescontroller();
+		$Controller->uses = array('Test', 'TestAlias');
+		$lastModel = end($Controller->uses);
+		$Controller->constructClasses();
+		$this->assertEquals($Controller->uses[0], $Controller->modelClass);
+	}
+
 }


### PR DESCRIPTION
We cannot be sure that Controller::$uses have not been iterated, so
reset the array to use the first value.

I have experienced this issue for a while in travis, eg: https://travis-ci.org/rchavik/croogo/jobs/7355091 but unable to reproduce the issue locally. A recent commit upstream 082257881 enable me to reproduce the issue consistently.

In a discussion in cakephp-dev, @AD7six commented: "depends on how merging occurs - is it current + plugin controller + app controller" that leads me to realize that the inheritance tree in Croogo may have caused this problem:

```
AppController extends Croogo.CroogoAppController
Croogo.CroogoAppController extends Controller    
```

This inheritance scheme is used to prepare for getting a plain cakephp application to easily extend Croogo functionality (slated for the next major release).
