### PR TITLE
Allowing the pathPrefix to be configured on settings

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1218,6 +1218,42 @@ class HtmlHelperTest extends CakeTestCase {
 	}
 
 /**
+ * Test assets in a CDN server
+ *
+ * @return void
+ */
+	public function testAssetsInCDN() {
+		$helper = new HtmlHelper($this->View, array(
+			'defaultCssPathPrefix' => '//css_server/',
+			'defaultJsPathPrefix' => 'http://js_server/build-123/',
+			'defaultImgPathPrefix' => 'https://img_server/',
+			'defaultMediaPathPrefix' => 'https://media_server/'
+		));
+
+		// CSS
+		$expects = array(
+			'link' => array('rel' => 'stylesheet', 'type' => 'text/css', 'href' => '//css_server/custom.css')
+		);
+		$this->assertTags($helper->css('custom'), $expects);
+
+		// JS
+		$expects = array(
+			'script' => array('type' => 'text/javascript', 'src' => 'http://js_server/build-123/custom.js')
+		);
+		$this->assertTags($helper->script('custom'), $expects);
+
+		// Images
+		$expects = array(
+			'img' => array('src' => 'https://img_server/cake.png', 'alt' => '')
+		);
+		$this->assertTags($helper->image('cake.png'), $expects);
+
+		// Media files
+		$expected = array('video' => array('src' => 'https://media_server/video.webm'), '/video');
+		$this->assertTags($helper->media('video.webm'), $expected);
+	}
+
+/**
  * testCharsetTag method
  *
  * @return void

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -322,6 +322,9 @@ class Helper extends Object {
 		) {
 			$path .= $options['ext'];
 		}
+		if (strpos($path, '://') !== false) {
+			return $path;
+		}
 		if (isset($plugin)) {
 			$path = Inflector::underscore($plugin) . '/' . $path;
 		}

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -39,6 +39,18 @@ class HtmlHelper extends AppHelper {
 	public $response;
 
 /**
+ * Settings for this helper.
+ *
+ * @var array
+ */
+	public $settings = array(
+		'defaultCssPathPrefix' => CSS_URL,
+		'defaultJsPathPrefix' => JS_URL,
+		'defaultImgPathPrefix' => IMAGES_URL,
+		'defaultMediaPathPrefix' => 'files/'
+	);
+
+/**
  * html tags used by this helper.
  *
  * @var array
@@ -441,7 +453,7 @@ class HtmlHelper extends AppHelper {
 		if (strpos($path, '//') !== false) {
 			$url = $path;
 		} else {
-			$url = $this->assetUrl($path, $options + array('pathPrefix' => CSS_URL, 'ext' => '.css'));
+			$url = $this->assetUrl($path, $options + array('pathPrefix' => $this->settings['defaultCssPathPrefix'], 'ext' => '.css'));
 			$options = array_diff_key($options, array('fullBase' => null));
 
 			if (Configure::read('Asset.filter.css')) {
@@ -543,7 +555,7 @@ class HtmlHelper extends AppHelper {
 		$this->_includedScripts[$url] = true;
 
 		if (strpos($url, '//') === false) {
-			$url = $this->assetUrl($url, $options + array('pathPrefix' => JS_URL, 'ext' => '.js'));
+			$url = $this->assetUrl($url, $options + array('pathPrefix' => $this->settings['defaultJsPathPrefix'], 'ext' => '.js'));
 			$options = array_diff_key($options, array('fullBase' => null));
 
 			if (Configure::read('Asset.filter.js')) {
@@ -802,7 +814,7 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::image
  */
 	public function image($path, $options = array()) {
-		$path = $this->assetUrl($path, $options + array('pathPrefix' => IMAGES_URL));
+		$path = $this->assetUrl($path, $options + array('pathPrefix' => $this->settings['defaultImgPathPrefix']));
 		$options = array_diff_key($options, array('fullBase' => null, 'pathPrefix' => null));
 
 		if (!isset($options['alt'])) {
@@ -1056,7 +1068,7 @@ class HtmlHelper extends AppHelper {
 	public function media($path, $options = array()) {
 		$options += array(
 			'tag' => null,
-			'pathPrefix' => 'files/',
+			'pathPrefix' => $this->settings['defaultMediaPathPrefix'],
 			'text' => ''
 		);
 
@@ -1105,7 +1117,7 @@ class HtmlHelper extends AppHelper {
 		}
 
 		if (isset($options['poster'])) {
-			$options['poster'] = $this->assetUrl($options['poster'], array('pathPrefix' => IMAGES_URL) + $options);
+			$options['poster'] = $this->assetUrl($options['poster'], array('pathPrefix' => $this->settings['defaultImgPathPrefix']) + $options);
 		}
 		$text = $options['text'];
 


### PR DESCRIPTION
This change will allow the prefix be configured in controller or
other helper/plugin. It helps the user to easily set CDN servers
or just a different host to avoid the cookies be set on the request

For example, if the user wants to use AWS CloudFront, CloudFlare, Rackspace Cloud Files, or any other CDN provider it can easily be configured on the helper.

Another usage is to setup a different hostname to avoid cookie and possible use a different webserver. Ie, can setup the configs to use '//static.cakephp.org/' to avoid session cookie.

In case the user wants use either CDN and no-CDN links it is possible defining 2 helpers on the controller, ie:

``` php
public $helpers = array(
    'Html',
    'HtmlCdn' => array(
        'defaultCssPathPrefix' => '//my.cdn.com/',
        // ...
    )
);
```

In the view:

``` php
echo $this->Html->css('layout'); // Will refer to /css/layout.css
echo $this->HtmlCdn->css('layout'); // Will refer to //my.cdn.com/layout.css
```
