### PR TITLE
Fix typo variable name in _deleteDependent().

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2449,7 +2449,7 @@ class Model extends Object implements CakeEventListener {
 			return;
 		}
 		if (!empty($this->__backAssociation)) {
-			$savedAssociatons = $this->__backAssociation;
+			$savedAssociations = $this->__backAssociation;
 			$this->__backAssociation = array();
 		}
 
@@ -2485,8 +2485,8 @@ class Model extends Object implements CakeEventListener {
 				}
 			}
 		}
-		if (isset($savedAssociatons)) {
-			$this->__backAssociation = $savedAssociatons;
+		if (isset($savedAssociations)) {
+			$this->__backAssociation = $savedAssociations;
 		}
 	}
 


### PR DESCRIPTION
It's not a big deal but there was a typo in _deleteDependent() method. 

$savedAssociatons instead of $savedAssociations.
