### PR TITLE
allow bake tasks to provide theme as cli option

### DIFF
--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -243,6 +243,8 @@ class BakeShell extends AppShell {
 			'help' => __d('cake_console', 'Database connection to use in conjunction with `bake all`.'),
 			'short' => 'c',
 			'default' => 'default'
+		))->addOption('theme', array(
+			'help' => __d('cake_console', 'Theme to use when baking code.')
 		));
 	}
 

--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -244,6 +244,7 @@ class BakeShell extends AppShell {
 			'short' => 'c',
 			'default' => 'default'
 		))->addOption('theme', array(
+			'short' => 't',
 			'help' => __d('cake_console', 'Theme to use when baking code.')
 		));
 	}

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -475,6 +475,7 @@ class ControllerTask extends BakeTask {
 				'short' => 'c',
 				'help' => __d('cake_console', 'The connection the controller\'s model is on.')
 			))->addOption('theme', array(
+				'short' => 't',
 				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addSubcommand('all', array(
 				'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -475,7 +475,7 @@ class ControllerTask extends BakeTask {
 				'short' => 'c',
 				'help' => __d('cake_console', 'The connection the controller\'s model is on.')
 			))->addOption('theme', array(
-				'help' => __d('cake_console', 'Theme to use when baking code`.')
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addSubcommand('all', array(
 				'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')
 			))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -474,6 +474,8 @@ class ControllerTask extends BakeTask {
 			))->addOption('connection', array(
 				'short' => 'c',
 				'help' => __d('cake_console', 'The connection the controller\'s model is on.')
+			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code`.')
 			))->addSubcommand('all', array(
 				'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')
 			))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -87,6 +87,8 @@ class FixtureTask extends BakeTask {
 			'help' => __d('cake_console', 'Importing schema for fixtures rather than hardcoding it.'),
 			'short' => 's',
 			'boolean' => true
+		))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 		))->addOption('records', array(
 			'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10.'),
 			'short' => 'r',

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -88,7 +88,8 @@ class FixtureTask extends BakeTask {
 			'short' => 's',
 			'boolean' => true
 		))->addOption('theme', array(
-				'help' => __d('cake_console', 'Theme to use when baking code.')
+			'short' => 't',
+			'help' => __d('cake_console', 'Theme to use when baking code.')
 		))->addOption('records', array(
 			'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10.'),
 			'short' => 'r',

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -992,6 +992,8 @@ class ModelTask extends BakeTask {
 			))->addOption('plugin', array(
 				'short' => 'p',
 				'help' => __d('cake_console', 'Plugin to bake the model into.')
+			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('connection', array(
 				'short' => 'c',
 				'help' => __d('cake_console', 'The connection the model table is on.')

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -993,6 +993,7 @@ class ModelTask extends BakeTask {
 				'short' => 'p',
 				'help' => __d('cake_console', 'Plugin to bake the model into.')
 			))->addOption('theme', array(
+				'short' => 't',
 				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('connection', array(
 				'short' => 'c',

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -439,6 +439,7 @@ class ProjectTask extends AppShell {
 				'boolean' => true,
 				'help' => __d('cake_console', 'Create empty files in each of the directories. Good if you are using git')
 			))->addOption('theme', array(
+				'short' => 't',
 				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('skel', array(
 				'default' => current(App::core('Console')) . 'Templates' . DS . 'skel',

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -438,6 +438,8 @@ class ProjectTask extends AppShell {
 			))->addOption('empty', array(
 				'boolean' => true,
 				'help' => __d('cake_console', 'Create empty files in each of the directories. Good if you are using git')
+			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('skel', array(
 				'default' => current(App::core('Console')) . 'Templates' . DS . 'skel',
 				'help' => __d('cake_console', 'The directory layout to use for the new application skeleton. Defaults to cake/Console/Templates/skel of CakePHP used to create the project.')

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -563,6 +563,8 @@ class TestTask extends BakeTask {
 				)
 			))->addArgument('name', array(
 				'help' => __d('cake_console', 'An existing class to bake tests for.')
+			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('plugin', array(
 				'short' => 'p',
 				'help' => __d('cake_console', 'CamelCased name of the plugin to bake tests for.')

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -564,6 +564,7 @@ class TestTask extends BakeTask {
 			))->addArgument('name', array(
 				'help' => __d('cake_console', 'An existing class to bake tests for.')
 			))->addOption('theme', array(
+				'short' => 't',
 				'help' => __d('cake_console', 'Theme to use when baking code.')
 			))->addOption('plugin', array(
 				'short' => 'p',

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -435,6 +435,8 @@ class ViewTask extends BakeTask {
 		))->addOption('admin', array(
 			'help' => __d('cake_console', 'Set to only bake views for a prefix in Routing.prefixes'),
 			'boolean' => true
+		))->addOption('theme', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')
 		))->addOption('connection', array(
 			'short' => 'c',
 			'help' => __d('cake_console', 'The connection the connected model is on.')

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -436,7 +436,8 @@ class ViewTask extends BakeTask {
 			'help' => __d('cake_console', 'Set to only bake views for a prefix in Routing.prefixes'),
 			'boolean' => true
 		))->addOption('theme', array(
-				'help' => __d('cake_console', 'Theme to use when baking code.')
+			'short' => 't',
+			'help' => __d('cake_console', 'Theme to use when baking code.')
 		))->addOption('connection', array(
 			'short' => 'c',
 			'help' => __d('cake_console', 'The connection the connected model is on.')


### PR DESCRIPTION
This PR enables developers to provide what CLI theme to use directly from CLI

```
Console/cake bake test model SampleModel -q --theme non_default_theme
```

This is very practical for automating generation of tests from CLI, as you otherwise can't skip the theme question if you have multiple themes in your app.

Considering that the TemplateTask actually checks for this param to be present, it seems to be an unintended omission that you can't pass it in to the bake classes. 

https://github.com/cakephp/cakephp/blob/2.4/lib/Cake/Console/Command/Task/TemplateTask.php#L173
