### PR TITLE
Fixed or removed some package/subpackage definitions to reflect director...

### DIFF
--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -13,7 +13,7 @@
 #
 # @copyright    Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 # @link         http://cakephp.org CakePHP(tm) Project
-# @package      cake.Console
+# @package      Cake.Console
 # @since        CakePHP(tm) v 1.2.0.5012
 # @license      MIT License (http://www.opensource.org/licenses/mit-license.php)
 #

--- a/lib/Cake/Console/cake.bat
+++ b/lib/Cake/Console/cake.bat
@@ -11,7 +11,7 @@
 ::
 :: @copyright		Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 :: @link			http://cakephp.org CakePHP(tm) Project
-:: @package   		cake.console
+:: @package   		Cake.Console
 :: @since			CakePHP(tm) v 1.2.0.5012
 :: @license			MIT License (http://www.opensource.org/licenses/mit-license.php)
 ::

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -30,7 +30,6 @@ App::uses('Router', 'Routing');
 /**
  * ContactTestController class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ContactTestController extends Controller {
@@ -46,7 +45,6 @@ class ContactTestController extends Controller {
 /**
  * Contact class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class Contact extends CakeTestModel {
@@ -138,7 +136,6 @@ class Contact extends CakeTestModel {
 /**
  * ContactTagsContact class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ContactTagsContact extends CakeTestModel {
@@ -176,7 +173,6 @@ class ContactTagsContact extends CakeTestModel {
 /**
  * ContactNonStandardPk class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ContactNonStandardPk extends Contact {
@@ -205,7 +201,6 @@ class ContactNonStandardPk extends Contact {
 /**
  * ContactTag class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ContactTag extends Model {
@@ -233,7 +228,6 @@ class ContactTag extends Model {
 /**
  * UserForm class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class UserForm extends CakeTestModel {
@@ -274,7 +268,6 @@ class UserForm extends CakeTestModel {
 /**
  * OpenidUrl class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class OpenidUrl extends CakeTestModel {
@@ -330,7 +323,6 @@ class OpenidUrl extends CakeTestModel {
 /**
  * ValidateUser class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ValidateUser extends CakeTestModel {
@@ -380,7 +372,6 @@ class ValidateUser extends CakeTestModel {
 /**
  * ValidateProfile class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ValidateProfile extends CakeTestModel {
@@ -440,7 +431,6 @@ class ValidateProfile extends CakeTestModel {
 /**
  * ValidateItem class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class ValidateItem extends CakeTestModel {
@@ -490,7 +480,6 @@ class ValidateItem extends CakeTestModel {
 /**
  * TestMail class
  *
- * @package	   cake
  * @package       Cake.Test.Case.View.Helper
  */
 class TestMail extends CakeTestModel {
@@ -507,7 +496,6 @@ class TestMail extends CakeTestModel {
 /**
  * FormHelperTest class
  *
- * @package	   cake
  * @subpackage       Cake.Test.Case.View.Helper
  * @property FormHelper $Form
  */

--- a/lib/Cake/Test/Fixture/DomainFixture.php
+++ b/lib/Cake/Test/Fixture/DomainFixture.php
@@ -12,8 +12,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  * @since         CakePHP(tm) v 2.1
  * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
  */
@@ -21,8 +20,7 @@
 /**
  * Short description for class.
  *
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  */
 class DomainFixture extends CakeTestFixture {
 

--- a/lib/Cake/Test/Fixture/DomainsSiteFixture.php
+++ b/lib/Cake/Test/Fixture/DomainsSiteFixture.php
@@ -12,8 +12,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  * @since         CakePHP(tm) v 2.1
  * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
  */
@@ -21,8 +20,7 @@
 /**
  * Short description for class.
  *
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  */
 class DomainsSiteFixture extends CakeTestFixture {
 

--- a/lib/Cake/Test/Fixture/PrefixTestFixture.php
+++ b/lib/Cake/Test/Fixture/PrefixTestFixture.php
@@ -13,7 +13,6 @@
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @package       Cake.Test.Fixture
- * @subpackage    cake.tests.fixtures
  * @since         CakePHP(tm) v 1.2.0.4667
  * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
  */
@@ -22,7 +21,6 @@
  * Short description for class.
  *
  * @package       Cake.Test.Fixture
- * @subpackage    cake.tests.fixtures
  */
 class PrefixTestFixture extends CakeTestFixture {
 

--- a/lib/Cake/Test/Fixture/SiteFixture.php
+++ b/lib/Cake/Test/Fixture/SiteFixture.php
@@ -12,8 +12,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  * @since         CakePHP(tm) v 2.1
  * @license       http://www.opensource.org/licenses/opengroup.php The Open Group Test Suite License
  */
@@ -21,8 +20,7 @@
 /**
  * Short description for class.
  *
- * @package       cake
- * @subpackage    cake.tests.fixtures
+ * @package       Cake.Test.Fixture
  */
 class SiteFixture extends CakeTestFixture {
 

--- a/lib/Cake/VERSION.txt
+++ b/lib/Cake/VERSION.txt
@@ -12,7 +12,7 @@
 //
 // @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 // @link          http://cakephp.org
-// @package       cake.libs
+// @package       Cake
 // @since         CakePHP(tm) v 0.2.9
 // @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
 // +--------------------------------------------------------------------------------------------+ //


### PR DESCRIPTION
...y structure

Lowercase cake instead of Cake
Tests instead of Test
Fixtures instead of Fixture

I noticed after generating the API for testing with phpDocumentator and ApiGen that it had duplicated package names like "cake" and "Cake"
