### PR TITLE
Synced PHP version annotations

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -4,7 +4,7 @@
  *
  * DBO-backed object data model, for mapping database tables to Cake objects.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -4,7 +4,7 @@
  *
  * Provides the Model validation logic.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -4,7 +4,7 @@
  *
  * Provides the Model validation logic.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -4,7 +4,7 @@
  *
  * Provides the Model validation logic.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
@@ -2,7 +2,7 @@
 /**
  * ConsoleErrorHandler Test case
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
+++ b/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
@@ -4,7 +4,7 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP version 5
+ * PHP 5
  *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Event/CakeEventTest.php
+++ b/lib/Cake/Test/Case/Event/CakeEventTest.php
@@ -4,7 +4,7 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP version 5
+ * PHP 5
  *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -4,7 +4,7 @@
  *
  * Test Case for CakeTestCase class
  *
- * PHP version 5
+ * PHP 5
  *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -4,7 +4,7 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP version 5
+ * PHP 5
  *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2,7 +2,7 @@
 /**
  * ValidationTest file
  *
- * PHP Version 5.x
+ * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Fixture/DomainFixture.php
+++ b/lib/Cake/Test/Fixture/DomainFixture.php
@@ -2,7 +2,7 @@
 /**
  * Short description for file.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Fixture/DomainsSiteFixture.php
+++ b/lib/Cake/Test/Fixture/DomainsSiteFixture.php
@@ -2,7 +2,7 @@
 /**
  * Short description for file.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Fixture/PrefixTestFixture.php
+++ b/lib/Cake/Test/Fixture/PrefixTestFixture.php
@@ -2,7 +2,7 @@
 /**
  * Short description for file.
  *
- * PHP versions 4 and 5
+ * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Fixture/SiteFixture.php
+++ b/lib/Cake/Test/Fixture/SiteFixture.php
@@ -2,7 +2,7 @@
 /**
  * Short description for file.
  *
- * PHP versions 5
+ * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/test_app/Config/routes.php
+++ b/lib/Cake/Test/test_app/Config/routes.php
@@ -4,7 +4,7 @@
  *
  * Routes for test app
  *
- * PHP versions 4 and 5
+ * PHP 5
  *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP Version 5.x
+ * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)


### PR DESCRIPTION
CakePHP seems to be just "PHP 5" as opposed to the PEAR header comment standard "PHP version 5"
http://pear.php.net/manual/en/standards.header.php
