### PR TITLE
3.0 Add index/constraint reflection

### DIFF
--- a/lib/Cake/Database/Dialect/MysqlDialectTrait.php
+++ b/lib/Cake/Database/Dialect/MysqlDialectTrait.php
@@ -18,7 +18,6 @@
 namespace Cake\Database\Dialect;
 
 use Cake\Database\SqlDialectTrait;
-use Cake\Error;
 
 /**
  * Contains functions that encapsulates the SQL dialect used by MySQL,

--- a/lib/Cake/Database/Dialect/SqliteDialectTrait.php
+++ b/lib/Cake/Database/Dialect/SqliteDialectTrait.php
@@ -21,7 +21,6 @@ use Cake\Database\ExpressionInterface;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Query;
 use Cake\Database\SqlDialectTrait;
-use Cake\Error;
 
 trait SqliteDialectTrait {
 

--- a/lib/Cake/Database/Driver.php
+++ b/lib/Cake/Database/Driver.php
@@ -11,7 +11,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Model
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */

--- a/lib/Cake/Database/Expression/OrderByExpression.php
+++ b/lib/Cake/Database/Expression/OrderByExpression.php
@@ -19,16 +19,28 @@ namespace Cake\Database\Expression;
 
 class OrderByExpression extends QueryExpression {
 
+/**
+ * Constructor
+ *
+ * @param array $conditions
+ * @param array $types
+ * @param string $conjunction The glue used to join conditions together.
+ */
 	public function __construct($conditions = [], $types = [], $conjunction = '') {
 		parent::__construct($conditions, $types, $conjunction);
 	}
 
+/**
+ * Convert the expression into a SQL fragment.
+ *
+ * @return string
+ */
 	public function sql() {
 		$order = [];
 		foreach ($this->_conditions as $k => $direction) {
 			$order[] = is_numeric($k) ? $direction : sprintf('%s %s', $k, $direction);
 		}
-		return sprintf ('ORDER BY %s', implode(', ', $order));
+		return sprintf('ORDER BY %s', implode(', ', $order));
 	}
 
 	protected function _addConditions(array $conditions, array $types) {

--- a/lib/Cake/Database/FunctionsTrait.php
+++ b/lib/Cake/Database/FunctionsTrait.php
@@ -16,6 +16,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 namespace Cake\Database;
+
 use Cake\Database\Expression\FunctionExpression;
 
 /**

--- a/lib/Cake/Database/Query.php
+++ b/lib/Cake/Database/Query.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\Exception;
 use Cake\Database\Expression\Comparison;
 use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\Expression\OrderByExpression;
@@ -1179,17 +1180,17 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param array|Query $data The data to insert.
  * @return Query
- * @throws Cake\Error\Exception if you try to set values before declaring columns.
+ * @throws Cake\Database\Exception if you try to set values before declaring columns.
  *   Or if you try to set values on non-insert queries.
  */
 	public function values($data) {
 		if ($this->_type !== 'insert') {
-			throw new Error\Exception(
+			throw new Exception(
 				__d('cake_dev', 'You cannot add values before defining columns to use.')
 			);
 		}
 		if (empty($this->_parts['insert'])) {
-			throw new Error\Exception(
+			throw new Exception(
 				__d('cake_dev', 'You cannot add values before defining columns to use.')
 			);
 		}

--- a/lib/Cake/Database/Schema/Collection.php
+++ b/lib/Cake/Database/Schema/Collection.php
@@ -17,8 +17,8 @@
 namespace Cake\Database\Schema;
 
 use Cake\Database\Connection;
+use Cake\Database\Exception;
 use Cake\Database\Schema\Table;
-use Cake\Error;
 
 /**
  * Represents a database schema collection
@@ -72,7 +72,7 @@ class Collection {
  *
  * @param string $name The name of the table to describe.
  * @return Cake\Schema\Table|null Object with column metadata, or null.
- * @throws Cake\Error\Exception when table cannot be described.
+ * @throws Cake\Database\Exception when table cannot be described.
  */
 	public function describe($name) {
 		list($sql, $params) = $this->_dialect->describeTableSql(
@@ -82,10 +82,10 @@ class Collection {
 		try {
 			$statement = $this->_connection->execute($sql, $params);
 		} catch (\PDOException $e) {
-			throw new Error\Exception($e->getMessage(), 500, $e);
+			throw new Exception($e->getMessage(), 500, $e);
 		}
 		if (count($statement) === 0) {
-			throw new Error\Exception(__d('cake_dev', 'Cannot describe %s. It has 0 columns.', $name));
+			throw new Exception(__d('cake_dev', 'Cannot describe %s. It has 0 columns.', $name));
 		}
 
 		$table = new Table($name);
@@ -100,7 +100,7 @@ class Collection {
 		try {
 			$statement = $this->_connection->execute($sql, $params);
 		} catch (\PDOException $e) {
-			throw new Error\Exception($e->getMessage(), 500, $e);
+			throw new Exception($e->getMessage(), 500, $e);
 		}
 		foreach ($statement->fetchAll('assoc') as $row) {
 			$this->_dialect->convertIndexDescription($table, $row);

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -137,20 +137,16 @@ class MysqlSchema {
  *
  * @param Cake\Database\Schema\Table $table The table object to append fields to.
  * @param array $row The row data from describeTableSql
- * @param array $fieldParams Additional field parameters to parse.
  * @return void
  */
-	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
+	public function convertFieldDescription(Table $table, $row) {
 		$field = $this->convertColumn($row['Type']);
 		$field += [
 			'null' => $row['Null'] === 'YES' ? true : false,
 			'default' => $row['Default'],
+			'collate' => $row['Collation'],
+			'comment' => $row['Comment'],
 		];
-		foreach ($fieldParams as $key => $metadata) {
-			if (!empty($row[$metadata['column']])) {
-				$field[$key] = $row[$metadata['column']];
-			}
-		}
 		$table->addColumn($row['Field'], $field);
 		if (!empty($row['Key']) && $row['Key'] === 'PRI') {
 			$table->addConstraint('primary', [
@@ -219,25 +215,6 @@ class MysqlSchema {
 				'length' => $length
 			]);
 		}
-	}
-
-/**
- * Get additional column meta data used in schema reflections.
- *
- * @return array
- */
-	public function extraSchemaColumns() {
-		return [
-			'charset' => [
-				'column' => false,
-			],
-			'collate' => [
-				'column' => 'Collation',
-			],
-			'comment' => [
-				'column' => 'Comment',
-			]
-		];
 	}
 
 /**

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -190,7 +190,11 @@ class MysqlSchema {
 		if (!empty($row['Sub_part'])) {
 			$length[$row['Column_name']] = $row['Sub_part'];
 		}
-		if ($type == 'index' || $type == 'fulltext') {
+		$isIndex = (
+			$type == 'index' ||
+			$type == 'fulltext'
+		);
+		if ($isIndex) {
 			$existing = $table->index($name);
 		} else {
 			$existing = $table->constraint($name);
@@ -202,7 +206,7 @@ class MysqlSchema {
 			$columns = array_merge($existing['columns'], $columns);
 			$length = array_merge($existing['length'], $length);
 		}
-		if ($type == 'index' || $type == 'fulltext') {
+		if ($isIndex) {
 			$table->addIndex($name, [
 				'type' => $type,
 				'columns' => $columns,

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -161,7 +161,7 @@ class MysqlSchema {
 	}
 
 /**
- * Convert an index into the abstrac description.
+ * Convert an index into the abstract description.
  *
  * @param Cake\Database\Schema\Table $table The table object to append
  *    an index or constraint to.

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -183,7 +183,7 @@ class MysqlSchema {
 			$type = strtolower($row['Index_type']);
 		} elseif ($row['Non_unique'] == 0 && $type !== 'primary') {
 			$type = 'unique';
-		} else {
+		} elseif ($type !== 'primary') {
 			$type = 'index';
 		}
 
@@ -203,7 +203,7 @@ class MysqlSchema {
 		// MySQL multi column indexes come back
 		// as multiple rows.
 		if (!empty($existing)) {
-			$columns = array_merge($existing['columns'], $columns);
+			$columns = array_unique(array_merge($existing['columns'], $columns));
 			$length = array_merge($existing['length'], $length);
 		}
 		if ($isIndex) {

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -16,8 +16,8 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Exception;
 use Cake\Database\Schema\Table;
-use Cake\Error;
 
 /**
  * Schema management/reflection features for MySQL
@@ -80,12 +80,12 @@ class MysqlSchema {
  *
  * @param string $column The column type + length
  * @return array Array of column information.
- * @throws Cake\Error\Exception When column type cannot be parsed.
+ * @throws Cake\Database\Exception When column type cannot be parsed.
  */
 	public function convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
 		if (empty($matches)) {
-			throw new Error\Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
+			throw new Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
 		}
 
 		$col = strtolower($matches[1]);

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -332,7 +332,6 @@ class MysqlSchema {
 		return $out;
 	}
 
-
 /**
  * Generate the SQL fragments for defining table constraints.
  *

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -185,6 +185,29 @@ class PostgresSchema {
 	}
 
 /**
+ * Get the SQL to describe the indexes in a table.
+ *
+ * @param string $table The table name to get information on.
+ * @return array An array of (sql, params) to execute.
+ */
+	public function describeIndexSql($table) {
+		$sql = '';
+		return [$sql, []];
+	}
+
+/**
+ * Convert an index into the abstract description.
+ *
+ * @param Cake\Database\Schema\Table $table The table object to append
+ *    an index or constraint to.
+ * @param array $row The row data from describeIndexSql
+ * @return void
+ */
+	public function convertIndexDescription(Table $table, $row) {
+	}
+
+
+/**
  * Generate the SQL fragment for a single column.
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -171,12 +171,6 @@ class PostgresSchema {
 		];
 		$field['length'] = $row['char_length'] ?: $field['length'];
 		$table->addColumn($row['name'], $field);
-		if (!empty($row['pk'])) {
-			$table->addConstraint('primary', [
-				'type' => Table::CONSTRAINT_PRIMARY,
-				'columns' => [$row['name']]
-			]);
-		}
 	}
 
 /**

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -150,10 +150,9 @@ class PostgresSchema {
  *
  * @param Cake\Database\Schema\Table $table The table object to append fields to.
  * @param array $row The row data from describeTableSql
- * @param array $fieldParams Additional field parameters to parse.
  * @return void
  */
-	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
+	public function convertFieldDescription(Table $table, $row) {
 		$field = $this->convertColumn($row['type']);
 
 		if ($field['type'] === 'boolean') {

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -231,12 +231,12 @@ class PostgresSchema {
 				'type' => $type,
 				'columns' => $columns
 			]);
-		} else {
-			$table->addIndex($name, [
-				'type' => $type,
-				'columns' => $columns
-			]);
+			return;
 		}
+		$table->addIndex($name, [
+			'type' => $type,
+			'columns' => $columns
+		]);
 	}
 
 /**

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -239,7 +239,6 @@ class PostgresSchema {
 		}
 	}
 
-
 /**
  * Generate the SQL fragment for a single column.
  *

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -16,8 +16,8 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Exception;
 use Cake\Database\Schema\Table;
-use Cake\Error;
 
 /**
  * Schema management/reflection features for Postgres.
@@ -84,13 +84,13 @@ class PostgresSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @throws Cake\Error\Exception when column cannot be parsed.
+ * @throws Cake\Database\Exception when column cannot be parsed.
  * @return array Array of column information.
  */
 	public function convertColumn($column) {
 		preg_match('/([a-z\s]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
 		if (empty($matches)) {
-			throw new Error\Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
+			throw new Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
 		}
 
 		$col = strtolower($matches[1]);

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -16,8 +16,8 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Exception;
 use Cake\Database\Schema\Table;
-use Cake\Error;
 
 /**
  * Schema management/reflection features for Sqlite
@@ -48,13 +48,13 @@ class SqliteSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @throws Cake\Error\Exception
+ * @throws Cake\Database\Exception
  * @return array Array of column information.
  */
 	public function convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
 		if (empty($matches)) {
-			throw new Error\Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
+			throw new Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
 		}
 		$col = strtolower($matches[1]);
 		$length = null;
@@ -195,7 +195,7 @@ class SqliteSchema {
  * @param Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
- * @throws Cake\Error\Exception On unknown column types.
+ * @throws Cake\Database\Exception On unknown column types.
  */
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);
@@ -214,7 +214,7 @@ class SqliteSchema {
 			'timestamp' => ' TIMESTAMP',
 		];
 		if (!isset($typeMap[$data['type']])) {
-			throw new Error\Exception(__d('cake_dev', 'Unknown column type for "%s"', $name));
+			throw new Exception(__d('cake_dev', 'Unknown column type for "%s"', $name));
 		}
 
 		$out = $this->_driver->quoteIdentifier($name);

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -119,9 +119,8 @@ class SqliteSchema {
  *
  * @param Cake\Database\Schema\Table $table The table object to append fields to.
  * @param array $row The row data from describeTableSql
- * @param array $fieldParams Additional field parameters to parse.
  */
-	public function convertFieldDescription(Table $table, $row, $fieldParams = []) {
+	public function convertFieldDescription(Table $table, $row) {
 		$field = $this->convertColumn($row['type']);
 		$field += [
 			'null' => !$row['notnull'],

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -140,6 +140,28 @@ class SqliteSchema {
 	}
 
 /**
+ * Get the SQL to describe the indexes in a table.
+ *
+ * @param string $table The table name to get information on.
+ * @return array An array of (sql, params) to execute.
+ */
+	public function describeIndexSql($table) {
+		$sql = '';
+		return [$sql, []];
+	}
+
+/**
+ * Convert an index into the abstract description.
+ *
+ * @param Cake\Database\Schema\Table $table The table object to append
+ *    an index or constraint to.
+ * @param array $row The row data from describeIndexSql
+ * @return void
+ */
+	public function convertIndexDescription(Table $table, $row) {
+	}
+
+/**
  * Generate the SQL fragment for a single column in Sqlite
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -195,6 +195,7 @@ class SqliteSchema {
  * @param Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
+ * @throws Cake\Error\Exception On unknown column types.
  */
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -178,12 +178,12 @@ class SqliteSchema {
 		}
 		if ($row['unique']) {
 			$table->addConstraint($row['name'], [
-				'type' => 'unique',
+				'type' => Table::CONSTRAINT_UNIQUE,
 				'columns' => $columns
 			]);
 		} else {
 			$table->addIndex($row['name'], [
-				'type' => 'index',
+				'type' => Table::INDEX_INDEX,
 				'columns' => $columns
 			]);
 		}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -155,7 +155,7 @@ class SqliteSchema {
 /**
  * Convert an index into the abstract description.
  *
- * Since Sqlite does not have a way to get metadata about all indexes at once,
+ * Since SQLite does not have a way to get metadata about all indexes at once,
  * additional queries are done here. Sqlite constraint names are not
  * stable, and the names for constraints will not match those used to create
  * the table. This is a limitation in Sqlite's metadata features.

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -16,8 +16,8 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Exception;
 use Cake\Database\Connection;
-use Cake\Error;
 
 /**
  * Represents a single table in a database schema.
@@ -215,7 +215,7 @@ class Table {
  * @param string $name The name of the index.
  * @param array $attrs The attributes for the index.
  * @return Table $this
- * @throws Cake\Error\Exception
+ * @throws Cake\Database\Exception
  */
 	public function addIndex($name, $attrs) {
 		if (is_string($attrs)) {
@@ -225,11 +225,11 @@ class Table {
 		$attrs = $attrs + $this->_indexKeys;
 
 		if (!in_array($attrs['type'], $this->_validIndexTypes, true)) {
-			throw new Error\Exception(__d('cake_dev', 'Invalid index type "%s"', $attrs['type']));
+			throw new Exception(__d('cake_dev', 'Invalid index type "%s"', $attrs['type']));
 		}
 		foreach ($attrs['columns'] as $field) {
 			if (empty($this->_columns[$field])) {
-				throw new Error\Exception(__d('cake_dev', 'Columns used in indexes must already exist.'));
+				throw new Exception(__d('cake_dev', 'Columns used in indexes must already exist.'));
 			}
 		}
 		$this->_indexes[$name] = $attrs;
@@ -288,7 +288,7 @@ class Table {
  * @param string $name The name of the constraint.
  * @param array $attrs The attributes for the constraint.
  * @return Table $this
- * @throws Cake\Error\Exception
+ * @throws Cake\Database\Exception
  */
 	public function addConstraint($name, $attrs) {
 		if (is_string($attrs)) {
@@ -298,11 +298,11 @@ class Table {
 		$attrs = $attrs + $this->_indexKeys;
 
 		if (!in_array($attrs['type'], $this->_validConstraintTypes, true)) {
-			throw new Error\Exception(__d('cake_dev', 'Invalid constraint type "%s"', $attrs['type']));
+			throw new Exception(__d('cake_dev', 'Invalid constraint type "%s"', $attrs['type']));
 		}
 		foreach ($attrs['columns'] as $field) {
 			if (empty($this->_columns[$field])) {
-				throw new Error\Exception(__d('cake_dev', 'Columns used in constraints must already exist.'));
+				throw new Exception(__d('cake_dev', 'Columns used in constraints must already exist.'));
 			}
 		}
 		$this->_constraints[$name] = $attrs;

--- a/lib/Cake/Database/Type.php
+++ b/lib/Cake/Database/Type.php
@@ -88,7 +88,7 @@ class Type {
  * Returns a Type object capable of converting a type identified by $name
  *
  * @param string $name type identifier
- * @throws InvalidArgumentException If type identifier is unknown
+ * @throws \InvalidArgumentException If type identifier is unknown
  * @return Type
  */
 	public static function build($name) {

--- a/lib/Cake/Test/TestCase/Database/Schema/CollectionTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/CollectionTest.php
@@ -53,7 +53,7 @@ class CollectionTest extends TestCase {
  * Tests for positive describe() calls are in each platformSchema
  * test case.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Database\Exception
  * @return void
  */
 	public function testDescribeIncorrectTable() {

--- a/lib/Cake/Test/TestCase/Database/Schema/CollectionTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/CollectionTest.php
@@ -53,6 +53,7 @@ class CollectionTest extends TestCase {
  * Tests for positive describe() calls are in each platformSchema
  * test case.
  *
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testDescribeIncorrectTable() {

--- a/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -282,6 +282,8 @@ SQL;
 		$schema = new SchemaCollection($connection);
 		$result = $schema->describe('articles');
 		$this->assertInstanceOf('Cake\Database\Schema\Table', $result);
+
+		$this->assertCount(2, $result->constraints());
 		$expected = [
 			'primary' => [
 				'type' => 'primary',
@@ -296,13 +298,16 @@ SQL;
 				]
 			]
 		];
-		foreach ($expected as $name => $props) {
-			$this->assertEquals(
-				$props,
-				$result->constraint($name),
-				'Index definition does not match for ' . $name
-			);
-		}
+		$this->assertEquals($expected['primary'], $result->constraint('primary'));
+		$this->assertEquals($expected['length_idx'], $result->constraint('length_idx'));
+
+		$this->assertCount(1, $result->indexes());
+		$expected = [
+			'type' => 'index',
+			'columns' => ['author_id'],
+			'length' => []
+		];
+		$this->assertEquals($expected, $result->index('author_idx'));
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -276,7 +276,10 @@ SQL;
 		];
 		$this->assertCount(2, $result->constraints());
 		$this->assertEquals($expected['primary'], $result->constraint('primary'));
-		$this->assertEquals($expected['sqlite_autoindex_articles_1'], $result->constraint('sqlite_autoindex_articles_1'));
+		$this->assertEquals(
+			$expected['sqlite_autoindex_articles_1'],
+			$result->constraint('sqlite_autoindex_articles_1')
+		);
 
 		$this->assertCount(1, $result->indexes());
 		$expected = [

--- a/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
@@ -109,7 +109,7 @@ class TableTest extends TestCase {
  * Test that an exception is raised when constraintes
  * are added for fields that do not exist.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Database\Exception
  * @return void
  */
 	public function testAddConstraintErrorWhenFieldIsMissing() {
@@ -141,7 +141,7 @@ class TableTest extends TestCase {
  * Test that an exception is raised when indexes
  * are added for fields that do not exist.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Database\Exception
  * @return void
  */
 	public function testAddIndexErrorWhenFieldIsMissing() {
@@ -155,7 +155,7 @@ class TableTest extends TestCase {
  * Test that exceptions are raised when indexes
  * are added with invalid types
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Database\Exception
  * @return void
  */
 	public function testAddIndexErrorWrongType() {


### PR DESCRIPTION
Adds the ability to reflect indexes/constraints. Since indexes are always reflected with field I've removed the duplicated code when processing fields/indexes where possible.

I've modified SchemaCollection to throw exceptions when an error is encountered when reflecting either columns or indexes. These cases should never come up and I felt they should be treated like that.
