### PR TITLE
Added a clear() function to Model.php

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1504,7 +1504,10 @@ class Model extends Object implements CakeEventListener {
  * @return array The current Model::data; after clearing via create(false)
  * @see Model::create()
  */
-	public function clear() { return $this->create(false); }
+	public function clear() {
+		$this->create(false);
+		return true;
+	}
 
 /**
  * Returns a list of fields from the database, and sets the current model

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1497,6 +1497,14 @@ class Model extends Object implements CakeEventListener {
 		}
 		return $this->data;
 	}
+	
+/**
+ * This function is a convenient wrapper class to create(false) and, as the name suggests, clears the id, data, and validation errors.
+ * 
+ * @return array The current Model::data; after clearing via create(false)
+ * @see Model::create()
+ */
+	public function clear() { return $this->create(false); }
 
 /**
  * Returns a list of fields from the database, and sets the current model


### PR DESCRIPTION
Many times `Model::create()` is used with a single parameter of `false`.  When this happens, what is actually happening is that the Model is being **_cleared**_ rather than **_created**_.

`Model::clear()` is lightweight (since its a wrapper), provides a convenient way to clear a model, and also more intuitively describes a developer's true intentions within application code than `Model::create(false)` does.
