### PR TITLE
remove $name where not necessary

### DIFF
--- a/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
@@ -31,9 +31,6 @@ App::uses('Controller', 'Controller');
 
 if (!class_exists('UsersController')) {
 	class UsersController extends Controller {
-
-		public $name = 'Users';
-
 	}
 }
 

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -33,16 +33,9 @@ App::uses('SchemaShell', 'Console/Command');
 class SchemaShellTestSchema extends CakeSchema {
 
 /**
- * name property
- *
- * @var string 'MyApp'
- */
-	public $name = 'SchemaShellTest';
-
-/**
  * connection property
  *
- * @var string 'test'
+ * @var string
  */
 	public $connection = 'test';
 

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -45,8 +45,6 @@ if (!$imported) {
  */
 	class BakeArticle extends Model {
 
-		public $name = 'BakeArticle';
-
 		public $hasMany = array('BakeComment');
 
 		public $hasAndBelongsToMany = array('BakeTag');

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -37,13 +37,6 @@ App::uses('Model', 'Model');
 class TestTaskArticle extends Model {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'TestTaskArticle';
-
-/**
  * Table name to use
  *
  * @var string
@@ -110,13 +103,6 @@ class TestTaskArticle extends Model {
 class TestTaskTag extends Model {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'TestTaskTag';
-
-/**
  * Table name
  *
  * @var string
@@ -154,13 +140,6 @@ class TestTaskAppModel extends Model {
 class TestTaskComment extends TestTaskAppModel {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'TestTaskComment';
-
-/**
  * Table name
  *
  * @var string
@@ -186,13 +165,6 @@ class TestTaskComment extends TestTaskAppModel {
  * @package       Cake.Test.Case.Console.Command.Task
  */
 class TestTaskCommentsController extends Controller {
-
-/**
- * Controller Name
- *
- * @var string
- */
-	public $name = 'TestTaskComments';
 
 /**
  * Models to use

--- a/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
@@ -40,13 +40,6 @@ App::uses('Controller', 'Controller');
 class ViewTaskComment extends Model {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'ViewTaskComment';
-
-/**
  * Table name
  *
  * @var string
@@ -74,13 +67,6 @@ class ViewTaskComment extends Model {
 class ViewTaskArticle extends Model {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'ViewTaskArticle';
-
-/**
  * Table name
  *
  * @var string
@@ -94,13 +80,6 @@ class ViewTaskArticle extends Model {
  * @package       Cake.Test.Case.Console.Command.Task
  */
 class ViewTaskCommentsController extends Controller {
-
-/**
- * Controller name
- *
- * @var string
- */
-	public $name = 'ViewTaskComments';
 
 /**
  * Testing public controller action
@@ -126,13 +105,6 @@ class ViewTaskCommentsController extends Controller {
  * @package       Cake.Test.Case.Console.Command.Task
  */
 class ViewTaskArticlesController extends Controller {
-
-/**
- * Controller name
- *
- * @var string
- */
-	public $name = 'ViewTaskArticles';
 
 /**
  * Test public controller action

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -35,7 +35,7 @@ class AclNodeTwoTestBase extends AclNode {
 /**
  * useDbConfig property
  *
- * @var string 'test'
+ * @var string
  */
 	public $useDbConfig = 'test';
 
@@ -57,14 +57,14 @@ class AroTwoTest extends AclNodeTwoTestBase {
 /**
  * name property
  *
- * @var string 'AroTwoTest'
+ * @var string
  */
 	public $name = 'AroTwoTest';
 
 /**
  * useTable property
  *
- * @var string 'aro_twos'
+ * @var string
  */
 	public $useTable = 'aro_twos';
 
@@ -86,14 +86,14 @@ class AcoTwoTest extends AclNodeTwoTestBase {
 /**
  * name property
  *
- * @var string 'AcoTwoTest'
+ * @var string
  */
 	public $name = 'AcoTwoTest';
 
 /**
  * useTable property
  *
- * @var string 'aco_twos'
+ * @var string
  */
 	public $useTable = 'aco_twos';
 
@@ -115,14 +115,14 @@ class PermissionTwoTest extends Permission {
 /**
  * name property
  *
- * @var string 'PermissionTwoTest'
+ * @var string
  */
 	public $name = 'PermissionTwoTest';
 
 /**
  * useTable property
  *
- * @var string 'aros_aco_twos'
+ * @var string
  */
 	public $useTable = 'aros_aco_twos';
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -60,16 +60,9 @@ class TestAuthComponent extends AuthComponent {
 class AuthUser extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'AuthUser'
- */
-	public $name = 'AuthUser';
-
-/**
  * useDbConfig property
  *
- * @var string 'test'
+ * @var string
  */
 	public $useDbConfig = 'test';
 
@@ -81,13 +74,6 @@ class AuthUser extends CakeTestModel {
  * @package       Cake.Test.Case.Controller.Component
  */
 class AuthTestController extends Controller {
-
-/**
- * name property
- *
- * @var string 'AuthTest'
- */
-	public $name = 'AuthTest';
 
 /**
  * uses property
@@ -204,13 +190,6 @@ class AuthTestController extends Controller {
 class AjaxAuthController extends Controller {
 
 /**
- * name property
- *
- * @var string 'AjaxAuth'
- */
-	public $name = 'AjaxAuth';
-
-/**
  * components property
  *
  * @var array
@@ -278,7 +257,7 @@ class AuthComponentTest extends CakeTestCase {
 /**
  * name property
  *
- * @var string 'Auth'
+ * @var string
  */
 	public $name = 'Auth';
 

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -94,13 +94,6 @@ class DebugCompTransport extends AbstractTransport {
 class EmailTestController extends Controller {
 
 /**
- * name property
- *
- * @var string 'EmailTest'
- */
-	public $name = 'EmailTest';
-
-/**
  * uses property
  *
  * @var mixed null
@@ -133,7 +126,7 @@ class EmailComponentTest extends CakeTestCase {
 /**
  * name property
  *
- * @var string 'Email'
+ * @var string
  */
 	public $name = 'Email';
 

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -33,13 +33,6 @@ App::uses('CakeResponse', 'Network');
 class PaginatorTestController extends Controller {
 
 /**
- * name property
- *
- * @var string 'PaginatorTest'
- */
-	public $name = 'PaginatorTest';
-
-/**
  * components property
  *
  * @var array
@@ -55,16 +48,9 @@ class PaginatorTestController extends Controller {
 class PaginatorControllerPost extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'PaginatorControllerPost'
- */
-	public $name = 'PaginatorControllerPost';
-
-/**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'posts';
 
@@ -125,16 +111,9 @@ class PaginatorControllerPost extends CakeTestModel {
 class ControllerPaginateModel extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'ControllerPaginateModel'
- */
-	public $name = 'ControllerPaginateModel';
-
-/**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -169,21 +148,21 @@ class PaginatorControllerComment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Comment'
+ * @var string
  */
 	public $name = 'Comment';
 
 /**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
 /**
  * alias property
  *
- * @var string 'PaginatorControllerComment'
+ * @var string
  */
 	public $alias = 'PaginatorControllerComment';
 }
@@ -196,30 +175,16 @@ class PaginatorControllerComment extends CakeTestModel {
 class PaginatorAuthor extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'PaginatorAuthor'
- */
-	public $name = 'PaginatorAuthor';
-
-/**
  * useTable property
  *
- * @var string 'authors'
+ * @var string
  */
 	public $useTable = 'authors';
 
 /**
  * alias property
  *
- * @var string 'PaginatorAuthor'
- */
-	public $alias = 'PaginatorAuthor';
-
-/**
- * alias property
- *
- * @var string 'PaginatorAuthor'
+ * @var string
  */
 	public $virtualFields = array(
 			'joined_offset' => 'PaginatorAuthor.id + 1'

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -48,13 +48,6 @@ class TestSecurityComponent extends SecurityComponent {
 class SecurityTestController extends Controller {
 
 /**
- * name property
- *
- * @var string 'SecurityTest'
- */
-	public $name = 'SecurityTest';
-
-/**
  * components property
  *
  * @var array

--- a/lib/Cake/Test/Case/Controller/ComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentTest.php
@@ -29,13 +29,6 @@ App::uses('Component', 'Controller');
 class ParamTestComponent extends Component {
 
 /**
- * name property
- *
- * @var string 'ParamTest'
- */
-	public $name = 'ParamTest';
-
-/**
  * components property
  *
  * @var array
@@ -49,13 +42,6 @@ class ParamTestComponent extends Component {
  * @package       Cake.Test.Case.Controller
  */
 class ComponentTestController extends Controller {
-
-/**
- * name property
- *
- * @var string 'ComponentTest'
- */
-	public $name = 'ComponentTest';
 
 /**
  * uses property
@@ -146,7 +132,7 @@ class BananaComponent extends Component {
 /**
  * testField property
  *
- * @var string 'BananaField'
+ * @var string
  */
 	public $testField = 'BananaField';
 

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -61,13 +61,6 @@ class MergeVarComponent extends Object {
 class MergeVariablesController extends MergeVarsAppController {
 
 /**
- * name
- *
- * @var string
- */
-	public $name = 'MergeVariables';
-
-/**
  * uses
  *
  * @var arrays
@@ -117,13 +110,6 @@ class MergeVarPluginAppController extends MergeVarsAppController {
  * @package       Cake.Test.Case.Controller
  */
 class MergePostsController extends MergeVarPluginAppController {
-
-/**
- * name
- *
- * @var string
- */
-	public $name = 'MergePosts';
 
 /**
  * uses

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -59,16 +59,9 @@ class ControllerTestAppController extends Controller {
 class ControllerPost extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'ControllerPost'
- */
-	public $name = 'ControllerPost';
-
-/**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'posts';
 
@@ -121,13 +114,6 @@ class ControllerPost extends CakeTestModel {
  */
 class ControllerCommentsController extends ControllerTestAppController {
 
-/**
- * name property
- *
- * @var string 'ControllerPost'
- */
-	public $name = 'ControllerComments';
-
 	protected $_mergeParent = 'ControllerTestAppController';
 }
 
@@ -141,14 +127,14 @@ class ControllerComment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ControllerComment'
+ * @var string
  */
 	public $name = 'Comment';
 
 /**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -162,7 +148,7 @@ class ControllerComment extends CakeTestModel {
 /**
  * alias property
  *
- * @var string 'ControllerComment'
+ * @var string
  */
 	public $alias = 'ControllerComment';
 }
@@ -175,23 +161,16 @@ class ControllerComment extends CakeTestModel {
 class ControllerAlias extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'ControllerAlias'
- */
-	public $name = 'ControllerAlias';
-
-/**
  * alias property
  *
- * @var string 'ControllerSomeAlias'
+ * @var string
  */
 	public $alias = 'ControllerSomeAlias';
 
 /**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'posts';
 }
@@ -205,20 +184,20 @@ class NameTest extends CakeTestModel {
 
 /**
  * name property
- * @var string 'Name'
+ * @var string
  */
 	public $name = 'Name';
 
 /**
  * useTable property
- * @var string 'names'
+ * @var string
  */
 	public $useTable = 'comments';
 
 /**
  * alias property
  *
- * @var string 'ControllerComment'
+ * @var string
  */
 	public $alias = 'Name';
 }
@@ -229,12 +208,6 @@ class NameTest extends CakeTestModel {
  * @package       Cake.Test.Case.Controller
  */
 class TestController extends ControllerTestAppController {
-
-/**
- * name property
- * @var string 'Name'
- */
-	public $name = 'Test';
 
 /**
  * helpers property
@@ -380,12 +353,6 @@ class Test2Component extends TestComponent {
  * @package       Cake.Test.Case.Controller
  */
 class AnotherTestController extends ControllerTestAppController {
-
-/**
- * name property
- * @var string 'Name'
- */
-	public $name = 'AnotherTest';
 
 /**
  * uses property

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -34,13 +34,6 @@ require_once dirname(dirname(__FILE__)) . DS . 'Model' . DS . 'models.php';
 class ScaffoldMockController extends Controller {
 
 /**
- * name property
- *
- * @var string 'ScaffoldMock'
- */
-	public $name = 'ScaffoldMock';
-
-/**
  * scaffold property
  *
  * @var mixed
@@ -58,7 +51,7 @@ class ScaffoldMockControllerWithFields extends Controller {
 /**
  * name property
  *
- * @var string 'ScaffoldMock'
+ * @var string
  */
 	public $name = 'ScaffoldMock';
 

--- a/lib/Cake/Test/Case/Core/ObjectTest.php
+++ b/lib/Cake/Test/Case/Core/ObjectTest.php
@@ -31,16 +31,9 @@ App::uses('Model', 'Model');
 class RequestActionPost extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'ControllerPost'
- */
-	public $name = 'RequestActionPost';
-
-/**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'posts';
 }
@@ -149,14 +142,14 @@ class TestObject extends Object {
 /**
  * firstName property
  *
- * @var string 'Joel'
+ * @var string
  */
 	public $firstName = 'Joel';
 
 /**
  * lastName property
  *
- * @var string 'Moss'
+ * @var string
  */
 	public $lastName = 'Moss';
 
@@ -281,8 +274,6 @@ class TestObject extends Object {
 class ObjectTestModel extends CakeTestModel {
 
 	public $useTable = false;
-
-	public $name = 'ObjectTestModel';
 
 }
 

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -31,13 +31,6 @@ App::uses('Router', 'Routing');
 class AuthBlueberryUser extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'AuthBlueberryUser'
- */
-	public $name = 'AuthBlueberryUser';
-
-/**
  * useTable property
  *
  * @var string

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -31,7 +31,7 @@ class DbAclNodeTestBase extends AclNode {
 /**
  * useDbConfig property
  *
- * @var string 'test'
+ * @var string
  */
 	public $useDbConfig = 'test';
 
@@ -51,16 +51,9 @@ class DbAclNodeTestBase extends AclNode {
 class DbAroTest extends DbAclNodeTestBase {
 
 /**
- * name property
- *
- * @var string 'DbAroTest'
- */
-	public $name = 'DbAroTest';
-
-/**
  * useTable property
  *
- * @var string 'aros'
+ * @var string
  */
 	public $useTable = 'aros';
 
@@ -80,16 +73,9 @@ class DbAroTest extends DbAclNodeTestBase {
 class DbAcoTest extends DbAclNodeTestBase {
 
 /**
- * name property
- *
- * @var string 'DbAcoTest'
- */
-	public $name = 'DbAcoTest';
-
-/**
  * useTable property
  *
- * @var string 'acos'
+ * @var string
  */
 	public $useTable = 'acos';
 
@@ -109,16 +95,9 @@ class DbAcoTest extends DbAclNodeTestBase {
 class DbPermissionTest extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'DbPermissionTest'
- */
-	public $name = 'DbPermissionTest';
-
-/**
  * useTable property
  *
- * @var string 'aros_acos'
+ * @var string
  */
 	public $useTable = 'aros_acos';
 
@@ -145,16 +124,9 @@ class DbPermissionTest extends CakeTestModel {
 class DbAcoActionTest extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'DbAcoActionTest'
- */
-	public $name = 'DbAcoActionTest';
-
-/**
  * useTable property
  *
- * @var string 'aco_actions'
+ * @var string
  */
 	public $useTable = 'aco_actions';
 
@@ -176,14 +148,14 @@ class DbAroUserTest extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'AuthUser'
+ * @var string
  */
 	public $name = 'AuthUser';
 
 /**
  * useTable property
  *
- * @var string 'auth_users'
+ * @var string
  */
 	public $useTable = 'auth_users';
 

--- a/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
@@ -34,13 +34,6 @@ App::uses('DbAcl', 'Model');
 class AclPerson extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string
- */
-	public $name = 'AclPerson';
-
-/**
  * useTable property
  *
  * @var string

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -30,16 +30,9 @@ App::uses('CakeTestFixture', 'TestSuite/Fixture');
 class MyAppSchema extends CakeSchema {
 
 /**
- * name property
- *
- * @var string 'MyApp'
- */
-	public $name = 'MyApp';
-
-/**
  * connection property
  *
- * @var string 'test'
+ * @var string
  */
 	public $connection = 'test';
 
@@ -127,7 +120,7 @@ class TestAppSchema extends CakeSchema {
 /**
  * name property
  *
- * @var string 'MyApp'
+ * @var string
  */
 	public $name = 'MyApp';
 
@@ -233,16 +226,9 @@ class TestAppSchema extends CakeSchema {
 class SchemaPost extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SchemaPost'
- */
-	public $name = 'SchemaPost';
-
-/**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'posts';
 
@@ -269,16 +255,9 @@ class SchemaPost extends CakeTestModel {
 class SchemaComment extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SchemaComment'
- */
-	public $name = 'SchemaComment';
-
-/**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -298,16 +277,9 @@ class SchemaComment extends CakeTestModel {
 class SchemaTag extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SchemaTag'
- */
-	public $name = 'SchemaTag';
-
-/**
  * useTable property
  *
- * @var string 'tags'
+ * @var string
  */
 	public $useTable = 'tags';
 
@@ -327,16 +299,9 @@ class SchemaTag extends CakeTestModel {
 class SchemaDatatype extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SchemaDatatype'
- */
-	public $name = 'SchemaDatatype';
-
-/**
  * useTable property
  *
- * @var string 'datatypes'
+ * @var string
  */
 	public $useTable = 'datatypes';
 }
@@ -352,13 +317,6 @@ class SchemaDatatype extends CakeTestModel {
  * @package       Cake.Test.Case.Model
  */
 class Testdescribe extends CakeTestModel {
-
-/**
- * name property
- *
- * @var string 'Testdescribe'
- */
-	public $name = 'Testdescribe';
 }
 
 /**
@@ -369,23 +327,16 @@ class Testdescribe extends CakeTestModel {
 class SchemaCrossDatabase extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SchemaCrossDatabase'
- */
-	public $name = 'SchemaCrossDatabase';
-
-/**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'cross_database';
 
 /**
  * useDbConfig property
  *
- * @var string 'test2'
+ * @var string
  */
 	public $useDbConfig = 'test2';
 }
@@ -400,13 +351,14 @@ class SchemaCrossDatabaseFixture extends CakeTestFixture {
 /**
  * name property
  *
- * @var string 'CrossDatabase'
+ * @var string
  */
 	public $name = 'CrossDatabase';
 
 /**
  * table property
  *
+ * @var string
  */
 	public $table = 'cross_database';
 
@@ -437,13 +389,6 @@ class SchemaCrossDatabaseFixture extends CakeTestFixture {
  * @package       Cake.Test.Case.Model
  */
 class SchemaPrefixAuthUser extends CakeTestModel {
-
-/**
- * name property
- *
- * @var string
- */
-	public $name = 'SchemaPrefixAuthUser';
 
 /**
  * table prefix

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -67,13 +67,6 @@ class DboPostgresTestDb extends Postgres {
 class PostgresTestModel extends Model {
 
 /**
- * name property
- *
- * @var string 'PostgresTestModel'
- */
-	public $name = 'PostgresTestModel';
-
-/**
  * useTable property
  *
  * @var bool false
@@ -153,13 +146,6 @@ class PostgresTestModel extends Model {
  * @package       Cake.Test.Case.Model.Datasource.Database
  */
 class PostgresClientTestModel extends Model {
-
-/**
- * name property
- *
- * @var string 'PostgresClientTestModel'
- */
-	public $name = 'PostgresClientTestModel';
 
 /**
  * useTable property

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -116,13 +116,6 @@ class SqlserverTestDb extends Sqlserver {
 class SqlserverTestModel extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SqlserverTestModel'
- */
-	public $name = 'SqlserverTestModel';
-
-/**
  * useTable property
  *
  * @var bool false
@@ -187,13 +180,6 @@ class SqlserverTestModel extends CakeTestModel {
  * @package       Cake.Test.Case.Model.Datasource.Database
  */
 class SqlserverClientTestModel extends CakeTestModel {
-
-/**
- * name property
- *
- * @var string 'SqlserverAssociatedTestModel'
- */
-	public $name = 'SqlserverClientTestModel';
 
 /**
  * useTable property

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -30,8 +30,6 @@ class_exists('CakeSession');
  */
 class SessionTestModel extends Model {
 
-	public $name = 'SessionTestModel';
-
 	public $useTable = 'sessions';
 
 }

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -75,7 +75,7 @@ class Test extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Test'
+ * @var string
  */
 	public $name = 'Test';
 
@@ -112,16 +112,9 @@ class TestAlias extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestAlias'
+ * @var string
  */
 	public $name = 'TestAlias';
-
-/**
- * alias property
- *
- * @var string 'TestAlias'
- */
-	public $alias = 'TestAlias';
 
 /**
  * schema property
@@ -155,7 +148,7 @@ class TestValidate extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestValidate'
+ * @var string
  */
 	public $name = 'TestValidate';
 
@@ -208,7 +201,7 @@ class User extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'User'
+ * @var string
  */
 	public $name = 'User';
 
@@ -246,7 +239,7 @@ class Article extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Article'
+ * @var string
  */
 	public $name = 'Article';
 
@@ -343,14 +336,14 @@ class NumericArticle extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'NumericArticle'
+ * @var string
  */
 	public $name = 'NumericArticle';
 
 /**
  * useTable property
  *
- * @var string 'numeric_articles'
+ * @var string
  */
 	public $useTable = 'numeric_articles';
 
@@ -366,14 +359,14 @@ class Article10 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Article10'
+ * @var string
  */
 	public $name = 'Article10';
 
 /**
  * useTable property
  *
- * @var string 'articles'
+ * @var string
  */
 	public $useTable = 'articles';
 
@@ -396,7 +389,7 @@ class ArticleFeatured extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ArticleFeatured'
+ * @var string
  */
 	public $name = 'ArticleFeatured';
 
@@ -447,7 +440,7 @@ class Featured extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Featured'
+ * @var string
  */
 	public $name = 'Featured';
 
@@ -469,7 +462,7 @@ class Tag extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Tag'
+ * @var string
  */
 	public $name = 'Tag';
 }
@@ -484,7 +477,7 @@ class ArticlesTag extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ArticlesTag'
+ * @var string
  */
 	public $name = 'ArticlesTag';
 }
@@ -499,7 +492,7 @@ class ArticleFeaturedsTag extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ArticleFeaturedsTag'
+ * @var string
  */
 	public $name = 'ArticleFeaturedsTag';
 }
@@ -514,7 +507,7 @@ class Comment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Comment'
+ * @var string
  */
 	public $name = 'Comment';
 
@@ -543,14 +536,14 @@ class ModifiedComment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Comment'
+ * @var string
  */
 	public $name = 'Comment';
 
 /**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -595,14 +588,14 @@ class AgainModifiedComment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Comment'
+ * @var string
  */
 	public $name = 'Comment';
 
 /**
  * useTable property
  *
- * @var string 'comments'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -702,7 +695,7 @@ class Attachment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Attachment'
+ * @var string
  */
 	public $name = 'Attachment';
 
@@ -724,14 +717,14 @@ class ModifiedAttachment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ModifiedAttachment'
+ * @var string
  */
 	public $name = 'ModifiedAttachment';
 
 /**
  * useTable property
  *
- * @var string 'attachments'
+ * @var string
  */
 	public $useTable = 'attachments';
 
@@ -759,7 +752,7 @@ class Category extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Category'
+ * @var string
  */
 	public $name = 'Category';
 }
@@ -774,7 +767,7 @@ class CategoryThread extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'CategoryThread'
+ * @var string
  */
 	public $name = 'CategoryThread';
 
@@ -796,7 +789,7 @@ class Apple extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Apple'
+ * @var string
  */
 	public $name = 'Apple';
 
@@ -839,14 +832,14 @@ class Sample extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Sample'
+ * @var string
  */
 	public $name = 'Sample';
 
 /**
  * belongsTo property
  *
- * @var string 'Apple'
+ * @var string
  */
 	public $belongsTo = 'Apple';
 }
@@ -861,14 +854,14 @@ class AnotherArticle extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'AnotherArticle'
+ * @var string
  */
 	public $name = 'AnotherArticle';
 
 /**
  * hasMany property
  *
- * @var string 'Home'
+ * @var string
  */
 	public $hasMany = 'Home';
 }
@@ -883,14 +876,14 @@ class Advertisement extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Advertisement'
+ * @var string
  */
 	public $name = 'Advertisement';
 
 /**
  * hasMany property
  *
- * @var string 'Home'
+ * @var string
  */
 	public $hasMany = 'Home';
 }
@@ -905,7 +898,7 @@ class Home extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Home'
+ * @var string
  */
 	public $name = 'Home';
 
@@ -927,7 +920,7 @@ class Post extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Post'
+ * @var string
  */
 	public $name = 'Post';
 
@@ -962,7 +955,7 @@ class Author extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Author'
+ * @var string
  */
 	public $name = 'Author';
 
@@ -996,7 +989,7 @@ class ModifiedAuthor extends Author {
 /**
  * name property
  *
- * @var string 'Author'
+ * @var string
  */
 	public $name = 'Author';
 
@@ -1025,7 +1018,7 @@ class Project extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Project'
+ * @var string
  */
 	public $name = 'Project';
 
@@ -1047,7 +1040,7 @@ class Thread extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Thread'
+ * @var string
  */
 	public $name = 'Thread';
 
@@ -1076,7 +1069,7 @@ class Message extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Message'
+ * @var string
  */
 	public $name = 'Message';
 
@@ -1098,7 +1091,7 @@ class Bid extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Bid'
+ * @var string
  */
 	public $name = 'Bid';
 
@@ -1120,14 +1113,14 @@ class BiddingMessage extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'BiddingMessage'
+ * @var string
  */
 	public $name = 'BiddingMessage';
 
 /**
  * primaryKey property
  *
- * @var string 'bidding'
+ * @var string
  */
 	public $primaryKey = 'bidding';
 
@@ -1154,7 +1147,7 @@ class Bidding extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Bidding'
+ * @var string
  */
 	public $name = 'Bidding';
 
@@ -1182,7 +1175,7 @@ class NodeAfterFind extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'NodeAfterFind'
+ * @var string
  */
 	public $name = 'NodeAfterFind';
 
@@ -1196,7 +1189,7 @@ class NodeAfterFind extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'apples'
+ * @var string
  */
 	public $useTable = 'apples';
 
@@ -1243,21 +1236,21 @@ class NodeAfterFindSample extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'NodeAfterFindSample'
+ * @var string
  */
 	public $name = 'NodeAfterFindSample';
 
 /**
  * useTable property
  *
- * @var string 'samples'
+ * @var string
  */
 	public $useTable = 'samples';
 
 /**
  * belongsTo property
  *
- * @var string 'NodeAfterFind'
+ * @var string
  */
 	public $belongsTo = 'NodeAfterFind';
 }
@@ -1272,7 +1265,7 @@ class NodeNoAfterFind extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'NodeAfterFind'
+ * @var string
  */
 	public $name = 'NodeAfterFind';
 
@@ -1286,7 +1279,7 @@ class NodeNoAfterFind extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'apples'
+ * @var string
  */
 	public $useTable = 'apples';
 
@@ -1322,7 +1315,7 @@ class Node extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Node'
+ * @var string
  */
 	public $name = 'Node';
 
@@ -1352,7 +1345,7 @@ class Dependency extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Dependency'
+ * @var string
  */
 	public $name = 'Dependency';
 }
@@ -1367,14 +1360,14 @@ class ModelA extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ModelA'
+ * @var string
  */
 	public $name = 'ModelA';
 
 /**
  * useTable property
  *
- * @var string 'apples'
+ * @var string
  */
 	public $useTable = 'apples';
 
@@ -1396,14 +1389,14 @@ class ModelB extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ModelB'
+ * @var string
  */
 	public $name = 'ModelB';
 
 /**
  * useTable property
  *
- * @var string 'messages'
+ * @var string
  */
 	public $useTable = 'messages';
 
@@ -1425,14 +1418,14 @@ class ModelC extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ModelC'
+ * @var string
  */
 	public $name = 'ModelC';
 
 /**
  * useTable property
  *
- * @var string 'bids'
+ * @var string
  */
 	public $useTable = 'bids';
 
@@ -1454,14 +1447,14 @@ class ModelD extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ModelD'
+ * @var string
  */
 	public $name = 'ModelD';
 
 /**
  * useTable property
  *
- * @var string 'threads'
+ * @var string
  */
 	public $useTable = 'threads';
 }
@@ -1476,7 +1469,7 @@ class Something extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Something'
+ * @var string
  */
 	public $name = 'Something';
 
@@ -1498,7 +1491,7 @@ class SomethingElse extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'SomethingElse'
+ * @var string
  */
 	public $name = 'SomethingElse';
 
@@ -1520,7 +1513,7 @@ class JoinThing extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'JoinThing'
+ * @var string
  */
 	public $name = 'JoinThing';
 
@@ -1542,7 +1535,7 @@ class Portfolio extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Portfolio'
+ * @var string
  */
 	public $name = 'Portfolio';
 
@@ -1564,7 +1557,7 @@ class Item extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Item'
+ * @var string
  */
 	public $name = 'Item';
 
@@ -1593,7 +1586,7 @@ class ItemsPortfolio extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ItemsPortfolio'
+ * @var string
  */
 	public $name = 'ItemsPortfolio';
 }
@@ -1608,7 +1601,7 @@ class Syfile extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Syfile'
+ * @var string
  */
 	public $name = 'Syfile';
 
@@ -1630,7 +1623,7 @@ class Image extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Image'
+ * @var string
  */
 	public $name = 'Image';
 }
@@ -1645,7 +1638,7 @@ class DeviceType extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'DeviceType'
+ * @var string
  */
 	public $name = 'DeviceType';
 
@@ -1685,7 +1678,7 @@ class DeviceTypeCategory extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'DeviceTypeCategory'
+ * @var string
  */
 	public $name = 'DeviceTypeCategory';
 }
@@ -1700,7 +1693,7 @@ class FeatureSet extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'FeatureSet'
+ * @var string
  */
 	public $name = 'FeatureSet';
 }
@@ -1715,7 +1708,7 @@ class ExteriorTypeCategory extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ExteriorTypeCategory'
+ * @var string
  */
 	public $name = 'ExteriorTypeCategory';
 
@@ -1737,7 +1730,7 @@ class Document extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Document'
+ * @var string
  */
 	public $name = 'Document';
 
@@ -1759,7 +1752,7 @@ class Device extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Device'
+ * @var string
  */
 	public $name = 'Device';
 }
@@ -1774,7 +1767,7 @@ class DocumentDirectory extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'DocumentDirectory'
+ * @var string
  */
 	public $name = 'DocumentDirectory';
 }
@@ -1789,7 +1782,7 @@ class PrimaryModel extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'PrimaryModel'
+ * @var string
  */
 	public $name = 'PrimaryModel';
 }
@@ -1804,7 +1797,7 @@ class SecondaryModel extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'SecondaryModel'
+ * @var string
  */
 	public $name = 'SecondaryModel';
 }
@@ -1819,7 +1812,7 @@ class JoinA extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'JoinA'
+ * @var string
  */
 	public $name = 'JoinA';
 
@@ -1841,7 +1834,7 @@ class JoinB extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'JoinB'
+ * @var string
  */
 	public $name = 'JoinB';
 
@@ -1863,7 +1856,7 @@ class JoinC extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'JoinC'
+ * @var string
  */
 	public $name = 'JoinC';
 
@@ -1885,14 +1878,14 @@ class ThePaper extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ThePaper'
+ * @var string
  */
 	public $name = 'ThePaper';
 
 /**
  * useTable property
  *
- * @var string 'apples'
+ * @var string
  */
 	public $useTable = 'apples';
 
@@ -1921,14 +1914,14 @@ class Monkey extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Monkey'
+ * @var string
  */
 	public $name = 'Monkey';
 
 /**
  * useTable property
  *
- * @var string 'devices'
+ * @var string
  */
 	public $useTable = 'devices';
 }
@@ -1943,14 +1936,14 @@ class AssociationTest1 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'join_as'
+ * @var string
  */
 	public $useTable = 'join_as';
 
 /**
  * name property
  *
- * @var string 'AssociationTest1'
+ * @var string
  */
 	public $name = 'AssociationTest1';
 
@@ -1974,14 +1967,14 @@ class AssociationTest2 extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'join_bs'
+ * @var string
  */
 	public $useTable = 'join_bs';
 
 /**
  * name property
  *
- * @var string 'AssociationTest2'
+ * @var string
  */
 	public $name = 'AssociationTest2';
 
@@ -2073,7 +2066,7 @@ class Uuid extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Uuid'
+ * @var string
  */
 	public $name = 'Uuid';
 }
@@ -2088,7 +2081,7 @@ class DataTest extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'DataTest'
+ * @var string
  */
 	public $name = 'DataTest';
 }
@@ -2103,7 +2096,7 @@ class TheVoid extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TheVoid'
+ * @var string
  */
 	public $name = 'TheVoid';
 
@@ -2125,7 +2118,7 @@ class ValidationTest1 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ValidationTest'
+ * @var string
  */
 	public $name = 'ValidationTest1';
 
@@ -2211,7 +2204,7 @@ class ValidationTest2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ValidationTest2'
+ * @var string
  */
 	public $name = 'ValidationTest2';
 
@@ -2268,7 +2261,7 @@ class Person extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Person'
+ * @var string
  */
 	public $name = 'Person';
 
@@ -2299,7 +2292,7 @@ class UnderscoreField extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'UnderscoreField'
+ * @var string
  */
 	public $name = 'UnderscoreField';
 }
@@ -2314,7 +2307,7 @@ class Product extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Product'
+ * @var string
  */
 	public $name = 'Product';
 }
@@ -2329,14 +2322,14 @@ class Story extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Story'
+ * @var string
  */
 	public $name = 'Story';
 
 /**
  * primaryKey property
  *
- * @var string 'story'
+ * @var string
  */
 	public $primaryKey = 'story';
 
@@ -2365,7 +2358,7 @@ class Cd extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Cd'
+ * @var string
  */
 	public $name = 'Cd';
 
@@ -2394,7 +2387,7 @@ class Book extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Book'
+ * @var string
  */
 	public $name = 'Book';
 
@@ -2423,7 +2416,7 @@ class OverallFavorite extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'OverallFavorite'
+ * @var string
  */
 	public $name = 'OverallFavorite';
 }
@@ -2438,7 +2431,7 @@ class MyUser extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'MyUser'
+ * @var string
  */
 	public $name = 'MyUser';
 
@@ -2460,7 +2453,7 @@ class MyCategory extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'MyCategory'
+ * @var string
  */
 	public $name = 'MyCategory';
 
@@ -2482,7 +2475,7 @@ class MyProduct extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'MyProduct'
+ * @var string
  */
 	public $name = 'MyProduct';
 
@@ -2504,7 +2497,7 @@ class MyCategoriesMyUser extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'MyCategoriesMyUser'
+ * @var string
  */
 	public $name = 'MyCategoriesMyUser';
 }
@@ -2519,7 +2512,7 @@ class MyCategoriesMyProduct extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'MyCategoriesMyProduct'
+ * @var string
  */
 	public $name = 'MyCategoriesMyProduct';
 }
@@ -2535,7 +2528,7 @@ class NumberTree extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'NumberTree'
+ * @var string
  */
 	public $name = 'NumberTree';
 
@@ -2599,7 +2592,7 @@ class NumberTreeTwo extends NumberTree {
 /**
  * name property
  *
- * @var string 'NumberTree'
+ * @var string
  */
 	public $name = 'NumberTreeTwo';
 
@@ -2621,7 +2614,7 @@ class FlagTree extends NumberTree {
 /**
  * name property
  *
- * @var string 'FlagTree'
+ * @var string
  */
 	public $name = 'FlagTree';
 }
@@ -2636,7 +2629,7 @@ class UnconventionalTree extends NumberTree {
 /**
  * name property
  *
- * @var string 'FlagTree'
+ * @var string
  */
 	public $name = 'UnconventionalTree';
 
@@ -2660,7 +2653,7 @@ class UuidTree extends NumberTree {
 /**
  * name property
  *
- * @var string 'FlagTree'
+ * @var string
  */
 	public $name = 'UuidTree';
 }
@@ -2675,7 +2668,7 @@ class Campaign extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Campaign'
+ * @var string
  */
 	public $name = 'Campaign';
 
@@ -2697,7 +2690,7 @@ class Ad extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Ad'
+ * @var string
  */
 	public $name = 'Ad';
 
@@ -2726,7 +2719,7 @@ class AfterTree extends NumberTree {
 /**
  * name property
  *
- * @var string 'AfterTree'
+ * @var string
  */
 	public $name = 'AfterTree';
 
@@ -2755,21 +2748,21 @@ class Content extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Content'
+ * @var string
  */
 	public $name = 'Content';
 
 /**
  * useTable property
  *
- * @var string 'Content'
+ * @var string
  */
 	public $useTable = 'Content';
 
 /**
  * primaryKey property
  *
- * @var string 'iContentId'
+ * @var string
  */
 	public $primaryKey = 'iContentId';
 
@@ -2791,21 +2784,21 @@ class Account extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Account'
+ * @var string
  */
 	public $name = 'Account';
 
 /**
  * useTable property
  *
- * @var string 'Account'
+ * @var string
  */
 	public $useTable = 'Accounts';
 
 /**
  * primaryKey property
  *
- * @var string 'iAccountId'
+ * @var string
  */
 	public $primaryKey = 'iAccountId';
 }
@@ -2820,21 +2813,21 @@ class ContentAccount extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Account'
+ * @var string
  */
 	public $name = 'ContentAccount';
 
 /**
  * useTable property
  *
- * @var string 'Account'
+ * @var string
  */
 	public $useTable = 'ContentAccounts';
 
 /**
  * primaryKey property
  *
- * @var string 'iAccountId'
+ * @var string
  */
 	public $primaryKey = 'iContentAccountsId';
 }
@@ -2881,7 +2874,7 @@ class TestPluginArticle extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestPluginArticle'
+ * @var string
  */
 	public $name = 'TestPluginArticle';
 
@@ -2916,7 +2909,7 @@ class TestPluginComment extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestPluginComment'
+ * @var string
  */
 	public $name = 'TestPluginComment';
 
@@ -2944,7 +2937,7 @@ class Uuidportfolio extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Uuidportfolio'
+ * @var string
  */
 	public $name = 'Uuidportfolio';
 
@@ -2966,7 +2959,7 @@ class Uuiditem extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Item'
+ * @var string
  */
 	public $name = 'Uuiditem';
 
@@ -2989,7 +2982,7 @@ class UuiditemsUuidportfolio extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ItemsPortfolio'
+ * @var string
  */
 	public $name = 'UuiditemsUuidportfolio';
 }
@@ -3019,21 +3012,21 @@ class TranslateTestModel extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslateTestModel'
+ * @var string
  */
 	public $name = 'TranslateTestModel';
 
 /**
  * useTable property
  *
- * @var string 'i18n'
+ * @var string
  */
 	public $useTable = 'i18n';
 
 /**
  * displayField property
  *
- * @var string 'field'
+ * @var string
  */
 	public $displayField = 'field';
 }
@@ -3048,21 +3041,21 @@ class TranslateWithPrefix extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslateTestModel'
+ * @var string
  */
 	public $name = 'TranslateWithPrefix';
 
 /**
  * tablePrefix property
  *
- * @var string 'i18n'
+ * @var string
  */
 	public $tablePrefix = 'i18n_';
 
 /**
  * displayField property
  *
- * @var string 'field'
+ * @var string
  */
 	public $displayField = 'field';
 
@@ -3078,7 +3071,7 @@ class TranslatedItem extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslatedItem'
+ * @var string
  */
 	public $name = 'TranslatedItem';
 
@@ -3099,7 +3092,7 @@ class TranslatedItem extends CakeTestModel {
 /**
  * translateModel property
  *
- * @var string 'TranslateTestModel'
+ * @var string
  */
 	public $translateModel = 'TranslateTestModel';
 
@@ -3115,7 +3108,7 @@ class TranslatedItem2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslatedItem'
+ * @var string
  */
 	public $name = 'TranslatedItem';
 
@@ -3152,14 +3145,14 @@ class TranslatedItemWithTable extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslatedItemWithTable'
+ * @var string
  */
 	public $name = 'TranslatedItemWithTable';
 
 /**
  * useTable property
  *
- * @var string 'translated_items'
+ * @var string
  */
 	public $useTable = 'translated_items';
 
@@ -3187,7 +3180,7 @@ class TranslatedItemWithTable extends CakeTestModel {
 /**
  * translateTable property
  *
- * @var string 'another_i18n'
+ * @var string
  */
 	public $translateTable = 'another_i18n';
 
@@ -3203,21 +3196,21 @@ class TranslateArticleModel extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslateArticleModel'
+ * @var string
  */
 	public $name = 'TranslateArticleModel';
 
 /**
  * useTable property
  *
- * @var string 'article_i18n'
+ * @var string
  */
 	public $useTable = 'article_i18n';
 
 /**
  * displayField property
  *
- * @var string 'field'
+ * @var string
  */
 	public $displayField = 'field';
 
@@ -3233,7 +3226,7 @@ class TranslatedArticle extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TranslatedArticle'
+ * @var string
  */
 	public $name = 'TranslatedArticle';
 
@@ -3254,7 +3247,7 @@ class TranslatedArticle extends CakeTestModel {
 /**
  * translateModel property
  *
- * @var string 'TranslateArticleModel'
+ * @var string
  */
 	public $translateModel = 'TranslateArticleModel';
 
@@ -3535,7 +3528,7 @@ class TestModel extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel'
+ * @var string
  */
 	public $name = 'TestModel';
 
@@ -3610,7 +3603,7 @@ class TestModel2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel2'
+ * @var string
  */
 	public $name = 'TestModel2';
 
@@ -3632,7 +3625,7 @@ class TestModel3 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel3'
+ * @var string
  */
 	public $name = 'TestModel3';
 
@@ -3654,14 +3647,14 @@ class TestModel4 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel4'
+ * @var string
  */
 	public $name = 'TestModel4';
 
 /**
  * table property
  *
- * @var string 'test_model4'
+ * @var string
  */
 	public $table = 'test_model4';
 
@@ -3738,14 +3731,14 @@ class TestModel4TestModel7 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel4TestModel7'
+ * @var string
  */
 	public $name = 'TestModel4TestModel7';
 
 /**
  * table property
  *
- * @var string 'test_model4_test_model7'
+ * @var string
  */
 	public $table = 'test_model4_test_model7';
 
@@ -3783,14 +3776,14 @@ class TestModel5 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel5'
+ * @var string
  */
 	public $name = 'TestModel5';
 
 /**
  * table property
  *
- * @var string 'test_model5'
+ * @var string
  */
 	public $table = 'test_model5';
 
@@ -3851,14 +3844,14 @@ class TestModel6 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel6'
+ * @var string
  */
 	public $name = 'TestModel6';
 
 /**
  * table property
  *
- * @var string 'test_model6'
+ * @var string
  */
 	public $table = 'test_model6';
 
@@ -3911,14 +3904,14 @@ class TestModel7 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel7'
+ * @var string
  */
 	public $name = 'TestModel7';
 
 /**
  * table property
  *
- * @var string 'test_model7'
+ * @var string
  */
 	public $table = 'test_model7';
 
@@ -3958,14 +3951,14 @@ class TestModel8 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel8'
+ * @var string
  */
 	public $name = 'TestModel8';
 
 /**
  * table property
  *
- * @var string 'test_model8'
+ * @var string
  */
 	public $table = 'test_model8';
 
@@ -4019,14 +4012,14 @@ class TestModel9 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'TestModel9'
+ * @var string
  */
 	public $name = 'TestModel9';
 
 /**
  * table property
  *
- * @var string 'test_model9'
+ * @var string
  */
 	public $table = 'test_model9';
 
@@ -4080,14 +4073,14 @@ class Level extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Level'
+ * @var string
  */
 	public $name = 'Level';
 
 /**
  * table property
  *
- * @var string 'level'
+ * @var string
  */
 	public $table = 'level';
 
@@ -4139,14 +4132,14 @@ class Group extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Group'
+ * @var string
  */
 	public $name = 'Group';
 
 /**
  * table property
  *
- * @var string 'group'
+ * @var string
  */
 	public $table = 'group';
 
@@ -4199,14 +4192,14 @@ class User2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'User2'
+ * @var string
  */
 	public $name = 'User2';
 
 /**
  * table property
  *
- * @var string 'user'
+ * @var string
  */
 	public $table = 'user';
 
@@ -4271,14 +4264,14 @@ class Category2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Category2'
+ * @var string
  */
 	public $name = 'Category2';
 
 /**
  * table property
  *
- * @var string 'category'
+ * @var string
  */
 	public $table = 'category';
 
@@ -4354,14 +4347,14 @@ class Article2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Article2'
+ * @var string
  */
 	public $name = 'Article2';
 
 /**
  * table property
  *
- * @var string 'article'
+ * @var string
  */
 	public $table = 'articles';
 
@@ -4426,14 +4419,14 @@ class CategoryFeatured2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'CategoryFeatured2'
+ * @var string
  */
 	public $name = 'CategoryFeatured2';
 
 /**
  * table property
  *
- * @var string 'category_featured'
+ * @var string
  */
 	public $table = 'category_featured';
 
@@ -4474,14 +4467,14 @@ class Featured2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Featured2'
+ * @var string
  */
 	public $name = 'Featured2';
 
 /**
  * table property
  *
- * @var string 'featured2'
+ * @var string
  */
 	public $table = 'featured2';
 
@@ -4532,14 +4525,14 @@ class Comment2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Comment2'
+ * @var string
  */
 	public $name = 'Comment2';
 
 /**
  * table property
  *
- * @var string 'comment'
+ * @var string
  */
 	public $table = 'comment';
 
@@ -4586,14 +4579,14 @@ class ArticleFeatured2 extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'ArticleFeatured2'
+ * @var string
  */
 	public $name = 'ArticleFeatured2';
 
 /**
  * table property
  *
- * @var string 'article_featured'
+ * @var string
  */
 	public $table = 'article_featured';
 
@@ -4666,7 +4659,7 @@ class MysqlTestModel extends Model {
 /**
  * name property
  *
- * @var string 'MysqlTestModel'
+ * @var string
  */
 	public $name = 'MysqlTestModel';
 
@@ -4758,7 +4751,7 @@ class ScaffoldMock extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'articles';
 
@@ -4812,7 +4805,7 @@ class ScaffoldUser extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'users';
 
@@ -4839,7 +4832,7 @@ class ScaffoldComment extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'comments';
 
@@ -4866,7 +4859,7 @@ class ScaffoldTag extends CakeTestModel {
 /**
  * useTable property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $useTable = 'tags';
 

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -123,13 +123,6 @@ interface DispatcherTestInterfaceController {
 class MyPluginController extends MyPluginAppController {
 
 /**
- * name property
- *
- * @var string 'MyPlugin'
- */
-	public $name = 'MyPlugin';
-
-/**
  * uses property
  *
  * @var array
@@ -172,13 +165,6 @@ class MyPluginController extends MyPluginAppController {
  * @package       Cake.Test.Case.Routing
  */
 class SomePagesController extends AppController {
-
-/**
- * name property
- *
- * @var string 'SomePages'
- */
-	public $name = 'SomePages';
 
 /**
  * uses property
@@ -235,13 +221,6 @@ class SomePagesController extends AppController {
 class OtherPagesController extends MyPluginAppController {
 
 /**
- * name property
- *
- * @var string 'OtherPages'
- */
-	public $name = 'OtherPages';
-
-/**
  * uses property
  *
  * @var array
@@ -275,13 +254,6 @@ class OtherPagesController extends MyPluginAppController {
  * @package       Cake.Test.Case.Routing
  */
 class TestDispatchPagesController extends AppController {
-
-/**
- * name property
- *
- * @var string 'TestDispatchPages'
- */
-	public $name = 'TestDispatchPages';
 
 /**
  * uses property
@@ -326,13 +298,6 @@ class ArticlesTestAppController extends AppController {
 class ArticlesTestController extends ArticlesTestAppController {
 
 /**
- * name property
- *
- * @var string 'ArticlesTest'
- */
-	public $name = 'ArticlesTest';
-
-/**
  * uses property
  *
  * @var array
@@ -365,13 +330,6 @@ class ArticlesTestController extends ArticlesTestAppController {
  * @package       Cake.Test.Case.Routing
  */
 class SomePostsController extends AppController {
-
-/**
- * name property
- *
- * @var string 'SomePosts'
- */
-	public $name = 'SomePosts';
 
 /**
  * uses property
@@ -429,13 +387,6 @@ class SomePostsController extends AppController {
 class TestCachedPagesController extends Controller {
 
 /**
- * name property
- *
- * @var string 'TestCachedPages'
- */
-	public $name = 'TestCachedPages';
-
-/**
  * uses property
  *
  * @var array
@@ -470,7 +421,7 @@ class TestCachedPagesController extends Controller {
 /**
  * viewPath property
  *
- * @var string 'posts'
+ * @var string
  */
 	public $viewPath = 'Posts';
 
@@ -528,13 +479,6 @@ class TestCachedPagesController extends Controller {
  * @package       Cake.Test.Case.Routing
  */
 class TimesheetsController extends Controller {
-
-/**
- * name property
- *
- * @var string 'Timesheets'
- */
-	public $name = 'Timesheets';
 
 /**
  * uses property

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -41,13 +41,6 @@ class ClassRegisterModel extends CakeTestModel {
  * @package       Cake.Test.Case.Utility
  */
 class RegisterArticle extends ClassRegisterModel {
-
-/**
- * name property
- *
- * @var string 'RegisterArticle'
- */
-	public $name = 'RegisterArticle';
 }
 
 /**
@@ -56,13 +49,6 @@ class RegisterArticle extends ClassRegisterModel {
  * @package       Cake.Test.Case.Utility
  */
 class RegisterArticleFeatured extends ClassRegisterModel {
-
-/**
- * name property
- *
- * @var string 'RegisterArticleFeatured'
- */
-	public $name = 'RegisterArticleFeatured';
 }
 
 /**
@@ -71,13 +57,6 @@ class RegisterArticleFeatured extends ClassRegisterModel {
  * @package       Cake.Test.Case.Utility
  */
 class RegisterArticleTag extends ClassRegisterModel {
-
-/**
- * name property
- *
- * @var string 'RegisterArticleTag'
- */
-	public $name = 'RegisterArticleTag';
 }
 
 /**
@@ -90,7 +69,7 @@ class RegistryPluginAppModel extends ClassRegisterModel {
 /**
  * tablePrefix property
  *
- * @var string 'something_'
+ * @var string
  */
 	public $tablePrefix = 'something_';
 }
@@ -101,13 +80,6 @@ class RegistryPluginAppModel extends ClassRegisterModel {
  * @package       Cake.Test.Case.Utility
  */
 class TestRegistryPluginModel extends RegistryPluginAppModel {
-
-/**
- * name property
- *
- * @var string 'TestRegistryPluginModel'
- */
-	public $name = 'TestRegistryPluginModel';
 }
 
 /**
@@ -116,13 +88,6 @@ class TestRegistryPluginModel extends RegistryPluginAppModel {
  * @package       Cake.Test.Case.Utility
  */
 class RegisterCategory extends ClassRegisterModel {
-
-/**
- * name property
- *
- * @var string 'RegisterCategory'
- */
-	public $name = 'RegisterCategory';
 }
 /**
  * RegisterPrefixedDs class
@@ -134,7 +99,7 @@ class RegisterPrefixedDs extends ClassRegisterModel {
 /**
  * useDbConfig property
  *
- * @var string 'doesnotexist'
+ * @var string
  */
 	public $useDbConfig = 'doesnotexist';
 }

--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -28,16 +28,9 @@ App::uses('Sanitize', 'Utility');
 class SanitizeDataTest extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'SanitizeDataTest'
- */
-	public $name = 'SanitizeDataTest';
-
-/**
  * useTable property
  *
- * @var string 'data_tests'
+ * @var string
  */
 	public $useTable = 'data_tests';
 }
@@ -50,16 +43,9 @@ class SanitizeDataTest extends CakeTestModel {
 class SanitizeArticle extends CakeTestModel {
 
 /**
- * name property
- *
- * @var string 'Article'
- */
-	public $name = 'SanitizeArticle';
-
-/**
  * useTable property
  *
- * @var string 'articles'
+ * @var string
  */
 	public $useTable = 'articles';
 }

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -31,7 +31,7 @@ class XmlArticle extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'Article'
+ * @var string
  */
 	public $name = 'Article';
 
@@ -58,7 +58,7 @@ class XmlUser extends CakeTestModel {
 /**
  * name property
  *
- * @var string 'User'
+ * @var string
  */
 	public $name = 'User';
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -181,7 +181,7 @@ class ContactNonStandardPk extends Contact {
 /**
  * primaryKey property
  *
- * @var string 'pk'
+ * @var string
  */
 	public $primaryKey = 'pk';
 

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -40,7 +40,7 @@ class TheHtmlTestController extends Controller {
 /**
  * name property
  *
- * @var string 'TheTest'
+ * @var string
  */
 	public $name = 'TheTest';
 

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -54,7 +54,7 @@ class ScaffoldViewMockController extends Controller {
 /**
  * name property
  *
- * @var string 'ScaffoldMock'
+ * @var string
  */
 	public $name = 'ScaffoldMock';
 

--- a/lib/Cake/Test/Case/View/ThemeViewTest.php
+++ b/lib/Cake/Test/Case/View/ThemeViewTest.php
@@ -32,7 +32,7 @@ class ThemePosts2Controller extends Controller {
 /**
  * name property
  *
- * @var string 'ThemePosts'
+ * @var string
  */
 	public $name = 'ThemePosts';
 

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -35,7 +35,7 @@ class ViewPostsController extends Controller {
 /**
  * name property
  *
- * @var string 'Posts'
+ * @var string
  */
 	public $name = 'Posts';
 
@@ -77,13 +77,6 @@ class ViewPostsController extends Controller {
  * @package       Cake.Test.Case.View
  */
 class ThemePostsController extends Controller {
-
-/**
- * name property
- *
- * @var string 'ThemePosts'
- */
-	public $name = 'ThemePosts';
 
 	public $theme = null;
 
@@ -200,7 +193,7 @@ class TestAfterHelper extends Helper {
 /**
  * property property
  *
- * @var string ''
+ * @var string
  */
 	public $property = '';
 


### PR DESCRIPTION
Unify that $name/$alias is only added to tests where actually necessary due to a custom change.
Otherwise it can be removed in favor of a more clear test environment.

Also cleaned up doc blocks.
