### PR TITLE
convenience wrapper for HTTP PATCH in HttpSocket class.

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -495,6 +495,19 @@ class HttpSocket extends CakeSocket {
 	}
 
 /**
+ * Issues a PATCH request to the specified URI, query, and request.
+ *
+ * @param string|array $uri URI to request, See HttpSocket::_parseUri()
+ * @param array $data Array of PATCH data keys and values.
+ * @param array $request An indexed array with indexes such as 'method' or uri
+ * @return mixed Result of request
+ */
+	public function patch($uri = null, $data = array(), $request = array()) {
+		$request = Hash::merge(array('method' => 'PATCH', 'uri' => $uri, 'body' => $data), $request);
+		return $this->request($request);
+	}
+
+/**
  * Issues a DELETE request to the specified URI, query, and request.
  *
  * @param string|array $uri URI to request (see {@link _parseUri()})

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -1148,6 +1148,30 @@ class HttpSocketTest extends CakeTestCase {
 	}
 
 /**
+ * testPatch
+ *
+ * @return void
+ */
+	public function testPatch() {
+		$this->RequestSocket->reset();
+		$this->RequestSocket->expects($this->at(0))
+			->method('request')
+			->with(array('method' => 'PATCH', 'uri' => 'http://www.google.com/', 'body' => array()));
+
+		$this->RequestSocket->expects($this->at(1))
+			->method('request')
+			->with(array('method' => 'PATCH', 'uri' => 'http://www.google.com/', 'body' => array('Foo' => 'bar')));
+
+		$this->RequestSocket->expects($this->at(2))
+			->method('request')
+			->with(array('method' => 'PATCH', 'uri' => 'http://www.google.com/', 'body' => null, 'line' => 'Hey Server'));
+
+		$this->RequestSocket->patch('http://www.google.com/');
+		$this->RequestSocket->patch('http://www.google.com/', array('Foo' => 'bar'));
+		$this->RequestSocket->patch('http://www.google.com/', null, array('line' => 'Hey Server'));
+	}
+
+/**
  * testDelete
  *
  * @return void


### PR DESCRIPTION
Not something I cannot live without, but noticed when working with GitHub API that HttpSocket does not have a `patch()` wrapper method.

Almost all of the API v3 requests to GitHub for modifying something has to be made in PATCH now.

More info on PATCH: http://tools.ietf.org/html/rfc5789
