### PR TITLE
allow serialize in json and xml alias

### DIFF
--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -68,6 +68,25 @@ class JsonViewTest extends CakeTestCase {
 	}
 
 /**
+ * Test render with an array in _serialize and alias
+ *
+ * @return void
+ */
+	public function testRenderWithoutViewMultipleAndAlias() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$data = array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2'));
+		$Controller->set($data);
+		$Controller->set('_serialize', array('no' => 'nope', 'user'));
+		$View = new JsonView($Controller);
+		$output = $View->render(false);
+
+		$this->assertSame(json_encode(array('nope' => $data['no'], 'user' => $data['user'])), $output);
+		$this->assertSame('application/json', $Response->type());
+	}
+
+/**
  * testJsonpResponse method
  *
  * @return void

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -104,6 +104,35 @@ class XmlViewTest extends CakeTestCase {
 	}
 
 /**
+ * Test render with an array in _serialize and alias
+ *
+ * @return void
+ */
+	public function testRenderWithoutViewMultipleAndAlias() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$data = array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2'));
+		$Controller->set($data);
+		$Controller->set('_serialize', array('no' => 'nope', 'user'));
+		$View = new XmlView($Controller);
+		$this->assertSame('application/xml', $Response->type());
+		$output = $View->render(false);
+		$expected = array(
+			'response' => array('nope' => $data['no'], 'user' => $data['user'])
+		);
+		$this->assertSame(Xml::build($expected)->asXML(), $output);
+
+		$Controller->set('_rootNode', 'custom_name');
+		$View = new XmlView($Controller);
+		$output = $View->render(false);
+		$expected = array(
+			'custom_name' => array('nope' => $data['no'], 'user' => $data['user'])
+		);
+		$this->assertSame(Xml::build($expected)->asXML(), $output);
+	}
+
+/**
  * testRenderWithView method
  *
  * @return void

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -13,6 +13,7 @@
  */
 
 App::uses('View', 'View');
+App::uses('Hash', 'Utility');
 
 /**
  * A view class that is used for JSON responses.
@@ -118,9 +119,14 @@ class JsonView extends View {
  */
 	protected function _serialize($serialize) {
 		if (is_array($serialize)) {
+			$serialize = Hash::normalize($serialize);
 			$data = array();
-			foreach ($serialize as $key) {
-				$data[$key] = $this->viewVars[$key];
+			foreach ($serialize as $key => $alias) {
+				if (empty($alias)) {
+					$alias = $key;
+				}
+
+				$data[$alias] = $this->viewVars[$key];
 			}
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -14,6 +14,7 @@
 
 App::uses('View', 'View');
 App::uses('Xml', 'Utility');
+App::uses('Hash', 'Utility');
 
 /**
  * A view class that is used for creating XML responses.
@@ -104,8 +105,13 @@ class XmlView extends View {
 
 		if (is_array($serialize)) {
 			$data = array($rootNode => array());
-			foreach ($serialize as $key) {
-				$data[$rootNode][$key] = $this->viewVars[$key];
+			$serialize = Hash::normalize($serialize);
+			foreach ($serialize as $key => $alias) {
+				if (empty($alias)) {
+					$alias = $key;
+				}
+
+				$data[$rootNode][$alias] = $this->viewVars[$key];
 			}
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;


### PR DESCRIPTION
if `_serialize` is an array `array('items', 'success')` it's expected that the viewVars exist with these names. 

It's may not always be desired to use the name set in the controller as the outgoing variable name.

If you use `array('items' => 'data', 'success' => 'went_ok');`  you can change the outgoing serialize value.

This may be an edge case feature, but for plugins like my Crud plugin it's very nice, and allow the system to much more flexible. 

NB. Updated success / went_ok logic order snafu
