### PR TITLE
3.0 plugin ns

### DIFF
--- a/lib/Cake/Core/Plugin.php
+++ b/lib/Cake/Core/Plugin.php
@@ -114,8 +114,7 @@ class Plugin {
 			$nsCount--;
 		}
 
-		$loader = new ClassLoader($config['namespace'], $path);
-		$loader->register();
+		static::_addClassLoader($config['namespace'], $path);
 		if (!empty(static::$_plugins[$plugin]['bootstrap'])) {
 			static::bootstrap($plugin);
 		}
@@ -266,6 +265,18 @@ class Plugin {
 		} else {
 			unset(static::$_plugins[$plugin]);
 		}
+	}
+
+/**
+ * Add a class loader instance for the specified namespace and path
+ *
+ * @param string $namespace
+ * @param string $path
+ * @return void
+ */
+	protected static function _addClassLoader($ns, $path) {
+		$loader = new ClassLoader($ns, $path);
+		$loader->register();
 	}
 
 /**

--- a/lib/Cake/Core/Plugin.php
+++ b/lib/Cake/Core/Plugin.php
@@ -80,7 +80,13 @@ class Plugin {
 			}
 			return;
 		}
-		$config += array('bootstrap' => false, 'routes' => false, 'namespace' => $plugin, 'ignoreMissing' => false);
+
+		$namespace = $plugin;
+		if (strpos($namespace, '\\', 1)) {
+			$plugin = substr($plugin, strrpos($plugin, '\\') + 1);
+		}
+		$config += array('bootstrap' => false, 'routes' => false, 'namespace' => $namespace, 'ignoreMissing' => false);
+
 		if (empty($config['path'])) {
 			$namespacePath = str_replace('\\', DS, $config['namespace']);
 			foreach (App::path('Plugin') as $path) {
@@ -100,7 +106,15 @@ class Plugin {
 		if (empty(static::$_plugins[$plugin]['path'])) {
 			throw new Error\MissingPluginException(array('plugin' => $plugin));
 		}
-		$loader = new ClassLoader($plugin, dirname(static::$_plugins[$plugin]['path']));
+
+		$path = dirname(static::$_plugins[$plugin]['path']);
+		$nsCount = substr_count($config['namespace'], '\\');
+		while ($nsCount) {
+			$path = dirname($path);
+			$nsCount--;
+		}
+
+		$loader = new ClassLoader($config['namespace'], $path);
 		$loader->register();
 		if (!empty(static::$_plugins[$plugin]['bootstrap'])) {
 			static::bootstrap($plugin);

--- a/lib/Cake/Test/TestCase/Core/PluginTest.php
+++ b/lib/Cake/Test/TestCase/Core/PluginTest.php
@@ -68,6 +68,16 @@ class PluginTest extends TestCase {
 		$this->assertEquals('Company\TestPluginThree', Plugin::getNamespace('CustomPlugin'));
 	}
 
+	public function testLoadNamespacedPlugin() {
+		App::build(array(
+			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin2' . DS)
+		), App::RESET);
+
+		Plugin::load('Company\TestPluginThree');
+		$expected = array('TestPluginThree');
+		$this->assertEquals($expected, Plugin::loaded());
+	}
+
 /**
  * Tests loading a single plugin
  *

--- a/lib/Cake/Test/TestCase/Core/PluginTest.php
+++ b/lib/Cake/Test/TestCase/Core/PluginTest.php
@@ -73,9 +73,14 @@ class PluginTest extends TestCase {
 			'Plugin' => array(CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin2' . DS)
 		), App::RESET);
 
-		Plugin::load('Company\TestPluginThree');
+		$mock = $this->getMock('Cake\Core\Plugin', array('_addClassLoader'));
+		$mock->staticExpects($this->once())
+			->method('_addClassLoader')
+			->with('Company\TestPluginThree', CAKE . 'Test' . DS . 'TestApp' . DS . 'Plugin2');
+		$mock::load('Company\TestPluginThree');
+
 		$expected = array('TestPluginThree');
-		$this->assertEquals($expected, Plugin::loaded());
+		$this->assertEquals($expected, $mock::loaded());
 	}
 
 /**

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -25,7 +25,9 @@
     },
     "autoload": {
         "psr-0": {
-            "Cake\\": "Cake/"
+            "Cake\\": "Cake/",
+            "": "App/Plugin/",
+            "": "plugins/"
         }
     },
     "bin": [


### PR DESCRIPTION
Allow loading Plugins with namespaces of the form 'Author\PluginName', and make it convenient to do so via `Plugin::load('Author\PluginName')`.

Also verify that a class loader is added with the correct path - previously classes in `Author\PluginName` named plugins were not possible to load ( the registered path would be `.../Author` leading to Cake trying to load `.../Author/Author/PluginName/.../Foo.php`).
