### PR TITLE
3.0 - Add Sqlite Foreign key support

### DIFF
--- a/lib/Cake/Database/Schema/Collection.php
+++ b/lib/Cake/Database/Schema/Collection.php
@@ -119,8 +119,7 @@ class Collection {
  */
 	protected function _executeSql($sql, $params) {
 		try {
-			$statement = $this->_connection->execute($sql, $params);
-			return $statement;
+			return $this->_connection->execute($sql, $params);
 		} catch (\PDOException $e) {
 			throw new Exception($e->getMessage(), 500, $e);
 		}

--- a/lib/Cake/Database/Schema/Collection.php
+++ b/lib/Cake/Database/Schema/Collection.php
@@ -104,7 +104,7 @@ class Collection {
 		);
 		$statement = $this->_executeSql($sql, $params);
 		foreach ($statement->fetchAll('assoc') as $row) {
-			$this->_dialect->convertForeignKeyDescription($table, $row);
+			$this->_dialect->convertForeignKey($table, $row);
 		}
 		return $table;
 	}

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -229,6 +229,7 @@ class MysqlSchema {
  */
 	public function convertForeignKey(Table $table, $row) {
 	}
+
 /**
  * Generate the SQL to truncate a table.
  *

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -212,6 +212,24 @@ class MysqlSchema {
 	}
 
 /**
+ * Generate the SQL to describe the foreign keys on a table.
+ *
+ * @return array List of sql, params
+ */
+	public function describeForeignKeySql($table) {
+		return ['', []];
+	}
+
+/**
+ * Convert a foreign key description into constraints on the Table object.
+ *
+ * @param Cake\Database\Table $table The table instance to populate.
+ * @param array $row The row of data.
+ * @return void
+ */
+	public function convertForeignKey(Table $table, $row) {
+	}
+/**
  * Generate the SQL to truncate a table.
  *
  * @param Cake\Database\Schema\Table $table Table instance

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -240,6 +240,25 @@ class PostgresSchema {
 	}
 
 /**
+ * Generate the SQL to describe the foreign keys on a table.
+ *
+ * @return array List of sql, params
+ */
+	public function describeForeignKeySql($table) {
+		return ['', []];
+	}
+
+/**
+ * Convert a foreign key description into constraints on the Table object.
+ *
+ * @param Cake\Database\Table $table The table instance to populate.
+ * @param array $row The row of data.
+ * @return void
+ */
+	public function convertForeignKey(Table $table, $row) {
+	}
+
+/**
  * Generate the SQL fragment for a single column.
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -229,9 +229,9 @@ class SqliteSchema {
 			return strtolower($clause);
 		}
 		if ($clause === 'NO ACTION') {
-			return 'noAction';
+			return Table::ACTION_NO_ACTION;
 		}
-		return 'setNull';
+		return Table::ACTION_SET_NULL;
 	}
 
 /**
@@ -347,16 +347,16 @@ class SqliteSchema {
  * @return string
  */
 	protected function _foreignOnClause($on) {
-		if ($on === 'setNull') {
+		if ($on === Table::ACTION_SET_NULL) {
 			return 'SET NULL';
 		}
-		if ($on === 'cascade') {
+		if ($on === Table::ACTION_CASCADE) {
 			return 'CASCADE';
 		}
-		if ($on === 'restrict') {
+		if ($on === Table::ACTION_RESTRICT) {
 			return 'RESTRICT';
 		}
-		if ($on === 'noAction') {
+		if ($on === Table::ACTION_NO_ACTION) {
 			return 'NO ACTION';
 		}
 	}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -231,9 +231,7 @@ class SqliteSchema {
 		if ($clause === 'NO ACTION') {
 			return 'none';
 		}
-		if ($clause === 'SET NULL') {
-			return null;
-		}
+		return null;
 	}
 
 /**

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -229,9 +229,9 @@ class SqliteSchema {
 			return strtolower($clause);
 		}
 		if ($clause === 'NO ACTION') {
-			return 'none';
+			return 'noAction';
 		}
-		return null;
+		return 'setNull';
 	}
 
 /**
@@ -347,7 +347,7 @@ class SqliteSchema {
  * @return string
  */
 	protected function _foreignOnClause($on) {
-		if ($on === null) {
+		if ($on === 'setNull') {
 			return 'SET NULL';
 		}
 		if ($on === 'cascade') {
@@ -356,7 +356,7 @@ class SqliteSchema {
 		if ($on === 'restrict') {
 			return 'RESTRICT';
 		}
-		if ($on === 'none') {
+		if ($on === 'noAction') {
 			return 'NO ACTION';
 		}
 	}

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -190,6 +190,25 @@ class SqliteSchema {
 	}
 
 /**
+ * Generate the SQL to describe the foreign keys on a table.
+ *
+ * @return array List of sql, params
+ */
+	public function describeForeignKeySql($table) {
+		return ['', []];
+	}
+
+/**
+ * Convert a foreign key description into constraints on the Table object.
+ *
+ * @param Cake\Database\Table $table The table instance to populate.
+ * @param array $row The row of data.
+ * @return void
+ */
+	public function convertForeignKey(Table $table, $row) {
+	}
+
+/**
  * Generate the SQL fragment for a single column in Sqlite
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -92,6 +92,9 @@ class Table {
 		'type' => null,
 		'columns' => [],
 		'length' => [],
+		'references' => null,
+		'update' => null,
+		'delete' => null,
 	];
 
 /**
@@ -223,6 +226,7 @@ class Table {
 		}
 		$attrs = array_intersect_key($attrs, $this->_indexKeys);
 		$attrs = $attrs + $this->_indexKeys;
+		unset($attrs['references'], $attrs['update'], $attrs['delete']);
 
 		if (!in_array($attrs['type'], $this->_validIndexTypes, true)) {
 			throw new Exception(__d('cake_dev', 'Invalid index type "%s"', $attrs['type']));
@@ -283,8 +287,12 @@ class Table {
  *
  * - `type` The type of constraint being added.
  * - `columns` The columns in the index.
+ * - `references` The table, column a foreign key references.
+ * - `update` The behavior on update. Options are 'restrict', `null`, 'cascade', 'none'.
+ * - `delete` The behavior on delete. Options are 'restrict', `null`, 'cascade', 'none'.
  *
- * @TODO implement foreign keys.
+ * The default for 'update' & 'delete' is 'cascade'.
+ *
  * @param string $name The name of the constraint.
  * @param array $attrs The attributes for the constraint.
  * @return Table $this
@@ -296,7 +304,6 @@ class Table {
 		}
 		$attrs = array_intersect_key($attrs, $this->_indexKeys);
 		$attrs = $attrs + $this->_indexKeys;
-
 		if (!in_array($attrs['type'], $this->_validConstraintTypes, true)) {
 			throw new Exception(__d('cake_dev', 'Invalid constraint type "%s"', $attrs['type']));
 		}
@@ -305,8 +312,38 @@ class Table {
 				throw new Exception(__d('cake_dev', 'Columns used in constraints must already exist.'));
 			}
 		}
+		if ($attrs['type'] === static::CONSTRAINT_FOREIGN) {
+			$attrs = $this->_checkForeignKey($attrs);
+		} else {
+			unset($attrs['references'], $attrs['update'], $attrs['delete']);
+		}
 		$this->_constraints[$name] = $attrs;
 		return $this;
+	}
+
+/**
+ * Helper method to check/validate foreign keys.
+ *
+ * @param array $attrs Attributes to set.
+ * @return array
+ */
+	protected function _checkForeignKey($attrs) {
+		$attrs += [
+			'references' => [],
+			'update' => 'cascade',
+			'delete' => 'cascade',
+		];
+		if (count($attrs['references']) < 2) {
+			throw new Exception(__d('cake_dev', 'References must contain a table and column.'));
+		}
+		$validActions = ['cascade', 'restrict', null, 'none'];
+		if (!in_array($attrs['update'], $validActions)) {
+			throw new Exception(__d('cake_dev', 'Update action is invalid.'));
+		}
+		if (!in_array($attrs['delete'], $validActions)) {
+			throw new Exception(__d('cake_dev', 'Delete action is invalid.'));
+		}
+		return $attrs;
 	}
 
 /**

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -125,6 +125,11 @@ class Table {
 	const INDEX_INDEX = 'index';
 	const INDEX_FULLTEXT = 'fulltext';
 
+	const ACTION_CASCADE = 'cascade';
+	const ACTION_SET_NULL = 'setNull';
+	const ACTION_NO_ACTION = 'noAction';
+	const ACTION_RESTRICT = 'restrict';
+
 /**
  * Constructor.
  *
@@ -288,8 +293,8 @@ class Table {
  * - `type` The type of constraint being added.
  * - `columns` The columns in the index.
  * - `references` The table, column a foreign key references.
- * - `update` The behavior on update. Options are 'restrict', `null`, 'cascade', 'none'.
- * - `delete` The behavior on delete. Options are 'restrict', `null`, 'cascade', 'none'.
+ * - `update` The behavior on update. Options are 'restrict', 'setNull', 'cascade', 'noAction'.
+ * - `delete` The behavior on delete. Options are 'restrict', 'setNull', 'cascade', 'noAction'.
  *
  * The default for 'update' & 'delete' is 'cascade'.
  *
@@ -331,7 +336,7 @@ class Table {
 		if (count($attrs['references']) < 2) {
 			throw new Exception(__d('cake_dev', 'References must contain a table and column.'));
 		}
-		$validActions = ['cascade', 'restrict', 'setNull', 'noAction'];
+		$validActions = [static::ACTION_CASCADE, static::ACTION_RESTRICT, static::ACTION_SET_NULL, static::ACTION_NO_ACTION];
 		if (!in_array($attrs['update'], $validActions)) {
 			throw new Exception(__d('cake_dev', 'Update action is invalid. Must be one of %s', implode(',', $validActions)));
 		}

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -93,8 +93,8 @@ class Table {
 		'columns' => [],
 		'length' => [],
 		'references' => [],
-		'update' => 'cascade',
-		'delete' => 'cascade',
+		'update' => 'restrict',
+		'delete' => 'restrict',
 	];
 
 /**

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -331,12 +331,12 @@ class Table {
 		if (count($attrs['references']) < 2) {
 			throw new Exception(__d('cake_dev', 'References must contain a table and column.'));
 		}
-		$validActions = ['cascade', 'restrict', null, 'none'];
+		$validActions = ['cascade', 'restrict', 'setNull', 'noAction'];
 		if (!in_array($attrs['update'], $validActions)) {
-			throw new Exception(__d('cake_dev', 'Update action is invalid.'));
+			throw new Exception(__d('cake_dev', 'Update action is invalid. Must be one of %s', implode(',', $validActions)));
 		}
 		if (!in_array($attrs['delete'], $validActions)) {
-			throw new Exception(__d('cake_dev', 'Delete action is invalid.'));
+			throw new Exception(__d('cake_dev', 'Delete action is invalid. Must be one of %s', implode(',', $validActions)));
 		}
 		return $attrs;
 	}

--- a/lib/Cake/Database/Schema/Table.php
+++ b/lib/Cake/Database/Schema/Table.php
@@ -92,9 +92,9 @@ class Table {
 		'type' => null,
 		'columns' => [],
 		'length' => [],
-		'references' => null,
-		'update' => null,
-		'delete' => null,
+		'references' => [],
+		'update' => 'cascade',
+		'delete' => 'cascade',
 	];
 
 /**
@@ -328,11 +328,6 @@ class Table {
  * @return array
  */
 	protected function _checkForeignKey($attrs) {
-		$attrs += [
-			'references' => [],
-			'update' => 'cascade',
-			'delete' => 'cascade',
-		];
 		if (count($attrs['references']) < 2) {
 			throw new Exception(__d('cake_dev', 'References must contain a table and column.'));
 		}

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -151,7 +151,7 @@ author_id INT(11) NOT NULL,
 published BOOLEAN DEFAULT 0,
 created DATETIME,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
-CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE
+CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT
 );
 SQL;
 		$connection->execute($table);
@@ -273,13 +273,25 @@ SQL;
 				'type' => 'unique',
 				'columns' => ['title', 'body'],
 				'length' => []
+			],
+			'author_id_fk' => [
+				'type' => 'foreign',
+				'columns' => ['author_id'],
+				'references' => ['schema_authors', 'id'],
+				'length' => [],
+				'update' => 'cascade',
+				'delete' => 'restrict',
 			]
 		];
-		$this->assertCount(2, $result->constraints());
+		$this->assertCount(3, $result->constraints());
 		$this->assertEquals($expected['primary'], $result->constraint('primary'));
 		$this->assertEquals(
 			$expected['sqlite_autoindex_schema_articles_1'],
 			$result->constraint('sqlite_autoindex_schema_articles_1')
+		);
+		$this->assertEquals(
+			$expected['author_id_fk'],
+			$result->constraint('author_id_fk')
 		);
 
 		$this->assertCount(1, $result->indexes());

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -477,25 +477,31 @@ SQL;
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id']],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'cascade'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'restrict'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE CASCADE'
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => null],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE CASCADE'
+				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT'
 			],
 			[
 				'author_id_idx',
 				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'none'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
-				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE CASCADE'
+				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT'
 			],
 		];
 	}

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -493,13 +493,13 @@ SQL;
 			],
 			[
 				'author_id_idx',
-				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => null],
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'setNull'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
 				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT'
 			],
 			[
 				'author_id_idx',
-				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'none'],
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
 				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
 				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT'
 			],

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -460,6 +460,30 @@ SQL;
 				['type' => 'unique', 'columns' => ['title', 'author_id']],
 				'CONSTRAINT "unique_idx" UNIQUE ("title", "author_id")'
 			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id']],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'restrict'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE CASCADE'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => null],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE CASCADE'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'none'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE CASCADE'
+			],
 		];
 	}
 

--- a/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -129,11 +129,11 @@ class SqliteSchemaTest extends TestCase {
  */
 	protected function _createTables($connection) {
 		$this->_needsConnection();
-		$connection->execute('DROP TABLE IF EXISTS articles');
-		$connection->execute('DROP TABLE IF EXISTS authors');
+		$connection->execute('DROP TABLE IF EXISTS schema_articles');
+		$connection->execute('DROP TABLE IF EXISTS schema_authors');
 
 		$table = <<<SQL
-CREATE TABLE authors(
+CREATE TABLE schema_authors (
 id INTEGER PRIMARY KEY AUTOINCREMENT,
 name VARCHAR(50),
 bio TEXT,
@@ -143,7 +143,7 @@ SQL;
 		$connection->execute($table);
 
 		$table = <<<SQL
-CREATE TABLE articles(
+CREATE TABLE schema_articles (
 id INTEGER PRIMARY KEY AUTOINCREMENT,
 title VARCHAR(20) DEFAULT 'testing',
 body TEXT,
@@ -151,10 +151,11 @@ author_id INT(11) NOT NULL,
 published BOOLEAN DEFAULT 0,
 created DATETIME,
 CONSTRAINT "title_idx" UNIQUE ("title", "body")
+CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON UPDATE CASCADE ON DELETE CASCADE
 );
 SQL;
 		$connection->execute($table);
-		$connection->execute('CREATE INDEX "created_idx" ON "articles" ("created")');
+		$connection->execute('CREATE INDEX "created_idx" ON "schema_articles" ("created")');
 	}
 
 /**
@@ -171,8 +172,8 @@ SQL;
 
 		$this->assertInternalType('array', $result);
 		$this->assertCount(3, $result);
-		$this->assertEquals('articles', $result[0]);
-		$this->assertEquals('authors', $result[1]);
+		$this->assertEquals('schema_articles', $result[0]);
+		$this->assertEquals('schema_authors', $result[1]);
 		$this->assertEquals('sqlite_sequence', $result[2]);
 	}
 
@@ -186,7 +187,7 @@ SQL;
 		$this->_createTables($connection);
 
 		$schema = new SchemaCollection($connection);
-		$result = $schema->describe('articles');
+		$result = $schema->describe('schema_articles');
 		$expected = [
 			'id' => [
 				'type' => 'integer',
@@ -260,7 +261,7 @@ SQL;
 		$this->_createTables($connection);
 
 		$schema = new SchemaCollection($connection);
-		$result = $schema->describe('articles');
+		$result = $schema->describe('schema_articles');
 		$this->assertInstanceOf('Cake\Database\Schema\Table', $result);
 		$expected = [
 			'primary' => [
@@ -268,7 +269,7 @@ SQL;
 				'columns' => ['id'],
 				'length' => []
 			],
-			'sqlite_autoindex_articles_1' => [
+			'sqlite_autoindex_schema_articles_1' => [
 				'type' => 'unique',
 				'columns' => ['title', 'body'],
 				'length' => []
@@ -277,8 +278,8 @@ SQL;
 		$this->assertCount(2, $result->constraints());
 		$this->assertEquals($expected['primary'], $result->constraint('primary'));
 		$this->assertEquals(
-			$expected['sqlite_autoindex_articles_1'],
-			$result->constraint('sqlite_autoindex_articles_1')
+			$expected['sqlite_autoindex_schema_articles_1'],
+			$result->constraint('sqlite_autoindex_schema_articles_1')
 		);
 
 		$this->assertCount(1, $result->indexes());

--- a/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/TableTest.php
@@ -227,4 +227,64 @@ class TableTest extends TestCase {
 		$this->assertEquals($options, $table->options());
 	}
 
+/**
+ * Add a basic foreign key constraint.
+ *
+ * @return void
+ */
+	public function testAddConstraintForeignKey() {
+		$table = new Table('articles');
+		$table->addColumn('author_id', 'integer')
+			->addConstraint('author_id_idx', [
+				'type' => Table::CONSTRAINT_FOREIGN,
+				'columns' => ['author_id'],
+				'references' => ['authors', 'id'],
+				'update' => 'cascade',
+				'delete' => 'cascade',
+			]);
+		$this->assertEquals(['author_id_idx'], $table->constraints());
+	}
+
+/**
+ * Provider for exceptionally bad foreign key data.
+ *
+ * @return array
+ */
+	public static function badForeignKeyProvider()
+	{
+		return [
+			'references is bad' => [[
+				'type' => Table::CONSTRAINT_FOREIGN,
+				'columns' => ['author_id'],
+				'references' => ['authors'],
+				'delete' => 'derp',
+			]],
+			'bad update value' => [[
+				'type' => Table::CONSTRAINT_FOREIGN,
+				'columns' => ['author_id'],
+				'references' => ['authors', 'id'],
+				'update' => 'derp',
+			]],
+			'bad delete value' => [[
+				'type' => Table::CONSTRAINT_FOREIGN,
+				'columns' => ['author_id'],
+				'references' => ['authors', 'id'],
+				'delete' => 'derp',
+			]],
+		];
+	}
+
+/**
+ * Add a foreign key constraint with bad data
+ *
+ * @dataProvider badForeignKeyProvider
+ * @expectedException Cake\Database\Exception
+ * @return void
+ */
+	public function testAddConstraintForeignKeyBadData($data) {
+		$table = new Table('articles');
+		$table->addColumn('author_id', 'integer')
+			->addConstraint('author_id_idx', $data);
+	}
+
 }


### PR DESCRIPTION
This add support to Sqlite for foreign key reflection and generation. I think the changes are pretty straightforward, and while they don't encompass all the various options available in Sqlite, it covers what I think are the most frequently and most portable features of foreign keys.

I'm not certain I've chosen the best names for the various delete/update options so any suggestions are more than welcome :smile:.
