### PR TITLE
Fix content-type header in cached views. Fixes issue #2358

### DIFF
--- a/lib/Cake/Routing/Filter/CacheDispatcher.php
+++ b/lib/Cake/Routing/Filter/CacheDispatcher.php
@@ -60,6 +60,7 @@ class CacheDispatcher extends DispatcherFilter {
 		if (file_exists($filename)) {
 			$controller = null;
 			$view = new View($controller);
+			$view->response = $event->data['response'];
 			$result = $view->renderCache($filename, microtime(true));
 			if ($result !== false) {
 				$event->stopPropagation();

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -307,7 +307,7 @@ class CacheHelper extends AppHelper {
 
 		$file .= '
 				$request = unserialize(base64_decode(\'' . base64_encode(serialize($this->request)) . '\'));
-				$response = new CakeResponse();
+				$response->type(\'' . $this->_View->response->type() . '\');
 				$controller = new ' . $this->_View->name . 'Controller($request, $response);
 				$controller->plugin = $this->plugin = \'' . $this->_View->plugin . '\';
 				$controller->helpers = $this->helpers = unserialize(base64_decode(\'' . base64_encode(serialize($this->_View->helpers)) . '\'));

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -565,7 +565,7 @@ class View extends Object {
 				unset($out);
 				return false;
 			} else {
-				if ($this->layout === 'xml') { 
+				if ($this->layout === 'xml') {
 					$response->type('xml');
 				}
 				return substr($out, strlen($match[0]));

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -565,6 +565,9 @@ class View extends Object {
 				unset($out);
 				return false;
 			} else {
+				if ($this->layout === 'xml') { 
+					$response->type('xml');
+				}
 				return substr($out, strlen($match[0]));
 			}
 		}

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -547,10 +547,12 @@ class View extends Object {
  * @return boolean Success of rendering the cached file.
  */
 	public function renderCache($filename, $timeStart) {
+		$response = $this->response;
 		ob_start();
 		include ($filename);
 
-		if (Configure::read('debug') > 0 && $this->layout !== 'xml') {
+		$type = $response->mapType($response->type());
+		if (Configure::read('debug') > 0 && $type === 'html') {
 			echo "<!-- Cached Render Time: " . round(microtime(true) - $timeStart, 4) . "s -->";
 		}
 		$out = ob_get_clean();
@@ -563,9 +565,6 @@ class View extends Object {
 				unset($out);
 				return false;
 			} else {
-				if ($this->layout === 'xml') {
-					header('Content-type: text/xml');
-				}
 				return substr($out, strlen($match[0]));
 			}
 		}


### PR DESCRIPTION
This patch fixes [issue #2358](https://cakephp.lighthouseapp.com/projects/42648/tickets/2358-cachehelper-defect-with-response).

It's not the most elegant solution but it seems to work. Let me know if there is any issues or if it can be improved.
