### PR TITLE
Use error() instead of err() for bevity

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -214,7 +214,7 @@ class FixtureTask extends BakeTask {
 		$this->_Schema = new CakeSchema();
 		$data = $this->_Schema->read(array('models' => false, 'connection' => $this->connection));
 		if (!isset($data['tables'][$useTable])) {
-			$this->err('Could not find your selected table ' . $useTable);
+			$this->error('Could not find your selected table ' . $useTable);
 			return false;
 		}
 


### PR DESCRIPTION
Using err() does not stop shell output when used in the context of a script. 

Also no nice color syntax to indicate that there was an error with one of the fixture generations.

Using error() fixes that.
