### PR TITLE
Fix locale for CakeTimeTest when configured different locale in app

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -42,6 +42,7 @@ class CakeTimeTest extends CakeTestCase {
 	public function setUp() {
 		$this->Time = new CakeTime();
 		$this->_systemTimezoneIdentifier = date_default_timezone_get();
+		Configure::write('Config.language', 'eng');
 	}
 
 /**


### PR DESCRIPTION
When configured a different locale in the application, almost all CakeTime tests fail.

Setting locale to 'eng' in setUp fixes the problem.
