### PR TITLE
Fix bug in Xml::_createChild Method

### DIFF
--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -375,6 +375,19 @@ XML;
 		$obj = Xml::fromArray($xml, 'attributes');
 		$xmlText = '<' . '?xml version="1.0" encoding="UTF-8"?><tags><tag id="1">defect</tag></tags>';
 		$this->assertXmlStringEqualsXmlString($xmlText, $obj->asXML());
+
+		$xml = array(
+			'tag' => array(
+				'@' => 0,
+				'@test' => 'A test'
+			)
+		);
+		$obj = Xml::fromArray($xml);
+		$xmlText = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<tag test="A test">0</tag>
+XML;
+		$this->assertXmlStringEqualsXmlString($xmlText, $obj->asXML());
 	}
 
 /**

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -310,7 +310,7 @@ class Xml {
 		}
 
 		$child = $dom->createElement($key);
-		if ($childValue) {
+		if (!is_null($childValue)) {
 			$child->appendChild($dom->createTextNode($childValue));
 		}
 		if ($childNS) {


### PR DESCRIPTION
# Hi !
# Problem :

Method : Xml::_createChild();

Example : 

``` php
$xml = array(
    'tag' => array(
        '@' => 0,
        '@test' => 'A test'
    )
);
$obj = Xml::fromArray($xml);
$obj->asXML()
```

Output is :

```
<?xml version="1.0" encoding="UTF-8"?>
<tag test="A test"/>
```

That must be :

```
<?xml version="1.0" encoding="UTF-8"?>
<tag test="A test">0</tag>
```
# Why ?

``` php
if ($childValue) {
    $child->appendChild($dom->createTextNode($childValue));
}
```

When `$childValue` equal "0", it's like `false`
# Solution :

Check if `$childValue` is null, because it's the default value of `$childValue`

``` php
if (!is_null($childValue)) {
    $child->appendChild($dom->createTextNode($childValue));
}
```
