### PR TITLE
Unify modified/created times

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1662,13 +1662,14 @@ class Model extends Object implements CakeEventListener {
 		}
 
 		$db = $this->getDataSource();
+		$now = time();
 
 		foreach ($dateFields as $updateCol) {
 			if ($this->hasField($updateCol) && !in_array($updateCol, $fields)) {
 				$default = array('formatter' => 'date');
 				$colType = array_merge($default, $db->columns[$this->getColumnType($updateCol)]);
 				if (!array_key_exists('format', $colType)) {
-					$time = strtotime('now');
+					$time = $now;
 				} else {
 					$time = call_user_func($colType['formatter'], $colType['format']);
 				}


### PR DESCRIPTION
The former implementation of strtotime('now') meant it was not possible to ensure that timestamps created yourself would be exactly equal to the ones created by default.
It was also theoretically possible for created and modified fields to be out of sync.

Using a single point of reference, available throughout an app, resolves both these issues.

(Title altered)
