### PR TITLE
Make CakePHP case insensitive on Windows hosts

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -250,8 +250,16 @@ class CakeRequest implements ArrayAccess {
 
 		$base = $this->base;
 
-		if (strlen($base) > 0 && strpos($uri, $base) === 0) {
-			$uri = substr($uri, strlen($base));
+		if (strlen($base) > 0) {
+			if (stripos(PHP_OS, 'win') === 0) {
+				if (strpos(strtolower($uri), strtolower($base)) === 0) {
+					$uri = substr($uri, strlen($base));
+				}
+			} else {
+				if (strpos($uri, $base) === 0) {
+					$uri = substr($uri, strlen($base));
+				}
+			}
 		}
 		if (strpos($uri, '?') !== false) {
 			list($uri) = explode('?', $uri, 2);


### PR DESCRIPTION
This change makes CakePHP case insensitive on Windows, which is as we all know
also case insensitive.
This works for IIS but also for Apache on Windows, while not changing the
CakeRequest properties.

Also it is a workaround for a crazy issue when using CakePHP in a subdirectory of the document root in conbination with IIS and the official rewrite module.
Because the first request after a restart of IIS as a whole or the application pool where CakePHP is within sets various environment variables to the used case of the sub directory in the request URL.
So let's say you have an application in D:\wwwroot\myapp\ where D:\wwwroot is the DocumentRoot of IIS.

Your first request though goes like
http://myserver/MyApp/
Now your
PHP_SELF
looks like
/MyApp/app/webroot/index.php
and your
REQUEST_URI
like
/MyApp/

Every subsequent request to your application with a different case e.g. lower case http://myserver/myapp/
doesn't change most environment variables.
So your
PHP_SELF
still looks like
/MyApp/app/webroot/index.php
but the
REQUEST_URI
is now correctly set to
/myapp/

This is a problem because CakePHP compares the uri (= REQUEST_URI) to the wrong cased base (=PHP_SELF).

The result is every subsequent call will show a MyAppController not found error while it either should have done this the other way round.
But since CakePHP is now case insensitive we don't have to care anyway.
