### PR TITLE
Fix to the date input year field when maxYear is informed

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -11,11 +11,11 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.View.Helper
- * @since         CakePHP(tm) v 1.2.0.4206
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright	 Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link		  http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package	   Cake.Test.Case.View.Helper
+ * @since		 CakePHP(tm) v 1.2.0.4206
+ * @license	   http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 App::uses('ClassRegistry', 'Utility');
@@ -31,7 +31,7 @@ App::uses('Router', 'Routing');
 /**
  * ContactTestController class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ContactTestController extends Controller {
 
@@ -46,7 +46,7 @@ class ContactTestController extends Controller {
 /**
  * Contact class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class Contact extends CakeTestModel {
 
@@ -137,7 +137,7 @@ class Contact extends CakeTestModel {
 /**
  * ContactTagsContact class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ContactTagsContact extends CakeTestModel {
 
@@ -174,7 +174,7 @@ class ContactTagsContact extends CakeTestModel {
 /**
  * ContactNonStandardPk class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ContactNonStandardPk extends Contact {
 
@@ -202,7 +202,7 @@ class ContactNonStandardPk extends Contact {
 /**
  * ContactTag class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ContactTag extends Model {
 
@@ -229,7 +229,7 @@ class ContactTag extends Model {
 /**
  * UserForm class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class UserForm extends CakeTestModel {
 
@@ -269,7 +269,7 @@ class UserForm extends CakeTestModel {
 /**
  * OpenidUrl class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class OpenidUrl extends CakeTestModel {
 
@@ -324,7 +324,7 @@ class OpenidUrl extends CakeTestModel {
 /**
  * ValidateUser class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ValidateUser extends CakeTestModel {
 
@@ -373,7 +373,7 @@ class ValidateUser extends CakeTestModel {
 /**
  * ValidateProfile class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ValidateProfile extends CakeTestModel {
 
@@ -432,7 +432,7 @@ class ValidateProfile extends CakeTestModel {
 /**
  * ValidateItem class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class ValidateItem extends CakeTestModel {
 
@@ -481,7 +481,7 @@ class ValidateItem extends CakeTestModel {
 /**
  * TestMail class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  */
 class TestMail extends CakeTestModel {
 
@@ -497,7 +497,7 @@ class TestMail extends CakeTestModel {
 /**
  * FormHelperTest class
  *
- * @package       Cake.Test.Case.View.Helper
+ * @package	   Cake.Test.Case.View.Helper
  * @property FormHelper $Form
  */
 class FormHelperTest extends CakeTestCase {
@@ -6634,94 +6634,22 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testInputDateMaxYear() {
-                // Let's say we want to only allow users born from
-                // 2006 to 2008 to register
-                // This beeing the first singup page, we still don't have any data
-                $this->Form->request->data = array();
-                $this->Form->create('User');
-                $result = $this->Form->input('birthday', 
-                        array(
-                            'label' => false, 
-                            'div' => false, 
-                            'type' => 'date', 
-                            'dateFormat' => 'DMY', 
-                            'minYear' => 2006,
-                            'maxYear' => 2008
-                        )
-                );
-                
-                $selected = array('selected' => 'selected');
-                $day = array();
-                $month = array();
-
-                for($i = 1; $i <= 31; $i++) {
-                    array_push($day, array('value' => ($i < 10?'0'.$i:$i)));
-                    if($i < 13)
-                        array_push($month, array('value' => ($i < 10?'0'.$i:$i)));
-                }
-                
-                $day[date('d')-1] = array_merge($day[date('d')-1], $selected);
-                $month[date('m')-1] = array_merge($day[date('m')-1], $selected);
-                
-                $expected = array(
-                    array('select' => array('name' => 'data[User][birthday][day]', 'id' => 'UserBirthdayDay')),
-			array('option' => $day[0]),  '1', '/option',
-			array('option' => $day[1]),  '2', '/option',
-			array('option' => $day[2]),  '3', '/option',
-			array('option' => $day[3]),  '4', '/option',
-			array('option' => $day[4]),  '5', '/option',
-			array('option' => $day[5]),  '6', '/option',
-			array('option' => $day[6]),  '7', '/option',
-			array('option' => $day[7]),  '8', '/option',
-			array('option' => $day[8]),  '9', '/option',
-			array('option' => $day[9]),  '10', '/option',
-			array('option' => $day[10]), '11', '/option',
-			array('option' => $day[11]), '12', '/option',
-			array('option' => $day[12]), '13', '/option',
-			array('option' => $day[13]), '14', '/option',
-			array('option' => $day[14]), '15', '/option',
-			array('option' => $day[15]), '16', '/option',
-			array('option' => $day[16]), '17', '/option',
-			array('option' => $day[17]), '18', '/option',
-			array('option' => $day[18]), '19', '/option',
-			array('option' => $day[19]), '20', '/option',
-			array('option' => $day[20]), '21', '/option',
-			array('option' => $day[21]), '22', '/option',
-			array('option' => $day[22]), '23', '/option',
-			array('option' => $day[23]), '24', '/option',
-			array('option' => $day[24]), '25', '/option',
-			array('option' => $day[25]), '26', '/option',
-			array('option' => $day[26]), '27', '/option',
-			array('option' => $day[27]), '28', '/option',
-			array('option' => $day[28]), '29', '/option',
-			array('option' => $day[29]), '30', '/option',
-			array('option' => $day[30]), '31', '/option',
-                    '/select',
-                    '-',                   
-                    array('select' => array('name' => 'data[User][birthday][month]', 'id' => 'UserBirthdayMonth')),
-			array('option' => $month[0]), 'January', '/option',
-			array('option' => $month[1]), 'February', '/option',
-			array('option' => $month[2]), 'March', '/option',
-			array('option' => $month[3]), 'April', '/option',
-			array('option' => $month[4]), 'May', '/option',
-			array('option' => $month[5]), 'June', '/option',
-			array('option' => $month[6]), 'July', '/option',
-			array('option' => $month[7]), 'August', '/option',
-			array('option' => $month[8]), 'September', '/option',
-			array('option' => $month[9]), 'October', '/option',
-			array('option' => $month[10]), 'November', '/option',
-			array('option' => $month[11]), 'December', '/option',
-                    '/select',
-                    '-',                   
-                    array('select' => array('name' => 'data[User][birthday][year]', 'id' => 'UserBirthdayYear')),
-			array('option' => array('value' => '2008', 'selected' => 'selected')), '2008', '/option',
-			array('option' => array('value' => '2007')), '2007', '/option',
-			array('option' => array('value' => '2006')), '2006', '/option',
-                    '/select',
-                    
-                    );
-
-		$this->assertTags($result, $expected, true);
+				// Let's say we want to only allow users born from
+				// 2006 to 2008 to register
+				// This beeing the first singup page, we still don't have any data
+				$this->Form->request->data = array();
+				$this->Form->create('User');
+				$result = $this->Form->input('birthday',
+						array(
+							'label' => false,
+							'div' => false,
+							'type' => 'date',
+							'dateFormat' => 'DMY',
+							'minYear' => 2006,
+							'maxYear' => 2008
+						)
+				);
+				$this->assertContains('value="2008" selected="selected"', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -6629,6 +6629,102 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testInputDateMaxYear method
+ *
+ * @return void
+ */
+	public function testInputDateMaxYear() {
+                // Let's say we want to only allow users born from
+                // 2006 to 2008 to register
+                // This beeing the first singup page, we still don't have any data
+                $this->Form->request->data = array();
+                $this->Form->create('User');
+                $result = $this->Form->input('birthday', 
+                        array(
+                            'label' => false, 
+                            'div' => false, 
+                            'type' => 'date', 
+                            'dateFormat' => 'DMY', 
+                            'minYear' => 2006,
+                            'maxYear' => 2008
+                        )
+                );
+                
+                $selected = array('selected' => 'selected');
+                $day = array();
+                $month = array();
+
+                for($i = 1; $i <= 31; $i++) {
+                    array_push($day, array('value' => ($i < 10?'0'.$i:$i)));
+                    if($i < 13)
+                        array_push($month, array('value' => ($i < 10?'0'.$i:$i)));
+                }
+                
+                $day[date('d')-1] = array_merge($day[date('d')-1], $selected);
+                $month[date('m')-1] = array_merge($day[date('m')-1], $selected);
+                
+                $expected = array(
+                    array('select' => array('name' => 'data[User][birthday][day]', 'id' => 'UserBirthdayDay')),
+			array('option' => $day[0]),  '1', '/option',
+			array('option' => $day[1]),  '2', '/option',
+			array('option' => $day[2]),  '3', '/option',
+			array('option' => $day[3]),  '4', '/option',
+			array('option' => $day[4]),  '5', '/option',
+			array('option' => $day[5]),  '6', '/option',
+			array('option' => $day[6]),  '7', '/option',
+			array('option' => $day[7]),  '8', '/option',
+			array('option' => $day[8]),  '9', '/option',
+			array('option' => $day[9]),  '10', '/option',
+			array('option' => $day[10]), '11', '/option',
+			array('option' => $day[11]), '12', '/option',
+			array('option' => $day[12]), '13', '/option',
+			array('option' => $day[13]), '14', '/option',
+			array('option' => $day[14]), '15', '/option',
+			array('option' => $day[15]), '16', '/option',
+			array('option' => $day[16]), '17', '/option',
+			array('option' => $day[17]), '18', '/option',
+			array('option' => $day[18]), '19', '/option',
+			array('option' => $day[19]), '20', '/option',
+			array('option' => $day[20]), '21', '/option',
+			array('option' => $day[21]), '22', '/option',
+			array('option' => $day[22]), '23', '/option',
+			array('option' => $day[23]), '24', '/option',
+			array('option' => $day[24]), '25', '/option',
+			array('option' => $day[25]), '26', '/option',
+			array('option' => $day[26]), '27', '/option',
+			array('option' => $day[27]), '28', '/option',
+			array('option' => $day[28]), '29', '/option',
+			array('option' => $day[29]), '30', '/option',
+			array('option' => $day[30]), '31', '/option',
+                    '/select',
+                    '-',                   
+                    array('select' => array('name' => 'data[User][birthday][month]', 'id' => 'UserBirthdayMonth')),
+			array('option' => $month[0]), 'January', '/option',
+			array('option' => $month[1]), 'February', '/option',
+			array('option' => $month[2]), 'March', '/option',
+			array('option' => $month[3]), 'April', '/option',
+			array('option' => $month[4]), 'May', '/option',
+			array('option' => $month[5]), 'June', '/option',
+			array('option' => $month[6]), 'July', '/option',
+			array('option' => $month[7]), 'August', '/option',
+			array('option' => $month[8]), 'September', '/option',
+			array('option' => $month[9]), 'October', '/option',
+			array('option' => $month[10]), 'November', '/option',
+			array('option' => $month[11]), 'December', '/option',
+                    '/select',
+                    '-',                   
+                    array('select' => array('name' => 'data[User][birthday][year]', 'id' => 'UserBirthdayYear')),
+			array('option' => array('value' => '2008', 'selected' => 'selected')), '2008', '/option',
+			array('option' => array('value' => '2007')), '2007', '/option',
+			array('option' => array('value' => '2006')), '2006', '/option',
+                    '/select',
+                    
+                    );
+
+		$this->assertTags($result, $expected, true);
+	}
+
+/**
  * testTextArea method
  *
  * @return void

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -11,11 +11,11 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice
  *
- * @copyright	 Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link		  http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package	   Cake.Test.Case.View.Helper
- * @since		 CakePHP(tm) v 1.2.0.4206
- * @license	   http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Case.View.Helper
+ * @since         CakePHP(tm) v 1.2.0.4206
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 App::uses('ClassRegistry', 'Utility');
@@ -31,7 +31,7 @@ App::uses('Router', 'Routing');
 /**
  * ContactTestController class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ContactTestController extends Controller {
 
@@ -46,7 +46,7 @@ class ContactTestController extends Controller {
 /**
  * Contact class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class Contact extends CakeTestModel {
 
@@ -137,7 +137,7 @@ class Contact extends CakeTestModel {
 /**
  * ContactTagsContact class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ContactTagsContact extends CakeTestModel {
 
@@ -174,7 +174,7 @@ class ContactTagsContact extends CakeTestModel {
 /**
  * ContactNonStandardPk class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ContactNonStandardPk extends Contact {
 
@@ -202,7 +202,7 @@ class ContactNonStandardPk extends Contact {
 /**
  * ContactTag class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ContactTag extends Model {
 
@@ -229,7 +229,7 @@ class ContactTag extends Model {
 /**
  * UserForm class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class UserForm extends CakeTestModel {
 
@@ -269,7 +269,7 @@ class UserForm extends CakeTestModel {
 /**
  * OpenidUrl class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class OpenidUrl extends CakeTestModel {
 
@@ -324,7 +324,7 @@ class OpenidUrl extends CakeTestModel {
 /**
  * ValidateUser class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ValidateUser extends CakeTestModel {
 
@@ -373,7 +373,7 @@ class ValidateUser extends CakeTestModel {
 /**
  * ValidateProfile class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ValidateProfile extends CakeTestModel {
 
@@ -432,7 +432,7 @@ class ValidateProfile extends CakeTestModel {
 /**
  * ValidateItem class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class ValidateItem extends CakeTestModel {
 
@@ -481,7 +481,7 @@ class ValidateItem extends CakeTestModel {
 /**
  * TestMail class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  */
 class TestMail extends CakeTestModel {
 
@@ -497,7 +497,7 @@ class TestMail extends CakeTestModel {
 /**
  * FormHelperTest class
  *
- * @package	   Cake.Test.Case.View.Helper
+ * @package       Cake.Test.Case.View.Helper
  * @property FormHelper $Form
  */
 class FormHelperTest extends CakeTestCase {

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -6634,94 +6634,22 @@ class FormHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testInputDateMaxYear() {
-                // Let's say we want to only allow users born from
-                // 2006 to 2008 to register
-                // This beeing the first singup page, we still don't have any data
-                $this->Form->request->data = array();
-                $this->Form->create('User');
-                $result = $this->Form->input('birthday', 
-                        array(
-                            'label' => false, 
-                            'div' => false, 
-                            'type' => 'date', 
-                            'dateFormat' => 'DMY', 
-                            'minYear' => 2006,
-                            'maxYear' => 2008
-                        )
-                );
-                
-                $selected = array('selected' => 'selected');
-                $day = array();
-                $month = array();
-
-                for($i = 1; $i <= 31; $i++) {
-                    array_push($day, array('value' => ($i < 10?'0'.$i:$i)));
-                    if($i < 13)
-                        array_push($month, array('value' => ($i < 10?'0'.$i:$i)));
-                }
-                
-                $day[date('d')-1] = array_merge($day[date('d')-1], $selected);
-                $month[date('m')-1] = array_merge($day[date('m')-1], $selected);
-                
-                $expected = array(
-                    array('select' => array('name' => 'data[User][birthday][day]', 'id' => 'UserBirthdayDay')),
-			array('option' => $day[0]),  '1', '/option',
-			array('option' => $day[1]),  '2', '/option',
-			array('option' => $day[2]),  '3', '/option',
-			array('option' => $day[3]),  '4', '/option',
-			array('option' => $day[4]),  '5', '/option',
-			array('option' => $day[5]),  '6', '/option',
-			array('option' => $day[6]),  '7', '/option',
-			array('option' => $day[7]),  '8', '/option',
-			array('option' => $day[8]),  '9', '/option',
-			array('option' => $day[9]),  '10', '/option',
-			array('option' => $day[10]), '11', '/option',
-			array('option' => $day[11]), '12', '/option',
-			array('option' => $day[12]), '13', '/option',
-			array('option' => $day[13]), '14', '/option',
-			array('option' => $day[14]), '15', '/option',
-			array('option' => $day[15]), '16', '/option',
-			array('option' => $day[16]), '17', '/option',
-			array('option' => $day[17]), '18', '/option',
-			array('option' => $day[18]), '19', '/option',
-			array('option' => $day[19]), '20', '/option',
-			array('option' => $day[20]), '21', '/option',
-			array('option' => $day[21]), '22', '/option',
-			array('option' => $day[22]), '23', '/option',
-			array('option' => $day[23]), '24', '/option',
-			array('option' => $day[24]), '25', '/option',
-			array('option' => $day[25]), '26', '/option',
-			array('option' => $day[26]), '27', '/option',
-			array('option' => $day[27]), '28', '/option',
-			array('option' => $day[28]), '29', '/option',
-			array('option' => $day[29]), '30', '/option',
-			array('option' => $day[30]), '31', '/option',
-                    '/select',
-                    '-',                   
-                    array('select' => array('name' => 'data[User][birthday][month]', 'id' => 'UserBirthdayMonth')),
-			array('option' => $month[0]), 'January', '/option',
-			array('option' => $month[1]), 'February', '/option',
-			array('option' => $month[2]), 'March', '/option',
-			array('option' => $month[3]), 'April', '/option',
-			array('option' => $month[4]), 'May', '/option',
-			array('option' => $month[5]), 'June', '/option',
-			array('option' => $month[6]), 'July', '/option',
-			array('option' => $month[7]), 'August', '/option',
-			array('option' => $month[8]), 'September', '/option',
-			array('option' => $month[9]), 'October', '/option',
-			array('option' => $month[10]), 'November', '/option',
-			array('option' => $month[11]), 'December', '/option',
-                    '/select',
-                    '-',                   
-                    array('select' => array('name' => 'data[User][birthday][year]', 'id' => 'UserBirthdayYear')),
-			array('option' => array('value' => '2008', 'selected' => 'selected')), '2008', '/option',
-			array('option' => array('value' => '2007')), '2007', '/option',
-			array('option' => array('value' => '2006')), '2006', '/option',
-                    '/select',
-                    
-                    );
-
-		$this->assertTags($result, $expected, true);
+				// Let's say we want to only allow users born from
+				// 2006 to 2008 to register
+				// This beeing the first singup page, we still don't have any data
+				$this->Form->request->data = array();
+				$this->Form->create('User');
+				$result = $this->Form->input('birthday',
+						array(
+							'label' => false,
+							'div' => false,
+							'type' => 'date',
+							'dateFormat' => 'DMY',
+							'minYear' => 2006,
+							'maxYear' => 2008
+						)
+				);
+				$this->assertContains('value="2008" selected="selected"', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -6630,13 +6630,14 @@ class FormHelperTest extends CakeTestCase {
 
 /**
  * testInputDateMaxYear method
+ * 
+ * Let's say we want to only allow users born from
+ * 2006 to 2008 to register
+ * This beeing the first singup page, we still don't have any data
  *
  * @return void
  */
 	public function testInputDateMaxYear() {
-				// Let's say we want to only allow users born from
-				// 2006 to 2008 to register
-				// This beeing the first singup page, we still don't have any data
 				$this->Form->request->data = array();
 				$this->Form->create('User');
 				$result = $this->Form->input('birthday',

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2359,9 +2359,12 @@ class FormHelper extends AppHelper {
 		}
 
 		if ($attributes['value'] === null && $attributes['empty'] != true) {
-			$attributes['value'] = time();
+      if(!empty($attributes['maxYear']))
+          $attributes['value'] = strtotime(date($attributes['maxYear'].'-m-d'));
+      else
+          $attributes['value'] = time();
 		}
-
+		
 		if (!empty($attributes['value'])) {
 			list($year, $month, $day, $hour, $min, $meridian) = $this->_getDateTimeValue(
 				$attributes['value'],

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2359,12 +2359,12 @@ class FormHelper extends AppHelper {
 		}
 
 		if ($attributes['value'] === null && $attributes['empty'] != true) {
-      if(!empty($attributes['maxYear']))
-          $attributes['value'] = strtotime(date($attributes['maxYear'].'-m-d'));
-      else
-          $attributes['value'] = time();
+			if(!empty($attributes['maxYear']))
+				$attributes['value'] = strtotime(date($attributes['maxYear'] . '-m-d'));
+			else
+				$attributes['value'] = time();
 		}
-		
+
 		if (!empty($attributes['value'])) {
 			list($year, $month, $day, $hour, $min, $meridian) = $this->_getDateTimeValue(
 				$attributes['value'],

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2359,10 +2359,11 @@ class FormHelper extends AppHelper {
 		}
 
 		if ($attributes['value'] === null && $attributes['empty'] != true) {
-			if(!empty($attributes['maxYear']) && $attributes['maxYear'] < date('Y'))
+			if(!empty($attributes['maxYear']) && $attributes['maxYear'] < date('Y')) {
 				$attributes['value'] = strtotime(date($attributes['maxYear'] . '-m-d'));
-			else
+			} else {
 				$attributes['value'] = time();
+			}
 		}
 
 		if (!empty($attributes['value'])) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2359,7 +2359,7 @@ class FormHelper extends AppHelper {
 		}
 
 		if ($attributes['value'] === null && $attributes['empty'] != true) {
-			if(!empty($attributes['maxYear']))
+			if(!empty($attributes['maxYear']) && $attributes['maxYear'] < date('Y'))
 				$attributes['value'] = strtotime(date($attributes['maxYear'] . '-m-d'));
 			else
 				$attributes['value'] = time();


### PR DESCRIPTION
Create the field if no value is informed only to the maxYear and not to
the current date.

If you follow the example in the cookbook on how to use maxYear, without "default" => false,  you can see that maxYear is ignored.

This issue was created by this fix, fd72f894ad091bbe3c10314091ee3ab34769afa2 , while it's still valid, it broke the input in another place
