### PR TITLE
AuthComponent: Allow suppressing authError message

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -211,7 +211,7 @@ class AuthComponent extends Component {
  * Error to display when user attempts to access an object or action to which they do not have
  * access.
  *
- * @var string
+ * @var string|bool Error message or boolean false to suppress flash message
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#AuthComponent::$authError
  */
 	public $authError = null;
@@ -431,7 +431,7 @@ class AuthComponent extends Component {
 			'authError' => __d('cake', 'You are not authorized to access that location.')
 		);
 		foreach ($defaults as $key => $value) {
-			if (empty($this->{$key})) {
+			if (!isset($this->{$key}) || $this->{$key} === true) {
 				$this->{$key} = $value;
 			}
 		}
@@ -819,6 +819,9 @@ class AuthComponent extends Component {
  * @return void
  */
 	public function flash($message) {
+		if ($message === false) {
+			return;
+		}
 		$this->Session->setFlash($message, $this->flash['element'], $this->flash['params'], $this->flash['key']);
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -902,6 +902,11 @@ class AuthComponentTest extends CakeTestCase {
 			array('on', 'redirect'),
 			array($CakeRequest, $CakeResponse)
 		);
+		$this->Auth->Session = $this->getMock(
+			'SessionComponent',
+			array('setFlash'),
+			array($Controller->Components)
+		);
 
 		$expected = array(
 			'controller' => 'no_can_do', 'action' => 'jack'
@@ -909,6 +914,47 @@ class AuthComponentTest extends CakeTestCase {
 		$Controller->expects($this->once())
 			->method('redirect')
 			->with($this->equalTo($expected));
+		$this->Auth->Session->expects($this->once())
+			->method('setFlash');
+		$this->Auth->startup($Controller);
+	}
+
+/**
+ * testRedirectToUnauthorizedRedirectSuppressedAuthError
+ *
+ * @return void
+ */
+	public function testRedirectToUnauthorizedRedirectSuppressedAuthError() {
+		$url = '/party/on';
+		$this->Auth->request = $CakeRequest = new CakeRequest($url);
+		$this->Auth->request->addParams(Router::parse($url));
+		$this->Auth->authorize = array('Controller');
+		$this->Auth->login(array('username' => 'admad', 'password' => 'cake'));
+		$this->Auth->unauthorizedRedirect = array(
+			'controller' => 'no_can_do', 'action' => 'jack'
+		);
+		$this->Auth->authError = false;
+
+		$CakeResponse = new CakeResponse();
+		$Controller = $this->getMock(
+			'Controller',
+			array('on', 'redirect'),
+			array($CakeRequest, $CakeResponse)
+		);
+		$this->Auth->Session = $this->getMock(
+			'SessionComponent',
+			array('setFlash'),
+			array($Controller->Components)
+		);
+
+		$expected = array(
+			'controller' => 'no_can_do', 'action' => 'jack'
+		);
+		$Controller->expects($this->once())
+			->method('redirect')
+			->with($this->equalTo($expected));
+		$this->Auth->Session->expects($this->never())
+			->method('setFlash');
 		$this->Auth->startup($Controller);
 	}
 


### PR DESCRIPTION
When unauthenticated users accesses protected areas, they are greeted
with the default `You are not allowed to access that location` which is
not desired in some cases.

This patch allows applications to suppress this message by setting
`AuthComponent::authError` to `false` bypassing the call to
`SessionComponent::setFlash()` altogether.

Refs: https://github.com/croogo/croogo/pull/175#discussion_r4714240

Note: Please fast-forward and don't use the merge button :)
