### PR TITLE
Postgres buildColumn() support for array-type columns.

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -835,7 +835,7 @@ class Postgres extends DboSource {
  * @return string
  */
 	public function buildColumn($column) {
-		if(preg_match('/^[[:graph:]]+(\[[[:digit:]]*\])+$/', $column['type'])){
+		if (preg_match('/^[[:graph:]]+(\[[[:digit:]]*\])+$/', $column['type'])) {
 			$this->columns[$column['type']] = array('name' => $column['type']);
 		}
 		$col = $this->columns[$column['type']];

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -826,9 +826,18 @@ class Postgres extends DboSource {
  * @param array $column An array structured like the following:
  *                      array('name'=>'value', 'type'=>'value'[, options]),
  *                      where options can be 'default', 'length', or 'key'.
+ *                      If given a Postgres array-type like 'integer[3][3]',
+ *                      that type will be incorporated into the $columns
+ *                      property and should be treated similarly to a string
+ *                      in subsequent operations. Postgres tends to ignore
+ *                      the 'fixed-size array' aspect; it just supports
+ *											the notation, but creates unlimited-size arrays.
  * @return string
  */
 	public function buildColumn($column) {
+		if(preg_match('/^[[:graph:]]+(\[[[:digit:]]*\])+$/', $column['type'])){
+			$this->columns[$column['type']] = array('name' => $column['type']);
+		}
 		$col = $this->columns[$column['type']];
 		if (!isset($col['length']) && !isset($col['limit'])) {
 			unset($column['length']);


### PR DESCRIPTION
It is now possible to write unit test fixtures that create
tables featuring array-type columns. If your database happens
to have advanced data types with custom names, those should
be fine, too (ex: tic_tac_toe[3][3] representing X's and O's).
The core idea was to support any of the basic types being
postfixed with the array-type notation.

An example fixture:

```
class RatingFixture extends CakeTestFixture {
  public $table = 'ratings';
  public $fields = array(
    'id' => array('type' => 'string', 'null' => false,
                  'length' => 36, 'key' => 'primary'),
    'ratings' => array('type' => 'integer[]', 'null' => true),
    'indexes' => array(
      'PRIMARY' => array('unique' => true, 'column' => 'id')
    ),
  );
  public $records = array(
    array(
      'id' => '0b07392c-d691-11e2-805f-080027347923',
      'ratings' => '{0,1,1,2,3,5,8,13,21,34}',
    ),
  );
}
```
