### PR TITLE
Make CakePHP accept case insensitive paths (e.g. on Windows hosts)

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -106,6 +106,22 @@
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 
 /**
+ * To configure CakePHP to accept case insensitive paths,
+ * e.g. on Windows hosts, uncomment the following setting.
+ *
+ * Once set to true the application will treat urls like
+ * http://www.myhost.com/MyApp/
+ * http://www.myhost.com/myapp/
+ * http://www.myhost.com/MYAPP/
+ * as they were the same.
+ *
+ * The controller, action, parameter and query string will be
+ * treated case sensitive as before.
+ */
+
+	//Configure::write('App.caseInsensitive', true);
+
+/**
  * Uncomment the define below to use CakePHP prefix routes.
  *
  * The value of the define determines the names of the routes

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -106,6 +106,22 @@
 	//Configure::write('App.baseUrl', env('SCRIPT_NAME'));
 
 /**
+ * To configure CakePHP to accept case insensitive paths,
+ * e.g. on Windows hosts, uncomment the following setting.
+ *
+ * Once set to true the application will treat urls like
+ * http://www.myhost.com/MyApp/
+ * http://www.myhost.com/myapp/
+ * http://www.myhost.com/MYAPP/
+ * as they were the same.
+ *
+ * The controller, action, parameter and query string will be
+ * treated case sensitive as before.
+ */
+
+	//Configure::write('App.caseInsensitive', true);
+
+/**
  * Uncomment the define below to use CakePHP prefix routes.
  *
  * The value of the define determines the names of the routes

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -250,7 +250,11 @@ class CakeRequest implements ArrayAccess {
 
 		$base = $this->base;
 
-		if (strlen($base) > 0 && strpos($uri, $base) === 0) {
+		$caseInsensitive = Configure::read('App.caseInsensitive');
+
+		if (!empty($base) &&
+			(($caseInsensitive === true && stripos($uri, $base) === 0) ||
+			strpos($uri, $base) === 0)) {
 			$uri = substr($uri, strlen($base));
 		}
 		if (strpos($uri, '?') !== false) {


### PR DESCRIPTION
This works for IIS but also for Apache on Windows, while not changing the
CakeRequest properties.

The controller, action, parameter and query string will be treated case sensitive as before.

See https://github.com/cakephp/cakephp/pull/1351 for more info
