### PR TITLE
assert proper array access for _dateTimeSelected()

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2272,8 +2272,8 @@ class FormHelper extends AppHelper {
  */
 	protected function _dateTimeSelected($select, $fieldName, $attributes) {
 		if ((empty($attributes['value']) || $attributes['value'] === true) && $value = $this->value($fieldName)) {
-			if (is_array($value) && isset($value[$select])) {
-				$attributes['value'] = $value[$select];
+			if (is_array($value)) {
+				$attributes['value'] = isset($value[$select]) ? $value[$select] : null;
 			} else {
 				if (empty($value)) {
 					if (!$attributes['empty']) {


### PR DESCRIPTION
I extend the FormHelper for some additional markup.
While using the inputs date/datetime I get "Warning (2): strlen() expects parameter 1 to be string, array given" when the array is not complete (contains only year, not month/day etc).
This happens since the isset() is on the same level as the is_array() and it can run into the scalar checks afterwards in the else block.
This fixes it.
