### PR TITLE
Change the default validation message

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -285,7 +285,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 				$message = __d($this->_validationDomain, $name);
 			}
 		} else {
-			$message = __d('cake', 'This field cannot be left blank');
+			$message = __d('cake', 'This field is invalid');
 		}
 
 		return $message;

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -1088,7 +1088,7 @@ class ControllerTest extends CakeTestCase {
 		$Post->set('title', '');
 		$result = $TestController->validateErrors($Post);
 
-		$expected = array('title' => array('This field cannot be left blank'));
+		$expected = array('title' => array('This field is invalid'));
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -957,7 +957,7 @@ class TranslateBehaviorTest extends CakeTestCase {
 		);
 		$TestModel->create();
 		$this->assertFalse($TestModel->save($data));
-		$this->assertEquals(array('This field cannot be left blank'), $TestModel->validationErrors['title']);
+		$this->assertEquals(array('This field is invalid'), $TestModel->validationErrors['title']);
 
 		$TestModel->locale = 'eng';
 		$TestModel->validate['title'] = '/Only this title/';

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -150,29 +150,29 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel->set(array('title' => '$$', 'name' => '##'));
 		$TestModel->invalidFields(array('fieldList' => array('title')));
 		$expected = array(
-			'title' => array('This field cannot be left blank')
+			'title' => array('This field is invalid')
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name')));
 		$expected = array(
-			'name' => array('This field cannot be left blank')
+			'name' => array('This field is invalid')
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->invalidFields(array('fieldList' => array('name', 'title')));
 		$expected = array(
-			'name' => array('This field cannot be left blank'),
-			'title' => array('This field cannot be left blank')
+			'name' => array('This field is invalid'),
+			'title' => array('This field is invalid')
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 		$TestModel->validationErrors = array();
 
 		$TestModel->whitelist = array('name');
 		$TestModel->invalidFields();
-		$expected = array('name' => array('This field cannot be left blank'));
+		$expected = array('name' => array('This field is invalid'));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$this->assertEquals($TestModel->validate, $validate);
@@ -198,7 +198,7 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel->whitelist = array('name');
 		$TestModel->save(array('name' => '#$$#', 'title' => '$$$$'));
 
-		$expected = array('name' => array('This field cannot be left blank'));
+		$expected = array('name' => array('This field is invalid'));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
 
@@ -581,7 +581,7 @@ class ModelValidationTest extends BaseModelTest {
 
 		$JoinThing->validate = array('doomed' => array('rule' => 'notEmpty'));
 
-		$expectedError = array('doomed' => array('This field cannot be left blank'));
+		$expectedError = array('doomed' => array('This field is invalid'));
 
 		$Something->create();
 		$result = $Something->save($data);
@@ -634,7 +634,7 @@ class ModelValidationTest extends BaseModelTest {
 		$JoinThing = $Something->JoinThing;
 
 		$JoinThing->validate = array('doomed' => array('rule' => 'notEmpty'));
-		$expectedError = array('doomed' => array('This field cannot be left blank'));
+		$expectedError = array('doomed' => array('This field is invalid'));
 
 		$Something->create();
 		$result = $Something->saveAll($data, array('validate' => 'only'));
@@ -1177,7 +1177,7 @@ class ModelValidationTest extends BaseModelTest {
 			'Comment' => array(
 				1 => array(
 					'Attachment' => array(
-						'attachment' => array('This field cannot be left blank')
+						'attachment' => array('This field is invalid')
 					)
 				)
 			)
@@ -1247,7 +1247,7 @@ class ModelValidationTest extends BaseModelTest {
 			'Comment' => array(
 				'Article' => array(
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -1273,9 +1273,9 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'Comment' => array(
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -1300,11 +1300,11 @@ class ModelValidationTest extends BaseModelTest {
 		$result = $TestModel->Comment->Attachment->validationErrors;
 		$expected = array(
 			'Comment' => array(
-				'comment' => array('This field cannot be left blank'),
+				'comment' => array('This field is invalid'),
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -1328,13 +1328,13 @@ class ModelValidationTest extends BaseModelTest {
 
 		$result = $TestModel->Comment->Attachment->validationErrors;
 		$expected = array(
-			'attachment' => array('This field cannot be left blank'),
+			'attachment' => array('This field is invalid'),
 			'Comment' => array(
-				'comment' => array('This field cannot be left blank'),
+				'comment' => array('This field is invalid'),
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -1343,11 +1343,11 @@ class ModelValidationTest extends BaseModelTest {
 
 		$result = $TestModel->Comment->validationErrors;
 		$expected = array(
-			'comment' => array('This field cannot be left blank'),
+			'comment' => array('This field is invalid'),
 			'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 		);
@@ -1389,7 +1389,7 @@ class ModelValidationTest extends BaseModelTest {
 		$result = $TestModel->validateAssociated($data, array('deep' => false));
 		$this->assertFalse($result);
 
-		$expected = array('body' => array('This field cannot be left blank'));
+		$expected = array('body' => array('This field is invalid'));
 		$result = $TestModel->validationErrors;
 		$this->assertSame($expected, $result);
 
@@ -1608,8 +1608,8 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertSame($expected, $result);
 
 		$expected = array('Comment' => array(
-			0 => array('comment' => array('This field cannot be left blank')),
-			2 => array('comment' => array('This field cannot be left blank'))
+			0 => array('comment' => array('This field is invalid')),
+			2 => array('comment' => array('This field is invalid'))
 		));
 		$this->assertEquals($expected['Comment'], $TestModel->Comment->validationErrors);
 
@@ -1619,9 +1619,9 @@ class ModelValidationTest extends BaseModelTest {
 		$model->Attachment->validate = array('attachment' => 'notEmpty');
 		$model->Attachment->bindModel(array('belongsTo' => array('Comment')));
 		$expected = array(
-			'comment' => array('This field cannot be left blank'),
+			'comment' => array('This field is invalid'),
 			'Attachment' => array(
-				'attachment' => array('This field cannot be left blank')
+				'attachment' => array('This field is invalid')
 			)
 		);
 
@@ -1651,7 +1651,7 @@ class ModelValidationTest extends BaseModelTest {
 			2 => array('title' => 'title 2'),
 		);
 		$expected = array(
-			0 => array('title' => array('This field cannot be left blank')),
+			0 => array('title' => array('This field is invalid')),
 		);
 
 		$result = $TestModel->saveAll($data, array('validate' => 'only'));
@@ -1667,7 +1667,7 @@ class ModelValidationTest extends BaseModelTest {
 			2 => array('title' => 'title 2'),
 		);
 		$expected = array(
-			1 => array('title' => array('This field cannot be left blank')),
+			1 => array('title' => array('This field is invalid')),
 		);
 		$result = $TestModel->saveAll($data, array('validate' => 'only'));
 		$this->assertFalse($result);
@@ -2290,13 +2290,13 @@ class ModelValidationTest extends BaseModelTest {
 		$expected = array(
 			'Comment' => array(
 				'comment' => array(
-					0 => 'This field cannot be left blank',
+					0 => 'This field is invalid',
 				),
 				'User' => array(
 					'Comment' => array(
 						0 => array(
 							'comment' => array(
-								0 => 'This field cannot be left blank',
+								0 => 'This field is invalid',
 							),
 						),
 					),
@@ -2358,7 +2358,7 @@ class ModelValidationTest extends BaseModelTest {
 				'Comment' => array(
 					0 => array(
 						'comment' => array(
-							0 => 'This field cannot be left blank',
+							0 => 'This field is invalid',
 						),
 					),
 				),

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -3002,9 +3002,9 @@ class ModelWriteTest extends BaseModelTest {
 		);
 		$this->assertEquals(false, $result);
 		$expected = array(
-			'comment' => array('This field cannot be left blank'),
+			'comment' => array('This field is invalid'),
 			'Attachment' => array(
-				'attachment' => array('This field cannot be left blank')
+				'attachment' => array('This field is invalid')
 			)
 		);
 		$this->assertEquals($expected, $model->validationErrors);
@@ -3165,7 +3165,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->Comment->Attachment->saveAll($data, array('deep' => true));
 		$this->assertFalse($result);
 
-		$expected = array('User' => array('user' => array('This field cannot be left blank')));
+		$expected = array('User' => array('user' => array('This field is invalid')));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$data['Comment']['Article']['User']['user'] = 'deepsave';
@@ -3279,12 +3279,12 @@ class ModelWriteTest extends BaseModelTest {
 
 		$expected = array(
 			0 => array(
-				'body' => array('This field cannot be left blank'),
+				'body' => array('This field is invalid'),
 				'Comment' => array(
 					0 => array(
-						'comment' => array('This field cannot be left blank'),
+						'comment' => array('This field is invalid'),
 						'User' => array(
-							'user' => array('This field cannot be left blank')
+							'user' => array('This field is invalid')
 						)
 					)
 				)
@@ -3293,11 +3293,11 @@ class ModelWriteTest extends BaseModelTest {
 				'Comment' => array(
 					0 => array(
 						'User' => array(
-							'password' => array('This field cannot be left blank')
+							'password' => array('This field is invalid')
 						)
 					),
 					1 => array(
-						'comment' => array('This field cannot be left blank')
+						'comment' => array('This field is invalid')
 					)
 				)
 			)
@@ -3443,7 +3443,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array(
 				1 => array(
 					'Attachment' => array(
-						'attachment' => array('This field cannot be left blank')
+						'attachment' => array('This field is invalid')
 					)
 				)
 			)
@@ -3507,7 +3507,7 @@ class ModelWriteTest extends BaseModelTest {
 			'Comment' => array(
 				'Article' => array(
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -3529,9 +3529,9 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			'Comment' => array(
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -3552,11 +3552,11 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->Comment->Attachment->validationErrors;
 		$expected = array(
 			'Comment' => array(
-				'comment' => array('This field cannot be left blank'),
+				'comment' => array('This field is invalid'),
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -3576,13 +3576,13 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $TestModel->Comment->Attachment->validationErrors;
 		$expected = array(
-			'attachment' => array('This field cannot be left blank'),
+			'attachment' => array('This field is invalid'),
 			'Comment' => array(
-				'comment' => array('This field cannot be left blank'),
+				'comment' => array('This field is invalid'),
 				'Article' => array(
-					'body' => array('This field cannot be left blank'),
+					'body' => array('This field is invalid'),
 					'User' => array(
-						'user' => array('This field cannot be left blank')
+						'user' => array('This field is invalid')
 					)
 				)
 			)
@@ -3591,11 +3591,11 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $TestModel->Comment->validationErrors;
 		$expected = array(
-			'comment' => array('This field cannot be left blank'),
+			'comment' => array('This field is invalid'),
 			'Article' => array(
-				'body' => array('This field cannot be left blank'),
+				'body' => array('This field is invalid'),
 				'User' => array(
-					'user' => array('This field cannot be left blank')
+					'user' => array('This field is invalid')
 				)
 			)
 		);
@@ -3733,7 +3733,7 @@ class ModelWriteTest extends BaseModelTest {
 
 		$expected = array(
 			0 => array(
-				'body' => array('This field cannot be left blank')
+				'body' => array('This field is invalid')
 			)
 		);
 		$result = $TestModel->validationErrors;
@@ -3782,7 +3782,7 @@ class ModelWriteTest extends BaseModelTest {
 		);
 		$this->assertFalse($result);
 
-		$expected = array('body' => array('This field cannot be left blank'));
+		$expected = array('body' => array('This field is invalid'));
 		$result = $TestModel->validationErrors;
 		$this->assertSame($expected, $result);
 
@@ -3999,11 +3999,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$expected = array('Comment' => array(
-			array('comment' => array('This field cannot be left blank'))
+			array('comment' => array('This field is invalid'))
 		));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 		$expected = array(
-			array('comment' => array('This field cannot be left blank'))
+			array('comment' => array('This field is invalid'))
 		);
 		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 
@@ -4403,7 +4403,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
-		$errors = array(1 => array('title' => array('This field cannot be left blank')));
+		$errors = array(1 => array('title' => array('This field is invalid')));
 		$transactionWorked = Set::matches('/Post[1][title=Baleeted First Post]', $result);
 		if (!$transactionWorked) {
 			$this->assertTrue(Set::matches('/Post[1][title=Un-Baleeted First Post]', $result));
@@ -4428,7 +4428,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->saveAll($data, array('validate' => true, 'atomic' => false));
 		$this->assertEquals(array(true, false), $result);
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
-		$errors = array(1 => array('title' => array('This field cannot be left blank')));
+		$errors = array(1 => array('title' => array('This field is invalid')));
 		$expected = array(
 			array(
 				'Post' => array(
@@ -4540,7 +4540,7 @@ class ModelWriteTest extends BaseModelTest {
 		);
 		$this->assertFalse($result);
 		$expected = array(
-			0 => array('title' => array('This field cannot be left blank')),
+			0 => array('title' => array('This field is invalid')),
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
@@ -4554,7 +4554,7 @@ class ModelWriteTest extends BaseModelTest {
 		);
 		$this->assertFalse($result);
 		$expected = array(
-			1 => array('title' => array('This field cannot be left blank')),
+			1 => array('title' => array('This field is invalid')),
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
@@ -4586,7 +4586,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $model->find('all');
 		$this->assertSame(array(), $result);
 		$expected = array('Comment' => array(
-			1 => array('comment' => array('This field cannot be left blank'))
+			1 => array('comment' => array('This field is invalid'))
 		));
 
 		$this->assertEquals($expected['Comment'], $model->Comment->validationErrors);
@@ -4761,14 +4761,14 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertSame($expected, $result);
 
 		$expected = array('Comment' => array(
-			0 => array('comment' => array('This field cannot be left blank')),
-			2 => array('comment' => array('This field cannot be left blank'))
+			0 => array('comment' => array('This field is invalid')),
+			2 => array('comment' => array('This field is invalid'))
 		));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$expected = array(
-			0 => array('comment' => array('This field cannot be left blank')),
-			2 => array('comment' => array('This field cannot be left blank'))
+			0 => array('comment' => array('This field is invalid')),
+			2 => array('comment' => array('This field is invalid'))
 		);
 		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 	}
@@ -4942,7 +4942,7 @@ class ModelWriteTest extends BaseModelTest {
 		$expected = array(
 			'Comment' => array(
 				array(
-					'comment' => array( 'This field cannot be left blank' )
+					'comment' => array( 'This field is invalid' )
 				)
 			)
 		);
@@ -5202,11 +5202,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 		$expected = array(
 			'comment' => array(
-				'This field cannot be left blank'
+				'This field is invalid'
 			),
 			'Attachment' => array(
 				'attachment' => array(
-					'This field cannot be left blank'
+					'This field is invalid'
 				)
 			)
 		);
@@ -5426,11 +5426,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$expected = array('Comment' => array(
-			array('comment' => array('This field cannot be left blank'))
+			array('comment' => array('This field is invalid'))
 		));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 		$expected = array(
-			array('comment' => array('This field cannot be left blank'))
+			array('comment' => array('This field is invalid'))
 		);
 		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 
@@ -5840,7 +5840,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 
 		$result = $TestModel->find('all', array('recursive' => -1, 'order' => 'Post.id ASC'));
-		$errors = array(1 => array('title' => array('This field cannot be left blank')));
+		$errors = array(1 => array('title' => array('This field is invalid')));
 		$transactionWorked = Set::matches('/Post[1][title=Baleeted First Post]', $result);
 		if (!$transactionWorked) {
 			$this->assertTrue(Set::matches('/Post[1][title=Un-Baleeted First Post]', $result));
@@ -5870,7 +5870,7 @@ class ModelWriteTest extends BaseModelTest {
 			'recursive' => -1,
 			'order' => 'Post.id ASC'
 		));
-		$errors = array(1 => array('title' => array('This field cannot be left blank')));
+		$errors = array(1 => array('title' => array('This field is invalid')));
 		$expected = array(
 			array(
 				'Post' => array(
@@ -5946,7 +5946,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->validateMany($data);
 		$this->assertFalse($result);
 		$expected = array(
-			0 => array('title' => array('This field cannot be left blank')),
+			0 => array('title' => array('This field is invalid')),
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
@@ -5958,7 +5958,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $TestModel->validateMany($data);
 		$this->assertFalse($result);
 		$expected = array(
-			1 => array('title' => array('This field cannot be left blank')),
+			1 => array('title' => array('This field is invalid')),
 		);
 		$this->assertEquals($expected, $TestModel->validationErrors);
 	}
@@ -5990,7 +5990,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $model->find('all');
 		$this->assertSame(array(), $result);
 		$expected = array('Comment' => array(
-			1 => array('comment' => array('This field cannot be left blank'))
+			1 => array('comment' => array('This field is invalid'))
 		));
 
 		$this->assertEquals($expected['Comment'], $model->Comment->validationErrors);
@@ -6175,14 +6175,14 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertSame($expected, $result);
 
 		$expected = array('Comment' => array(
-			0 => array('comment' => array('This field cannot be left blank')),
-			2 => array('comment' => array('This field cannot be left blank'))
+			0 => array('comment' => array('This field is invalid')),
+			2 => array('comment' => array('This field is invalid'))
 		));
 		$this->assertEquals($expected, $TestModel->validationErrors);
 
 		$expected = array(
-			0 => array('comment' => array('This field cannot be left blank')),
-			2 => array('comment' => array('This field cannot be left blank'))
+			0 => array('comment' => array('This field is invalid')),
+			2 => array('comment' => array('This field is invalid'))
 		);
 		$this->assertEquals($expected, $TestModel->Comment->validationErrors);
 	}
@@ -6719,11 +6719,11 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse($result);
 		$expected = array(
 			'body' => array(
-				'This field cannot be left blank'
+				'This field is invalid'
 			),
 			'Featured' => array(
 				'end_date' => array(
-					'This field cannot be left blank'
+					'This field is invalid'
 				)
 			)
 		);

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
@@ -50,7 +50,7 @@ class CakeValidationSetTest extends CakeTestCase {
 		);
 
 		$result = $Field->validate($data);
-		$expected = array('This field cannot be left blank');
+		$expected = array('This field is invalid');
 		$this->assertEquals($expected, $result);
 
 		$Field = new CakeValidationSet('body', 'notEmpty');

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1763,7 +1763,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testFormValidationMultiRecord() {
 		$Contact = ClassRegistry::getObject('Contact');
 		$Contact->validationErrors[2] = array(
-			'name' => array('This field cannot be left blank')
+			'name' => array('This field is invalid')
 		);
 		$result = $this->Form->input('Contact.2.name');
 		$expected = array(
@@ -1776,7 +1776,7 @@ class FormHelperTest extends CakeTestCase {
 				'class' => 'form-error', 'maxlength' => 255
 			),
 			array('div' => array('class' => 'error-message')),
-			'This field cannot be left blank',
+			'This field is invalid',
 			'/div',
 			'/div'
 		);


### PR DESCRIPTION
The default validation message of "This field cannot be left blank" makes an assumption that the field was left blank.  Example case:  A recently employee new to Cake was left scratching his head because the validation message was reporting the field was blank, even though he saw a value for the field in $this->request->data.  The 'numeric' rule on the table's FK was still left over from the bake (auto increment), but we have since switched over to UUIDs.  While this is a relatively easy thing to trace, it still makes an assumption, and may even trip up newer Cake developers.  Semantically, I believe a more generic default message is appropriate as this message is not always set whenever the field is actually blank.
