### PR TITLE
Removing $transform param from Query::sql()

### DIFF
--- a/lib/Cake/Database/Query.php
+++ b/lib/Cake/Database/Query.php
@@ -160,7 +160,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 		if ($connection === null) {
 			return $this->_connection;
 		}
-		$this->_dirty = false;
+		$this->_dirty = true;
 		$this->_connection = $connection;
 		return $this;
 	}
@@ -184,7 +184,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  */
 	public function execute() {
 		$query = $this->_transformQuery();
-		$statement = $this->_connection->prepare($query->sql(false));
+		$statement = $this->_connection->prepare($query->sql());
 		$query->_bindStatement($statement);
 		$statement->execute();
 
@@ -194,7 +194,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 /**
  * Returns the SQL representation of this object.
  *
- * By default, this function will transform this query to make it compatible
+ * This function will compile this query to make it compatible
  * with the SQL dialect that is used by the connection, This process might
  * add, remove or alter any query part or internal expression to make it
  * executable in the target platform.
@@ -203,11 +203,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * values when the query is executed, hence it is most suitable to use with
  * prepared statements.
  *
- * @param boolean $transform Whether to let the connection transform the query
- *    to the specific dialect or not
  * @return string
  */
-	public function sql($transform = true) {
+	public function sql() {
 		$sql = '';
 		$visitor = function($parts, $name) use (&$sql) {
 			if (!count($parts)) {
@@ -222,7 +220,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 			return $sql .= $this->{'_build' . ucfirst($name) . 'Part'}($parts, $sql);
 		};
 
-		$query = $transform ? $this->_transformQuery() : $this;
+		$query = $this->_transformQuery();
 		$query->traverse($visitor->bindTo($query));
 		return $sql;
 	}
@@ -1536,7 +1534,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
 		// TODO: Should Query actually get the driver or just let the connection decide where
 		// to get the query translator?
 		$translator = $this->connection()->driver()->queryTranslator($this->_type);
-		return $this->_transformedQuery = $translator($this);
+		$transformed = $this->_transformedQuery = $translator($this);
+		$transformed->_dirty = false;
+		return $transformed;
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/QueryTest.php
+++ b/lib/Cake/Test/TestCase/Database/QueryTest.php
@@ -1493,7 +1493,7 @@ class QueryTest extends TestCase {
 			->from('authors')
 			->where('1 = 1');
 
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertContains('DELETE FROM authors', $result);
 
 		$result = $query->execute();
@@ -1512,7 +1512,7 @@ class QueryTest extends TestCase {
 		$query->delete('authors')
 			->where('1 = 1');
 
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertContains('DELETE FROM authors ', $result);
 
 		$result = $query->execute();
@@ -1530,7 +1530,7 @@ class QueryTest extends TestCase {
 		$result = $query->select()
 			->delete('authors')
 			->where('1 = 1');
-		$result = $query->sql(false);
+		$result = $query->sql();
 
 		$this->assertContains('DELETE FROM authors', $result);
 		$this->assertContains('authors WHERE 1 = 1', $result);
@@ -1546,7 +1546,7 @@ class QueryTest extends TestCase {
 		$query->update('authors')
 			->set('name', 'mark')
 			->where(['id' => 1]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertContains('UPDATE authors SET name = :', $result);
 
 		$result = $query->execute();
@@ -1564,7 +1564,7 @@ class QueryTest extends TestCase {
 			->set('title', 'mark', 'string')
 			->set('body', 'some text', 'string')
 			->where(['id' => 1]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 
 		$this->assertRegExp(
 			'/UPDATE articles SET title = :[0-9a-z]+ , body = :[0-9a-z]+/',
@@ -1589,7 +1589,7 @@ class QueryTest extends TestCase {
 				'body' => 'some text'
 			], ['title' => 'string', 'body' => 'string'])
 			->where(['id' => 1]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 
 		$this->assertRegExp(
 			'/UPDATE articles SET title = :[0-9a-z]+ , body = :[0-9a-z]+/',
@@ -1615,7 +1615,7 @@ class QueryTest extends TestCase {
 		$query->update('articles')
 			->set($expr)
 			->where(['id' => 1]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 
 		$this->assertContains(
 			'UPDATE articles SET title = author_id WHERE id = :',
@@ -1653,7 +1653,7 @@ class QueryTest extends TestCase {
 				'title' => 'mark',
 				'body' => 'test insert'
 			]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertEquals(
 			'INSERT INTO articles (title, body) VALUES (?, ?)',
 			$result
@@ -1686,7 +1686,7 @@ class QueryTest extends TestCase {
 			->values([
 				'title' => 'mark',
 			]);
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertEquals(
 			'INSERT INTO articles (title, body) VALUES (?, ?)',
 			$result
@@ -1721,11 +1721,6 @@ class QueryTest extends TestCase {
 			->values([
 				'title' => 'jose',
 			]);
-		$result = $query->sql(false);
-		$this->assertEquals(
-			'INSERT INTO articles (title, body) VALUES (?, ?), (?, ?)',
-			$result
-		);
 
 		$result = $query->execute();
 		$this->assertCount(2, $result, '2 rows should be inserted');
@@ -1767,7 +1762,7 @@ class QueryTest extends TestCase {
 		)
 		->values($select);
 
-		$result = $query->sql(false);
+		$result = $query->sql();
 		$this->assertContains('INSERT INTO articles (title, body, author_id) SELECT', $result);
 		$this->assertContains("SELECT name, 'some text', 99 FROM authors", $result);
 		$result = $query->execute();

--- a/lib/Cake/TestSuite/Fixture/FixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/FixtureManager.php
@@ -194,15 +194,22 @@ class FixtureManager {
 			return;
 		}
 
+		$dbs = [];
 		foreach ($fixtures as $f) {
 			if (!empty($this->_loaded[$f])) {
 				$fixture = $this->_loaded[$f];
-				$db = ConnectionManager::getDataSource($fixture->connection);
-				$db->begin();
+				$dbs[$fixture->connection][$f] = $fixture;
+			}
+		}
+
+		foreach ($dbs as $db => $fixtures) {
+			$db = ConnectionManager::getDataSource($fixture->connection);
+			$db->begin();
+			foreach ($fixtures as $fixture) {
 				$this->_setupTable($fixture, $db, $test->dropTables);
 				$fixture->insert($db);
-				$db->commit();
 			}
+			$db->commit();
 		}
 	}
 


### PR DESCRIPTION
As pointed out by @markstory it was very confusing that the sql() method had two modes that could potentially return very different sql. I went back and realized it was a hack after all to workaround a bug which this PR fixes. This also has the side effect that the query is only processed once giving a small performance boost.
