### PR TITLE
unify engine to not require the suffix

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -878,12 +878,12 @@ class Shell extends Object {
 			return;
 		}
 		CakeLog::config('stdout', array(
-			'engine' => 'ConsoleLog',
+			'engine' => 'Console',
 			'types' => array('notice', 'info'),
 			'stream' => $this->stdout,
 		));
 		CakeLog::config('stderr', array(
-			'engine' => 'ConsoleLog',
+			'engine' => 'Console',
 			'types' => array('emergency', 'alert', 'critical', 'error', 'warning', 'debug'),
 			'stream' => $this->stderr,
 		));

--- a/lib/Cake/Console/Templates/skel/Config/bootstrap.php
+++ b/lib/Cake/Console/Templates/skel/Config/bootstrap.php
@@ -89,12 +89,12 @@ Configure::write('Dispatcher.filters', array(
  */
 App::uses('CakeLog', 'Log');
 CakeLog::config('debug', array(
-	'engine' => 'FileLog',
+	'engine' => 'File',
 	'types' => array('notice', 'info', 'debug'),
 	'file' => 'debug',
 ));
 CakeLog::config('error', array(
-	'engine' => 'FileLog',
+	'engine' => 'File',
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -34,7 +34,7 @@ App::uses('LogEngineCollection', 'Log');
  * A sample configuration would look like:
  *
  * {{{
- * CakeLog::config('my_log', array('engine' => 'FileLog'));
+ * CakeLog::config('my_log', array('engine' => 'File'));
  * }}}
  *
  * See the documentation on CakeLog::config() for more detail.
@@ -133,7 +133,7 @@ class CakeLog {
  *
  * {{{
  * CakeLog::config('second_file', array(
- *     'engine' => 'FileLog',
+ *     'engine' => 'File',
  *     'path' => '/var/logs/my_app/'
  * ));
  * }}}
@@ -378,7 +378,7 @@ class CakeLog {
  */
 	protected static function _autoConfig() {
 		self::$_Collection->load('default', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'path' => LOGS,
 		));
 	}

--- a/lib/Cake/Log/Engine/SyslogLog.php
+++ b/lib/Cake/Log/Engine/SyslogLog.php
@@ -45,7 +45,7 @@ class SyslogLog extends BaseLog {
  *
  * {{{
  *	CakeLog::config('error', array(
- *		'engine' => 'SyslogLog',
+ *		'engine' => 'Syslog',
  *		'types' => array('emergency', 'alert', 'critical', 'error'),
  *		'format' => "%s: My-App - %s",
  *		'prefix' => 'Web Server 01'

--- a/lib/Cake/Log/LogEngineCollection.php
+++ b/lib/Cake/Log/LogEngineCollection.php
@@ -63,7 +63,9 @@ class LogEngineCollection extends ObjectCollection {
  */
 	protected static function _getLogger($loggerName) {
 		list($plugin, $loggerName) = pluginSplit($loggerName, true);
-
+		if (substr($loggerName, -3) !== 'Log') {
+			$loggerName .= 'Log';
+		}
 		App::uses($loggerName, $plugin . 'Log/Engine');
 		if (!class_exists($loggerName)) {
 			throw new CakeLogException(__d('cake_dev', 'Could not load class %s', $loggerName));

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -855,7 +855,7 @@ TEXT;
 			array('types' => 'error'),
 		));
 		TestCakeLog::config('console', array(
-			'engine' => 'ConsoleLog',
+			'engine' => 'Console',
 			'stream' => 'php://stderr',
 			));
 		TestCakeLog::replace('console', $mock);

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -87,6 +87,18 @@ class CakeLogTest extends CakeTestCase {
  * @return void
  */
 	public function testValidKeyName() {
+		CakeLog::config('valid', array('engine' => 'File'));
+		$stream = CakeLog::stream('valid');
+		$this->assertInstanceOf('FileLog', $stream);
+		CakeLog::drop('valid');
+	}
+
+/**
+ * test config() with valid key name including the deprecated Log suffix
+ *
+ * @return void
+ */
+	public function testValidKeyNameLogSuffix() {
 		CakeLog::config('valid', array('engine' => 'FileLog'));
 		$stream = CakeLog::stream('valid');
 		$this->assertInstanceOf('FileLog', $stream);
@@ -100,7 +112,7 @@ class CakeLogTest extends CakeTestCase {
  * @return void
  */
 	public function testInvalidKeyName() {
-		CakeLog::config('1nv', array('engine' => 'FileLog'));
+		CakeLog::config('1nv', array('engine' => 'File'));
 	}
 
 /**
@@ -144,7 +156,7 @@ class CakeLogTest extends CakeTestCase {
  */
 	public function testConfig() {
 		CakeLog::config('file', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
@@ -168,7 +180,7 @@ class CakeLogTest extends CakeTestCase {
  */
 	public function testDrop() {
 		CakeLog::config('file', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'path' => LOGS
 		));
 		$result = CakeLog::configured();
@@ -214,12 +226,12 @@ class CakeLogTest extends CakeTestCase {
 			unlink(LOGS . 'eggs.log');
 		}
 		CakeLog::config('spam', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => 'debug',
 			'file' => 'spam',
 		));
 		CakeLog::config('eggs', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('eggs', 'debug', 'error', 'warning'),
 			'file' => 'eggs',
 		));
@@ -253,7 +265,7 @@ class CakeLogTest extends CakeTestCase {
  */
 	public function testStreamEnable() {
 		CakeLog::config('spam', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'file' => 'spam',
 			));
 		$this->assertTrue(CakeLog::enabled('spam'));
@@ -268,7 +280,7 @@ class CakeLogTest extends CakeTestCase {
  */
 	public function testStreamDisable() {
 		CakeLog::config('spam', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'file' => 'spam',
 			));
 		$this->assertTrue(CakeLog::enabled('spam'));
@@ -298,12 +310,12 @@ class CakeLogTest extends CakeTestCase {
 
 	protected function _resetLogConfig() {
 		CakeLog::config('debug', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
 		CakeLog::config('error', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 			'file' => 'error',
 		));
@@ -339,7 +351,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->_resetLogConfig();
 
 		CakeLog::config('shops', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops',
@@ -393,13 +405,13 @@ class CakeLogTest extends CakeTestCase {
 		$this->_deleteLogs();
 
 		CakeLog::config('shops', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops.log',
 		));
 		CakeLog::config('eggs', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('eggs'),
 			'file' => 'eggs.log',
@@ -426,7 +438,7 @@ class CakeLogTest extends CakeTestCase {
 		$this->_deleteLogs();
 
 		CakeLog::config('string-scope', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => 'string-scope',
 			'file' => 'string-scope.log'
@@ -437,7 +449,7 @@ class CakeLogTest extends CakeTestCase {
 		CakeLog::drop('string-scope');
 
 		CakeLog::config('shops', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops.log',
@@ -526,7 +538,7 @@ class CakeLogTest extends CakeTestCase {
 
 		$this->_resetLogConfig();
 		CakeLog::config('shops', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('info', 'debug', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops',
@@ -563,12 +575,12 @@ class CakeLogTest extends CakeTestCase {
 		$this->_deleteLogs();
 
 		CakeLog::config('debug', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
 		CakeLog::config('error', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('emergency', 'alert', 'critical', 'error', 'warning'),
 			'file' => 'error',
 		));
@@ -677,12 +689,12 @@ class CakeLogTest extends CakeTestCase {
 		$this->assertContains('Error: ' . $testMessage, $contents);
 
 		CakeLog::config('spam', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'file' => 'spam.log',
 			'types' => 'spam',
 			));
 		CakeLog::config('eggs', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'file' => 'eggs.log',
 			'types' => array('spam', 'eggs'),
 			));

--- a/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
@@ -78,7 +78,7 @@ class ConsoleLogTest extends CakeTestCase {
  */
 	public function testConsoleOutputWrites() {
 		TestCakeLog::config('test_console_log', array(
-			'engine' => 'TestConsoleLog',
+			'engine' => 'TestConsole',
 			));
 
 		$mock = $this->getMock('TestConsoleLog', array('write'), array(
@@ -97,7 +97,7 @@ class ConsoleLogTest extends CakeTestCase {
  */
 	public function testCombinedLogWriting() {
 		TestCakeLog::config('test_console_log', array(
-			'engine' => 'TestConsoleLog',
+			'engine' => 'TestConsole',
 			));
 		$mock = $this->getMock('TestConsoleLog', array('write'), array(
 			array('types' => 'error'),
@@ -133,7 +133,7 @@ class ConsoleLogTest extends CakeTestCase {
  */
 	public function testDefaultOutputAs() {
 		TestCakeLog::config('test_console_log', array(
-			'engine' => 'TestConsoleLog',
+			'engine' => 'TestConsole',
 			));
 		if (DS === '\\' && !(bool)env('ANSICON')) {
 			$expected = ConsoleOutput::PLAIN;

--- a/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
@@ -52,12 +52,12 @@ class ConsoleLogTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		CakeLog::config('debug', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
 		CakeLog::config('error', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'types' => array('error', 'warning'),
 			'file' => 'error',
 		));

--- a/lib/Cake/Test/Case/Log/LogEngineCollectionTest.php
+++ b/lib/Cake/Test/Case/Log/LogEngineCollectionTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * LogEngineCollectionTest file
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Case.Log
+ * @since         CakePHP(tm) v 2.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+App::uses('LogEngineCollection', 'Log');
+App::uses('FileLog', 'Log/Engine');
+
+/**
+ * LoggerEngineLog class
+ */
+class LoggerEngineLog extends FileLog {
+}
+
+/**
+ * LogEngineCollectionTest class
+ *
+ * @package       Cake.Test.Case.Log
+ */
+class LogEngineCollectionTest extends CakeTestCase {
+
+	public $Collection;
+
+/**
+ * Start test callback
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+
+		$this->Collection = new LogEngineCollection();
+	}
+
+/**
+ * test load
+ *
+ * @return void
+ */
+	public function testLoad() {
+		$result = $this->Collection->load('key', array('engine' => 'File'));
+		$this->assertInstanceOf('CakeLogInterface', $result);
+	}
+
+/**
+ * test load with deprecated Log suffix
+ *
+ * @return void
+ */
+	public function testLoadWithSuffix() {
+		$result = $this->Collection->load('key', array('engine' => 'FileLog'));
+		$this->assertInstanceOf('CakeLogInterface', $result);
+	}
+
+/**
+ * test that engines starting with Log also work properly
+ *
+ * @return void
+ */
+	public function testLoadWithSuffixAtBeginning() {
+		$result = $this->Collection->load('key', array('engine' => 'LoggerEngine'));
+		$this->assertInstanceOf('CakeLogInterface', $result);
+	}
+
+/**
+ * test load with invalid Log
+ *
+ * @return void
+ * @expectedException CakeLogException
+ */
+	public function testLoadInvalid() {
+		$result = $this->Collection->load('key', array('engine' => 'ImaginaryFile'));
+		$this->assertInstanceOf('CakeLogInterface', $result);
+	}
+
+}

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -999,7 +999,7 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testSendWithLog() {
 		CakeLog::config('email', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'path' => TMP
 		));
 		CakeLog::drop('default');
@@ -1026,7 +1026,7 @@ class CakeEmailTest extends CakeTestCase {
  */
 	public function testSendWithLogAndScope() {
 		CakeLog::config('email', array(
-			'engine' => 'FileLog',
+			'engine' => 'File',
 			'path' => TMP,
 			'types' => array('cake_test_emails'),
 			'scopes' => array('email')


### PR DESCRIPTION
For Cache and other places we also say engine=>File.
So it might make sense to unify this to not include the suffix.

Note: this is BC so it can easily be done in 2.4
