### PR TITLE
3.0 - Add basic implementation of deleteAll().

### DIFF
--- a/lib/Cake/Database/Query.php
+++ b/lib/Cake/Database/Query.php
@@ -180,7 +180,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Resulting statement is traversable, so it can be used in any loop as you would
  * with an array.
  *
- * @return Cake\Database\Statement
+ * @return Cake\Database\StatementInterface
  */
 	public function execute() {
 		$query = $this->_transformQuery();

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -307,7 +307,7 @@ class Query extends DatabaseQuery {
 
 /**
  * Compiles the SQL representation of this query and executes it using the
- * configured connection object. Returns a ResultSet iterator object
+ * provided connection object. Returns a ResultSet iterator object
  *
  * Resulting object is traversable, so it can be used in any loop as you would
  * with an array.
@@ -316,6 +316,16 @@ class Query extends DatabaseQuery {
  */
 	public function execute() {
 		return new ResultSet($this, parent::execute());
+	}
+
+/**
+ * Compiles the SQL representation of this query ane executes it using
+ * the provided connection object.
+ *
+ * @return Cake\Database\StatementInterface
+ */
+	public function executeStatement() {
+		return parent::execute();
 	}
 
 /**

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -506,4 +506,27 @@ class Table {
 		return true;
 	}
 
+/**
+ * Delete all matching rows.
+ *
+ * Deletes all rows matching the provided conditions.
+ *
+ * This method will *not* trigger beforeDelete/afterDelete events. If you
+ * need those first load a collection of records and delete them.
+ *
+ * This method will *not* execute on associations `cascade` attribute. You should
+ * use database foreign keys + ON CASCADE rules if you need cascading deletes combined
+ * with this method.
+ *
+ * @param array $conditions An array of conditions, similar to those used with find()
+ * @return boolean Success
+ */
+	public function deleteAll($conditions) {
+		$query = $this->_buildQuery();
+		$query->delete($this->table())
+			->where($conditions);
+		$query->execute();
+		return true;
+	}
+
 }

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -495,15 +495,15 @@ class Table {
  *
  * @param array $fields A hash of field => new value.
  * @param array $conditions An array of conditions, similar to those used with find()
- * @return boolean Success
+ * @return boolean Success Returns true if one or more rows are effected.
  */
 	public function updateAll($fields, $conditions) {
 		$query = $this->_buildQuery();
 		$query->update($this->table())
 			->set($fields)
 			->where($conditions);
-		$query->execute();
-		return true;
+		$statement = $query->executeStatement();
+		return $statement->rowCount() > 0;
 	}
 
 /**
@@ -519,14 +519,14 @@ class Table {
  * with this method.
  *
  * @param array $conditions An array of conditions, similar to those used with find()
- * @return boolean Success
+ * @return boolean Success Returns true if one or more rows are effected.
  */
 	public function deleteAll($conditions) {
 		$query = $this->_buildQuery();
 		$query->delete($this->table())
 			->where($conditions);
-		$query->execute();
-		return true;
+		$statement = $query->executeStatement();
+		return $statement->rowCount() > 0;
 	}
 
 }

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -402,12 +402,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['_buildQuery'],
 			['table' => 'users', 'connection' => $this->connection]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection]);
+		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection]);
 		$table->expects($this->once())
 			->method('_buildQuery')
 			->will($this->returnValue($query));
 		$query->expects($this->once())
-			->method('execute')
+			->method('executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 		$table->updateAll(['username' => 'mark'], []);
 	}
@@ -438,12 +438,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['_buildQuery'],
 			['table' => 'users', 'connection' => $this->connection]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection]);
+		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection]);
 		$table->expects($this->once())
 			->method('_buildQuery')
 			->will($this->returnValue($query));
 		$query->expects($this->once())
-			->method('execute')
+			->method('executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 		$table->deleteAll(['id >' => 4]);
 	}

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -412,4 +412,40 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->updateAll(['username' => 'mark'], []);
 	}
 
+/**
+ * Test deleting many records.
+ *
+ * @return void
+ */
+	public function testDeleteAll() {
+		$table = new Table(['table' => 'users', 'connection' => $this->connection]);
+		$result = $table->deleteAll(['id <' => 4]);
+		$this->assertTrue($result);
+
+		$result = $table->find('all')->toArray();
+		$this->assertCount(1, $result, 'Only one record should remain');
+		$this->assertEquals(4, $result[0]['id']);
+	}
+
+/**
+ * Test that exceptions from the Query bubble up.
+ *
+ * @expectedException Cake\Database\Exception
+ */
+	public function testDeleteAllFailure() {
+		$table = $this->getMock(
+			'Cake\ORM\Table',
+			['_buildQuery'],
+			['table' => 'users', 'connection' => $this->connection]
+		);
+		$query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection]);
+		$table->expects($this->once())
+			->method('_buildQuery')
+			->will($this->returnValue($query));
+		$query->expects($this->once())
+			->method('execute')
+			->will($this->throwException(new \Cake\Database\Exception('Not good')));
+		$table->deleteAll(['id >' => 4]);
+	}
+
 }


### PR DESCRIPTION
Add `Table::deleteAll()`. Much like updateAll this method doesn't trigger any events or handle the pseudo cascade features in associations. This is intentional to some degree. The code that handled events in 2.x did so in an unsafe way when concurrency was involved. 

Joins during deletes have also been omitted. Joins are not evenly supported well across platform, and in almost all situations a delete + subquery will do the same thing in a more portable way. I'm also considering removing join support for update for the same reasons.
