### PR TITLE
add convenience method param() for PaginatorHelper

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2143,7 +2143,31 @@ class PaginatorHelperTest extends CakeTestCase {
 	}
 
 /**
- * test Last method
+ * test params() method
+ *
+ * @return void
+ */
+	public function testParams() {
+		$result = $this->Paginator->params();
+		$this->assertArrayHasKey('page', $result);
+		$this->assertArrayHasKey('pageCount', $result);
+	}
+
+/**
+ * test param() method
+ *
+ * @return void
+ */
+	public function testParam() {
+		$result = $this->Paginator->param('count');
+		$this->assertIdentical(62, $result);
+
+		$result = $this->Paginator->param('imaginary');
+		$this->assertNull($result);
+	}
+
+/**
+ * test last() method
  *
  * @return void
  */

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -134,6 +134,22 @@ class PaginatorHelper extends AppHelper {
 	}
 
 /**
+ * Convenience access to any of the paginator params.
+ *
+ * @param string $key Key of the paginator params array to retreive.
+ * @param string $model Optional model name. Uses the default if none is specified.
+ * @return mixed Content of the requested param.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::params
+ */
+	public function param($key, $model = null) {
+		$params = $this->params($model);
+		if (!isset($params[$key])) {
+			return null;
+		}
+		return $params[$key];
+	}
+
+/**
  * Sets default options for all pagination links
  *
  * @param array|string $options Default options for pagination links. If a string is supplied - it


### PR DESCRIPTION
Similar to CakeRequest::query(), data(), Session/Cookie read() and other access methods, this seems to be a clean wrapper for the params of PaginatorHelper.
In my case

```
$params = $this->Paginator->params();
if (!empty($params['count'] && ...) {}
```

can then be the cleaner version

```
if ($this->Paginator->param('count') > $x) {}
```

What do you think?
