### PR TITLE
Move boundary calculation inside _render()

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1071,7 +1071,6 @@ class CakeEmail {
 		}
 
 		$this->_textMessage = $this->_htmlMessage = '';
-		$this->_createBoundary();
 		$this->_message = $this->_render($this->_wrap($content));
 
 		$contents = $this->transportClass()->send($this);
@@ -1447,6 +1446,7 @@ class CakeEmail {
 		$content = implode("\n", $content);
 		$rendered = $this->_renderTemplates($content);
 
+		$this->_createBoundary();
 		$msg = array();
 
 		$contentIds = array_filter((array)Hash::extract($this->_attachments, '{s}.contentId'));

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1070,7 +1070,6 @@ class CakeEmail {
 			$content = implode("\n", $content) . "\n";
 		}
 
-		$this->_textMessage = $this->_htmlMessage = '';
 		$this->_message = $this->_render($this->_wrap($content));
 
 		$contents = $this->transportClass()->send($this);
@@ -1443,6 +1442,8 @@ class CakeEmail {
  * @return array Email body ready to be sent
  */
 	protected function _render($content) {
+		$this->_textMessage = $this->_htmlMessage = '';
+
 		$content = implode("\n", $content);
 		$rendered = $this->_renderTemplates($content);
 

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -65,6 +65,14 @@ class TestCakeEmail extends CakeEmail {
 		return $this->_encode($text);
 	}
 
+/**
+ * Render to protected method
+ *
+ */
+	public function render($content) {
+		return $this->_render($content);
+	}
+
 }
 
 /*
@@ -1482,6 +1490,22 @@ class CakeEmailTest extends CakeTestCase {
 			''
 		);
 		$this->assertSame($expected, $result);
+	}
+
+/**
+ * testRender method
+ *
+ * @return void
+ */
+	public function testRenderWithLayoutAndAttachment() {
+		$this->CakeEmail->emailFormat('html');
+		$this->CakeEmail->template('html', 'default');
+		$this->CakeEmail->attachments(array(CAKE . 'basics.php'));
+		$result = $this->CakeEmail->render(array());
+		$this->assertNotEmpty($result);
+
+		$result = $this->CakeEmail->getBoundary();
+		$this->assertNotEmpty($result);
 	}
 
 /**


### PR DESCRIPTION
Bug-Fix: Fixes error / invalid emails when including more attachments via template rendering and callbacks.

Currently, its unfortunate that the boundary value is only calculated prior to the rendering of the HTML layout (which possible can attach more inline images due to included images - e.g. via callback afterLayout as in my case).
But then the boundary value is in some cases not available due to the early decision and as a result the email is invalid.

Either we move the calculation down where the decision can be made with certainty.

Or we also prepare the boundary even if its not needed. It sure does not hurt to do so - but it fixes the issue in a quick way. At least for me the emails were ok again (had to switch to "both" in the meantime here).

We could probably also just remove the if() statement completely. That is what I then did in the second commit. 

But I reverted that part in the 3rd commit to display that it is not needed. Moving the decision down itself resolves the issue.
