### PR TITLE
3.0 postgres foreign keys

### DIFF
--- a/lib/Cake/Database/Dialect/PostgresDialectTrait.php
+++ b/lib/Cake/Database/Dialect/PostgresDialectTrait.php
@@ -81,40 +81,6 @@ trait PostgresDialectTrait {
 	}
 
 /**
- * Returns an update query that has been transformed for Postgres.
- *
- * Postgres requires joins to be defined in the FROM list instead of
- * as standard joins. This translator will erase joins and replace them with
- * an expression object in the FROM clause.
- *
- * @param Cake\Database\Query $query
- * @return Cake\Database\Query
- */
-	protected function _updateQueryTranslator($query) {
-		$joins = $query->clause('join');
-		if (empty($joins)) {
-			return $query;
-		}
-		$first = array_shift($joins);
-		$sql = sprintf('%s %s', $first['table'], $first['alias']);
-		if (isset($first['conditions']) && count($first['conditions'])) {
-			$query->where($first['conditions']);
-		}
-		foreach ($joins as $i => $join) {
-			$sql .= sprintf(' %s JOIN %s %s', $join['type'], $join['table'], $join['alias']);
-			if (isset($join['conditions']) && count($join['conditions'])) {
-				$sql .= sprintf(' ON %s', $join['conditions']);
-			} else {
-				$sql .= ' ON 1 = 1';
-			}
-		}
-		$expr = $query->newExpr()->add($sql);
-		$query->join([], [], true);
-		$query->from([$expr]);
-		return $query;
-	}
-
-/**
  * Returns a function that will be used as a callback for a results decorator.
  * this function is responsible for deleting the artificial column in results
  * used for paginating the query.

--- a/lib/Cake/Database/Query.php
+++ b/lib/Cake/Database/Query.php
@@ -410,12 +410,13 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return string
  */
 	protected function _buildSelectPart($parts) {
+		$driver = $this->_connection->driver();
 		$select = 'SELECT %s%s';
 		$distinct = null;
 		$normalized = [];
 		foreach ($parts as $k => $p) {
 			if (!is_numeric($k)) {
-				$p = $p . ' AS ' . $k;
+				$p = $p . ' AS ' . $driver->quoteIdentifier($k);
 			}
 			$normalized[] = $p;
 		}

--- a/lib/Cake/Database/Query.php
+++ b/lib/Cake/Database/Query.php
@@ -289,7 +289,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return void
  */
 	protected function _traverseUpdate(callable $visitor) {
-		$parts = ['update', 'join', 'set', 'from', 'where'];
+		$parts = ['update', 'set', 'where'];
 		foreach ($parts as $name) {
 			call_user_func($visitor, $this->_parts[$name], $name);
 		}

--- a/lib/Cake/Database/Schema/BaseSchema.php
+++ b/lib/Cake/Database/Schema/BaseSchema.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Database\Schema;
+
+/**
+ * Base class for schema implementations.
+ *
+ * This class contains methods that are common across
+ * the various SQL dialects.
+ */
+class BaseSchema {
+
+/**
+ * Generate an ON clause for a foreign key.
+ *
+ * @param string|null $on The on clause
+ * @return string
+ */
+	protected function _foreignOnClause($on) {
+		if ($on === Table::ACTION_SET_NULL) {
+			return 'SET NULL';
+		}
+		if ($on === Table::ACTION_CASCADE) {
+			return 'CASCADE';
+		}
+		if ($on === Table::ACTION_RESTRICT) {
+			return 'RESTRICT';
+		}
+		if ($on === Table::ACTION_NO_ACTION) {
+			return 'NO ACTION';
+		}
+	}
+
+/**
+ * Convert string on clauses to the abstract ones.
+ *
+ * @param string $clause
+ * @return string|null
+ */
+	protected function _convertOnClause($clause) {
+		if ($clause === 'CASCADE' || $clause === 'RESTRICT') {
+			return strtolower($clause);
+		}
+		if ($clause === 'NO ACTION') {
+			return Table::ACTION_NO_ACTION;
+		}
+		return Table::ACTION_SET_NULL;
+	}
+
+
+/**
+ * Generate the SQL to drop a table.
+ *
+ * @param Cake\Database\Schema\Table $table Table instance
+ * @return array SQL statements to drop DROP a table.
+ */
+	public function dropTableSql(Table $table) {
+		$sql = sprintf(
+			'DROP TABLE %s',
+			$this->_driver->quoteIdentifier($table->name())
+		);
+		return [$sql];
+	}
+
+}

--- a/lib/Cake/Database/Schema/BaseSchema.php
+++ b/lib/Cake/Database/Schema/BaseSchema.php
@@ -61,7 +61,6 @@ class BaseSchema {
 		return Table::ACTION_SET_NULL;
 	}
 
-
 /**
  * Generate the SQL to drop a table.
  *

--- a/lib/Cake/Database/Schema/MysqlSchema.php
+++ b/lib/Cake/Database/Schema/MysqlSchema.php
@@ -22,7 +22,7 @@ use Cake\Database\Schema\Table;
 /**
  * Schema management/reflection features for MySQL
  */
-class MysqlSchema {
+class MysqlSchema extends BaseSchema {
 
 /**
  * The driver instance being used.
@@ -245,22 +245,6 @@ class MysqlSchema {
 	}
 
 /**
- * Convert MySQL on clauses to the abstract ones.
- *
- * @param string $clause
- * @return string|null
- */
-	protected function _convertOnClause($clause) {
-		if ($clause === 'CASCADE' || $clause === 'RESTRICT') {
-			return strtolower($clause);
-		}
-		if ($clause === 'NO ACTION') {
-			return Table::ACTION_NO_ACTION;
-		}
-		return Table::ACTION_SET_NULL;
-	}
-
-/**
  * Generate the SQL to truncate a table.
  *
  * @param Cake\Database\Schema\Table $table Table instance
@@ -268,16 +252,6 @@ class MysqlSchema {
  */
 	public function truncateTableSql(Table $table) {
 		return [sprintf("TRUNCATE TABLE `%s`", $table->name())];
-	}
-
-/**
- * Generate the SQL to drop a table.
- *
- * @param Cake\Database\Schema\Table $table Table instance
- * @return array DROP TABLE sql
- */
-	public function dropTableSql(Table $table) {
-		return [sprintf("DROP TABLE `%s`", $table->name())];
 	}
 
 /**
@@ -454,27 +428,6 @@ class MysqlSchema {
 			);
 		}
 		return $prefix . ' (' . implode(', ', $columns) . ')';
-	}
-
-/**
- * Generate an ON clause for a foreign key.
- *
- * @param string|null $on The on clause
- * @return string
- */
-	protected function _foreignOnClause($on) {
-		if ($on === Table::ACTION_SET_NULL) {
-			return 'SET NULL';
-		}
-		if ($on === Table::ACTION_CASCADE) {
-			return 'CASCADE';
-		}
-		if ($on === Table::ACTION_RESTRICT) {
-			return 'RESTRICT';
-		}
-		if ($on === Table::ACTION_NO_ACTION) {
-			return 'NO ACTION';
-		}
 	}
 
 }

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -22,7 +22,7 @@ use Cake\Database\Schema\Table;
 /**
  * Schema management/reflection features for Postgres.
  */
-class PostgresSchema {
+class PostgresSchema extends BaseSchema {
 
 /**
  * The driver instance being used.
@@ -449,27 +449,6 @@ class PostgresSchema {
 		return $prefix . ' (' . implode(', ', $columns) . ')';
 	}
 
-/**
- * Generate an ON clause for a foreign key.
- *
- * @param string|null $on The on clause
- * @return string
- */
-	protected function _foreignOnClause($on) {
-		if ($on === Table::ACTION_SET_NULL) {
-			return 'SET NULL';
-		}
-		if ($on === Table::ACTION_CASCADE) {
-			return 'CASCADE';
-		}
-		if ($on === Table::ACTION_RESTRICT) {
-			return 'RESTRICT';
-		}
-		if ($on === Table::ACTION_NO_ACTION) {
-			return 'NO ACTION';
-		}
-	}
-
 
 /**
  * Generate the SQL to create a table.
@@ -500,16 +479,6 @@ class PostgresSchema {
 			}
 		}
 		return $out;
-	}
-
-/**
- * Generate the SQL to drop a table.
- *
- * @param Cake\Database\Schema\Table $table Table instance
- * @return array SQL statements to drop DROP a table.
- */
-	public function dropTableSql(Table $table) {
-		return [sprintf('DROP TABLE "%s"', $table->name())];
 	}
 
 /**

--- a/lib/Cake/Database/Schema/PostgresSchema.php
+++ b/lib/Cake/Database/Schema/PostgresSchema.php
@@ -449,7 +449,6 @@ class PostgresSchema extends BaseSchema {
 		return $prefix . ' (' . implode(', ', $columns) . ')';
 	}
 
-
 /**
  * Generate the SQL to create a table.
  *

--- a/lib/Cake/Database/Schema/SqliteSchema.php
+++ b/lib/Cake/Database/Schema/SqliteSchema.php
@@ -22,7 +22,7 @@ use Cake\Database\Schema\Table;
 /**
  * Schema management/reflection features for Sqlite
  */
-class SqliteSchema {
+class SqliteSchema extends BaseSchema {
 
 /**
  * The driver instance being used.
@@ -219,22 +219,6 @@ class SqliteSchema {
 	}
 
 /**
- * Convert Sqlite on clauses to the abstract ones.
- *
- * @param string $clause
- * @return string|null
- */
-	protected function _convertOnClause($clause) {
-		if ($clause === 'CASCADE' || $clause === 'RESTRICT') {
-			return strtolower($clause);
-		}
-		if ($clause === 'NO ACTION') {
-			return Table::ACTION_NO_ACTION;
-		}
-		return Table::ACTION_SET_NULL;
-	}
-
-/**
  * Generate the SQL fragment for a single column in Sqlite
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.
@@ -341,27 +325,6 @@ class SqliteSchema {
 	}
 
 /**
- * Generate an ON clause for a foreign key.
- *
- * @param string|null $on The on clause
- * @return string
- */
-	protected function _foreignOnClause($on) {
-		if ($on === Table::ACTION_SET_NULL) {
-			return 'SET NULL';
-		}
-		if ($on === Table::ACTION_CASCADE) {
-			return 'CASCADE';
-		}
-		if ($on === Table::ACTION_RESTRICT) {
-			return 'RESTRICT';
-		}
-		if ($on === Table::ACTION_NO_ACTION) {
-			return 'NO ACTION';
-		}
-	}
-
-/**
  * Generate the SQL fragment for a single index.
  *
  * @param Cake\Database\Schema\Table $table The table object the column is in.
@@ -399,16 +362,6 @@ class SqliteSchema {
 			$out[] = $index;
 		}
 		return $out;
-	}
-
-/**
- * Generate the SQL to drop a table.
- *
- * @param Cake\Database\Schema\Table $table Table instance
- * @return string DROP TABLE sql
- */
-	public function dropTableSql(Table $table) {
-		return [sprintf('DROP TABLE "%s"', $table->name())];
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Database/ConnectionTest.php
+++ b/lib/Cake/Test/TestCase/Database/ConnectionTest.php
@@ -18,17 +18,17 @@ namespace Cake\Test\TestCase\Database;
 
 use Cake\Core\Configure;
 use Cake\Database\Connection;
+use Cake\Model\ConnectionManager;
 use Cake\TestSuite\TestCase;
 
 /**
  * Tests Connection class
- *
- **/
+ */
 class ConnectionTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->connection = new Connection(Configure::read('Datasource.test'));
+		$this->connection = ConnectionManager::getDataSource('test');
 	}
 
 	public function tearDown() {
@@ -673,8 +673,13 @@ class ConnectionTest extends TestCase {
  * @return void
  */
 	public function testLogBeginRollbackTransaction() {
+		$connection = $this->getMock(
+			'\Cake\Database\Connection',
+			['connect'],
+			[Configure::read('Datasource.test')]
+		);
 		$logger = $this->getMock('\Cake\Database\Log\QueryLogger');
-		$this->connection->logger($logger);
+		$connection->logger($logger);
 		$logger->expects($this->at(0))->method('log')
 			->with($this->logicalAnd(
 				$this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
@@ -685,10 +690,10 @@ class ConnectionTest extends TestCase {
 				$this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
 				$this->attributeEqualTo('query', 'ROLLBACK')
 			));
-		$this->connection->logQueries(true);
-		$this->connection->begin();
-		$this->connection->begin(); //This one will not be logged
-		$this->connection->rollback();
+		$connection->logQueries(true);
+		$connection->begin();
+		$connection->begin(); //This one will not be logged
+		$connection->rollback();
 	}
 
 /**
@@ -698,15 +703,20 @@ class ConnectionTest extends TestCase {
  */
 	public function testLogCommitTransaction() {
 		$logger = $this->getMock('\Cake\Database\Log\QueryLogger');
-		$this->connection->logger($logger);
+		$connection = $this->getMock(
+			'\Cake\Database\Connection',
+			['connect'],
+			[Configure::read('Datasource.test')]
+		);
+		$connection->logger($logger);
 		$logger->expects($this->at(1))->method('log')
 			->with($this->logicalAnd(
 				$this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
 				$this->attributeEqualTo('query', 'COMMIT')
 			));
-		$this->connection->logQueries(true);
-		$this->connection->begin();
-		$this->connection->commit();
+		$connection->logQueries(true);
+		$connection->begin();
+		$connection->commit();
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
+++ b/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
@@ -136,28 +136,4 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 		$driver->connect();
 	}
 
-	public function testUpdateWithJoin() {
-		$driver = $this->getMock('Cake\Database\driver\Postgres', ['_connect', 'connection']);
-		$connection = new Connection(Configure::read('Datasource.test'));
-		$connection->driver($driver);
-
-		$query = new Query($connection);
-
-		$query->update('articles')
-			->set('title', 'New title')
-			->join([
-				'table' => 'authors',
-				'alias' => 'a',
-				'conditions' => 'author_id = a.id'
-			])
-			->join('comments')
-			->where(['articles.id' => 1]);
-		$result = $query->sql(true);
-
-		$this->assertContains('UPDATE articles SET title = :', $result);
-		$this->assertContains('FROM authors a INNER JOIN comments  ON 1 = 1', $result);
-		$this->assertContains('WHERE (articles.id = :', $result);
-		$this->assertContains('AND author_id = a.id)', $result);
-	}
-
 }

--- a/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
+++ b/lib/Cake/Test/TestCase/Database/Driver/PostgresTest.php
@@ -25,7 +25,6 @@ use \PDO;
 
 /**
  * Tests Postgres driver
- *
  */
 class PostgresTest extends \Cake\TestSuite\TestCase {
 

--- a/lib/Cake/Test/TestCase/Database/QueryTest.php
+++ b/lib/Cake/Test/TestCase/Database/QueryTest.php
@@ -1636,35 +1636,6 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Test updates with joins.
- *
- * @return void
- */
-	public function testUpdateWithJoins() {
-		$config = Configure::read('Datasource.test');
-		$this->skipIf(strpos($config['datasource'], 'Sqlite') !== false, 'Sqlite update with join does not work.');
-
-		$query = new Query($this->connection);
-
-		$query->update('articles')
-			->set('title', 'New title')
-			->join([
-				'table' => 'authors',
-				'alias' => 'a',
-				'conditions' => 'author_id = a.id'
-			])
-			->where(['articles.id' => 1]);
-		$result = $query->sql(false);
-
-		$this->assertContains('UPDATE articles INNER JOIN authors a ON author_id = a.id', $result);
-		$this->assertContains('SET title = :', $result);
-		$this->assertContains('WHERE articles.id = :', $result);
-
-		$result = $query->execute();
-		$this->assertCount(1, $result);
-	}
-
-/**
  * You cannot call values() before insert() it causes all sorts of pain.
  *
  * @expectedException Cake\Error\Exception

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -331,7 +331,7 @@ SQL;
 				'columns' => ['title', 'body'],
 				'length' => []
 			],
-			'schema_articles_fk_1' => [
+			'author_idx' => [
 				'type' => 'foreign',
 				'columns' => ['author_id'],
 				'references' => ['schema_authors', 'id'],
@@ -342,7 +342,7 @@ SQL;
 		];
 		$this->assertEquals($expected['primary'], $result->constraint('primary'));
 		$this->assertEquals($expected['content_idx'], $result->constraint('content_idx'));
-		$this->assertEquals($expected['schema_articles_fk_1'], $result->constraint('schema_articles_fk_1'));
+		$this->assertEquals($expected['author_idx'], $result->constraint('author_idx'));
 
 		$this->assertCount(1, $result->indexes());
 		$expected = [

--- a/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/lib/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -46,21 +46,22 @@ class PostgresSchemaTest extends TestCase {
 	protected function _createTables($connection) {
 		$this->_needsConnection();
 
-		$connection->execute('DROP TABLE IF EXISTS articles');
-		$connection->execute('DROP TABLE IF EXISTS authors');
+		$connection->execute('DROP TABLE IF EXISTS schema_articles');
+		$connection->execute('DROP TABLE IF EXISTS schema_authors');
 
 		$table = <<<SQL
-CREATE TABLE authors(
+CREATE TABLE schema_authors (
 id SERIAL,
 name VARCHAR(50),
 bio DATE,
-created TIMESTAMP
+created TIMESTAMP,
+PRIMARY KEY (id)
 )
 SQL;
 		$connection->execute($table);
 
 		$table = <<<SQL
-CREATE TABLE articles(
+CREATE TABLE schema_articles (
 id BIGINT PRIMARY KEY,
 title VARCHAR(20),
 body TEXT,
@@ -68,12 +69,13 @@ author_id INTEGER NOT NULL,
 published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 created TIMESTAMP,
-CONSTRAINT "content_idx" UNIQUE ("title", "body")
+CONSTRAINT "content_idx" UNIQUE ("title", "body"),
+CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE 
 )
 SQL;
 		$connection->execute($table);
-		$connection->execute('COMMENT ON COLUMN "articles"."title" IS \'a title\'');
-		$connection->execute('CREATE INDEX "author_idx" ON "articles" ("author_id")');
+		$connection->execute('COMMENT ON COLUMN "schema_articles"."title" IS \'a title\'');
+		$connection->execute('CREATE INDEX "author_idx" ON "schema_articles" ("author_id")');
 	}
 
 /**
@@ -207,8 +209,8 @@ SQL;
 		$result = $schema->listTables();
 		$this->assertInternalType('array', $result);
 		$this->assertCount(2, $result);
-		$this->assertEquals('articles', $result[0]);
-		$this->assertEquals('authors', $result[1]);
+		$this->assertEquals('schema_articles', $result[0]);
+		$this->assertEquals('schema_authors', $result[1]);
 	}
 
 /**
@@ -221,7 +223,7 @@ SQL;
 		$this->_createTables($connection);
 
 		$schema = new SchemaCollection($connection);
-		$result = $schema->describe('articles');
+		$result = $schema->describe('schema_articles');
 		$expected = [
 			'id' => [
 				'type' => 'biginteger',
@@ -303,7 +305,7 @@ SQL;
 		$this->_createTables($connection);
 
 		$schema = new SchemaCollection($connection);
-		$result = $schema->describe('articles');
+		$result = $schema->describe('schema_articles');
 		$this->assertInstanceOf('Cake\Database\Schema\Table', $result);
 		$expected = [
 			'primary' => [
@@ -317,9 +319,30 @@ SQL;
 				'length' => []
 			]
 		];
-		$this->assertCount(2, $result->constraints());
+		$this->assertCount(3, $result->constraints());
+		$expected = [
+			'primary' => [
+				'type' => 'primary',
+				'columns' => ['id'],
+				'length' => []
+			],
+			'content_idx' => [
+				'type' => 'unique',
+				'columns' => ['title', 'body'],
+				'length' => []
+			],
+			'schema_articles_fk_1' => [
+				'type' => 'foreign',
+				'columns' => ['author_id'],
+				'references' => ['schema_authors', 'id'],
+				'length' => [],
+				'update' => 'cascade',
+				'delete' => 'restrict',
+			]
+		];
 		$this->assertEquals($expected['primary'], $result->constraint('primary'));
 		$this->assertEquals($expected['content_idx'], $result->constraint('content_idx'));
+		$this->assertEquals($expected['schema_articles_fk_1'], $result->constraint('schema_articles_fk_1'));
 
 		$this->assertCount(1, $result->indexes());
 		$expected = [
@@ -465,7 +488,7 @@ SQL;
 		$driver = $this->_getMockedDriver();
 		$schema = new PostgresSchema($driver);
 
-		$table = (new Table('articles'))->addColumn($name, $data);
+		$table = (new Table('schema_articles'))->addColumn($name, $data);
 		$this->assertEquals($expected, $schema->columnSql($table, $name));
 	}
 
@@ -478,7 +501,7 @@ SQL;
 		$driver = $this->_getMockedDriver();
 		$schema = new PostgresSchema($driver);
 
-		$table = new Table('articles');
+		$table = new Table('schema_articles');
 		$table->addColumn('id', [
 				'type' => 'integer',
 				'null' => false
@@ -508,6 +531,36 @@ SQL;
 				['type' => 'unique', 'columns' => ['title', 'author_id']],
 				'CONSTRAINT "unique_idx" UNIQUE ("title", "author_id")'
 			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id']],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'cascade'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE CASCADE ON DELETE RESTRICT'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'restrict'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE RESTRICT ON DELETE RESTRICT'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'setNull'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE SET NULL ON DELETE RESTRICT'
+			],
+			[
+				'author_id_idx',
+				['type' => 'foreign', 'columns' => ['author_id'], 'references' => ['authors', 'id'], 'update' => 'noAction'],
+				'CONSTRAINT "author_id_idx" FOREIGN KEY ("author_id") ' .
+				'REFERENCES "authors" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT'
+			],
 		];
 	}
 
@@ -520,7 +573,7 @@ SQL;
 		$driver = $this->_getMockedDriver();
 		$schema = new PostgresSchema($driver);
 
-		$table = (new Table('articles'))->addColumn('title', [
+		$table = (new Table('schema_articles'))->addColumn('title', [
 			'type' => 'string',
 			'length' => 255
 		])->addColumn('author_id', [
@@ -541,7 +594,7 @@ SQL;
 		$connection->expects($this->any())->method('driver')
 			->will($this->returnValue($driver));
 
-		$table = (new Table('articles'))->addColumn('id', [
+		$table = (new Table('schema_articles'))->addColumn('id', [
 				'type' => 'integer',
 				'null' => false
 			])
@@ -562,7 +615,7 @@ SQL;
 			]);
 
 		$expected = <<<SQL
-CREATE TABLE "articles" (
+CREATE TABLE "schema_articles" (
 "id" SERIAL,
 "title" VARCHAR NOT NULL,
 "body" TEXT,
@@ -575,11 +628,11 @@ SQL;
 		$this->assertCount(3, $result);
 		$this->assertEquals($expected, $result[0]);
 		$this->assertEquals(
-			'CREATE INDEX "title_idx" ON "articles" ("title")',
+			'CREATE INDEX "title_idx" ON "schema_articles" ("title")',
 			$result[1]
 		);
 		$this->assertEquals(
-			'COMMENT ON COLUMN "articles"."title" IS "This is the title"',
+			'COMMENT ON COLUMN "schema_articles"."title" IS "This is the title"',
 			$result[2]
 		);
 	}
@@ -595,10 +648,10 @@ SQL;
 		$connection->expects($this->any())->method('driver')
 			->will($this->returnValue($driver));
 
-		$table = new Table('articles');
+		$table = new Table('schema_articles');
 		$result = $table->dropSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals('DROP TABLE "articles"', $result[0]);
+		$this->assertEquals('DROP TABLE "schema_articles"', $result[0]);
 	}
 
 /**
@@ -612,7 +665,7 @@ SQL;
 		$connection->expects($this->any())->method('driver')
 			->will($this->returnValue($driver));
 
-		$table = new Table('articles');
+		$table = new Table('schema_articles');
 		$table->addColumn('id', 'integer')
 			->addConstraint('primary', [
 				'type' => 'primary',
@@ -620,7 +673,7 @@ SQL;
 			]);
 		$result = $table->truncateSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals('TRUNCATE "articles" RESTART IDENTITY', $result[0]);
+		$this->assertEquals('TRUNCATE "schema_articles" RESTART IDENTITY', $result[0]);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -312,7 +312,11 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		$query = new Query($this->connection);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		Table::build('article', ['connection' => $this->connection]);
-		$table->hasMany('article', ['property' => 'articles', 'strategy' => $strategy]);
+		$table->hasMany('article', [
+			'property' => 'articles',
+			'strategy' => $strategy,
+			'sort' => ['article.id' => 'asc']
+		]);
 
 		$results = $query->repository($table)->select()->contain('article')->toArray();
 		$expected = [
@@ -432,7 +436,11 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		$query = new Query($this->connection);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		$article = Table::build('article', ['connection' => $this->connection]);
-		$table->hasMany('article', ['property' => 'articles'] + compact('strategy'));
+		$table->hasMany('article', [
+			'property' => 'articles',
+			'stratgey' => $strategy,
+			'sort' => ['article.id' => 'asc']
+		]);
 		$article->belongsTo('author');
 
 		$results = $query->repository($table)


### PR DESCRIPTION
Adding basic generation & reflection of foreign keys in postgres. I'm considering that we should probably also add support for `deferred` option as both sqlite and postgres need this option to make foreign keys only take effect at the end of a transaction. MySQL is terrible and doesn't support deferred keys though.

This is also partially a work in progress as there is a now a fair bit of duplicate code in the various schema objects that needs to be cleaned up and extracted into a base class or helper object. I'm open to whether a base class or helper object would be better as I could see it working either way right now.
