### PR TITLE
Set extension with multiple accept based on order in parseExtensions, cu...

### DIFF
--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -229,7 +229,10 @@ class RequestHandlerComponentTest extends CakeTestCase {
 	}
 
 /**
- * Test that ext is not set with multiple accepted content types.
+ * Test that ext is set to the first listed extension with multiple accepted
+ * content types.
+ * Having multiple types accepted with same weight, means the client lets the
+ * server choose the returned content type.
  *
  * @return void
  */
@@ -239,7 +242,27 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		Router::parseExtensions('xml', 'json');
 
 		$this->RequestHandler->initialize($this->Controller);
+		$this->assertEquals('xml', $this->RequestHandler->ext);
+
+		$this->RequestHandler->ext = null;
+		Router::setExtensions(array('json', 'xml'), false);
+
+		$this->RequestHandler->initialize($this->Controller);
+		$this->assertEquals('json', $this->RequestHandler->ext);
+	}
+
+/**
+ * Test that ext is set to type with highest weight
+ *
+ * @return void
+ */
+	public function testInitializeContentTypeWithMultipleAcceptedTypes() {
+		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
 		$this->assertNull($this->RequestHandler->ext);
+		Router::parseExtensions('xml', 'json');
+
+		$this->RequestHandler->initialize($this->Controller);
+		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
 /**


### PR DESCRIPTION
...rrently with multiple accepted types, no extension is set at all
Also when highest weight type is not in parseExtensions, but lower weighted types are, it now will set the lower one, instead of none.
Example: `$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';`
would not change to json, while html is not even accepted here.
