### PR TITLE
Fixed @return statement in DboSource::disconnect

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -280,7 +280,7 @@ class DboSource extends DataSource {
 /**
  * Disconnects from database.
  *
- * @return boolean True if the database could be disconnected, else false
+ * @return boolean Always true
  */
 	public function disconnect() {
 		if ($this->_result instanceof PDOStatement) {


### PR DESCRIPTION
As an alternative we could  check for the return value of closeCursor(), but I thnk it doesn't matter enough in this case...
