### PR TITLE
CakeEmail class be able to setting custom email validation rule.

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -535,8 +535,8 @@ class CakeEmail {
  * @param string $regexp
  * @return string|CakeEmail
  */
-	public function emailRegex($regex = false) {
-		if ($regex === false) {
+	public function emailRegex($regex = null) {
+		if ($regex === null) {
 			return $this->_emailRegex;
 		}
 		$this->_emailRegex = $regex;

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -319,6 +319,14 @@ class CakeEmail {
 	);
 
 /**
+ * Regex for email validation
+ * If null, it will use built in regex
+ *
+ * @var string
+ */
+	protected $_emailRegex = null;
+
+/**
  * Constructor
  *
  * @param array|string $config Array of configs, or string to load configs from email.php
@@ -519,6 +527,20 @@ class CakeEmail {
 			return $this->headerCharset;
 		}
 		return $this->headerCharset = $charset;
+	}
+
+/**
+ * EmailRegex setter/getter
+ *
+ * @param string $regexp
+ * @return string|CakeEmail
+ */
+	public function emailRegex($regex = false) {
+		if ($regex === false) {
+			return $this->_emailRegex;
+		}
+		$this->_emailRegex = $regex;
+		return $this;
 	}
 
 /**
@@ -1161,7 +1183,7 @@ class CakeEmail {
 		$simpleMethods = array(
 			'from', 'sender', 'to', 'replyTo', 'readReceipt', 'returnPath', 'cc', 'bcc',
 			'messageId', 'domain', 'subject', 'viewRender', 'viewVars', 'attachments',
-			'transport', 'emailFormat', 'theme', 'helpers'
+			'transport', 'emailFormat', 'theme', 'helpers', 'emailRegex'
 		);
 		foreach ($simpleMethods as $method) {
 			if (isset($config[$method])) {
@@ -1218,6 +1240,7 @@ class CakeEmail {
 		$this->headerCharset = null;
 		$this->_attachments = array();
 		$this->_config = array();
+		$this->_emailRegex = null;
 		return $this;
 	}
 

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -324,7 +324,7 @@ class CakeEmail {
  *
  * @var string
  */
-	protected $_emailRegex = null;
+	protected $_emailPattern = null;
 
 /**
  * Constructor
@@ -530,16 +530,16 @@ class CakeEmail {
 	}
 
 /**
- * EmailRegex setter/getter
+ * EmailPattern setter/getter
  *
- * @param string $regexp
+ * @param string $regex for email address validation
  * @return string|CakeEmail
  */
-	public function emailRegex($regex = null) {
+	public function emailPattern($regex = null) {
 		if ($regex === null) {
-			return $this->_emailRegex;
+			return $this->_emailPattern;
 		}
-		$this->_emailRegex = $regex;
+		$this->_emailPattern = $regex;
 		return $this;
 	}
 
@@ -554,7 +554,7 @@ class CakeEmail {
  */
 	protected function _setEmail($varName, $email, $name) {
 		if (!is_array($email)) {
-			if (!Validation::email($email, false, $this->_emailRegex)) {
+			if (!Validation::email($email, false, $this->_emailPattern)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));
 			}
 			if ($name === null) {
@@ -568,7 +568,7 @@ class CakeEmail {
 			if (is_int($key)) {
 				$key = $value;
 			}
-			if (!Validation::email($key, false, $this->_emailRegex)) {
+			if (!Validation::email($key, false, $this->_emailPattern)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $key));
 			}
 			$list[$key] = $value;
@@ -608,7 +608,7 @@ class CakeEmail {
  */
 	protected function _addEmail($varName, $email, $name) {
 		if (!is_array($email)) {
-			if (!Validation::email($email, false, $this->_emailRegex)) {
+			if (!Validation::email($email, false, $this->_emailPattern)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));
 			}
 			if ($name === null) {
@@ -622,7 +622,7 @@ class CakeEmail {
 			if (is_int($key)) {
 				$key = $value;
 			}
-			if (!Validation::email($key, false, $this->_emailRegex)) {
+			if (!Validation::email($key, false, $this->_emailPattern)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $key));
 			}
 			$list[$key] = $value;
@@ -1183,7 +1183,7 @@ class CakeEmail {
 		$simpleMethods = array(
 			'from', 'sender', 'to', 'replyTo', 'readReceipt', 'returnPath', 'cc', 'bcc',
 			'messageId', 'domain', 'subject', 'viewRender', 'viewVars', 'attachments',
-			'transport', 'emailFormat', 'theme', 'helpers', 'emailRegex'
+			'transport', 'emailFormat', 'theme', 'helpers', 'emailPattern'
 		);
 		foreach ($simpleMethods as $method) {
 			if (isset($config[$method])) {
@@ -1240,7 +1240,7 @@ class CakeEmail {
 		$this->headerCharset = null;
 		$this->_attachments = array();
 		$this->_config = array();
-		$this->_emailRegex = null;
+		$this->_emailPattern = null;
 		return $this;
 	}
 

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -554,7 +554,7 @@ class CakeEmail {
  */
 	protected function _setEmail($varName, $email, $name) {
 		if (!is_array($email)) {
-			if (!Validation::email($email)) {
+			if (!Validation::email($email, false, $this->_emailRegex)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));
 			}
 			if ($name === null) {
@@ -568,7 +568,7 @@ class CakeEmail {
 			if (is_int($key)) {
 				$key = $value;
 			}
-			if (!Validation::email($key)) {
+			if (!Validation::email($key, false, $this->_emailRegex)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $key));
 			}
 			$list[$key] = $value;
@@ -608,7 +608,7 @@ class CakeEmail {
  */
 	protected function _addEmail($varName, $email, $name) {
 		if (!is_array($email)) {
-			if (!Validation::email($email)) {
+			if (!Validation::email($email, false, $this->_emailRegex)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $email));
 			}
 			if ($name === null) {
@@ -622,7 +622,7 @@ class CakeEmail {
 			if (is_int($key)) {
 				$key = $value;
 			}
-			if (!Validation::email($key)) {
+			if (!Validation::email($key, false, $this->_emailRegex)) {
 				throw new SocketException(__d('cake_dev', 'Invalid email: "%s"', $key));
 			}
 			$list[$key] = $value;

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -265,14 +265,14 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
- * test emailRegex method
+ * test emailPattern method
  *
  * @return void
  */
-	public function testEmailRegex() {
+	public function testEmailPattern() {
 		$regex = '/.+@.+\..+/i';
-		$this->assertNull($this->CakeEmail->emailRegex());
-		$this->assertSame($regex, $this->CakeEmail->emailRegex($regex)->emailRegex());
+		$this->assertNull($this->CakeEmail->emailPattern());
+		$this->assertSame($regex, $this->CakeEmail->emailPattern($regex)->emailPattern());
 	}
 
 /**
@@ -280,10 +280,10 @@ class CakeEmailTest extends CakeTestCase {
  *
  * @return void
  */
-	public function testConfigEmailRegex() {
+	public function testConfigEmailPattern() {
 		$regex = '/.+@.+\..+/i';
-		$email = new CakeEmail(array('emailRegex' => $regex));
-		$this->assertSame($regex, $email->emailRegex());
+		$email = new CakeEmail(array('emailPattern' => $regex));
+		$this->assertSame($regex, $email->emailPattern());
 	}
 
 /**
@@ -292,7 +292,7 @@ class CakeEmailTest extends CakeTestCase {
 	public function testCustomEmailValidation() {
 		$regex = '/^[\.a-z0-9!#$%&\'*+\/=?^_`{|}~-]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]{2,6}$/i';
 
-		$this->CakeEmail->emailRegex($regex)->to('pass.@example.com');
+		$this->CakeEmail->emailPattern($regex)->to('pass.@example.com');
 		$this->assertSame(array(
 			'pass.@example.com' => 'pass.@example.com',
 		), $this->CakeEmail->to());
@@ -312,7 +312,7 @@ class CakeEmailTest extends CakeTestCase {
 			'.extend.@example.com',
 			'.docomo@example.com'
 		);
-		$this->CakeEmail->emailRegex($regex)->to($emails);
+		$this->CakeEmail->emailPattern($regex)->to($emails);
 		$this->assertSame(array(
 			'pass.@example.com' => 'pass.@example.com',
 			'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
@@ -1490,13 +1490,13 @@ class CakeEmailTest extends CakeTestCase {
 	public function testReset() {
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->theme('TestTheme');
-		$this->CakeEmail->emailRegex('/.+@.+\..+/i');
+		$this->CakeEmail->emailPattern('/.+@.+\..+/i');
 		$this->assertSame($this->CakeEmail->to(), array('cake@cakephp.org' => 'cake@cakephp.org'));
 
 		$this->CakeEmail->reset();
 		$this->assertSame($this->CakeEmail->to(), array());
 		$this->assertSame(null, $this->CakeEmail->theme());
-		$this->assertSame(null, $this->CakeEmail->emailRegex());
+		$this->assertSame(null, $this->CakeEmail->emailPattern());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -265,6 +265,28 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
+ * test emailRegex method
+ *
+ * @return void
+ */
+	public function testEmailRegex() {
+		$regex = '/.+@.+\..+/i';
+		$this->assertNull($this->CakeEmail->emailRegex());
+		$this->assertSame($regex, $this->CakeEmail->emailRegex($regex)->emailRegex());
+	}
+
+/**
+ * Tests that it is possible to set email regex configuration to a CakeEmail object
+ *
+ * @return void
+ */
+	public function testConfigEmailRegex() {
+		$regex = '/.+@.+\..+/i';
+		$email = new CakeEmail(array('emailRegex' => $regex));
+		$this->assertSame($regex, $email->emailRegex());
+	}
+
+/**
  * testFormatAddress method
  *
  * @return void
@@ -1427,11 +1449,13 @@ class CakeEmailTest extends CakeTestCase {
 	public function testReset() {
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->theme('TestTheme');
+		$this->CakeEmail->emailRegex('/.+@.+\..+/i');
 		$this->assertSame($this->CakeEmail->to(), array('cake@cakephp.org' => 'cake@cakephp.org'));
 
 		$this->CakeEmail->reset();
 		$this->assertSame($this->CakeEmail->to(), array());
 		$this->assertSame(null, $this->CakeEmail->theme());
+		$this->assertSame(null, $this->CakeEmail->emailRegex());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -287,6 +287,47 @@ class CakeEmailTest extends CakeTestCase {
 	}
 
 /**
+ * Tests that it is possible set custom email validation
+ */
+	public function testCustomEmailValidation() {
+		$regex = '/^[\.a-z0-9!#$%&\'*+\/=?^_`{|}~-]+@[-a-z0-9]+(\.[-a-z0-9]+)*\.[a-z]{2,6}$/i';
+
+		$this->CakeEmail->emailRegex($regex)->to('pass.@example.com');
+		$this->assertSame(array(
+			'pass.@example.com' => 'pass.@example.com',
+		), $this->CakeEmail->to());
+
+		$this->CakeEmail->addTo('pass..old.docomo@example.com');
+		$this->assertSame(array(
+			'pass.@example.com' => 'pass.@example.com',
+			'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+		), $this->CakeEmail->to());
+
+		$this->CakeEmail->reset();
+		$emails = array(
+			'pass.@example.com',
+			'pass..old.docomo@example.com'
+		);
+		$additionalEmails = array(
+			'.extend.@example.com',
+			'.docomo@example.com'
+		);
+		$this->CakeEmail->emailRegex($regex)->to($emails);
+		$this->assertSame(array(
+			'pass.@example.com' => 'pass.@example.com',
+			'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+		), $this->CakeEmail->to());
+
+		$this->CakeEmail->addTo($additionalEmails);
+		$this->assertSame(array(
+			'pass.@example.com' => 'pass.@example.com',
+			'pass..old.docomo@example.com' => 'pass..old.docomo@example.com',
+			'.extend.@example.com' => '.extend.@example.com',
+			'.docomo@example.com' => '.docomo@example.com',
+		), $this->CakeEmail->to());
+	}
+
+/**
  * testFormatAddress method
  *
  * @return void


### PR DESCRIPTION
Some of Japanese cellphone carriers (NTT Docomo and KDDI au) introduced RFC violated mail addresses. Even they fixed it for new registration, they are still widely used.

eg. foo.[at]example.com, .bar[at]example.com, foo..bar[at]example.com

CakeEmail can't set these email address.

This patch be able to set email validation rule to CakeEmail class.

https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3891
