### PR TITLE
Added proper asset exclusion

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -1,6 +1,9 @@
+ErrorDocument 404 /404-not-found
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_URI} !^/(app/webroot/)?(img|css|js)/(.*)$
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
Incorrect assets currently are parsed by the controller, when they should simply be ignored and sent to a webserver 404. 

A 404 ErrorDocument is added so that bad assets are sent to a cakePHP 404 page or could be modified to load a 'static' page 

This removes bad assets from the Controller logic and prevents overloading the server when improper asset requests are made.
