### PR TITLE
MySql DBO Source - Join Support For Update

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -353,6 +353,9 @@ class Mysql extends DboSource {
 		if (isset($conditions['joins'])) {
 			$query['joins'] = $conditions['joins'];
 			unset($conditions['joins']);
+			if (!$conditions) {
+				$conditions = true;
+			}
 		}
 		
 		if (!$this->_useAlias) {

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -349,6 +349,12 @@ class Mysql extends DboSource {
  * @return array
  */
 	public function update(Model $model, $fields = array(), $values = null, $conditions = null) {
+		$query = array('joins' => array());
+		if (isset($conditions['joins'])) {
+			$query['joins'] = $conditions['joins'];
+			unset($conditions['joins']);
+		}
+		
 		if (!$this->_useAlias) {
 			return parent::update($model, $fields, $values, $conditions);
 		}
@@ -367,7 +373,15 @@ class Mysql extends DboSource {
 		if (!empty($conditions)) {
 			$alias = $this->name($model->alias);
 			if ($model->name == $model->alias) {
-				$joins = implode(' ', $this->_getJoins($model));
+				if (!empty($query['joins'])) {
+					$count = count($query['joins']);
+					for ($i = 0; $i < $count; $i++) {
+						if (is_array($query['joins'][$i])) {
+							$query['joins'][$i] = $this->buildJoinStatement($query['joins'][$i]);
+						}
+					}
+				}
+				$joins = implode(' ', array_merge($this->_getJoins($model), $query['joins']));
 			}
 		}
 		$conditions = $this->conditions($this->defaultConditions($model, $conditions, $alias), true, true, $model);


### PR DESCRIPTION
This addition allows the `$conditions` param to contain the standard 'joins' array, and will, if provided, apply the joins to the update, allowing for more advanced usage if desired. 

This enhancement doesn't change anything else, just the meaning of a 'joins' key in the `$conditions` array, which if sticking to standards isn't being used as a model or column name anyway.  This makes for easy adaptation into and most likely no changes to any existing applications in order to use the enhanced datasource.

I'd like to continue this and add more support for `update()`.  Adding other `find` keys into the `$conditions` param seems like a great place to start.

I'd love to hear other thoughts, was there a reason this function doesn't support all of this already?
