### PR TITLE
Hash passwords even when users don't exist.

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -83,6 +83,9 @@ abstract class BaseAuthenticate {
  * conditions for Model::find('first'). If the $password param is not provided
  * the password field will be present in returned array.
  *
+ * Input passwords will be hashed even when a user doesn't exist. This
+ * helps mitigate timing attacks that are attempting to find valid usernames.
+ *
  * @param string|array $username The username/identifier, or an array of find conditions.
  * @param string $password The password, only used if $username param is string.
  * @return boolean|array Either false on failure, or an array of user data.
@@ -95,9 +98,6 @@ abstract class BaseAuthenticate {
 		if (is_array($username)) {
 			$conditions = $username;
 		} else {
-			if (!$password) {
-				return false;
-			}
 			$conditions = array(
 				$model . '.' . $fields['username'] => $username
 			);
@@ -113,6 +113,7 @@ abstract class BaseAuthenticate {
 			'contain' => $this->settings['contain'],
 		));
 		if (empty($result[$model])) {
+			$this->passwordHasher()->hash($password);
 			return false;
 		}
 

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -86,7 +86,8 @@ class DigestAuthenticate extends BasicAuthenticate {
 		'realm' => '',
 		'qop' => 'auth',
 		'nonce' => '',
-		'opaque' => ''
+		'opaque' => '',
+		'passwordHasher' => 'Simple',
 	);
 
 /**


### PR DESCRIPTION
Not hashing passwords when users don't exist means there is an opportunity for timing attacks when people use blowfish or other expensive hashing algorithms.
