### PR TITLE
Removed superfluous break

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -537,7 +537,6 @@ class Sqlserver extends DboSource {
 				} else {
 					return "SELECT {$limit} {$fields} FROM {$table} {$alias} {$joins} {$conditions} {$group} {$order}";
 				}
-			break;
 			case "schema":
 				extract($data);
 


### PR DESCRIPTION
In every case of the if clause it will return, so break is not needed.
