### PR TITLE
3.0 - Event simplification and Helper event migration

### DIFF
--- a/lib/Cake/Event/Event.php
+++ b/lib/Cake/Event/Event.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
@@ -10,11 +9,11 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright	  Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link		  http://cakephp.org CakePHP(tm) Project
- * @package		  Cake.Observer
- * @since		  CakePHP(tm) v 2.1
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link http://cakephp.org CakePHP(tm) Project
+ * @package Cake.Observer
+ * @since CakePHP(tm) v 2.1
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Event;
 
@@ -46,7 +45,7 @@ class Event {
  *
  * @var mixed $data
  */
-	public $data = null;
+	protected $_data = null;
 
 /**
  * Property used to retain the result value of the event listeners
@@ -65,10 +64,6 @@ class Event {
 /**
  * Constructor
  *
- * @param string $name Name of the event
- * @param object $subject the object that this event applies to (usually the object that is generating the event)
- * @param mixed $data any value you wish to be transported with this event to it can be read by listeners
- *
  * ## Examples of usage:
  *
  * {{{
@@ -76,10 +71,13 @@ class Event {
  *	$event = new Event('User.afterRegister', $UserModel);
  * }}}
  *
+ * @param string $name Name of the event
+ * @param object $subject the object that this event applies to (usually the object that is generating the event)
+ * @param array $data any value you wish to be transported with this event to it can be read by listeners
  */
 	public function __construct($name, $subject = null, $data = null) {
 		$this->_name = $name;
-		$this->data = $data;
+		$this->_data = $data;
 		$this->_subject = $subject;
 	}
 
@@ -90,7 +88,7 @@ class Event {
  * @return mixed
  */
 	public function __get($attribute) {
-		if ($attribute === 'name' || $attribute === 'subject') {
+		if ($attribute === 'data' || $attribute === 'name' || $attribute === 'subject') {
 			return $this->{$attribute}();
 		}
 	}
@@ -129,6 +127,15 @@ class Event {
  */
 	public function isStopped() {
 		return $this->_stopped;
+	}
+
+/**
+ * Access the event data/payload.
+ *
+ * @return array
+ */
+	public function data() {
+		return (array)$this->_data;
 	}
 
 }

--- a/lib/Cake/Event/Event.php
+++ b/lib/Cake/Event/Event.php
@@ -45,7 +45,7 @@ class Event {
  *
  * @var mixed $data
  */
-	protected $_data = null;
+	public $data = null;
 
 /**
  * Property used to retain the result value of the event listeners
@@ -77,7 +77,7 @@ class Event {
  */
 	public function __construct($name, $subject = null, $data = null) {
 		$this->_name = $name;
-		$this->_data = $data;
+		$this->data = $data;
 		$this->_subject = $subject;
 	}
 
@@ -88,7 +88,7 @@ class Event {
  * @return mixed
  */
 	public function __get($attribute) {
-		if ($attribute === 'data' || $attribute === 'name' || $attribute === 'subject') {
+		if ($attribute === 'name' || $attribute === 'subject') {
 			return $this->{$attribute}();
 		}
 	}
@@ -135,7 +135,7 @@ class Event {
  * @return array
  */
 	public function data() {
-		return (array)$this->_data;
+		return (array)$this->data;
 	}
 
 }

--- a/lib/Cake/Event/Event.php
+++ b/lib/Cake/Event/Event.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -11,7 +9,6 @@
  *
  * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link http://cakephp.org CakePHP(tm) Project
- * @package Cake.Observer
  * @since CakePHP(tm) v 2.1
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */

--- a/lib/Cake/Event/EventManager.php
+++ b/lib/Cake/Event/EventManager.php
@@ -82,7 +82,7 @@ class EventManager {
 	}
 
 /**
- * Adds a new listener to an event. Listeners
+ * Adds a new listener to an event.
  *
  * @param callback|Cake\Event\EventListener $callable PHP valid callback type or instance of Cake\Event\EventListener to be called
  * when the event named with $eventKey is triggered. If a Cake\Event\EventListener instance is passed, then the `implementedEvents`
@@ -92,10 +92,9 @@ class EventManager {
  * @param string $eventKey The event unique identifier name with which the callback will be associated. If $callable
  * is an instance of Cake\Event\EventListener this argument will be ignored
  *
- * @param array $options used to set the `priority` and `passParams` flags to the listener.
+ * @param array $options used to set the `priority` flag to the listener. In the future more options may be added.
  * Priorities are handled like queues, and multiple attachments added to the same priority queue will be treated in
- * the order of insertion. `passParams` means that the event data property will be converted to function arguments
- * when the listener is called. If $called is an instance of Cake\Event\EventListener, this parameter will be ignored
+ * the order of insertion. 
  *
  * @return void
  * @throws InvalidArgumentException When event key is missing or callable is not an
@@ -109,10 +108,9 @@ class EventManager {
 			$this->_attachSubscriber($callable);
 			return;
 		}
-		$options = $options + array('priority' => static::$defaultPriority, 'passParams' => false);
+		$options = $options + array('priority' => static::$defaultPriority);
 		$this->_listeners[$eventKey][$options['priority']][] = array(
 			'callable' => $callable,
-			'passParams' => $options['passParams'],
 		);
 	}
 
@@ -243,8 +241,10 @@ class EventManager {
 			if ($event->isStopped()) {
 				break;
 			}
-			if ($listener['passParams'] === true) {
-				$result = call_user_func_array($listener['callable'], $event->data);
+			$data = $event->data();
+			if ($data !== null) {
+				array_unshift($data, $event);
+				$result = call_user_func_array($listener['callable'], $data);
 			} else {
 				$result = call_user_func($listener['callable'], $event);
 			}

--- a/lib/Cake/Event/EventManager.php
+++ b/lib/Cake/Event/EventManager.php
@@ -1,8 +1,5 @@
 <?php
 /**
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -10,11 +7,10 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright	  Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link		  http://cakephp.org CakePHP(tm) Project
- * @package		  Cake.Event
- * @since		  CakePHP(tm) v 2.1
- * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link http://cakephp.org CakePHP(tm) Project
+ * @since CakePHP(tm) v 2.1
+ * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Event;
 
@@ -25,8 +21,6 @@ use Cake\Error;
  * data to them, and firing them in the correct order, when associated events are triggered. You
  * can create multiple instances of this object to manage local events or keep a single instance
  * and pass it around to manage all events in your app.
- *
- * @package Cake.Event
  */
 class EventManager {
 

--- a/lib/Cake/Test/TestApp/View/Posts/test_nocache_tags.ctp
+++ b/lib/Cake/Test/TestApp/View/Posts/test_nocache_tags.ctp
@@ -1,5 +1,4 @@
 <?php
-use Cake\Cache\Cache;
 use Cake\Model\ConnectionManager;
 use Cake\Core\Configure;
 ?>
@@ -16,36 +15,6 @@ use Cake\Core\Configure;
 		?>
 	</span>
 	<!--/nocache-->
-</p>
-<p>
-	<span class="notice">
-		<?php
-			echo __d('cake', 'Your cache is ');
-			if (Cache::engine('default')):
-				echo __d('cake', 'set up and initialized properly.');
-				$settings = Cache::settings();
-				echo '<p>' . $settings['engine'];
-				echo __d('cake', ' is being used to cache, to change this edit App/Config/cache.php ');
-				echo '</p>';
-
-				echo 'Settings: <ul>';
-				foreach ($settings as $name => $value):
-					if (is_array($value)):
-						$value = join(',', $value);
-					endif;
-					echo '<li>' . $name . ': ' . $value . '</li>';
-				endforeach;
-				echo '</ul>';
-
-			else:
-				echo __d('cake', 'NOT working.');
-				echo '<br />';
-				if (is_writable(TMP)):
-					echo __d('cake', 'Edit: App/Config/cache.php to insure you have the newset version of this file and the variable $cakeCache set properly');
-				endif;
-			endif;
-		?>
-	</span>
 </p>
 <p>
 	<span class="notice">

--- a/lib/Cake/Test/TestCase/Event/EventManagerTest.php
+++ b/lib/Cake/Test/TestCase/Event/EventManagerTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -11,7 +9,6 @@
  *
  * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link http://cakephp.org CakePHP Project
- * @package Cake.Test.Case.Event
  * @since CakePHP v 2.1
  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -24,8 +21,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * Mock class used to test event dispatching
- *
- * @package Cake.Test.TestCase.Event
  */
 class EventTestListener {
 
@@ -63,8 +58,6 @@ class EventTestListener {
 
 /**
  * Mock used for testing the subscriber objects
- *
- * @package Cake.Test.TestCase.Event
  */
 class CustomTestEventListerner extends EventTestListener implements EventListener {
 
@@ -95,7 +88,6 @@ class CustomTestEventListerner extends EventTestListener implements EventListene
  *
  */
 class EventManagerTest extends TestCase {
-
 /**
  * Tests the attach() method for a single event key in multiple queues
  *

--- a/lib/Cake/Test/TestCase/Event/EventTest.php
+++ b/lib/Cake/Test/TestCase/Event/EventTest.php
@@ -1,11 +1,5 @@
 <?php
 /**
- * ControllerTestCaseTest file
- *
- * Test Case for ControllerTestCase class
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -15,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP Project
- * @package       Cake.Test.Case.Event
  * @since         CakePHP v 2.1
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */

--- a/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
@@ -365,7 +365,6 @@ object(Cake\View\View) {
 	[protected] _currentType => ''
 	[protected] _stack => array()
 	[protected] _eventManager => object(Cake\Event\EventManager) {}
-	[protected] _eventManagerConfigured => false
 }
 TEXT;
 

--- a/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
@@ -120,16 +120,16 @@ class CacheHelperTest extends TestCase {
 
 		$View = new View($this->Controller);
 		$result = $View->render('index');
-		$this->assertNotRegExp('/cake:nocache/', $result);
-		$this->assertNotRegExp('/php echo/', $result);
+		$this->assertNotContains('cake:nocache', $result);
+		$this->assertNotContains('<?php echo', $result);
 
 		$filename = CACHE . 'views/cachetest_cache_parsing.php';
 		$this->assertTrue(file_exists($filename));
 
 		$contents = file_get_contents($filename);
-		$this->assertRegExp('/php echo \$variable/', $contents);
-		$this->assertRegExp('/php echo microtime()/', $contents);
-		$this->assertRegExp('/clark kent/', $result);
+		$this->assertContains('<?php echo $variable', $contents);
+		$this->assertContains('<?php echo microtime()', $contents);
+		$this->assertContains('clark kent', $result);
 
 		unlink($filename);
 	}
@@ -547,14 +547,7 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', 'content')
 			->will($this->returnValue(''));
 
-		$Cache->afterRenderFile('posts/index', 'content');
-
-		Configure::write('Cache.check', false);
-		$Cache->afterRender('posts/index');
-
-		Configure::write('Cache.check', true);
-		$View->cacheAction = false;
-		$Cache->afterRender('posts/index');
+		$Cache->afterRenderFile(null, 'posts/index', 'content');
 	}
 
 /**
@@ -574,14 +567,14 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', $View->fetch('content'))
 			->will($this->returnValue(''));
 
-		$Cache->afterLayout('posts/index');
+		$Cache->afterLayout(null, 'posts/index');
 
 		Configure::write('Cache.check', false);
-		$Cache->afterLayout('posts/index');
+		$Cache->afterLayout(null, 'posts/index');
 
 		Configure::write('Cache.check', true);
 		$View->cacheAction = false;
-		$Cache->afterLayout('posts/index');
+		$Cache->afterLayout(null, 'posts/index');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
@@ -547,7 +547,7 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', 'content')
 			->will($this->returnValue(''));
 
-		$event = $this->getMock('Cake\Event\Event');
+		$event = $this->getMock('Cake\Event\Event', [], ['View.afterRenderFile']);
 		$Cache->afterRenderFile($event, 'posts/index', 'content');
 	}
 
@@ -568,7 +568,7 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', $View->fetch('content'))
 			->will($this->returnValue(''));
 
-		$event = $this->getMock('Cake\Event\Event');
+		$event = $this->getMock('Cake\Event\Event', [], ['View.afterLayout']);
 		$Cache->afterLayout($event, 'posts/index');
 
 		Configure::write('Cache.check', false);

--- a/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
@@ -547,7 +547,8 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', 'content')
 			->will($this->returnValue(''));
 
-		$Cache->afterRenderFile(null, 'posts/index', 'content');
+		$event = $this->getMock('Cake\Event\Event');
+		$Cache->afterRenderFile($event, 'posts/index', 'content');
 	}
 
 /**
@@ -567,14 +568,15 @@ class CacheHelperTest extends TestCase {
 			->with('posts/index', $View->fetch('content'))
 			->will($this->returnValue(''));
 
-		$Cache->afterLayout(null, 'posts/index');
+		$event = $this->getMock('Cake\Event\Event');
+		$Cache->afterLayout($event, 'posts/index');
 
 		Configure::write('Cache.check', false);
-		$Cache->afterLayout(null, 'posts/index');
+		$Cache->afterLayout($event, 'posts/index');
 
 		Configure::write('Cache.check', true);
 		$View->cacheAction = false;
-		$Cache->afterLayout(null, 'posts/index');
+		$Cache->afterLayout($event, 'posts/index');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -741,7 +741,7 @@ class PaginatorHelperTest extends TestCase {
 
 		$this->Paginator->request->params['pass'] = array(2);
 		$this->Paginator->request->query = array('foo' => 'bar', 'x' => 'y');
-		$this->Paginator->beforeRender('posts/index');
+		$this->Paginator->beforeRender(null, 'posts/index');
 
 		$result = $this->Paginator->sort('title');
 		$expected = array(

--- a/lib/Cake/Test/TestCase/View/HelperTest.php
+++ b/lib/Cake/Test/TestCase/View/HelperTest.php
@@ -984,12 +984,14 @@ class HelperTest extends TestCase {
 		), App::RESET);
 		Plugin::loadAll();
 
+		$events = $this->getMock('\Cake\Event\EventManager');
+		$this->View->setEventManager($events);
+
+		$events->expects($this->never())
+			->method('attach');
+
 		$Helper = new TestHelper($this->View);
 		$Helper->OtherHelper;
-
-		$result = $this->View->Helpers->enabled();
-		$expected = array();
-		$this->assertEquals($expected, $result, 'Helper helpers were attached to the collection.');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/View/ViewTest.php
+++ b/lib/Cake/Test/TestCase/View/ViewTest.php
@@ -699,13 +699,16 @@ class ViewTest extends TestCase {
  *
  */
 	public function testElementCallbacks() {
-		$mock = $this->getMock('Cake\View\Helper', [], [$this->View]);
-		$mock->expects($this->at(0))->method('beforeRender');
-		$mock->expects($this->at(1))->method('afterRender');
-		$this->View->Helpers->set('Test', $mock);
-		$this->View->Helpers->enable('Test');
+		$count = 0;
+		$callback = function ($event, $file) use (&$count) {
+			$count++;
+		};
+		$events = $this->View->getEventManager();
+		$events->attach($callback, 'View.beforeRender');
+		$events->attach($callback, 'View.afterRender');
 
 		$this->View->element('test_element', array(), array('callbacks' => true));
+		$this->assertEquals(2, $count);
 	}
 
 /**
@@ -854,10 +857,11 @@ class ViewTest extends TestCase {
  */
 	public function testHelperCallbackTriggering() {
 		$View = new View($this->PostsController);
-		$View->helpers = array();
-		$View->Helpers = $this->getMock('Cake\View\HelperCollection', array('trigger'), array($View));
 
-		$View->Helpers->expects($this->at(0))->method('trigger')
+		$manager = $this->getMock('Cake\Event\EventManager');
+		$View->setEventManager($manager);
+
+		$manager->expects($this->at(0))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -865,7 +869,8 @@ class ViewTest extends TestCase {
 					$this->attributeEqualTo('_subject', $View)
 				)
 			);
-		$View->Helpers->expects($this->at(1))->method('trigger')
+
+		$manager->expects($this->at(1))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -874,7 +879,7 @@ class ViewTest extends TestCase {
 				)
 			);
 
-		$View->Helpers->expects($this->at(2))->method('trigger')
+		$manager->expects($this->at(2))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -882,7 +887,8 @@ class ViewTest extends TestCase {
 					$this->attributeEqualTo('_subject', $View)
 				)
 			);
-		$View->Helpers->expects($this->at(3))->method('trigger')
+
+		$manager->expects($this->at(3))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -891,7 +897,7 @@ class ViewTest extends TestCase {
 				)
 			);
 
-		$View->Helpers->expects($this->at(4))->method('trigger')
+		$manager->expects($this->at(4))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -900,7 +906,7 @@ class ViewTest extends TestCase {
 				)
 			);
 
-		$View->Helpers->expects($this->at(5))->method('trigger')
+		$manager->expects($this->at(5))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -909,7 +915,7 @@ class ViewTest extends TestCase {
 				)
 			);
 
-		$View->Helpers->expects($this->at(6))->method('trigger')
+		$manager->expects($this->at(6))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),
@@ -918,7 +924,7 @@ class ViewTest extends TestCase {
 				)
 			);
 
-		$View->Helpers->expects($this->at(7))->method('trigger')
+		$manager->expects($this->at(7))->method('dispatch')
 			->with(
 				$this->logicalAnd(
 					$this->isInstanceOf('Cake\Event\Event'),

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -19,6 +19,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Object;
 use Cake\Core\Plugin;
+use Cake\Event\EventListener;
 use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Hash;
@@ -31,7 +32,7 @@ use Cake\Utility\ObjectCollection;
  *
  * @package       Cake.View
  */
-class Helper extends Object {
+class Helper extends Object implements EventListener {
 
 /**
  * Settings for this helper.
@@ -861,6 +862,35 @@ class Helper extends Object {
  * @return void
  */
 	public function afterRenderFile($viewfile, $content) {
+	}
+
+/**
+ * Get the View callbacks this helper is interested in.
+ *
+ * By defining one of the callback methods a helper is assumed
+ * to be interested in the related event.
+ *
+ * Override this method if you need to add non-conventional event listeners.
+ * Or if you want helpers to listen to non-standard events.
+ *
+ * @return array
+ */
+	public function implementedEvents() {
+		$eventMap = [
+			'View.beforeRenderFile' => 'beforeRenderFile',
+			'View.afterRenderFile' => 'afterRenderFile',
+			'View.beforeRender' => 'beforeRender',
+			'View.afterRender' => 'afterRender',
+			'View.beforeLayout' => 'beforeLayout',
+			'View.afterLayout' => 'afterLayout'
+		];
+		$events = [];
+		foreach ($eventMap as $event => $method) {
+			if (method_exists($this, $method)) {
+				$events[$event] = $method;
+			}
+		}
+		return $events;
 	}
 
 /**

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -30,6 +30,23 @@ use Cake\Utility\ObjectCollection;
  * Abstract base class for all other Helpers in CakePHP.
  * Provides common methods and features.
  *
+ *
+ * ## Callback methods
+ *
+ * Helpers support a number of callback methods. These callbacks allow you to hook into
+ * the various view lifecycle events and either modify existing view content or perform
+ * other application specific logic. The events are not implemented by this base class, as
+ * implementing a callback method subscribes a helper to the related event. The callback methods
+ * are as follows:
+ *
+ * - `beforeRender(Event $event, $viewFile)` - beforeRender is called before the view file is rendered.
+ * - `afterRender(Event $event, $viewFile)` - afterRender is called after the view file is rendered
+ *   but before the layout has been rendered.
+ * - beforeLayout(Event $event, $layoutFile)` - beforeLayout is called before the layout is rendered.
+ * - `afterLayout(Event $event, $layoutFile)` - afterLayout is called after the layout has rendered.
+ * - `beforeRenderFile(Event $event, $viewFile)` - Called before any view fragment is rendered.
+ * - `afterRenderFile(Event $event, $viewFile, $content)` - Called after any view fragment is rendered.
+ *
  * @package       Cake.View
  */
 class Helper extends Object implements EventListener {
@@ -792,76 +809,6 @@ class Helper extends Object implements EventListener {
  */
 	public function output($str) {
 		return $str;
-	}
-
-/**
- * Before render callback. beforeRender is called before the view file is rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $viewFile The view file that is going to be rendered
- * @return void
- */
-	public function beforeRender($viewFile) {
-	}
-
-/**
- * After render callback. afterRender is called after the view file is rendered
- * but before the layout has been rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $viewFile The view file that was rendered.
- * @return void
- */
-	public function afterRender($viewFile) {
-	}
-
-/**
- * Before layout callback. beforeLayout is called before the layout is rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $layoutFile The layout about to be rendered.
- * @return void
- */
-	public function beforeLayout($layoutFile) {
-	}
-
-/**
- * After layout callback. afterLayout is called after the layout has rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $layoutFile The layout file that was rendered.
- * @return void
- */
-	public function afterLayout($layoutFile) {
-	}
-
-/**
- * Before render file callback.
- * Called before any view fragment is rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $viewFile The file about to be rendered.
- * @return void
- */
-	public function beforeRenderFile($viewfile) {
-	}
-
-/**
- * After render file callback.
- * Called after any view fragment is rendered.
- *
- * Overridden in subclasses.
- *
- * @param string $viewFile The file just be rendered.
- * @param string $content The content that was rendered.
- * @return void
- */
-	public function afterRenderFile($viewfile, $content) {
 	}
 
 /**

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -46,6 +46,7 @@ use Cake\Utility\ObjectCollection;
  * - `afterLayout(Event $event, $layoutFile)` - afterLayout is called after the layout has rendered.
  * - `beforeRenderFile(Event $event, $viewFile)` - Called before any view fragment is rendered.
  * - `afterRenderFile(Event $event, $viewFile, $content)` - Called after any view fragment is rendered.
+ *   If a listener returns a non-null value, the output of the rendered file will be set to that.
  *
  * @package       Cake.View
  */

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -64,10 +64,11 @@ class CacheHelper extends Helper {
 /**
  * Parses the view file and stores content for cache file building.
  *
+ * @param Cake\Event\Event $event The event instance.
  * @param string $viewFile
  * @return void
  */
-	public function afterRenderFile($viewFile, $output) {
+	public function afterRenderFile($event, $viewFile, $output) {
 		if ($this->_enabled()) {
 			return $this->_parseContent($viewFile, $output);
 		}
@@ -76,10 +77,11 @@ class CacheHelper extends Helper {
 /**
  * Parses the layout file and stores content for cache file building.
  *
+ * @param Cake\Event\Event $event The event instance.
  * @param string $layoutFile
  * @return void
  */
-	public function afterLayout($layoutFile) {
+	public function afterLayout($event, $layoutFile) {
 		if ($this->_enabled()) {
 			$this->_View->assign(
 				'content',

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -64,15 +64,15 @@ class PaginatorHelper extends Helper {
 /**
  * Before render callback. Overridden to merge passed args with url options.
  *
+ * @param Cake\Event\Event $event The event instance.
  * @param string $viewFile
  * @return void
  */
-	public function beforeRender($viewFile) {
+	public function beforeRender($event, $viewFile) {
 		$this->options['url'] = array_merge($this->request->params['pass']);
 		if (!empty($this->request->query)) {
 			$this->options['url']['?'] = $this->request->query;
 		}
-		parent::beforeRender($viewFile);
 	}
 
 /**

--- a/lib/Cake/View/HelperCollection.php
+++ b/lib/Cake/View/HelperCollection.php
@@ -62,8 +62,7 @@ class HelperCollection {
  */
 	public function __construct(View $view) {
 		$this->_View = $view;
-		$eventManager = $view->getEventManager();
-		$this->_eventManager = $eventManager;
+		$this->_eventManager = $view->getEventManager();
 	}
 
 /**

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -305,13 +305,6 @@ class View extends Object {
 	protected $_eventManager = null;
 
 /**
- * Whether the event manager was already configured for this object
- *
- * @var boolean
- */
-	protected $_eventManagerConfigured = false;
-
-/**
  * Constant for view file type 'view'
  */
 	const TYPE_VIEW = 'view';
@@ -365,10 +358,6 @@ class View extends Object {
 	public function getEventManager() {
 		if (empty($this->_eventManager)) {
 			$this->_eventManager = new EventManager();
-		}
-		if (!$this->_eventManagerConfigured) {
-			$this->_eventManager->attach($this->Helpers);
-			$this->_eventManagerConfigured = true;
 		}
 		return $this->_eventManager;
 	}

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -363,6 +363,18 @@ class View extends Object {
 	}
 
 /**
+ * Set the Eventmanager used by View.
+ *
+ * Primarily useful for testing.
+ *
+ * @param Cake\Event\EventManager $eventManager.
+ * @return void
+ */
+	public function setEventManager(EventManager $eventManager) {
+		$this->_eventManager = $eventManager;
+	}
+
+/**
  * Renders a piece of PHP with provided parameters and returns HTML, XML, or any other string.
  *
  * This realizes the concept of Elements, (or "partial layouts") and the $params array is used to send
@@ -854,9 +866,10 @@ class View extends Object {
 		$content = $this->_evaluate($viewFile, $data);
 
 		$afterEvent = new Event('View.afterRenderFile', $this, array($viewFile, $content));
-		$afterEvent->modParams = 1;
 		$eventManager->dispatch($afterEvent);
-		$content = $afterEvent->data[1];
+		if (isset($afterEvent->result)) {
+			$content = $afterEvent->result;
+		}
 
 		if (isset($this->_parents[$viewFile])) {
 			$this->_stack[] = $this->fetch('content');

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -823,7 +823,7 @@ class View extends Object {
  * @return void
  */
 	public function loadHelpers() {
-		$helpers = HelperCollection::normalizeObjectArray($this->helpers);
+		$helpers = ObjectCollection::normalizeObjectArray($this->helpers);
 		foreach ($helpers as $properties) {
 			list(, $class) = pluginSplit($properties['class']);
 			$this->{$class} = $this->Helpers->load($properties['class'], $properties['settings']);


### PR DESCRIPTION
This is the first pull request in an upcoming series focused on cleaning up and streamlining the callbacks used in the various tiers of the frameworks. I've made a number of intentional and API breaking changes:
- No more enabled/disabled get/set methods on Collection/Factory objects.
- Many options removed from Event subsystem.
- passParams is always on now, and there is no way to disable it. Fewer configuration options and runtime options means simpler code that requires fewer tests and less documentation. I'll be removing more options/flags in future pull requests.
- Helpers now directly bind to event managers. This cuts out a layer of indirection saving some time.
- Helper no longer implements callback methods. While this breaks callbacks with parent calls, it also greatly reduces the number of event handlers that are bound/invoked cutting response times down.

I've documented the plan I'll be following for the larger set of changes [in this wiki page](https://github.com/markstory/cakephp/wiki/Event-system-cleanup).
