### PR TITLE
ticket-3902 - paginator and display of order via model default order

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -396,7 +396,9 @@ class PaginatorComponent extends Component {
 			}
 			$options['order'] = $order;
 		}
-
+		if (empty($options['order']) && !empty($object->order)) {
+			$options['order'] = $object->order;
+		}
 		return $options;
 	}
 

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -578,6 +578,31 @@ class PaginatorComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test paginate() and  model default order
+ *
+ * @return void
+ */
+	public function testPaginateOrderModelDefault() {
+		$Controller = new PaginatorTestController($this->request);
+		$Controller->uses = array('PaginatorControllerPost');
+		$Controller->params['url'] = array();
+		$Controller->constructClasses();
+		$Controller->PaginatorControllerPost->order = array(
+			$Controller->PaginatorControllerPost->alias . '.created' => 'desc'
+		);
+
+		$Controller->Paginator->settings = array(
+			'fields' => array('id', 'title', 'created'),
+			'maxLimit' => 10,
+			'paramType' => 'named'
+		);
+		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
+		$expected = array('2007-03-18 10:43:23',  '2007-03-18 10:41:23', '2007-03-18 10:39:23');
+		$this->assertEquals($expected, Hash::extract($result, '{n}.PaginatorControllerPost.created'));
+		$this->assertEquals($Controller->PaginatorControllerPost->order, $this->Controller->request['paging']['PaginatorControllerPost']['order']);
+	}
+
+/**
  * test paginate() and virtualField interactions
  *
  * @return void

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -597,7 +597,7 @@ class PaginatorComponentTest extends CakeTestCase {
 			'paramType' => 'named'
 		);
 		$result = $Controller->Paginator->paginate('PaginatorControllerPost');
-		$expected = array('2007-03-18 10:43:23',  '2007-03-18 10:41:23', '2007-03-18 10:39:23');
+		$expected = array('2007-03-18 10:43:23', '2007-03-18 10:41:23', '2007-03-18 10:39:23');
 		$this->assertEquals($expected, Hash::extract($result, '{n}.PaginatorControllerPost.created'));
 		$this->assertEquals($Controller->PaginatorControllerPost->order, $this->Controller->request['paging']['PaginatorControllerPost']['order']);
 	}


### PR DESCRIPTION
see https://cakephp.lighthouseapp.com/projects/42648/tickets/3902-pagination-helper-sort-output-issue

to be clear: it does not change the ordering itself. but without this the helper does not get any "order" info. so the ordering would be applied all right, but the paginator does not add the asc/desc class to the header row.

this fixes the display as the component now passes this information back into the request object array "paging".
