### PR TITLE
Minor doc block improvements

### DIFF
--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -36,13 +36,12 @@ class CakeBaseException extends RuntimeException {
 /**
  * Get/set the response header to be used
  *
- * See also CakeResponse::header()
- *
  * @param string|array $header. An array of header strings or a single header string
  *	- an associative array of "header name" => "header value"
  *	- an array of string headers is also accepted
  * @param string $value. The header value.
  * @return array
+ * @see CakeResponse::header() See also
  */
 	public function responseHeader($header = null, $value = null) {
 		if ($header) {
@@ -79,7 +78,7 @@ class BadRequestException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Bad Request' will be the message
- * @param string $code Status code, defaults to 400
+ * @param int $code Status code, defaults to 400
  */
 	public function __construct($message = null, $code = 400) {
 		if (empty($message)) {
@@ -101,7 +100,7 @@ class UnauthorizedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Unauthorized' will be the message
- * @param string $code Status code, defaults to 401
+ * @param int $code Status code, defaults to 401
  */
 	public function __construct($message = null, $code = 401) {
 		if (empty($message)) {
@@ -123,7 +122,7 @@ class ForbiddenException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Forbidden' will be the message
- * @param string $code Status code, defaults to 403
+ * @param int $code Status code, defaults to 403
  */
 	public function __construct($message = null, $code = 403) {
 		if (empty($message)) {
@@ -145,7 +144,7 @@ class NotFoundException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Not Found' will be the message
- * @param string $code Status code, defaults to 404
+ * @param int $code Status code, defaults to 404
  */
 	public function __construct($message = null, $code = 404) {
 		if (empty($message)) {
@@ -167,7 +166,7 @@ class MethodNotAllowedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Method Not Allowed' will be the message
- * @param string $code Status code, defaults to 405
+ * @param int $code Status code, defaults to 405
  */
 	public function __construct($message = null, $code = 405) {
 		if (empty($message)) {
@@ -189,7 +188,7 @@ class InternalErrorException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Internal Server Error' will be the message
- * @param string $code Status code, defaults to 500
+ * @param int $code Status code, defaults to 500
  */
 	public function __construct($message = null, $code = 500) {
 		if (empty($message)) {
@@ -231,7 +230,7 @@ class CakeException extends CakeBaseException {
  *
  * @param string|array $message Either the string of the error message, or an array of attributes
  *   that are made available in the view, and sprintf()'d into CakeException::$_messageTemplate
- * @param string $code The code of the error, is also the HTTP status code for the error.
+ * @param int $code The code of the error, is also the HTTP status code for the error.
  */
 	public function __construct($message, $code = 500) {
 		if (is_array($message)) {


### PR DESCRIPTION
http://ch1.php.net/manual/de/exception.construct.php
Second parameter gets only passed by. Exception constructor uses an int for the second parameter,not a string.

Replaced text by docblock @see
http://www.phpdoc.org/docs/latest/for-users/phpdoc/tags/see.html
