### PR TITLE
Some love for a deprecated class

### DIFF
--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -29,9 +29,9 @@ App::uses('CakeEmail', 'Network/Email');
  * based on the standard outlined in http://www.rfc-editor.org/rfc/rfc2822.txt
  *
  * @package       Cake.Controller.Component
- * @link http://book.cakephp.org/2.0/en/core-libraries/components/email.html
- * @link http://book.cakephp.org/2.0/en/core-utility-libraries/email.html
- * @deprecated Use Network/CakeEmail
+ * @link          http://book.cakephp.org/2.0/en/core-libraries/components/email.html
+ * @link          http://book.cakephp.org/2.0/en/core-utility-libraries/email.html
+ * @deprecated    Will be removed in 3.0. Use Network/CakeEmail instead
  */
 class EmailComponent extends Component {
 


### PR DESCRIPTION
Whitespace and wording.

Optionally we could include a version number until when this class will work. I assumed this will be 3.0...
http://www.phpdoc.org/docs/latest/for-users/phpdoc/tags/deprecated.html
I treid that but after I let apigen generate the doc and I saw it did nothing special about it ;-/
