### PR TITLE
remove @access and unnecessary $name

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -338,7 +338,6 @@ class TestShell extends Shell {
  * @param string $file
  * @param string $category
  * @param boolean $throwOnMissingFile
- * @access protected
  * @return array array(type, case)
  * @throws Exception
  */
@@ -414,7 +413,6 @@ class TestShell extends Shell {
  * For the given file, what category of test is it? returns app, core or the name of the plugin
  *
  * @param string $file
- * @access protected
  * @return string
  */
 	protected function _mapFileToCategory($file) {

--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -415,7 +415,6 @@ class DataSource extends Object {
  * Returns the schema name. Override this in subclasses.
  *
  * @return string schema name
- * @access public
  */
 	public function getSchemaName() {
 		return null;
@@ -425,7 +424,6 @@ class DataSource extends Object {
  * Closes a connection. Override in subclasses
  *
  * @return boolean
- * @access public
  */
 	public function close() {
 		return $this->connected = false;

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -95,7 +95,6 @@ class Model extends Object implements CakeEventListener {
  * Holds physical schema/database name for this model. Automatically set during Model creation.
  *
  * @var string
- * @access public
  */
 	public $schemaName = null;
 

--- a/lib/Cake/Test/Case/Core/ObjectTest.php
+++ b/lib/Cake/Test/Case/Core/ObjectTest.php
@@ -49,14 +49,12 @@ class RequestActionController extends Controller {
  * uses property
  *
  * @var array
- * @access public
  */
 	public $uses = array('RequestActionPost');
 
 /**
  * test_request_action method
  *
- * @access public
  * @return void
  */
 	public function test_request_action() {
@@ -68,7 +66,6 @@ class RequestActionController extends Controller {
  *
  * @param mixed $id
  * @param mixed $other
- * @access public
  * @return void
  */
 	public function another_ra_test($id, $other) {

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -533,7 +533,6 @@ class CakeSchemaTest extends CakeTestCase {
 /**
  * testSchemaReadWithAppModel method
  *
- * @access public
  * @return void
  */
 	public function testSchemaReadWithAppModel() {

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -239,7 +239,6 @@ class ModelIntegrationTest extends BaseModelTest {
 /**
  * testFindWithJoinsOption method
  *
- * @access public
  * @return void
  */
 	public function testFindWithJoinsOption() {

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -63,7 +63,6 @@ class ModelWriteTest extends BaseModelTest {
 /**
  * testInsertAnotherHabtmRecordWithSameForeignKey method
  *
- * @access public
  * @return void
  */
 	public function testInsertAnotherHabtmRecordWithSameForeignKey() {
@@ -511,7 +510,6 @@ class ModelWriteTest extends BaseModelTest {
 /**
  * Tests having multiple counter caches for an associated model
  *
- * @access public
  * @return void
  */
 	public function testCounterCacheMultipleCaches() {

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -39,7 +39,6 @@ if (!class_exists('AppController', false)) {
 	 * helpers property
 	 *
 	 * @var array
-	 * @access public
 	 */
 		public $helpers = array('Html');
 
@@ -47,7 +46,6 @@ if (!class_exists('AppController', false)) {
 	 * uses property
 	 *
 	 * @var array
-	 * @access public
 	 */
 		public $uses = array('ControllerPost');
 
@@ -55,7 +53,6 @@ if (!class_exists('AppController', false)) {
 	 * components property
 	 *
 	 * @var array
-	 * @access public
 	 */
 		public $components = array('Cookie');
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -779,7 +779,6 @@ class FormHelperTest extends CakeTestCase {
 /**
  * Tests correct generation of number fields for integer fields
  *
- * @access public
  * @return void
  */
 	public function testTextFieldTypeNumberGenerationForIntegers() {
@@ -1525,7 +1524,6 @@ class FormHelperTest extends CakeTestCase {
 /**
  * Test validation errors, when validation message is an empty string.
  *
- * @access public
  * @return void
  */
 	public function testEmptyErrorValidation() {
@@ -1566,7 +1564,6 @@ class FormHelperTest extends CakeTestCase {
 /**
  * Test validation errors, when calling input() overriding validation message by an empty string.
  *
- * @access public
  * @return void
  */
 	public function testEmptyInputErrorValidation() {

--- a/lib/Cake/Test/Fixture/AccountFixture.php
+++ b/lib/Cake/Test/Fixture/AccountFixture.php
@@ -25,13 +25,6 @@
  */
 class AccountFixture extends CakeTestFixture {
 
-/**
- * name property
- *
- * @var string 'Aco'
- */
-	public $name = 'Account';
-
 	public $table = 'Accounts';
 
 /**

--- a/lib/Cake/Test/Fixture/AcoActionFixture.php
+++ b/lib/Cake/Test/Fixture/AcoActionFixture.php
@@ -26,13 +26,6 @@
 class AcoActionFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AcoAction'
- */
-	public $name = 'AcoAction';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AcoFixture.php
+++ b/lib/Cake/Test/Fixture/AcoFixture.php
@@ -26,13 +26,6 @@
 class AcoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Aco'
- */
-	public $name = 'Aco';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AcoTwoFixture.php
+++ b/lib/Cake/Test/Fixture/AcoTwoFixture.php
@@ -26,13 +26,6 @@
 class AcoTwoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AcoTwo'
- */
-	public $name = 'AcoTwo';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AdFixture.php
+++ b/lib/Cake/Test/Fixture/AdFixture.php
@@ -27,13 +27,6 @@
 class AdFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Ad'
- */
-	public $name = 'Ad';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AdvertisementFixture.php
+++ b/lib/Cake/Test/Fixture/AdvertisementFixture.php
@@ -26,13 +26,6 @@
 class AdvertisementFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Advertisement'
- */
-	public $name = 'Advertisement';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AfterTreeFixture.php
+++ b/lib/Cake/Test/Fixture/AfterTreeFixture.php
@@ -27,13 +27,6 @@
 class AfterTreeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AfterTree'
- */
-	public $name = 'AfterTree';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AnotherArticleFixture.php
+++ b/lib/Cake/Test/Fixture/AnotherArticleFixture.php
@@ -26,13 +26,6 @@
 class AnotherArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AnotherArticle'
- */
-	public $name = 'AnotherArticle';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AppleFixture.php
+++ b/lib/Cake/Test/Fixture/AppleFixture.php
@@ -26,13 +26,6 @@
 class AppleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Apple'
- */
-	public $name = 'Apple';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArmorFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorFixture.php
@@ -26,13 +26,6 @@
 class ArmorFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Armor'
- */
-	public $name = 'Armor';
-
-/**
  * Datasource
  *
  * Used for Multi database fixture test

--- a/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
@@ -26,13 +26,6 @@
 class ArmorsPlayerFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArmorsPlayer'
- */
-	public $name = 'ArmorsPlayer';
-
-/**
  * Datasource
  *
  * Used for Multi database fixture test

--- a/lib/Cake/Test/Fixture/AroFixture.php
+++ b/lib/Cake/Test/Fixture/AroFixture.php
@@ -26,13 +26,6 @@
 class AroFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Aro'
- */
-	public $name = 'Aro';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AroTwoFixture.php
+++ b/lib/Cake/Test/Fixture/AroTwoFixture.php
@@ -26,13 +26,6 @@
 class AroTwoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AroTwo'
- */
-	public $name = 'AroTwo';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArosAcoFixture.php
+++ b/lib/Cake/Test/Fixture/ArosAcoFixture.php
@@ -26,13 +26,6 @@
 class ArosAcoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArosAco'
- */
-	public $name = 'ArosAco';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArosAcoTwoFixture.php
+++ b/lib/Cake/Test/Fixture/ArosAcoTwoFixture.php
@@ -26,13 +26,6 @@
 class ArosAcoTwoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArosAcoTwo'
- */
-	public $name = 'ArosAcoTwo';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
@@ -26,13 +26,6 @@
 class ArticleFeaturedFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArticleFeatured'
- */
-	public $name = 'ArticleFeatured';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArticleFeaturedsTagsFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFeaturedsTagsFixture.php
@@ -26,13 +26,6 @@
 class ArticleFeaturedsTagsFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArticleFeaturedsTags'
- */
-	public $name = 'ArticleFeaturedsTags';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArticleFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFixture.php
@@ -26,13 +26,6 @@
 class ArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Article'
- */
-	public $name = 'Article';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ArticlesTagFixture.php
+++ b/lib/Cake/Test/Fixture/ArticlesTagFixture.php
@@ -26,13 +26,6 @@
 class ArticlesTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArticlesTag'
- */
-	public $name = 'ArticlesTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AttachmentFixture.php
+++ b/lib/Cake/Test/Fixture/AttachmentFixture.php
@@ -26,13 +26,6 @@
 class AttachmentFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Attachment'
- */
-	public $name = 'Attachment';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
@@ -26,13 +26,6 @@
 class AuthUserCustomFieldFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AuthUser'
- */
-	public $name = 'AuthUserCustomField';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AuthUserFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserFixture.php
@@ -26,13 +26,6 @@
 class AuthUserFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'AuthUser'
- */
-	public $name = 'AuthUser';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/AuthorFixture.php
+++ b/lib/Cake/Test/Fixture/AuthorFixture.php
@@ -26,13 +26,6 @@
 class AuthorFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Author'
- */
-	public $name = 'Author';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BakeArticleFixture.php
+++ b/lib/Cake/Test/Fixture/BakeArticleFixture.php
@@ -26,13 +26,6 @@
 class BakeArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string
- */
-	public $name = 'BakeArticle';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BakeArticlesBakeTagFixture.php
+++ b/lib/Cake/Test/Fixture/BakeArticlesBakeTagFixture.php
@@ -26,13 +26,6 @@
 class BakeArticlesBakeTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ArticlesTag'
- */
-	public $name = 'BakeArticlesBakeTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BakeCommentFixture.php
+++ b/lib/Cake/Test/Fixture/BakeCommentFixture.php
@@ -26,13 +26,6 @@
 class BakeCommentFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Comment'
- */
-	public $name = 'BakeComment';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BakeTagFixture.php
+++ b/lib/Cake/Test/Fixture/BakeTagFixture.php
@@ -26,13 +26,6 @@
 class BakeTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Tag'
- */
-	public $name = 'BakeTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BasketFixture.php
+++ b/lib/Cake/Test/Fixture/BasketFixture.php
@@ -26,13 +26,6 @@
 class BasketFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Basket'
- */
-	public $name = 'Basket';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BidFixture.php
+++ b/lib/Cake/Test/Fixture/BidFixture.php
@@ -26,13 +26,6 @@
 class BidFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Bid'
- */
-	public $name = 'Bid';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BiddingFixture.php
+++ b/lib/Cake/Test/Fixture/BiddingFixture.php
@@ -26,13 +26,6 @@
 class BiddingFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Bidding'
- */
-	public $name = 'Bidding';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BiddingMessageFixture.php
+++ b/lib/Cake/Test/Fixture/BiddingMessageFixture.php
@@ -26,13 +26,6 @@
 class BiddingMessageFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'BiddingMessage'
- */
-	public $name = 'BiddingMessage';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BinaryTestFixture.php
+++ b/lib/Cake/Test/Fixture/BinaryTestFixture.php
@@ -26,13 +26,6 @@
 class BinaryTestFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'BinaryTest'
- */
-	public $name = 'BinaryTest';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/BookFixture.php
+++ b/lib/Cake/Test/Fixture/BookFixture.php
@@ -26,13 +26,6 @@
 class BookFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Book'
- */
-	public $name = 'Book';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CacheTestModelFixture.php
+++ b/lib/Cake/Test/Fixture/CacheTestModelFixture.php
@@ -26,13 +26,6 @@
 class CacheTestModelFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'CacheTestModel'
- */
-	public $name = 'CacheTestModel';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CakeSessionFixture.php
+++ b/lib/Cake/Test/Fixture/CakeSessionFixture.php
@@ -22,13 +22,6 @@
 class CakeSessionFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string
- */
-	public $name = 'CakeSession';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CallbackFixture.php
+++ b/lib/Cake/Test/Fixture/CallbackFixture.php
@@ -26,13 +26,6 @@
 class CallbackFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Callback'
- */
-	public $name = 'Callback';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CampaignFixture.php
+++ b/lib/Cake/Test/Fixture/CampaignFixture.php
@@ -27,13 +27,6 @@
 class CampaignFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Campaign'
- */
-	public $name = 'Campaign';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CategoryFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryFixture.php
@@ -26,13 +26,6 @@
 class CategoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Category'
- */
-	public $name = 'Category';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CategoryThreadFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryThreadFixture.php
@@ -26,13 +26,6 @@
 class CategoryThreadFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'CategoryThread'
- */
-	public $name = 'CategoryThread';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CdFixture.php
+++ b/lib/Cake/Test/Fixture/CdFixture.php
@@ -26,13 +26,6 @@
 class CdFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Cd'
- */
-	public $name = 'Cd';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/CommentFixture.php
+++ b/lib/Cake/Test/Fixture/CommentFixture.php
@@ -26,13 +26,6 @@
 class CommentFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Comment'
- */
-	public $name = 'Comment';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ContentAccountFixture.php
+++ b/lib/Cake/Test/Fixture/ContentAccountFixture.php
@@ -25,13 +25,6 @@
  */
 class ContentAccountFixture extends CakeTestFixture {
 
-/**
- * name property
- *
- * @var string 'Aco'
- */
-	public $name = 'ContentAccount';
-
 	public $table = 'ContentAccounts';
 
 /**

--- a/lib/Cake/Test/Fixture/ContentFixture.php
+++ b/lib/Cake/Test/Fixture/ContentFixture.php
@@ -25,13 +25,6 @@
  */
 class ContentFixture extends CakeTestFixture {
 
-/**
- * name property
- *
- * @var string 'Aco'
- */
-	public $name = 'Content';
-
 	public $table = 'Content';
 
 /**

--- a/lib/Cake/Test/Fixture/CounterCachePostFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCachePostFixture.php
@@ -25,8 +25,6 @@
  */
 class CounterCachePostFixture extends CakeTestFixture {
 
-	public $name = 'CounterCachePost';
-
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'title' => array('type' => 'string', 'length' => 255),

--- a/lib/Cake/Test/Fixture/CounterCachePostNonstandardPrimaryKeyFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCachePostNonstandardPrimaryKeyFixture.php
@@ -25,8 +25,6 @@
  */
 class CounterCachePostNonstandardPrimaryKeyFixture extends CakeTestFixture {
 
-	public $name = 'CounterCachePostNonstandardPrimaryKey';
-
 	public $fields = array(
 		'pid' => array('type' => 'integer', 'key' => 'primary'),
 		'title' => array('type' => 'string', 'length' => 255, 'null' => false),

--- a/lib/Cake/Test/Fixture/CounterCacheUserFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCacheUserFixture.php
@@ -25,8 +25,6 @@
  */
 class CounterCacheUserFixture extends CakeTestFixture {
 
-	public $name = 'CounterCacheUser';
-
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),

--- a/lib/Cake/Test/Fixture/CounterCacheUserNonstandardPrimaryKeyFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCacheUserNonstandardPrimaryKeyFixture.php
@@ -25,8 +25,6 @@
  */
 class CounterCacheUserNonstandardPrimaryKeyFixture extends CakeTestFixture {
 
-	public $name = 'CounterCacheUserNonstandardPrimaryKey';
-
 	public $fields = array(
 		'uid' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),

--- a/lib/Cake/Test/Fixture/DataTestFixture.php
+++ b/lib/Cake/Test/Fixture/DataTestFixture.php
@@ -26,13 +26,6 @@
 class DataTestFixture extends CakeTestFixture {
 
 /**
- * Name property
- *
- * @var string 'DataTest'
- */
-	public $name = 'DataTest';
-
-/**
  * Fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DatatypeFixture.php
+++ b/lib/Cake/Test/Fixture/DatatypeFixture.php
@@ -26,13 +26,6 @@
 class DatatypeFixture extends CakeTestFixture {
 
 /**
- * Name property
- *
- * @var string 'Datatype'
- */
-	public $name = 'Datatype';
-
-/**
  * Fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DependencyFixture.php
+++ b/lib/Cake/Test/Fixture/DependencyFixture.php
@@ -27,13 +27,6 @@
 class DependencyFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Dependency'
- */
-	public $name = 'Dependency';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DeviceFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceFixture.php
@@ -26,13 +26,6 @@
 class DeviceFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Device'
- */
-	public $name = 'Device';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DeviceTypeCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceTypeCategoryFixture.php
@@ -26,13 +26,6 @@
 class DeviceTypeCategoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'DeviceTypeCategory'
- */
-	public $name = 'DeviceTypeCategory';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DeviceTypeFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceTypeFixture.php
@@ -26,13 +26,6 @@
 class DeviceTypeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'DeviceType'
- */
-	public $name = 'DeviceType';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DocumentDirectoryFixture.php
+++ b/lib/Cake/Test/Fixture/DocumentDirectoryFixture.php
@@ -26,13 +26,6 @@
 class DocumentDirectoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'DocumentDirectory'
- */
-	public $name = 'DocumentDirectory';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DocumentFixture.php
+++ b/lib/Cake/Test/Fixture/DocumentFixture.php
@@ -26,13 +26,6 @@
 class DocumentFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Document'
- */
-	public $name = 'Document';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/DomainFixture.php
+++ b/lib/Cake/Test/Fixture/DomainFixture.php
@@ -25,18 +25,9 @@
 class DomainFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Domain'
- * @access public
- */
-	public $name = 'Domain';
-
-/**
  * fields property
  *
  * @var array
- * @access public
  */
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
@@ -49,7 +40,6 @@ class DomainFixture extends CakeTestFixture {
  * records property
  *
  * @var array
- * @access public
  */
 	public $records = array(
 		array('domain' => 'cakephp.org', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),

--- a/lib/Cake/Test/Fixture/DomainsSiteFixture.php
+++ b/lib/Cake/Test/Fixture/DomainsSiteFixture.php
@@ -25,18 +25,9 @@
 class DomainsSiteFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Domain'
- * @access public
- */
-	public $name = 'DomainsSite';
-
-/**
  * fields property
  *
  * @var array
- * @access public
  */
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
@@ -51,7 +42,6 @@ class DomainsSiteFixture extends CakeTestFixture {
  * records property
  *
  * @var array
- * @access public
  */
 	public $records = array(
 		array('site_id' => 1, 'domain_id' => 1, 'active' => true, 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),

--- a/lib/Cake/Test/Fixture/ExteriorTypeCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/ExteriorTypeCategoryFixture.php
@@ -26,13 +26,6 @@
 class ExteriorTypeCategoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ExteriorTypeCategory'
- */
-	public $name = 'ExteriorTypeCategory';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FeatureSetFixture.php
+++ b/lib/Cake/Test/Fixture/FeatureSetFixture.php
@@ -26,13 +26,6 @@
 class FeatureSetFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'FeatureSet'
- */
-	public $name = 'FeatureSet';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/FeaturedFixture.php
@@ -26,13 +26,6 @@
 class FeaturedFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Featured'
- */
-	public $name = 'Featured';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FilmFileFixture.php
+++ b/lib/Cake/Test/Fixture/FilmFileFixture.php
@@ -26,13 +26,6 @@
 class FilmFileFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'FilmFile'
- */
-	public $name = 'FilmFile';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FlagTreeFixture.php
+++ b/lib/Cake/Test/Fixture/FlagTreeFixture.php
@@ -30,13 +30,6 @@
 class FlagTreeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'FlagTree'
- */
-	public $name = 'FlagTree';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FruitFixture.php
+++ b/lib/Cake/Test/Fixture/FruitFixture.php
@@ -26,13 +26,6 @@
 class FruitFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Fruit'
- */
-	public $name = 'Fruit';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/FruitsUuidTagFixture.php
+++ b/lib/Cake/Test/Fixture/FruitsUuidTagFixture.php
@@ -26,13 +26,6 @@
 class FruitsUuidTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'FruitsUuidTag'
- */
-	public $name = 'FruitsUuidTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/GroupUpdateAllFixture.php
+++ b/lib/Cake/Test/Fixture/GroupUpdateAllFixture.php
@@ -25,8 +25,6 @@
  */
 class GroupUpdateAllFixture extends CakeTestFixture {
 
-	public $name = 'GroupUpdateAll';
-
 	public $table = 'group_update_all';
 
 	public $fields = array(

--- a/lib/Cake/Test/Fixture/GuildFixture.php
+++ b/lib/Cake/Test/Fixture/GuildFixture.php
@@ -26,13 +26,6 @@
 class GuildFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Guild'
- */
-	public $name = 'Guild';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
@@ -25,13 +25,6 @@
  */
 class GuildsPlayerFixture extends CakeTestFixture {
 
-/**
- * name property
- *
- * @var string 'GuildsPlayer'
- */
-	public $name = 'GuildsPlayer';
-
 	public $useDbConfig = 'test2';
 
 /**

--- a/lib/Cake/Test/Fixture/HomeFixture.php
+++ b/lib/Cake/Test/Fixture/HomeFixture.php
@@ -26,13 +26,6 @@
 class HomeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Home'
- */
-	public $name = 'Home';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ImageFixture.php
+++ b/lib/Cake/Test/Fixture/ImageFixture.php
@@ -26,13 +26,6 @@
 class ImageFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Image'
- */
-	public $name = 'Image';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/InnoFixture.php
+++ b/lib/Cake/Test/Fixture/InnoFixture.php
@@ -26,13 +26,6 @@
 class InnoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Article'
- */
-	public $name = 'Inno';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ItemFixture.php
+++ b/lib/Cake/Test/Fixture/ItemFixture.php
@@ -26,13 +26,6 @@
 class ItemFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Item'
- */
-	public $name = 'Item';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ItemsPortfolioFixture.php
+++ b/lib/Cake/Test/Fixture/ItemsPortfolioFixture.php
@@ -26,13 +26,6 @@
 class ItemsPortfolioFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ItemsPortfolio'
- */
-	public $name = 'ItemsPortfolio';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/JoinAFixture.php
+++ b/lib/Cake/Test/Fixture/JoinAFixture.php
@@ -26,13 +26,6 @@
 class JoinAFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'JoinA'
- */
-	public $name = 'JoinA';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/JoinBFixture.php
+++ b/lib/Cake/Test/Fixture/JoinBFixture.php
@@ -26,13 +26,6 @@
 class JoinBFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'JoinB'
- */
-	public $name = 'JoinB';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/JoinCFixture.php
+++ b/lib/Cake/Test/Fixture/JoinCFixture.php
@@ -26,13 +26,6 @@
 class JoinCFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'JoinC'
- */
-	public $name = 'JoinC';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/JoinThingFixture.php
+++ b/lib/Cake/Test/Fixture/JoinThingFixture.php
@@ -26,13 +26,6 @@
 class JoinThingFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'JoinThing'
- */
-	public $name = 'JoinThing';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MessageFixture.php
+++ b/lib/Cake/Test/Fixture/MessageFixture.php
@@ -26,13 +26,6 @@
 class MessageFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Message'
- */
-	public $name = 'Message';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MyCategoriesMyProductsFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoriesMyProductsFixture.php
@@ -26,13 +26,6 @@
 class MyCategoriesMyProductsFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'MyCategoriesMyProducts'
- */
-	public $name = 'MyCategoriesMyProducts';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MyCategoriesMyUsersFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoriesMyUsersFixture.php
@@ -26,13 +26,6 @@
 class MyCategoriesMyUsersFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'MyCategoriesMyUsers'
- */
-	public $name = 'MyCategoriesMyUsers';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MyCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoryFixture.php
@@ -26,13 +26,6 @@
 class MyCategoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'MyCategory'
- */
-	public $name = 'MyCategory';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MyProductFixture.php
+++ b/lib/Cake/Test/Fixture/MyProductFixture.php
@@ -26,13 +26,6 @@
 class MyProductFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'MyProduct'
- */
-	public $name = 'MyProduct';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/MyUserFixture.php
+++ b/lib/Cake/Test/Fixture/MyUserFixture.php
@@ -26,13 +26,6 @@
 class MyUserFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'MyUser'
- */
-	public $name = 'MyUser';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/NodeFixture.php
+++ b/lib/Cake/Test/Fixture/NodeFixture.php
@@ -27,13 +27,6 @@
 class NodeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Node'
- */
-	public $name = 'Node';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/NumberTreeFixture.php
+++ b/lib/Cake/Test/Fixture/NumberTreeFixture.php
@@ -30,13 +30,6 @@
 class NumberTreeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'NumberTree'
- */
-	public $name = 'NumberTree';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/NumberTreeTwoFixture.php
+++ b/lib/Cake/Test/Fixture/NumberTreeTwoFixture.php
@@ -30,13 +30,6 @@
 class NumberTreeTwoFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'NumberTree'
- */
-	public $name = 'NumberTreeTwo';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/NumericArticleFixture.php
+++ b/lib/Cake/Test/Fixture/NumericArticleFixture.php
@@ -26,13 +26,6 @@
 class NumericArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'NumericArticle'
- */
-	public $name = 'NumericArticle';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/OverallFavoriteFixture.php
+++ b/lib/Cake/Test/Fixture/OverallFavoriteFixture.php
@@ -26,13 +26,6 @@
 class OverallFavoriteFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'OverallFavorite'
- */
-	public $name = 'OverallFavorite';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PersonFixture.php
+++ b/lib/Cake/Test/Fixture/PersonFixture.php
@@ -26,13 +26,6 @@
 class PersonFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Person'
- */
-	public $name = 'Person';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PlayerFixture.php
+++ b/lib/Cake/Test/Fixture/PlayerFixture.php
@@ -26,13 +26,6 @@
 class PlayerFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Player'
- */
-	public $name = 'Player';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PortfolioFixture.php
+++ b/lib/Cake/Test/Fixture/PortfolioFixture.php
@@ -26,13 +26,6 @@
 class PortfolioFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Portfolio'
- */
-	public $name = 'Portfolio';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PostFixture.php
+++ b/lib/Cake/Test/Fixture/PostFixture.php
@@ -26,13 +26,6 @@
 class PostFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Post'
- */
-	public $name = 'Post';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PostsTagFixture.php
+++ b/lib/Cake/Test/Fixture/PostsTagFixture.php
@@ -26,13 +26,6 @@
 class PostsTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'PostsTag'
- */
-	public $name = 'PostsTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/PrefixTestFixture.php
+++ b/lib/Cake/Test/Fixture/PrefixTestFixture.php
@@ -24,8 +24,6 @@
  */
 class PrefixTestFixture extends CakeTestFixture {
 
-	public $name = 'PrefixTest';
-
 	public $table = 'prefix_prefix_tests';
 
 	public $fields = array(

--- a/lib/Cake/Test/Fixture/PrimaryModelFixture.php
+++ b/lib/Cake/Test/Fixture/PrimaryModelFixture.php
@@ -26,13 +26,6 @@
 class PrimaryModelFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'PrimaryModel'
- */
-	public $name = 'PrimaryModel';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ProductFixture.php
+++ b/lib/Cake/Test/Fixture/ProductFixture.php
@@ -26,13 +26,6 @@
 class ProductFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Product'
- */
-	public $name = 'Product';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ProductUpdateAllFixture.php
+++ b/lib/Cake/Test/Fixture/ProductUpdateAllFixture.php
@@ -25,8 +25,6 @@
  */
 class ProductUpdateAllFixture extends CakeTestFixture {
 
-	public $name = 'ProductUpdateAll';
-
 	public $table = 'product_update_all';
 
 	public $fields = array(

--- a/lib/Cake/Test/Fixture/ProjectFixture.php
+++ b/lib/Cake/Test/Fixture/ProjectFixture.php
@@ -26,13 +26,6 @@
 class ProjectFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Project'
- */
-	public $name = 'Project';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SampleFixture.php
+++ b/lib/Cake/Test/Fixture/SampleFixture.php
@@ -26,13 +26,6 @@
 class SampleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Sample'
- */
-	public $name = 'Sample';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SecondaryModelFixture.php
+++ b/lib/Cake/Test/Fixture/SecondaryModelFixture.php
@@ -26,13 +26,6 @@
 class SecondaryModelFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'SecondaryModel'
- */
-	public $name = 'SecondaryModel';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SessionFixture.php
+++ b/lib/Cake/Test/Fixture/SessionFixture.php
@@ -26,13 +26,6 @@
 class SessionFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Session'
- */
-	public $name = 'Session';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SiteFixture.php
+++ b/lib/Cake/Test/Fixture/SiteFixture.php
@@ -25,18 +25,9 @@
 class SiteFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Site'
- * @access public
- */
-	public $name = 'Site';
-
-/**
  * fields property
  *
  * @var array
- * @access public
  */
 	public $fields = array(
 		'id' => array('type' => 'integer', 'key' => 'primary'),
@@ -49,7 +40,6 @@ class SiteFixture extends CakeTestFixture {
  * records property
  *
  * @var array
- * @access public
  */
 	public $records = array(
 		array('name' => 'cakephp', 'created' => '2007-03-17 01:16:23', 'updated' => '2007-03-17 01:18:31'),

--- a/lib/Cake/Test/Fixture/SomethingElseFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingElseFixture.php
@@ -26,13 +26,6 @@
 class SomethingElseFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'SomethingElse'
- */
-	public $name = 'SomethingElse';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SomethingFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingFixture.php
@@ -26,13 +26,6 @@
 class SomethingFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Something'
- */
-	public $name = 'Something';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/StoriesTagFixture.php
+++ b/lib/Cake/Test/Fixture/StoriesTagFixture.php
@@ -26,13 +26,6 @@
 class StoriesTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'StoriesTag'
- */
-	public $name = 'StoriesTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/StoryFixture.php
+++ b/lib/Cake/Test/Fixture/StoryFixture.php
@@ -26,13 +26,6 @@
 class StoryFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Story'
- */
-	public $name = 'Story';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/SyfileFixture.php
+++ b/lib/Cake/Test/Fixture/SyfileFixture.php
@@ -26,13 +26,6 @@
 class SyfileFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Syfile'
- */
-	public $name = 'Syfile';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/TagFixture.php
+++ b/lib/Cake/Test/Fixture/TagFixture.php
@@ -26,13 +26,6 @@
 class TagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Tag'
- */
-	public $name = 'Tag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
@@ -26,13 +26,6 @@
 class TestPluginArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Article'
- */
-	public $name = 'TestPluginArticle';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
@@ -26,13 +26,6 @@
 class TestPluginCommentFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Comment'
- */
-	public $name = 'TestPluginComment';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ThePaperMonkiesFixture.php
+++ b/lib/Cake/Test/Fixture/ThePaperMonkiesFixture.php
@@ -26,13 +26,6 @@
 class ThePaperMonkiesFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'ThePaperMonkies'
- */
-	public $name = 'ThePaperMonkies';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/ThreadFixture.php
+++ b/lib/Cake/Test/Fixture/ThreadFixture.php
@@ -26,13 +26,6 @@
 class ThreadFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Thread'
- */
-	public $name = 'Thread';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/TranslateArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateArticleFixture.php
@@ -26,13 +26,6 @@
 class TranslateArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Translate'
- */
-	public $name = 'TranslateArticle';
-
-/**
  * table property
  *
  * @var string 'i18n'

--- a/lib/Cake/Test/Fixture/TranslateFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateFixture.php
@@ -26,13 +26,6 @@
 class TranslateFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Translate'
- */
-	public $name = 'Translate';
-
-/**
  * table property
  *
  * @var string 'i18n'

--- a/lib/Cake/Test/Fixture/TranslateTableFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateTableFixture.php
@@ -26,13 +26,6 @@
 class TranslateTableFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'TranslateTable'
- */
-	public $name = 'TranslateTable';
-
-/**
  * table property
  *
  * @var string 'another_i18n'

--- a/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
@@ -30,13 +30,6 @@
 class TranslateWithPrefixFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Translate'
- */
-	public $name = 'TranslateWithPrefix';
-
-/**
  * table property
  *
  * @var string 'i18n'

--- a/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
@@ -26,13 +26,6 @@
 class TranslatedArticleFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'TranslatedItem'
- */
-	public $name = 'TranslatedArticle';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/TranslatedItemFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedItemFixture.php
@@ -26,13 +26,6 @@
 class TranslatedItemFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'TranslatedItem'
- */
-	public $name = 'TranslatedItem';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UnconventionalTreeFixture.php
+++ b/lib/Cake/Test/Fixture/UnconventionalTreeFixture.php
@@ -29,13 +29,6 @@
 class UnconventionalTreeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'FlagTree'
- */
-	public $name = 'UnconventionalTree';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UnderscoreFieldFixture.php
+++ b/lib/Cake/Test/Fixture/UnderscoreFieldFixture.php
@@ -26,13 +26,6 @@
 class UnderscoreFieldFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'UnderscoreField'
- */
-	public $name = 'UnderscoreField';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UserFixture.php
+++ b/lib/Cake/Test/Fixture/UserFixture.php
@@ -26,13 +26,6 @@
 class UserFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'User'
- */
-	public $name = 'User';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuidFixture.php
+++ b/lib/Cake/Test/Fixture/UuidFixture.php
@@ -26,13 +26,6 @@
 class UuidFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Uuid'
- */
-	public $name = 'Uuid';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuidTagFixture.php
+++ b/lib/Cake/Test/Fixture/UuidTagFixture.php
@@ -26,13 +26,6 @@
 class UuidTagFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'UuidTag'
- */
-	public $name = 'UuidTag';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuidTreeFixture.php
+++ b/lib/Cake/Test/Fixture/UuidTreeFixture.php
@@ -27,13 +27,6 @@
 class UuidTreeFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'UuidTree'
- */
-	public $name = 'UuidTree';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuiditemFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemFixture.php
@@ -26,13 +26,6 @@
 class UuiditemFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Uuiditem'
- */
-	public $name = 'Uuiditem';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
@@ -26,13 +26,6 @@
 class UuiditemsUuidportfolioFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'UuiditemsUuidportfolio'
- */
-	public $name = 'UuiditemsUuidportfolio';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
@@ -26,13 +26,6 @@
 class UuiditemsUuidportfolioNumericidFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'UuiditemsUuidportfolioNumericid'
- */
-	public $name = 'UuiditemsUuidportfolioNumericid';
-
-/**
  * fields property
  *
  * @var array

--- a/lib/Cake/Test/Fixture/UuidportfolioFixture.php
+++ b/lib/Cake/Test/Fixture/UuidportfolioFixture.php
@@ -26,13 +26,6 @@
 class UuidportfolioFixture extends CakeTestFixture {
 
 /**
- * name property
- *
- * @var string 'Uuidportfolio'
- */
-	public $name = 'Uuidportfolio';
-
-/**
  * fields property
  *
  * @var array


### PR DESCRIPTION
`@access` is not used anymore. Removed the last bits.

$name is not necessary. Files are not baked anymore with it - and the core should reflect that.
The remaining `public $name = 'JoinAsJoinB';` etc show more clear where it is actually required to modify/adjust the name param (2 Fixture classes to be exact).

Travis is fine, but seems to be linked wrong below: https://travis-ci.org/dereuromark/cakephp/builds/8848229
