### PR TITLE
Fixes plugin short routes to work as described in the file's docblock.

### DIFF
--- a/lib/Cake/Config/routes.php
+++ b/lib/Cake/Config/routes.php
@@ -61,10 +61,12 @@ if ($plugins = CakePlugin::loaded()) {
 		$params = array('prefix' => $prefix, $prefix => true);
 		$indexParams = $params + array('action' => 'index');
 		Router::connect("/{$prefix}/:plugin", $indexParams, $shortParams);
+		Router::connect("/{$prefix}/:plugin/:action/*", $params, $shortParams);
 		Router::connect("/{$prefix}/:plugin/:controller", $indexParams, $match);
 		Router::connect("/{$prefix}/:plugin/:controller/:action/*", $params, $match);
 	}
 	Router::connect('/:plugin', array('action' => 'index'), $shortParams);
+	Router::connect('/:plugin/:action/*', array(), $shortParams);
 	Router::connect('/:plugin/:controller', array('action' => 'index'), $match);
 	Router::connect('/:plugin/:controller/:action/*', array(), $match);
 }


### PR DESCRIPTION
According to the `lib/Cake/Config/routes.php` description, the `/:prefix/:plugin/:action/*` and `/:plugin/:action/*` routes are added when in fact they are missing. 

Without these routes:
- short plugin routes do not work for other than the index action
- pagination (even on the index action) fails
