### PR TITLE
Added debug check and cacheClear when looking at views

### DIFF
--- a/lib/Cake/Routing/Filter/CacheDispatcher.php
+++ b/lib/Cake/Routing/Filter/CacheDispatcher.php
@@ -38,7 +38,8 @@ class CacheDispatcher extends DispatcherFilter {
  * @return CakeResponse with cached content if found, null otherwise
  */
 	public function beforeDispatch(CakeEvent $event) {
-		if (Configure::read('Cache.check') !== true) {
+		if (Configure::read('Cache.check') !== true || Configure::read('debug') > 0) {
+			clearCache();
 			return;
 		}
 


### PR DESCRIPTION
CacheDispatcher should clear the cache when the site is set in debug and also prevent the view from loading the cache.
Failing to do so, results in odd behaviors when trying to debug a view, yet with caching enabled for production.
