### PR TITLE
Pages controller should render 404 on missing view file

### DIFF
--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -50,6 +50,8 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
+ * @throws NotFoundException When the view file could not be found
+ *	or MissingViewException in debug mode.
  */
 	public function display() {
 		$path = func_get_args();
@@ -70,6 +72,14 @@ class PagesController extends AppController {
 			$title_for_layout = Inflector::humanize($path[$count - 1]);
 		}
 		$this->set(compact('page', 'subpage', 'title_for_layout'));
-		$this->render(implode('/', $path));
+
+		try {
+			$this->render(implode('/', $path));
+		} catch (MissingViewException $e) {
+			if (Configure::read('debug')) {
+				throw $e;
+			}
+			throw new NotFoundException();
+		}
 	}
 }

--- a/lib/Cake/Console/Templates/skel/Controller/PagesController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/PagesController.php
@@ -42,6 +42,8 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
+ * @throws NotFoundException When the view file could not be found
+ *	or MissingViewException in debug mode.
  */
 	public function display() {
 		$path = func_get_args();
@@ -62,6 +64,14 @@ class PagesController extends AppController {
 			$title_for_layout = Inflector::humanize($path[$count - 1]);
 		}
 		$this->set(compact('page', 'subpage', 'title_for_layout'));
-		$this->render(implode('/', $path));
+
+		try {
+			$this->render(implode('/', $path));
+		} catch (MissingViewException $e) {
+			if (Configure::read('debug')) {
+				throw $e;
+			}
+			throw new NotFoundException();
+		}
 	}
 }

--- a/lib/Cake/Test/Case/Controller/PagesControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/PagesControllerTest.php
@@ -51,4 +51,30 @@ class PagesControllerTest extends CakeTestCase {
 		$this->assertEquals('TestTheme', $Pages->viewVars['page']);
 		$this->assertEquals('Posts', $Pages->viewVars['subpage']);
 	}
+
+/**
+ * Test that missing view renders 404 page in production
+ *
+ * @expectedException NotFoundException
+ * @expectedExceptionCode 404
+ * @return void
+ */
+	public function testMissingView() {
+		Configure::write('debug', 0);
+		$Pages = new PagesController(new CakeRequest(null, false), new CakeResponse());
+		$Pages->display('non_existing_page');
+	}
+
+/**
+ * Test that missing view in debug mode renders missing_view error page
+ *
+ * @expectedException MissingViewException
+ * @expectedExceptionCode 500
+ * @return void
+ */
+	public function testMissingViewInDebug() {
+		Configure::write('debug', 1);
+		$Pages = new PagesController(new CakeRequest(null, false), new CakeResponse());
+		$Pages->display('non_existing_page');
+	}
 }

--- a/lib/Cake/Test/test_app/Controller/PagesController.php
+++ b/lib/Cake/Test/test_app/Controller/PagesController.php
@@ -51,6 +51,8 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
+ * @throws NotFoundException When the view file could not be found
+ *	or MissingViewException in debug mode.
  */
 	public function display() {
 		$path = func_get_args();
@@ -75,7 +77,15 @@ class PagesController extends AppController {
 			'subpage' => $subpage,
 			'title_for_layout' => $titleForLayout
 		));
-		$this->render(implode('/', $path));
+
+		try {
+			$this->render(implode('/', $path));
+		} catch (MissingViewException $e) {
+			if (Configure::read('debug')) {
+				throw $e;
+			}
+			throw new NotFoundException();
+		}
 	}
 
 }


### PR DESCRIPTION
Currently `/pages/non-existing-page` renders "Internal server error 500" instead of 404 and pollutes the error log 
