### PR TITLE
use a simpler rewrite rule

### DIFF
--- a/app/webroot/.htaccess
+++ b/app/webroot/.htaccess
@@ -2,5 +2,5 @@
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php [QSA,L]
+    RewriteRule ^ index.php [L]
 </IfModule>

--- a/lib/Cake/Console/Templates/skel/webroot/.htaccess
+++ b/lib/Cake/Console/Templates/skel/webroot/.htaccess
@@ -2,5 +2,5 @@
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php [QSA,L]
+    RewriteRule ^ index.php [L]
 </IfModule>


### PR DESCRIPTION
The capture group isn't used - so there's no need to captuer it.

There are no get args in the rewrite rule so there's no need to
request appending the existing get args - they are unmodified.
