### PR TITLE
3.0 component events

### DIFF
--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -15,7 +15,9 @@
 namespace Cake\Controller;
 
 use Cake\Core\Object;
+use Cake\Event\Event;
 use Cake\Event\EventListener;
+use Cake\Utility\ObjectCollection;
 
 /**
  * Base class for an individual Component. Components provide reusable bits of
@@ -30,9 +32,17 @@ use Cake\Event\EventListener;
  * - `initialize()` - Fired before the controller's beforeFilter method.
  * - `startup()` - Fired after the controller's beforeFilter method.
  * - `beforeRender()` - Fired before the view + layout are rendered.
- * - `shutdown()` - Fired after the action is complete and the view has been rendered
+ * - `shutdown()` - Fired after the action is complete and the view has been rendered.
  *    but before Controller::afterFilter().
  * - `beforeRedirect()` - Fired before a redirect() is done.
+ *
+ * Each callback has a slightly different signature:
+ *
+ * - `intitalize(Event $event, Controller $controller)`
+ * - `startup(Event $event, Controller $controller)`
+ * - `beforeRender(Event $event, Controller $controller)`
+ * - `beforeRedirect(Event $event, Controller $controller, $url, $status, $exit)`
+ * - `shutdown(Event $event, Controller $controller)`
  *
  * @package       Cake.Controller
  * @link          http://book.cakephp.org/2.0/en/controllers/components.html
@@ -79,7 +89,7 @@ class Component extends Object implements EventListener {
 		$this->settings = $settings;
 		$this->_set($settings);
 		if (!empty($this->components)) {
-			$this->_componentMap = ComponentCollection::normalizeObjectArray($this->components);
+			$this->_componentMap = ObjectCollection::normalizeObjectArray($this->components);
 		}
 	}
 
@@ -102,42 +112,46 @@ class Component extends Object implements EventListener {
 /**
  * Called before the Controller::beforeFilter().
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Controller with components to initialize
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::initialize
  */
-	public function initialize(Controller $controller) {
+	public function initialize(Event $event, Controller $controller) {
 	}
 
 /**
  * Called after the Controller::beforeFilter() and before the controller action
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Controller with components to startup
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::startup
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 	}
 
 /**
  * Called before the Controller::beforeRender(), and before
  * the view class is loaded, and before Controller::render()
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Controller with components to beforeRender
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRender
  */
-	public function beforeRender(Controller $controller) {
+	public function beforeRender(Event $event, Controller $controller) {
 	}
 
 /**
  * Called after Controller::render() and before the output is printed to the browser.
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Controller with components to shutdown
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::shutdown
  */
-	public function shutdown(Controller $controller) {
+	public function shutdown(Event $event, Controller $controller) {
 	}
 
 /**
@@ -152,6 +166,7 @@ class Component extends Object implements EventListener {
  * If your response is a string or an array that does not contain a 'url' key it will
  * be used as the new URL to redirect to.
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Controller with components to beforeRedirect
  * @param string|array $url Either the string or URL array that is being redirected to.
  * @param integer $status The status code of the redirect
@@ -159,7 +174,7 @@ class Component extends Object implements EventListener {
  * @return array|void Either an array or null.
  * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRedirect
  */
-	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, Controller $controller, $url, $status = null, $exit = true) {
 	}
 
 /**
@@ -190,4 +205,5 @@ class Component extends Object implements EventListener {
 		}
 		return $events;
 	}
+
 }

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -29,12 +29,24 @@ use Cake\Utility\ObjectCollection;
  * Components can provide several callbacks that are fired at various stages of the request
  * cycle. The available callbacks are:
  *
- * - `initialize()` - Fired before the controller's beforeFilter method.
- * - `startup()` - Fired after the controller's beforeFilter method.
- * - `beforeRender()` - Fired before the view + layout are rendered.
- * - `shutdown()` - Fired after the action is complete and the view has been rendered.
+ * - `initialize()` - Called before the controller's beforeFilter method.
+ * - `startup()` - Called after the controller's beforeFilter method,
+ *   and before the controller action is called.
+ * - `beforeRender()` - Called before the Controller beforeRender, and
+ *   before the view class is loaded.
+ * - `shutdown()` - Called after the action is complete and the view has been rendered.
  *    but before Controller::afterFilter().
- * - `beforeRedirect()` - Fired before a redirect() is done.
+ * - `beforeRedirect()` - Called before Controller::redirect(), and
+ *   before a redirect() is done. Allows you to replace the URL that will
+ *   be redirected to with a new URL. The return of this method can either be an
+ *   array or a string. If the return is an array and contains a 'url' key.
+ *   You may also supply the following:
+ *
+ *   - `status` The status code for the redirect
+ *   - `exit` Whether or not the redirect should exit.
+ *
+ *   If your response is a string or an array that does not contain a 'url' key it will
+ *   be used as the new URL to redirect to.
  *
  * Each callback has a slightly different signature:
  *
@@ -107,74 +119,6 @@ class Component extends Object implements EventListener {
 		if (isset($this->{$name})) {
 			return $this->{$name};
 		}
-	}
-
-/**
- * Called before the Controller::beforeFilter().
- *
- * @param Event $event An Event instance
- * @param Controller $controller Controller with components to initialize
- * @return void
- * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::initialize
- */
-	public function initialize(Event $event, Controller $controller) {
-	}
-
-/**
- * Called after the Controller::beforeFilter() and before the controller action
- *
- * @param Event $event An Event instance
- * @param Controller $controller Controller with components to startup
- * @return void
- * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::startup
- */
-	public function startup(Event $event, Controller $controller) {
-	}
-
-/**
- * Called before the Controller::beforeRender(), and before
- * the view class is loaded, and before Controller::render()
- *
- * @param Event $event An Event instance
- * @param Controller $controller Controller with components to beforeRender
- * @return void
- * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRender
- */
-	public function beforeRender(Event $event, Controller $controller) {
-	}
-
-/**
- * Called after Controller::render() and before the output is printed to the browser.
- *
- * @param Event $event An Event instance
- * @param Controller $controller Controller with components to shutdown
- * @return void
- * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::shutdown
- */
-	public function shutdown(Event $event, Controller $controller) {
-	}
-
-/**
- * Called before Controller::redirect(). Allows you to replace the URL that will
- * be redirected to with a new URL. The return of this method can either be an array or a string.
- *
- * If the return is an array and contains a 'url' key. You may also supply the following:
- *
- * - `status` The status code for the redirect
- * - `exit` Whether or not the redirect should exit.
- *
- * If your response is a string or an array that does not contain a 'url' key it will
- * be used as the new URL to redirect to.
- *
- * @param Event $event An Event instance
- * @param Controller $controller Controller with components to beforeRedirect
- * @param string|array $url Either the string or URL array that is being redirected to.
- * @param integer $status The status code of the redirect
- * @param boolean $exit Will the script exit.
- * @return array|void Either an array or null.
- * @link http://book.cakephp.org/2.0/en/controllers/components.html#Component::beforeRedirect
- */
-	public function beforeRedirect(Event $event, Controller $controller, $url, $status = null, $exit = true) {
 	}
 
 /**

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -53,7 +53,7 @@ use Cake\Utility\ObjectCollection;
  * - `intitalize(Event $event)`
  * - `startup(Event $event)`
  * - `beforeRender(Event $event)`
- * - `beforeRedirect(Cake\Event\Event $event $url, Cake\Network\Response $response)`
+ * - `beforeRedirect(Event $event $url, Response $response)`
  * - `shutdown(Event $event)`
  *
  * While the controller is not an explicit argument it is the subject of each event

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -15,6 +15,7 @@
 namespace Cake\Controller;
 
 use Cake\Core\Object;
+use Cake\Event\EventListener;
 
 /**
  * Base class for an individual Component. Components provide reusable bits of
@@ -37,7 +38,7 @@ use Cake\Core\Object;
  * @link          http://book.cakephp.org/2.0/en/controllers/components.html
  * @see Controller::$components
  */
-class Component extends Object {
+class Component extends Object implements EventListener {
 
 /**
  * Component collection class used to lazy load components.
@@ -161,4 +162,32 @@ class Component extends Object {
 	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {
 	}
 
+/**
+ * Get the Controller callbacks this Component is interested in.
+ *
+ * Uses Conventions to map controller events to standard component
+ * callback method names. By defining one of the callback methods a 
+ * component is assumed to be interested in the related event.
+ *
+ * Override this method if you need to add non-conventional event listeners.
+ * Or if you want components to listen to non-standard events.
+ *
+ * @return array
+ */
+	public function implementedEvents() {
+		$eventMap = [
+			'Controller.initialize' => 'initialize',
+			'Controller.startup' => 'startup',
+			'Controller.beforeRender' => 'beforeRender',
+			'Controller.beforeRedirect' => 'beforeRedirect',
+			'Controller.shutdown' => 'shutdown',
+		];
+		$events = [];
+		foreach ($eventMap as $event => $method) {
+			if (method_exists($this, $method)) {
+				$events[$event] = $method;
+			}
+		}
+		return $events;
+	}
 }

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -50,14 +50,16 @@ use Cake\Utility\ObjectCollection;
  *
  * Each callback has a slightly different signature:
  *
- * - `intitalize(Event $event, Controller $controller)`
- * - `startup(Event $event, Controller $controller)`
- * - `beforeRender(Event $event, Controller $controller)`
- * - `beforeRedirect(Event $event, Controller $controller, $url, $status, $exit)`
- * - `shutdown(Event $event, Controller $controller)`
+ * - `intitalize(Event $event)`
+ * - `startup(Event $event)`
+ * - `beforeRender(Event $event)`
+ * - `beforeRedirect(Event $event $url, $status, $exit)`
+ * - `shutdown(Event $event)`
  *
- * @package       Cake.Controller
- * @link          http://book.cakephp.org/2.0/en/controllers/components.html
+ * While the controller is not an explicit argument it is the subject of each event
+ * and can be fetched using Event::subject().
+ *
+ * @link http://book.cakephp.org/2.0/en/controllers/components.html
  * @see Controller::$components
  */
 class Component extends Object implements EventListener {

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -53,7 +53,7 @@ use Cake\Utility\ObjectCollection;
  * - `intitalize(Event $event)`
  * - `startup(Event $event)`
  * - `beforeRender(Event $event)`
- * - `beforeRedirect(Event $event $url, $status, $exit)`
+ * - `beforeRedirect(Cake\Event\Event $event $url, Cake\Network\Response $response)`
  * - `shutdown(Event $event)`
  *
  * While the controller is not an explicit argument it is the subject of each event

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -20,6 +20,7 @@ use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Error;
+use Cake\Event\Event;
 use Cake\Model\Datasource\Session;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -257,10 +258,11 @@ class AuthComponent extends Component {
 /**
  * Initializes AuthComponent for use in the controller
  *
- * @param Controller $controller A reference to the instantiating controller object
+ * @param Event $event The initialize event.
  * @return void
  */
-	public function initialize(Controller $controller) {
+	public function initialize(Event $event) {
+		$controller = $event->subject();
 		$this->request = $controller->request;
 		$this->response = $controller->response;
 		$this->_methods = $controller->methods;
@@ -274,10 +276,11 @@ class AuthComponent extends Component {
  * Main execution method. Handles redirecting of invalid users, and processing
  * of login form data.
  *
- * @param Controller $controller A reference to the instantiating controller object
+ * @param Event $event The startup event.
  * @return boolean
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event) {
+		$controller = $event->subject();
 		$methods = array_flip(array_map('strtolower', $controller->methods));
 		$action = strtolower($controller->request->params['action']);
 

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -1,11 +1,5 @@
 <?php
 /**
- * Authentication component
- *
- * Manages user logins and permissions.
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -15,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 0.10.0.1076
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -40,7 +33,6 @@ use Cake\Utility\Security;
  *
  * Binds access control with user authentication and session management.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html
  */
 class AuthComponent extends Component {

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Cookie Component
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 1.2.0.4213
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -34,7 +29,6 @@ use Cake\Utility\Security;
  *
  * Cookie handling for the controller.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html
  *
  */
@@ -206,10 +200,9 @@ class CookieComponent extends Component {
  * Start CookieComponent for use in the controller
  *
  * @param Event $event An Event instance
- * @param Controller $controller
  * @return void
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
 		$this->_expire($this->time);
 
 		$this->_values[$this->name] = array();

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -23,6 +23,7 @@ use Cake\Controller\Component;
 use Cake\Controller\ComponentCollection;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Hash;
@@ -204,10 +205,11 @@ class CookieComponent extends Component {
 /**
  * Start CookieComponent for use in the controller
  *
+ * @param Event $event An Event instance
  * @param Controller $controller
  * @return void
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$this->_expire($this->time);
 
 		$this->_values[$this->name] = array();

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Paginator Component
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -71,7 +66,6 @@ use Cake\Utility\Hash;
  *
  * Would paginate using the `find('popular')` method.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/pagination.html
  */
 class PaginatorComponent extends Component {

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -21,6 +21,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Event\Event;
+use Cake\Network\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\Xml;
@@ -246,11 +247,10 @@ class RequestHandlerComponent extends Component {
  *
  * @param Event $event The Controller.beforeRedirect event.
  * @param string|array $url A string or array containing the redirect location
- * @param integer|array $status HTTP Status for redirect
- * @param boolean $exit
+ * @param Cake\Network\Response $response The response object.
  * @return void
  */
-	public function beforeRedirect(Event $event, $url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, $url, $response) {
 		if (!$this->request->is('ajax')) {
 			return;
 		}
@@ -265,13 +265,13 @@ class RequestHandlerComponent extends Component {
 			$url = Router::url($url + array('base' => false));
 		}
 		if (!empty($status)) {
-			$statusCode = $this->response->httpCodes($status);
+			$statusCode = $response->httpCodes($status);
 			$code = key($statusCode);
-			$this->response->statusCode($code);
+			$response->statusCode($code);
 		}
 		$controller = $event->subject();
-		$this->response->body($controller->requestAction($url, array('return', 'bare' => false)));
-		$this->response->send();
+		$response->body($controller->requestAction($url, array('return', 'bare' => false)));
+		$response->send();
 		$this->_stop();
 	}
 
@@ -310,7 +310,7 @@ class RequestHandlerComponent extends Component {
 	public function isFlash() {
 		return $this->request->is('flash');
 	}
-
+;
 /**
  * Returns true if the current request is over HTTPS, false otherwise.
  *

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -123,11 +123,10 @@ class RequestHandlerComponent extends Component {
  * and the requested mime-types, RequestHandler::$ext is set to that value.
  *
  * @param Event $event The initialize event that was fired.
- * @param Controller $controller A reference to the controller
  * @return void
  * @see Router::parseExtensions()
  */
-	public function initialize(Event $event, Controller $controller) {
+	public function initialize(Event $event) {
 		if (isset($this->request->params['_ext'])) {
 			$this->ext = $this->request->params['_ext'];
 		}
@@ -198,7 +197,8 @@ class RequestHandlerComponent extends Component {
  * @param Controller $controller A reference to the controller
  * @return void
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
+		$controller = $event->subject();
 		$controller->request->params['isAjax'] = $this->request->is('ajax');
 		$isRecognized = (
 			!in_array($this->ext, array('html', 'htm')) &&
@@ -245,13 +245,12 @@ class RequestHandlerComponent extends Component {
  * Modifies the $_POST and $_SERVER['REQUEST_METHOD'] to simulate a new GET request.
  *
  * @param Event $event The Controller.beforeRedirect event.
- * @param Controller $controller A reference to the controller
  * @param string|array $url A string or array containing the redirect location
  * @param integer|array $status HTTP Status for redirect
  * @param boolean $exit
  * @return void
  */
-	public function beforeRedirect(Event $event, Controller $controller, $url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, $url, $status = null, $exit = true) {
 		if (!$this->request->is('ajax')) {
 			return;
 		}
@@ -270,6 +269,7 @@ class RequestHandlerComponent extends Component {
 			$code = key($statusCode);
 			$this->response->statusCode($code);
 		}
+		$controller = $event->subject();
 		$this->response->body($controller->requestAction($url, array('return', 'bare' => false)));
 		$this->response->send();
 		$this->_stop();
@@ -285,7 +285,7 @@ class RequestHandlerComponent extends Component {
  * @param Controller $controller
  * @return boolean false if the render process should be aborted
  */
-	public function beforeRender(Event $event, Controller $controller) {
+	public function beforeRender(Event $event) {
 		if ($this->settings['checkHttpCache'] && $this->response->checkNotModified($this->request)) {
 			return false;
 		}

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -264,11 +264,6 @@ class RequestHandlerComponent extends Component {
 		if (is_array($url)) {
 			$url = Router::url($url + array('base' => false));
 		}
-		if (!empty($status)) {
-			$statusCode = $response->httpCodes($status);
-			$code = key($statusCode);
-			$response->statusCode($code);
-		}
 		$controller = $event->subject();
 		$response->body($controller->requestAction($url, array('return', 'bare' => false)));
 		$response->send();

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -1,11 +1,5 @@
 <?php
 /**
- * Request object for handling alternative HTTP requests
- *
- * Alternative HTTP requests can come from wireless units like mobile phones, palmtop computers,
- * and the like. These units have no use for Ajax requests, and this Component can tell how Cake
- * should respond to the different needs of a handheld computer and a desktop machine.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -15,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 0.10.4.1076
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -27,6 +20,7 @@ use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Error;
+use Cake\Event\Event;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\Xml;
@@ -38,9 +32,7 @@ use Cake\Utility\Xml;
  * and the like. These units have no use for Ajax requests, and this Component can tell how Cake
  * should respond to the different needs of a handheld computer and a desktop machine.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/request-handling.html
- *
  */
 class RequestHandlerComponent extends Component {
 
@@ -130,11 +122,12 @@ class RequestHandlerComponent extends Component {
  * If there is only one matching type between the supported content types & extensions,
  * and the requested mime-types, RequestHandler::$ext is set to that value.
  *
+ * @param Event $event The initialize event that was fired.
  * @param Controller $controller A reference to the controller
  * @return void
  * @see Router::parseExtensions()
  */
-	public function initialize(Controller $controller) {
+	public function initialize(Event $event, Controller $controller) {
 		if (isset($this->request->params['_ext'])) {
 			$this->ext = $this->request->params['_ext'];
 		}
@@ -201,10 +194,11 @@ class RequestHandlerComponent extends Component {
  * - If the XML data is POSTed, the data is parsed into an XML object, which is assigned
  *   to the $data property of the controller, which can then be saved to a model object.
  *
+ * @param Event $event The startup event that was fired.
  * @param Controller $controller A reference to the controller
  * @return void
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$controller->request->params['isAjax'] = $this->request->is('ajax');
 		$isRecognized = (
 			!in_array($this->ext, array('html', 'htm')) &&
@@ -250,13 +244,14 @@ class RequestHandlerComponent extends Component {
  * Handles (fakes) redirects for Ajax requests using requestAction()
  * Modifies the $_POST and $_SERVER['REQUEST_METHOD'] to simulate a new GET request.
  *
+ * @param Event $event The Controller.beforeRedirect event.
  * @param Controller $controller A reference to the controller
  * @param string|array $url A string or array containing the redirect location
  * @param integer|array $status HTTP Status for redirect
  * @param boolean $exit
  * @return void
  */
-	public function beforeRedirect(Controller $controller, $url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, Controller $controller, $url, $status = null, $exit = true) {
 		if (!$this->request->is('ajax')) {
 			return;
 		}
@@ -286,10 +281,11 @@ class RequestHandlerComponent extends Component {
  * render process is skipped. And the client will get a blank response with a
  * "304 Not Modified" header.
  *
- * @params Controller $controller
+ * @param Event $event The Controller.beforeRender event.
+ * @param Controller $controller
  * @return boolean false if the render process should be aborted
  */
-	public function beforeRender(Controller $controller) {
+	public function beforeRender(Event $event, Controller $controller) {
 		if ($this->settings['checkHttpCache'] && $this->response->checkNotModified($this->request)) {
 			return false;
 		}

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -310,7 +310,7 @@ class RequestHandlerComponent extends Component {
 	public function isFlash() {
 		return $this->request->is('flash');
 	}
-;
+
 /**
  * Returns true if the current request is over HTTPS, false otherwise.
  *

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -34,7 +34,6 @@ use Cake\Utility\Security;
  * - Requiring that SSL be used.
  * - Limiting cross controller communication.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html
  */
 class SecurityComponent extends Component {

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -217,10 +217,10 @@ class SecurityComponent extends Component {
  * Component startup. All security checking happens here.
  *
  * @param Event $event An Event instance
- * @param Controller $controller Instantiating controller
  * @return void
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
+		$controller = $event->subject();
 		$this->request = $controller->request;
 		$this->_action = $this->request->params['action'];
 		$this->_methodsRequired($controller);

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -19,6 +19,7 @@ use Cake\Controller\ComponentCollection;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Error;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
@@ -216,10 +217,11 @@ class SecurityComponent extends Component {
 /**
  * Component startup. All security checking happens here.
  *
+ * @param Event $event An Event instance
  * @param Controller $controller Instantiating controller
  * @return void
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$this->request = $controller->request;
 		$this->_action = $this->request->params['action'];
 		$this->_methodsRequired($controller);

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * SessionComponent. Provides access to Sessions from the Controller layer
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller.Component
  * @since         CakePHP(tm) v 0.10.0.1232
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -27,7 +22,6 @@ use Cake\Model\Datasource\Session;
  * page requests. It acts as a wrapper for the `$_SESSION` as well as providing
  * convenience methods for several `$_SESSION` related functions.
  *
- * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html
  * @link http://book.cakephp.org/2.0/en/development/sessions.html
  */

--- a/lib/Cake/Controller/ComponentCollection.php
+++ b/lib/Cake/Controller/ComponentCollection.php
@@ -17,6 +17,7 @@ namespace Cake\Controller;
 use Cake\Core\App;
 use Cake\Error;
 use Cake\Event\EventListener;
+use Cake\Event\EventManager;
 
 /**
  * Components collection is used as a registry for loaded components
@@ -51,9 +52,13 @@ class ComponentCollection {
  *
  * @param Cake\Controller\Controller $Controller
  */
-	public function __construct(Controller $Controller) {
-		$this->_Controller = $Controller;
-		$this->_eventManager = $Controller->getEventManager();
+	public function __construct(Controller $Controller = null) {
+		if ($Controller) {
+			$this->_Controller = $Controller;
+			$this->_eventManager = $Controller->getEventManager();
+		} else {
+			$this->_eventManager = new EventManager();
+		}
 	}
 
 /**

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -650,8 +650,8 @@ class Controller extends Object implements EventListener {
  * @return void
  */
 	public function startupProcess() {
-		$this->getEventManager()->dispatch(new Event('Controller.initialize', $this));
-		$this->getEventManager()->dispatch(new Event('Controller.startup', $this));
+		$this->getEventManager()->dispatch(new Event('Controller.initialize', $this, [$this]));
+		$this->getEventManager()->dispatch(new Event('Controller.startup', $this, [$this]));
 	}
 
 /**
@@ -664,7 +664,7 @@ class Controller extends Object implements EventListener {
  * @return void
  */
 	public function shutdownProcess() {
-		$this->getEventManager()->dispatch(new Event('Controller.shutdown', $this));
+		$this->getEventManager()->dispatch(new Event('Controller.shutdown', $this, [$this]));
 	}
 
 /**
@@ -738,8 +738,7 @@ class Controller extends Object implements EventListener {
 		if (is_array($status)) {
 			extract($status, EXTR_OVERWRITE);
 		}
-		$event = new Event('Controller.beforeRedirect', $this, array($url, $status, $exit));
-		list($event->break, $event->breakOn, $event->collectReturn) = array(true, false, true);
+		$event = new Event('Controller.beforeRedirect', $this, array($this, $url, $status, $exit));
 		$this->getEventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
@@ -877,7 +876,7 @@ class Controller extends Object implements EventListener {
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::render
  */
 	public function render($view = null, $layout = null) {
-		$event = new Event('Controller.beforeRender', $this);
+		$event = new Event('Controller.beforeRender', $this, [$this]);
 		$this->getEventManager()->dispatch($event);
 		if ($event->isStopped()) {
 			$this->autoRender = false;

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -745,9 +745,8 @@ class Controller extends Object implements EventListener {
 			return;
 		}
 
-		$headers = $response->header();
-		if ($url !== null && empty($headers['Location'])) {
-			$response->header('Location', Router::url($url, true));
+		if ($url !== null && !$response->location()) {
+			$response->location(Router::url($url, true));
 		}
 
 		if (is_string($status)) {

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -54,6 +54,18 @@ use Cake\View\View;
  * use conventional names. For example `/posts/index` maps to `PostsController::index()`. You can re-map URLs
  * using Router::connect().
  *
+ * ### Life cycle callbacks
+ *
+ * CakePHP fires a number of life cycle callbacks during each request. By implementing a method
+ * you can receive the related events. The available callbacks are:
+ *
+ * - `beforeFilter(Event $event)` - Called before the before each action. This is a good place to
+ *   do general logic that applies to all actions.
+ * - `beforeRender(Event $event)` - Called before the view is rendered.
+ * - `beforeRedirect(Cake\Event\Event $event $url, Cake\Network\Response $response)` - Called before
+ *   a redirect is done.
+ * - `afterFilter(Event $event)` - Called after each action is complete and after the view is rendered.
+ *
  * @package       Cake.Controller
  * @property      AclComponent $Acl
  * @property      AuthComponent $Auth

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -28,8 +28,8 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
-use Cake\Utility\MergeVariablesTrait;
 use Cake\Utility\ObjectCollection;
+use Cake\Utility\MergeVariablesTrait;
 use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
 
@@ -747,10 +747,11 @@ class Controller extends Object implements EventListener {
 	public function redirect($url, $status = null, $exit = true) {
 		$this->autoRender = false;
 
-		if (is_array($status)) {
-			extract($status, EXTR_OVERWRITE);
-		}
 		$response = $this->response;
+		if ($status && $response->statusCode() === 200) {
+			$response->statusCode($status);
+		}
+
 		$event = new Event('Controller.beforeRedirect', $this, [$response, $url, $status]);
 		$this->getEventManager()->dispatch($event);
 		if ($event->isStopped()) {
@@ -759,17 +760,6 @@ class Controller extends Object implements EventListener {
 
 		if ($url !== null && !$response->location()) {
 			$response->location(Router::url($url, true));
-		}
-
-		if (is_string($status)) {
-			$codes = array_flip($response->httpCodes());
-			if (isset($codes[$status])) {
-				$status = $codes[$status];
-			}
-		}
-
-		if ($status && $response->statusCode() === 200) {
-			$response->statusCode($status);
 		}
 
 		if ($exit) {

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -28,8 +28,8 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
-use Cake\Utility\ObjectCollection;
 use Cake\Utility\MergeVariablesTrait;
+use Cake\Utility\ObjectCollection;
 use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
 

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -17,7 +17,6 @@ namespace Cake\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Object;
-use Cake\Core\ObjectCollection;
 use Cake\Core\Plugin;
 use Cake\Error;
 use Cake\Event\Event;
@@ -29,6 +28,7 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
+use Cake\Utility\ObjectCollection;
 use Cake\Utility\MergeVariablesTrait;
 use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
@@ -565,8 +565,8 @@ class Controller extends Object implements EventListener {
 		return array(
 			'Controller.initialize' => 'beforeFilter',
 			'Controller.beforeRender' => 'beforeRender',
-			'Controller.beforeRedirect' => array('callable' => 'beforeRedirect', 'passParams' => true),
-			'Controller.shutdown' => 'afterFilter'
+			'Controller.beforeRedirect' => 'beforeRedirect',
+			'Controller.shutdown' => 'afterFilter',
 		);
 	}
 
@@ -979,20 +979,22 @@ class Controller extends Object implements EventListener {
  * Called before the controller action. You can use this method to configure and customize components
  * or perform logic that needs to happen before each controller action.
  *
+ * @param Event $event An Event instance
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#request-life-cycle-callbacks
  */
-	public function beforeFilter() {
+	public function beforeFilter(Event $event) {
 	}
 
 /**
  * Called after the controller action is run, but before the view is rendered. You can use this method
  * to perform logic or set view variables that are required on every request.
  *
+ * @param Event $event An Event instance
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#request-life-cycle-callbacks
  */
-	public function beforeRender() {
+	public function beforeRender(Event $event) {
 	}
 
 /**
@@ -1004,6 +1006,7 @@ class Controller extends Object implements EventListener {
  * return a string which will be interpreted as the url to redirect to or return associative array with
  * key 'url' and optionally 'status' and 'exit'.
  *
+ * @param Event $event An Event instance
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
  * @param integer $status Optional HTTP status code (eg: 404)
@@ -1014,16 +1017,17 @@ class Controller extends Object implements EventListener {
  *   array with the keys url, status and exit to be used by the redirect method.
  * @link http://book.cakephp.org/2.0/en/controllers.html#request-life-cycle-callbacks
  */
-	public function beforeRedirect($url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, $url, $status = null, $exit = true) {
 	}
 
 /**
  * Called after the controller action is run and rendered.
  *
+ * @param Event $event An Event instance
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#request-life-cycle-callbacks
  */
-	public function afterFilter() {
+	public function afterFilter(Event $event) {
 	}
 
 /**

--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -650,8 +650,8 @@ class Controller extends Object implements EventListener {
  * @return void
  */
 	public function startupProcess() {
-		$this->getEventManager()->dispatch(new Event('Controller.initialize', $this, [$this]));
-		$this->getEventManager()->dispatch(new Event('Controller.startup', $this, [$this]));
+		$this->getEventManager()->dispatch(new Event('Controller.initialize', $this));
+		$this->getEventManager()->dispatch(new Event('Controller.startup', $this));
 	}
 
 /**
@@ -664,7 +664,7 @@ class Controller extends Object implements EventListener {
  * @return void
  */
 	public function shutdownProcess() {
-		$this->getEventManager()->dispatch(new Event('Controller.shutdown', $this, [$this]));
+		$this->getEventManager()->dispatch(new Event('Controller.shutdown', $this));
 	}
 
 /**
@@ -738,7 +738,7 @@ class Controller extends Object implements EventListener {
 		if (is_array($status)) {
 			extract($status, EXTR_OVERWRITE);
 		}
-		$event = new Event('Controller.beforeRedirect', $this, array($this, $url, $status, $exit));
+		$event = new Event('Controller.beforeRedirect', $this, array($url, $status, $exit));
 		$this->getEventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
@@ -876,7 +876,7 @@ class Controller extends Object implements EventListener {
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::render
  */
 	public function render($view = null, $layout = null) {
-		$event = new Event('Controller.beforeRender', $this, [$this]);
+		$event = new Event('Controller.beforeRender', $this);
 		$this->getEventManager()->dispatch($event);
 		if ($event->isStopped()) {
 			$this->autoRender = false;

--- a/lib/Cake/Controller/ErrorController.php
+++ b/lib/Cake/Controller/ErrorController.php
@@ -53,11 +53,12 @@ class ErrorController extends Controller {
 		) {
 			$this->RequestHandler = $this->Components->load('RequestHandler');
 		}
-		if ($this->Components->enabled('Auth')) {
-			$this->Components->disable('Auth');
+		$eventManager = $this->getEventManager();
+		if (isset($this->Auth)) {
+			$eventManager->detach($this->Auth);
 		}
-		if ($this->Components->enabled('Security')) {
-			$this->Components->disable('Security');
+		if (isset($this->Security)) {
+			$eventManager->detach($this->Security);
 		}
 		$this->_set(array('cacheAction' => false, 'viewPath' => 'Errors'));
 	}

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -164,8 +164,8 @@ class ExceptionRenderer {
 			$controller->startupProcess();
 		} catch (\Exception $e) {
 			if (!empty($controller) && isset($controller->RequestHandler)) {
-				$event = new Event('Controller.startup', $controller, [$controller]);
-				$controller->RequestHandler->startup($event, $controller);
+				$event = new Event('Controller.startup', $controller);
+				$controller->RequestHandler->startup($event);
 			}
 		}
 		if (empty($controller)) {
@@ -281,7 +281,7 @@ class ExceptionRenderer {
 	protected function _outputMessage($template) {
 		try {
 			$this->controller->render($template);
-			$event = new Event('Controller.shutdown', $this->controller, [$this->controller]);
+			$event = new Event('Controller.shutdown', $this->controller);
 			$this->controller->afterFilter($event);
 			$this->controller->response->send();
 		} catch (Error\MissingViewException $e) {

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -162,7 +162,7 @@ class ExceptionRenderer {
 			$controller = new ErrorController($request, $response);
 			$controller->startupProcess();
 		} catch (\Exception $e) {
-			if (!empty($controller) && $controller->Components->enabled('RequestHandler')) {
+			if (!empty($controller) && isset($controller->RequestHandler)) {
 				$controller->RequestHandler->startup($controller);
 			}
 		}

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -26,6 +26,7 @@ use Cake\Controller\Controller;
 use Cake\Controller\ErrorController;
 use Cake\Core\Configure;
 use Cake\Error;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
@@ -163,7 +164,8 @@ class ExceptionRenderer {
 			$controller->startupProcess();
 		} catch (\Exception $e) {
 			if (!empty($controller) && isset($controller->RequestHandler)) {
-				$controller->RequestHandler->startup($controller);
+				$event = new Event('Controller.startup', $controller, [$controller]);
+				$controller->RequestHandler->startup($event, $controller);
 			}
 		}
 		if (empty($controller)) {
@@ -279,7 +281,8 @@ class ExceptionRenderer {
 	protected function _outputMessage($template) {
 		try {
 			$this->controller->render($template);
-			$this->controller->afterFilter();
+			$event = new Event('Controller.shutdown', $this->controller, [$this->controller]);
+			$this->controller->afterFilter($event);
 			$this->controller->response->send();
 		} catch (Error\MissingViewException $e) {
 			$attributes = $e->getAttributes();

--- a/lib/Cake/Event/EventManager.php
+++ b/lib/Cake/Event/EventManager.php
@@ -262,16 +262,18 @@ class EventManager {
 		if ($length) {
 			$data = array_values($data);
 		}
+		$subject = $event->subject();
 		switch ($length) {
 			case 0:
-				return $listener($event);
+				return $listener($event, $subject());
 			case 1:
-				return $listener($event, $data[0]);
+				return $listener($event, $subject(), $data[0]);
 			case 2:
-				return $listener($event, $data[0], $data[1]);
+				return $listener($event, $subject, $data[0], $data[1]);
 			case 3:
-				return $listener($event, $data[0], $data[1], $data[2]);
+				return $listener($event, $subject, $data[0], $data[1], $data[2]);
 			default:
+				array_unshift($data, $subject);
 				array_unshift($data, $event);
 				return call_user_func_array($listener, $data);
 		}

--- a/lib/Cake/Event/EventManager.php
+++ b/lib/Cake/Event/EventManager.php
@@ -262,18 +262,16 @@ class EventManager {
 		if ($length) {
 			$data = array_values($data);
 		}
-		$subject = $event->subject();
 		switch ($length) {
 			case 0:
-				return $listener($event, $subject());
+				return $listener($event);
 			case 1:
-				return $listener($event, $subject(), $data[0]);
+				return $listener($event, $data[0]);
 			case 2:
-				return $listener($event, $subject, $data[0], $data[1]);
+				return $listener($event, $data[0], $data[1]);
 			case 3:
-				return $listener($event, $subject, $data[0], $data[1], $data[2]);
+				return $listener($event, $data[0], $data[1], $data[2]);
 			default:
-				array_unshift($data, $subject);
 				array_unshift($data, $event);
 				return call_user_func_array($listener, $data);
 		}

--- a/lib/Cake/Test/TestApp/Controller/Component/AppleComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/AppleComponent.php
@@ -50,7 +50,7 @@ class AppleComponent extends Component {
  * @param mixed $controller
  * @return void
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
 		$this->testName = $controller->name;
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/Component/AppleComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/AppleComponent.php
@@ -20,6 +20,7 @@ namespace TestApp\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
+use Cake\Event\Event;
 
 /**
  * AppleComponent class
@@ -45,10 +46,11 @@ class AppleComponent extends Component {
 /**
  * startup method
  *
+ * @param Event $event
  * @param mixed $controller
  * @return void
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$this->testName = $controller->name;
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/Component/BananaComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/BananaComponent.php
@@ -20,6 +20,7 @@ namespace TestApp\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
+use Cake\Event\Event;
 
 /**
  * BananaComponent class
@@ -38,10 +39,11 @@ class BananaComponent extends Component {
 /**
  * startup method
  *
+ * @param Event $event
  * @param Controller $controller
  * @return string
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$controller->bar = 'fail';
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/Component/BananaComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/BananaComponent.php
@@ -43,7 +43,7 @@ class BananaComponent extends Component {
  * @param Controller $controller
  * @return string
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
 		$controller->bar = 'fail';
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/Component/OrangeComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/OrangeComponent.php
@@ -38,8 +38,8 @@ class OrangeComponent extends Component {
  * @param Controller $controller
  * @return void
  */
-	public function initialize(Event $event, Controller $controller) {
-		$this->Controller = $controller;
+	public function initialize(Event $event) {
+		$this->Controller = $event->subject();
 		$this->Banana->testField = 'OrangeField';
 	}
 
@@ -50,7 +50,7 @@ class OrangeComponent extends Component {
  * @param Controller $controller
  * @return string
  */
-	public function startup(Event $event, Controller $controller) {
+	public function startup(Event $event) {
 		$controller->foo = 'pass';
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/Component/OrangeComponent.php
+++ b/lib/Cake/Test/TestApp/Controller/Component/OrangeComponent.php
@@ -16,6 +16,7 @@ namespace TestApp\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\Controller;
+use Cake\Event\Event;
 
 /**
  * OrangeComponent class
@@ -33,10 +34,11 @@ class OrangeComponent extends Component {
 /**
  * initialize method
  *
- * @param mixed $controller
+ * @param Event $event
+ * @param Controller $controller
  * @return void
  */
-	public function initialize(Controller $controller) {
+	public function initialize(Event $event, Controller $controller) {
 		$this->Controller = $controller;
 		$this->Banana->testField = 'OrangeField';
 	}
@@ -44,10 +46,11 @@ class OrangeComponent extends Component {
 /**
  * startup method
  *
+ * @param Event $event
  * @param Controller $controller
  * @return string
  */
-	public function startup(Controller $controller) {
+	public function startup(Event $event, Controller $controller) {
 		$controller->foo = 'pass';
 	}
 }

--- a/lib/Cake/Test/TestApp/Controller/RequestHandlerTestController.php
+++ b/lib/Cake/Test/TestApp/Controller/RequestHandlerTestController.php
@@ -1,12 +1,15 @@
 <?php
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/lib/Cake/Test/TestApp/Controller/RequestHandlerTestController.php
+++ b/lib/Cake/Test/TestApp/Controller/RequestHandlerTestController.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * RequestHandlerTestController
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -12,7 +8,6 @@
  *
  * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Controller
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */

--- a/lib/Cake/Test/TestApp/Controller/SomePostsController.php
+++ b/lib/Cake/Test/TestApp/Controller/SomePostsController.php
@@ -14,6 +14,7 @@
 namespace TestApp\Controller;
 
 use Cake\Controller\Controller;
+use Cake\Event\Event;
 
 /**
  * SomePostsController class
@@ -48,7 +49,7 @@ class SomePostsController extends Controller {
  *
  * @return void
  */
-	public function beforeFilter() {
+	public function beforeFilter(Event $event) {
 		if ($this->request->params['action'] == 'index') {
 			$this->request->params['action'] = 'view';
 		} else {

--- a/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/Component/OtherComponent.php
+++ b/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/Component/OtherComponent.php
@@ -18,8 +18,8 @@
  */
 namespace TestPlugin\Controller\Component;
 
-use Cake\Core\Object;
 use Cake\Controller\Component;
+use Cake\Core\Object;
 
 class OtherComponent extends Component {
 }

--- a/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/Component/OtherComponent.php
+++ b/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/Component/OtherComponent.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Short description for file.
- *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,19 +9,17 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.TestApp.Plugin.TestPlugin.Controller.Component
  * @since         CakePHP(tm) v 1.2.0.4206
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 /**
  * Class OtherComponent
- *
- * @package       Cake.Test.TestApp.Plugin.TestPlugin.Controller.Component
  */
 namespace TestPlugin\Controller\Component;
 
 use Cake\Core\Object;
+use Cake\Controller\Component;
 
-class OtherComponent extends Object {
+class OtherComponent extends Component {
 }

--- a/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/TestPluginController.php
+++ b/lib/Cake/Test/TestApp/Plugin/TestPlugin/Controller/TestPluginController.php
@@ -20,8 +20,6 @@
 
 /**
  * Class TestPluginController
- *
- * @package       Cake.Test.TestApp.Plugin.TestPlugin.Controller
  */
 namespace TestPlugin\Controller;
 

--- a/lib/Cake/Test/TestCase/Console/Command/ApiShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/ApiShellTest.php
@@ -55,7 +55,7 @@ class ApiShellTest extends TestCase {
 		$this->Shell->expects($this->at(2))
 			->method('out')
 			->with($this->logicalAnd(
-				$this->contains('8. beforeFilter()'),
+				$this->contains('8. beforeFilter($event)'),
 				$this->contains('24. render($view = NULL, $layout = NULL)')
 			));
 

--- a/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * AuthComponentTest file
- *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.Controller.Component
  * @since         CakePHP(tm) v 1.2.0.5347
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -25,6 +20,7 @@ use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Error;
+use Cake\Event\Event;
 use Cake\Model\Datasource\Session;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -129,18 +125,19 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testIsErrorOrTests() {
-		$this->Controller->Auth->initialize($this->Controller);
+		$event = new Event('Controller.startup');
+		$this->Controller->Auth->initialize($event, $this->Controller);
 
 		$this->Controller->name = 'Error';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->name = 'Post';
 		$this->Controller->request['action'] = 'thisdoesnotexist';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->scaffold = null;
 		$this->Controller->request['action'] = 'index';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 	}
 
 /**
@@ -200,11 +197,11 @@ class AuthComponentTest extends TestCase {
 		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
 
 		$this->Auth->authenticate = array('Form');
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$this->assertEquals('/auth_test/admin_add', $this->Auth->Session->read('Auth.redirect'));
 
 		$this->Auth->Session->write('Auth.User', array('username' => 'admad'));
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
 	}
 
@@ -214,23 +211,24 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAuthorizeFalse() {
+		$event = new Event('Controller.startup');
 		$this->AuthUser = new AuthUser();
 		$user = $this->AuthUser->find();
 		$this->Auth->Session->write('Auth.User', $user['AuthUser']);
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->authorize = false;
 		$this->Controller->request->addParams(Router::parse('auth_test/add'));
-		$this->Controller->Auth->initialize($this->Controller);
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$this->Controller->Auth->initialize($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result);
 
 		$this->Auth->Session->delete('Auth');
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertFalse($result);
 		$this->assertTrue($this->Auth->Session->check('Message.auth'));
 
 		$this->Controller->request->addParams(Router::parse('auth_test/camelCase'));
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertFalse($result);
 	}
 
@@ -382,58 +380,59 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAllowDenyAll() {
-		$this->Controller->Auth->initialize($this->Controller);
+		$event = new Event('Controller.startup');
+		$this->Controller->Auth->initialize($event, $this->Controller);
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny('add', 'camelCase');
 
 		$this->Controller->request['action'] = 'delete';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->request['action'] = 'add';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny(array('add', 'camelCase'));
 
 		$this->Controller->request['action'] = 'delete';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->Auth->allow('*');
 		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->request['action'] = 'add';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->Auth->allow('camelCase');
 		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->request['action'] = 'login';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->Auth->deny();
 		$this->Controller->Auth->allow(null);
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertTrue($this->Controller->Auth->startup($this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny(null);
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 	}
 
 /**
@@ -442,7 +441,8 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testDenyWithCamelCaseMethods() {
-		$this->Controller->Auth->initialize($this->Controller);
+		$event = new Event('Controller.startup');
+		$this->Controller->Auth->initialize($event, $this->Controller);
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny('add', 'camelCase');
 
@@ -450,12 +450,12 @@ class AuthComponentTest extends TestCase {
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
 
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 
 		$url = '/auth_test/CamelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->assertFalse($this->Controller->Auth->startup($this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
 	}
 
 /**
@@ -464,39 +464,40 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAllowedActionsWithCamelCaseMethods() {
+		$event = new Event('Controller.startup');
 		$url = '/auth_test/camelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($this->Controller);
+		$this->Controller->Auth->initialize($event, $this->Controller);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->allow();
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 
 		$url = '/auth_test/camelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($this->Controller);
+		$this->Controller->Auth->initialize($event, $this->Controller);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->allowedActions = array('delete', 'camelCase', 'add');
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 
 		$this->Controller->Auth->allowedActions = array('delete', 'add');
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertFalse($result, 'startup() should return false, as action is not allowed. %s');
 
 		$url = '/auth_test/delete';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($this->Controller);
+		$this->Controller->Auth->initialize($event, $this->Controller);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 
 		$this->Controller->Auth->allow(array('delete', 'add'));
-		$result = $this->Controller->Auth->startup($this->Controller);
+		$result = $this->Controller->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 	}
 
@@ -504,7 +505,7 @@ class AuthComponentTest extends TestCase {
 		$url = '/auth_test/action_name';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($this->Controller);
+		$this->Controller->Auth->initialize($event, $this->Controller);
 		$this->Controller->Auth->allow('action_name', 'anotherAction');
 		$this->assertEquals(array('action_name', 'anotherAction'), $this->Controller->Auth->allowedActions);
 	}
@@ -515,6 +516,8 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testLoginRedirect() {
+		$event = new Event('Controller.startup');
+		$url = '/auth_test/camelCase';
 		$_SERVER['HTTP_REFERER'] = false;
 		$_ENV['HTTP_REFERER'] = false;
 		putenv('HTTP_REFERER=');
@@ -525,12 +528,12 @@ class AuthComponentTest extends TestCase {
 
 		$this->Auth->request->addParams(Router::parse('users/login'));
 		$this->Auth->request->url = 'users/login';
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 
 		$this->Auth->loginRedirect = array(
 			'controller' => 'pages', 'action' => 'display', 'welcome'
 		);
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize($this->Auth->loginRedirect);
 		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
@@ -549,13 +552,13 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->addParams(Router::parse($url));
 		array_push($this->Controller->methods, 'view', 'edit', 'index');
 
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->authorize = 'controller';
 
 		$this->Auth->loginAction = array(
 			'controller' => 'AuthTest', 'action' => 'login'
 		);
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('/AuthTest/login');
 		$this->assertEquals($expected, $this->Controller->testUrl);
 
@@ -566,10 +569,10 @@ class AuthComponentTest extends TestCase {
 		));
 		$this->Auth->request->params['action'] = 'login';
 		$this->Auth->request->url = 'auth_test/login';
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = 'auth_test/login';
 		$this->Auth->loginRedirect = false;
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('/admin');
 		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
@@ -578,9 +581,9 @@ class AuthComponentTest extends TestCase {
 		$url = '/posts/view/1';
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('posts/view/1');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -596,9 +599,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
 		$this->Auth->request->query = $_GET;
 
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('posts/index/29?print=true&refer=menu');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -613,9 +616,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request = $this->Controller->request = $request;
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('/posts/edit/1');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -626,9 +629,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request = $this->Controller->request = new Request($url);
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = Router::normalize($url);
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$expected = Router::normalize('/');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -641,6 +644,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testDefaultToLoginRedirect() {
+		$event = new Event('Controller.startup');
 		$_SERVER['HTTP_REFERER'] = false;
 		$_ENV['HTTP_REFERER'] = false;
 		putenv('HTTP_REFERER=');
@@ -665,7 +669,7 @@ class AuthComponentTest extends TestCase {
 		$Controller->expects($this->once())
 			->method('redirect')
 			->with($this->equalTo($expected));
-		$this->Auth->startup($Controller);
+		$this->Auth->startup($event, $Controller);
 	}
 
 /**
@@ -703,7 +707,7 @@ class AuthComponentTest extends TestCase {
 			->with($this->equalTo($expected));
 		$this->Auth->Session->expects($this->once())
 			->method('setFlash');
-		$this->Auth->startup($Controller);
+		$this->Auth->startup($event, $Controller);
 	}
 
 /**
@@ -712,6 +716,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testRedirectToUnauthorizedRedirectSuppressedAuthError() {
+		$event = new Event('Controller.startup');
 		$url = '/party/on';
 		$this->Auth->request = $CakeRequest = new CakeRequest($url);
 		$this->Auth->request->addParams(Router::parse($url));
@@ -742,7 +747,7 @@ class AuthComponentTest extends TestCase {
 			->with($this->equalTo($expected));
 		$this->Auth->Session->expects($this->never())
 			->method('setFlash');
-		$this->Auth->startup($Controller);
+		$this->Auth->startup($event, $Controller);
 	}
 
 /**
@@ -751,6 +756,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testForbiddenException() {
+		$event = new Event('Controller.startup');
 		$url = '/party/on';
 		$this->Auth->request = $request = new Request($url);
 		$this->Auth->request->addParams(Router::parse($url));
@@ -766,7 +772,7 @@ class AuthComponentTest extends TestCase {
 			array($request, $response)
 		);
 
-		$this->Auth->startup($Controller);
+		$this->Auth->startup($event, $Controller);
 	}
 
 /**
@@ -775,6 +781,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testNoRedirectOnLoginAction() {
+		$event = new Event('Controller.startup');
 		$controller = $this->getMock('Cake\Controller\Controller');
 		$controller->methods = array('login');
 
@@ -787,7 +794,7 @@ class AuthComponentTest extends TestCase {
 		$controller->expects($this->never())
 			->method('redirect');
 
-		$this->Auth->startup($controller);
+		$this->Auth->startup($event, $controller);
 	}
 
 /**
@@ -797,10 +804,11 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testNoRedirectOn404() {
+		$event = new Event('Controller.startup');
 		$this->Auth->Session->delete('Auth');
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->request->addParams(Router::parse('auth_test/something_totally_wrong'));
-		$result = $this->Auth->startup($this->Controller);
+		$result = $this->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result, 'Auth redirected a missing action %s');
 	}
 
@@ -810,6 +818,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAdminRoute() {
+		$event = new Event('Controller.startup');
 		$pref = Configure::read('Routing.prefixes');
 		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
@@ -821,13 +830,13 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->base = '';
 
 		Router::setRequestInfo($this->Auth->request);
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 
 		$this->Auth->loginAction = array(
 			'prefix' => 'admin', 'controller' => 'auth_test', 'action' => 'login'
 		);
 
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 		$this->assertEquals('/admin/auth_test/login', $this->Controller->testUrl);
 
 		Configure::write('Routing.prefixes', $pref);
@@ -859,6 +868,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testLoginActionRedirect() {
+		$event = new Event('Controller.startup');
 		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
 		require CAKE . 'Config/routes.php';
@@ -879,13 +889,13 @@ class AuthComponentTest extends TestCase {
 		$request->url = ltrim($url, '/');
 		Router::setRequestInfo($request);
 
-		$this->Auth->initialize($this->Controller);
+		$this->Auth->initialize($event, $this->Controller);
 		$this->Auth->loginAction = [
 			'prefix' => 'admin',
 			'controller' => 'auth_test',
 			'action' => 'login'
 		];
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 
 		$this->assertNull($this->Controller->testUrl);
 	}
@@ -897,6 +907,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testStatelessAuthWorksWithUser() {
+		$event = new Event('Controller.startup');
 		$_SERVER['PHP_AUTH_USER'] = 'mariano';
 		$_SERVER['PHP_AUTH_PW'] = 'cake';
 		$url = '/auth_test/add';
@@ -905,7 +916,7 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->authenticate = array(
 			'Basic' => array('userModel' => 'AuthUser')
 		);
-		$this->Auth->startup($this->Controller);
+		$this->Auth->startup($event, $this->Controller);
 
 		$result = $this->Auth->user();
 		$this->assertEquals('mariano', $result['username']);
@@ -930,9 +941,7 @@ class AuthComponentTest extends TestCase {
 			),
 			'Session'
 		);
-		$this->Controller->Components->init($this->Controller);
-		$this->Controller->Components->trigger('initialize', array(&$this->Controller));
-		Router::reload();
+		$this->Controller->constructClasses();
 
 		$expected = array(
 			'loginAction' => array('controller' => 'people', 'action' => 'login'),
@@ -1173,13 +1182,14 @@ class AuthComponentTest extends TestCase {
 			session_destroy();
 			Session::$id = null;
 		}
+		$event = new Event('Controller.startup');
 		$_SESSION = null;
 
 		AuthComponent::$sessionKey = false;
 		$this->Auth->authenticate = array('Basic');
 		$this->Controller->request['action'] = 'admin_add';
 
-		$result = $this->Auth->startup($this->Controller);
+		$result = $this->Auth->startup($event, $this->Controller);
 	}
 
 /**
@@ -1192,6 +1202,7 @@ class AuthComponentTest extends TestCase {
 			session_destroy();
 			Session::$id = null;
 		}
+		$event = new Event('Controller.startup');
 		$_SESSION = null;
 
 		$_SERVER['PHP_AUTH_USER'] = 'mariano';
@@ -1203,7 +1214,7 @@ class AuthComponentTest extends TestCase {
 		);
 		$this->Controller->request['action'] = 'admin_add';
 
-		$result = $this->Auth->startup($this->Controller);
+		$result = $this->Auth->startup($event, $this->Controller);
 		$this->assertTrue($result);
 
 		$this->assertNull(Session::id());
@@ -1215,13 +1226,14 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testStatelessFollowedByStatefulAuth() {
+		$event = new Event('Controller.startup');
 		$this->Auth->authenticate = array('Basic', 'Form');
 		$this->Controller->request['action'] = 'admin_add';
 
 		$this->Auth->response->expects($this->never())->method('statusCode');
 		$this->Auth->response->expects($this->never())->method('send');
 
-		$result = $this->Auth->startup($this->Controller);
+		$result = $this->Auth->startup($event, $this->Controller);
 		$this->assertFalse($result);
 
 		$this->assertEquals('/users/login', $this->Controller->testUrl);

--- a/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
@@ -125,19 +125,19 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testIsErrorOrTests() {
-		$event = new Event('Controller.startup');
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Controller->Auth->initialize($event);
 
 		$this->Controller->name = 'Error';
-		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event));
 
 		$this->Controller->name = 'Post';
 		$this->Controller->request['action'] = 'thisdoesnotexist';
-		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event));
 
 		$this->Controller->scaffold = null;
 		$this->Controller->request['action'] = 'index';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 	}
 
 /**
@@ -197,7 +197,7 @@ class AuthComponentTest extends TestCase {
 		$this->assertNull($this->Auth->Session->read('Auth.redirect'));
 
 		$this->Auth->authenticate = array('Form');
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$this->assertEquals('/auth_test/admin_add', $this->Auth->Session->read('Auth.redirect'));
 
 		$this->Auth->Session->write('Auth.User', array('username' => 'admad'));
@@ -211,24 +211,24 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAuthorizeFalse() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->AuthUser = new AuthUser();
 		$user = $this->AuthUser->find();
 		$this->Auth->Session->write('Auth.User', $user['AuthUser']);
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->authorize = false;
 		$this->Controller->request->addParams(Router::parse('auth_test/add'));
-		$this->Controller->Auth->initialize($event, $this->Controller);
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$this->Controller->Auth->initialize($event);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertTrue($result);
 
 		$this->Auth->Session->delete('Auth');
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertFalse($result);
 		$this->assertTrue($this->Auth->Session->check('Message.auth'));
 
 		$this->Controller->request->addParams(Router::parse('auth_test/camelCase'));
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertFalse($result);
 	}
 
@@ -380,59 +380,59 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAllowDenyAll() {
-		$event = new Event('Controller.startup');
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Controller->Auth->initialize($event);
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny('add', 'camelCase');
 
 		$this->Controller->request['action'] = 'delete';
-		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event));
 
 		$this->Controller->request['action'] = 'add';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny(array('add', 'camelCase'));
 
 		$this->Controller->request['action'] = 'delete';
-		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event));
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->Auth->allow('*');
 		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->request['action'] = 'add';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->Auth->allow('camelCase');
 		$this->Controller->Auth->deny();
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->request['action'] = 'login';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$this->Controller->Auth->deny();
 		$this->Controller->Auth->allow(null);
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertTrue($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertTrue($this->Controller->Auth->startup($event));
 
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny(null);
 
 		$this->Controller->request['action'] = 'camelCase';
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 	}
 
 /**
@@ -441,8 +441,8 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testDenyWithCamelCaseMethods() {
-		$event = new Event('Controller.startup');
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->allow();
 		$this->Controller->Auth->deny('add', 'camelCase');
 
@@ -450,12 +450,12 @@ class AuthComponentTest extends TestCase {
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
 
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 
 		$url = '/auth_test/CamelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->assertFalse($this->Controller->Auth->startup($event, $this->Controller));
+		$this->assertFalse($this->Controller->Auth->startup($event));
 	}
 
 /**
@@ -464,40 +464,40 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAllowedActionsWithCamelCaseMethods() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$url = '/auth_test/camelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->allow();
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 
 		$url = '/auth_test/camelCase';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 		$this->Controller->Auth->allowedActions = array('delete', 'camelCase', 'add');
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 
 		$this->Controller->Auth->allowedActions = array('delete', 'add');
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertFalse($result, 'startup() should return false, as action is not allowed. %s');
 
 		$url = '/auth_test/delete';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
 		$this->Controller->Auth->userModel = 'AuthUser';
 
 		$this->Controller->Auth->allow(array('delete', 'add'));
-		$result = $this->Controller->Auth->startup($event, $this->Controller);
+		$result = $this->Controller->Auth->startup($event);
 		$this->assertTrue($result, 'startup() should return true, as action is allowed. %s');
 	}
 
@@ -505,7 +505,7 @@ class AuthComponentTest extends TestCase {
 		$url = '/auth_test/action_name';
 		$this->Controller->request->addParams(Router::parse($url));
 		$this->Controller->request->query['url'] = Router::normalize($url);
-		$this->Controller->Auth->initialize($event, $this->Controller);
+		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->allow('action_name', 'anotherAction');
 		$this->assertEquals(array('action_name', 'anotherAction'), $this->Controller->Auth->allowedActions);
 	}
@@ -516,7 +516,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testLoginRedirect() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$url = '/auth_test/camelCase';
 		$_SERVER['HTTP_REFERER'] = false;
 		$_ENV['HTTP_REFERER'] = false;
@@ -528,12 +528,12 @@ class AuthComponentTest extends TestCase {
 
 		$this->Auth->request->addParams(Router::parse('users/login'));
 		$this->Auth->request->url = 'users/login';
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 
 		$this->Auth->loginRedirect = array(
 			'controller' => 'pages', 'action' => 'display', 'welcome'
 		);
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize($this->Auth->loginRedirect);
 		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
@@ -552,13 +552,13 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->addParams(Router::parse($url));
 		array_push($this->Controller->methods, 'view', 'edit', 'index');
 
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->authorize = 'controller';
 
 		$this->Auth->loginAction = array(
 			'controller' => 'AuthTest', 'action' => 'login'
 		);
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('/AuthTest/login');
 		$this->assertEquals($expected, $this->Controller->testUrl);
 
@@ -569,10 +569,10 @@ class AuthComponentTest extends TestCase {
 		));
 		$this->Auth->request->params['action'] = 'login';
 		$this->Auth->request->url = 'auth_test/login';
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = 'auth_test/login';
 		$this->Auth->loginRedirect = false;
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('/admin');
 		$this->assertEquals($expected, $this->Auth->redirectUrl());
 
@@ -581,9 +581,9 @@ class AuthComponentTest extends TestCase {
 		$url = '/posts/view/1';
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('posts/view/1');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -599,9 +599,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
 		$this->Auth->request->query = $_GET;
 
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('posts/index/29?print=true&refer=menu');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -616,9 +616,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request = $this->Controller->request = $request;
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = $this->Auth->request->here = Router::normalize($url);
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('/posts/edit/1');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -629,9 +629,9 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request = $this->Controller->request = new Request($url);
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->request->url = Router::normalize($url);
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = array('controller' => 'AuthTest', 'action' => 'login');
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$expected = Router::normalize('/');
 		$this->assertEquals($expected, $this->Auth->Session->read('Auth.redirect'));
 
@@ -644,7 +644,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testDefaultToLoginRedirect() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SERVER['HTTP_REFERER'] = false;
 		$_ENV['HTTP_REFERER'] = false;
 		putenv('HTTP_REFERER=');
@@ -669,7 +669,7 @@ class AuthComponentTest extends TestCase {
 		$Controller->expects($this->once())
 			->method('redirect')
 			->with($this->equalTo($expected));
-		$this->Auth->startup($event, $Controller);
+		$this->Auth->startup($event);
 	}
 
 /**
@@ -707,7 +707,7 @@ class AuthComponentTest extends TestCase {
 			->with($this->equalTo($expected));
 		$this->Auth->Session->expects($this->once())
 			->method('setFlash');
-		$this->Auth->startup($event, $Controller);
+		$this->Auth->startup($event);
 	}
 
 /**
@@ -716,7 +716,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testRedirectToUnauthorizedRedirectSuppressedAuthError() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$url = '/party/on';
 		$this->Auth->request = $CakeRequest = new CakeRequest($url);
 		$this->Auth->request->addParams(Router::parse($url));
@@ -747,7 +747,7 @@ class AuthComponentTest extends TestCase {
 			->with($this->equalTo($expected));
 		$this->Auth->Session->expects($this->never())
 			->method('setFlash');
-		$this->Auth->startup($event, $Controller);
+		$this->Auth->startup($event);
 	}
 
 /**
@@ -756,7 +756,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testForbiddenException() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$url = '/party/on';
 		$this->Auth->request = $request = new Request($url);
 		$this->Auth->request->addParams(Router::parse($url));
@@ -772,7 +772,7 @@ class AuthComponentTest extends TestCase {
 			array($request, $response)
 		);
 
-		$this->Auth->startup($event, $Controller);
+		$this->Auth->startup($event);
 	}
 
 /**
@@ -781,7 +781,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testNoRedirectOnLoginAction() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$controller = $this->getMock('Cake\Controller\Controller');
 		$controller->methods = array('login');
 
@@ -794,7 +794,7 @@ class AuthComponentTest extends TestCase {
 		$controller->expects($this->never())
 			->method('redirect');
 
-		$this->Auth->startup($event, $controller);
+		$this->Auth->startup($event);
 	}
 
 /**
@@ -804,11 +804,11 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testNoRedirectOn404() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Auth->Session->delete('Auth');
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->request->addParams(Router::parse('auth_test/something_totally_wrong'));
-		$result = $this->Auth->startup($event, $this->Controller);
+		$result = $this->Auth->startup($event);
 		$this->assertTrue($result, 'Auth redirected a missing action %s');
 	}
 
@@ -818,7 +818,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testAdminRoute() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$pref = Configure::read('Routing.prefixes');
 		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
@@ -830,13 +830,13 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request->base = '';
 
 		Router::setRequestInfo($this->Auth->request);
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 
 		$this->Auth->loginAction = array(
 			'prefix' => 'admin', 'controller' => 'auth_test', 'action' => 'login'
 		);
 
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 		$this->assertEquals('/admin/auth_test/login', $this->Controller->testUrl);
 
 		Configure::write('Routing.prefixes', $pref);
@@ -868,7 +868,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testLoginActionRedirect() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		Configure::write('Routing.prefixes', array('admin'));
 		Router::reload();
 		require CAKE . 'Config/routes.php';
@@ -889,13 +889,13 @@ class AuthComponentTest extends TestCase {
 		$request->url = ltrim($url, '/');
 		Router::setRequestInfo($request);
 
-		$this->Auth->initialize($event, $this->Controller);
+		$this->Auth->initialize($event);
 		$this->Auth->loginAction = [
 			'prefix' => 'admin',
 			'controller' => 'auth_test',
 			'action' => 'login'
 		];
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 
 		$this->assertNull($this->Controller->testUrl);
 	}
@@ -907,7 +907,7 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testStatelessAuthWorksWithUser() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SERVER['PHP_AUTH_USER'] = 'mariano';
 		$_SERVER['PHP_AUTH_PW'] = 'cake';
 		$url = '/auth_test/add';
@@ -916,7 +916,7 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->authenticate = array(
 			'Basic' => array('userModel' => 'AuthUser')
 		);
-		$this->Auth->startup($event, $this->Controller);
+		$this->Auth->startup($event);
 
 		$result = $this->Auth->user();
 		$this->assertEquals('mariano', $result['username']);
@@ -1182,14 +1182,14 @@ class AuthComponentTest extends TestCase {
 			session_destroy();
 			Session::$id = null;
 		}
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SESSION = null;
 
 		AuthComponent::$sessionKey = false;
 		$this->Auth->authenticate = array('Basic');
 		$this->Controller->request['action'] = 'admin_add';
 
-		$result = $this->Auth->startup($event, $this->Controller);
+		$result = $this->Auth->startup($event);
 	}
 
 /**
@@ -1202,7 +1202,7 @@ class AuthComponentTest extends TestCase {
 			session_destroy();
 			Session::$id = null;
 		}
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SESSION = null;
 
 		$_SERVER['PHP_AUTH_USER'] = 'mariano';
@@ -1214,7 +1214,7 @@ class AuthComponentTest extends TestCase {
 		);
 		$this->Controller->request['action'] = 'admin_add';
 
-		$result = $this->Auth->startup($event, $this->Controller);
+		$result = $this->Auth->startup($event);
 		$this->assertTrue($result);
 
 		$this->assertNull(Session::id());
@@ -1226,14 +1226,14 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testStatelessFollowedByStatefulAuth() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Auth->authenticate = array('Basic', 'Form');
 		$this->Controller->request['action'] = 'admin_add';
 
 		$this->Auth->response->expects($this->never())->method('statusCode');
 		$this->Auth->response->expects($this->never())->method('send');
 
-		$result = $this->Auth->startup($event, $this->Controller);
+		$result = $this->Auth->startup($event);
 		$this->assertFalse($result);
 
 		$this->assertEquals('/users/login', $this->Controller->testUrl);

--- a/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * CookieComponentTest file
- *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.Controller.Component
  * @since         CakePHP(tm) v 1.2.0.5435
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -22,6 +17,7 @@ namespace Cake\Test\TestCase\Controller\Component;
 use Cake\Controller\ComponentCollection;
 use Cake\Controller\Component\CookieComponent;
 use Cake\Controller\Controller;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
@@ -29,8 +25,6 @@ use Cake\Utility\Security;
 
 /**
  * CookieComponentTest class
- *
- * @package       Cake.Test.Case.Controller.Component
  */
 class CookieComponentTest extends TestCase {
 
@@ -58,7 +52,8 @@ class CookieComponentTest extends TestCase {
 		$this->Cookie->secure = false;
 		$this->Cookie->key = 'somerandomhaskey';
 
-		$this->Cookie->startup($this->Controller);
+		$event = new Event('Controller.startup');
+		$this->Cookie->startup($event, $this->Controller);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
@@ -52,8 +52,8 @@ class CookieComponentTest extends TestCase {
 		$this->Cookie->secure = false;
 		$this->Cookie->key = 'somerandomhaskey';
 
-		$event = new Event('Controller.startup');
-		$this->Cookie->startup($event, $this->Controller);
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->Cookie->startup($event);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -107,10 +107,10 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeCallback() {
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		$this->Controller->request->params['_ext'] = 'rss';
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('rss', $this->RequestHandler->ext);
 	}
 
@@ -120,13 +120,13 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeContentTypeSettingExt() {
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
 		Router::parseExtensions('json');
 
 		$this->assertNull($this->RequestHandler->ext);
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -137,11 +137,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithjQueryAccept() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('json');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -153,11 +153,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithjQueryAcceptAndMultiplesExtensions() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('rss', 'json');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -168,11 +168,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeNoContentTypeWithSingleAccept() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('json');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 	}
 
@@ -186,17 +186,17 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeNoContentTypeWithMultipleAcceptedTypes() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, application/xml, */*; q=0.01';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('xml', 'json');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('xml', $this->RequestHandler->ext);
 
 		$this->RequestHandler->ext = null;
 		Router::setExtensions(array('json', 'xml'), false);
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -207,11 +207,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithMultipleAcceptedTypes() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('xml', 'json');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -222,11 +222,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeAmbiguousAndroidAccepts() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('html', 'xml');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 	}
 
@@ -236,7 +236,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeContentTypeAndExtensionMismatch() {
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		$extensions = Router::extensions();
 		Router::parseExtensions('xml');
@@ -246,7 +246,7 @@ class RequestHandlerComponentTest extends TestCase {
 			->method('accepts')
 			->will($this->returnValue(array('application/json')));
 
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 
 		call_user_func_array(array('Cake\Routing\Router', 'parseExtensions'), $extensions);
@@ -258,9 +258,9 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testViewClassMap() {
-		$event = new Event('Controller.initialize');
+		$event = new Event('Controller.initialize', $this->Controller);
 		$this->RequestHandler->settings = array('viewClassMap' => array('json' => 'CustomJson'));
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$result = $this->RequestHandler->viewClassMap();
 		$expected = array(
 			'json' => 'CustomJson',
@@ -288,10 +288,10 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testDisabling() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 		$this->_init();
-		$event = new Event('Controller.startup');
-		$this->RequestHandler->initialize($event, $this->Controller);
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->RequestHandler->initialize($event);
 		$this->Controller->beforeFilter($event);
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$this->assertEquals(true, $this->Controller->request->params['isAjax']);
 	}
 
@@ -301,11 +301,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testAutoResponseType() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->ext = '.thtml';
 		$this->Controller->request->params['_ext'] = 'rss';
-		$this->RequestHandler->initialize($event, $this->Controller);
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
+		$this->RequestHandler->startup($event);
 		$this->assertEquals('.ctp', $this->Controller->ext);
 	}
 
@@ -315,15 +315,15 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testAutoAjaxLayout() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$this->assertEquals($this->Controller->layout, $this->RequestHandler->ajaxLayout);
 
 		$this->_init();
 		$this->Controller->request->params['_ext'] = 'js';
-		$this->RequestHandler->initialize($event, $this->Controller);
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->initialize($event);
+		$this->RequestHandler->startup($event);
 		$this->assertNotEquals('ajax', $this->Controller->layout);
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
@@ -335,11 +335,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testStartupCallback() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$_SERVER['CONTENT_TYPE'] = 'application/xml';
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$this->assertTrue(is_array($this->Controller->request->data));
 		$this->assertFalse(is_object($this->Controller->request->data));
 	}
@@ -350,11 +350,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testStartupCallbackCharset() {
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$_SERVER['CONTENT_TYPE'] = 'application/xml; charset=UTF-8';
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$this->assertTrue(is_array($this->Controller->request->data));
 		$this->assertFalse(is_object($this->Controller->request->data));
 	}
@@ -370,13 +370,13 @@ class RequestHandlerComponentTest extends TestCase {
 		}
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['CONTENT_TYPE'] = 'text/csv';
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
 		$this->Controller->request->expects($this->once())
 			->method('_readInput')
 			->will($this->returnValue('"A","csv","string"'));
 		$this->RequestHandler->addInputType('csv', array('str_getcsv'));
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$expected = array(
 			'A', 'csv', 'string'
 		);
@@ -389,10 +389,10 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testNonAjaxRedirect() {
-		$event = new Event('Controller.startup');
-		$this->RequestHandler->initialize($event, $this->Controller);
-		$this->RequestHandler->startup($event, $this->Controller);
-		$this->assertNull($this->RequestHandler->beforeRedirect($event, $this->Controller, '/'));
+		$event = new Event('Controller.startup', $this->Controller);
+		$this->RequestHandler->initialize($event);
+		$this->RequestHandler->startup($event);
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, '/'));
 	}
 
 /**
@@ -402,15 +402,15 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testAjaxRedirectWithNoUrl() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->response = $this->getMock('CakeResponse');
 
 		$this->Controller->response->expects($this->never())
 			->method('body');
 
-		$this->RequestHandler->initialize($event, $this->Controller);
-		$this->RequestHandler->startup($event, $this->Controller);
-		$this->assertNull($this->RequestHandler->beforeRedirect($event, $this->Controller, null));
+		$this->RequestHandler->initialize($event);
+		$this->RequestHandler->startup($event);
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, null));
 	}
 
 /**
@@ -721,9 +721,9 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCustomContent() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/x-mobile,text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5';
-		$event = new Event('Controller.startup');
+		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->setContent('mobile', 'text/x-mobile');
-		$this->RequestHandler->startup($event, $this->Controller);
+		$this->RequestHandler->startup($event);
 		$this->assertEquals('mobile', $this->RequestHandler->prefers());
 	}
 
@@ -754,7 +754,7 @@ class RequestHandlerComponentTest extends TestCase {
 			'View' => array(CAKE . 'Test/TestApp/View/')
 		), App::RESET);
 		Router::connect('/:controller/:action');
-		$event = new Event('Controller.beforeRedirect');
+		$event = new Event('Controller.beforeRedirect', $this->Controller);
 
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
@@ -771,7 +771,7 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
 			$event,
-			$this->Controller, array('controller' => 'request_handler_test', 'action' => 'destination')
+			array('controller' => 'request_handler_test', 'action' => 'destination')
 		);
 		$result = ob_get_clean();
 		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
@@ -791,7 +791,7 @@ class RequestHandlerComponentTest extends TestCase {
 			'View' => array(CAKE . 'Test/TestApp/View/')
 		), App::RESET);
 		Router::connect('/:controller/:action');
-		$event = new Event('Controller.beforeRedirect');
+		$event = new Event('Controller.beforeRedirect', $this->Controller);
 
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
@@ -808,7 +808,6 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
 			$event,
-			$this->Controller,
 			array('controller' => 'request_handler_test', 'action' => 'ajax2_layout')
 		);
 		$result = ob_get_clean();
@@ -828,7 +827,7 @@ class RequestHandlerComponentTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 		Router::connect('/:controller/:action/*');
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 
 		Router::setRequestInfo(array(
 			array('plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => array()),
@@ -847,7 +846,6 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$RequestHandler->beforeRedirect(
 			$event,
-			$this->Controller,
 			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second')
 		);
 		$result = ob_get_clean();
@@ -862,7 +860,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testBeforeRedirectCallingHeader() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 		$controller = $this->getMock('Cake\Controller\Controller', array('header'));
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('_sendHeader','statusCode'));
@@ -874,7 +872,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler->response->expects($this->once())->method('statusCode')->with(403);
 
 		ob_start();
-		$RequestHandler->beforeRedirect($event, $controller, 'request_handler_test/param_method/first/second', 403);
+		$RequestHandler->beforeRedirect($event, 'request_handler_test/param_method/first/second', 403);
 		ob_get_clean();
 	}
 
@@ -893,7 +891,7 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedByEtagStar() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = '*';
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something');
@@ -908,7 +906,7 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedByEtagExact() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
@@ -924,7 +922,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testCheckNotModifiedByEtagAndTime() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
 		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
@@ -939,7 +937,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckNotModifiedNoInfo() {
-		$event = new Event('Controller.beforeRender');
+		$event = new Event('Controller.beforeRender', $this->Controller);
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->expects($this->never())->method('notModified');

--- a/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -856,30 +856,6 @@ class RequestHandlerComponentTest extends TestCase {
 	}
 
 /**
- * assure that beforeRedirect with a status code will correctly set the status header
- *
- * @return void
- */
-	public function testBeforeRedirectCallingHeader() {
-		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-
-		$event = new Event('Controller.beforeRender', $this->Controller);
-		$controller = $this->getMock('Cake\Controller\Controller', array('header'));
-		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
-		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('_sendHeader','statusCode'));
-		$RequestHandler->request = $this->getMock('Cake\Network\Request');
-		$RequestHandler->request->expects($this->once())->method('is')
-			->with('ajax')
-			->will($this->returnValue(true));
-
-		$RequestHandler->response->expects($this->once())->method('statusCode')->with(403);
-
-		ob_start();
-		$RequestHandler->beforeRedirect($event, 'request_handler_test/param_method/first/second', $controller->response);
-		ob_get_clean();
-	}
-
-/**
  * @expectedException Cake\Error\Exception
  * @return void
  */
@@ -944,6 +920,6 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->expects($this->never())->method('notModified');
-		$this->assertNull($RequestHandler->beforeRender($event));
+		$this->assertNull($RequestHandler->beforeRender($event, '', $RequestHandler->response));
 	}
 }

--- a/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -392,7 +392,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
 		$this->RequestHandler->startup($event);
-		$this->assertNull($this->RequestHandler->beforeRedirect($event, '/'));
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, '/', $this->Controller->response));
 	}
 
 /**
@@ -410,7 +410,7 @@ class RequestHandlerComponentTest extends TestCase {
 
 		$this->RequestHandler->initialize($event);
 		$this->RequestHandler->startup($event);
-		$this->assertNull($this->RequestHandler->beforeRedirect($event, null));
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, null, $this->Controller->response));
 	}
 
 /**
@@ -771,7 +771,8 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
 			$event,
-			array('controller' => 'request_handler_test', 'action' => 'destination')
+			array('controller' => 'request_handler_test', 'action' => 'destination'),
+			$this->Controller->response
 		);
 		$result = ob_get_clean();
 		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
@@ -808,7 +809,8 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
 			$event,
-			array('controller' => 'request_handler_test', 'action' => 'ajax2_layout')
+			array('controller' => 'request_handler_test', 'action' => 'ajax2_layout'),
+			$this->Controller->response
 		);
 		$result = ob_get_clean();
 		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
@@ -846,7 +848,8 @@ class RequestHandlerComponentTest extends TestCase {
 		ob_start();
 		$RequestHandler->beforeRedirect(
 			$event,
-			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second')
+			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second'),
+			$this->Controller->response
 		);
 		$result = ob_get_clean();
 		$this->assertEquals('one: first two: second', $result);
@@ -872,7 +875,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler->response->expects($this->once())->method('statusCode')->with(403);
 
 		ob_start();
-		$RequestHandler->beforeRedirect($event, 'request_handler_test/param_method/first/second', 403);
+		$RequestHandler->beforeRedirect($event, 'request_handler_test/param_method/first/second', $controller->response);
 		ob_get_clean();
 	}
 
@@ -896,7 +899,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something');
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event));
 	}
 
 /**
@@ -906,12 +909,12 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedByEtagExact() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
-		$event = new Event('Controller.beforeRender', $this->Controller);
+		$event = new Event('Controller.beforeRender');
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event));
 	}
 
 /**
@@ -928,7 +931,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->modified('2012-01-01 00:00:00');
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event));
 	}
 
 /**
@@ -941,6 +944,6 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->expects($this->never())->method('notModified');
-		$this->assertNull($RequestHandler->beforeRender($event, $this->Controller));
+		$this->assertNull($RequestHandler->beforeRender($event));
 	}
 }

--- a/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * RequestHandlerComponentTest file
- *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.Controller.Component
  * @since         CakePHP(tm) v 1.2.0.5435
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -24,6 +19,7 @@ use Cake\Controller\Component\RequestHandlerComponent;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
@@ -32,8 +28,6 @@ use TestApp\Controller\RequestHandlerTestController;
 
 /**
  * RequestHandlerComponentTest class
- *
- * @package       Cake.Test.Case.Controller.Component
  */
 class RequestHandlerComponentTest extends TestCase {
 
@@ -100,11 +94,11 @@ class RequestHandlerComponentTest extends TestCase {
 			'ajaxLayout' => 'test_ajax',
 			'viewClassMap' => array('json' => 'MyPlugin.MyJson')
 		);
-		$Collection = new ComponentCollection();
-		$Collection->init($this->Controller);
-		$RequestHandler = new RequestHandlerComponent($Collection, $settings);
-		$this->assertEquals('test_ajax', $RequestHandler->ajaxLayout);
-		$this->assertEquals(array('json' => 'MyPlugin.MyJson'), $RequestHandler->settings['viewClassMap']);
+		$controller = $this->getMock('Cake\Controller\Controller');
+		$collection = new ComponentCollection($controller);
+		$requestHandler = new RequestHandlerComponent($collection, $settings);
+		$this->assertEquals('test_ajax', $requestHandler->ajaxLayout);
+		$this->assertEquals(array('json' => 'MyPlugin.MyJson'), $requestHandler->settings['viewClassMap']);
 	}
 
 /**
@@ -113,9 +107,10 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeCallback() {
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		$this->Controller->request->params['_ext'] = 'rss';
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('rss', $this->RequestHandler->ext);
 	}
 
@@ -125,12 +120,13 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeContentTypeSettingExt() {
-		$this->assertNull($this->RequestHandler->ext);
-
+		$event = new Event('Controller.initialize');
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
 		Router::parseExtensions('json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->assertNull($this->RequestHandler->ext);
+
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -141,10 +137,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithjQueryAccept() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -156,10 +153,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithjQueryAcceptAndMultiplesExtensions() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('rss', 'json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -170,10 +168,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeNoContentTypeWithSingleAccept() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 	}
 
@@ -187,16 +186,17 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeNoContentTypeWithMultipleAcceptedTypes() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, application/xml, */*; q=0.01';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('xml', 'json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('xml', $this->RequestHandler->ext);
 
 		$this->RequestHandler->ext = null;
 		Router::setExtensions(array('json', 'xml'), false);
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -207,10 +207,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeContentTypeWithMultipleAcceptedTypes() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('xml', 'json');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertEquals('json', $this->RequestHandler->ext);
 	}
 
@@ -221,10 +222,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInitializeAmbiguousAndroidAccepts() {
 		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		Router::parseExtensions('html', 'xml');
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 	}
 
@@ -234,6 +236,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testInitializeContentTypeAndExtensionMismatch() {
+		$event = new Event('Controller.initialize');
 		$this->assertNull($this->RequestHandler->ext);
 		$extensions = Router::extensions();
 		Router::parseExtensions('xml');
@@ -243,7 +246,7 @@ class RequestHandlerComponentTest extends TestCase {
 			->method('accepts')
 			->will($this->returnValue(array('application/json')));
 
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 
 		call_user_func_array(array('Cake\Routing\Router', 'parseExtensions'), $extensions);
@@ -255,8 +258,9 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testViewClassMap() {
+		$event = new Event('Controller.initialize');
 		$this->RequestHandler->settings = array('viewClassMap' => array('json' => 'CustomJson'));
-		$this->RequestHandler->initialize($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
 		$result = $this->RequestHandler->viewClassMap();
 		$expected = array(
 			'json' => 'CustomJson',
@@ -284,9 +288,10 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testDisabling() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 		$this->_init();
-		$this->RequestHandler->initialize($this->Controller);
-		$this->Controller->beforeFilter();
-		$this->RequestHandler->startup($this->Controller);
+		$event = new Event('Controller.startup');
+		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->Controller->beforeFilter($event);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertEquals(true, $this->Controller->request->params['isAjax']);
 	}
 
@@ -296,10 +301,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testAutoResponseType() {
+		$event = new Event('Controller.startup');
 		$this->Controller->ext = '.thtml';
 		$this->Controller->request->params['_ext'] = 'rss';
-		$this->RequestHandler->initialize($this->Controller);
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertEquals('.ctp', $this->Controller->ext);
 	}
 
@@ -309,14 +315,15 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testAutoAjaxLayout() {
+		$event = new Event('Controller.startup');
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertEquals($this->Controller->layout, $this->RequestHandler->ajaxLayout);
 
 		$this->_init();
 		$this->Controller->request->params['_ext'] = 'js';
-		$this->RequestHandler->initialize($this->Controller);
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertNotEquals('ajax', $this->Controller->layout);
 
 		unset($_SERVER['HTTP_X_REQUESTED_WITH']);
@@ -328,10 +335,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testStartupCallback() {
+		$event = new Event('Controller.startup');
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$_SERVER['CONTENT_TYPE'] = 'application/xml';
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertTrue(is_array($this->Controller->request->data));
 		$this->assertFalse(is_object($this->Controller->request->data));
 	}
@@ -342,10 +350,11 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testStartupCallbackCharset() {
+		$event = new Event('Controller.startup');
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$_SERVER['CONTENT_TYPE'] = 'application/xml; charset=UTF-8';
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertTrue(is_array($this->Controller->request->data));
 		$this->assertFalse(is_object($this->Controller->request->data));
 	}
@@ -361,12 +370,13 @@ class RequestHandlerComponentTest extends TestCase {
 		}
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_SERVER['CONTENT_TYPE'] = 'text/csv';
+		$event = new Event('Controller.startup');
 		$this->Controller->request = $this->getMock('Cake\Network\Request', array('_readInput'));
 		$this->Controller->request->expects($this->once())
 			->method('_readInput')
 			->will($this->returnValue('"A","csv","string"'));
 		$this->RequestHandler->addInputType('csv', array('str_getcsv'));
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$expected = array(
 			'A', 'csv', 'string'
 		);
@@ -379,9 +389,10 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testNonAjaxRedirect() {
-		$this->RequestHandler->initialize($this->Controller);
-		$this->RequestHandler->startup($this->Controller);
-		$this->assertNull($this->RequestHandler->beforeRedirect($this->Controller, '/'));
+		$event = new Event('Controller.startup');
+		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, $this->Controller, '/'));
 	}
 
 /**
@@ -391,14 +402,15 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testAjaxRedirectWithNoUrl() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		$event = new Event('Controller.startup');
 		$this->Controller->response = $this->getMock('CakeResponse');
 
 		$this->Controller->response->expects($this->never())
 			->method('body');
 
-		$this->RequestHandler->initialize($this->Controller);
-		$this->RequestHandler->startup($this->Controller);
-		$this->assertNull($this->RequestHandler->beforeRedirect($this->Controller, null));
+		$this->RequestHandler->initialize($event, $this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
+		$this->assertNull($this->RequestHandler->beforeRedirect($event, $this->Controller, null));
 	}
 
 /**
@@ -709,8 +721,9 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCustomContent() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/x-mobile,text/html;q=0.9,text/plain;q=0.8,*/*;q=0.5';
+		$event = new Event('Controller.startup');
 		$this->RequestHandler->setContent('mobile', 'text/x-mobile');
-		$this->RequestHandler->startup($this->Controller);
+		$this->RequestHandler->startup($event, $this->Controller);
 		$this->assertEquals('mobile', $this->RequestHandler->prefers());
 	}
 
@@ -741,6 +754,7 @@ class RequestHandlerComponentTest extends TestCase {
 			'View' => array(CAKE . 'Test/TestApp/View/')
 		), App::RESET);
 		Router::connect('/:controller/:action');
+		$event = new Event('Controller.beforeRedirect');
 
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
@@ -756,6 +770,7 @@ class RequestHandlerComponentTest extends TestCase {
 
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
+			$event,
 			$this->Controller, array('controller' => 'request_handler_test', 'action' => 'destination')
 		);
 		$result = ob_get_clean();
@@ -776,6 +791,7 @@ class RequestHandlerComponentTest extends TestCase {
 			'View' => array(CAKE . 'Test/TestApp/View/')
 		), App::RESET);
 		Router::connect('/:controller/:action');
+		$event = new Event('Controller.beforeRedirect');
 
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
@@ -791,7 +807,9 @@ class RequestHandlerComponentTest extends TestCase {
 
 		ob_start();
 		$this->Controller->RequestHandler->beforeRedirect(
-			$this->Controller, array('controller' => 'request_handler_test', 'action' => 'ajax2_layout')
+			$event,
+			$this->Controller,
+			array('controller' => 'request_handler_test', 'action' => 'ajax2_layout')
 		);
 		$result = ob_get_clean();
 		$this->assertRegExp('/posts index/', $result, 'RequestAction redirect failed.');
@@ -810,6 +828,7 @@ class RequestHandlerComponentTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 		Router::connect('/:controller/:action/*');
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		$event = new Event('Controller.beforeRender');
 
 		Router::setRequestInfo(array(
 			array('plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => array()),
@@ -827,6 +846,7 @@ class RequestHandlerComponentTest extends TestCase {
 
 		ob_start();
 		$RequestHandler->beforeRedirect(
+			$event,
 			$this->Controller,
 			array('controller' => 'request_handler_test', 'action' => 'param_method', 'first', 'second')
 		);
@@ -842,6 +862,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testBeforeRedirectCallingHeader() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 
+		$event = new Event('Controller.beforeRender');
 		$controller = $this->getMock('Cake\Controller\Controller', array('header'));
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('_sendHeader','statusCode'));
@@ -853,7 +874,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler->response->expects($this->once())->method('statusCode')->with(403);
 
 		ob_start();
-		$RequestHandler->beforeRedirect($controller, 'request_handler_test/param_method/first/second', 403);
+		$RequestHandler->beforeRedirect($event, $controller, 'request_handler_test/param_method/first/second', 403);
 		ob_get_clean();
 	}
 
@@ -872,11 +893,12 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedByEtagStar() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = '*';
+		$event = new Event('Controller.beforeRender');
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something');
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
 	}
 
 /**
@@ -886,11 +908,12 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedByEtagExact() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
+		$event = new Event('Controller.beforeRender');
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
 	}
 
 /**
@@ -901,12 +924,13 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testCheckNotModifiedByEtagAndTime() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
 		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
+		$event = new Event('Controller.beforeRender');
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->modified('2012-01-01 00:00:00');
 		$RequestHandler->response->expects($this->once())->method('notModified');
-		$this->assertFalse($RequestHandler->beforeRender($this->Controller));
+		$this->assertFalse($RequestHandler->beforeRender($event, $this->Controller));
 	}
 
 /**
@@ -915,9 +939,10 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckNotModifiedNoInfo() {
+		$event = new Event('Controller.beforeRender');
 		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->expects($this->never())->method('notModified');
-		$this->assertNull($RequestHandler->beforeRender($this->Controller));
+		$this->assertNull($RequestHandler->beforeRender($event, $this->Controller));
 	}
 }

--- a/lib/Cake/Test/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/SecurityComponentTest.php
@@ -141,7 +141,7 @@ class SecurityComponentTest extends TestCase {
 		$request = new Request('posts/index');
 		$request->addParams(array('controller' => 'posts', 'action' => 'index'));
 		$this->Controller = new SecurityTestController($request);
-		$this->Controller->Components->init($this->Controller);
+		$this->Controller->constructClasses();
 		$this->Controller->Security = $this->Controller->TestSecurity;
 		$this->Controller->Security->blackHoleCallback = 'fail';
 		$this->Security = $this->Controller->Security;

--- a/lib/Cake/Test/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/SecurityComponentTest.php
@@ -208,9 +208,7 @@ class SecurityComponentTest extends TestCase {
 			'requireGet' => array('index'),
 			'validatePost' => false,
 		);
-		$event = new Event('Controller.initialize');
 		$Security = new SecurityComponent($this->Controller->Components, $settings);
-		$this->Controller->Security->initialize($event, $this->Controller, $settings);
 		$this->assertEquals($Security->requirePost, $settings['requirePost']);
 		$this->assertEquals($Security->requireSecure, $settings['requireSecure']);
 		$this->assertEquals($Security->requireGet, $settings['requireGet']);

--- a/lib/Cake/Test/TestCase/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ComponentCollectionTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * ComponentCollectionTest file
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,12 +9,12 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.Controller
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\Controller;
 
+use Cake\Controller\Controller;
 use Cake\Controller\ComponentCollection;
 use Cake\Controller\Component\CookieComponent;
 use Cake\Core\App;
@@ -40,7 +36,8 @@ class ComponentCollectionTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->Components = new ComponentCollection();
+		$controller = new Controller();
+		$this->Components = new ComponentCollection($controller);
 	}
 
 /**
@@ -66,8 +63,6 @@ class ComponentCollectionTest extends TestCase {
 		$result = $this->Components->loaded();
 		$this->assertEquals(array('Cookie'), $result, 'loaded() results are wrong.');
 
-		$this->assertTrue($this->Components->enabled('Cookie'));
-
 		$result = $this->Components->load('Cookie');
 		$this->assertSame($result, $this->Components->Cookie);
 	}
@@ -85,8 +80,6 @@ class ComponentCollectionTest extends TestCase {
 
 		$result = $this->Components->loaded();
 		$this->assertEquals(array('Cookie'), $result, 'loaded() results are wrong.');
-
-		$this->assertTrue($this->Components->enabled('Cookie'));
 
 		$result = $this->Components->load('Cookie');
 		$this->assertInstanceOf(__NAMESPACE__ . '\CookieAliasComponent', $result);
@@ -109,11 +102,15 @@ class ComponentCollectionTest extends TestCase {
  * @return void
  */
 	public function testLoadWithEnableFalse() {
+		$mock = $this->getMock('Cake\Event\EventManager');
+		$mock->expects($this->never())
+			->method('attach');
+
+		$this->Components->getController()->setEventManager($mock);
+
 		$result = $this->Components->load('Cookie', array('enabled' => false));
 		$this->assertInstanceOf('Cake\Controller\Component\CookieComponent', $result);
 		$this->assertInstanceOf('Cake\Controller\Component\CookieComponent', $this->Components->Cookie);
-
-		$this->assertFalse($this->Components->enabled('Cookie'), 'Cookie should be disabled');
 	}
 
 /**
@@ -144,39 +141,12 @@ class ComponentCollectionTest extends TestCase {
 	}
 
 /**
- * test unload()
- *
- * @return void
- */
-	public function testUnload() {
-		$this->Components->load('Cookie');
-		$this->Components->load('Security');
-
-		$result = $this->Components->loaded();
-		$this->assertEquals(array('Cookie', 'Security'), $result, 'loaded components is wrong');
-
-		$this->Components->unload('Cookie');
-		$this->assertFalse(isset($this->Components->Cookie));
-		$this->assertTrue(isset($this->Components->Security));
-
-		$result = $this->Components->loaded();
-		$this->assertEquals(array('Security'), $result, 'loaded components is wrong');
-
-		$result = $this->Components->enabled();
-		$this->assertEquals(array('Security'), $result, 'enabled components is wrong');
-	}
-
-/**
  * test getting the controller out of the collection
  *
  * @return void
  */
 	public function testGetController() {
-		$controller = $this->getMock('Cake\Controller\Controller');
-		$controller->components = array('Security');
-		$this->Components->init($controller);
 		$result = $this->Components->getController();
-
-		$this->assertSame($controller, $result);
+		$this->assertInstanceOf('Cake\Controller\Controller', $result);
 	}
 }

--- a/lib/Cake/Test/TestCase/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ComponentCollectionTest.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Test\TestCase\Controller;
 
-use Cake\Controller\Controller;
-use Cake\Controller\ComponentCollection;
 use Cake\Controller\Component\CookieComponent;
+use Cake\Controller\ComponentCollection;
+use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;

--- a/lib/Cake/Test/TestCase/Controller/ComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ComponentTest.php
@@ -84,12 +84,18 @@ class ComponentTest extends TestCase {
  * @return void
  */
 	public function testInnerComponentsAreNotEnabled() {
-		$Collection = new ComponentCollection();
+		$mock = $this->getMock('Cake\Event\EventManager');
+		$controller = new Controller();
+		$controller->setEventManager($mock);
+
+		$mock->expects($this->once())
+			->method('attach')
+			->with($this->isInstanceOf('TestApp\Controller\Component\AppleComponent'));
+
+		$Collection = new ComponentCollection($controller);
 		$Apple = $Collection->load('Apple');
 
 		$this->assertInstanceOf('TestApp\Controller\Component\OrangeComponent', $Apple->Orange, 'class is wrong');
-		$result = $Collection->enabled();
-		$this->assertEquals(array('Apple'), $result, 'Too many components enabled.');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Controller/ComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ComponentTest.php
@@ -118,9 +118,7 @@ class ComponentTest extends TestCase {
 		$Controller->components = array('SomethingWithCookie');
 		$Controller->uses = false;
 		$Controller->constructClasses();
-		$Controller->Components->trigger('initialize', array(&$Controller));
-		$Controller->beforeFilter();
-		$Controller->Components->trigger('startup', array(&$Controller));
+		$Controller->startupProcess();
 
 		$this->assertInstanceOf('TestApp\Controller\Component\SomethingWithCookieComponent', $Controller->SomethingWithCookie);
 		$this->assertInstanceOf('Cake\Controller\Component\CookieComponent', $Controller->SomethingWithCookie->Cookie);

--- a/lib/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Test\TestCase\Controller;
 
-use Cake\Controller\Controller;
 use Cake\Controller\Component;
+use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Object;

--- a/lib/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -562,23 +562,6 @@ class ControllerTest extends TestCase {
 	}
 
 /**
- * test redirecting by message
- *
- * @dataProvider statusCodeProvider
- * @return void
- */
-	public function testRedirectByMessage($code, $msg) {
-		$Controller = new Controller(null);
-		$Controller->response = new Response();
-
-		$Controller->redirect('http://cakephp.org', $msg, false);
-		$this->assertEquals($code, $Controller->response->statusCode());
-		$this->assertEquals('http://cakephp.org', $Controller->response->header()['Location']);
-		$this->assertFalse($Controller->autoRender);
-		$this->assertFalse($Controller->autoRender);
-	}
-
-/**
  * test that beforeRedirect callbacks can set the URL that is being redirected to.
  *
  * @return void

--- a/lib/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/lib/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -183,21 +183,6 @@ class TestComponent extends Component {
 
 }
 
-class Test2Component extends TestComponent {
-
-	public $model;
-
-	public function __construct(ComponentCollection $collection, $settings) {
-		$this->controller = $collection->getController();
-		$this->model = $this->controller->modelClass;
-	}
-
-	public function beforeRender(Event $event) {
-		return false;
-	}
-
-}
-
 /**
  * AnotherTestController class
  *
@@ -361,10 +346,10 @@ class ControllerTest extends TestCase {
 
 		$Controller = new TestPluginController(new Request(), new Response());
 		$Controller->uses = [];
-		$Controller->components[] = 'Test2';
+		$Controller->components[] = 'TestPlugin.Other';
 
 		$Controller->constructClasses();
-		$this->assertInstanceOf(__NAMESPACE__ . '\\Test2Component', $Controller->Test2);
+		$this->assertInstanceOf('TestPlugin\Controller\Component\OtherComponent', $Controller->Other);
 	}
 
 /**
@@ -603,7 +588,7 @@ class ControllerTest extends TestCase {
 		$Controller->response = new Response();
 
 		$Controller->getEventManager()->attach(function ($event, $response, $url) {
-			$response->header('Location', 'http://book.cakephp.org');
+			$response->location('http://book.cakephp.org');
 		}, 'Controller.beforeRedirect');
 
 		$Controller->redirect('http://cakephp.org', 301, false);

--- a/lib/Cake/Test/TestCase/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/TestCase/Error/ExceptionRendererTest.php
@@ -20,6 +20,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Error\ExceptionRenderer;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Routing\Router;
 use Cake\TestSuite\Fixture\TestModel;
@@ -59,7 +60,7 @@ class BlueberryComponent extends Component {
  *
  * @return void
  */
-	public function initialize(Controller $controller) {
+	public function initialize(Event $event, Controller $controller) {
 		$this->testName = 'BlueberryComponent';
 	}
 
@@ -91,7 +92,7 @@ class TestErrorController extends Controller {
  *
  * @return void
  */
-	public function beforeRender() {
+	public function beforeRender(Event $event) {
 		echo $this->Blueberry->testName;
 	}
 

--- a/lib/Cake/Test/TestCase/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/TestCase/Error/ExceptionRendererTest.php
@@ -60,7 +60,7 @@ class BlueberryComponent extends Component {
  *
  * @return void
  */
-	public function initialize(Event $event, Controller $controller) {
+	public function initialize(Event $event) {
 		$this->testName = 'BlueberryComponent';
 	}
 


### PR DESCRIPTION
Start updating the Component callbacks to be similar to the new helper changes I did recently. I still have a few things I'm undecided on/unsure of:
- The `$controller` parameter to each callback seems a bit redundant. It is rarely used, and can be fetched easily using `$event->subject()`.
- The `beforeRedirect()` callback currently does not work as it should. The changes made during the event are lost. I've considered replacing the url, status, and exit parameters with a reference to the response object. That would allow each callback listener to modify the response as required.

There will need to be some more work done around reducing the duplication between HelperCollection and ComponentCollection. The names are no longer very good, but that can be dealt with in a future pull request.
