### PR TITLE
add SSL support to MySQL PDO connections

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -145,6 +145,13 @@ class Mysql extends DboSource {
 			if (!empty($config['encoding'])) {
 				$flags[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $config['encoding'];
 			}
+			if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {
+				$flags[PDO::MYSQL_ATTR_SSL_KEY] = $config['ssl_key'];
+				$flags[PDO::MYSQL_ATTR_SSL_CERT] = $config['ssl_cert'];
+			}
+			if (!empty($config['ssl_ca'])) {
+				$flags[PDO::MYSQL_ATTR_SSL_CA] = $config['ssl_ca'];
+			}
 			if (empty($config['unix_socket'])) {
 				$dsn = "mysql:host={$config['host']};port={$config['port']};dbname={$config['database']}";
 			} else {


### PR DESCRIPTION
I had a project which required SSL communication between the web box and MySQL server, so I added checks of the config in app/Config/database.php to check for the presence of cert options. If accepted I can write documentation.

I don't have a way to test support for other databases, but this code works for projects that do and do not require SSL, and the 'ssl_ca' is optional but not recommended, to avoid MITM.

Config options like this will work in app/Config/database.php:

public $default = array(
'datasource' => 'Database/Mysql',
'persistent' => false,
'host' => 'remote_server',
'login' => 'mysql_user',
'password' => 'my_secure_password',
'database' => 'my_db_name',
'prefix' => '',
'encoding' => 'utf8',
'ssl_key' => '/etc/pki/tls/certs/mysql-client-key.pem',
'ssl_cert' => '/etc/pki/tls/certs/mysql-client-cert.pem',
'ssl_ca' => '/etc/pki/tls/certs/mysql-ca-cert.pem'
);
