### PR TITLE
2.4 timeagoinwords

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -187,6 +187,27 @@ class CakeTimeTest extends CakeTestCase {
 	}
 
 /**
+ * test the custom string options for timeAgoInWords
+ *
+ * @return void
+ */
+	public function testTimeAgoInWordsCustomStrings() {
+		$result = $this->Time->timeAgoInWords(
+			strtotime('-8 years -4 months -2 weeks -3 days'),
+			array('relativeString' => 'at least %s ago', 'accuracy' => array('year' => 'year'), 'end' => '+10 years')
+		);
+		$expected = 'at least 8 years ago';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Time->timeAgoInWords(
+			strtotime('+4 months +2 weeks +3 days'),
+			array('absoluteString' => 'exactly on %s', 'accuracy' => array('year' => 'year'), 'end' => '+2 months')
+		);
+		$expected = 'exactly on 3/12/13';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test the accuracy option for timeAgoInWords()
  *
  * @return void

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -692,7 +692,7 @@ class CakeTime {
 	}
 
 /**
- * Returns either a relative or an absolute formatted date depending
+ * Returns either a relative or a formatted absolute date depending
  * on the difference between the current time and given datetime.
  * $datetime should be in a *strtotime* - parsable format, like MySQL's datetime datatype.
  *

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -692,7 +692,7 @@ class CakeTime {
 	}
 
 /**
- * Returns either a relative date or a formatted date depending
+ * Returns either a relative or an absolute formatted date depending
  * on the difference between the current time and given datetime.
  * $datetime should be in a *strtotime* - parsable format, like MySQL's datetime datatype.
  *
@@ -708,6 +708,8 @@ class CakeTime {
  *    - minute => The format if minutes > 0 (default "minute")
  *    - second => The format if seconds > 0 (default "second")
  * - `end` => The end of relative time telling
+ * - `relativeString` => The printf compatible string when outputting relative time
+ * - `absoluteString` => The printf compatible string when outputting absolute time
  * - `userOffset` => Users offset from GMT (in hours) *Deprecated* use timezone intead.
  * - `timezone` => The user timezone the timestamp should be formatted in.
  *
@@ -732,6 +734,8 @@ class CakeTime {
 		$timezone = null;
 		$format = self::$wordFormat;
 		$end = self::$wordEnd;
+		$relativeString = __d('cake', '%s ago');
+		$absoluteString = __d('cake', 'on %s');
 		$accuracy = self::$wordAccuracy;
 
 		if (is_array($options)) {
@@ -756,6 +760,14 @@ class CakeTime {
 			}
 			if (isset($options['end'])) {
 				$end = $options['end'];
+			}
+			if (isset($options['relativeString'])) {
+				$relativeString = $options['relativeString'];
+				unset($options['relativeString']);
+			}
+			if (isset($options['absoluteString'])) {
+				$absoluteString = $options['absoluteString'];
+				unset($options['absoluteString']);
 			}
 			unset($options['end'], $options['format']);
 		} else {
@@ -843,7 +855,7 @@ class CakeTime {
 		}
 
 		if ($diff > abs($now - self::fromString($end))) {
-			return __d('cake', 'on %s', date($format, $inSeconds));
+			return sprintf($absoluteString, date($format, $inSeconds));
 		}
 
 		$f = $accuracy['second'];
@@ -887,7 +899,7 @@ class CakeTime {
 		}
 
 		if (!$backwards) {
-			return __d('cake', '%s ago', $relativeDate);
+			return sprintf($relativeString, $relativeDate);
 		}
 
 		return $relativeDate;


### PR DESCRIPTION
see https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/544-enhancement-to-timehelper

It also allows one to use the method in some special cases where you cannot use "%s ago" (as the translation would mean sth else in this context) and you simply need the timeAgo without any pre or suffix:

```
$res = CakeTime::timeAgoInWords($dateTime, array('relativeString' => '%s');
```
