### PR TITLE
Fix currency output for fraction values.

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -302,6 +302,40 @@ class CakeNumberTest extends CakeTestCase {
 	}
 
 /**
+ * Test currency format with places and fraction exponents.
+ * Places should only matter for non fraction values and vice versa.
+ *
+ * @return void
+ */
+	public function testCurrencyWithFractionAndPlaces() {
+		$result = $this->Number->currency('1.23', 'GBP', array('places' => 3));
+		$expected = '£1.230';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency('0.23', 'GBP', array('places' => 3));
+		$expected = '23p';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency('0.001', 'GBP', array('places' => 3));
+		$expected = '0p';
+		$this->assertEquals($expected, $result);
+
+		$this->Number->addFormat('BHD', array('before' => 'BD ', 'fractionSymbol' => ' fils',
+			'fractionExponent' => 3));
+		$result = $this->Number->currency('1.234', 'BHD', array('places' => 2));
+		$expected = 'BD 1.23';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency('0.234', 'BHD', array('places' => 2));
+		$expected = '234 fils';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->currency('0.001', 'BHD', array('places' => 2));
+		$expected = '1 fils';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test adding currency format options to the number helper
  *
  * @return void

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -39,27 +39,33 @@ class CakeNumber {
 	protected static $_currencies = array(
 		'AUD' => array(
 			'wholeSymbol' => '$', 'wholePosition' => 'before', 'fractionSymbol' => 'c', 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true
+			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true,
+			'fractionExponent' => 2
 		),
 		'CAD' => array(
 			'wholeSymbol' => '$', 'wholePosition' => 'before', 'fractionSymbol' => 'c', 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true
+			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true,
+			'fractionExponent' => 2
 		),
 		'USD' => array(
 			'wholeSymbol' => '$', 'wholePosition' => 'before', 'fractionSymbol' => 'c', 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true
+			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true,
+			'fractionExponent' => 2
 		),
 		'EUR' => array(
 			'wholeSymbol' => '€', 'wholePosition' => 'before', 'fractionSymbol' => false, 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => '.', 'decimals' => ',', 'negative' => '()', 'escape' => true
+			'zero' => 0, 'places' => 2, 'thousands' => '.', 'decimals' => ',', 'negative' => '()', 'escape' => true,
+			'fractionExponent' => 0
 		),
 		'GBP' => array(
 			'wholeSymbol' => '£', 'wholePosition' => 'before', 'fractionSymbol' => 'p', 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()','escape' => true
+			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()','escape' => true,
+			'fractionExponent' => 2
 		),
 		'JPY' => array(
-			'wholeSymbol' => '¥', 'wholePosition' => 'before', 'fractionSymbol' => 'c', 'fractionPosition' => 'after',
-			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true
+			'wholeSymbol' => '¥', 'wholePosition' => 'before', 'fractionSymbol' => false, 'fractionPosition' => 'after',
+			'zero' => 0, 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true,
+			'fractionExponent' => 0
 		),
 	);
 
@@ -71,6 +77,7 @@ class CakeNumber {
 	protected static $_currencyDefaults = array(
 		'wholeSymbol' => '', 'wholePosition' => 'before', 'fractionSymbol' => '', 'fractionPosition' => 'after',
 		'zero' => '0', 'places' => 2, 'thousands' => ',', 'decimals' => '.','negative' => '()', 'escape' => true,
+		'fractionExponent' => 2
 	);
 
 /**
@@ -230,6 +237,7 @@ class CakeNumber {
  * ### Options
  *
  * - `places` - Number of decimal places to use. ie. 2
+ * - `fractionExponent` - Fraction exponent of this specific currency. Defaults to 2.
  * - `before` - The string to place before whole numbers. ie. '['
  * - `after` - The string to place after decimal numbers. ie. ']'
  * - `thousands` - Thousands separator ie. ','
@@ -297,6 +305,7 @@ class CakeNumber {
  * - `zero` - The text to use for zero values, can be a
  *   string or a number. ie. 0, 'Free!'
  * - `places` - Number of decimal places to use. ie. 2
+ * - `fractionExponent` - Fraction exponent of this specific currency. Defaults to 2.
  * - `thousands` - Thousands separator ie. ','
  * - `decimals` - Decimal separator symbol ie. '.'
  * - `negative` - Symbol for negative numbers. If equal to '()',
@@ -344,7 +353,7 @@ class CakeNumber {
 			}
 		} elseif ($value < 1 && $value > -1) {
 			if ($options['fractionSymbol'] !== false) {
-				$multiply = intval('1' . str_pad('', $options['places'], '0'));
+				$multiply = pow(10, $options['fractionExponent']);
 				$value = $value * $multiply;
 				$options['places'] = null;
 				$symbolKey = 'fraction';


### PR DESCRIPTION
Fixes #1329: https://cakephp.lighthouseapp.com/projects/42648/tickets/1329-numberhelpers-currency-method-ouputs-wrong-numbers-when-places3-and-number-between-1-and-1

The places are for decimal places (as documented: "Number of decimal places to use") and should not be used to artificially modify the fraction value. Multiply for fraction output should be 100 (fixed) as default, but adjustable via some option (as there are many different used formats here).
