### PR TITLE
2.4 location

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -585,6 +585,22 @@ class CakeResponse {
 	}
 
 /**
+ * Acccessor for the location header.
+ *
+ * Get/Set the Location header value.
+ * @param null|string $url Either null to get the current location, or a string to set one.
+ * @return string|null When setting the location null will be returned. When reading the location
+ *    a string of the current location header value (if any) will be returned.
+ */
+	public function location($url = null) {
+		if ($url === null) {
+			$headers = $this->header();
+			return isset($headers['Location']) ? $headers['Location'] : null;
+		}
+		$this->header('Location', $url);
+	}
+
+/**
  * Buffers the response message to be sent
  * if $content is null the current buffer is returned
  *

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -1488,9 +1488,9 @@ class CakeResponseTest extends CakeTestCase {
  */
 	public function testLocation() {
 		$response = new CakeResponse();
-		$this->assertNull($response->location());
-		$this->assertNull($response->location('http://example.org'));
-		$this->assertEquals('http://example.org', $response->location());
+		$this->assertNull($response->location(), 'No header should be set.');
+		$this->assertNull($response->location('http://example.org'), 'Setting a location should return null');
+		$this->assertEquals('http://example.org', $response->location(), 'Reading a location should return the value.');
 	}
 
 }

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -1481,4 +1481,16 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->send();
 	}
 
+/**
+ * Test the location method.
+ *
+ * @return void
+ */
+	public function testLocation() {
+		$response = new CakeResponse();
+		$this->assertNull($response->location());
+		$this->assertNull($response->location('http://example.org'));
+		$this->assertEquals('http://example.org', $response->location());
+	}
+
 }


### PR DESCRIPTION
This method provides an easy to use interface to get/set the location header in a response object. This is primarily to facilitate future development in 3.x.

See #1418 for more context as to where this method will be used in the future.
