### PR TITLE
2.4 formhelper textarea

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -260,6 +260,7 @@ class UserForm extends CakeTestModel {
 		'other' => array('type' => 'text', 'null' => true, 'default' => null, 'length' => null),
 		'stuff' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 10),
 		'something' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
+		'something_long' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 300),
 		'active' => array('type' => 'boolean', 'null' => false, 'default' => false),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
 		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
@@ -8220,6 +8221,21 @@ class FormHelperTest extends CakeTestCase {
 				'type' => 'text', 'name' => 'data[UserForm][stuff]',
 				'id' => 'UserFormStuff', 'maxlength' => 10
 			),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('UserForm.something_long');
+		$expected = array(
+			'div' => array('class' => 'input textarea'),
+			'label' => array('for' => 'UserFormSomethingLong'),
+			'Something Long',
+			'/label',
+			'textarea' => array(
+				'name' => 'data[UserForm][something_long]', 'cols' => 30, 'rows' => 6,
+				'id' => 'UserFormSomethingLong'
+			),
+			'/textarea',
 			'/div'
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1160,6 +1160,9 @@ class FormHelper extends AppHelper {
 			if ($fieldKey == $primaryKey) {
 				$options['type'] = 'hidden';
 			}
+			if ($options['type'] === 'text' && !empty($fieldDef['length']) && $fieldDef['length'] > 255) {
+				$options['type'] = 'textarea';
+			}
 			if (
 				$options['type'] === 'number' &&
 				$type === 'float' &&


### PR DESCRIPTION
closes ticket https://cakephp.lighthouseapp.com/projects/42648/tickets/368-form-input-should-output-a-textarea-for-varchar-fields-with-more-than-150-chars

btw, there is also https://cakephp.lighthouseapp.com/projects/42648/tickets/1125-longtext-fields-on-schema-generate (related)
