### PR TITLE
localize paginator counter output and CakeNumber::toPercentage

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -36,6 +36,9 @@ class CakeNumberTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->Number = new CakeNumber();
+
+		Configure::delete('L10n.decimals');
+		Configure::delete('L10n.thousands');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -90,6 +90,29 @@ class CakeNumberTest extends CakeTestCase {
 	}
 
 /**
+ * testFormatLocalized method
+ *
+ * @return void
+ */
+	public function testFormatLocalized() {
+		// German format
+		Configure::write('L10n.decimals', ',');
+		Configure::write('L10n.thousands', '.');
+
+		$value = 1234.56;
+		$options = array('before' => '', 'places' => 2);
+		$result = $this->Number->format($value, $options);
+		$expected = '1.234,56';
+		$this->assertEquals($expected, $result);
+
+		$value = -1.23;
+		$options = array('before' => '', 'places' => 1);
+		$result = $this->Number->format($value, $options);
+		$expected = '-1,2';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testFormatDelta method
  *
  * @return void
@@ -673,6 +696,25 @@ class CakeNumberTest extends CakeTestCase {
 
 		$result = $this->Number->toPercentage(0.456, 2, array('multiply' => true));
 		$expected = '45.60%';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testToPercentageLocalized method
+ *
+ * @return void
+ */
+	public function testToPercentageLocalized() {
+		// German format
+		Configure::write('L10n.decimals', ',');
+		Configure::write('L10n.thousands', '.');
+
+		$result = $this->Number->toPercentage(45, 2);
+		$expected = '45,00%';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->toPercentage(0.456, 1, array('multiply' => true));
+		$expected = '45,6%';
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -43,6 +43,8 @@ class PaginatorHelperTest extends CakeTestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('Config.language', 'eng');
+		Configure::delete('L10n.decimals');
+		Configure::delete('L10n.thousands');
 		$controller = null;
 		$this->View = new View($controller);
 		$this->Paginator = new PaginatorHelper($this->View);

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2338,6 +2338,46 @@ class PaginatorHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testCounterLocalized method
+ *
+ * @return void
+ */
+	public function testCounterLocalized() {
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 1001,
+				'current' => 3,
+				'count' => 6006,
+				'prevPage' => true,
+				'nextPage' => true,
+				'pageCount' => 3003,
+				'limit' => 3,
+				'options' => array(
+					'page' => 3,
+					'order' => array('Client.name' => 'DESC'),
+				),
+				'paramType' => 'named'
+			)
+		);
+		$input = 'Page %page% of %pages%, showing %current% records out of %count% total, ';
+		$input .= 'starting on record %start%, ending on %end%';
+
+		$result = $this->Paginator->counter($input);
+		$expected = 'Page 1,001 of 3,003, showing 3 records out of 6,006 total, starting on record 3,001, ';
+		$expected .= 'ending on 3,003';
+		$this->assertEquals($expected, $result);
+
+		// German format
+		Configure::write('L10n.decimals', ',');
+		Configure::write('L10n.thousands', '.');
+
+		$result = $this->Paginator->counter($input);
+		$expected = 'Page 1.001 of 3.003, showing 3 records out of 6.006 total, starting on record 3.001, ';
+		$expected .= 'ending on 3.003';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testHasPage method
  *
  * @return void

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -175,11 +175,14 @@ class CakeNumber {
 		if ($options['multiply']) {
 			$value *= 100;
 		}
-		return self::precision($value, $precision) . '%';
+		return self::format(self::precision($value, $precision), $precision) . '%';
 	}
 
 /**
  * Formats a number into a currency format.
+ *
+ * Uses Configure::read('L10n.thousands') and Configure::read('L10n.decimals') to
+ * localize the output. Defaults to ',' and '.'.
  *
  * @param float $value A floating point number
  * @param integer $options if int then places, if string then before, if (,.-) then use it
@@ -199,18 +202,24 @@ class CakeNumber {
 		if (is_string($options) && !in_array($options, $separators)) {
 			$before = $options;
 		}
-		$thousands = ',';
+		$thousands = Configure::read('L10n.thousands');
+		if ($thousands === null) {
+			 $thousands = ',';
+		}
 		if (!is_array($options) && in_array($options, $separators)) {
 			$thousands = $options;
 		}
-		$decimals = '.';
+		$decimals = Configure::read('L10n.decimals');
+		if ($decimals === null) {
+			 $decimals = '.';
+		}
 		if (!is_array($options) && in_array($options, $separators)) {
 			$decimals = $options;
 		}
 
 		$escape = true;
 		if (is_array($options)) {
-			$defaults = array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.');
+			$defaults = compact('thousands', 'decimals') + array('before' => '$', 'places' => 2);
 			$options += $defaults;
 			extract($options);
 		}
@@ -270,7 +279,7 @@ class CakeNumber {
 			$after = substr($value, $foundDecimal);
 			$value = substr($value, 0, $foundDecimal);
 		}
-		while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $value)) !== $value) {
+  while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $value)) !== $value) {
 			$value = $foundThousand;
 		}
 		$value .= $after;

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -279,7 +279,7 @@ class CakeNumber {
 			$after = substr($value, $foundDecimal);
 			$value = substr($value, 0, $foundDecimal);
 		}
-  while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $value)) !== $value) {
+		while (($foundThousand = preg_replace('/(\d+)(\d\d\d)/', '\1 \2', $value)) !== $value) {
 			$value = $foundThousand;
 		}
 		$value .= $after;

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -19,6 +19,7 @@
  */
 
 App::uses('AppHelper', 'View/Helper');
+App::uses('CakeNumber', 'Utility');
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -639,6 +640,26 @@ class PaginatorHelper extends AppHelper {
 		$end = $start + $paging['limit'] - 1;
 		if ($paging['count'] < $end) {
 			$end = $paging['count'];
+		}
+
+		$formatOptions = array('before' => null, 'places' => 0);
+		if ($paging['page'] > 1000) {
+			$paging['page'] = CakeNumber::format($paging['page'], $formatOptions);
+		}
+		if ($paging['pageCount'] > 1000) {
+			$paging['pageCount'] = CakeNumber::format($paging['pageCount'], $formatOptions);
+		}
+		if ($paging['current'] > 1000) {
+			$paging['current'] = CakeNumber::format($paging['current'], $formatOptions);
+		}
+		if ($paging['count'] > 1000) {
+			$paging['count'] = CakeNumber::format($paging['count'], $formatOptions);
+		}
+		if ($start > 1000) {
+			$start = CakeNumber::format($start, $formatOptions);
+		}
+		if ($end > 1000) {
+			$end = CakeNumber::format($end, $formatOptions);
 		}
 
 		switch ($options['format']) {


### PR DESCRIPTION
Currently L10n is still an issue throughout the core.
There are also different approachs.
One - using setlocale(LC_NUMERIC) I don't like as it creates even more issues and complicates things. Mainly because all the internal output is wrong then (it should stay in the normal numeric format). It also breaks lots of normal echo/output calls where there is also normal non-localized numbers expected.

As clean approach I recommend using two Configure values, `L10n.decimals` and `L10n.thousands`.
Those will mainly be used for any user output regarding localized numberic values then.

Resolves:
- https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/2927-number_format-in-paginationhelpercounter
- https://cakephp.lighthouseapp.com/projects/42648/tickets/2763-cakenumbertopercentage-should-allow-separator-localization

Long term I can see those values go into other places where localization should use those config values:
- defaults for format/formatDelta (non currency, though)
- toReadableSize
