### PR TITLE
Fixes errors in tests with APC installed but not enabled in CLI.

### DIFF
--- a/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
@@ -36,6 +36,10 @@ class ApcEngineTest extends CakeTestCase {
 		parent::setUp();
 		$this->skipIf(!function_exists('apc_store'), 'Apc is not installed or configured properly.');
 
+		if (php_sapi_name() === 'cli') {
+			$this->skipIf(!ini_get('apc.enable_cli'), 'APC is not enabled for the CLI.');
+		}
+
 		$this->_cacheDisable = Configure::read('Cache.disable');
 		Configure::write('Cache.disable', false);
 		Cache::config('apc', array('engine' => 'Apc', 'prefix' => 'cake_'));


### PR DESCRIPTION
When you have APC installed, but not enabled on the CLI the test was still running and producing errors. The APC functions exist, but they will trigger errors when you use them. This fix will make sure the test is skipped when that happens.
