### PR TITLE
Adds order to the test models to make the results more predictable.

### DIFF
--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -320,6 +320,8 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->request->query = array();
 		$Controller->constructClasses();
 
+		$Controller->PaginatorControllerPost->order = null;
+
 		$Controller->Paginator->settings = array(
 			'order' => array('PaginatorControllerComment.id' => 'ASC')
 		);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
@@ -62,6 +62,7 @@ class TreeBehaviorAfterTest extends CakeTestCase {
  */
 	public function testAftersaveCallback() {
 		$this->Tree = new AfterTree();
+		$this->Tree->order = null;
 
 		$expected = array('AfterTree' => array('name' => 'Six and One Half Changed in AfterTree::afterSave() but not in database', 'parent_id' => 6, 'lft' => 11, 'rght' => 12));
 		$result = $this->Tree->save(array('AfterTree' => array('name' => 'Six and One Half', 'parent_id' => 6)));

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -65,6 +65,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testInitialize() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->find('count');
@@ -82,6 +83,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidLeft() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
@@ -108,6 +110,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidRight() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
@@ -134,6 +137,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
@@ -159,6 +163,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectNoneExistentParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
@@ -182,6 +187,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRecoverUsingParentMode() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->Behaviors->disable('Tree');
 
 		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
@@ -233,6 +239,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRecoverUsingParentModeAndDelete() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->Behaviors->disable('Tree');
 
 		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
@@ -301,6 +308,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRecoverFromMissingParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->findByName('1.1');
@@ -324,6 +332,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidParents() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->updateAll(array($parentField => null));
@@ -346,6 +355,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectInvalidLftsRghts() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->updateAll(array($leftField => 0, $rightField => 0));
@@ -367,6 +377,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDetectEqualLftsRghts() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 3);
 
 		$result = $this->Tree->findByName('1.1');
@@ -394,6 +405,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddOrphan() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
@@ -413,6 +425,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddMiddle() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
@@ -444,6 +457,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddWithPreSpecifiedId() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array(
@@ -474,6 +488,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -498,6 +513,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testAddNotIndexedByModel() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->save(array('name' => 'testAddNotIndexed', $parentField => null));
@@ -517,6 +533,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMovePromote() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -543,6 +560,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveWithWhitelist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -570,6 +588,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testInsertWithWhitelist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->whitelist = array('name', $parentField);
@@ -588,6 +607,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveBefore() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -616,6 +636,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveAfter() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -644,6 +665,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDemoteInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -676,6 +698,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -700,6 +723,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveSelfInvalid() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -725,6 +749,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpSuccess() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.2')));
@@ -746,6 +771,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpFail() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.1')));
@@ -768,6 +794,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUp2() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
@@ -798,6 +825,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveUpFirst() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
@@ -828,6 +856,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownSuccess() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
@@ -849,6 +878,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownFail() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2')));
@@ -870,6 +900,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDownLast() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
@@ -900,6 +931,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveDown2() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
@@ -930,6 +962,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testSaveNoMove() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 10);
 
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.5')));
@@ -960,6 +993,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testMoveToRootAndMoveUp() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(1, 1);
 		$data = $this->Tree->find('first', array('fields' => array('id'), 'conditions' => array($modelClass . '.name' => '1.1')));
 		$this->Tree->id = $data[$modelClass]['id'];
@@ -984,6 +1018,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDelete() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$initialCount = $this->Tree->find('count');
@@ -1019,6 +1054,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testDeleteDoesNotExist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->delete(99999);
 	}
@@ -1031,6 +1067,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemove() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$initialCount = $this->Tree->find('count');
 		$result = $this->Tree->findByName('1.1');
@@ -1063,6 +1100,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveLastTopParent() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$initialCount = $this->Tree->find('count');
@@ -1096,6 +1134,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$initialCount = $this->Tree->find('count');
 
@@ -1130,6 +1169,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveAndDelete() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$initialCount = $this->Tree->find('count');
@@ -1164,6 +1204,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testRemoveAndDeleteNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$initialCount = $this->Tree->find('count');
 
@@ -1196,6 +1237,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -1226,6 +1268,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testCountChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -1251,6 +1294,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGetParentNode() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2.2')));
@@ -1269,6 +1313,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGetPath() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1.2.2')));
@@ -1289,6 +1334,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testNoAmbiguousColumn() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
 		$this->Tree->initialize(2, 2);
@@ -1321,6 +1367,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testReorderTree() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(3, 3);
 		$nodes = $this->Tree->find('list', array('order' => $leftField));
 
@@ -1352,6 +1399,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testReorderBigTreeWithQueryCaching() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 10);
 
 		$original = $this->Tree->cacheQueries;
@@ -1369,6 +1417,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGenerateTreeListWithSelfJoin() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
 		$this->Tree->initialize(2, 2);
@@ -1386,6 +1435,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testGenerateTreeListFormatting() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$result = $this->Tree->generateTreeList(
@@ -1406,6 +1456,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	public function testArraySyntax() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(3, 3);
 		$this->assertSame($this->Tree->childCount(2), $this->Tree->childCount(array('id' => 2)));
 		$this->assertSame($this->Tree->getParentNode(2), $this->Tree->getParentNode(array('id' => 2)));

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -64,6 +64,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
  */
 	public function testStringScope() {
 		$this->Tree = new FlagTree();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 3);
 
 		$this->Tree->id = 1;
@@ -100,6 +101,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
  */
 	public function testArrayScope() {
 		$this->Tree = new FlagTree();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 3);
 
 		$this->Tree->id = 1;
@@ -136,6 +138,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
  */
 	public function testMoveUpWithScope() {
 		$this->Ad = new Ad();
+		$this->Ad->order = null;
 		$this->Ad->Behaviors->attach('Tree', array('scope' => 'Campaign'));
 		$this->Ad->moveUp(6);
 
@@ -152,6 +155,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
  */
 	public function testMoveDownWithScope() {
 		$this->Ad = new Ad();
+		$this->Ad->order = null;
 		$this->Ad->Behaviors->attach('Tree', array('scope' => 'Campaign'));
 		$this->Ad->moveDown(6);
 
@@ -169,6 +173,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
  */
 	public function testTranslatingTree() {
 		$this->Tree = new FlagTree();
+		$this->Tree->order = null;
 		$this->Tree->cacheQueries = false;
 		$this->Tree->Behaviors->attach('Translate', array('title'));
 
@@ -286,9 +291,11 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 	public function testAliasesWithScopeInTwoTreeAssociations() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->TreeTwo = new NumberTreeTwo();
+		$this->TreeTwo->order = null;
 
 		$record = $this->Tree->find('first');
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -66,6 +66,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testAddWithPreSpecifiedId() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array(
@@ -97,6 +98,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testMovePromote() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -123,6 +125,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testMoveWithWhitelist() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$this->Tree->id = null;
 
@@ -150,6 +153,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testRemoveNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$initialCount = $this->Tree->find('count');
 
@@ -184,6 +188,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testRemoveAndDeleteNoChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 		$initialCount = $this->Tree->find('count');
 
@@ -216,6 +221,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testChildren() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$data = $this->Tree->find('first', array('conditions' => array($modelClass . '.name' => '1. Root')));
@@ -244,6 +250,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testNoAmbiguousColumn() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
@@ -280,6 +287,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 	public function testGenerateTreeListWithSelfJoin() {
 		extract($this->settings);
 		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
 		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
 			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
 		$this->Tree->initialize(2, 2);

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -570,6 +570,7 @@ class ModelDeleteTest extends BaseModelTest {
 			'Tag' => array('with' => 'TestPlugin.ArticlesTag')
 		)), false);
 
+		$Article->ArticlesTag->order = null;
 		$this->assertTrue($Article->delete(1));
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -6302,6 +6302,7 @@ class ModelReadTest extends BaseModelTest {
 		$this->loadFixtures('User');
 		$TestModel = new User();
 		$TestModel->cacheQueries = false;
+		$TestModel->order = null;
 
 		$expected = array(
 			'conditions' => array(
@@ -6849,6 +6850,8 @@ class ModelReadTest extends BaseModelTest {
 		));
 		$this->assertEquals('mariano', $result);
 
+		$TestModel->order = null;
+
 		$result = $TestModel->field('COUNT(*) AS count', true);
 		$this->assertEquals(4, $result);
 
@@ -6904,7 +6907,9 @@ class ModelReadTest extends BaseModelTest {
 		$this->assertNotRegExp('/ORDER\s+BY/', $log['log'][0]['query']);
 
 		$Article = new Article();
+		$Article->order = null;
 		$Article->recursive = -1;
+
 		$expected = count($Article->find('all', array(
 			'fields' => array('Article.user_id'),
 			'group' => 'Article.user_id')
@@ -7760,6 +7765,8 @@ class ModelReadTest extends BaseModelTest {
 			'limit' => 1
 		));
 		$this->assertEquals(2, $result['Post']['id']);
+
+		$Post->order = null;
 
 		$Post->virtualFields = array('other_field' => 'Post.id + 1');
 		$result = $Post->find('all', array(

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2498,6 +2498,7 @@ class ModelWriteTest extends BaseModelTest {
 	public function testHabtmSavingWithNoPrimaryKeyUuidJoinTable() {
 		$this->loadFixtures('UuidTag', 'Fruit', 'FruitsUuidTag');
 		$Fruit = new Fruit();
+		$Fruit->FruitsUuidTag->order = null;
 		$data = array(
 			'Fruit' => array(
 				'color' => 'Red',

--- a/lib/Cake/TestSuite/Fixture/CakeTestModel.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestModel.php
@@ -32,27 +32,15 @@ class CakeTestModel extends Model {
  * incorrect order when no order has been defined in the finds.
  * Postgres can return the results in any order it considers appropriate if none is specified
  *
- * @param array $queryData
- * @return array $queryData
+ * @param integer|string|array $id Set this ID for this model on startup, can also be an array of options, see above.
+ * @param string $table Name of database table to use.
+ * @param string $ds DataSource connection name.
  */
-	public function beforeFind($queryData) {
-		$pk = $this->primaryKey;
-		$aliasedPk = $this->alias . '.' . $this->primaryKey;
-		switch (true) {
-			case !$pk:
-			case !$this->useTable:
-			case !$this->schema('id'):
-			case !empty($queryData['order'][0]):
-			case !empty($queryData['group']):
-			case
-				(is_string($queryData['fields']) && !($queryData['fields'] == $pk || $queryData['fields'] == $aliasedPk)) ||
-				(is_array($queryData['fields']) && !(array_key_exists($pk, $queryData['fields']) || array_key_exists($aliasedPk, $queryData['fields']))):
-				break;
-			default:
-				$queryData['order'] = array($this->alias . '.' . $this->primaryKey => 'ASC');
-		}
-		return $queryData;
+	public function __construct($id = false, $table = null, $ds = null) {
+		parent::__construct($id, $table, $ds);
+		$this->order = array($this->alias . '.' . $this->primaryKey => 'ASC');
 	}
+
 /**
  * Overriding save() to set CakeTestSuiteDispatcher::date() as formatter for created, modified and updated fields
  *


### PR DESCRIPTION
Even though there was some code in place to prevent results in random order from PostgreSQL we were still experiencing this with Jenkins and Travis.

This commit removes the old code that handled this. From now on this will be handled differently. Every test model will order by its primary key. You can disable this by changing the order property of the model to `null`: `$testModel->order = null`.

All those `$model->order = null` are necessary so that the tests can remain the same.

Let's hope it helps. I was only able to reproduce it once, before the changes.
