### PR TITLE
Added a reset parameter to View:start + minor cleanup of ViewTests.php

### DIFF
--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -106,7 +106,7 @@ class TestThemeView extends View {
  *
  * @param string $name
  * @param array $params
- * @return void
+ * @return string The given name
  */
 	public function renderElement($name, $params = array()) {
 		return $name;
@@ -115,8 +115,8 @@ class TestThemeView extends View {
 /**
  * getViewFileName method
  *
- * @param string $name
- * @return void
+ * @param string $name Controller action to find template filename for
+ * @return string Template filename
  */
 	public function getViewFileName($name = null) {
 		return $this->_getViewFileName($name);
@@ -125,8 +125,8 @@ class TestThemeView extends View {
 /**
  * getLayoutFileName method
  *
- * @param string $name
- * @return void
+ * @param string $name The name of the layout to find.
+ * @return string Filename for layout file (.ctp).
  */
 	public function getLayoutFileName($name = null) {
 		return $this->_getLayoutFileName($name);
@@ -144,8 +144,8 @@ class TestView extends View {
 /**
  * getViewFileName method
  *
- * @param string $name
- * @return void
+ * @param string $name Controller action to find template filename for
+ * @return string Template filename
  */
 	public function getViewFileName($name = null) {
 		return $this->_getViewFileName($name);
@@ -154,8 +154,8 @@ class TestView extends View {
 /**
  * getLayoutFileName method
  *
- * @param string $name
- * @return void
+ * @param string $name The name of the layout to find.
+ * @return string Filename for layout file (.ctp).
  */
 	public function getLayoutFileName($name = null) {
 		return $this->_getLayoutFileName($name);
@@ -164,9 +164,9 @@ class TestView extends View {
 /**
  * paths method
  *
- * @param string $plugin
- * @param boolean $cached
- * @return void
+ * @param string $plugin Optional plugin name to scan for view files.
+ * @param boolean $cached Set to true to force a refresh of view paths.
+ * @return array paths
  */
 	public function paths($plugin = null, $cached = true) {
 		return $this->_paths($plugin, $cached);
@@ -200,6 +200,7 @@ class TestAfterHelper extends Helper {
 /**
  * beforeLayout method
  *
+ * @param string $viewFile
  * @return void
  */
 	public function beforeLayout($viewFile) {
@@ -209,6 +210,7 @@ class TestAfterHelper extends Helper {
 /**
  * afterLayout method
  *
+ * @param string $layoutFile
  * @return void
  */
 	public function afterLayout($layoutFile) {
@@ -529,7 +531,7 @@ class ViewTest extends CakeTestCase {
 
 		$View = new TestView($this->Controller);
 		ob_start();
-		$result = $View->getViewFileName('does_not_exist');
+		$View->getViewFileName('does_not_exist');
 
 		$this->ThemeController->plugin = null;
 		$this->ThemeController->name = 'Pages';
@@ -557,8 +559,8 @@ class ViewTest extends CakeTestCase {
 
 		$View = new TestView($this->Controller);
 		ob_start();
-		$result = $View->getLayoutFileName();
-		$expected = ob_get_clean();
+		$View->getLayoutFileName();
+		ob_get_clean();
 
 		$this->ThemeController->plugin = null;
 		$this->ThemeController->name = 'Posts';
@@ -567,7 +569,7 @@ class ViewTest extends CakeTestCase {
 		$this->ThemeController->theme = 'my_theme';
 
 		$View = new TestThemeView($this->ThemeController);
-		$result = $View->getLayoutFileName();
+		$View->getLayoutFileName();
 	}
 
 /**
@@ -762,7 +764,7 @@ class ViewTest extends CakeTestCase {
 		$result = Cache::read('element__test_element_cache_callbacks_param_foo', 'test_view');
 		$this->assertEquals($expected, $result);
 
-		$result = $View->element('test_element', array(
+		$View->element('test_element', array(
 			'param' => 'one',
 			'foo' => 'two'
 		), array(
@@ -772,7 +774,7 @@ class ViewTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$View->elementCache = 'default';
-		$result = $View->element('test_element', array(
+		$View->element('test_element', array(
 			'param' => 'one',
 			'foo' => 'two'
 		), array(
@@ -1246,6 +1248,38 @@ class ViewTest extends CakeTestCase {
 	}
 
 /**
+ * Test creating a block with capturing output with and without resetting.
+ *
+ * @return void
+ */
+	public function testBlockCaptureWithAndWithoutReset() {
+		$this->View->start('test', true);
+		echo 'Block content 1';
+		$this->View->end();
+
+		$result = $this->View->fetch('test');
+		$this->assertEquals('Block content 1', $result);
+
+		$this->View->start('test', false);
+		echo 'Block content 2';
+		$this->View->end();
+
+		$result = $this->View->fetch('test');
+		$this->assertEquals('Block content 1Block content 2', $result);
+
+		$this->View->start('test', true);
+		echo 'Block content 3';
+		$this->View->end();
+
+		$this->View->start('test', true);
+		echo 'Block content 4';
+		$this->View->end();
+
+		$result = $this->View->fetch('test');
+		$this->assertEquals('Block content 4', $result);
+	}
+
+/**
  * Test block with startIfEmpty
  *
  * @return void
@@ -1308,6 +1342,17 @@ class ViewTest extends CakeTestCase {
 		$this->View->assign('test', 'Block content');
 		$result = $this->View->fetch('test');
 		$this->assertEquals('Block content', $result);
+	}
+
+/**
+ * Test resetting a block's content.
+ *
+ * @return void
+ */
+	public function testBlockReset() {
+		$this->View->assign('test', '');
+		$result = $this->View->fetch('test', 'This should not be returned');
+		$this->assertSame('', $result);
 	}
 
 /**

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -617,10 +617,14 @@ class View extends Object {
  * Start capturing output for a 'block'
  *
  * @param string $name The name of the block to capture for.
+ * @param bool $reset Whether to reset the content, defaults to false
  * @return void
  * @see ViewBlock::start()
  */
-	public function start($name) {
+	public function start($name, $reset = false) {
+		if ($reset === true) {
+			$this->Blocks->set($name, '');
+		}
 		return $this->Blocks->start($name);
 	}
 


### PR DESCRIPTION
This provides an alternative to calling $this->assign('myBlock', ''); to clear a view block.

Added a test for the new parameter.
Added missing block reset test through assign().
Also made some minor cleanup in ViewTests.php. Mostly docblocks (params, returns) but also some unused variables.
