### PR TITLE
Replaces deprecated paginate() calls in controller bake templates.

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -370,10 +370,11 @@ class ControllerTask extends BakeTask {
  * @return array Components the user wants to use.
  */
 	public function doComponents() {
-		return $this->_doPropertyChoices(
-			__d('cake_console', "Would you like this controller to use any components?"),
+		$components = array('Paginator');
+		return array_merge($components, $this->_doPropertyChoices(
+			__d('cake_console', "Would you like this controller to use other components\nbesides PaginatorComponent?"),
 			__d('cake_console', "Please provide a comma separated list of the component names you'd like to use.\nExample: 'Acl, Security, RequestHandler'")
-		);
+		));
 	}
 
 /**

--- a/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
+++ b/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
@@ -26,7 +26,7 @@
  */
 	public function <?php echo $admin ?>index() {
 		$this-><?php echo $currentModelName ?>->recursive = 0;
-		$this->set('<?php echo $pluralName ?>', $this->paginate());
+		$this->set('<?php echo $pluralName ?>', $this->Paginator->paginate());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -224,7 +224,7 @@ class ControllerTaskTest extends CakeTestCase {
 	public function testDoComponentsNo() {
 		$this->Task->expects($this->any())->method('in')->will($this->returnValue('n'));
 		$result = $this->Task->doComponents();
-		$this->assertSame(array(), $result);
+		$this->assertSame(array('Paginator'), $result);
 	}
 
 /**
@@ -237,7 +237,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' RequestHandler, Security  '));
 
 		$result = $this->Task->doComponents();
-		$expected = array('RequestHandler', 'Security');
+		$expected = array('Paginator', 'RequestHandler', 'Security');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -251,7 +251,7 @@ class ControllerTaskTest extends CakeTestCase {
 		$this->Task->expects($this->at(1))->method('in')->will($this->returnValue(' RequestHandler, Security, , '));
 
 		$result = $this->Task->doComponents();
-		$expected = array('RequestHandler', 'Security');
+		$expected = array('Paginator', 'RequestHandler', 'Security');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -350,7 +350,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$this->assertContains('function index() {', $result);
 		$this->assertContains('$this->BakeArticle->recursive = 0;', $result);
-		$this->assertContains("\$this->set('bakeArticles', \$this->paginate());", $result);
+		$this->assertContains("\$this->set('bakeArticles', \$this->Paginator->paginate());", $result);
 
 		$this->assertContains('function view($id = null)', $result);
 		$this->assertContains("throw new NotFoundException(__('Invalid bake article'));", $result);
@@ -388,7 +388,7 @@ class ControllerTaskTest extends CakeTestCase {
 
 		$this->assertContains('function index() {', $result);
 		$this->assertContains('$this->BakeArticle->recursive = 0;', $result);
-		$this->assertContains("\$this->set('bakeArticles', \$this->paginate());", $result);
+		$this->assertContains("\$this->set('bakeArticles', \$this->Paginator->paginate());", $result);
 
 		$this->assertContains('function view($id = null)', $result);
 		$this->assertContains("throw new NotFoundException(__('Invalid bake article'));", $result);


### PR DESCRIPTION
Fixes #3895.

See: https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/3895-baking-a-controller-uses-deprecated-paginate-et-al
