### PR TITLE
Narrow the substitution of = by IN in queries

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1332,10 +1332,10 @@ class DboSource extends DataSource {
  * @return array Association results
  */
 	public function fetchAssociated(Model $model, $query, $ids) {
-		$query = str_replace('{$__cakeID__$}', implode(', ', $ids), $query);
 		if (count($ids) > 1) {
-			$query = str_replace('= (', 'IN (', $query);
+			$query = str_replace('= ({$__cakeID__$}', 'IN ({$__cakeID__$}', $query);
 		}
+		$query = str_replace('{$__cakeID__$}', implode(', ', $ids), $query);
 		return $this->fetchAll($query, $model->cacheQueries);
 	}
 


### PR DESCRIPTION
## What I did

Created a virtual field with a subquery in the WHERE part. The subquery had a limit statement.
## What happened

SQLSTATE[42000]: Syntax error or access violation: 1235 This version of MySQL doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'
## What I expected to happen

There should have been no error, since the virtual field had no IN/ALL/ANY/SOME subquery. However, DboSource::fetchAssociated() (in lib/Cake/Model/Datasource/DboSource.php) had replaced the '= (' by 'IN ('. 
## Possible solution

Please restrict the replacement to the part for which it is meant, i.e. the part where the ids are inserted by Cake? E.g.:

``` php
public function fetchAssociated(Model $model, $query, $ids) {
    if (count($ids) > 1) {
        $query = str_replace('= ({$__cakeID__$}', 'IN ({$__cakeID__$}', $query);
    }
    $query = str_replace('{$__cakeID__$}', implode(', ', $ids), $query);
    return $this->fetchAll($query, $model->cacheQueries);
}
```
