### PR TITLE
2.4 l10n

### DIFF
--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -63,7 +63,7 @@ class L10n {
  *
  * @var string
  */
-	public $default = null;
+	public $default = 'en';
 
 /**
  * Encoding used for current locale

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -58,7 +58,8 @@ class L10n {
 /**
  * Default ISO 639-3 language.
  *
- * DEFAULT_LANGUAGE is defined in an application this will be set as a fall back
+ * If Configure::read('Config.language') is defined in an application this will be set
+ * as a fall back, otherwise DEFAULT_LANGUAGE will be used if defined.
  *
  * @var string
  */
@@ -337,6 +338,10 @@ class L10n {
 		if (defined('DEFAULT_LANGUAGE')) {
 			$this->default = DEFAULT_LANGUAGE;
 		}
+		$default = Configure::read('Config.language');
+		if ($default) {
+			$this->default = $default;
+		}
 	}
 
 /**
@@ -344,7 +349,7 @@ class L10n {
  * If $language is null it attempt to get settings from L10n::_autoLanguage(); if this fails
  * the method will get the settings from L10n::_setLanguage();
  *
- * @param string $language Language (if null will use DEFAULT_LANGUAGE if defined)
+ * @param string $language Language (if null will use default language if defined)
  * @return mixed
  */
 	public function get($language = null) {
@@ -360,9 +365,9 @@ class L10n {
 
 /**
  * Sets the class vars to correct values for $language.
- * If $language is null it will use the DEFAULT_LANGUAGE if defined
+ * If $language is null it will use the default language if defined
  *
- * @param string $language Language (if null will use DEFAULT_LANGUAGE if defined)
+ * @param string $language Language (if null will use default language if defined)
  * @return mixed
  */
 	protected function _setLanguage($language = null) {
@@ -371,16 +376,14 @@ class L10n {
 			$langKey = $this->_l10nMap[$language];
 		} elseif ($language !== null && isset($this->_l10nCatalog[$language])) {
 			$langKey = $language;
-		} elseif (defined('DEFAULT_LANGUAGE')) {
-			$langKey = $language = DEFAULT_LANGUAGE;
+		} elseif ($this->default) {
+			$langKey = $language = $this->default;
 		}
 
 		if ($langKey !== null && isset($this->_l10nCatalog[$langKey])) {
 			$this->language = $this->_l10nCatalog[$langKey]['language'];
-			$this->languagePath = array(
-				$this->_l10nCatalog[$langKey]['locale'],
-				$this->_l10nCatalog[$langKey]['localeFallback']
-			);
+			$this->languagePath = array($this->_l10nCatalog[$langKey]['locale']);
+			$this->_addLanguagePath($this->_l10nCatalog[$langKey]['localeFallback']);
 			$this->lang = $language;
 			$this->locale = $this->_l10nCatalog[$langKey]['locale'];
 			$this->charset = $this->_l10nCatalog[$langKey]['charset'];
@@ -392,9 +395,9 @@ class L10n {
 
 		if ($this->default) {
 			if (isset($this->_l10nMap[$this->default]) && isset($this->_l10nCatalog[$this->_l10nMap[$this->default]])) {
-				$this->languagePath[] = $this->_l10nCatalog[$this->_l10nMap[$this->default]]['localeFallback'];
+				$this->_addLanguagePath($this->_l10nCatalog[$this->_l10nMap[$this->default]]['localeFallback']);
 			} elseif (isset($this->_l10nCatalog[$this->default])) {
-				$this->languagePath[] = $this->_l10nCatalog[$this->default]['localeFallback'];
+				$this->_addLanguagePath($this->_l10nCatalog[$this->default]['localeFallback']);
 			}
 		}
 		$this->found = true;
@@ -406,6 +409,18 @@ class L10n {
 		if ($language) {
 			return $language;
 		}
+	}
+
+/**
+ * Adds the language to the language path array if not already in there.
+ *
+ * @return void
+ */
+	protected function _addLanguagePath($lang) {
+		if (in_array($lang, $this->languagePath)) {
+			return;
+		}
+		$this->languagePath[] = $lang;
 	}
 
 /**

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -63,7 +63,7 @@ class L10n {
  *
  * @var string
  */
-	public $default = 'en';
+	public $default = null;
 
 /**
  * Encoding used for current locale

--- a/lib/Cake/Test/Case/I18n/L10nTest.php
+++ b/lib/Cake/Test/Case/I18n/L10nTest.php
@@ -98,6 +98,8 @@ class L10nTest extends CakeTestCase {
  * @return void
  */
 	public function testGetWithDeprecatedConstant() {
+		$this->skipIf(defined('DEFAULT_LANGUAGE'), 'Cannot re-define already defined constant.');
+
 		define('DEFAULT_LANGUAGE', 'en-us');
 		$localize = new L10n();
 

--- a/lib/Cake/Test/Case/I18n/L10nTest.php
+++ b/lib/Cake/Test/Case/I18n/L10nTest.php
@@ -28,6 +28,17 @@ App::uses('L10n', 'I18n');
 class L10nTest extends CakeTestCase {
 
 /**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+
+		Configure::delete('Config.language');
+	}
+
+/**
  * testGet method
  *
  * @return void
@@ -40,14 +51,14 @@ class L10nTest extends CakeTestCase {
 
 		$this->assertEquals('en', $lang);
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		// Map Entry
 		$localize->get('eng');
 
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		// Catalog Entry
@@ -58,8 +69,8 @@ class L10nTest extends CakeTestCase {
 		$this->assertEquals('en_ca', $localize->locale);
 
 		// Default Entry
-		define('DEFAULT_LANGUAGE', 'en-us');
-
+		Configure::write('Config.language', 'en-us');
+		$localize = new L10n();
 		$lang = $localize->get('use_default');
 
 		$this->assertEquals('en-us', $lang);
@@ -67,6 +78,7 @@ class L10nTest extends CakeTestCase {
 		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
 		$this->assertEquals('en_us', $localize->locale);
 
+		$localize = new L10n();
 		$localize->get('es');
 		$localize->get('');
 		$this->assertEquals('en-us', $localize->lang);
@@ -76,7 +88,24 @@ class L10nTest extends CakeTestCase {
 
 		$localize->get('use_default');
 		$this->assertEquals('English (United States)', $localize->language);
-		$this->assertEquals(array('en_us', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_us', $localize->locale);
+	}
+
+/**
+ * testGet method with deprecated constant DEFAULT_LANGUAGE
+ *
+ * @return void
+ */
+	public function testGetWithDeprecatedConstant() {
+		define('DEFAULT_LANGUAGE', 'en-us');
+		$localize = new L10n();
+
+		$lang = $localize->get('use_default');
+
+		$this->assertEquals('en-us', $lang);
+		$this->assertEquals('English (United States)', $localize->language);
+		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
 		$this->assertEquals('en_us', $localize->locale);
 	}
 
@@ -94,10 +123,12 @@ class L10nTest extends CakeTestCase {
 
 		$this->assertEquals('en-ca', $lang);
 		$this->assertEquals('English (Canadian)', $localize->language);
-		$this->assertEquals(array('en_ca', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('en_ca', 'eng'), $localize->languagePath);
 		$this->assertEquals('en_ca', $localize->locale);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es_mx';
+
+		$localize = new L10n();
 		$lang = $localize->get();
 
 		$this->assertEquals('es-mx', $lang);
@@ -106,10 +137,12 @@ class L10nTest extends CakeTestCase {
 		$this->assertEquals('es_mx', $localize->locale);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en_xy,en_ca';
+
+		$localize = new L10n();
 		$localize->get();
 
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		$_SERVER = $serverBackup;


### PR DESCRIPTION
After several other recent constant deprecations it only makes sense to use Configure value "Config.language" instead of DEFAULT_LANGUAGE constant here, as well.

What do you think?
I can than also modify docs etc.

Also cleaned up the resulting path array. No need to have "eng" three times in the array.
The I18n class might iterate over it 2 times more without any other result.
