### PR TITLE
Strips the base off the generated URL from the AuthComponent.

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -677,7 +677,7 @@ class AuthComponent extends Component {
 			$redir = '/';
 		}
 		if (is_array($redir)) {
-			return Router::url($redir);
+			return Router::url($redir + array('base' => false));
 		}
 		return $redir;
 	}

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -1269,6 +1269,41 @@ class AuthComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test that the returned URL doesn't contain the base URL.
+ *
+ * @see https://cakephp.lighthouseapp.com/projects/42648/tickets/3922-authcomponentredirecturl-prepends-appbaseurl
+ *
+ * @return void This test method doesn't return anything.
+ */
+	public function testRedirectUrlWithBaseSet() {
+		$App = Configure::read('App');
+
+		Configure::write('App', array(
+			'dir' => APP_DIR,
+			'webroot' => WEBROOT_DIR,
+			'base' => false,
+			'baseUrl' => '/cake/index.php'
+		));
+
+		$url = '/users/login';
+		$this->Auth->request = $this->Controller->request = new CakeRequest($url);
+		$this->Auth->request->addParams(Router::parse($url));
+		$this->Auth->request->url = Router::normalize($url);
+
+		Router::setRequestInfo($this->Auth->request);
+
+		$this->Auth->loginAction = array('controller' => 'users', 'action' => 'login');
+		$this->Auth->loginRedirect = array('controller' => 'users', 'action' => 'home');
+
+		$result = $this->Auth->redirectUrl();
+		$this->assertEquals('/users/home', $result);
+		$this->assertFalse($this->Auth->Session->check('Auth.redirect'));
+
+		Configure::write('App', $App);
+		Router::reload();
+	}
+
+/**
  * test password hashing
  *
  * @return void


### PR DESCRIPTION
Fixes #3922.

Reference: https://cakephp.lighthouseapp.com/projects/42648/tickets/3922-authcomponentredirecturl-prepends-appbaseurl
