### PR TITLE
Removed unused setup & teardown methods

### DIFF
--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -78,24 +78,6 @@ class MyAppSchema extends CakeSchema {
 	protected $_foo = array('bar');
 
 /**
- * setup method
- *
- * @param mixed $version
- * @return void
- */
-	public function setup($version) {
-	}
-
-/**
- * teardown method
- *
- * @param mixed $version
- * @return void
- */
-	public function teardown($version) {
-	}
-
-/**
  * getVar method
  *
  * @param string $var Name of var


### PR DESCRIPTION
 from MyAppSchema in CakeSchemaTest.

They seem to be unused. I assume they were meant to be test callbacks setUp & tearDown or if they were used once their calls have been removed.
