### PR TITLE
Required fields not recognised by FormHelper when only using ModelValidator::add()

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -8007,7 +8007,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
-	
+
 /**
  * Test that required fields are created when only using ModelValidator::add().
  *
@@ -8015,7 +8015,7 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testFormInputRequiredDetectionModelValidator() {
 		ClassRegistry::getObject('ContactTag')->validator()->add('iwillberequired', 'required', array('rule' => 'notEmpty'));
-		
+
 		$this->Form->create('ContactTag');
 		$result = $this->Form->input('ContactTag.iwillberequired');
 		$expected = array(

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -8007,6 +8007,32 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+	
+/**
+ * Test that required fields are created when only using ModelValidator::add().
+ *
+ * @return void
+ */
+	public function testFormInputRequiredDetectionModelValidator() {
+		ClassRegistry::getObject('ContactTag')->validator()->add('iwillberequired', 'required', array('rule' => 'notEmpty'));
+		
+		$this->Form->create('ContactTag');
+		$result = $this->Form->input('ContactTag.iwillberequired');
+		$expected = array(
+			'div' => array('class' => 'input text required'),
+			'label' => array('for' => 'ContactTagIwillberequired'),
+			'Iwillberequired',
+			'/label',
+			'input' => array(
+				'name' => 'data[ContactTag][iwillberequired]',
+				'type' => 'text',
+				'id' => 'ContactTagIwillberequired',
+				'required' => 'required'
+			),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
 
 /**
  * testFormMagicInput method

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -218,11 +218,9 @@ class FormHelper extends AppHelper {
 
 		if ($key === 'validates' && !isset($this->fieldset[$model]['validates'])) {
 			$validates = array();
-			if ($object->validator()->count() > 0) {
-				foreach ($object->validator() as $validateField => $validateProperties) {
-					if ($this->_isRequiredField($validateProperties)) {
-						$validates[$validateField] = true;
-					}
+			foreach ($object->validator() as $validateField => $validateProperties) {
+				if ($this->_isRequiredField($validateProperties)) {
+					$validates[$validateField] = true;
 				}
 			}
 			$this->fieldset[$model]['validates'] = $validates;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -218,7 +218,7 @@ class FormHelper extends AppHelper {
 
 		if ($key === 'validates' && !isset($this->fieldset[$model]['validates'])) {
 			$validates = array();
-			if (!empty($object->validate)) {
+			if ($object->validator()->count() > 0) {
 				foreach ($object->validator() as $validateField => $validateProperties) {
 					if ($this->_isRequiredField($validateProperties)) {
 						$validates[$validateField] = true;


### PR DESCRIPTION
If you only use `ModelValidator::add()` to add validation rules to a model, then `FormHelper` will not recognise required fields. This only occurs when you don't use the `Model::$validate` property at all.
