### PR TITLE
3.0 beforefind

### DIFF
--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -334,7 +334,7 @@ class Query extends DatabaseQuery {
  * @param Cake\ORM\ResultSet $results The results this query should return.
  * @return Query The query instance.
  */
-	public function setResult(ResultSet $results) {
+	public function setResult($results) {
 		$this->_results = $results;
 		return $this;
 	}

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -91,6 +91,15 @@ class Query extends DatabaseQuery {
 	protected $_results;
 
 /**
+ * @param Cake\Database\Connection $connection
+ * @param Cake\ORM\Table $table
+ */
+	public function __construct($connection, $table) {
+		$this->connection($connection);
+		$this->repository($table);
+	}
+
+/**
  * Returns the default table object that will be used by this query,
  * that is, the table that will appear in the from clause.
  *

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -83,6 +83,14 @@ class Query extends DatabaseQuery {
 	];
 
 /**
+ * A hydrated ResultSet.
+ *
+ * @var Cake\ORM\ResultSet
+ * @see setResult()
+ */
+	protected $_results;
+
+/**
  * Returns the default table object that will be used by this query,
  * that is, the table that will appear in the from clause.
  *
@@ -306,8 +314,27 @@ class Query extends DatabaseQuery {
 	}
 
 /**
+ * Set the result set for a query.
+ *
+ * Setting the resultset of a query will make execute() a no-op. Instead
+ * of executing the SQL query and fetching results, the ResultSet provided to this
+ * method will be returned.
+ *
+ * This method is most useful when combined with results stored in a persistent cache.
+ *
+ * @param Cake\ORM\ResultSet $results The results this query should return.
+ * @return Query The query instance.
+ */
+	public function setResult(ResultSet $results) {
+		$this->_results = $results;
+		return $this;
+	}
+
+/**
  * Compiles the SQL representation of this query and executes it using the
- * provided connection object. Returns a ResultSet iterator object
+ * provided connection object. Returns a ResultSet iterator object.
+ *
+ * If a result set was set using setResult() that ResultSet will be returned.
  *
  * Resulting object is traversable, so it can be used in any loop as you would
  * with an array.
@@ -315,6 +342,9 @@ class Query extends DatabaseQuery {
  * @return Cake\ORM\ResultSet
  */
 	public function execute() {
+		if (isset($this->_results)) {
+			return $this->_results;
+		}
 		return new ResultSet($this, parent::execute());
 	}
 

--- a/lib/Cake/ORM/ResultSet.php
+++ b/lib/Cake/ORM/ResultSet.php
@@ -47,14 +47,14 @@ class ResultSet implements Iterator {
  *
  * @var integer
  */
-	protected $_count = 0;
+	protected $_index = 0;
 
 /**
  * Points to the last record number that was fetched
  *
  * @var integer
  */
-	protected $_counter = -1;
+	protected $_lastIndex = -1;
 
 /**
  * Last record fetched from the statement
@@ -123,7 +123,7 @@ class ResultSet implements Iterator {
  * @return integer
  */
 	public function key() {
-		return $this->_count;
+		return $this->_index;
 	}
 
 /**
@@ -132,7 +132,7 @@ class ResultSet implements Iterator {
  * @return void
  */
 	public function next() {
-		$this->_count++;
+		$this->_index++;
 		$this->_fetchResult();
 	}
 
@@ -187,9 +187,9 @@ class ResultSet implements Iterator {
  * @return void
  */
 	protected function _fetchResult() {
-		if ($this->_counter < $this->_count) {
+		if ($this->_lastIndex < $this->_index) {
 			$this->_current = $this->_statement->fetch('assoc');
-			$this->_counter = $this->_count;
+			$this->_lastIndex = $this->_index;
 		}
 	}
 

--- a/lib/Cake/ORM/ResultSet.php
+++ b/lib/Cake/ORM/ResultSet.php
@@ -144,11 +144,16 @@ class ResultSet implements Iterator {
 	}
 
 /**
- * Not implemented
+ * Rewind a ResultSet.
+ *
+ * Once rewound results will not be refetched from
+ * the database.
  *
  * @return void
  */
 	public function rewind() {
+		$this->_index = 0;
+		$this->_lastIndex = -1;
 	}
 
 /**
@@ -194,14 +199,21 @@ class ResultSet implements Iterator {
  * @return void
  */
 	protected function _fetchResult() {
-		if ($this->_lastIndex < $this->_index) {
-			$row = $this->_statement->fetch('assoc');
-			if ($row !== false) {
-				$row = $this->_groupResult($row);
-			}
-			$this->_current = $row;
-			$this->_lastIndex = $this->_index;
+		$advance = ($this->_lastIndex < $this->_index);
+		if (!$advance) {
+			return;
 		}
+		if (isset($this->_results[$this->_index])) {
+			$this->_current = $this->_results[$this->_index];
+			return;
+		}
+		$row = $this->_statement->fetch('assoc');
+		if ($row !== false) {
+			$row = $this->_groupResult($row);
+		}
+		$this->_current = $row;
+		$this->_results[] = $row;
+		$this->_lastIndex = $this->_index;
 	}
 
 /**

--- a/lib/Cake/ORM/ResultSet.php
+++ b/lib/Cake/ORM/ResultSet.php
@@ -18,6 +18,7 @@ namespace Cake\ORM;
 
 use Cake\Database\Type;
 use \Iterator;
+use \Serializable;
 
 /**
  * Represents the results obtained after executing a query for an specific table
@@ -26,7 +27,7 @@ use \Iterator;
  * queries required for eager loading external associations.
  *
  */
-class ResultSet implements Iterator {
+class ResultSet implements Iterator, Serializable {
 
 /**
  * Original query from where results where generated
@@ -284,6 +285,31 @@ class ResultSet implements Iterator {
 		}
 
 		return $values;
+	}
+
+/**
+ * Serialize a resultset.
+ *
+ * Part of Serializable Interface
+ *
+ * @return string Serialized object
+ */
+	public function serialize() {
+		iterator_to_array($this);
+		return serialize($this->_results);
+	}
+
+/**
+ * Unserialize a resultset.
+ *
+ * Part of Serializable Interface
+ *
+ * @param string Serialized object
+ * @return ResultSet The hydrated result set.
+ */
+	public function unserialize($serialized) {
+		$this->_results = unserialize($serialized);
+		return $this;
 	}
 
 }

--- a/lib/Cake/ORM/ResultSet.php
+++ b/lib/Cake/ORM/ResultSet.php
@@ -86,6 +86,13 @@ class ResultSet implements Iterator {
 	protected $_map;
 
 /**
+ * Results that have been fetched or hydrated into the results.
+ *
+ * @var array
+ */
+	protected $_results = [];
+
+/**
  * Constructor
  *
  * @param Query from where results come
@@ -114,7 +121,7 @@ class ResultSet implements Iterator {
  * @return array|object
  */
 	public function current() {
-		return $this->_groupResult($this->_current);
+		return $this->_current;
 	}
 
 /**
@@ -188,7 +195,11 @@ class ResultSet implements Iterator {
  */
 	protected function _fetchResult() {
 		if ($this->_lastIndex < $this->_index) {
-			$this->_current = $this->_statement->fetch('assoc');
+			$row = $this->_statement->fetch('assoc');
+			if ($row !== false) {
+				$row = $this->_groupResult($row);
+			}
+			$this->_current = $row;
 			$this->_lastIndex = $this->_index;
 		}
 	}
@@ -198,10 +209,10 @@ class ResultSet implements Iterator {
  *
  * @return array
  */
-	protected function _groupResult() {
+	protected function _groupResult($row) {
 		$defaultAlias = $this->_defaultTable->alias();
 		$results = [];
-		foreach ($this->_current as $key => $value) {
+		foreach ($row as $key => $value) {
 			$table = $defaultAlias;
 			$field = $key;
 

--- a/lib/Cake/ORM/ResultSet.php
+++ b/lib/Cake/ORM/ResultSet.php
@@ -71,13 +71,6 @@ class ResultSet implements Iterator {
 	protected $_defaultTable;
 
 /**
- * Default table alias
- *
- * @var string
- */
-	protected $_defaultAlias;
-
-/**
  * List of associations that should be eager loaded
  *
  * @var array
@@ -103,7 +96,6 @@ class ResultSet implements Iterator {
 		$this->_query = $query;
 		$this->_statement = $statement;
 		$this->_defaultTable = $this->_query->repository();
-		$this->_defaultAlias = $this->_defaultTable->alias();
 		$this->_calculateAssociationMap();
 	}
 
@@ -207,9 +199,10 @@ class ResultSet implements Iterator {
  * @return array
  */
 	protected function _groupResult() {
+		$defaultAlias = $this->_defaultTable->alias();
 		$results = [];
 		foreach ($this->_current as $key => $value) {
-			$table = $this->_defaultAlias;
+			$table = $defaultAlias;
 			$field = $key;
 
 			if (empty($this->_map[$key])) {
@@ -226,9 +219,9 @@ class ResultSet implements Iterator {
 			$results[$table][$field] = $value;
 		}
 
-		$results[$this->_defaultAlias] = $this->_castValues(
+		$results[$defaultAlias] = $this->_castValues(
 			$this->_defaultTable,
-			$results[$this->_defaultAlias]
+			$results[$defaultAlias]
 		);
 
 		foreach (array_reverse($this->_associationMap) as $alias => $assoc) {
@@ -239,7 +232,7 @@ class ResultSet implements Iterator {
 			$results = $assoc->transformRow($results);
 		}
 
-		return $results[$this->_defaultAlias];
+		return $results[$defaultAlias];
 	}
 
 /**
@@ -269,4 +262,5 @@ class ResultSet implements Iterator {
 
 		return $values;
 	}
+
 }

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -16,6 +16,8 @@
  */
 namespace Cake\ORM;
 
+use Cake\Event\Event;
+use Cake\Event\EventManager;
 use Cake\Database\Schema\Table as Schema;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
@@ -29,6 +31,16 @@ use Cake\Utility\Inflector;
  * instances of this class can be created for the same database table with
  * different aliases, this allows you to address your database structure in a
  * richer and more expressive way.
+ *
+ * ### Callbacks/events
+ *
+ * Table objects provide a few callbacks/events you can hook into to augment/replace
+ * find operations. Each event uses the standard Event subsystem in CakePHP
+ *
+ * - beforeFind($event, $query, $options) - Fired before each find operation. By stopping
+ *   the event and supplying a return value you can bypass the find operation entirely. Any
+ *   changes done to the $query instance will be retained for the rest of the find.
+ *
  */
 class Table {
 
@@ -93,6 +105,15 @@ class Table {
 	protected $_associations = [];
 
 /**
+ * EventManager for this model.
+ *
+ * All model/behavior callbacks will be dispatched on this manager.
+ *
+ * @var Cake\Event\EventManager
+ */
+	protected $_eventManager;
+
+/**
  * Initializes a new instance
  *
  * The $config array understands the following keys:
@@ -106,7 +127,7 @@ class Table {
  * @param array config Lsit of options for this table
  * @return void
  */
-	public function __construct($config = array()) {
+	public function __construct($config = []) {
 		if (!empty($config['table'])) {
 			$this->table($config['table']);
 		}
@@ -126,6 +147,11 @@ class Table {
 		if (!empty($config['schema'])) {
 			$this->schema($config['schema']);
 		}
+		$eventManager = null;
+		if (!empty($config['eventManager'])) {
+			$eventManager = $config['eventManager'];
+		}
+		$this->_eventManager = $eventManager ?: new EventManager();
 	}
 
 /**
@@ -262,6 +288,15 @@ class Table {
 			return $this->_connection;
 		}
 		return $this->_connection = $conn;
+	}
+
+/**
+ * Get the event manager for this Table.
+ *
+ * @return Cake\Event\EventManager
+ */
+	public function getEventManager() {
+		return $this->_eventManager;
 	}
 
 /**
@@ -461,6 +496,12 @@ class Table {
 	public function find($type, $options = []) {
 		$query = $this->_buildQuery();
 		$query->select();
+
+		$event = new Event('Model.beforeFind', $this, [$query, $options]);
+		$this->_eventManager->dispatch($event);
+		if ($event->isStopped()) {
+			return $event->result;
+		}
 		return $this->{'find' . ucfirst($type)}($query, $options);
 	}
 

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -523,8 +523,7 @@ class Table {
  * @return \Cake\ORM\Query
  */
 	protected function _buildQuery() {
-		$query = new Query($this->connection());
-		return $query->repository($this);
+		return new Query($this->connection(), $this);
 	}
 
 /**

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -487,7 +487,14 @@ class Table {
 
 /**
  * Creates a new Query for this table and applies some defaults based on the
- * type of search that was selected
+ * type of search that was selected.
+ *
+ * ### Model.beforeFind event
+ *
+ * Each find() will trigger a `Model.beforeFind` event for all attached
+ * listeners. Any listener can stop the event to prevent the default
+ * find handler from being called. When a find() is stopped the Query
+ * object will still be returned.
  *
  * @param string $type the type of query to perform
  * @param array $options
@@ -500,7 +507,7 @@ class Table {
 		$event = new Event('Model.beforeFind', $this, [$query, $options]);
 		$this->_eventManager->dispatch($event);
 		if ($event->isStopped()) {
-			return $event->result;
+			return $query;
 		}
 		return $this->{'find' . ucfirst($type)}($query, $options);
 	}

--- a/lib/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/lib/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -157,7 +157,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -207,7 +207,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -263,7 +263,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 		]);
 		$association = new BelongsToMany('Tag', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['execute', 'contain'], [null]);
+		$query = $this->getMock('Cake\ORM\Query', ['execute', 'contain'], [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -320,7 +320,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsToMany('Tag', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -372,7 +372,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsToMany('Tag', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order', 'select'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -441,7 +441,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsToMany('Tag', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order', 'select'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$query->expects($this->any())->method('contain')->will($this->returnSelf());
@@ -474,14 +474,14 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			]
 		]);
 		$association = new BelongsToMany('Tag', $config);
-		$parent = (new Query(null))
+		$parent = (new Query(null, null))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
 
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
-			[null]
+			[null, null]
 		);
 
 		$this->tag->expects($this->once())->method('find')->with('all')

--- a/lib/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/lib/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -75,7 +75,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -106,7 +106,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -140,7 +140,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->client,
 			'targetTable' => $this->company,

--- a/lib/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/lib/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -108,7 +108,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasMany('Article', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['execute'], [null]);
+		$query = $this->getMock('Cake\ORM\Query', ['execute'], [null, null]);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -152,7 +152,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['execute', 'where', 'andWhere', 'order'],
-			[null]
+			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -197,7 +197,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
-			[null]
+			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -262,7 +262,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['execute'],
-			[null]
+			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -281,14 +281,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->article,
 		];
 		$association = new HasMany('Article', $config);
-		$parent = (new Query(null))
+		$parent = (new Query(null, null))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
 
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
-			[null]
+			[null, null]
 		);
 
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -340,7 +340,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -371,7 +371,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -405,7 +405,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,

--- a/lib/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/lib/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -75,7 +75,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
@@ -107,7 +107,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
@@ -142,7 +142,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Core\Configure;
 use Cake\Model\ConnectionManager;
 use Cake\ORM\Query;
+use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
 
 /**
@@ -810,6 +811,19 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 			]
 		];
 		$this->assertEquals($expected, $results);
+	}
+
+/**
+ * Test setResult()
+ *
+ * @return void
+ */
+	public function testSetResult() {
+		$query = new Query($this->connection);
+		$stmt = $this->getMock('Cake\Database\StatementInterface');
+		$results = new ResultSet($query, $stmt);
+		$query->setResult($results);
+		$this->assertSame($results, $query->execute());
 	}
 
 }

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -21,12 +21,13 @@ use Cake\Model\ConnectionManager;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
 
 /**
  * Tests Query class
  *
  */
-class QueryTest extends \Cake\TestSuite\TestCase {
+class QueryTest extends TestCase {
 
 	public $fixtures = ['core.article', 'core.author', 'core.tag',
 		'core.articles_tag', 'core.post'];
@@ -101,7 +102,7 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 			]
 		];
 
-		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
 
 		$query->expects($this->at(0))->method('join')
 			->with(['client' => [
@@ -181,9 +182,9 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		];
 
 		$table = Table::build('foo', ['schema' => ['id' => ['type' => 'integer']]]);
-		$query = new Query($this->connection);
+		$query = new Query($this->connection, $table);
 
-		$query->select('foo.id')->repository($table)->contain($contains)->sql();
+		$query->select('foo.id')->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
 			'foo__id' => 'foo.id', 'client__name' => 'client.name',
@@ -203,8 +204,8 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testContainToFieldsDefault() {
 		$contains = ['client' => ['order']];
 
-		$query = new Query($this->connection);
-		$query->select()->repository($this->table)->contain($contains)->sql();
+		$query = new Query($this->connection, $this->table);
+		$query->select()->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
 			'foo__id' => 'foo.id', 'client__name' => 'client.name',
@@ -215,16 +216,16 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals($expected, $select);
 
 		$contains['client']['fields'] = ['name'];
-		$query = new Query($this->connection);
-		$query->select('foo.id')->repository($this->table)->contain($contains)->sql();
+		$query = new Query($this->connection, $this->table);
+		$query->select('foo.id')->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = ['foo__id' => 'foo.id', 'client__name' => 'client.name'];
 		$this->assertEquals($expected, $select);
 
 		$contains['client']['fields'] = [];
 		$contains['client']['order']['fields'] = false;
-		$query = new Query($this->connection);
-		$query->select()->repository($this->table)->contain($contains)->sql();
+		$query = new Query($this->connection, $this->table);
+		$query->select()->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
 			'foo__id' => 'foo.id',
@@ -243,12 +244,12 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testContainResultFetchingOneLevel() {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$table = Table::build('article', ['table' => 'articles']);
 		Table::build('author', ['connection' => $this->connection]);
 		$table->belongsTo('author');
-		$results = $query->repository($table)
-			->select()
+
+		$query = new Query($this->connection, $table);
+		$results = $query->select()
 			->contain('author')
 			->order(['article.id' => 'asc'])
 			->toArray();
@@ -310,7 +311,6 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testHasManyEagerLoading($strategy) {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		Table::build('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
@@ -318,8 +318,9 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 			'strategy' => $strategy,
 			'sort' => ['article.id' => 'asc']
 		]);
+		$query = new Query($this->connection, $table);
 
-		$results = $query->repository($table)->select()->contain('article')->toArray();
+		$results = $query->select()->contain('article')->toArray();
 		$expected = [
 			[
 				'id' => 1,
@@ -383,13 +384,12 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testHasManyEagerLoadingFieldsAndOrder($strategy) {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		Table::build('article', ['connection' => $this->connection]);
 		$table->hasMany('article', ['property' => 'articles'] + compact('strategy'));
 
-		$results = $query->repository($table)
-			->select()
+		$query = new Query($this->connection, $table);
+		$results = $query->select()
 			->contain([
 				'article' => [
 					'fields' => ['title', 'author_id'],
@@ -434,7 +434,6 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testHasManyEagerLoadingDeep($strategy) {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		$article = Table::build('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
@@ -443,9 +442,9 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 			'sort' => ['article.id' => 'asc']
 		]);
 		$article->belongsTo('author');
+		$query = new Query($this->connection, $table);
 
-		$results = $query->repository($table)
-			->select()
+		$results = $query->select()
 			->contain(['article' => ['author']])
 			->toArray();
 		$expected = [
@@ -513,7 +512,6 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testHasManyEagerLoadingFromSecondaryTable($strategy) {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$author = Table::build('author', ['connection' => $this->connection]);
 		$article = Table::build('article', ['connection' => $this->connection]);
 		$post = Table::build('post', ['connection' => $this->connection]);
@@ -521,8 +519,9 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		$author->hasMany('post', ['property' => 'posts'] + compact('strategy'));
 		$article->belongsTo('author');
 
-		$results = $query->repository($article)
-			->select()
+		$query = new Query($this->connection, $article);
+
+		$results = $query->select()
 			->contain(['author' => ['post']])
 			->order(['article.id' => 'ASC'])
 			->toArray();
@@ -616,7 +615,6 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testBelongsToManyEagerLoading($strategy) {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
 		$table = Table::build('Article', ['connection' => $this->connection]);
 		Table::build('Tag', ['connection' => $this->connection]);
 		Table::build('ArticleTag', [
@@ -624,8 +622,9 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 			'table' => 'articles_tags'
 		]);
 		$table->belongsToMany('Tag', ['property' => 'tags', 'strategy' => $strategy]);
+		$query = new Query($this->connection, $table);
 
-		$results = $query->repository($table)->select()->contain('Tag')->toArray();
+		$results = $query->select()->contain('Tag')->toArray();
 		$expected = [
 			[
 				'id' => 1,
@@ -675,8 +674,7 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		];
 		$this->assertEquals($expected, $results);
 
-		$results = $query->repository($table)
-			->select()
+		$results = $query->select()
 			->contain(['Tag' => ['conditions' => ['id' => 3]]])
 			->toArray();
 		$expected = [
@@ -721,7 +719,7 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testFilteringByHasMany() {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
+		$query = new Query($this->connection, $this->table);
 		$table = Table::build('author', ['connection' => $this->connection]);
 		Table::build('article', ['connection' => $this->connection]);
 		$table->hasMany('article', ['property' => 'articles']);
@@ -759,7 +757,7 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 	public function testFilteringByBelongsToMany() {
 		$this->_createTables();
 
-		$query = new Query($this->connection);
+		$query = new Query($this->connection, $this->table);
 		$table = Table::build('Article', ['connection' => $this->connection]);
 		Table::build('Tag', ['connection' => $this->connection]);
 		Table::build('ArticleTag', [
@@ -789,9 +787,8 @@ class QueryTest extends \Cake\TestSuite\TestCase {
 		];
 		$this->assertEquals($expected, $results);
 
-		$query = new Query($this->connection);
-		$results = $query->repository($table)
-			->select()
+		$query = new Query($this->connection, $table);
+		$results = $query->select()
 			->contain(['Tag' => [
 				'matching' => true,
 				'conditions' => ['Tag.name' => 'tag2']]
@@ -819,7 +816,7 @@ class QueryTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testSetResult() {
-		$query = new Query($this->connection);
+		$query = new Query($this->connection, $this->table);
 		$stmt = $this->getMock('Cake\Database\StatementInterface');
 		$results = new ResultSet($query, $stmt);
 		$query->setResult($results);

--- a/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -54,4 +54,44 @@ class ResultSetTest extends TestCase {
 		$this->assertEquals($first, $second);
 	}
 
+/**
+ * An integration test for testing serialize and unserialize features.
+ *
+ * Compare the results of a query with the results iterated, with
+ * those of a different query that have been serialized/unserialized.
+ *
+ * @return void
+ */
+	public function testSerialization() {
+		$query = $this->table->find('all');
+		$results = $query->execute();
+		$expected = $results->toArray();
+
+		$query2 = $this->table->find('all');
+		$results2 = $query2->execute();
+		$serialized = serialize($results2);
+		$outcome = unserialize($serialized);
+		$this->assertEquals($expected, $outcome->toArray());
+	}
+
+/**
+ * Test iteration after serialization
+ *
+ * @return void
+ */
+	public function testIteratorAfterSerialization() {
+		$query = $this->table->find('all');
+		$results = unserialize(serialize($query->execute()));
+
+		$expected = [
+			['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
+			['id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+			['id' => 3, 'author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y']
+		];
+		// Use a loop to test Iterator implementation
+		foreach ($results as $i => $row) {
+			$this->assertEquals($expected[$i], $row, "Row $i does not match");
+		}
+	}
+
 }

--- a/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Core\Configure;
+use Cake\Model\ConnectionManager;
+use Cake\ORM\Query;
+use Cake\ORM\ResultSet;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ResultSet test case.
+ */
+class ResultSetTest extends TestCase {
+
+	public $fixtures = ['core.article'];
+
+	public function setUp() {
+		parent::setUp();
+		$this->connection = ConnectionManager::getDataSource('test');
+		$this->table = new Table(['table' => 'articles', 'connection' => $this->connection]);
+	}
+
+/**
+ * Test that result sets can be rewound and re-used.
+ *
+ * @return void
+ */
+	public function testRewind() {
+		$query = $this->table->find('all');
+		$results = $query->execute();
+		$first = $second = [];
+		foreach ($results as $result) {
+			$first[] = $result;
+		}
+		foreach ($results as $result) {
+			$second[] = $result;
+		}
+		$this->assertEquals($first, $second);
+	}
+
+}

--- a/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -105,7 +105,7 @@ class ResultSetTest extends TestCase {
 		$results = $query->execute();
 
 		$expected = json_encode($this->fixtureData);
-		$this->assertEquals(json_encode($results), $expected);
+		$this->assertEquals($expected, json_encode($results));
 	}
 
 }

--- a/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -34,6 +34,12 @@ class ResultSetTest extends TestCase {
 		parent::setUp();
 		$this->connection = ConnectionManager::getDataSource('test');
 		$this->table = new Table(['table' => 'articles', 'connection' => $this->connection]);
+
+		$this->fixtureData = [
+			['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
+			['id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
+			['id' => 3, 'author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y']
+		];
 	}
 
 /**
@@ -83,15 +89,23 @@ class ResultSetTest extends TestCase {
 		$query = $this->table->find('all');
 		$results = unserialize(serialize($query->execute()));
 
-		$expected = [
-			['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],
-			['id' => 2, 'author_id' => 3, 'title' => 'Second Article', 'body' => 'Second Article Body', 'published' => 'Y'],
-			['id' => 3, 'author_id' => 1, 'title' => 'Third Article', 'body' => 'Third Article Body', 'published' => 'Y']
-		];
 		// Use a loop to test Iterator implementation
 		foreach ($results as $i => $row) {
-			$this->assertEquals($expected[$i], $row, "Row $i does not match");
+			$this->assertEquals($this->fixtureData[$i], $row, "Row $i does not match");
 		}
+	}
+
+/**
+ * Test converting resultsets into json
+ *
+ * @return void
+ */
+	public function testJsonSerialize() {
+		$query = $this->table->find('all');
+		$results = $query->execute();
+
+		$expected = json_encode($this->fixtureData);
+		$this->assertEquals(json_encode($results), $expected);
 	}
 
 }

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -321,11 +321,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->getEventManager()->attach(function ($event, $query, $options) use ($expected) {
 			$query->setResult($expected);
 			$event->stopPropagation();
-			return $query;
 		}, 'Model.beforeFind');
 
-		$result = $table->find('all');
-		$this->assertEquals($expected, $result->execute());
+		$query = $table->find('all');
+		$query->limit(1);
+		$this->assertEquals($expected, $query->execute());
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -317,13 +317,15 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testFindBeforeFindEventOverrideReturn() {
 		$table = new Table(['table' => 'users', 'connection' => $this->connection]);
-		$table->getEventManager()->attach(function ($event, $query, $options) {
+		$expected = ['One', 'Two', 'Three'];
+		$table->getEventManager()->attach(function ($event, $query, $options) use ($expected) {
+			$query->setResult($expected);
 			$event->stopPropagation();
-			return 'Something else';
+			return $query;
 		}, 'Model.beforeFind');
 
 		$result = $table->find('all');
-		$this->assertEquals('Something else', $result);
+		$this->assertEquals($expected, $result->execute());
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -437,7 +437,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['_buildQuery'],
 			['table' => 'users', 'connection' => $this->connection]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection]);
+		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection, null]);
 		$table->expects($this->once())
 			->method('_buildQuery')
 			->will($this->returnValue($query));
@@ -473,7 +473,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['_buildQuery'],
 			['table' => 'users', 'connection' => $this->connection]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection]);
+		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection, null]);
 		$table->expects($this->once())
 			->method('_buildQuery')
 			->will($this->returnValue($query));

--- a/lib/Cake/Test/TestCase/ORM/TableTest.php
+++ b/lib/Cake/Test/TestCase/ORM/TableTest.php
@@ -295,6 +295,38 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test that beforeFind events can mutate the query.
+ *
+ * @return void
+ */
+	public function testFindBeforeFindEventMutateQuery() {
+		$table = new Table(['table' => 'users', 'connection' => $this->connection]);
+		$table->getEventManager()->attach(function ($event, $query, $options) {
+			$query->limit(1);
+		}, 'Model.beforeFind');
+
+		$result = $table->find('all')->execute();
+		$this->assertCount(1, $result, 'Should only have 1 record, limit 1 applied.');
+	}
+
+/**
+ * Test that beforeFind events are fired and can stop the find and
+ * return custom results.
+ *
+ * @return void
+ */
+	public function testFindBeforeFindEventOverrideReturn() {
+		$table = new Table(['table' => 'users', 'connection' => $this->connection]);
+		$table->getEventManager()->attach(function ($event, $query, $options) {
+			$event->stopPropagation();
+			return 'Something else';
+		}, 'Model.beforeFind');
+
+		$result = $table->find('all');
+		$this->assertEquals('Something else', $result);
+	}
+
+/**
  * Tests that belongsTo() creates and configures correctly the association
  *
  * @return void


### PR DESCRIPTION
Add beforeFind event to ORM\Table.

Keep things simple and add a very basic event for beforeFind. In the future the updated behaviors will be able to use this event.

I've decided to solve a long standing problem and make it super simple to replace the result of a find() entirely. Stopping the event and setting a return will circumvent the entire find and return the provided value. This makes it really easy to replace find actions with cache results for example. One outstanding issue to making this really easy to do is that find() currently returns an ORM\Query instance. If instead it always returned an ORM\ResultSet it would be much simpler to do cache bypasses on find operations. I'm considering changing the return of Table::find() for that reason. Perhaps with the addition of scoped finders that change will be easier to accept.
