### PR TITLE
2.4 form helper iso 8601

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -5975,7 +5975,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testFormDateTimeMulti() {
 		extract($this->dateRegex);
 
-		$result = $this->Form->dateTime('Contact.1.updated');
+		$result = $this->Form->dateTime('Contact.1.updated', 'DMY', '12');
 		$expected = array(
 			array('select' => array('name' => 'data[Contact][1][updated][day]', 'id' => 'Contact1UpdatedDay')),
 			$daysRegex,
@@ -6014,7 +6014,7 @@ class FormHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->dateTime('Contact.2.updated');
+		$result = $this->Form->dateTime('Contact.2.updated', 'DMY', '12');
 		$expected = array(
 			array('select' => array('name' => 'data[Contact][2][updated][day]', 'id' => 'Contact2UpdatedDay')),
 			$daysRegex,
@@ -7794,7 +7794,7 @@ class FormHelperTest extends CakeTestCase {
 	public function testDateTimeWithGetForms() {
 		extract($this->dateRegex);
 		$this->Form->create('Contact', array('type' => 'get'));
-		$result = $this->Form->datetime('created');
+		$result = $this->Form->datetime('created', 'DMY', '12');
 
 		$this->assertRegExp('/name="created\[year\]"/', $result, 'year name attribute is wrong.');
 		$this->assertRegExp('/name="created\[month\]"/', $result, 'month name attribute is wrong.');

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2355,7 +2355,7 @@ class FormHelper extends AppHelper {
  * @return string Generated set of select boxes for the date and time formats chosen.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::dateTime
  */
-	public function dateTime($fieldName, $dateFormat = 'DMY', $timeFormat = '12', $attributes = array()) {
+	public function dateTime($fieldName, $dateFormat = 'DMY', $timeFormat = '24', $attributes = array()) {
 		$attributes += array('empty' => true, 'value' => null);
 		$year = $month = $day = $hour = $min = $meridian = null;
 


### PR DESCRIPTION
CakePHP is not just "American" anymore, its a globally used framework. Therefore, after already complying to ISO standards regarding localization I recommend that it complies with the hour format used internationally.
The 12 hour system is only used by a handful of countries and the ISO standard implies that the 24 hour system is the one that should be used as default: "ISO 8601 uses the 24-hour clock system".

See http://en.wikipedia.org/wiki/ISO_8601

Doc update and migration guide entry coming up.
