### PR TITLE
3.0 security improvements

### DIFF
--- a/App/Config/app.php
+++ b/App/Config/app.php
@@ -76,13 +76,10 @@ use Cake\Core\Configure;
  * The level of CakePHP security.
  *
  * - salt - A random string used in security hashing methods.
- * - cipherSeed - A random numeric string (digits only) used to seed 
- *   the xor cipher functions in Security.
+ *   The salt value is also used as the encryption key. You should treat it
+ *   as extremely sensitive data.
  */
-	Configure::write('Security', [
-		'salt' => 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi',
-		'cipherSeed' => '76859309657453542496749683645',
-	]);
+	Configure::write('Security.salt', 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi');
 
 /**
  * Apply timestamps with the last modified time to static assets (js, css, images).

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -98,13 +98,6 @@ class ProjectTask extends Shell {
 				$success = false;
 			}
 
-			if ($this->securityCipherSeed($path) === true) {
-				$this->out(__d('cake_console', ' * Random seed created for \'Security.cipherSeed\''));
-			} else {
-				$this->err(__d('cake_console', 'Unable to generate random seed for \'Security.cipherSeed\', you should change it in %s', APP . 'Config' . DS . 'app.php'));
-				$success = false;
-			}
-
 			if ($this->cachePrefix($path)) {
 				$this->out(__d('cake_console', ' * Cache prefix set'));
 			} else {
@@ -287,31 +280,8 @@ class ProjectTask extends Shell {
 		$contents = $File->read();
 		$newSalt = Security::generateAuthKey();
 		$contents = preg_replace(
-			"/^(\s+'salt'\s+\=\>\s+')([^']+)(',)/m",
+			"/('Security.salt',\s+')([^']+)(')/m",
 			'${1}' . $newSalt . '\\3',
-			$contents,
-			-1,
-			$count
-		);
-		if ($count && $File->write($contents)) {
-			return true;
-		}
-		return false;
-	}
-
-/**
- * Generates and writes 'Security.cipherSeed'
- *
- * @param string $path Project path
- * @return boolean Success
- */
-	public function securityCipherSeed($path) {
-		$File = new File($path . 'Config/app.php');
-		$contents = $File->read();
-		$newCipher = substr(bin2hex(Security::generateAuthKey()), 0, 30);
-		$contents = preg_replace(
-			"/^(\s+'cipherSeed'\s+\=\>\s+')([^']+)(',)/m",
-			'${1}' . $newCipher . '\\3',
 			$contents,
 			-1,
 			$count

--- a/lib/Cake/Console/Templates/skel/Config/app.php
+++ b/lib/Cake/Console/Templates/skel/Config/app.php
@@ -76,13 +76,10 @@ use Cake\Core\Configure;
  * The level of CakePHP security.
  *
  * - salt - A random string used in security hashing methods.
- * - cipherSeed - A random numeric string (digits only) used to seed
- *   the xor cipher functions in Security.
+ *   The salt value is also used as the encryption key. You should treat it
+ *   as extremely sensitive data.
  */
-	Configure::write('Security', [
-		'salt' => 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi',
-		'cipherSeed' => '76859309657453542496749683645',
-	]);
+	Configure::write('Security.salt', 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi');
 
 /**
  * Apply timestamps with the last modified time to static assets (js, css, images).

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -200,11 +200,6 @@
 	Configure::write('Security.salt', 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi');
 
 /**
- * A random numeric string (digits only) used to encrypt/decrypt strings.
- */
-	Configure::write('Security.cipherSeed', '76859309657453542496749683645');
-
-/**
  * Apply timestamps with the last modified time to static assets (js, css, images).
  * Will append a query string parameter containing the time the file was modified. This is
  * useful for invalidating browser caches.

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -132,12 +132,11 @@ class CookieComponent extends Component {
 /**
  * Type of encryption to use.
  *
- * Currently two methods are available: cipher and rijndael
- * Defaults to Security::cipher();
+ * Defaults to Security::rijndael();
  *
  * @var string
  */
-	protected $_type = 'cipher';
+	protected $_type = 'rijndael';
 
 /**
  * Used to reset cookie time if $expire is passed to CookieComponent::write()
@@ -376,14 +375,12 @@ class CookieComponent extends Component {
  * @param string $type Encryption method
  * @return void
  */
-	public function type($type = 'cipher') {
+	public function type($type = 'rijndael') {
 		$availableTypes = array(
-			'cipher',
 			'rijndael'
 		);
 		if (!in_array($type, $availableTypes)) {
-			trigger_error(__d('cake_dev', 'You must use cipher or rijndael for cookie encryption type'), E_USER_WARNING);
-			$type = 'cipher';
+			trigger_error(__d('cake_dev', 'You must use rijndael for cookie encryption type'), E_USER_WARNING);
 		}
 		$this->_type = $type;
 	}

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -18,6 +18,7 @@ use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Error;
 use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -374,13 +375,14 @@ class CookieComponent extends Component {
  *
  * @param string $type Encryption method
  * @return void
+ * @throws Cake\Error\Exception When an unknown type is used.
  */
 	public function type($type = 'rijndael') {
-		$availableTypes = array(
+		$availableTypes = [
 			'rijndael'
-		);
+		];
 		if (!in_array($type, $availableTypes)) {
-			trigger_error(__d('cake_dev', 'You must use rijndael for cookie encryption type'), E_USER_WARNING);
+			throw new Error\Exception(__d('cake_dev', 'You must use rijndael for cookie encryption type'));
 		}
 		$this->_type = $type;
 	}

--- a/lib/Cake/Test/TestCase/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/Task/ProjectTaskTest.php
@@ -249,23 +249,6 @@ class ProjectTaskTest extends TestCase {
 	}
 
 /**
- * test generation of Security.cipherSeed
- *
- * @return void
- */
-	public function testSecurityCipherSeedGeneration() {
-		$this->_setupTestProject();
-
-		$path = $this->Task->path . 'BakeTestApp/';
-		$result = $this->Task->securityCipherSeed($path);
-		$this->assertTrue($result);
-
-		$File = new File($path . 'Config/app.php');
-		$contents = $File->read();
-		$this->assertNotRegExp('/76859309657453542496749683645/', $contents, 'Default CipherSeed left behind. %s');
-	}
-
-/**
  * test generation of cache prefix
  *
  * @return void

--- a/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/AuthComponentTest.php
@@ -72,7 +72,6 @@ class AuthComponentTest extends TestCase {
 		$this->markTestIncomplete('Need to revisit once models work again.');
 
 		Configure::write('Security.salt', 'YJfIxfs2guVoUubWDYhG93b0qyJfIxfs2guwvniR2G0FgaC9mi');
-		Configure::write('Security.cipherSeed', 770011223369876);
 		Configure::write('App.namespace', 'TestApp');
 
 		$request = new Request();

--- a/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/TestCase/Controller/Component/CookieComponentTest.php
@@ -50,7 +50,7 @@ class CookieComponentTest extends TestCase {
 		$this->Cookie->path = '/';
 		$this->Cookie->domain = '';
 		$this->Cookie->secure = false;
-		$this->Cookie->key = 'somerandomhaskey';
+		$this->Cookie->key = 'somerandomhaskeysomerandomhaskey';
 
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->Cookie->startup($event);
@@ -647,7 +647,7 @@ class CookieComponentTest extends TestCase {
 		if (is_array($value)) {
 			$value = $this->_implode($value);
 		}
-		return "Q2FrZQ==." . base64_encode(Security::cipher($value, $this->Cookie->key));
+		return "Q2FrZQ==." . base64_encode(Security::rijndael($value, $this->Cookie->key, 'encrypt'));
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Core/ObjectTest.php
+++ b/lib/Cake/Test/TestCase/Core/ObjectTest.php
@@ -198,7 +198,6 @@ class ObjectTest extends TestCase {
 		$this->object = new TestObject();
 		Configure::write('App.namespace', 'TestApp');
 		Configure::write('Security.salt', 'not-the-default');
-		Configure::write('Security.cipherSeed', '123456');
 		Log::disable('stdout');
 		Log::disable('stderr');
 	}

--- a/lib/Cake/Test/TestCase/Utility/SecurityTest.php
+++ b/lib/Cake/Test/TestCase/Utility/SecurityTest.php
@@ -70,7 +70,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashInvalidSalt method
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testHashInvalidSalt() {
@@ -80,7 +80,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashAnotherInvalidSalt
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testHashAnotherInvalidSalt() {
@@ -90,7 +90,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashYetAnotherInvalidSalt
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testHashYetAnotherInvalidSalt() {
@@ -100,7 +100,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashInvalidCost method
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testHashInvalidCost() {
@@ -225,7 +225,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -237,7 +237,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException PHPUnit_Framework_Error
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidKey() {

--- a/lib/Cake/Test/TestCase/Utility/SecurityTest.php
+++ b/lib/Cake/Test/TestCase/Utility/SecurityTest.php
@@ -266,22 +266,6 @@ class SecurityTest extends TestCase {
 	}
 
 /**
- * Test that rijndael() can still decrypt values with a fixed iv.
- *
- * @return void
- */
-	public function testRijndaelBackwardCompatibility() {
-		$this->skipIf(!function_exists('mcrypt_encrypt'));
-
-		$txt = 'The quick brown fox jumped over the lazy dog.';
-		$key = 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi';
-
-		// Encrypted before random iv
-		$value = base64_decode('1WPjnq96LMzLGwNgmudHF+cAIqVUN5DaUZEpf5tm1EzSgt5iYY9o3d66iRI/fKJLTlTVGsa8HzW0jDNitmVXoQ==');
-		$this->assertEquals($txt, Security::rijndael($value, $key, 'decrypt'));
-	}
-
-/**
  * testRijndaelInvalidOperation method
  *
  * @expectedException PHPUnit_Framework_Error

--- a/lib/Cake/Test/TestCase/Utility/SecurityTest.php
+++ b/lib/Cake/Test/TestCase/Utility/SecurityTest.php
@@ -199,49 +199,6 @@ class SecurityTest extends TestCase {
 	}
 
 /**
- * testCipher method
- *
- * @return void
- */
-	public function testCipher() {
-		$length = 10;
-		$txt = '';
-		for ($i = 0; $i < $length; $i++) {
-			$txt .= mt_rand(0, 255);
-		}
-		$key = 'my_key';
-		$result = Security::cipher($txt, $key);
-		$this->assertEquals($txt, Security::cipher($result, $key));
-
-		$txt = '';
-		$key = 'my_key';
-		$result = Security::cipher($txt, $key);
-		$this->assertEquals($txt, Security::cipher($result, $key));
-
-		$txt = 123456;
-		$key = 'my_key';
-		$result = Security::cipher($txt, $key);
-		$this->assertEquals($txt, Security::cipher($result, $key));
-
-		$txt = '123456';
-		$key = 'my_key';
-		$result = Security::cipher($txt, $key);
-		$this->assertEquals($txt, Security::cipher($result, $key));
-	}
-
-/**
- * testCipherEmptyKey method
- *
- * @expectedException PHPUnit_Framework_Error
- * @return void
- */
-	public function testCipherEmptyKey() {
-		$txt = 'some_text';
-		$key = '';
-		Security::cipher($txt, $key);
-	}
-
-/**
  * testRijndael method
  *
  * @return void

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -850,10 +850,6 @@ class Debugger {
 		if (Configure::read('Security.salt') === 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi') {
 			trigger_error(__d('cake_dev', 'Please change the value of \'Security.salt\' in App/Config/app.php to a salt value specific to your application'), E_USER_NOTICE);
 		}
-
-		if (Configure::read('Security.cipherSeed') === '76859309657453542496749683645') {
-			trigger_error(__d('cake_dev', 'Please change the value of \'Security.cipherSeed\' in app/Config/app.php to a numeric (digits only) seed value specific to your application'), E_USER_NOTICE);
-		}
 	}
 
 }

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -159,12 +159,11 @@ class Security {
  */
 	public static function setCost($cost) {
 		if ($cost < 4 || $cost > 31) {
-			trigger_error(__d(
+			throw new Error\Exception(__d(
 				'cake_dev',
 				'Invalid value, cost must be between %s and %s',
 				array(4, 31)
-			), E_USER_WARNING);
-			return null;
+			));
 		}
 		static::$hashCost = $cost;
 	}
@@ -186,20 +185,18 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
+ * @throws Cake\Error\Exception When there are errors.
  * @return string Encrypted/Decrypted string
  */
 	public static function rijndael($text, $key, $operation) {
 		if (empty($key)) {
-			trigger_error(__d('cake_dev', 'You cannot use an empty key for Security::rijndael()'), E_USER_WARNING);
-			return '';
+			throw new Error\Exception(__d('cake_dev', 'You cannot use an empty key for Security::rijndael()'));
 		}
 		if (empty($operation) || !in_array($operation, array('encrypt', 'decrypt'))) {
-			trigger_error(__d('cake_dev', 'You must specify the operation for Security::rijndael(), either encrypt or decrypt'), E_USER_WARNING);
-			return '';
+			throw new Error\Exception(__d('cake_dev', 'You must specify the operation for Security::rijndael(), either encrypt or decrypt'));
 		}
 		if (strlen($key) < 32) {
-			trigger_error(__d('cake_dev', 'You must use a key larger than 32 bytes for Security::rijndael()'), E_USER_WARNING);
-			return '';
+			throw new Error\Exception(__d('cake_dev', 'You must use a key larger than 32 bytes for Security::rijndael()'));
 		}
 		$algorithm = MCRYPT_RIJNDAEL_256;
 		$mode = MCRYPT_MODE_CBC;
@@ -239,6 +236,7 @@ class Security {
  * @param string $password The string to be encrypted.
  * @param mixed $salt false to generate a new salt or an existing salt.
  * @return string The hashed string or an empty string on error.
+ * @throws Cake\Error\Exception on invalid salt values.
  */
 	protected static function _crypt($password, $salt = false) {
 		if ($salt === false) {
@@ -247,12 +245,11 @@ class Security {
 		}
 
 		if ($salt === true || strpos($salt, '$2a$') !== 0 || strlen($salt) < 29) {
-			trigger_error(__d(
+			throw new Error\Exception(__d(
 				'cake_dev',
 				'Invalid salt: %s for %s Please visit http://www.php.net/crypt and read the appropriate section for building %s salts.',
 				array($salt, 'blowfish', 'blowfish')
-			), E_USER_WARNING);
-			return '';
+			));
 		}
 		return crypt($password, $salt);
 	}

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -20,6 +20,7 @@
 namespace Cake\Utility;
 
 use Cake\Core\Configure;
+use Cake\Error;
 
 /**
  * Security Library contains utility methods related to security
@@ -169,39 +170,14 @@ class Security {
 	}
 
 /**
- * Runs $text through a XOR cipher.
- *
- * *Note* This is not a cryptographically strong method and should not be used
- * for sensitive data. Additionally this method does *not* work in environments
- * where suhosin is enabled.
- *
- * Instead you should use Security::rijndael() when you need strong
- * encryption.
- *
+ * Deprecated method. Does nothing.
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use
- * @return string Encrypted/Decrypted string
+ * @throws Cake\Error\Exception
  * @deprecated This method will be removed in 3.x
  */
 	public static function cipher($text, $key) {
-		if (empty($key)) {
-			trigger_error(__d('cake_dev', 'You cannot use an empty key for Security::cipher()'), E_USER_WARNING);
-			return '';
-		}
-
-		srand(Configure::read('Security.cipherSeed'));
-		$out = '';
-		$keyLength = strlen($key);
-		for ($i = 0, $textLength = strlen($text); $i < $textLength; $i++) {
-			$j = ord(substr($key, $i % $keyLength, 1));
-			while ($j--) {
-				rand(0, 255);
-			}
-			$mask = rand(0, 255);
-			$out .= chr(ord(substr($text, $i, 1)) ^ $mask);
-		}
-		srand();
-		return $out;
+		throw new Error\Exception(__d('cake_dev', 'Security::cipher() has been removed. Use Security::rijndael() to encrypt data'));
 	}
 
 /**

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -232,7 +232,7 @@ class Security {
 		$cryptKey = substr($key, 0, 32);
 
 		if ($operation === 'encrypt') {
-			$iv = mcrypt_create_iv($ivSize, MCRYPT_RAND);
+			$iv = mcrypt_create_iv($ivSize, MCRYPT_DEV_URANDOM);
 			return $iv . '$$' . mcrypt_encrypt($algorithm, $cryptKey, $text, $mode, $iv);
 		}
 		$iv = substr($text, 0, $ivSize);

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -207,10 +207,6 @@ class Security {
 /**
  * Encrypts/Decrypts a text using the given key using rijndael method.
  *
- * Prior to 2.3.1, a fixed initialization vector was used. This was not
- * secure. This method now uses a random iv, and will silently upgrade values when
- * they are re-encrypted.
- *
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
@@ -238,11 +234,6 @@ class Security {
 		if ($operation === 'encrypt') {
 			$iv = mcrypt_create_iv($ivSize, MCRYPT_RAND);
 			return $iv . '$$' . mcrypt_encrypt($algorithm, $cryptKey, $text, $mode, $iv);
-		}
-		// Backwards compatible decrypt with fixed iv
-		if (substr($text, $ivSize, 2) !== '$$') {
-			$iv = substr($key, strlen($key) - 32, 32);
-			return rtrim(mcrypt_decrypt($algorithm, $cryptKey, $text, $mode, $iv), "\0");
 		}
 		$iv = substr($text, 0, $ivSize);
 		$text = substr($text, $ivSize + 2);


### PR DESCRIPTION
Remove really bad crypto features in Security. I've opted to make Security::cipher() throw exceptions for now instead of removing it entirely. The backwards compatibility in rijndael has also been removed. I'll update the migration guide to recommend re-encrypting all data before upgrading.

The CookieComponent now only uses rijndael, this is a big BC break as all previous cookies may be "encrypted" with cipher. I don't have a good plan on how people can migrate other than they can't.

I've also considered adding AES-256 as new methods on Security class, does that sound like a reasonable thing to do?
