### PR TITLE
Ensure Configure::boostrap() doesn't overwrite existing configs under 'A...

### DIFF
--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -67,13 +67,7 @@ class Configure {
  */
 	public static function bootstrap($boot = true) {
 		if ($boot) {
-			self::write('App', array(
-				'base' => false,
-				'baseUrl' => false,
-				'dir' => APP_DIR,
-				'webroot' => WEBROOT_DIR,
-				'www_root' => WWW_ROOT
-			));
+			self::_appDefaults();
 
 			if (!include APP . 'Config' . DS . 'core.php') {
 				trigger_error(__d('cake_dev', "Can't find application core file. Please create %score.php, and make sure it is readable by PHP.", APP . 'Config' . DS), E_USER_ERROR);
@@ -107,6 +101,20 @@ class Configure {
 				class_exists('String');
 			}
 		}
+	}
+
+/**
+ * Set app's default configs
+ * @return void
+ */
+	protected static function _appDefaults() {
+		self::write('App', (array)self::read('App') + array(
+			'base' => false,
+			'baseUrl' => false,
+			'dir' => APP_DIR,
+			'webroot' => WEBROOT_DIR,
+			'www_root' => WWW_ROOT
+		));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -70,6 +70,23 @@ class ConfigureTest extends CakeTestCase {
 	}
 
 /**
+ * Test to ensure bootrapping doesn't overwrite prior configs set under 'App' key
+ * @return void
+ */
+	public function testBootstrap() {
+		$expected = array(
+			'foo' => 'bar'
+		);
+		Configure::write('App', $expected);
+
+		Configure::bootstrap(true);
+		$result = Configure::read('App');
+
+		$this->assertEquals($expected['foo'], $result['foo']);
+		$this->assertFalse($result['base']);
+	}
+
+/**
  * testRead method
  *
  * @return void

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -150,10 +150,6 @@ App::uses('Cache', 'Cache');
 App::uses('Object', 'Core');
 App::uses('Multibyte', 'I18n');
 
-App::$bootstrapping = true;
-
-Configure::bootstrap(isset($boot) ? $boot : true);
-
 /**
  * Full URL prefix
  */
@@ -171,6 +167,10 @@ if (!defined('FULL_BASE_URL')) {
 	}
 	unset($httpHost, $s);
 }
+
+App::$bootstrapping = true;
+
+Configure::bootstrap(isset($boot) ? $boot : true);
 
 if (function_exists('mb_internal_encoding')) {
 	$encoding = Configure::read('App.encoding');


### PR DESCRIPTION
...pp' key.

Fixes #3874
