### PR TITLE
RFC: pretty print json and xml responses in debug mode

### DIFF
--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -30,6 +30,11 @@ App::uses('JsonView', 'View');
  */
 class JsonViewTest extends CakeTestCase {
 
+	public function setUp() {
+		parent::setUp();
+		Configure::write('debug', 0);
+	}
+
 /**
  * testRenderWithoutView method
  *

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -30,6 +30,11 @@ App::uses('XmlView', 'View');
  */
 class XmlViewTest extends CakeTestCase {
 
+	public function setUp() {
+		parent::setUp();
+		Configure::write('debug', 0);
+	}
+
 /**
  * testRenderWithoutView method
  *

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -125,6 +125,11 @@ class JsonView extends View {
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 		}
+
+		if (version_compare(PHP_VERSION, '5.4.0', '>=') && Configure::read('debug')) {
+			return json_encode($data, JSON_PRETTY_PRINT);
+		}
+
 		return json_encode($data);
 	}
 

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -113,7 +113,13 @@ class XmlView extends View {
 				$data = array($rootNode => array($serialize => $data));
 			}
 		}
-		return Xml::fromArray($data)->asXML();
+
+		$options = array();
+		if (Configure::read('debug')) {
+			$options['pretty'] = true;
+		}
+
+		return Xml::fromArray($data, $options)->asXML();
 	}
 
 }


### PR DESCRIPTION
For xml and json responses - it's handy for them to be pretty-printed in development mode.

Make cake do that by default?
