### PR TITLE
Missing url slash at Router::url() in 3.0

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -800,11 +800,7 @@ class Router {
 			if ($plainString) {
 				return $url;
 			}
-			$output = $url;
-			if ($hasLeadingSlash && strlen($output) > 1) {
-				$output = substr($output, 1);
-			}
-			$output = $base . $output;
+			$output = $base . $url;
 		}
 		$protocol = preg_match('#^[a-z][a-z0-9+\-.]*\://#i', $output);
 		if ($protocol === 0) {

--- a/lib/Cake/Test/TestCase/Routing/RouterTest.php
+++ b/lib/Cake/Test/TestCase/Routing/RouterTest.php
@@ -411,6 +411,12 @@ class RouterTest extends TestCase {
 		$result = Router::url('/');
 		$this->assertEquals('/magazine/', $result);
 
+		$result = Router::url('/articles/');
+		$this->assertEquals('/magazine/articles/', $result);
+
+		$result = Router::url('/articles/view');
+		$this->assertEquals('/magazine/articles/view', $result);
+
 		$result = Router::url(['controller' => 'articles', 'action' => 'view', 1]);
 		$this->assertEquals('/magazine/articles/view/1', $result);
 	}


### PR DESCRIPTION
I don't speak much English.
## Problem

Example : 
<?= $this->Form->create(null, array('controller' => 'Menus')); ?>
<?= $this->Form->create(null, array('url' => '/Menus')); ?>

output is:
<form action="/cakephpMenus" ...

That must be :
<form action="/cakephp/Menus" ...
## Solution

Because String argument test does not exist in "Router::url()",
I add two assertEquals().
## comment

I run test "Router" and it is success. And I run all tests.
Since I do not understand specification well, I have a possibility of being wrong. 
