### PR TITLE
Make mocking random models easier

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -353,6 +353,11 @@ class CakeTestCaseTest extends CakeTestCase {
  * @return void
  */
 	public function testGetMockForModel() {
+		App::build(array(
+				'Model' => array(
+					CAKE . 'Test' . DS . 'test_app' . DS . 'Model' . DS
+				)
+		), App::RESET);
 		$Post = $this->getMockForModel('Post');
 
 		$this->assertInstanceOf('Post', $Post);
@@ -372,6 +377,13 @@ class CakeTestCaseTest extends CakeTestCase {
  * @return void
  */
 	public function testGetMockForModelWithPlugin() {
+		App::build(array(
+				'Plugin' => array(
+					CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS
+				)
+		), App::RESET);
+		CakePlugin::load('TestPlugin');
+		$this->getMockForModel('TestPlugin.TestPluginAppModel');
 		$TestPluginComment = $this->getMockForModel('TestPlugin.TestPluginComment');
 
 		$result = ClassRegistry::init('TestPlugin.TestPluginComment');
@@ -388,5 +400,27 @@ class CakeTestCaseTest extends CakeTestCase {
 			->will($this->returnValue(false));
 		$this->assertTrue($TestPluginComment->save(array()));
 		$this->assertFalse($TestPluginComment->save(array()));
+	}
+
+/**
+ * testGetMockForModelModel
+ *
+ * @return void
+ */
+	public function testGetMockForModelModel() {
+		$Mock = $this->getMockForModel('Model', array('save'), array('name' => 'Comment'));
+
+		$result = ClassRegistry::init('Comment');
+		$this->assertInstanceOf('Model', $result);
+
+		$Mock->expects($this->at(0))
+			->method('save')
+			->will($this->returnValue(true));
+		$Mock->expects($this->at(1))
+			->method('save')
+			->will($this->returnValue(false));
+
+		$this->assertTrue($Mock->save(array()));
+		$this->assertFalse($Mock->save(array()));
 	}
 }

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -423,4 +423,15 @@ class CakeTestCaseTest extends CakeTestCase {
 		$this->assertTrue($Mock->save(array()));
 		$this->assertFalse($Mock->save(array()));
 	}
+
+/**
+ * testGetMockForModelDoesNotExist
+ *
+ * @expectedException MissingModelException
+ * @expectedExceptionMessage Model IDoNotExist could not be found
+ * @return void
+ */
+	public function testGetMockForModelDoesNotExist() {
+		$this->getMockForModel('IDoNotExist');
+	}
 }

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -689,13 +689,11 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  *
  * @param string $model
  * @param mixed $methods
- * @param mixed $config
+ * @param array $config
  * @return Model
  */
-	public function getMockForModel($model, $methods = array(), $config = null) {
-		if (is_null($config)) {
-			$config = ClassRegistry::config('Model');
-		}
+	public function getMockForModel($model, $methods = array(), $config = array()) {
+		$config += ClassRegistry::config('Model');
 
 		list($plugin, $name) = pluginSplit($model, true);
 		App::uses($name, $plugin . 'Model');

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -690,6 +690,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @param string $model
  * @param mixed $methods
  * @param array $config
+ * @throws MissingModelException
  * @return Model
  */
 	public function getMockForModel($model, $methods = array(), $config = array()) {
@@ -698,6 +699,11 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
 		list($plugin, $name) = pluginSplit($model, true);
 		App::uses($name, $plugin . 'Model');
 		$config = array_merge((array)$config, array('name' => $name));
+
+		if (!class_exists($name)) {
+			throw new MissingModelException(array($model));
+		}
+
 		$mock = $this->getMock($name, $methods, array($config));
 		ClassRegistry::removeObject($name);
 		ClassRegistry::addObject($name, $mock);


### PR DESCRIPTION
Right now it's quite cumbersome to mock "a" model (where a test needs a model, but not a specific model).

Make it easier. Also address the way model-not-found errors are reported.
