### PR TITLE
Use a method to generate confirm() links

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1784,8 +1784,7 @@ class FormHelper extends AppHelper {
 		$url = '#';
 		$onClick = 'document.' . $formName . '.submit();';
 		if ($confirmMessage) {
-			$confirmMessage = str_replace(array("'", '"'), array("\'", '\"'), $confirmMessage);
-			$options['onclick'] = "if (confirm('{$confirmMessage}')) { {$onClick} }";
+			$options['onclick'] = $this->_confirmHandler($confirmMessage, $onClick);
 		} else {
 			$options['onclick'] = $onClick;
 		}
@@ -1794,6 +1793,18 @@ class FormHelper extends AppHelper {
 		$out .= $this->Html->link($title, $url, $options);
 		return $out;
 	}
+
+/**
+ * Returns a string to be used as onclick handler for confirm dialogs.
+ *
+ * @param string $message Message to be displayed
+ * @param string $action Code to execute if user chooses 'OK'.
+ */
+	protected function _confirmHandler($message, $action) {
+		$message = str_replace(array("'", '"'), array("\'", '\"'), $message);
+		return "if (confirm('{$message}')) { {$action} }";
+	}
+
 
 /**
  * Creates a submit button element. This method will generate `<input />` elements that

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -355,9 +355,7 @@ class HtmlHelper extends AppHelper {
 			unset($options['confirm']);
 		}
 		if ($confirmMessage) {
-			$confirmMessage = str_replace("'", "\'", $confirmMessage);
-			$confirmMessage = str_replace('"', '\"', $confirmMessage);
-			$options['onclick'] = "return confirm('{$confirmMessage}');";
+			$options['onclick'] = $this->_confirmHandler($confirmMessage);
 		} elseif (isset($options['default']) && !$options['default']) {
 			if (isset($options['onclick'])) {
 				$options['onclick'] .= ' event.returnValue = false; return false;';
@@ -367,6 +365,16 @@ class HtmlHelper extends AppHelper {
 			unset($options['default']);
 		}
 		return sprintf($this->_tags['link'], $url, $this->_parseAttributes($options), $title);
+	}
+
+/**
+ * Returns a string to be used as onclick handler for confirm dialogs.
+ *
+ * @param string $message Message to be displayed
+ */
+	protected function _confirmHandler($message) {
+		$message = str_replace(array("'", '"'), array("\'", '\"'), $message);
+		return "return confirm('{$message}');";
 	}
 
 /**


### PR DESCRIPTION
This allows for overriding the the default behavior of showing a
confirm()-dialog.
