### PR TITLE
Follow up of #1450 for L10n

### DIFF
--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -39,7 +39,7 @@ class L10n {
  *
  * @var array
  */
-	public $languagePath = array('eng');
+	public $languagePath = array('en_us', 'eng');
 
 /**
  * ISO 639-3 for current locale
@@ -56,9 +56,11 @@ class L10n {
 	public $locale = 'en_us';
 
 /**
- * Default ISO 639-3 language.
+ * Default language.
  *
- * DEFAULT_LANGUAGE is defined in an application this will be set as a fall back
+ * If config value 'Config.language' is set in an application this will be set
+ * as a fall back else if DEFAULT_LANGUAGE it defined it will be used.
+ * Constant DEFAULT_LANGUAGE has been deprecated in 2.4
  *
  * @var string
  */
@@ -77,13 +79,6 @@ class L10n {
  * @var string
  */
 	public $direction = 'ltr';
-
-/**
- * Set to true if a locale is found
- *
- * @var string
- */
-	public $found = false;
 
 /**
  * Maps ISO 639-3 to I10n::_l10nCatalog
@@ -337,6 +332,10 @@ class L10n {
 		if (defined('DEFAULT_LANGUAGE')) {
 			$this->default = DEFAULT_LANGUAGE;
 		}
+		$default = Configure::read('Config.language');
+		if ($default) {
+			$this->default = $default;
+		}
 	}
 
 /**
@@ -360,44 +359,44 @@ class L10n {
 
 /**
  * Sets the class vars to correct values for $language.
- * If $language is null it will use the DEFAULT_LANGUAGE if defined
+ * If $language is null it will use the L10n::$default if defined
  *
- * @param string $language Language (if null will use DEFAULT_LANGUAGE if defined)
+ * @param string $language Language (if null will use L10n::$default if defined)
  * @return mixed
  */
 	protected function _setLanguage($language = null) {
-		$langKey = null;
-		if ($language !== null && isset($this->_l10nMap[$language]) && isset($this->_l10nCatalog[$this->_l10nMap[$language]])) {
-			$langKey = $this->_l10nMap[$language];
-		} elseif ($language !== null && isset($this->_l10nCatalog[$language])) {
-			$langKey = $language;
-		} elseif (defined('DEFAULT_LANGUAGE')) {
-			$langKey = $language = DEFAULT_LANGUAGE;
+		$catalog = false;
+		if ($language !== null) {
+			$catalog = $this->catalog($language);
 		}
 
-		if ($langKey !== null && isset($this->_l10nCatalog[$langKey])) {
-			$this->language = $this->_l10nCatalog[$langKey]['language'];
-			$this->languagePath = array(
-				$this->_l10nCatalog[$langKey]['locale'],
-				$this->_l10nCatalog[$langKey]['localeFallback']
-			);
+		if (!$catalog && $this->default) {
+			$language = $this->default;
+			$catalog = $this->catalog($language);
+		}
+
+		if ($catalog) {
+			$this->language = $catalog['language'];
+			$this->languagePath = array_unique(array(
+				$catalog['locale'],
+				$catalog['localeFallback']
+			));
 			$this->lang = $language;
-			$this->locale = $this->_l10nCatalog[$langKey]['locale'];
-			$this->charset = $this->_l10nCatalog[$langKey]['charset'];
-			$this->direction = $this->_l10nCatalog[$langKey]['direction'];
-		} else {
+			$this->locale = $catalog['locale'];
+			$this->charset = $catalog['charset'];
+			$this->direction = $catalog['direction'];
+		} elseif ($language) {
 			$this->lang = $language;
 			$this->languagePath = array($language);
 		}
 
-		if ($this->default) {
-			if (isset($this->_l10nMap[$this->default]) && isset($this->_l10nCatalog[$this->_l10nMap[$this->default]])) {
-				$this->languagePath[] = $this->_l10nCatalog[$this->_l10nMap[$this->default]]['localeFallback'];
-			} elseif (isset($this->_l10nCatalog[$this->default])) {
-				$this->languagePath[] = $this->_l10nCatalog[$this->default]['localeFallback'];
+		if ($this->default && $language !== $this->default) {
+			$catalog = $this->catalog($this->default);
+			$fallback = $catalog['localeFallback'];
+			if (!in_array($fallback, $this->languagePath)) {
+				$this->languagePath[] = $fallback;
 			}
 		}
-		$this->found = true;
 
 		if (Configure::read('Config.language') === null) {
 			Configure::write('Config.language', $this->lang);

--- a/lib/Cake/Test/Case/I18n/L10nTest.php
+++ b/lib/Cake/Test/Case/I18n/L10nTest.php
@@ -28,6 +28,16 @@ App::uses('L10n', 'I18n');
 class L10nTest extends CakeTestCase {
 
 /**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		Configure::delete('Config.language');
+	}
+
+/**
  * testGet method
  *
  * @return void
@@ -40,14 +50,14 @@ class L10nTest extends CakeTestCase {
 
 		$this->assertEquals('en', $lang);
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		// Map Entry
 		$localize->get('eng');
 
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		// Catalog Entry
@@ -58,8 +68,7 @@ class L10nTest extends CakeTestCase {
 		$this->assertEquals('en_ca', $localize->locale);
 
 		// Default Entry
-		define('DEFAULT_LANGUAGE', 'en-us');
-
+		$localize->default = 'en-us';
 		$lang = $localize->get('use_default');
 
 		$this->assertEquals('en-us', $lang);
@@ -70,14 +79,6 @@ class L10nTest extends CakeTestCase {
 		$localize->get('es');
 		$localize->get('');
 		$this->assertEquals('en-us', $localize->lang);
-
-		// Using $this->default
-		$localize = new L10n();
-
-		$localize->get('use_default');
-		$this->assertEquals('English (United States)', $localize->language);
-		$this->assertEquals(array('en_us', 'eng', 'eng'), $localize->languagePath);
-		$this->assertEquals('en_us', $localize->locale);
 	}
 
 /**
@@ -94,7 +95,7 @@ class L10nTest extends CakeTestCase {
 
 		$this->assertEquals('en-ca', $lang);
 		$this->assertEquals('English (Canadian)', $localize->language);
-		$this->assertEquals(array('en_ca', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('en_ca', 'eng'), $localize->languagePath);
 		$this->assertEquals('en_ca', $localize->locale);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'es_mx';
@@ -102,17 +103,50 @@ class L10nTest extends CakeTestCase {
 
 		$this->assertEquals('es-mx', $lang);
 		$this->assertEquals('Spanish (Mexican)', $localize->language);
-		$this->assertEquals(array('es_mx', 'spa', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('es_mx', 'spa'), $localize->languagePath);
 		$this->assertEquals('es_mx', $localize->locale);
+
+		$localize = new L10n();
+		$localize->default = 'en-us';
+		$lang = $localize->get();
+		$this->assertEquals(array('es_mx', 'spa', 'eng'), $localize->languagePath);
 
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en_xy,en_ca';
 		$localize->get();
 
 		$this->assertEquals('English', $localize->language);
-		$this->assertEquals(array('eng', 'eng', 'eng'), $localize->languagePath);
+		$this->assertEquals(array('eng'), $localize->languagePath);
 		$this->assertEquals('eng', $localize->locale);
 
 		$_SERVER = $serverBackup;
+	}
+
+/**
+ * testGet method with deprecated constant DEFAULT_LANGUAGE
+ *
+ * @return void
+ */
+	public function testGetWithDeprecatedConstant() {
+		$this->skipIf(defined('DEFAULT_LANGUAGE'), 'Cannot re-define already defined constant.');
+
+		define('DEFAULT_LANGUAGE', 'en-us');
+		$localize = new L10n();
+
+		$lang = $localize->get('use_default');
+
+		$this->assertEquals('en-us', $lang);
+		$this->assertEquals('English (United States)', $localize->language);
+		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_us', $localize->locale);
+
+		$localize = new L10n();
+
+		$lang = $localize->get();
+
+		$this->assertEquals('en-us', $lang);
+		$this->assertEquals('English (United States)', $localize->language);
+		$this->assertEquals(array('en_us', 'eng'), $localize->languagePath);
+		$this->assertEquals('en_us', $localize->locale);
 	}
 
 /**


### PR DESCRIPTION
I improved upon PR #1450 by @euromark by cleaning up L10n::_setLanguage(). The existing code wasn't DRY with all the isset() checks when L10n::catalog() already does that job. Also removed unused L10n::$found.
