### PR TITLE
Update .gitignore, rename database.php to datasources.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # User specific & automatically generated files #
 #################################################
-/App/Config
-/App/Config/database.php
+/App/Config/datasources.php
 /App/tmp
 /lib/Cake/Console/Templates/skel/tmp/
 /plugins


### PR DESCRIPTION
I don't speak much English.
## Problem

"/App/Config/database.default.php" was removed.
"/App/Config/datasources.default.php" was added.
## Solution

Rename "database.php" to "datasources.php".
I deleted "/App/Config" according to  the .gitignore file of the version 2.3. 
## Comment

Since I do not understand specification well, I have a possibility of being wrong. 
