### PR TITLE
Improper usage of gettext

### DIFF
--- a/lib/Cake/Console/Command/TestsuiteShell.php
+++ b/lib/Cake/Console/Command/TestsuiteShell.php
@@ -40,10 +40,9 @@ class TestsuiteShell extends TestShell {
  */
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
-		$parser->description(__d('cake_console',
-			"The CakePHP Testsuite allows you to run test cases from the command line\n" .
-				"<warning>This shell is for backwards-compatibility only</warning>\n" .
-				"use the test shell instead"
+		$parser->description(array(
+			__d('cake_console', 'The CakePHP Testsuite allows you to run test cases from the command line'),
+			__d('cake_console', "<warning>This shell is for backwards-compatibility only</warning>\nuse the test shell instead"),
 		));
 
 		return $parser;

--- a/lib/Cake/Console/Command/TestsuiteShell.php
+++ b/lib/Cake/Console/Command/TestsuiteShell.php
@@ -40,10 +40,10 @@ class TestsuiteShell extends TestShell {
  */
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
-		$parser->description(array(
-			__d('cake_console', 'The CakePHP Testsuite allows you to run test cases from the command line'),
-			__d('cake_console', '<warning>This shell is for backwards-compatibility only</warning>'),
-			__d('cake_console', 'use the test shell instead')
+		$parser->description(__d('cake_console',
+			"The CakePHP Testsuite allows you to run test cases from the command line\n" .
+				"<warning>This shell is for backwards-compatibility only</warning>\n" .
+				"use the test shell instead"
 		));
 
 		return $parser;


### PR DESCRIPTION
Combined 3 strings (they are hard to translate without context) into a one complete translatable sentence.
