### PR TITLE
2.4 mime

### DIFF
--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -557,9 +557,14 @@ class File {
 		}
 		if (function_exists('finfo_open')) {
 			$finfo = finfo_open(FILEINFO_MIME);
-			list($type, $charset) = explode(';', finfo_file($finfo, $this->pwd()));
+			$finfo = finfo_file($finfo, $this->pwd());
+			if (!$finfo) {
+				return false;
+			}
+			list($type, $charset) = explode(';', $finfo);
 			return $type;
-		} elseif (function_exists('mime_content_type')) {
+		}
+		if (function_exists('mime_content_type')) {
 			return mime_content_type($this->pwd());
 		}
 		return false;


### PR DESCRIPTION
```
list($type, $charset) = explode(';', finfo_file($finfo, $this->pwd()));
```

Results sometimes in

```
Undefined offset: 1 in [/lib/Cake/Utility/File.php, line 560]
```

If an error occured for finfo_file() it can return false it seems.
Maybe that should be refactored?
