### PR TITLE
remove undocumented code and unnecessary in_array() checks + cleanup

### DIFF
--- a/lib/Cake/Controller/ComponentCollection.php
+++ b/lib/Cake/Controller/ComponentCollection.php
@@ -94,7 +94,7 @@ class ComponentCollection extends ObjectCollection implements CakeEventListener 
  * @throws MissingComponentException when the component could not be found
  */
 	public function load($component, $settings = array()) {
-		if (is_array($settings) && isset($settings['className'])) {
+		if (isset($settings['className'])) {
 			$alias = $component;
 			$component = $settings['className'];
 		}

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -418,7 +418,8 @@ class L10n {
 			if (isset($this->_l10nCatalog[$langKey])) {
 				$this->_setLanguage($langKey);
 				return true;
-			} elseif (strpos($langKey, '-') !== false) {
+			}
+			if (strpos($langKey, '-') !== false) {
 				$langKey = substr($langKey, 0, 2);
 				if (isset($this->_l10nCatalog[$langKey])) {
 					$this->_setLanguage($langKey);
@@ -445,10 +446,12 @@ class L10n {
 				}
 			}
 			return $result;
-		} elseif (is_string($mixed)) {
+		}
+		if (is_string($mixed)) {
 			if (strlen($mixed) === 2 && in_array($mixed, $this->_l10nMap)) {
 				return array_search($mixed, $this->_l10nMap);
-			} elseif (isset($this->_l10nMap[$mixed])) {
+			}
+			if (isset($this->_l10nMap[$mixed])) {
 				return $this->_l10nMap[$mixed];
 			}
 			return false;
@@ -472,10 +475,12 @@ class L10n {
 				}
 			}
 			return $result;
-		} elseif (is_string($language)) {
+		}
+		if (is_string($language)) {
 			if (isset($this->_l10nCatalog[$language])) {
 				return $this->_l10nCatalog[$language];
-			} elseif (isset($this->_l10nMap[$language]) && isset($this->_l10nCatalog[$this->_l10nMap[$language]])) {
+			}
+			if (isset($this->_l10nMap[$language]) && isset($this->_l10nCatalog[$this->_l10nMap[$language]])) {
 				return $this->_l10nCatalog[$this->_l10nMap[$language]];
 			}
 			return false;

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -103,7 +103,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
  * @throws MissingBehaviorException when a behavior could not be found.
  */
 	public function load($behavior, $config = array()) {
-		if (is_array($config) && isset($config['className'])) {
+		if (isset($config['className'])) {
 			$alias = $behavior;
 			$behavior = $config['className'];
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2727,7 +2727,7 @@ class Model extends Object implements CakeEventListener {
  *
  * Model::_readDataSource() is used by all find() calls to read from the data source and can be overloaded to allow
  * caching of datasource calls.
- * 
+ *
  * {{{
  * protected function _readDataSource($type, $query) {
  * 		$cacheName = md5(json_encode($query));
@@ -2741,7 +2741,7 @@ class Model extends Object implements CakeEventListener {
  * 		return $results;
  * }
  * }}}
- * 
+ *
  * @param string $type Type of find operation (all / first / count / neighbors / list / threaded)
  * @param array $query Option fields (conditions / fields / joins / limit / offset / order / page / group / callbacks)
  * @return array

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1832,9 +1832,6 @@ class HtmlHelperTest extends CakeTestCase {
 		$result = $this->Html->tag('div', 'text');
 		$this->assertTags($result, '<div', 'text', '/div');
 
-		$result = $this->Html->tag('div', '<text>', 'class-name');
-		$this->assertTags($result, array('div' => array('class' => 'class-name'), 'preg:/<text>/', '/div'));
-
 		$result = $this->Html->tag('div', '<text>', array('class' => 'class-name', 'escape' => true));
 		$this->assertTags($result, array('div' => array('class' => 'class-name'), '&lt;text&gt;', '/div'));
 

--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -87,7 +87,7 @@ class TimeHelperTest extends CakeTestCase {
 			'nice', 'niceShort', 'daysAsSql', 'dayAsSql',
 			'isToday', 'isThisMonth', 'isThisYear', 'wasYesterday',
 			'isTomorrow', 'toQuarter', 'toUnix', 'toAtom', 'toRSS',
-			'timeAgoInWords', 'wasWithinLast', 'gmt', 'format', 'i18nFormat',
+			'wasWithinLast', 'gmt', 'format', 'i18nFormat',
 		);
 		$CakeTime = $this->getMock('CakeTimeMock', $methods);
 		$Time = new TimeHelperTestObject($this->View, array('engine' => 'CakeTimeMock'));
@@ -96,6 +96,12 @@ class TimeHelperTest extends CakeTestCase {
 			$CakeTime->expects($this->at(0))->method($method);
 			$Time->{$method}('who', 'what', 'when', 'where', 'how');
 		}
+
+		$CakeTime = $this->getMock('CakeTimeMock', array('timeAgoInWords'));
+		$Time = new TimeHelperTestObject($this->View, array('engine' => 'CakeTimeMock'));
+		$Time->attach($CakeTime);
+		$CakeTime->expects($this->at(0))->method('timeAgoInWords');
+		$Time->timeAgoInWords('who', array('what'), array('when'), array('where'), array('how'));
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -918,12 +918,9 @@ class HtmlHelper extends AppHelper {
 		if (empty($name)) {
 			return $text;
 		}
-		if (is_array($options) && isset($options['escape']) && $options['escape']) {
+		if (isset($options['escape']) && $options['escape']) {
 			$text = h($text);
 			unset($options['escape']);
-		}
-		if (!is_array($options)) {
-			$options = array('class' => $options);
 		}
 		if ($text === null) {
 			$tag = 'tagstart';

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -82,7 +82,7 @@ class JsHelper extends AppHelper {
  * Constructor - determines engine helper
  *
  * @param View $View the view object the helper is attached to.
- * @param array $settings Settings array contains name of engine helper.
+ * @param string|array $settings Settings array contains name of engine helper.
  */
 	public function __construct(View $View, $settings = array()) {
 		$className = 'Jquery';

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -361,7 +361,7 @@ class TimeHelper extends AppHelper {
 	public function timeAgoInWords($dateTime, $options = array()) {
 		$element = null;
 
-		if (is_array($options) && !empty($options['element'])) {
+		if (!empty($options['element'])) {
 			$element = array(
 				'tag' => 'span',
 				'class' => 'time-ago-in-words',

--- a/lib/Cake/View/HelperCollection.php
+++ b/lib/Cake/View/HelperCollection.php
@@ -113,7 +113,7 @@ class HelperCollection extends ObjectCollection implements CakeEventListener {
  * @throws MissingHelperException when the helper could not be found
  */
 	public function load($helper, $settings = array()) {
-		if (is_array($settings) && isset($settings['className'])) {
+		if (isset($settings['className'])) {
 			$alias = $helper;
 			$helper = $settings['className'];
 		}


### PR DESCRIPTION
Applying a third param as string ("class") was undocumented even in 1.x:

```
$this->Html->tag('div', '<text>', 'class-name');
```

Removed as well as some unnecessary is_array() checks.

Waiting on travis report.
