### PR TITLE
3.0 Add Query::bufferResults()

### DIFF
--- a/lib/Cake/ORM/BufferedResultSet.php
+++ b/lib/Cake/ORM/BufferedResultSet.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM;
+
+/**
+ * Buffered ResultSets differ from un-buffered ResultSets in a few ways.
+ *
+ * - They can be iterated multiple times.
+ * - They can be both cached and iterated using the same object.
+ */
+class BufferedResultSet extends ResultSet {
+
+/**
+ * Rewind the ResultSet
+ *
+ * @return void
+ */
+	public function rewind() {
+		$this->_index = 0;
+		$this->_lastIndex = -1;
+	}
+
+/**
+ * Fetch a result and buffer the fetched row.
+ *
+ * @return mixed
+ */
+	public function valid() {
+		$result = parent::valid();
+		if (!isset($this->_results[$this->_index])) {
+			$this->_results[] = $this->_current;
+		}
+		return $result;
+	}
+
+}

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -83,12 +83,22 @@ class Query extends DatabaseQuery {
 	];
 
 /**
- * A hydrated ResultSet.
+ * A ResultSet.
+ *
+ * When set, query execution will be bypassed.
  *
  * @var Cake\ORM\ResultSet
  * @see setResult()
  */
 	protected $_results;
+
+/**
+ * Boolean for tracking whether or not buffered results
+ * are enabled.
+ *
+ * @var boolean
+ */
+	protected $_useBufferedResults = false;
 
 /**
  * @param Cake\Database\Connection $connection
@@ -323,6 +333,23 @@ class Query extends DatabaseQuery {
 	}
 
 /**
+ * Enable buffered results.
+ *
+ * When enabled the ResultSet returned by this Query will be
+ * buffered. This enables you to iterate a ResultSet multiple times, or
+ * both cache and iterate the ResultSet.
+ *
+ * This mode will consume more memory as the result set will stay in memory
+ * until the ResultSet if freed.
+ *
+ * @return Query The query instance;
+ */
+	public function bufferResults() {
+		$this->_useBufferedResults = true;
+		return $this;
+	}
+
+/**
  * Set the result set for a query.
  *
  * Setting the resultset of a query will make execute() a no-op. Instead
@@ -353,6 +380,9 @@ class Query extends DatabaseQuery {
 	public function execute() {
 		if (isset($this->_results)) {
 			return $this->_results;
+		}
+		if ($this->_useBufferedResults) {
+			return new BufferedResultSet($this, parent::execute());
 		}
 		return new ResultSet($this, parent::execute());
 	}

--- a/lib/Cake/Test/TestCase/ORM/BufferedResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/BufferedResultSetTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Core\Configure;
+use Cake\Model\ConnectionManager;
+use Cake\ORM\Query;
+use Cake\ORM\BufferedResultSet;
+use Cake\ORM\Table;
+use Cake\TestSuite\TestCase;
+
+/**
+ * BufferedResultSet test case.
+ */
+class BufferedResultSetTest extends TestCase {
+
+	public $fixtures = ['core.article'];
+
+	public function setUp() {
+		parent::setUp();
+		$this->connection = ConnectionManager::getDataSource('test');
+		$this->table = new Table(['table' => 'articles', 'connection' => $this->connection]);
+	}
+
+/**
+ * Test that result sets can be rewound and re-used.
+ *
+ * @return void
+ */
+	public function testRewind() {
+		$query = $this->table->find('all');
+		$results = $query->bufferResults()->execute();
+		$first = $second = [];
+		foreach ($results as $result) {
+			$first[] = $result;
+		}
+		foreach ($results as $result) {
+			$second[] = $result;
+		}
+		$this->assertEquals($first, $second);
+	}
+
+}

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -823,4 +823,19 @@ class QueryTest extends TestCase {
 		$this->assertSame($results, $query->execute());
 	}
 
+/**
+ * Test enabling buffering of results.
+ *
+ * @return void
+ */
+	public function testBufferResults() {
+		$table = Table::build('article', ['connection' => $this->connection, 'table' => 'articles']);
+		$query = new Query($this->connection, $table);
+
+		$result = $query->select()->bufferResults();
+		$this->assertSame($query, $result, 'Query should be the same');
+		$result = $query->execute();
+		$this->assertInstanceOf('Cake\ORM\BufferedResultSet', $result);
+	}
+
 }

--- a/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/lib/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -45,6 +45,7 @@ class ResultSetTest extends TestCase {
 /**
  * Test that result sets can be rewound and re-used.
  *
+ * @expectedException Cake\Database\Exception
  * @return void
  */
 	public function testRewind() {
@@ -57,7 +58,6 @@ class ResultSetTest extends TestCase {
 		foreach ($results as $result) {
 			$second[] = $result;
 		}
-		$this->assertEquals($first, $second);
 	}
 
 /**


### PR DESCRIPTION
Following the discussion on fce427a6f13b5a7a56ce482127fd754be37145a5 I've split out the buffering in ResultSets. It is now an optional feature that is enabled per query. I've still left the serialization and JSON serialization features on the base class as I think you shouldn't need a buffered result set before you can cache or convert to JSON.
