### PR TITLE
options in paginator url() can sometimes be null

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -580,6 +580,10 @@ class PaginatorHelperTest extends CakeTestCase {
 		$options = array('order' => array('Article.name' => 'desc'));
 		$result = $this->Paginator->url($options);
 		$this->assertEquals('/index/page:3/sort:Article.name/direction:desc', $result);
+
+		$this->Paginator->request->params['paging']['Article']['options'] = null;
+		$result = $this->Paginator->url();
+		$this->assertEquals('/', $result);
 	}
 
 /**

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -400,7 +400,8 @@ class PaginatorHelper extends AppHelper {
  */
 	public function url($options = array(), $asArray = false, $model = null) {
 		$paging = $this->params($model);
-		$url = array_merge(array_filter($paging['options']), $options);
+		$defaults = !empty($paging['options']) ? array_filter($paging['options']) : array();
+		$url = array_merge($defaults, $options);
 
 		if (isset($url['order'])) {
 			$sort = $direction = null;


### PR DESCRIPTION
Since a few days/weeks ago we encounter a strange issue with the Paginator helper in our productive 2.3.8 versions running. The error logs fill up with:

```
Warning: Warning (2): array_merge() [http://php.net/function.array-merge]: Argument #1 is not an array in [/.../lib/Cake/View/Helper/PaginatorHelper.php, line 403]
Trace:
array_merge - [internal], line ??
PaginatorHelper::url() - CORE/Cake/View/Helper/PaginatorHelper.php, line 403
PaginatorHelper::link() - CORE/Cake/View/Helper/PaginatorHelper.php, line 386
PaginatorHelper::sort() - CORE/Cake/View/Helper/PaginatorHelper.php, line 353
include - APP/View/Elements/pagination.ctp, line 28
```

as well as as:

```
Warning: Warning (2): array_filter() expects parameter 1 to be array, null given in [/.../lib/Cake/View/Helper/PaginatorHelper.php, line 403]
Trace:
array_filter - [internal], line ??
PaginatorHelper::url() - CORE/Cake/View/Helper/PaginatorHelper.php, line 403
PaginatorHelper::link() - CORE/Cake/View/Helper/PaginatorHelper.php, line 386
PaginatorHelper::sort() - CORE/Cake/View/Helper/PaginatorHelper.php, line 353
include - APP/View/Elements/pagination.ctp, line 28
```

Line 28 merely states:

```
<?php echo $this->Paginator->sort('distance', null, array('direction'=>'asc'));?> | <?php echo $this->Paginator->sort('price', null, array('direction'=>'asc'));?>
```

Seems like `$paging['options']` can be null in some cases, thus the direct access as array is not healthy.  

A similar issue reported here (in an older version probably):
http://stackoverflow.com/questions/18123095/cakephp-paginator-array-error
