### PR TITLE
Fix unlink() for CacheEngine::clear() failed on windows.

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -223,6 +223,8 @@ class FileEngine extends CacheEngine {
 		if (!$this->_init) {
 			return false;
 		}
+		$this->_File = null;
+
 		$threshold = $now = false;
 		if ($check) {
 			$now = time();
@@ -233,11 +235,17 @@ class FileEngine extends CacheEngine {
 
 		$directory = new RecursiveDirectoryIterator($this->settings['path']);
 		$contents = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
+		$cleared = array();
 		foreach ($contents as $path) {
 			if ($path->isFile()) {
 				continue;
 			}
-			$this->_clearDirectory($path->getRealPath() . DS, $now, $threshold);
+
+			$path = $path->getRealPath() . DS;
+			if (!in_array($path, $cleared)) {
+				$this->_clearDirectory($path, $now, $threshold);
+				$cleared[] = $path;
+			}
 		}
 		return true;
 	}
@@ -263,7 +271,7 @@ class FileEngine extends CacheEngine {
 				continue;
 			}
 			$filePath = $path . $entry;
-			if (is_dir($filePath)) {
+			if (!file_exists($filePath) || is_dir($filePath)) {
 				continue;
 			}
 			$file = new SplFileObject($path . $entry, 'r');
@@ -282,7 +290,7 @@ class FileEngine extends CacheEngine {
 			}
 			if ($file->isFile()) {
 				$_path = $file->getRealPath();
-				unset($file);
+				$file = null;
 				unlink($_path);
 			}
 		}
@@ -390,6 +398,7 @@ class FileEngine extends CacheEngine {
  * @return boolean success
  */
 	public function clearGroup($group) {
+		$this->_File = null;
 		$directoryIterator = new RecursiveDirectoryIterator($this->settings['path']);
 		$contents = new RecursiveIteratorIterator($directoryIterator, RecursiveIteratorIterator::CHILD_FIRST);
 		foreach ($contents as $object) {
@@ -399,7 +408,6 @@ class FileEngine extends CacheEngine {
 				unlink($object->getPathName());
 			}
 		}
-		$this->_File = null;
 		return true;
 	}
 }

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -281,7 +281,9 @@ class FileEngine extends CacheEngine {
 				}
 			}
 			if ($file->isFile()) {
-				unlink($file->getRealPath());
+				$_path = $file->getRealPath();
+				unset($file);
+				unlink($_path);
 			}
 		}
 	}


### PR DESCRIPTION
fixed once in 7dae4a7fd834011df6bbc3b5d4eec3073d7c5500
but reproduced with b3860b399221d5b2c5b9fac85a8881cb4ca9e146
