### PR TITLE
Rename paranoid function to removeNonAlphanumerics

### DIFF
--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -241,14 +241,14 @@ class SanitizeTest extends CakeTestCase {
 	}
 
 /**
- * testParanoid method
+ * testRemoveNonAlphanumerics method
  *
  * @return void
  */
-	public function testParanoid() {
+	public function testRemoveNonAlphanumerics() {
 		$string = 'I would like to !%@#% & dance & sing ^$&*()-+';
 		$expected = 'Iwouldliketodancesing';
-		$result = Sanitize::paranoid($string);
+		$result = Sanitize::removeNonAlphanumerics($string);
 		$this->assertEquals($expected, $result);
 
 		$string = array('This |s th% s0ng that never ends it g*es',
@@ -257,27 +257,27 @@ class SanitizeTest extends CakeTestCase {
 		$expected = array('This s th% s0ng that never ends it g*es',
 						'on and on my friends bcause it is the',
 						'sog tht never ends.');
-		$result = Sanitize::paranoid($string, array('%', '*', '.', ' '));
+		$result = Sanitize::removeNonAlphanumerics($string, array('%', '*', '.', ' '));
 		$this->assertEquals($expected, $result);
 
 		$string = "anything' OR 1 = 1";
 		$expected = 'anythingOR11';
-		$result = Sanitize::paranoid($string);
+		$result = Sanitize::removeNonAlphanumerics($string);
 		$this->assertEquals($expected, $result);
 
 		$string = "x' AND email IS NULL; --";
 		$expected = 'xANDemailISNULL';
-		$result = Sanitize::paranoid($string);
+		$result = Sanitize::removeNonAlphanumerics($string);
 		$this->assertEquals($expected, $result);
 
 		$string = "x' AND 1=(SELECT COUNT(*) FROM users); --";
 		$expected = 'xAND1SELECTCOUNTFROMusers';
-		$result = Sanitize::paranoid($string);
+		$result = Sanitize::removeNonAlphanumerics($string);
 		$this->assertEquals($expected, $result);
 
 		$string = "x'; DROP TABLE members; --";
 		$expected = 'xDROPTABLEmembers';
-		$result = Sanitize::paranoid($string);
+		$result = Sanitize::removeNonAlphanumerics($string);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -69,7 +69,7 @@ class Sanitize {
  * @return string Sanitized string
  */
   public static function paranoid($string, $allowed = array()) {
-    return $this->removeNonAlphanumerics($string, $allowed);
+    return self::removeNonAlphanumerics($string, $allowed);
   }
 
 /**

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -60,6 +60,19 @@ class Sanitize {
 	}
 
 /**
+ * Removes any non-alphanumeric characters.
+ * Alternate name of the function
+ *
+ * @deprecated
+ * @param string $string String to sanitize
+ * @param array $allowed An array of additional characters that are not to be removed.
+ * @return string Sanitized string
+ */
+  public static function paranoid($string, $allowed = array()) {
+    return $this->removeNonAlphanumerics($string, $allowed);
+  }
+
+/**
  * Makes a string SQL-safe.
  *
  * @param string $string String to sanitize

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -39,7 +39,7 @@ class Sanitize {
  * @param array $allowed An array of additional characters that are not to be removed.
  * @return string Sanitized string
  */
-	public static function paranoid($string, $allowed = array()) {
+	public static function removeNonAlphanumerics($string, $allowed = array()) {
 		$allow = null;
 		if (!empty($allowed)) {
 			foreach ($allowed as $value) {


### PR DESCRIPTION
`removeNonAlphanumerics` more properly describes what the function is doing.  Also updated the tests.

Cons:
- It will remove humor from the cakephp repository.

Pros:
- It will help dispel the myth that php developers are professionals without standards.
- It will be properly named.
