### PR TITLE
Rename paranoid function to removeNonAlphanumerics

### DIFF
--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -282,6 +282,47 @@ class SanitizeTest extends CakeTestCase {
 	}
 
 /**
+ * testRemoveNonAlphanumerics method
+ *
+ * @return void
+ */
+  public function testRemoveNonAlphanumerics() {
+    $string = 'I would like to !%@#% & dance & sing ^$&*()-+';
+    $expected = 'Iwouldliketodancesing';
+    $result = Sanitize::removeNonAlphanumerics($string);
+    $this->assertEquals($expected, $result);
+
+    $string = array('This |s th% s0ng that never ends it g*es',
+            'on and on my friends, b^ca#use it is the',
+            'so&g th===t never ends.');
+    $expected = array('This s th% s0ng that never ends it g*es',
+            'on and on my friends bcause it is the',
+            'sog tht never ends.');
+    $result = Sanitize::removeNonAlphanumerics($string, array('%', '*', '.', ' '));
+    $this->assertEquals($expected, $result);
+
+    $string = "anything' OR 1 = 1";
+    $expected = 'anythingOR11';
+    $result = Sanitize::removeNonAlphanumerics($string);
+    $this->assertEquals($expected, $result);
+
+    $string = "x' AND email IS NULL; --";
+    $expected = 'xANDemailISNULL';
+    $result = Sanitize::removeNonAlphanumerics($string);
+    $this->assertEquals($expected, $result);
+
+    $string = "x' AND 1=(SELECT COUNT(*) FROM users); --";
+    $expected = 'xAND1SELECTCOUNTFROMusers';
+    $result = Sanitize::removeNonAlphanumerics($string);
+    $this->assertEquals($expected, $result);
+
+    $string = "x'; DROP TABLE members; --";
+    $expected = 'xDROPTABLEmembers';
+    $result = Sanitize::removeNonAlphanumerics($string);
+    $this->assertEquals($expected, $result);
+  }
+
+/**
  * testStripImages method
  *
  * @return void

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -39,7 +39,7 @@ class Sanitize {
  * @param array $allowed An array of additional characters that are not to be removed.
  * @return string Sanitized string
  */
-	public static function paranoid($string, $allowed = array()) {
+	public static function removeNonAlphanumerics($string, $allowed = array()) {
 		$allow = null;
 		if (!empty($allowed)) {
 			foreach ($allowed as $value) {
@@ -58,6 +58,19 @@ class Sanitize {
 
 		return $cleaned;
 	}
+
+/**
+ * Removes any non-alphanumeric characters.
+ * Alternate name of the function
+ *
+ * @deprecated
+ * @param string $string String to sanitize
+ * @param array $allowed An array of additional characters that are not to be removed.
+ * @return string Sanitized string
+ */
+  public static function paranoid($string, $allowed = array()) {
+    return self::removeNonAlphanumerics($string, $allowed);
+  }
 
 /**
  * Makes a string SQL-safe.


### PR DESCRIPTION
Per discussion in https://github.com/cakephp/cakephp/pull/1498, pointing to the new branch.

`removeNonAlphanumerics` more properly describes what the function is doing.  Also updated the tests.

Cons:
- It will remove humor from the cakephp repository.

Pros:
- It will help dispel the myth that php developers are professionals without standards.
- It will be properly named.
- Still backwards compatabile

Tagging previous code reviewers:
@ravage84
@dereuromark
