### PR TITLE
Updated the handling of HTTP status codes in the response

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -618,7 +618,7 @@ class CakeResponse {
  * Sets the HTTP status code to be sent
  * if $code is null the current code is returned
  *
- * @param integer $code
+ * @param integer $code the HTTP status code
  * @return integer current status code
  * @throws CakeException When an unknown status code is reached.
  */
@@ -635,31 +635,47 @@ class CakeResponse {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param integer|array $code If $code is an integer, then the corresponding code/message is
- *        returned if it exists, null if it does not exist. If $code is an array,
- *        then the 'code' and 'message' keys of each nested array are added to the default
- *        HTTP codes. Example:
+ * @param integer|array $code If $code is an integer, then the corresponding code/message is 
+ *        returned if it exists, null if it does not exist. If $code is an array, then the 
+ *        keys are used as codes and the values as messages to add to the default HTTP 
+ *        codes. The codes must be integers greater than 99 and less than 1000. Keep in 
+ *        mind that the HTTP specification outlines that status codes begin with a digit 
+ *        between 1 and 5, which defines the class of response the client is to expect. 
+ *        Example:
  *
  *        httpCodes(404); // returns array(404 => 'Not Found')
  *
  *        httpCodes(array(
- *            701 => 'Unicorn Moved',
- *            800 => 'Unexpected Minotaur'
+ *            381 => 'Unicorn Moved',
+ *            555 => 'Unexpected Minotaur'
  *        )); // sets these new values, and returns true
+ *
+ *        httpCodes(array(
+ *            0 => 'Nothing Here',
+ *            -1 => 'Reverse Infinity',
+ *            12345 => 'Universal Password',
+ *            'Hello' => 'World'
+ *        )); // throws an error due to invalid codes
+ *
+ *        For more on HTTP status codes see: http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
  *
  * @return mixed associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
+ * @throws CakeException If an attempt is made to add an invalid status code
  */
 	public function httpCodes($code = null) {
 		if (empty($code)) {
 			return $this->_statusCodes;
 		}
-
 		if (is_array($code)) {
+			$codes = array_keys($code);
+			$min = min($codes);
+			if (!is_int($min) || $min < 100 || max($codes) > 999) {
+				throw new CakeException(__d('cake_dev', 'Invalid status code'));
+			}
 			$this->_statusCodes = $code + $this->_statusCodes;
 			return true;
 		}
-
 		if (!isset($this->_statusCodes[$code])) {
 			return null;
 		}

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -655,7 +655,7 @@ class CakeResponse {
  *            -1 => 'Reverse Infinity',
  *            12345 => 'Universal Password',
  *            'Hello' => 'World'
- *        )); // throws an error due to invalid codes
+ *        )); // throws an exception due to invalid codes
  *
  *        For more on HTTP status codes see: http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
  *

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -361,6 +361,7 @@ class CakeResponseTest extends CakeTestCase {
 /**
  * Tests the httpCodes method
  *
+ * @expectedException CakeException
  */
 	public function testHttpCodes() {
 		$response = new CakeResponse();
@@ -372,16 +373,16 @@ class CakeResponseTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$codes = array(
-			1337 => 'Undefined Unicorn',
-			1729 => 'Hardy-Ramanujan Located'
+			381 => 'Unicorn Moved',
+			555 => 'Unexpected Minotaur'
 		);
 
 		$result = $response->httpCodes($codes);
 		$this->assertTrue($result);
 		$this->assertEquals(42, count($response->httpCodes()));
 
-		$result = $response->httpCodes(1337);
-		$expected = array(1337 => 'Undefined Unicorn');
+		$result = $response->httpCodes(381);
+		$expected = array(381 => 'Unicorn Moved');
 		$this->assertEquals($expected, $result);
 
 		$codes = array(404 => 'Sorry Bro');
@@ -392,6 +393,14 @@ class CakeResponseTest extends CakeTestCase {
 		$result = $response->httpCodes(404);
 		$expected = array(404 => 'Sorry Bro');
 		$this->assertEquals($expected, $result);
+
+		//Throws exception
+		$response->httpCodes(array(
+			0 => 'Nothing Here',
+			-1 => 'Reverse Infinity',
+			12345 => 'Universal Password',
+			'Hello' => 'World'
+		));
 	}
 
 /**


### PR DESCRIPTION
Improved API integrity by blocking the ability to set invalid status codes according to the HTTP spec. This includes any non-numeric codes, or any code that is greater or less than 3 digits in length (100-999 being the accepted range).

From the spec: "The Status-Code element is a 3-digit integer result code of the attempt to understand and satisfy the request."

Spec details here: http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
