### PR TITLE
making the config method of email-transport-classes mergable

### DIFF
--- a/lib/Cake/Network/Email/AbstractTransport.php
+++ b/lib/Cake/Network/Email/AbstractTransport.php
@@ -48,7 +48,7 @@ abstract class AbstractTransport {
  */
 	public function config($config = null) {
 		if (is_array($config)) {
-			$this->_config = $config;
+			$this->_config = $config + $this->_config;
 		}
 		return $this->_config;
 	}

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -86,7 +86,7 @@ class SmtpTransport extends AbstractTransport {
 			'client' => null,
 			'tls' => false
 		);
-		$this->_config = empty($config) ? $this->_config + $default : $config + $default;
+		$this->_config = array_merge($default, $this->_config, $config);
 		return $this->_config;
 	}
 

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -95,6 +95,20 @@ class EmailConfig {
 		'helpers' => array('Html', 'Form'),
 	);
 
+/**
+ * test config 2
+ *
+ * @var string
+ */
+	public $test2 = array(
+		'from' => array('some@example.com' => 'My website'),
+		'to' => array('test@example.com' => 'Testname'),
+		'subject' => 'Test mail subject',
+		'transport' => 'Smtp',
+		'host' => 'cakephp.org',
+		'timeout' => 60
+	);
+
 }
 
 /*
@@ -726,12 +740,13 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertSame($this->CakeEmail->config(), $config);
 
 		$this->CakeEmail->config(array());
-		$this->assertSame($transportClass->config(), array());
+		$this->assertSame($transportClass->config(), $config);
 
 		$config = array('test' => 'test@example.com');
 		$this->CakeEmail->config($config);
 		$expected = array('test' => 'test@example.com', 'test2' => true);
 		$this->assertSame($expected, $this->CakeEmail->config());
+		$this->assertSame($expected, $transportClass->config());
 	}
 
 /**
@@ -763,6 +778,35 @@ class CakeEmailTest extends CakeTestCase {
 
 		$result = $this->CakeEmail->helpers();
 		$this->assertEquals($configs->test['helpers'], $result);
+	}
+
+/**
+ * Test updating config doesn't reset transport's config.
+ *
+ * @return void
+ */
+	public function testConfigMerge() {
+		$this->CakeEmail->config('test2');
+
+		$expected = array(
+			'host' => 'cakephp.org',
+			'port' => 25,
+			'timeout' => 60,
+			'username' => null,
+			'password' => null,
+			'client' => null,
+			'tls' => false
+		);
+		$this->assertEquals($expected, $this->CakeEmail->transportClass()->config());
+
+		$this->CakeEmail->config(array('log' => true));
+		$result = $this->CakeEmail->transportClass()->config();
+		$expected += array('log' => true);
+		$this->assertEquals($expected, $this->CakeEmail->transportClass()->config());
+
+		$this->CakeEmail->config(array('timeout' => 45));
+		$result = $this->CakeEmail->transportClass()->config();
+		$this->assertEquals(45, $result['timeout']);
 	}
 
 /**


### PR DESCRIPTION
At the comment of CakeEmail::config method, it is explained that it can merge new configuration into existing values.

But the configuration of the  email-transport-classes are initialized when CakeEmail::config method is used.
The following code does not work.

```
$email = new CakeEmail('smtp');
$email->config(array('log' => true));
//SmtpTransport::_config is overwrote by using $default value.
```

This change make the config method of email-transport-classes mergable into the current config value.
