### PR TITLE
Fixed statement about Security:hash's salt parameter

### DIFF
--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -99,7 +99,7 @@ class Security {
  *
  * @param string $string String to hash
  * @param string $type Method to use (sha1/sha256/md5/blowfish)
- * @param mixed $salt If true, automatically appends the application's salt
+ * @param mixed $salt If true, automatically prepends the application's salt
  *     value to $string (Security.salt). If you are using blowfish the salt
  *     must be false or a previously generated salt.
  * @return string Hash


### PR DESCRIPTION
Just nitpicking, but it prepends the salt, not appends it:
https://github.com/cakephp/cakephp/blob/master/lib/Cake/Utility/Security.php#L120
