### PR TITLE
2.4 return early

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -538,9 +538,8 @@ class Cache {
 		}
 		if (isset(self::$_groups[$group])) {
 			return array($group => self::$_groups[$group]);
-		} else {
-			throw new CacheException(__d('cake_dev', 'Invalid cache group %s', $group));
 		}
+		throw new CacheException(__d('cake_dev', 'Invalid cache group %s', $group));
 	}
 
 }

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -235,10 +235,9 @@ class SchemaShell extends AppShell {
 			if ($File->write($contents)) {
 				$this->out(__d('cake_console', 'SQL dump file created in %s', $File->pwd()));
 				return $this->_stop();
-			} else {
-				$this->err(__d('cake_console', 'SQL dump could not be created'));
-				return $this->_stop();
 			}
+			$this->err(__d('cake_console', 'SQL dump could not be created'));
+			return $this->_stop();
 		}
 		$this->out($contents);
 		return $contents;

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -789,10 +789,9 @@ class TreeBehavior extends ModelBehavior {
 		if ($node[$right] == $node[$left] + 1) {
 			if ($delete) {
 				return $Model->delete($id);
-			} else {
-				$Model->id = $id;
-				return $Model->saveField($parent, null);
 			}
+			$Model->id = $id;
+			return $Model->saveField($parent, null);
 		} elseif ($node[$parent]) {
 			list($parentNode) = array_values($Model->find('first', array(
 				'conditions' => array($scope, $Model->escapeField() => $node[$parent]),

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -556,9 +556,8 @@ class HtmlHelper extends AppHelper {
 
 		if (empty($options['block'])) {
 			return $out;
-		} else {
-			$this->_View->append($options['block'], $out);
 		}
+		$this->_View->append($options['block'], $out);
 	}
 
 /**
@@ -593,9 +592,8 @@ class HtmlHelper extends AppHelper {
 
 		if (empty($options['block'])) {
 			return $out;
-		} else {
-			$this->_View->append($options['block'], $out);
 		}
+		$this->_View->append($options['block'], $out);
 	}
 
 /**


### PR DESCRIPTION
My new sniff found a few "return early" occurances, that have an else block afterwards that is not necessary.
https://github.com/cakephp/cakephp-codesniffer/issues/46
