### PR TITLE
Support DboSource expressions as data values in Model saveAssociated

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2219,7 +2219,7 @@ class Model extends Object implements CakeEventListener {
 		$return = array();
 		$validates = true;
 		foreach ($data as $association => $values) {
-			$notEmpty = !empty($values[$association]) || (!isset($values[$association]) && !empty($values));
+			$notEmpty = (is_object($values)) || !empty($values[$association]) || (!isset($values[$association]) && !empty($values));
 			if (isset($associations[$association]) && $associations[$association] === 'belongsTo' && $notEmpty) {
 				$validates = $this->{$association}->create(null) !== null;
 				$saved = false;
@@ -2255,7 +2255,7 @@ class Model extends Object implements CakeEventListener {
 			if (!$validates) {
 				break;
 			}
-			$notEmpty = !empty($values[$association]) || (!isset($values[$association]) && !empty($values));
+			$notEmpty = (is_object($values)) || !empty($values[$association]) || (!isset($values[$association]) && !empty($values));
 			if (isset($associations[$association]) && $notEmpty) {
 				$type = $associations[$association];
 				$key = $this->{$type}[$association]['foreignKey'];


### PR DESCRIPTION
Check if $values is an object (before assuming it is an array) in saveAssociated. Objects are treated as "not empty" so that we can support DboSource expresssions as described in ticket #3978
