### PR TITLE
2.4 wordwrap unicode aware

### DIFF
--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -315,6 +315,33 @@ class StringTest extends CakeTestCase {
 	}
 
 /**
+ * test wordWrap() to handle unicode strings properly.
+ *
+ * @return void
+ */
+	public function testWordWrap() {
+		$text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
+		$result = String::wordWrap($text, 33, "\n", true);
+		$expected = <<<TEXT
+Но вим омниюм факёльиси элыктрам,
+мюнырэ лэгыры векж ыт. Выльёт квю
+андо нюмквуам ты кюм. Зыд эю рыбю
+м.
+TEXT;
+		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
+
+		$text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
+		$result = String::wordWrap($text, 33, "\n");
+		$expected = <<<TEXT
+Но вим омниюм факёльиси элыктрам,
+мюнырэ лэгыры векж ыт. Выльёт
+квюандо нюмквуам ты кюм. Зыд эю
+рыбюм.
+TEXT;
+		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
+	}
+
+/**
  * test wrap method.
  *
  * @return void
@@ -342,8 +369,9 @@ TEXT;
 		$result = String::wrap($text, 33);
 		$expected = <<<TEXT
 Но вим омниюм факёльиси элыктрам,
-мюнырэ лэгыры векж ыт. Выльёт квюа
-ндо нюмквуам ты кюм. Зыд эю рыбюм.
+мюнырэ лэгыры векж ыт. Выльёт
+квюандо нюмквуам ты кюм. Зыд эю
+рыбюм.
 TEXT;
 		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
 	}

--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -337,6 +337,15 @@ TEXT;
 			'the song that never' . "\n" .
 			' ends.';
 		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
+
+		$text = 'Но вим омниюм факёльиси элыктрам, мюнырэ лэгыры векж ыт. Выльёт квюандо нюмквуам ты кюм. Зыд эю рыбюм.';
+		$result = String::wrap($text, 33);
+		$expected = <<<TEXT
+Но вим омниюм факёльиси элыктрам,
+мюнырэ лэгыры векж ыт. Выльёт квюа
+ндо нюмквуам ты кюм. Зыд эю рыбюм.
+TEXT;
+		$this->assertTextEquals($expected, $result, 'Text not wrapped.');
 	}
 
 /**

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -319,12 +319,12 @@ class String {
  *
  * ### Options
  *
- * - `width` The width to wrap to. Defaults to 72
+ * - `width` The width to wrap to. Defaults to 72.
  * - `wordWrap` Only wrap on words breaks (spaces) Defaults to true.
  * - `indent` String to indent with. Defaults to null.
  * - `indentAt` 0 based index to start indenting at. Defaults to 0.
  *
- * @param string $text Text the text to format.
+ * @param string $text The text to format.
  * @param array|integer $options Array of options to use, or an integer to wrap the text to.
  * @return string Formatted text.
  */
@@ -334,7 +334,7 @@ class String {
 		}
 		$options += array('width' => 72, 'wordWrap' => true, 'indent' => null, 'indentAt' => 0);
 		if ($options['wordWrap']) {
-			$wrapped = wordwrap($text, $options['width'], "\n");
+			$wrapped = self::wordWrap($text, $options['width'], "\n");
 		} else {
 			$wrapped = trim(chunk_split($text, $options['width'] - 1, "\n"));
 		}
@@ -346,6 +346,39 @@ class String {
 			$wrapped = implode("\n", $chunks);
 		}
 		return $wrapped;
+	}
+
+/**
+ * Unicode aware version of wordwrap.
+ *
+ * @param string $text The text to format.
+ * @param integer $width The width to wrap to. Defaults to 72.
+ * @param string $break The line is broken using the optional break parameter. Defaults to '\n'.
+ * @param bool $cut If the cut is set to true, the string is always wrapped at the specified width.
+ * @return string Formatted text.
+ */
+	public static function wordWrap($text, $width = 72, $break = "\n", $cut = false) {
+		if (!$cut) {
+			$regexp = '#^(?:[\x00-\x7F]|[\xC0-\xFF][\x80-\xBF]+){' . $width . ',}\b#U';
+		} else {
+			$regexp = '#^(?:[\x00-\x7F]|[\xC0-\xFF][\x80-\xBF]+){' . $width . '}#';
+		}
+		$length = mb_strlen($text);
+		$whileWhat = ceil($length / $width);
+		$i = 1;
+		$return = '';
+		while ($i < $whileWhat) {
+			preg_match($regexp, $text, $matches);
+			if (!$matches) {
+				$i++;
+				continue;
+			}
+			$string = $matches[0];
+			$return .= trim($string) . $break;
+			$text = substr($text, strlen($string));
+			$i++;
+		}
+		return $return . $text;
 	}
 
 /**

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -358,11 +358,9 @@ class String {
  * @return string Formatted text.
  */
 	public static function wordWrap($text, $width = 72, $break = "\n", $cut = false) {
-		if (!$cut) {
-			$regexp = '#^(?:[\x00-\x7F]|[\xC0-\xFF][\x80-\xBF]+){' . $width . ',}\b#U';
-		} else {
-			$regexp = '#^(?:[\x00-\x7F]|[\xC0-\xFF][\x80-\xBF]+){' . $width . '}#';
-		}
+		$widthAndBoundary = $cut ? '{' . $width . '}#' : '{' . $width . ',}\b#U';
+		$regexp = '#^(?:[\x00-\x7F]|[\xC0-\xFF][\x80-\xBF]+)' . $widthAndBoundary;
+
 		$length = mb_strlen($text);
 		$whileWhat = ceil($length / $width);
 		$i = 1;
@@ -375,7 +373,7 @@ class String {
 			}
 			$string = $matches[0];
 			$return .= trim($string) . $break;
-			$text = substr($text, strlen($string));
+			$text = trim(mb_substr($text, mb_strlen($string)));
 			$i++;
 		}
 		return $return . $text;


### PR DESCRIPTION
Solves https://cakephp.lighthouseapp.com/projects/42648/tickets/3981-stringwrap-is-not-unicode-aware
Not sure if that is the cleanest solution, though..

The only other place where the plain wordwrap() method is still used is the CakeEmail class:

```
 explode("\n", wordwrap($line, $wrapLength, "\n", $cut))
```

But I think this is fine as it is just the splitting into the required max length (this does not need to be this exact). IMO performance outweights accuracy here.
