### PR TITLE
Corrected translation string

### DIFF
--- a/lib/Cake/View/Errors/missing_connection.ctp
+++ b/lib/Cake/View/Errors/missing_connection.ctp
@@ -36,7 +36,7 @@
 <?php endif; ?>
 <p class="notice">
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
-	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s.', APP_DIR . DS . 'View' . DS . 'Errors' . DS . basename(__FILE__)); ?>
+	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . basename(__FILE__)); ?>
 </p>
 
 <?php


### PR DESCRIPTION
Corrected the string to be the same as in:

```
/Cake/View/Errors/fatal_error.ctp:35
/Cake/View/Errors/missing_action.ctp:41
/Cake/View/Errors/missing_behavior.ctp:38
/Cake/View/Errors/missing_component.ctp:38
/lib/Cake/View/Errors/missing_controller.ctp:38
/lib/Cake/View/Errors/missing_database.ctp:31
/Cake/View/Errors/missing_datasource.ctp:31
/Cake/View/Errors/missing_datasource_config.ctp:27
/Cake/View/Errors/missing_helper.ctp:38
/lib/Cake/View/Errors/missing_layout.ctp:31
/lib/Cake/View/Errors/missing_plugin.ctp:43
/lib/Cake/View/Errors/missing_table.ctp:27
/lib/Cake/View/Errors/missing_view.ctp:31
/lib/Cake/View/Errors/pdo_error.ctp:37
/lib/Cake/View/Errors/private_action.ctp:27
/lib/Cake/View/Errors/scaffold_error.ctp:27
```
