### PR TITLE
3.0 - Use registry objects in Cache & Log and remove Configure based configuration.

### DIFF
--- a/App/Config/cache.php
+++ b/App/Config/cache.php
@@ -14,7 +14,7 @@
  */
 namespace App\Config;
 
-use Cake\Core\Configure;
+use Cake\Cache\Cache;
 
 /**
  * Turn off all caching application-wide.
@@ -33,6 +33,16 @@ use Cake\Core\Configure;
  */
 	//Configure::write('Cache.check', true);
 
+/**
+ * Enable cache view prefixes.
+ *
+ * If set it will be prepended to the cache name for view file caching. This is
+ * helpful if you deploy the same application via multiple subdomains and languages,
+ * for instance. Each version can then have its own view cache namespace.
+ * Note: The final cache file name will then be `prefix_cachefilename`.
+ */
+	//Configure::write('Cache.viewPrefix', 'prefix');
+
 // In development mode, caches should expire quickly.
 $duration = '+999 days';
 if (Configure::read('debug') >= 1) {
@@ -48,29 +58,33 @@ $engine = 'File';
 // Prefix each application on the same server with a different string, to avoid Memcache and APC conflicts.
 $prefix = 'myapp_';
 
+
+$cacheConfigs = [];
+
 /**
  * Configure the cache used for general framework caching.  Path information,
  * object listings, and translation cache files are stored with this configuration.
  */
-Configure::write('Cache._cake_core_', [
+$cacheConfigs['_cake_core_'] = [
 	'engine' => $engine,
 	'prefix' => $prefix . 'cake_core_',
 	'path' => CACHE . 'persistent' . DS,
 	'serialize' => ($engine === 'File'),
 	'duration' => $duration
-]);
+];
+
 
 /**
  * Configure the cache for model and datasource caches.  This cache configuration
  * is used to store schema descriptions, and table listings in connections.
  */
-Configure::write('Cache._cake_model_', [
+$cacheConfigs['_cake_model_'] = [
 	'engine' => $engine,
 	'prefix' => $prefix . 'cake_model_',
 	'path' => CACHE . 'models' . DS,
 	'serialize' => ($engine === 'File'),
 	'duration' => $duration
-]);
+];
 
 /**
  * Cache Engine Configuration
@@ -145,14 +159,8 @@ Configure::write('Cache._cake_model_', [
  *		'persistent' => true, // [optional] set this to false for non-persistent connections
  *	));
  */
-Configure::write('Cache.default', array('engine' => 'File'));
+$cacheConfigs['default'] = [
+	'engine' => 'File'
+];
 
-/**
- * Enable cache view prefixes.
- *
- * If set it will be prepended to the cache name for view file caching. This is
- * helpful if you deploy the same application via multiple subdomains and languages,
- * for instance. Each version can then have its own view cache namespace.
- * Note: The final cache file name will then be `prefix_cachefilename`.
- */
-	//Configure::write('Cache.viewPrefix', 'prefix');
+Cache::config($cacheConfigs);

--- a/App/Config/cache.php
+++ b/App/Config/cache.php
@@ -15,6 +15,7 @@
 namespace App\Config;
 
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 
 /**
  * Turn off all caching application-wide.

--- a/App/Config/logging.php
+++ b/App/Config/logging.php
@@ -14,25 +14,22 @@
  */
 namespace App\Config;
 
-use Cake\Core\Configure;
+use Cake\Log\Log;
 
-/**
- * Defines the default error type when using the log() function. Used for
- * differentiating error logging and debugging. Currently PHP supports LOG_DEBUG.
- */
-	define('LOG_ERROR', LOG_ERR);
+$logConfig = [];
 
 /**
  * Configures default file logging options
  */
-Configure::write('Log.debug', [
+$logConfig['debug'] = [
 	'engine' => 'Cake\Log\Engine\FileLog',
 	'levels' => ['notice', 'info', 'debug'],
 	'file' => 'debug',
-]);
-
-Configure::write('Log.error', [
+];
+$logConfig['error'] = [
 	'engine' => 'Cake\Log\Engine\FileLog',
 	'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
 	'file' => 'error',
-]);
+];
+
+Log::config($logConfig);

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -142,6 +142,7 @@ class Cache {
 			static::$_config[$key] = $config;
 			return;
 		}
+
 		static::$_config = array_merge(static::$_config, $key);
 	}
 
@@ -159,6 +160,7 @@ class Cache {
 		if (empty(static::$_config[$name]['engine'])) {
 			return false;
 		}
+
 		$config = static::$_config[$name];
 		$config['className'] = $config['engine'];
 
@@ -197,6 +199,7 @@ class Cache {
 		if (!isset(static::$_registry->{$config})) {
 			return false;
 		}
+
 		static::$_registry->unload($config);
 		unset(static::$_config[$config], static::$_restore[$config]);
 		return true;
@@ -215,9 +218,11 @@ class Cache {
 		if (Configure::read('Cache.disable')) {
 			return false;
 		}
+
 		if (isset(static::$_registry->{$config})) {
 			return static::$_registry->{$config};
 		}
+
 		if (!static::_buildEngine($config)) {
 			$message = __d(
 				'cake_dev',
@@ -318,6 +323,7 @@ class Cache {
 		if (!$engine) {
 			return;
 		}
+
 		$engine->gc($expires);
 	}
 
@@ -390,10 +396,12 @@ class Cache {
 		if (!$engine) {
 			return false;
 		}
+
 		$key = $engine->key($key);
 		if (!$key) {
 			return false;
 		}
+
 		return $engine->read($settings['prefix'] . $key);
 	}
 
@@ -496,6 +504,7 @@ class Cache {
 		if (!$engine) {
 			return false;
 		}
+
 		$success = $engine->clear($check);
 		static::set(null, $config);
 		return $success;
@@ -513,6 +522,7 @@ class Cache {
 		if (!$engine) {
 			return false;
 		}
+
 		$success = $engine->clearGroup($group);
 		static::set(null, $config);
 		return $success;
@@ -530,6 +540,7 @@ class Cache {
 		if (!$engine) {
 			return [];
 		}
+
 		return $engine->settings();
 	}
 
@@ -552,9 +563,11 @@ class Cache {
 		if ($group == null) {
 			return static::$_groups;
 		}
+
 		if (isset(self::$_groups[$group])) {
 			return array($group => self::$_groups[$group]);
 		}
+
 		throw new Error\Exception(__d('cake_dev', 'Invalid cache group %s', $group));
 	}
 

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -150,15 +150,14 @@ class Cache {
  * Finds and builds the instance of the required engine class.
  *
  * @param string $name Name of the config array that needs an engine instance built
- * @return boolean
- * @throws Cake\Error\Exception
+ * @throws Cake\Error\Exception When a cache engine cannot be created.
  */
 	protected static function _buildEngine($name) {
 		if (empty(static::$_registry)) {
 			static::$_registry = new CacheRegistry();
 		}
 		if (empty(static::$_config[$name]['engine'])) {
-			return false;
+			throw new Error\Exception(__d('cake_dev', 'The "%s" cache configuration does not exist.', $name));
 		}
 
 		$config = static::$_config[$name];
@@ -173,8 +172,6 @@ class Cache {
 				sort(static::$_groups[$group]);
 			}
 		}
-
-		return true;
 	}
 
 /**
@@ -223,14 +220,7 @@ class Cache {
 			return static::$_registry->{$config};
 		}
 
-		if (!static::_buildEngine($config)) {
-			$message = __d(
-				'cake_dev',
-				'The "%s" cache configuration does not exist.',
-				$config
-			);
-			trigger_error($message, E_USER_WARNING);
-		}
+		static::_buildEngine($config);
 		return static::$_registry->{$config};
 	}
 

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -32,7 +32,7 @@ use Cake\Utility\Inflector;
  * A sample configuration would be:
  *
  * {{{
- * Configure::write('Cache.shared', array(
+ * Cache::config('shared', array(
  *    'engine' => 'Cake\Cache\Engine\ApcEngine',
  *    'prefix' => 'my_app_'
  * ));
@@ -83,7 +83,18 @@ use Cake\Utility\Inflector;
 class Cache {
 
 /**
- * Cache configuration stack
+ * Configuraiton backup.
+ *
+ * Keeps the permanent/default settings for each cache engine.
+ * These settings are used to reset the engines after temporary modification.
+ *
+ * @var array
+ */
+	protected static $_restore = array();
+
+/**
+ * Cache configuration.
+ *
  * Keeps the permanent/default settings for each cache engine.
  * These settings are used to reset the engines after temporary modification.
  *
@@ -106,22 +117,32 @@ class Cache {
 	protected static $_reset = false;
 
 /**
- * Engine instances keyed by configuration name.
+ * Cache Registry used for creating and using cache adapters.
  *
- * @var array
+ * @var Cake\Cache\CacheRegistry
  */
-	protected static $_engines = array();
+	protected static $_registry;
 
 /**
- * Deprecated method. Will be removed in 3.0.0
+ * This method can be used to define cache adapters for an application
+ * during the bootstrapping process. You can use this method to add new cache adapters
+ * at runtime as well. New cache configurations will be constructed upon the next write.
  *
- * @deprecated
+ * To change an adapter's configuration at runtime, first drop the adapter and then
+ * reconfigure it.
+ *
+ * Adapters will not be constructed until the first operation is done.
+ *
+ * @param string|array $key The name of the cache config, or an array of multiple configs.
+ * @param array $config An array of name => config data for adapter.
+ * @return void
  */
-	public static function config($name = null, $settings = array()) {
-		trigger_error(
-			__d('cake_dev', 'You must use Configure::write() to define cache configuration. Or use engine() to inject new adapter.'),
-			E_USER_WARNING
-		);
+	public static function config($key, $config = null) {
+		if ($config !== null && is_string($key)) {
+			static::$_config[$key] = $config;
+			return;
+		}
+		static::$_config = array_merge(static::$_config, $key);
 	}
 
 /**
@@ -132,35 +153,22 @@ class Cache {
  * @throws Cake\Error\Exception
  */
 	protected static function _buildEngine($name) {
-		$config = Configure::read('Cache.' . $name);
-		if (empty($config['engine'])) {
+		if (empty(static::$_registry)) {
+			static::$_registry = new CacheRegistry();
+		}
+		if (empty(static::$_config[$name]['engine'])) {
 			return false;
 		}
-		$cacheClass = App::classname($config['engine'], 'Cache/Engine', 'Engine');
-		if (!$cacheClass) {
-			throw new Error\Exception(
-				__d('cake_dev', 'Cache engine %s is not available.', $name)
-			);
-		}
-		if (!is_subclass_of($cacheClass, 'Cake\Cache\CacheEngine')) {
-			throw new Error\Exception(__d('cake_dev', 'Cache engines must use Cake\Cache\CacheEngine as a base class.'));
-		}
-		$engine = new $cacheClass();
-		if (!$engine->init($config)) {
-			throw new Error\Exception(
-				__d('cake_dev', 'Cache engine %s is not properly configured.', $name)
-			);
-		}
-		if ($engine->settings['probability'] && time() % $engine->settings['probability'] === 0) {
-			$engine->gc();
-		}
-		static::$_engines[$name] = $engine;
+		$config = static::$_config[$name];
+		$config['className'] = $config['engine'];
+
+		static::$_registry->load($name, $config);
 
 		if (!empty($config['groups'])) {
 			foreach ($config['groups'] as $group) {
 				static::$_groups[$group][] = $name;
-				sort(static::$_groups[$group]);
 				static::$_groups[$group] = array_unique(static::$_groups[$group]);
+				sort(static::$_groups[$group]);
 			}
 		}
 
@@ -168,14 +176,12 @@ class Cache {
 	}
 
 /**
- * Returns an array containing the connected Cache engines.
- * This will not return engines that are configured, but have not
- * been used yet.
+ * Returns an array containing the configured Cache engines.
  *
- * @return array Array of connected Cache config names.
+ * @return array Array of configured Cache config names.
  */
 	public static function configured() {
-		return array_keys(static::$_engines);
+		return array_keys(static::$_config);
 	}
 
 /**
@@ -188,47 +194,39 @@ class Cache {
  * @return boolean success of the removal, returns false when the config does not exist.
  */
 	public static function drop($config) {
-		if (isset(static::$_engines[$config])) {
-			unset(static::$_engines[$config]);
-			unset(static::$_config[$config]);
-			return true;
+		if (!isset(static::$_registry->{$config})) {
+			return false;
 		}
-		return false;
+		static::$_registry->unload($config);
+		unset(static::$_config[$config], static::$_restore[$config]);
+		return true;
 	}
 
 /**
  * Fetch the engine attached to a specific configuration name.
- * If the engine does not exist, configuration data will be read from
- * `Configure`.
  *
  * If the cache engine & configuration are missing an error will be
  * triggered.
  *
- * @param string $config The configuration name you want an engine.
- * @param Cake\Cache\CacheEngine $engine An engine instance if you are manually
- *   injecting a cache engine.
+ * @param string $config The configuration name you want an engine for.
  * @return Cake\Cache\Engine
  */
-	public static function engine($config, CacheEngine $engine = null) {
+	public static function engine($config) {
 		if (Configure::read('Cache.disable')) {
 			return false;
 		}
-		if (isset(static::$_engines[$config])) {
-			return static::$_engines[$config];
+		if (isset(static::$_registry->{$config})) {
+			return static::$_registry->{$config};
 		}
-		if (!$engine && !static::_buildEngine($config, $engine)) {
+		if (!static::_buildEngine($config)) {
 			$message = __d(
 				'cake_dev',
-				'The "%s" cache configuration does not exist, nor could configuration be found at "Cache.%s".',
-				$config,
+				'The "%s" cache configuration does not exist.',
 				$config
 			);
 			trigger_error($message, E_USER_WARNING);
 		}
-		if ($engine) {
-			static::$_engines[$config] = $engine;
-		}
-		return static::$_engines[$config];
+		return static::$_registry->{$config};
 	}
 
 /**
@@ -269,8 +267,8 @@ class Cache {
 			return false;
 		}
 
-		if (empty(static::$_config[$config])) {
-			static::$_config[$config] = $engine->settings();
+		if (empty(static::$_restore[$config])) {
+			static::$_restore[$config] = $engine->settings();
 		}
 
 		if (!empty($settings)) {
@@ -292,11 +290,11 @@ class Cache {
  * @return void
  */
 	protected static function _modifySettings($engine, $config, $settings) {
-		$restore = static::$_config[$config];
+		$restore = static::$_restore[$config];
 		if (empty($settings)) {
 			static::$_reset = false;
 			$settings = $restore;
-			unset(static::$_config[$config]);
+			unset(static::$_restore[$config]);
 		} else {
 			$settings = array_merge($restore, $settings);
 			if (isset($settings['duration']) && !is_numeric($settings['duration'])) {

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -68,21 +68,25 @@ class CacheRegistry extends ObjectRegistry {
 		if (is_object($class)) {
 			$instance = $class;
 		}
+
 		unset($settings['engine'], $settings['className']);
 		if (!isset($instance)) {
 			$instance = new $class($settings);
 		}
+
 		if (!($instance instanceof CacheEngine)) {
 			throw new Error\Exception(__d(
 				'cake_dev',
 				'Cache engines must use Cake\Cache\CacheEngine as a base class.'
 			));
 		}
+
 		if (!$instance->init($settings)) {
 			throw new Error\Exception(
 				__d('cake_dev', 'Cache engine %s is not properly configured.', $class)
 			);
 		}
+
 		if ($instance->settings['probability'] && time() % $instance->settings['probability'] === 0) {
 			$instance->gc();
 		}

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Cache;
+
+use Cake\Core\App;
+use Cake\Error;
+use Cake\Utility\ObjectRegistry;
+
+/**
+ * An object registry for cache engines.
+ *
+ * Used by Cake\Cache\Cache to load and manage cache engines.
+ *
+ * @since CakePHP 3.0
+ */
+class CacheRegistry extends ObjectRegistry {
+
+/**
+ * Resolve a cache engine classname.
+ *
+ * Part of the template method for Cake\Utility\ObjectRegistry::load()
+ *
+ * @param string $class Partial classname to resolve.
+ * @return string|false Either the correct classname or false.
+ */
+	protected function _resolveClassName($class) {
+		if (is_object($class)) {
+			return $class;
+		}
+		return App::classname($class, 'Cache/Engine', 'Engine');
+	}
+
+/**
+ * Throws an exception when a cache engine is missing.
+ *
+ * Part of the template method for Cake\Utility\ObjectRegistry::load()
+ *
+ * @param string $class The classname that is missing.
+ * @param string $plugin The plugin the cache is missing in.
+ * @throws Cake\Error\Exception
+ */
+	protected function _throwMissingClassError($class, $plugin) {
+		throw new Error\Exception(__d('cake_dev', 'Cache engine %s is not available.', $class));
+	}
+
+/**
+ * Create the cache engine instance.
+ *
+ * Part of the template method for Cake\Utility\ObjectRegistry::load()
+ * @param string|CacheEngine $class The classname or object to make.
+ * @param array $settings An array of settings to use for the cache engine.
+ * @return CacheEngine The constructed CacheEngine class.
+ * @throws Cake\Error\Exception when an object doesn't implement
+ *    the correct interface.
+ */
+	protected function _create($class, $settings) {
+		if (is_object($class)) {
+			$instance = $class;
+		}
+		unset($settings['engine'], $settings['className']);
+		if (!isset($instance)) {
+			$instance = new $class($settings);
+		}
+		if (!($instance instanceof CacheEngine)) {
+			throw new Error\Exception(__d(
+				'cake_dev',
+				'Cache engines must use Cake\Cache\CacheEngine as a base class.'
+			));
+		}
+		if (!$instance->init($settings)) {
+			throw new Error\Exception(
+				__d('cake_dev', 'Cache engine %s is not properly configured.', $class)
+			);
+		}
+		if ($instance->settings['probability'] && time() % $instance->settings['probability'] === 0) {
+			$instance->gc();
+		}
+		return $instance;
+	}
+
+/**
+ * Remove a single adapter from the registry.
+ *
+ * @param string $name The adapter name.
+ * @return void
+ */
+	public function unload($name) {
+		unset($this->_loaded[$name]);
+	}
+
+	
+}

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -99,5 +99,4 @@ class CacheRegistry extends ObjectRegistry {
 		unset($this->_loaded[$name]);
 	}
 
-	
 }

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -246,54 +246,6 @@ class UpgradeShell extends Shell {
 	}
 
 /**
- * Update log configs.
- *
- * @return void
- */
-	public function log_config() {
-		$path = $this->_getPath();
-
-		$Folder = new Folder($path);
-		$this->_paths = $Folder->tree(null, false, 'dir');
-		$this->_findFiles('php');
-		foreach ($this->_files as $filePath) {
-			$patterns = [
-				[
-					' Log::config to Configure::write',
-					'#(Log\:\:config\()(\s*[\'"])([^\'"]+)([\'"])#ms',
-					"Configure::write('Log.\\3'",
-				]
-			];
-			$this->_updateFile($filePath, $patterns);
-		}
-		$this->out(__d('cake_console', '<success>Log::config() replaced successfully</success>'));
-	}
-
-/**
- * Update cache configs.
- *
- * @return void
- */
-	public function cache_config() {
-		$path = $this->_getPath();
-
-		$Folder = new Folder($path);
-		$this->_paths = $Folder->tree(null, false, 'dir');
-		$this->_findFiles('php');
-		foreach ($this->_files as $filePath) {
-			$patterns = [
-				[
-					' Cache::config to Configure::write',
-					'#(Cache\:\:config\()(\s*[\'"])([^\'"]+)([\'"])#ms',
-					"Configure::write('Cache.\\3'",
-				]
-			];
-			$this->_updateFile($filePath, $patterns);
-		}
-		$this->out(__d('cake_console', '<success>Cache::config() replaced successfully</success>'));
-	}
-
-/**
  * Update fixtures
  *
  * @return void
@@ -641,14 +593,6 @@ class UpgradeShell extends Shell {
 			])
 			->addSubcommand('rename_collections', [
 				'help' => __d('cake_console', "Rename HelperCollection, ComponentCollection, and TaskCollection. Will also rename component constructor arguments and _Collection properties on all objects."),
-				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')]
-			])
-			->addSubcommand('cache_config', [
-				'help' => __d('cake_console', "Replace Cache::config() with Configure."),
-				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')]
-			])
-			->addSubcommand('log_config', [
-				'help' => __d('cake_console', "Replace CakeLog::config() with Configure."),
 				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')]
 			]);
 	}

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -893,7 +893,7 @@ class Shell extends Object {
 			'types' => ['emergency', 'alert', 'critical', 'error', 'warning'],
 			'stream' => $this->stderr,
 		]);
-		Log::engine('stdout', $stdout);
-		Log::engine('stderr', $stderr);
+		Log::config('stdout', ['engine' => $stdout]);
+		Log::config('stderr', ['engine' => $stderr]);
 	}
 }

--- a/lib/Cake/Log/Log.php
+++ b/lib/Cake/Log/Log.php
@@ -174,8 +174,11 @@ class Log {
  */
 	protected static function _loadConfig() {
 		$loggers = Configure::read('Log');
-		foreach ((array)$loggers as $key => $config) {
-			static::$_registry->load($key, $config);
+		foreach ((array)$loggers as $name => $properties) {
+			if (isset($properties['engine'])) {
+				$properties['className'] = $properties['engine'];
+			}
+			static::$_registry->load($name, $properties);
 		}
 	}
 
@@ -285,7 +288,7 @@ class Log {
 	public static function engine($name, $engine = null) {
 		static::_init();
 		if ($engine) {
-			static::$_registry->load($name, $engine);
+			static::$_registry->add($name, $engine);
 			return;
 		}
 		if (static::$_registry->{$name}) {
@@ -346,7 +349,7 @@ class Log {
 			$level = static::$_levels[$level];
 		}
 		$logged = false;
-		foreach (static::$_registry->enabled() as $streamName) {
+		foreach (static::$_registry->loaded() as $streamName) {
 			$logger = static::$_registry->{$streamName};
 			$levels = $scopes = null;
 			if ($logger instanceof BaseLog) {

--- a/lib/Cake/Log/Log.php
+++ b/lib/Cake/Log/Log.php
@@ -193,18 +193,6 @@ class Log {
 	}
 
 /**
- * @deprecated Use Configure::write() to configure logging.
- * @see App/Config/logging.php
- * @return void
- */
-	public static function config($key, $config) {
-		trigger_error(
-			__d('cake_dev', 'You must use Configure::write() to define logging configuration. Or use engine() to inject new adapter.'),
-			E_USER_WARNING
-		);
-	}
-
-/**
  * Returns the keynames of the currently active streams
  *
  * @return array Array of configured log streams.
@@ -227,6 +215,18 @@ class Log {
 	}
 
 /**
+ * @deprecated Use Configure::write() to configure logging.
+ * @see App/Config/logging.php
+ * @return void
+ */
+	public static function config($key, $config) {
+		trigger_error(
+			__d('cake_dev', 'You must use Configure::write() to define logging configuration. Or use engine() to inject new adapter.'),
+			E_USER_WARNING
+		);
+	}
+
+/**
  * Removes a stream from the active streams.  Once a stream has been removed
  * it will no longer have messages sent to it.
  *
@@ -239,51 +239,39 @@ class Log {
 	}
 
 /**
- * Checks wether $streamName is enabled
+ * Checks whether $streamName is enabled
  *
  * @param string $streamName to check
  * @return bool
  * @throws Cake\Error\Exception
+ * @deprecated This method will be removed in 3.0 stable.
  */
 	public static function enabled($streamName) {
-		static::_init();
-		if (!isset(static::$_registry->{$streamName})) {
-			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
-		}
-		return static::$_registry->enabled($streamName);
+		throw new Error\Exception(__d('cake_dev', 'Log::enabled() is deprecated. Use Log::configured() instead.'));
 	}
 
 /**
- * Enable stream.  Streams that were previously disabled
- * can be re-enabled with this method.
+ * Enable stream.
  *
  * @param string $streamName to enable
  * @return void
  * @throws Cake\Error\Exception
+ * @deprecated This method will be removed in 3.0 stable.
  */
 	public static function enable($streamName) {
-		static::_init();
-		if (!isset(static::$_registry->{$streamName})) {
-			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
-		}
-		static::$_registry->enable($streamName);
+		throw new Error\Exception(__d('cake_dev', 'Log::enable() is deprecated. Use Log::engine() instead.'));
 	}
 
 /**
- * Disable stream.  Disabling a stream will
- * prevent that log stream from receiving any messages until
- * its re-enabled.
+ * Disable stream.
  *
  * @param string $streamName to disable
  * @return void
  * @throws Cake\Error\Exception
+ * @deprecated This method will be removed in 3.0 stable.
  */
 	public static function disable($streamName) {
-		static::_init();
-		if (!isset(static::$_registry->{$streamName})) {
-			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
-		}
-		static::$_registry->disable($streamName);
+		throw new Error\Exception(__d('cake_dev', 'Log::disable() is deprecated. Use Log::drop() instead.'));
 	}
 
 /**

--- a/lib/Cake/Log/Log.php
+++ b/lib/Cake/Log/Log.php
@@ -115,11 +115,11 @@ use Cake\Log\Engine\BaseLog;
 class Log {
 
 /**
- * LogEngineCollection class
+ * LogEngineRegistry class
  *
- * @var LogEngineCollection
+ * @var LogEngineRegistry
  */
-	protected static $_Collection;
+	protected static $_registry;
 
 /**
  * Log levels as detailed in RFC 5424
@@ -160,8 +160,8 @@ class Log {
  * @return void
  */
 	protected static function _init() {
-		if (empty(static::$_Collection)) {
-			static::$_Collection = new LogEngineCollection();
+		if (empty(static::$_registry)) {
+			static::$_registry = new LogEngineRegistry();
 			static::_loadConfig();
 		}
 	}
@@ -175,7 +175,7 @@ class Log {
 	protected static function _loadConfig() {
 		$loggers = Configure::read('Log');
 		foreach ((array)$loggers as $key => $config) {
-			static::$_Collection->load($key, $config);
+			static::$_registry->load($key, $config);
 		}
 	}
 
@@ -189,7 +189,7 @@ class Log {
  * @return void
  */
 	public static function reset() {
-		static::$_Collection = null;
+		static::$_registry = null;
 	}
 
 /**
@@ -211,7 +211,7 @@ class Log {
  */
 	public static function configured() {
 		static::_init();
-		return static::$_Collection->attached();
+		return static::$_registry->loaded();
 	}
 
 /**
@@ -235,7 +235,7 @@ class Log {
  */
 	public static function drop($streamName) {
 		static::_init();
-		static::$_Collection->unload($streamName);
+		static::$_registry->unload($streamName);
 	}
 
 /**
@@ -247,10 +247,10 @@ class Log {
  */
 	public static function enabled($streamName) {
 		static::_init();
-		if (!isset(static::$_Collection->{$streamName})) {
+		if (!isset(static::$_registry->{$streamName})) {
 			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
 		}
-		return static::$_Collection->enabled($streamName);
+		return static::$_registry->enabled($streamName);
 	}
 
 /**
@@ -263,10 +263,10 @@ class Log {
  */
 	public static function enable($streamName) {
 		static::_init();
-		if (!isset(static::$_Collection->{$streamName})) {
+		if (!isset(static::$_registry->{$streamName})) {
 			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
 		}
-		static::$_Collection->enable($streamName);
+		static::$_registry->enable($streamName);
 	}
 
 /**
@@ -280,10 +280,10 @@ class Log {
  */
 	public static function disable($streamName) {
 		static::_init();
-		if (!isset(static::$_Collection->{$streamName})) {
+		if (!isset(static::$_registry->{$streamName})) {
 			throw new Error\Exception(__d('cake_dev', 'Stream %s not found', $streamName));
 		}
-		static::$_Collection->disable($streamName);
+		static::$_registry->disable($streamName);
 	}
 
 /**
@@ -297,11 +297,11 @@ class Log {
 	public static function engine($name, $engine = null) {
 		static::_init();
 		if ($engine) {
-			static::$_Collection->load($name, $engine);
+			static::$_registry->load($name, $engine);
 			return;
 		}
-		if (static::$_Collection->{$name}) {
-			return static::$_Collection->{$name};
+		if (static::$_registry->{$name}) {
+			return static::$_registry->{$name};
 		}
 		return false;
 	}
@@ -358,8 +358,8 @@ class Log {
 			$level = static::$_levels[$level];
 		}
 		$logged = false;
-		foreach (static::$_Collection->enabled() as $streamName) {
-			$logger = static::$_Collection->{$streamName};
+		foreach (static::$_registry->enabled() as $streamName) {
+			$logger = static::$_registry->{$streamName};
 			$levels = $scopes = null;
 			if ($logger instanceof BaseLog) {
 				$levels = $logger->levels();

--- a/lib/Cake/Log/Log.php
+++ b/lib/Cake/Log/Log.php
@@ -248,6 +248,7 @@ class Log {
 			static::$_config[$key] = (array) $config;
 			return;
 		}
+
 		static::$_config = array_merge(static::$_config, $key);
 	}
 
@@ -310,6 +311,7 @@ class Log {
 		if (static::$_registry->{$name}) {
 			return static::$_registry->{$name};
 		}
+
 		return false;
 	}
 

--- a/lib/Cake/Log/LogEngineRegistry.php
+++ b/lib/Cake/Log/LogEngineRegistry.php
@@ -24,7 +24,6 @@ use Cake\Utility\ObjectRegistry;
  */
 class LogEngineRegistry extends ObjectRegistry {
 
-
 /**
  * Resolve a logger classname.
  *
@@ -34,6 +33,9 @@ class LogEngineRegistry extends ObjectRegistry {
  * @return string|false Either the correct classname or false.
  */
 	protected function _resolveClassName($class) {
+		if (is_object($class)) {
+			return $class;
+		}
 		return App::classname($class, 'Log/Engine', 'Log');
 	}
 
@@ -54,43 +56,26 @@ class LogEngineRegistry extends ObjectRegistry {
  * Create the logger instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string $class The classname that is missing.
+ * @param string|LogInterface $class The classname or object to make.
  * @param array $settings An array of settings to use for the logger.
  * @return LogEngine The constructed logger class.
- */
-	protected function _create($class, $settings) {
-		$instance = new $class($settings);
-		$this->_checkInstance($instance);
-		return $instance;
-	}
-
-/**
- * Check an instance to see if it implements the LogInterface.
- *
- * @param mixed $instance The instance to check.
- * @return void
- * @throws Cake\Error\Exception when an object doesn't implement 
+ * @throws Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
-	protected function _checkInstance($instance) {
+	protected function _create($class, $settings) {
+		if (is_object($class)) {
+			$instance = $class;
+		}
+		if (!isset($instance)) {
+			$instance = new $class($settings);
+		}
 		if ($instance instanceof LogInterface) {
-			return;
+			return $instance;
 		}
 		throw new Error\Exception(__d(
 			'cake_dev',
 			'Loggers must implement Cake\Log\LogInterface.'
 		));
-	}
-
-/**
- * Add a logger into a given name.
- *
- * @param string $name The name of the logger.
- * @param Cake\Log\LogInterface $instance A logger implementing LogInterface.
- */
-	public function add($name, $instance) {
-		$this->_checkInstance($instance);
-		$this->_loaded[$name] = $instance;
 	}
 
 /**

--- a/lib/Cake/Log/LogEngineRegistry.php
+++ b/lib/Cake/Log/LogEngineRegistry.php
@@ -36,6 +36,7 @@ class LogEngineRegistry extends ObjectRegistry {
 		if (is_object($class)) {
 			return $class;
 		}
+
 		return App::classname($class, 'Log/Engine', 'Log');
 	}
 
@@ -66,12 +67,15 @@ class LogEngineRegistry extends ObjectRegistry {
 		if (is_object($class)) {
 			$instance = $class;
 		}
+
 		if (!isset($instance)) {
 			$instance = new $class($settings);
 		}
+
 		if ($instance instanceof LogInterface) {
 			return $instance;
 		}
+
 		throw new Error\Exception(__d(
 			'cake_dev',
 			'Loggers must implement Cake\Log\LogInterface.'

--- a/lib/Cake/Log/LogEngineRegistry.php
+++ b/lib/Cake/Log/LogEngineRegistry.php
@@ -24,7 +24,7 @@ use Cake\Utility\ObjectCollection;
  *
  * @package       Cake.Log
  */
-class LogEngineCollection extends ObjectCollection {
+class LogEngineRegistry extends ObjectCollection {
 
 /**
  * Loads/constructs a Log engine.

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -141,7 +141,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException PHPUnit_Framework_Error_Warning
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testWriteNonExistingConfig() {
@@ -151,7 +151,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException PHPUnit_Framework_Error_Warning
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testIncrementNonExistingConfig() {
@@ -161,7 +161,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException PHPUnit_Framework_Error_Warning
+ * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testDecrementNonExistingConfig() {

--- a/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
@@ -43,7 +43,7 @@ class ApcEngineTest extends TestCase {
 		}
 
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.apc', ['engine' => 'Apc', 'prefix' => 'cake_']);
+		Cache::config('apc', ['engine' => 'Apc', 'prefix' => 'cake_']);
 	}
 
 /**
@@ -86,7 +86,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testReadWriteDurationZero() {
-		Configure::write('apc', ['engine' => 'Apc', 'duration' => 0, 'prefix' => 'cake_']);
+		Cache::config('apc', ['engine' => 'Apc', 'duration' => 0, 'prefix' => 'cake_']);
 		Cache::write('zero', 'Should save', 'apc');
 		sleep(1);
 
@@ -214,7 +214,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupsReadWrite() {
-		Configure::write('Cache.apc_groups', [
+		Cache::config('apc_groups', [
 			'engine' => 'Apc',
 			'duration' => 0,
 			'groups' => array('group_a', 'group_b'),
@@ -240,7 +240,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.apc_groups', array(
+		Cache::config('apc_groups', array(
 			'engine' => 'Apc',
 			'duration' => 0,
 			'groups' => array('group_a', 'group_b'),
@@ -259,7 +259,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.apc_groups', array(
+		Cache::config('apc_groups', array(
 			'engine' => 'Apc',
 			'duration' => 0,
 			'groups' => array('group_a', 'group_b'),

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -45,7 +45,7 @@ class FileEngineTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.file_test', [
+		Cache::config('file_test', [
 			'engine' => 'File',
 			'path' => CACHE
 		]);
@@ -162,7 +162,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testSerialize() {
-		Configure::write('Cache.file_test', ['engine' => 'File', 'serialize' => true]);
+		Cache::config('file_test', ['engine' => 'File', 'serialize' => true]);
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test', $data, 'file_test');
 		$this->assertTrue($write);
@@ -181,7 +181,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testClear() {
-		Configure::write('Cache.file_test', ['engine' => 'File', 'duration' => 1]);
+		Cache::config('file_test', ['engine' => 'File', 'duration' => 1]);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test1', $data, 'file_test');
@@ -299,7 +299,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testRemoveWindowsSlashesFromCache() {
-		Configure::write('Cache.windows_test', [
+		Cache::config('windows_test', [
 			'engine' => 'File',
 			'isWindows' => true,
 			'prefix' => null,
@@ -349,13 +349,13 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testWriteQuotedString() {
-		Configure::write('Cache.file_test', array('engine' => 'File', 'path' => TMP . 'tests'));
+		Cache::config('file_test', array('engine' => 'File', 'path' => TMP . 'tests'));
 		Cache::write('App.doubleQuoteTest', '"this is a quoted string"', 'file_test');
 		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
 		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
 
-		Configure::write('Cache.file_test', array('isWindows' => true, 'path' => TMP . 'tests'));
+		Cache::config('file_test', array('isWindows' => true, 'path' => TMP . 'tests'));
 		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
 		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
@@ -371,7 +371,7 @@ class FileEngineTest extends TestCase {
 	public function testPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
 
-		Configure::write('Cache.autocreate', array(
+		Cache::config('autocreate', array(
 			'engine' => 'File',
 			'path' => TMP . 'tests' . DS . 'autocreate'
 		));
@@ -388,7 +388,7 @@ class FileEngineTest extends TestCase {
 		if (DS === '\\') {
 			$this->markTestSkipped('File permission testing does not work on Windows.');
 		}
-		Configure::write('Cache.mask_test', ['engine' => 'File', 'path' => TMP . 'tests']);
+		Cache::config('mask_test', ['engine' => 'File', 'path' => TMP . 'tests']);
 		$data = 'This is some test content';
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
@@ -397,7 +397,7 @@ class FileEngineTest extends TestCase {
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Configure::write('Cache.mask_test', ['engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests']);
+		Cache::config('mask_test', ['engine' => 'File', 'mask' => 0666, 'path' => TMP . 'tests']);
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
 		$expected = '0666';
@@ -405,7 +405,7 @@ class FileEngineTest extends TestCase {
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Configure::write('Cache.mask_test', ['engine' => 'File', 'mask' => 0644, 'path' => TMP . 'tests']);
+		Cache::config('mask_test', ['engine' => 'File', 'mask' => 0644, 'path' => TMP . 'tests']);
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
 		$expected = '0644';
@@ -413,7 +413,7 @@ class FileEngineTest extends TestCase {
 		Cache::delete('masking_test', 'mask_test');
 		Cache::drop('mask_test');
 
-		Configure::write('Cache.mask_test', ['engine' => 'File', 'mask' => 0640, 'path' => TMP . 'tests']);
+		Cache::config('mask_test', ['engine' => 'File', 'mask' => 0640, 'path' => TMP . 'tests']);
 		$write = Cache::write('masking_test', $data, 'mask_test');
 		$result = substr(sprintf('%o', fileperms(TMP . 'tests/cake_masking_test')), -4);
 		$expected = '0640';
@@ -428,7 +428,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupsReadWrite() {
-		Configure::write('Cache.file_groups', [
+		Cache::config('file_groups', [
 			'engine' => 'File',
 			'duration' => 3600,
 			'groups' => array('group_a', 'group_b')
@@ -444,7 +444,7 @@ class FileEngineTest extends TestCase {
  * Test that clearing with repeat writes works properly
  */
 	public function testClearingWithRepeatWrites() {
-		Configure::write('Cache.repeat', [
+		Cache::config('repeat', [
 			'engine' => 'File',
 			'groups' => array('users')
 		]);
@@ -473,7 +473,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.file_groups', [
+		Cache::config('file_groups', [
 			'engine' => 'File',
 			'duration' => 3600,
 			'groups' => array('group_a', 'group_b')
@@ -491,17 +491,17 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.file_groups', [
+		Cache::config('file_groups', [
 			'engine' => 'File',
 			'duration' => 3600,
 			'groups' => array('group_a', 'group_b')
 		]);
-		Configure::write('Cache.file_groups2', [
+		Cache::config('file_groups2', [
 			'engine' => 'File',
 			'duration' => 3600,
 			'groups' => array('group_b')
 		]);
-		Configure::write('Cache.file_groups3', [
+		Cache::config('file_groups3', [
 			'engine' => 'File',
 			'duration' => 3600,
 			'groups' => array('group_b'),

--- a/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
@@ -63,7 +63,7 @@ class MemcacheEngineTest extends TestCase {
 		$this->skipIf(!class_exists('Memcache'), 'Memcache is not installed or configured properly.');
 
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.memcache', array(
+		Cache::config('memcache', array(
 			'engine' => 'Memcache',
 			'prefix' => 'cake_',
 			'duration' => 3600
@@ -97,7 +97,7 @@ class MemcacheEngineTest extends TestCase {
 			'servers' => array('127.0.0.1'),
 			'persistent' => true,
 			'compress' => false,
-			'engine' => 'Memcache',
+			'engine' => 'Cake\Cache\Engine\MemcacheEngine',
 			'groups' => array()
 		);
 		$this->assertEquals($expecting, $settings);
@@ -317,17 +317,17 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testConfigurationConflict() {
-		Configure::write('Cache.long_memcache', [
+		Cache::config('long_memcache', [
 			'engine' => 'Memcache',
 			'duration' => '+2 seconds',
 			'servers' => ['127.0.0.1:11211'],
 		]);
-		Configure::write('Cache.short_memcache', [
+		Cache::config('short_memcache', [
 			'engine' => 'Memcache',
 			'duration' => '+1 seconds',
 			'servers' => ['127.0.0.1:11211'],
 		]);
-		Configure::write('Cache.some_file', ['engine' => 'File']);
+		Cache::config('some_file', ['engine' => 'File']);
 
 		$this->assertTrue(Cache::write('duration_test', 'yay', 'long_memcache'));
 		$this->assertTrue(Cache::write('short_duration_test', 'boo', 'short_memcache'));
@@ -352,7 +352,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testClear() {
-		Configure::write('Cache.memcache2', [
+		Cache::config('memcache2', [
 			'engine' => 'Memcache',
 			'prefix' => 'cake2_',
 			'duration' => 3600
@@ -378,7 +378,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testZeroDuration() {
-		Configure::write('Cache.memcache', [
+		Cache::config('memcache', [
 			'engine' => 'Memcache',
 			'prefix' => 'cake_',
 			'duration' => 0
@@ -417,13 +417,13 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupReadWrite() {
-		Configure::write('Cache.memcache_groups', [
+		Cache::config('memcache_groups', [
 			'engine' => 'Memcache',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b'],
 			'prefix' => 'test_'
 		]);
-		Configure::write('Cache.memcache_helper', [
+		Cache::config('memcache_helper', [
 			'engine' => 'Memcache',
 			'duration' => 3600,
 			'prefix' => 'test_'
@@ -448,7 +448,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.memcache_groups', [
+		Cache::config('memcache_groups', [
 			'engine' => 'Memcache',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b']
@@ -466,7 +466,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.memcache_groups', [
+		Cache::config('memcache_groups', [
 			'engine' => 'Memcache',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b']

--- a/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
@@ -36,7 +36,7 @@ class RedisEngineTest extends TestCase {
 		$this->skipIf(!class_exists('Redis'), 'Redis is not installed or configured properly.');
 
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.redis', array(
+		Cache::config('redis', array(
 			'engine' => 'Cake\Cache\Engine\RedisEngine',
 			'prefix' => 'cake_',
 			'duration' => 3600
@@ -223,7 +223,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testClear() {
-		Configure::write('Cache.redis2', array(
+		Cache::config('redis2', array(
 			'engine' => 'Redis',
 			'prefix' => 'cake2_',
 			'duration' => 3600
@@ -265,13 +265,13 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupReadWrite() {
-		Configure::write('Cache.redis_groups', [
+		Cache::config('redis_groups', [
 			'engine' => 'Redis',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b'],
 			'prefix' => 'test_'
 		]);
-		Configure::write('Cache.redis_helper', [
+		Cache::config('redis_helper', [
 			'engine' => 'Redis',
 			'duration' => 3600,
 			'prefix' => 'test_'
@@ -296,7 +296,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.redis_groups', [
+		Cache::config('redis_groups', [
 			'engine' => 'Redis',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b']
@@ -314,7 +314,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.redis_groups', [
+		Cache::config('redis_groups', [
 			'engine' => 'Redis',
 			'duration' => 3600,
 			'groups' => ['group_a', 'group_b']

--- a/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -39,7 +39,7 @@ class WincacheEngineTest extends TestCase {
 		parent::setUp();
 		$this->skipIf(!function_exists('wincache_ucache_set'), 'Wincache is not installed or configured properly.');
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.wincache', ['engine' => 'Wincache', 'prefix' => 'cake_']);
+		Cache::config('wincache', ['engine' => 'Wincache', 'prefix' => 'cake_']);
 	}
 
 /**
@@ -201,7 +201,7 @@ class WincacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupsReadWrite() {
-		Configure::write('Cache.wincache_groups', [
+		Cache::config('wincache_groups', [
 			'engine' => 'Wincache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],
@@ -227,7 +227,7 @@ class WincacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.wincache_groups', [
+		Cache::config('wincache_groups', [
 			'engine' => 'Wincache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],
@@ -246,7 +246,7 @@ class WincacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.wincache_groups', [
+		Cache::config('wincache_groups', [
 			'engine' => 'Wincache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],

--- a/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -40,7 +40,7 @@ class XcacheEngineTest extends TestCase {
 			$this->markTestSkipped('Xcache is not installed or configured properly');
 		}
 		Configure::write('Cache.disable', false);
-		Configure::write('Cache.xcache', ['engine' => 'Xcache', 'prefix' => 'cake_']);
+		Cache::config('xcache', ['engine' => 'Xcache', 'prefix' => 'cake_']);
 	}
 
 /**
@@ -209,7 +209,7 @@ class XcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupsReadWrite() {
-		Configure::write('Cache.xcache_groups', [
+		Cache::config('xcache_groups', [
 			'engine' => 'Xcache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],
@@ -235,7 +235,7 @@ class XcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupDelete() {
-		Configure::write('Cache.xcache_groups', [
+		Cache::config('xcache_groups', [
 			'engine' => 'Xcache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],
@@ -254,7 +254,7 @@ class XcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testGroupClear() {
-		Configure::write('Cache.xcache_groups', [
+		Cache::config('xcache_groups', [
 			'engine' => 'Xcache',
 			'duration' => 0,
 			'groups' => ['group_a', 'group_b'],

--- a/lib/Cake/Test/TestCase/Console/ShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/ShellTest.php
@@ -833,7 +833,7 @@ TEXT;
 			['write'],
 			[['types' => 'error']]
 		);
-		Log::engine('console', $mock);
+		Log::config('console', ['engine' => $mock]);
 		$mock->expects($this->once())
 			->method('write')
 			->with('error', $this->Shell->testMessage);
@@ -841,6 +841,8 @@ TEXT;
 		$this->assertTrue(file_exists(LOGS . 'error.log'));
 		$contents = file_get_contents(LOGS . 'error.log');
 		$this->assertContains($this->Shell->testMessage, $contents);
+
+		Log::drop('console');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Core/ObjectTest.php
+++ b/lib/Cake/Test/TestCase/Core/ObjectTest.php
@@ -198,8 +198,8 @@ class ObjectTest extends TestCase {
 		$this->object = new TestObject();
 		Configure::write('App.namespace', 'TestApp');
 		Configure::write('Security.salt', 'not-the-default');
-		Log::disable('stdout');
-		Log::disable('stderr');
+		Log::drop('stdout');
+		Log::drop('stderr');
 	}
 
 /**
@@ -210,6 +210,7 @@ class ObjectTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		Plugin::unload();
+		Log::reset();
 		unset($this->object);
 	}
 

--- a/lib/Cake/Test/TestCase/Database/Log/QueryLoggerTest.php
+++ b/lib/Cake/Test/TestCase/Database/Log/QueryLoggerTest.php
@@ -23,16 +23,8 @@ use Cake\Log\Log;
 /**
  * Tests QueryLogger class
  *
- **/
-class QueryLoggerTest extends \Cake\TestSuite\TestCase {
-
-/**
- * Contains a list of disabled logging engines that will be re-enabled
- * on tearDown
- *
- * @var array
  */
-	protected $_disabledEngines = [];
+class QueryLoggerTest extends \Cake\TestSuite\TestCase {
 
 /**
  * Set up
@@ -40,12 +32,8 @@ class QueryLoggerTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function setUp() {
-		foreach (Log::configured() as $e) {
-			if (Log::enabled($e)) {
-				Log::disable($e);
-				$this->_disabledEngines[] = $e;
-			}
-		}
+		parent::setUp();
+		Log::reset();
 	}
 
 /**
@@ -54,11 +42,8 @@ class QueryLoggerTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function tearDown() {
-		Log::drop('queryLoggerTest');
-		Log::drop('queryLoggerTest2');
-		foreach ($this->_disabledEngines as $e) {
-			Log::enable($e);
-		}
+		parent::tearDown();
+		Log::reset();
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Log/LogTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTest.php
@@ -28,13 +28,8 @@ use Cake\TestSuite\TestCase;
  */
 class LogTest extends TestCase {
 
-/**
- * Start test callback, clears all streams enabled.
- *
- * @return void
- */
-	public function setUp() {
-		parent::setUp();
+	public function tearDown() {
+		parent::tearDown();
 		Log::reset();
 	}
 
@@ -51,12 +46,12 @@ class LogTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 		Plugin::load('TestPlugin');
 
-		Configure::write('Log.libtest', array(
+		Log::config('libtest', [
 			'engine' => 'TestApp'
-		));
-		Configure::write('Log.plugintest', array(
+		]);
+		Log::config('plugintest', [
 			'engine' => 'TestPlugin.TestPlugin'
-		));
+		]);
 
 		$result = Log::engine('libtest');
 		$this->assertInstanceOf('TestApp\Log\Engine\TestAppLog', $result);
@@ -80,7 +75,7 @@ class LogTest extends TestCase {
  * @return void
  */
 	public function testImportingLoggerFailure() {
-		Configure::write('Log.fail', array());
+		Log::config('fail', []);
 		Log::engine('fail');
 	}
 
@@ -90,7 +85,7 @@ class LogTest extends TestCase {
  * @return void
  */
 	public function testValidKeyName() {
-		Configure::write('Log.valid', array('engine' => 'File'));
+		Log::config('valid', array('engine' => 'File'));
 		$stream = Log::engine('valid');
 		$this->assertInstanceOf('Cake\Log\Engine\FileLog', $stream);
 	}
@@ -102,7 +97,7 @@ class LogTest extends TestCase {
  * @return void
  */
 	public function testNotImplementingInterface() {
-		Configure::write('Log.fail', array('engine' => '\stdClass'));
+		Log::config('fail', array('engine' => '\stdClass'));
 		Log::engine('fail');
 	}
 
@@ -112,14 +107,13 @@ class LogTest extends TestCase {
  * @return void
  **/
 	public function testDrop() {
-		Configure::write('Log.file', array(
+		Log::config('file', array(
 			'engine' => 'File',
 			'path' => LOGS
 		));
 		$result = Log::configured();
 		$this->assertContains('file', $result);
 
-		Configure::delete('Log.file');
 		Log::drop('file');
 
 		$result = Log::configured();
@@ -134,17 +128,18 @@ class LogTest extends TestCase {
  * @return void
  */
 	public function testEngineInjectErrorOnWrongType() {
-		Log::engine('test', new \StdClass);
+		Log::config('test', ['engine' => new \StdClass]);
+		Log::info('testing');
 	}
 
 /**
- * Test that engine() can add logger instances.
+ * Test that config() can inject instances
  *
  * @return void
  */
-	public function testEngineInjectInstance() {
+	public function testConfigInjectInstance() {
 		$logger = new FileLog();
-		Log::engine('test', $logger);
+		Log::config('test', ['engine' => $logger]);
 		$result = Log::engine('test');
 		$this->assertSame($logger, $result);
 	}
@@ -155,6 +150,7 @@ class LogTest extends TestCase {
  * @return void
  */
 	public function testLogFileWriting() {
+		$this->_resetLogConfig();
 		if (file_exists(LOGS . 'error.log')) {
 			unlink(LOGS . 'error.log');
 		}
@@ -183,12 +179,12 @@ class LogTest extends TestCase {
 		if (file_exists(LOGS . 'eggs.log')) {
 			unlink(LOGS . 'eggs.log');
 		}
-		Configure::write('Log.spam', array(
+		Log::config('spam', array(
 			'engine' => 'File',
 			'types' => 'debug',
 			'file' => 'spam',
 		));
-		Configure::write('Log.eggs', array(
+		Log::config('eggs', array(
 			'engine' => 'File',
 			'types' => array('eggs', 'debug', 'error', 'warning'),
 			'file' => 'eggs',
@@ -244,12 +240,12 @@ class LogTest extends TestCase {
 	}
 
 	protected function _resetLogConfig() {
-		Configure::write('Log.debug', array(
+		Log::config('debug', array(
 			'engine' => 'File',
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
-		Configure::write('Log.error', array(
+		Log::config('error', array(
 			'engine' => 'File',
 			'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 			'file' => 'error',
@@ -285,7 +281,7 @@ class LogTest extends TestCase {
 	public function testScopedLogging() {
 		$this->_deleteLogs();
 		$this->_resetLogConfig();
-		Configure::write('Log.shops', array(
+		Log::config('shops', array(
 			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
@@ -331,7 +327,7 @@ class LogTest extends TestCase {
 		}
 
 		$this->_resetLogConfig();
-		Configure::write('Log.shops', array(
+		Log::config('shops', array(
 			'engine' => 'File',
 			'types' => array('info', 'debug', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
@@ -370,13 +366,13 @@ class LogTest extends TestCase {
 	public function testScopedLoggingExclusive() {
 		$this->_deleteLogs();
 
-		Configure::write('Log.shops', array(
+		Log::config('shops', array(
 			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('transactions', 'orders'),
 			'file' => 'shops.log',
 		));
-		Configure::write('Log.eggs', array(
+		Log::config('eggs', array(
 			'engine' => 'File',
 			'types' => array('info', 'notice', 'warning'),
 			'scopes' => array('eggs'),
@@ -400,12 +396,12 @@ class LogTest extends TestCase {
 	public function testConvenienceMethods() {
 		$this->_deleteLogs();
 
-		Configure::write('Log.debug', array(
+		Log::config('debug', array(
 			'engine' => 'File',
 			'types' => array('notice', 'info', 'debug'),
 			'file' => 'debug',
 		));
-		Configure::write('Log.error', array(
+		Log::config('error', array(
 			'engine' => 'File',
 			'types' => array('emergency', 'alert', 'critical', 'error', 'warning'),
 			'file' => 'error',

--- a/lib/Cake/Test/TestCase/Log/LogTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTest.php
@@ -217,53 +217,30 @@ class LogTest extends TestCase {
 	}
 
 /**
- * test enable
+ * test enable() throws exceptions
  *
  * @expectedException Cake\Error\Exception
  */
 	public function testStreamEnable() {
-		Configure::write('Log.spam', array(
-			'engine' => 'File',
-			'file' => 'spam',
-		));
-		$this->assertTrue(Log::enabled('spam'));
-		Log::drop('spam');
-		Log::enable('bogus_stream');
+		Log::enable('debug');
 	}
 
 /**
- * test disable
+ * test enabled() throws exceptions
+ *
+ * @expectedException Cake\Error\Exception
+ */
+	public function testStreamEnabled() {
+		Log::enabled('debug');
+	}
+
+/**
+ * test disable() throws exceptions
  *
  * @expectedException Cake\Error\Exception
  */
 	public function testStreamDisable() {
-		Configure::write('Log.spam', array(
-			'engine' => 'File',
-			'file' => 'spam',
-		));
-		$this->assertTrue(Log::enabled('spam'));
-		Log::disable('spam');
-		$this->assertFalse(Log::enabled('spam'));
-		Log::drop('spam');
-		Log::enable('bogus_stream');
-	}
-
-/**
- * test enabled() invalid stream
- *
- * @expectedException Cake\Error\Exception
- */
-	public function testStreamEnabledInvalid() {
-		Log::enabled('bogus_stream');
-	}
-
-/**
- * test disable invalid stream
- *
- * @expectedException Cake\Error\Exception
- */
-	public function testStreamDisableInvalid() {
-		Log::disable('bogus_stream');
+		Log::disable('debug');
 	}
 
 	protected function _resetLogConfig() {

--- a/lib/Cake/Test/TestCase/Log/LogTraitTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTraitTest.php
@@ -45,7 +45,7 @@ class LogTraitTest extends TestCase {
 			->method('write')
 			->with('debug', print_r(array(1, 2), true));
 
-		Log::engine('trait_test', $mock);
+		Log::config('trait_test', ['engine' => $mock]);
 		$subject = $this->getObjectForTrait('Cake\Log\LogTrait');
 
 		$subject->log('Testing');

--- a/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/TestCase/Utility/DebuggerTest.php
@@ -444,7 +444,7 @@ TEXT;
  */
 	public function testLog() {
 		$mock = $this->getMock('Cake\Log\Engine\BaseLog', ['write']);
-		Log::engine('test', $mock);
+		Log::config('test', ['engine' => $mock]);
 
 		$mock->expects($this->at(0))
 			->method('write')

--- a/lib/Cake/Test/TestCase/View/ViewTest.php
+++ b/lib/Cake/Test/TestCase/View/ViewTest.php
@@ -751,7 +751,7 @@ class ViewTest extends TestCase {
  */
 	public function testElementCache() {
 		Cache::drop('test_view');
-		Configure::write('Cache.test_view', [
+		Cache::config('test_view', [
 			'engine' => 'File',
 			'duration' => '+1 day',
 			'path' => CACHE . 'views/',

--- a/lib/Cake/Test/init.php
+++ b/lib/Cake/Test/init.php
@@ -13,6 +13,8 @@
  */
 
 use Cake\Core\Configure;
+use Cake\Cache\Cache;
+use Cake\Log\Log;
 
 define('DS', DIRECTORY_SEPARATOR);
 define('ROOT', dirname(dirname(dirname(__DIR__))));
@@ -55,10 +57,12 @@ Configure::write('App', [
 	'cssBaseUrl' => 'css/',
 ]);
 
-Configure::write('Cache._cake_core_', [
-	'engine' => 'File',
-	'prefix' => 'cake_core_',
-	'serialize' => true
+Cache::config([
+	'_cake_core_' => [
+		'engine' => 'File',
+		'prefix' => 'cake_core_',
+		'serialize' => true
+	]
 ]);
 
 Configure::write('Datasource.test', [
@@ -73,16 +77,17 @@ Configure::write('Session', [
 	'defaults' => 'php'
 ]);
 
-Configure::write('Log.debug', [
-	'engine' => 'Cake\Log\Engine\FileLog',
-	'levels' => ['notice', 'info', 'debug'],
-	'file' => 'debug',
-]);
-
-Configure::write('Log.error', [
-	'engine' => 'Cake\Log\Engine\FileLog',
-	'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
-	'file' => 'error',
+Log::config([
+	'debug' => [
+		'engine' => 'Cake\Log\Engine\FileLog',
+		'levels' => ['notice', 'info', 'debug'],
+		'file' => 'debug',
+	],
+	'error' => [
+		'engine' => 'Cake\Log\Engine\FileLog',
+		'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+		'file' => 'error',
+	]
 ]);
 
 $autoloader = new Cake\Core\ClassLoader('TestApp', dirname(__DIR__) . '/Test');


### PR DESCRIPTION
With the new registry objects complete, I thought Log and Cache could benefit from re-using this logic as well. LogEngineCollection uses ObjectCollection presently and inherits a pile of useless behavior. Converting this to a Registry saves some complexity and allows the removal of some seldom used features in Log.

I've also been thinking quite a bit about the changes I did to 'unify configuration' and I think they are a bad idea, and am proposing they be replaced with the code here. Not using Configure to setup caching has a couple benefits.
- Using Configure creates magic at a distance. Setting things in one class creates effects in another. This is the biggest problem.
- Cache engines are always configured the same way. Currently Log adapters have to be configured differently depending on when your code is executed. This is a big smell to me and indicates the whole idea is flawed. Either we shouldn't allow runtime configuration changes or we do. Having 2 separate ways to do things is silly.
- Dropped cache engines won't magically re-create themselves. This is pretty non-obvious and feels wrong to me.
- It is still simple to create cache adapters using configuration files, or inject instances directly.

I feel the new code is simpler, and has no drawbacks when compared to the old Configure based code.
