### PR TITLE
Cakenumber fix

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -597,6 +597,21 @@ class CakeNumberTest extends CakeTestCase {
 	}
 
 /**
+ * test precision() with locales
+ *
+ * @return void
+ */
+	public function testPrecisionLocalized() {
+		$restore = setlocale(LC_NUMERIC, 0);
+
+		$this->skipIf(setlocale(LC_NUMERIC, 'de_DE') === false, "The German locale isn't available.");
+
+		$result = $this->Number->precision(1.234);
+		$this->assertEquals('1,234', $result);
+		setlocale(LC_NUMERIC, $restore);
+	}
+
+/**
  * testToPercentage method
  *
  * @return void

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -84,7 +84,7 @@ class CakeNumber {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::precision
  */
 	public static function precision($value, $precision = 3) {
-		return sprintf("%01.{$precision}F", $value);
+		return sprintf("%01.{$precision}f", $value);
 	}
 
 /**
@@ -99,13 +99,13 @@ class CakeNumber {
 			case $size < 1024:
 				return __dn('cake', '%d Byte', '%d Bytes', $size, $size);
 			case round($size / 1024) < 1024:
-				return __d('cake', '%d KB', self::precision($size / 1024, 0));
+				return __d('cake', '%s KB', self::precision($size / 1024, 0));
 			case round($size / 1024 / 1024, 2) < 1024:
-				return __d('cake', '%.2f MB', self::precision($size / 1024 / 1024, 2));
+				return __d('cake', '%s MB', self::precision($size / 1024 / 1024, 2));
 			case round($size / 1024 / 1024 / 1024, 2) < 1024:
-				return __d('cake', '%.2f GB', self::precision($size / 1024 / 1024 / 1024, 2));
+				return __d('cake', '%s GB', self::precision($size / 1024 / 1024 / 1024, 2));
 			default:
-				return __d('cake', '%.2f TB', self::precision($size / 1024 / 1024 / 1024 / 1024, 2));
+				return __d('cake', '%s TB', self::precision($size / 1024 / 1024 / 1024 / 1024, 2));
 		}
 	}
 


### PR DESCRIPTION
Fixes formatting with locales using , as decimal separator in CakeNumber precision. This is a repair fix for the fix in ticket #2958 (https://cakephp.lighthouseapp.com/projects/42648/tickets/2958-cakenumber-precision).
