### PR TITLE
Properly test locale settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         - PHPCS=1
 
 before_script:
+  - sudo locale-gen de_DE
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test3;'; fi"

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -587,12 +587,14 @@ class CakeNumberTest extends CakeTestCase {
  */
 	public function testReadableSizeLocalized() {
 		$restore = setlocale(LC_NUMERIC, 0);
-		setlocale(LC_NUMERIC, 'de_DE');
+
+		$this->skipIf(setlocale(LC_NUMERIC, 'de_DE') === false, "The German locale isn't available.");
+
 		$result = $this->Number->toReadableSize(1321205);
-		$this->assertRegExp('/1[,.]26 MB/', $result);
+		$this->assertEquals('1,26 MB', $result);
 
 		$result = $this->Number->toReadableSize(1024 * 1024 * 1024 * 512);
-		$this->assertRegExp('/512[,.]00 GB/', $result);
+		$this->assertEquals('512,00 GB', $result);
 		setlocale(LC_NUMERIC, $restore);
 	}
 


### PR DESCRIPTION
The test always passed, making it completely useless. This PR refactors the test so that it is skipped with a message if the locale isn't available and assert properly if it is.

Also adds the locale to the install script of Travis so that the test isn't skipped. If you look closely to the test results, you'll see the number of skipped tests and the number of passes remains the same with the previous build indicating it works.

Reference: #1520
