### PR TITLE
Added workaround for strtotime("0000-00-00 00:00:00") returning -6216995...

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -583,6 +583,9 @@ class CakeTimeTest extends CakeTestCase {
 
 		$result = $this->Time->format('nonsense', '%d-%m-%Y', 'invalid', 'UTC');
 		$this->assertEquals('invalid', $result);
+
+		$result = $this->Time->format('0000-00-00', '%d-%m-%Y', 'invalid');
+		$this->assertEquals('invalid', $result);
 	}
 
 /**

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -328,7 +328,12 @@ class CakeTime {
 		} elseif ($dateString instanceof DateTime) {
 			$date = (int)$dateString->format('U');
 		} else {
-			$date = strtotime($dateString);
+			// workaround for strtotime("0000-00-00 00:00:00") returning -62169955200 on a 64 bit system.
+			if (substr($dateString, 0, 10) === '0000-00-00') {
+				$date = false;
+			} else {
+				$date = strtotime($dateString);
+			}
 		}
 
 		if ($date === -1 || empty($date)) {

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -316,6 +316,11 @@ class CakeTime {
 			return false;
 		}
 
+		$containsDummyDate = (is_string($dateString) && substr($dateString, 0, 10) === '0000-00-00');
+		if ($containsDummyDate) {
+			return false;
+		}
+
 		if (is_int($dateString) || is_numeric($dateString)) {
 			$date = intval($dateString);
 		} elseif (
@@ -328,12 +333,7 @@ class CakeTime {
 		} elseif ($dateString instanceof DateTime) {
 			$date = (int)$dateString->format('U');
 		} else {
-			// workaround for strtotime("0000-00-00 00:00:00") returning -62169955200 on a 64 bit system.
-			if (substr($dateString, 0, 10) === '0000-00-00') {
-				$date = false;
-			} else {
-				$date = strtotime($dateString);
-			}
+			$date = strtotime($dateString);
 		}
 
 		if ($date === -1 || empty($date)) {


### PR DESCRIPTION
Conform docs (http://api.cakephp.org/2.3/class-CakeTime.html#_format) CakeTime::format should return the passed default when invalid date is passed (for example: 0000-00-00).
This patch will fix the function when used on 64 bit system, because strtotime will return a negative integer on those systems for date strings with only zeros.
