### PR TITLE
RedirectRoute with persist and custom route elements doesn't work as expected

### DIFF
--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -80,6 +80,13 @@ class RedirectRoute extends CakeRoute {
 		}
 		if (isset($this->options['persist']) && is_array($redirect)) {
 			$redirect += array('named' => $params['named'], 'pass' => $params['pass'], 'url' => array());
+			if (is_array($this->options['persist'])) {
+				foreach ($this->options['persist'] as $elem) {
+					if (isset($params[$elem])) {
+						$redirect[$elem] = $params[$elem];
+					}
+				}
+			}
 			$redirect = Router::reverse($redirect);
 		}
 		$status = 301;

--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -80,6 +80,11 @@ class RedirectRoute extends CakeRoute {
 		}
 		if (isset($this->options['persist']) && is_array($redirect)) {
 			$redirect += array('named' => $params['named'], 'pass' => $params['pass'], 'url' => array());
+			if(is_array($this->options['persist'])) {
+				foreach($this->options['persist'] as $elem) {
+					if(isset($params[$elem])) $redirect[$elem] = $params[$elem];
+				}
+			}
 			$redirect = Router::reverse($redirect);
 		}
 		$status = 301;

--- a/lib/Cake/Routing/Route/RedirectRoute.php
+++ b/lib/Cake/Routing/Route/RedirectRoute.php
@@ -80,9 +80,11 @@ class RedirectRoute extends CakeRoute {
 		}
 		if (isset($this->options['persist']) && is_array($redirect)) {
 			$redirect += array('named' => $params['named'], 'pass' => $params['pass'], 'url' => array());
-			if(is_array($this->options['persist'])) {
-				foreach($this->options['persist'] as $elem) {
-					if(isset($params[$elem])) $redirect[$elem] = $params[$elem];
+			if (is_array($this->options['persist'])) {
+				foreach ($this->options['persist'] as $elem) {
+					if (isset($params[$elem])) {
+						$redirect[$elem] = $params[$elem];
+					}
 				}
 			}
 			$redirect = Router::reverse($redirect);

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -103,6 +103,22 @@ class RedirectRouteTest extends CakeTestCase {
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
 		$header = $route->response->header();
 		$this->assertEquals(Router::url('/tags/add', true), $header['Location']);
+
+		$route = new RedirectRoute('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$route->stop = false;
+		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
+		$result = $route->parse('/nl/my_controllers/');
+		$header = $route->response->header();
+		$this->assertEquals(Router::url('/tags/add/lang:nl', true), $header['Location']);
+
+		Router::$routes = array(); // reset default routes
+		Router::connect('/:lang/preferred_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$route = new RedirectRoute('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$route->stop = false;
+		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
+		$result = $route->parse('/nl/my_controllers/');
+		$header = $route->response->header();
+		$this->assertEquals(Router::url('/nl/preferred_controllers', true), $header['Location']);
 	}
 
 }

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -113,8 +113,7 @@ class RedirectRouteTest extends CakeTestCase {
 
 		Router::$routes = array(); // reset default routes
 		Router::connect('/:lang/preferred_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
-		$allRoutes = Router::redirect('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
-		$route = end($allRoutes);
+		$route = new RedirectRoute('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
 		$route->stop = false;
 		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
 		$result = $route->parse('/nl/my_controllers/');

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -103,6 +103,13 @@ class RedirectRouteTest extends CakeTestCase {
 		$result = $route->parse('/my_controllers/do_something/passme/named:param');
 		$header = $route->response->header();
 		$this->assertEquals(Router::url('/tags/add', true), $header['Location']);
+
+		$route = new RedirectRoute('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$route->stop = false;
+		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
+		$result = $route->parse('/nl/my_controllers/');
+		$header = $route->response->header();
+		$this->assertEquals(Router::url('/tags/add/lang:nl', true), $header['Location']);
 	}
 
 }

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -110,6 +110,16 @@ class RedirectRouteTest extends CakeTestCase {
 		$result = $route->parse('/nl/my_controllers/');
 		$header = $route->response->header();
 		$this->assertEquals(Router::url('/tags/add/lang:nl', true), $header['Location']);
+
+		Router::$routes = array(); // reset default routes
+		Router::connect('/:lang/preferred_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$allRoutes = Router::redirect('/:lang/my_controllers', array('controller' => 'tags', 'action' => 'add'), array('lang' => '(nl|en)', 'persist' => array('lang')));
+		$route = end($allRoutes);
+		$route->stop = false;
+		$route->response = $this->getMock('CakeResponse', array('_sendHeader'));
+		$result = $route->parse('/nl/my_controllers/');
+		$header = $route->response->header();
+		$this->assertEquals(Router::url('/nl/preferred_controllers', true), $header['Location']);
 	}
 
 }


### PR DESCRIPTION
Custom router element values such as `'/:lang/rest-of-url'` are not 'copied' to the redirect url when using the `persist` option. See the test-cases.

Here, the value of `persist` must be an array containing element names.
