### PR TITLE
unify null checks - avoid method call in favor of strict check

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -407,7 +407,7 @@ class ControllerTask extends BakeTask {
  * @return array Set of controllers
  */
 	public function listAll($useDbConfig = null) {
-		if (is_null($useDbConfig)) {
+		if ($useDbConfig === null) {
 			$useDbConfig = $this->connection;
 		}
 		$this->__tables = $this->Model->getAllTables($useDbConfig);

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -219,7 +219,7 @@ class FixtureTask extends BakeTask {
 		}
 
 		$tableInfo = $data['tables'][$useTable];
-		if (is_null($modelImport)) {
+		if ($modelImport === null) {
 			$schema = $this->_generateSchema($tableInfo);
 		}
 

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -661,7 +661,7 @@ class AuthComponent extends Component {
  * @return string Redirect URL
  */
 	public function redirectUrl($url = null) {
-		if (!is_null($url)) {
+		if ($url !== null) {
 			$redir = $url;
 			$this->Session->write('Auth.redirect', $redir);
 		} elseif ($this->Session->check('Auth.redirect')) {

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -219,7 +219,7 @@ class CookieComponent extends Component {
 			$this->read();
 		}
 
-		if (is_null($encrypt)) {
+		if ($encrypt === null) {
 			$encrypt = true;
 		}
 		$this->_encrypted = $encrypt;
@@ -262,7 +262,7 @@ class CookieComponent extends Component {
 		if (empty($this->_values[$this->name])) {
 			$this->_values[$this->name] = array();
 		}
-		if (is_null($key)) {
+		if ($key === null) {
 			return $this->_values[$this->name];
 		}
 
@@ -387,7 +387,7 @@ class CookieComponent extends Component {
  * @return integer Unix timestamp
  */
 	protected function _expire($expires = null) {
-		if (is_null($expires)) {
+		if ($expires === null) {
 			return $this->_expires;
 		}
 		$this->_reset = $this->_expires;

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -228,7 +228,7 @@ class CakePlugin {
  * @return void
  */
 	public static function unload($plugin = null) {
-		if (is_null($plugin)) {
+		if ($plugin === null) {
 			self::$_plugins = array();
 		} else {
 			unset(self::$_plugins[$plugin]);

--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -161,7 +161,7 @@ class I18n {
 			$_this->_lang = $lang;
 		}
 
-		if (is_null($domain)) {
+		if ($domain === null) {
 			$domain = self::$defaultDomain;
 		}
 		if ($domain === '') {

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -513,7 +513,7 @@ class TranslateBehavior extends ModelBehavior {
  * @return mixed string or false
  */
 	protected function _getLocale(Model $Model) {
-		if (!isset($Model->locale) || is_null($Model->locale)) {
+		if (!isset($Model->locale) || $Model->locale === null) {
 			$I18n = I18n::getInstance();
 			$I18n->l10n->get(Configure::read('Config.language'));
 			$Model->locale = $I18n->l10n->locale;
@@ -588,7 +588,7 @@ class TranslateBehavior extends ModelBehavior {
 
 			$this->_removeField($Model, $field);
 
-			if (is_null($association)) {
+			if ($association === null) {
 				if ($reset) {
 					$this->runtime[$Model->alias]['fields'][] = $field;
 				} else {
@@ -677,7 +677,7 @@ class TranslateBehavior extends ModelBehavior {
 
 			$this->_removeField($Model, $field);
 
-			if (!is_null($association) && (isset($Model->hasMany[$association]) || isset($Model->__backAssociation['hasMany'][$association]))) {
+			if ($association !== null && (isset($Model->hasMany[$association]) || isset($Model->__backAssociation['hasMany'][$association]))) {
 				$associations[] = $association;
 			}
 		}

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -307,7 +307,7 @@ class TreeBehavior extends ModelBehavior {
 
 		extract($this->settings[$Model->alias]);
 
-		if (!is_null($overrideRecursive)) {
+		if ($overrideRecursive !== null) {
 			$recursive = $overrideRecursive;
 		}
 		if (!$order) {
@@ -353,7 +353,7 @@ class TreeBehavior extends ModelBehavior {
 	public function generateTreeList(Model $Model, $conditions = null, $keyPath = null, $valuePath = null, $spacer = '_', $recursive = null) {
 		$overrideRecursive = $recursive;
 		extract($this->settings[$Model->alias]);
-		if (!is_null($overrideRecursive)) {
+		if ($overrideRecursive !== null) {
 			$recursive = $overrideRecursive;
 		}
 
@@ -415,7 +415,7 @@ class TreeBehavior extends ModelBehavior {
 			$id = $Model->id;
 		}
 		extract($this->settings[$Model->alias]);
-		if (!is_null($overrideRecursive)) {
+		if ($overrideRecursive !== null) {
 			$recursive = $overrideRecursive;
 		}
 		$parentId = $Model->find('first', array('conditions' => array($Model->primaryKey => $id), 'fields' => array($parent), 'recursive' => -1));
@@ -448,7 +448,7 @@ class TreeBehavior extends ModelBehavior {
 			$id = $Model->id;
 		}
 		extract($this->settings[$Model->alias]);
-		if (!is_null($overrideRecursive)) {
+		if ($overrideRecursive !== null) {
 			$recursive = $overrideRecursive;
 		}
 		$result = $Model->find('first', array('conditions' => array($Model->escapeField() => $id), 'fields' => array($left, $right), 'recursive' => $recursive));
@@ -817,7 +817,7 @@ class TreeBehavior extends ModelBehavior {
 		))));
 
 		foreach ($Model->find('all', array('conditions' => $scope, 'recursive' => 0)) as $instance) {
-			if (is_null($instance[$Model->alias][$left]) || is_null($instance[$Model->alias][$right])) {
+			if ($instance[$Model->alias][$left] === null || $instance[$Model->alias][$right] === null) {
 				$errors[] = array('node', $instance[$Model->alias][$Model->primaryKey],
 					'has invalid left or right values');
 			} elseif ($instance[$Model->alias][$left] == $instance[$Model->alias][$right]) {

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -366,7 +366,7 @@ class CakeSession {
 		if (!self::start()) {
 			return false;
 		}
-		if (is_null($name)) {
+		if ($name === null) {
 			return self::_returnSessionVars();
 		}
 		if (empty($name)) {

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -657,7 +657,7 @@ class Mysql extends DboSource {
  * @return string Formatted length part of an index field
  */
 	protected function _buildIndexSubPart($lengths, $column) {
-		if (is_null($lengths)) {
+		if ($lengths === null) {
 			return '';
 		}
 		if (!isset($lengths[$column])) {

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -748,11 +748,11 @@ class Postgres extends DboSource {
 
 				switch ($type) {
 					case 'bool':
-						$resultRow[$table][$column] = is_null($row[$index]) ? null : $this->boolean($row[$index]);
+						$resultRow[$table][$column] = $row[$index] === null ? null : $this->boolean($row[$index]);
 						break;
 					case 'binary':
 					case 'bytea':
-						$resultRow[$table][$column] = is_null($row[$index]) ? null : stream_get_contents($row[$index]);
+						$resultRow[$table][$column] = $row[$index] === null ? null : stream_get_contents($row[$index]);
 						break;
 					default:
 						$resultRow[$table][$column] = $row[$index];

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -357,7 +357,7 @@ class Sqlite extends DboSource {
 			foreach ($this->map as $col => $meta) {
 				list($table, $column, $type) = $meta;
 				$resultRow[$table][$column] = $row[$col];
-				if ($type === 'boolean' && !is_null($row[$col])) {
+				if ($type === 'boolean' && $row[$col] !== null) {
 					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
 				}
 			}

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -615,7 +615,7 @@ class Sqlserver extends DboSource {
 					continue;
 				}
 				$resultRow[$table][$column] = $row[$col];
-				if ($type === 'boolean' && !is_null($row[$col])) {
+				if ($type === 'boolean' && $row[$col] !== null) {
 					$resultRow[$table][$column] = $this->boolean($resultRow[$table][$column]);
 				}
 			}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1035,7 +1035,7 @@ class DboSource extends DataSource {
 			$recursive = $queryData['recursive'];
 		}
 
-		if (!is_null($recursive)) {
+		if ($recursive !== null) {
 			$_recursive = $model->recursive;
 			$model->recursive = $recursive;
 		}
@@ -1123,7 +1123,7 @@ class DboSource extends DataSource {
 			}
 		}
 
-		if (!is_null($recursive)) {
+		if ($recursive !== null) {
 			$model->recursive = $_recursive;
 		}
 		return $resultSet;

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2693,7 +2693,7 @@ class Model extends Object implements CakeEventListener {
 		$this->id = $this->getID();
 
 		$query = $this->buildQuery($type, $query);
-		if (is_null($query)) {
+		if ($query === null) {
 			return null;
 		}
 

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -514,7 +514,7 @@ class CakeResponse {
  */
 	protected function _sendHeader($name, $value = null) {
 		if (!headers_sent()) {
-			if (is_null($value)) {
+			if ($value === null) {
 				header($name);
 			} else {
 				header("{$name}: {$value}");
@@ -560,7 +560,7 @@ class CakeResponse {
  * @return array list of headers to be sent
  */
 	public function header($header = null, $value = null) {
-		if (is_null($header)) {
+		if ($header === null) {
 			return $this->_headers;
 		}
 		if (is_array($header)) {
@@ -574,7 +574,7 @@ class CakeResponse {
 			return $this->_headers;
 		}
 
-		if (!is_null($value)) {
+		if ($value !== null) {
 			$this->_headers[$header] = $value;
 			return $this->_headers;
 		}
@@ -592,7 +592,7 @@ class CakeResponse {
  * @return string current message buffer if $content param is passed as null
  */
 	public function body($content = null) {
-		if (is_null($content)) {
+		if ($content === null) {
 			return $this->_body;
 		}
 		return $this->_body = $content;
@@ -607,7 +607,7 @@ class CakeResponse {
  * @throws CakeException When an unknown status code is reached.
  */
 	public function statusCode($code = null) {
-		if (is_null($code)) {
+		if ($code === null) {
 			return $this->_status;
 		}
 		if (!isset($this->_statusCodes[$code])) {
@@ -676,7 +676,7 @@ class CakeResponse {
  * @return mixed current content type or false if supplied an invalid content type
  */
 	public function type($contentType = null) {
-		if (is_null($contentType)) {
+		if ($contentType === null) {
 			return $this->_contentType;
 		}
 		if (is_array($contentType)) {
@@ -741,7 +741,7 @@ class CakeResponse {
  * @return string current charset
  */
 	public function charset($charset = null) {
-		if (is_null($charset)) {
+		if ($charset === null) {
 			return $this->_charset;
 		}
 		return $this->_charset = $charset;
@@ -1248,7 +1248,7 @@ class CakeResponse {
 
 		$extension = strtolower($file->ext());
 		$download = $options['download'];
-		if ((!$extension || $this->type($extension) === false) && is_null($download)) {
+		if ((!$extension || $this->type($extension) === false) && $download === null) {
 			$download = true;
 		}
 
@@ -1265,7 +1265,7 @@ class CakeResponse {
 			if (!empty($contentType)) {
 				$this->type($contentType);
 			}
-			if (is_null($options['name'])) {
+			if ($options['name'] === null) {
 				$name = $file->name;
 			} else {
 				$name = $options['name'];

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -231,7 +231,7 @@ class SmtpTransport extends AbstractTransport {
  * @throws SocketException
  */
 	protected function _smtpSend($data, $checkCode = '250') {
-		if (!is_null($data)) {
+		if ($data !== null) {
 			$this->_socket->write($data . "\r\n");
 		}
 		while ($checkCode !== false) {

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -536,7 +536,7 @@ class HttpSocket extends CakeSocket {
  * @return mixed Either false on failure or a string containing the composed URL.
  */
 	public function url($url = null, $uriTemplate = null) {
-		if (is_null($url)) {
+		if ($url === null) {
 			$url = '/';
 		}
 		if (is_string($url)) {

--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -138,7 +138,7 @@ class HttpSocketResponse implements ArrayAccess {
  * @return boolean
  */
 	public function isRedirect() {
-		return in_array($this->code, array(301, 302, 303, 307)) && !is_null($this->getHeader('Location'));
+		return in_array($this->code, array(301, 302, 303, 307)) && $this->getHeader('Location') !== null;
 	}
 
 /**

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -175,7 +175,7 @@ class Router {
  * @throws RouterException
  */
 	public static function defaultRouteClass($routeClass = null) {
-		if (is_null($routeClass)) {
+		if ($routeClass === null) {
 			return self::$_routeClass;
 		}
 

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -588,7 +588,7 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertFalse($result, 'Save occurred even when with models failed. %s');
 		$this->assertEquals($expectedError, $JoinThing->validationErrors);
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
-		$this->assertSame($count, 0);
+		$this->assertSame(0, $count);
 
 		$data = array(
 			'Something' => array(
@@ -651,7 +651,7 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertEquals($expectedError, $JoinThing->validationErrors);
 
 		$count = $Something->find('count', array('conditions' => array('Something.id' => $data['Something']['id'])));
-		$this->assertSame($count, 0);
+		$this->assertSame(0, $count);
 
 		$joinRecords = $JoinThing->find('count', array(
 			'conditions' => array('JoinThing.something_id' => $data['Something']['id'])
@@ -692,11 +692,11 @@ class ModelValidationTest extends BaseModelTest {
 		$Author->create();
 		$result = $Author->saveAll($data, array('validate' => 'first'));
 		$this->assertTrue($result);
-		$this->assertFalse($Author->id === null);
+		$this->assertNotNull($Author->id);
 
 		$id = $Author->id;
 		$count = $Author->find('count', array('conditions' => array('Author.id' => $id)));
-		$this->assertSame($count, 1);
+		$this->assertSame(1, $count);
 
 		$count = $Post->find('count', array(
 			'conditions' => array('Post.author_id' => $id)
@@ -2315,7 +2315,7 @@ class ModelValidationTest extends BaseModelTest {
 				),
 			),
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -2376,7 +2376,7 @@ class ModelValidationTest extends BaseModelTest {
 				),
 			),
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -692,7 +692,7 @@ class ModelValidationTest extends BaseModelTest {
 		$Author->create();
 		$result = $Author->saveAll($data, array('validate' => 'first'));
 		$this->assertTrue($result);
-		$this->assertFalse(is_null($Author->id));
+		$this->assertFalse($Author->id === null);
 
 		$id = $Author->id;
 		$count = $Author->find('count', array('conditions' => array('Author.id' => $id)));

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -217,19 +217,19 @@ class FileTest extends CakeTestCase {
 		$this->assertTrue(is_resource($this->File->handle));
 
 		$result = $this->File->offset();
-		$expecting = 0;
-		$this->assertSame($result, $expecting);
+		$expected = 0;
+		$this->assertSame($expected, $result);
 
 		$data = file_get_contents(__FILE__);
 		$success = $this->File->offset(5);
-		$expecting = substr($data, 5, 3);
+		$expected = substr($data, 5, 3);
 		$result = $this->File->read(3);
 		$this->assertTrue($success);
-		$this->assertEquals($expecting, $result);
+		$this->assertEquals($expected, $result);
 
 		$result = $this->File->offset();
-		$expecting = 5 + 3;
-		$this->assertSame($result, $expecting);
+		$expected = 5 + 3;
+		$this->assertSame($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -2209,7 +2209,7 @@ class HashTest extends CakeTestCase {
 				)
 			)
 		);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$data = array('a.b.100.a' => null, 'a.b.200.a' => null);
 		$expected = array(

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -693,7 +693,7 @@ abstract class CakeTestCase extends PHPUnit_Framework_TestCase {
  * @return Model
  */
 	public function getMockForModel($model, $methods = array(), $config = null) {
-		if (is_null($config)) {
+		if ($config === null) {
 			$config = ClassRegistry::config('Model');
 		}
 

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -248,7 +248,7 @@ class CakeTime {
  */
 	public static function convert($serverTime, $timezone) {
 		static $serverTimezone = null;
-		if (is_null($serverTimezone) || (date_default_timezone_get() !== $serverTimezone->getName())) {
+		if ($serverTimezone === null || (date_default_timezone_get() !== $serverTimezone->getName())) {
 			$serverTimezone = new DateTimeZone(date_default_timezone_get());
 		}
 		$serverOffset = $serverTimezone->getOffset(new DateTime('@' . $serverTime));
@@ -647,7 +647,7 @@ class CakeTime {
 	public static function toRSS($dateString, $timezone = null) {
 		$date = self::fromString($dateString, $timezone);
 
-		if (is_null($timezone)) {
+		if ($timezone === null) {
 			return date("r", $date);
 		}
 

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -289,7 +289,7 @@ class ClassRegistry {
 		if (empty($param) && is_array($type)) {
 			$param = $type;
 			$type = 'Model';
-		} elseif (is_null($param)) {
+		} elseif ($param === null) {
 			unset($_this->_config[$type]);
 		} elseif (empty($param) && is_string($type)) {
 			return isset($_this->_config[$type]) ? $_this->_config[$type] : null;

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -706,7 +706,7 @@ class Debugger {
 		$self = Debugger::getInstance();
 		$data = null;
 
-		if (is_null($format)) {
+		if ($format === null) {
 			return Debugger::outputAs();
 		}
 
@@ -815,7 +815,7 @@ class Debugger {
 		if (is_object($var)) {
 			return get_class($var);
 		}
-		if (is_null($var)) {
+		if ($var === null) {
 			return 'null';
 		}
 		if (is_string($var)) {

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -395,7 +395,7 @@ class File {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::pwd
  */
 	public function pwd() {
-		if (is_null($this->path)) {
+		if ($this->path === null) {
 			$this->path = $this->Folder->slashTerm($this->Folder->pwd()) . $this->name;
 		}
 		return $this->path;

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -816,7 +816,7 @@ class Hash {
 		$stack = array();
 		foreach ($data as $k => $r) {
 			$id = $k;
-			if (!is_null($key)) {
+			if ($key !== null) {
 				$id = $key;
 			}
 			if (is_array($r) && !empty($r)) {

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -225,7 +225,7 @@ abstract class ObjectCollection {
 		}
 		foreach ($name as $object => $objectPriority) {
 			if (isset($this->_loaded[$object])) {
-				if (is_null($objectPriority)) {
+				if ($objectPriority === null) {
 					$objectPriority = $this->defaultPriority;
 				}
 				$this->_loaded[$object]->settings['priority'] = $objectPriority;

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -935,7 +935,7 @@ class Set {
 		$stack = array();
 		foreach ($results as $k => $r) {
 			$id = $k;
-			if (!is_null($key)) {
+			if ($key !== null) {
 				$id = $key;
 			}
 			if (is_array($r) && !empty($r)) {

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -149,7 +149,7 @@ class Validation {
 			return false;
 		}
 
-		if (!is_null($regex)) {
+		if ($regex !== null) {
 			if (self::_check($check, $regex)) {
 				return self::luhn($check, $deep);
 			}
@@ -295,7 +295,7 @@ class Validation {
  * @return boolean Success
  */
 	public static function date($check, $format = 'ymd', $regex = null) {
-		if (!is_null($regex)) {
+		if ($regex !== null) {
 			return self::_check($check, $regex);
 		}
 
@@ -386,7 +386,7 @@ class Validation {
  * @return boolean Success
  */
 	public static function decimal($check, $places = null, $regex = null) {
-		if (is_null($regex)) {
+		if ($regex === null) {
 			$lnum = '[0-9]+';
 			$dnum = "[0-9]*[\.]{$lnum}";
 			$sign = '[+-]?';
@@ -426,7 +426,7 @@ class Validation {
 			extract(self::_defaults($check));
 		}
 
-		if (is_null($regex)) {
+		if ($regex === null) {
 			$regex = '/^[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+\/=?^_`{|}~-]+)*@' . self::$_pattern['hostname'] . '$/i';
 		}
 		$return = self::_check($check, $regex);
@@ -608,7 +608,7 @@ class Validation {
 			extract(self::_defaults($check));
 		}
 
-		if (is_null($regex)) {
+		if ($regex === null) {
 			switch ($country) {
 				case 'us':
 				case 'all':
@@ -638,7 +638,7 @@ class Validation {
 			extract(self::_defaults($check));
 		}
 
-		if (is_null($regex)) {
+		if ($regex === null) {
 			switch ($country) {
 				case 'uk':
 					$regex = '/\\A\\b[A-Z]{1,2}[0-9][A-Z0-9]? [0-9][ABD-HJLNP-UW-Z]{2}\\b\\z/i';
@@ -699,7 +699,7 @@ class Validation {
 			extract(self::_defaults($check));
 		}
 
-		if (is_null($regex)) {
+		if ($regex === null) {
 			switch ($country) {
 				case 'dk':
 					$regex = '/\\A\\b[0-9]{6}-[0-9]{4}\\b\\z/i';

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -310,7 +310,7 @@ class Xml {
 		}
 
 		$child = $dom->createElement($key);
-		if (!is_null($childValue)) {
+		if ($childValue !== null) {
 			$child->appendChild($dom->createTextNode($childValue));
 		}
 		if ($childNS) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2864,7 +2864,7 @@ class FormHelper extends AppHelper {
  * @return array inputDefaults
  */
 	public function inputDefaults($defaults = null, $merge = false) {
-		if (!is_null($defaults)) {
+		if ($defaults !== null) {
 			if ($merge) {
 				$this->_inputDefaults = array_merge($this->_inputDefaults, (array)$defaults);
 			} else {

--- a/lib/Cake/View/Helper/RssHelper.php
+++ b/lib/Cake/View/Helper/RssHelper.php
@@ -260,7 +260,7 @@ class RssHelper extends AppHelper {
 				default:
 					$attrib = $att;
 			}
-			if (!is_null($val) && $escape) {
+			if ($val !== null && $escape) {
 				$val = h($val);
 			}
 			$elements[$key] = $this->elem($key, $attrib, $val);

--- a/lib/Cake/View/ScaffoldView.php
+++ b/lib/Cake/View/ScaffoldView.php
@@ -58,7 +58,7 @@ class ScaffoldView extends View {
 
 		$scaffoldAction = 'scaffold.' . $name;
 
-		if (!is_null($this->subDir)) {
+		if ($this->subDir !== null) {
 			$subDir = strtolower($this->subDir) . DS;
 		} else {
 			$subDir = null;

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -972,7 +972,7 @@ class View extends Object {
 	protected function _getViewFileName($name = null) {
 		$subDir = null;
 
-		if (!is_null($this->subDir)) {
+		if ($this->subDir !== null) {
 			$subDir = $this->subDir . DS;
 		}
 
@@ -1054,7 +1054,7 @@ class View extends Object {
 		}
 		$subDir = null;
 
-		if (!is_null($this->layoutPath)) {
+		if ($this->layoutPath !== null) {
 			$subDir = $this->layoutPath . DS;
 		}
 		list($plugin, $name) = $this->pluginSplit($name);


### PR DESCRIPTION
Most of the code uses `=== null`. Only some places use `is_null()` - and a few mix those even in the same method.
This unifies it.

As a side note:
It also slightly increases performance. There is no need to invoke a method for a simple `=== null` check. This is not noticeable for some higher methods, but some Utility ones like in Hash or CakeTime class might be used quite a few times per request, so there it might make a difference in the long run, as well.

Also corrected the last wrong assert method param orders.

EDIT:
I did not touch the comparisons in https://github.com/cakephp/cakephp/blob/master/lib/Cake/Model/CakeSchema.php#L554 by the way.
As there it is used in some shortcut way to check equality.
I could resolve it as
`if ($value === null && $correspondingValue !== null || $value !== null && $correspondingValue === null) {`
if desired.
