### PR TITLE
3.0 cache log config changes

### DIFF
--- a/App/Config/cache.php
+++ b/App/Config/cache.php
@@ -21,7 +21,7 @@ use Cake\Core\Configure;
  * Turn off all caching application-wide.
  *
  */
-	//Configure::write('Cache.disable', true);
+	// Cache::disable();
 
 /**
  * Enable cache checking.

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -83,6 +83,13 @@ use Cake\Utility\Inflector;
 class Cache {
 
 /**
+ * Flag for tracking whether or not caching is enabled.
+ *
+ * @var boolean
+ */
+	protected static $_enabled = true;
+
+/**
  * Configuraiton backup.
  *
  * Keeps the permanent/default settings for each cache engine.
@@ -221,8 +228,8 @@ class Cache {
 /**
  * Drops a constructed cache engine.
  *
- * The engine's configuration will remain in Configure. If you wish to re-configure a
- * cache engine you should drop it, change configuration and then re-use it.
+ * If you wish to re-configure a cache engine you should drop it, 
+ * change configuration and then re-use it.
  *
  * @param string $config A currently configured cache config you wish to remove.
  * @return boolean success of the removal, returns false when the config does not exist.
@@ -245,7 +252,7 @@ class Cache {
  * @return Cake\Cache\Engine
  */
 	public static function engine($config) {
-		if (Configure::read('Cache.disable')) {
+		if (!static::$_enabled) {
 			return false;
 		}
 
@@ -592,6 +599,37 @@ class Cache {
 		}
 
 		throw new Error\Exception(__d('cake_dev', 'Invalid cache group %s', $group));
+	}
+
+/**
+ * Re-enable caching.
+ *
+ * If caching has been disabled with Cache::disable() this method will reverse that effect.
+ *
+ * @return void
+ */
+	public static function enable() {
+		static::$_enabled = true;
+	}
+
+/**
+ * Disable caching.
+ *
+ * When disabled all cache operations will return null.
+ *
+ * @return void
+ */
+	public static function disable() {
+		static::$_enabled = false;
+	}
+
+/**
+ * Check whether or not caching is enabled.
+ *
+ * @return boolean
+ */
+	public static function enabled() {
+		return static::$_enabled;
 	}
 
 }

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -178,6 +178,7 @@ class Cache {
 		}
 		if (isset($config['engine']) && empty($config['className'])) {
 			$config['className'] = $config['engine'];
+			unset($config['engine']);
 		}
 		static::$_config[$key] = $config;
 	}

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -65,11 +65,14 @@ class CacheRegistry extends ObjectRegistry {
  *    the correct interface.
  */
 	protected function _create($class, $settings) {
-		if (is_object($class)) {
+		$isObject = is_object($class);
+		if ($isObject && $class instanceof \Closure) {
+			$instance = $class();
+		} elseif ($isObject) {
 			$instance = $class;
 		}
 
-		unset($settings['engine'], $settings['className']);
+		unset($settings['className']);
 		if (!isset($instance)) {
 			$instance = new $class($settings);
 		}

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -58,7 +58,7 @@ class CacheRegistry extends ObjectRegistry {
  * Create the cache engine instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string|CacheEngine $class The classname or object to make.
+ * @param string|CacheEngine|Closure $class The classname or object to make, or a closure factory.
  * @param array $settings An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
  * @throws Cake\Error\Exception when an object doesn't implement

--- a/lib/Cake/Cache/Engine/ApcEngine.php
+++ b/lib/Cake/Cache/Engine/ApcEngine.php
@@ -45,7 +45,6 @@ class ApcEngine extends CacheEngine {
 		if (!isset($settings['prefix'])) {
 			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
-		$settings += array('engine' => __CLASS__);
 		parent::init($settings);
 		return function_exists('apc_dec');
 	}

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -75,7 +75,6 @@ class FileEngine extends CacheEngine {
  */
 	public function init($settings = array()) {
 		$settings += array(
-			'engine' => __CLASS__,
 			'path' => CACHE,
 			'prefix' => 'cake_',
 			'lock' => true,

--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -70,7 +70,6 @@ class MemcacheEngine extends CacheEngine {
 			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
 		$settings += array(
-			'engine' => __CLASS__,
 			'servers' => array('127.0.0.1'),
 			'compress' => false,
 			'persistent' => true

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -57,7 +57,6 @@ class RedisEngine extends CacheEngine {
 			return false;
 		}
 		parent::init(array_merge(array(
-			'engine' => __CLASS__,
 			'prefix' => null,
 			'server' => '127.0.0.1',
 			'port' => 6379,

--- a/lib/Cake/Cache/Engine/WincacheEngine.php
+++ b/lib/Cake/Cache/Engine/WincacheEngine.php
@@ -47,7 +47,6 @@ class WincacheEngine extends CacheEngine {
 		if (!isset($settings['prefix'])) {
 			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
-		$settings += array('engine' => __CLASS__);
 		parent::init($settings);
 		return function_exists('wincache_ucache_info');
 	}

--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -51,7 +51,6 @@ class XcacheEngine extends CacheEngine {
 	public function init($settings = array()) {
 		if (php_sapi_name() !== 'cli') {
 			parent::init(array_merge(array(
-				'engine' => __CLASS__,
 				'prefix' => Inflector::slug(APP_DIR) . '_',
 				'PHP_AUTH_USER' => 'user',
 				'PHP_AUTH_PW' => 'password'

--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -15,6 +15,7 @@
 namespace Cake\Console\Command;
 
 use Cake\Console\Shell;
+use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Model\Model;
@@ -54,7 +55,7 @@ class BakeShell extends Shell {
 	public function startup() {
 		parent::startup();
 		Configure::write('debug', 2);
-		Configure::write('Cache.disable', 1);
+		Cache::disable();
 
 		$task = Inflector::classify($this->command);
 		if (isset($this->{$task}) && !in_array($task, array('Project', 'DbConfig'))) {

--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Console\Command;
 
-use Cake\Console\Shell;
 use Cake\Cache\Cache;
+use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Model\Model;

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -15,6 +15,7 @@
 namespace Cake\Console\Command;
 
 use Cake\Console\Shell;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Model\ConnectionManager;
 use Cake\Model\Schema;
@@ -60,7 +61,7 @@ class SchemaShell extends Shell {
 
 		throw new \Cake\Error\Exception('Schema shell is not working at this time.');
 
-		Configure::write('Cache.disable', 1);
+		Cache::disable();
 
 		$name = $path = $connection = $plugin = null;
 		if (!empty($this->params['name'])) {
@@ -152,13 +153,12 @@ class SchemaShell extends Shell {
 			}
 		}
 
-		$cacheDisable = Configure::read('Cache.disable');
-		Configure::write('Cache.disable', true);
+		Cache::enable();
 
 		$content = $this->Schema->read($options);
 		$content['file'] = $this->params['file'];
 
-		Configure::write('Cache.disable', $cacheDisable);
+		Cache::disable();
 
 		if (!empty($this->params['exclude']) && !empty($content)) {
 			$excluded = String::tokenize($this->params['exclude']);

--- a/lib/Cake/Console/Command/Task/BakeTask.php
+++ b/lib/Cake/Console/Command/Task/BakeTask.php
@@ -19,6 +19,7 @@
 namespace Cake\Console\Command\Task;
 
 use Cake\Console\Shell;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 
 /**
@@ -57,7 +58,7 @@ class BakeTask extends Shell {
  */
 	public function startup() {
 		Configure::write('debug', 2);
-		Configure::write('Cache.disable', 1);
+		Cache::disable();
 		parent::startup();
 	}
 

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -134,7 +134,7 @@ class UpgradeShell extends Shell {
 			$matches = $this->_mapClassName($matches);
 			if (count($matches) === 4) {
 				$use = $matches[3] . '\\' . $matches[2] . '\\' . $matches[1];
-			} else if ($matches[2] == 'Vendor') {
+			} elseif ($matches[2] == 'Vendor') {
 				$this->out(
 					__d('cake_console', '<info>Skip %s as it is a vendor library.</info>', $matches[1]),
 					1,

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -880,9 +880,9 @@ class Shell extends Object {
  * @return void
  */
 	protected function _useLogger($enable = true) {
+		Log::drop('stdout');
+		Log::drop('stderr');
 		if (!$enable) {
-			Log::drop('stdout');
-			Log::drop('stderr');
 			return;
 		}
 		$stdout = new ConsoleLog([

--- a/lib/Cake/Console/Templates/skel/Config/cache.php
+++ b/lib/Cake/Console/Templates/skel/Config/cache.php
@@ -20,7 +20,7 @@ use Cake\Core\Configure;
  * Turn off all caching application-wide.
  *
  */
-	//Configure::write('Cache.disable', true);
+	// Cache::disable();
 
 /**
  * Enable cache checking.

--- a/lib/Cake/Log/LogEngineRegistry.php
+++ b/lib/Cake/Log/LogEngineRegistry.php
@@ -57,14 +57,17 @@ class LogEngineRegistry extends ObjectRegistry {
  * Create the logger instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string|LogInterface $class The classname or object to make.
+ * @param string|LogInterface|Closure $class The classname or object to make, or a closure factory
  * @param array $settings An array of settings to use for the logger.
  * @return LogEngine The constructed logger class.
  * @throws Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $settings) {
-		if (is_object($class)) {
+		$isObject = is_object($class);
+		if ($isObject && $class instanceof \Closure) {
+			$instance = $class();
+		} elseif ($isObject) {
 			$instance = $class;
 		}
 

--- a/lib/Cake/Test/TestCase/BasicsTest.php
+++ b/lib/Cake/Test/TestCase/BasicsTest.php
@@ -19,6 +19,7 @@
  */
 namespace Cake\Test\TestCase;
 
+use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Log\Log;
@@ -281,17 +282,14 @@ class BasicsTest extends TestCase {
  * @return void
  */
 	public function testCache() {
-		$_cacheDisable = Configure::read('Cache.disable');
-		$this->skipIf($_cacheDisable, 'Cache is disabled, skipping cache() tests.');
-
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 		$result = cache('basics_test', 'simple cache write');
 		$this->assertNull($result);
 
 		$result = cache('basics_test');
 		$this->assertNull($result);
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		$result = cache('basics_test', 'simple cache write');
 		$this->assertTrue((boolean)$result);
 		$this->assertTrue(file_exists(CACHE . 'basics_test'));
@@ -306,8 +304,6 @@ class BasicsTest extends TestCase {
 		sleep(2);
 		$result = cache('basics_test', null, '+1 second');
 		$this->assertNull($result);
-
-		Configure::write('Cache.disable', $_cacheDisable);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -35,7 +35,7 @@ class CacheTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 	}
 
 /**
@@ -62,7 +62,7 @@ class CacheTest extends TestCase {
  * @return void
  */
 	public function testNonFatalErrorsWithCachedisable() {
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 		$this->_configCache();
 
 		Cache::write('no_save', 'Noooo!', 'tests');
@@ -378,7 +378,7 @@ class CacheTest extends TestCase {
  * @return void
  */
 	public function testCacheDisable() {
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('test_cache_disable_1', [
 			'engine' => 'File',
 			'path' => TMP . 'tests'
@@ -387,17 +387,17 @@ class CacheTest extends TestCase {
 		$this->assertTrue(Cache::write('key_1', 'hello', 'test_cache_disable_1'));
 		$this->assertSame(Cache::read('key_1', 'test_cache_disable_1'), 'hello');
 
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 
 		$this->assertFalse(Cache::write('key_2', 'hello', 'test_cache_disable_1'));
 		$this->assertFalse(Cache::read('key_2', 'test_cache_disable_1'));
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 
 		$this->assertTrue(Cache::write('key_3', 'hello', 'test_cache_disable_1'));
 		$this->assertSame(Cache::read('key_3', 'test_cache_disable_1'), 'hello');
 
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 		Cache::config('test_cache_disable_2', [
 			'engine' => 'File',
 			'path' => TMP . 'tests'
@@ -406,12 +406,12 @@ class CacheTest extends TestCase {
 		$this->assertFalse(Cache::write('key_4', 'hello', 'test_cache_disable_2'));
 		$this->assertFalse(Cache::read('key_4', 'test_cache_disable_2'));
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 
 		$this->assertTrue(Cache::write('key_5', 'hello', 'test_cache_disable_2'));
 		$this->assertSame(Cache::read('key_5', 'test_cache_disable_2'), 'hello');
 
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 
 		$this->assertFalse(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
 		$this->assertFalse(Cache::read('key_6', 'test_cache_disable_2'));

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -496,4 +496,16 @@ class CacheTest extends TestCase {
 		$this->assertEquals(strtotime('+1 year') - time(), $settings['duration']);
 	}
 
+/**
+ * Test toggling enabled state of cache.
+ *
+ * @return void
+ */
+	public function testEnableDisableEnabled() {
+		$this->assertNull(Cache::enable());
+		$this->assertTrue(Cache::enabled(), 'Should be on');
+		$this->assertNull(Cache::disable());
+		$this->assertFalse(Cache::enabled(), 'Should be off');
+	}
+
 }

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -219,7 +219,7 @@ class CacheTest extends TestCase {
 		Cache::config('tests', $settings);
 		$expected = $settings;
 		$expected['className'] = $settings['engine'];
-		unset($settings['engine']);
+		unset($expected['engine']);
 		$this->assertEquals($expected, Cache::config('tests'));
 	}
 

--- a/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
@@ -42,7 +42,7 @@ class ApcEngineTest extends TestCase {
 			$this->skipIf(!ini_get('apc.enable_cli'), 'APC is not enabled for the CLI.');
 		}
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('apc', ['engine' => 'Apc', 'prefix' => 'cake_']);
 	}
 

--- a/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
@@ -86,6 +86,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testReadWriteDurationZero() {
+		Cache::drop('apc');
 		Cache::config('apc', ['engine' => 'Apc', 'duration' => 0, 'prefix' => 'cake_']);
 		Cache::write('zero', 'Should save', 'apc');
 		sleep(1);

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -45,10 +45,12 @@ class FileEngineTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Cache::enable();
+		Cache::drop('file_test');
 		Cache::config('file_test', [
 			'engine' => 'File',
 			'path' => TMP . 'tests',
 		]);
+		Cache::clear(false, 'file_test');
 	}
 
 /**
@@ -57,12 +59,11 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function tearDown() {
-		parent::tearDown();
-		Cache::clear(false, 'file_test');
 		Cache::drop('file_test');
 		Cache::drop('file_groups');
 		Cache::drop('file_groups2');
 		Cache::drop('file_groups3');
+		parent::tearDown();
 	}
 
 /**
@@ -377,6 +378,7 @@ class FileEngineTest extends TestCase {
  */
 	public function testPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
+		Configure::write('debug', 2);
 
 		Cache::drop('file_test');
 		Cache::config('file_test', array(
@@ -386,7 +388,9 @@ class FileEngineTest extends TestCase {
 		Cache::read('Test', 'file_test');
 
 		$this->assertTrue(file_exists(TMP . 'tests/autocreate'), 'Dir should exist.');
-		unlink(TMP . 'tests/autocreate');
+
+		// Cleanup
+		rmdir(TMP . 'tests/autocreate');
 	}
 
 /**
@@ -399,14 +403,15 @@ class FileEngineTest extends TestCase {
 		$this->skipIf(is_dir(TMP . 'tests/autocreate'), 'Cannot run if test directory exists.');
 		Configure::write('debug', 0);
 
-		Cache::drop('file_test');
-		Cache::config('file_test', array(
+		Cache::drop('file_groups');
+		Cache::config('file_groups', array(
 			'engine' => 'File',
 			'duration' => '+1 year',
 			'prefix' => 'testing_invalid_',
 			'path' => TMP . 'tests/autocreate',
 		));
-		Cache::read('Test', 'test');
+		Cache::read('Test', 'file_groups');
+		Cache::drop('file_groups');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -371,12 +371,33 @@ class FileEngineTest extends TestCase {
 	public function testPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
 
-		Cache::config('autocreate', array(
+		Cache::config('test', array(
 			'engine' => 'File',
 			'path' => TMP . 'tests' . DS . 'autocreate'
 		));
+		Cache::read('Test', 'test');
 
-		Cache::drop('autocreate');
+		Cache::drop('test');
+		unlink(TMP . 'tests' . DS . 'autocreate');
+	}
+
+/**
+ * Test that under debug 0 directories do not get made.
+ *
+ * @expectedException PHPUnit_Framework_Error_Warning
+ * @return void
+ */
+	public function testPathDoesNotExistDebugOff() {
+		$this->skipIf(is_dir(TMP . 'tests/autocreate'), 'Cannot run if test directory exists.');
+		Configure::write('debug', 0);
+
+		Cache::config('test', array(
+			'engine' => 'File',
+			'duration' => '+1 year',
+			'prefix' => 'testing_invalid_',
+			'path' => TMP . 'tests/autocreate',
+		));
+		Cache::read('Test', 'test');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -47,7 +47,7 @@ class FileEngineTest extends TestCase {
 		Configure::write('Cache.disable', false);
 		Cache::config('file_test', [
 			'engine' => 'File',
-			'path' => CACHE
+			'path' => TMP . 'tests',
 		]);
 	}
 
@@ -57,12 +57,12 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function tearDown() {
+		parent::tearDown();
 		Cache::clear(false, 'file_test');
 		Cache::drop('file_test');
 		Cache::drop('file_groups');
 		Cache::drop('file_groups2');
 		Cache::drop('file_groups3');
-		parent::tearDown();
 	}
 
 /**
@@ -82,7 +82,7 @@ class FileEngineTest extends TestCase {
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('test', $data, 'file_test');
-		$this->assertTrue(file_exists(CACHE . 'cake_test'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_test'));
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = $data;
@@ -162,6 +162,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testSerialize() {
+		Cache::drop('file_test');
 		Cache::config('file_test', ['engine' => 'File', 'serialize' => true]);
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test', $data, 'file_test');
@@ -181,6 +182,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testClear() {
+		Cache::drop('file_test');
 		Cache::config('file_test', ['engine' => 'File', 'duration' => 1]);
 
 		$data = 'this is a test of the emergency broadcasting system';
@@ -284,7 +286,7 @@ class FileEngineTest extends TestCase {
 	public function testKeyPath() {
 		$result = Cache::write('views.countries.something', 'here', 'file_test');
 		$this->assertTrue($result);
-		$this->assertTrue(file_exists(CACHE . 'cake_views_countries_something'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_views_countries_something'));
 
 		$result = Cache::read('views.countries.something', 'file_test');
 		$this->assertEquals('here', $result);
@@ -349,13 +351,18 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testWriteQuotedString() {
-		Cache::config('file_test', array('engine' => 'File', 'path' => TMP . 'tests'));
 		Cache::write('App.doubleQuoteTest', '"this is a quoted string"', 'file_test');
 		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
 		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
 
-		Cache::config('file_test', array('isWindows' => true, 'path' => TMP . 'tests'));
+		Cache::drop('file_test');
+		Cache::config('file_test', array(
+			'className' => 'File',
+			'isWindows' => true,
+			'path' => TMP . 'tests'
+		));
+
 		$this->assertSame(Cache::read('App.doubleQuoteTest', 'file_test'), '"this is a quoted string"');
 		Cache::write('App.singleQuoteTest', "'this is a quoted string'", 'file_test');
 		$this->assertSame(Cache::read('App.singleQuoteTest', 'file_test'), "'this is a quoted string'");
@@ -371,14 +378,15 @@ class FileEngineTest extends TestCase {
 	public function testPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
 
-		Cache::config('test', array(
+		Cache::drop('file_test');
+		Cache::config('file_test', array(
 			'engine' => 'File',
-			'path' => TMP . 'tests' . DS . 'autocreate'
+			'path' => TMP . 'tests/autocreate'
 		));
-		Cache::read('Test', 'test');
+		Cache::read('Test', 'file_test');
 
-		Cache::drop('test');
-		unlink(TMP . 'tests' . DS . 'autocreate');
+		$this->assertTrue(file_exists(TMP . 'tests/autocreate'), 'Dir should exist.');
+		unlink(TMP . 'tests/autocreate');
 	}
 
 /**
@@ -391,7 +399,8 @@ class FileEngineTest extends TestCase {
 		$this->skipIf(is_dir(TMP . 'tests/autocreate'), 'Cannot run if test directory exists.');
 		Configure::write('debug', 0);
 
-		Cache::config('test', array(
+		Cache::drop('file_test');
+		Cache::config('file_test', array(
 			'engine' => 'File',
 			'duration' => '+1 year',
 			'prefix' => 'testing_invalid_',

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -44,7 +44,7 @@ class FileEngineTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('file_test', [
 			'engine' => 'File',
 			'path' => TMP . 'tests',

--- a/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
@@ -61,7 +61,7 @@ class MemcacheEngineTest extends TestCase {
 		parent::setUp();
 		$this->skipIf(!class_exists('Memcache'), 'Memcache is not installed or configured properly.');
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('memcache', array(
 			'className' => 'Memcache',
 			'prefix' => 'cake_',

--- a/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
@@ -26,7 +26,6 @@ use Cake\TestSuite\TestCase;
 /**
  * Class TestMemcacheEngine
  *
- * @package       Cake.Test.Case.Cache.Engine
  */
 class TestMemcacheEngine extends MemcacheEngine {
 
@@ -64,7 +63,7 @@ class MemcacheEngineTest extends TestCase {
 
 		Configure::write('Cache.disable', false);
 		Cache::config('memcache', array(
-			'engine' => 'Memcache',
+			'className' => 'Memcache',
 			'prefix' => 'cake_',
 			'duration' => 3600
 		));
@@ -97,7 +96,6 @@ class MemcacheEngineTest extends TestCase {
 			'servers' => array('127.0.0.1'),
 			'persistent' => true,
 			'compress' => false,
-			'engine' => 'Cake\Cache\Engine\MemcacheEngine',
 			'groups' => array()
 		);
 		$this->assertEquals($expecting, $settings);
@@ -378,6 +376,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testZeroDuration() {
+		Cache::drop('memcache');
 		Cache::config('memcache', [
 			'engine' => 'Memcache',
 			'prefix' => 'cake_',

--- a/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
@@ -35,7 +35,7 @@ class RedisEngineTest extends TestCase {
 		parent::setUp();
 		$this->skipIf(!class_exists('Redis'), 'Redis is not installed or configured properly.');
 
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('redis', array(
 			'engine' => 'Cake\Cache\Engine\RedisEngine',
 			'prefix' => 'cake_',

--- a/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
@@ -67,7 +67,6 @@ class RedisEngineTest extends TestCase {
 			'duration' => 3600,
 			'probability' => 100,
 			'groups' => array(),
-			'engine' => 'Cake\Cache\Engine\RedisEngine',
 			'server' => '127.0.0.1',
 			'port' => 6379,
 			'timeout' => 0,

--- a/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -38,7 +38,7 @@ class WincacheEngineTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->skipIf(!function_exists('wincache_ucache_set'), 'Wincache is not installed or configured properly.');
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('wincache', ['engine' => 'Wincache', 'prefix' => 'cake_']);
 	}
 

--- a/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -65,7 +65,6 @@ class XcacheEngineTest extends TestCase {
 			'prefix' => 'cake_',
 			'duration' => 3600,
 			'probability' => 100,
-			'engine' => 'Xcache',
 		];
 		$this->assertTrue(isset($settings['PHP_AUTH_USER']));
 		$this->assertTrue(isset($settings['PHP_AUTH_PW']));

--- a/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -39,7 +39,7 @@ class XcacheEngineTest extends TestCase {
 		if (!function_exists('xcache_set')) {
 			$this->markTestSkipped('Xcache is not installed or configured properly');
 		}
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('xcache', ['engine' => 'Xcache', 'prefix' => 'cake_']);
 	}
 

--- a/lib/Cake/Test/TestCase/Console/ShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/ShellTest.php
@@ -833,7 +833,7 @@ TEXT;
 			['write'],
 			[['types' => 'error']]
 		);
-		Log::config('console', ['engine' => $mock]);
+		Log::config('console', $mock);
 		$mock->expects($this->once())
 			->method('write')
 			->with('error', $this->Shell->testMessage);

--- a/lib/Cake/Test/TestCase/Core/ConfigureTest.php
+++ b/lib/Cake/Test/TestCase/Core/ConfigureTest.php
@@ -340,17 +340,22 @@ class ConfigureTest extends TestCase {
  */
 	public function testStoreAndRestore() {
 		Configure::write('Cache.disable', false);
+		Cache::config('configure', [
+			'className' => 'File',
+			'path' => TMP . 'tests'
+		]);
 
 		Configure::write('Testing', 'yummy');
-		$this->assertTrue(Configure::store('store_test', 'default'));
+		$this->assertTrue(Configure::store('store_test', 'configure'));
 
 		Configure::delete('Testing');
 		$this->assertNull(Configure::read('Testing'));
 
-		Configure::restore('store_test', 'default');
+		Configure::restore('store_test', 'configure');
 		$this->assertEquals('yummy', Configure::read('Testing'));
 
-		Cache::delete('store_test', 'default');
+		Cache::delete('store_test', 'configure');
+		Cache::drop('configure');
 	}
 
 /**
@@ -360,17 +365,22 @@ class ConfigureTest extends TestCase {
  */
 	public function testStoreAndRestoreWithData() {
 		Configure::write('Cache.disable', false);
+		Cache::config('configure', [
+			'className' => 'File',
+			'path' => TMP . 'tests'
+		]);
 
 		Configure::write('testing', 'value');
-		Configure::store('store_test', 'default', array('store_test' => 'one'));
+		Configure::store('store_test', 'configure', array('store_test' => 'one'));
 		Configure::delete('testing');
 		$this->assertNull(Configure::read('store_test'), 'Calling store with data shouldn\'t modify runtime.');
 
-		Configure::restore('store_test', 'default');
+		Configure::restore('store_test', 'configure');
 		$this->assertEquals('one', Configure::read('store_test'));
 		$this->assertNull(Configure::read('testing'), 'Values that were not stored are not restored.');
 
-		Cache::delete('store_test', 'default');
+		Cache::delete('store_test', 'configure');
+		Cache::drop('configure');
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Core/ConfigureTest.php
+++ b/lib/Cake/Test/TestCase/Core/ConfigureTest.php
@@ -42,7 +42,7 @@ class ConfigureTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Configure::write('Cache.disable', true);
+		Cache::disable();
 		App::build();
 		App::objects('Plugin', null, true);
 	}
@@ -339,7 +339,7 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testStoreAndRestore() {
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('configure', [
 			'className' => 'File',
 			'path' => TMP . 'tests'
@@ -364,7 +364,7 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testStoreAndRestoreWithData() {
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		Cache::config('configure', [
 			'className' => 'File',
 			'path' => TMP . 'tests'

--- a/lib/Cake/Test/TestCase/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelWriteTest.php
@@ -260,12 +260,8 @@ class ModelWriteTest extends ModelTestBase {
  * @return void
  */
 	public function testCacheClearOnSave() {
-		$_back = array(
-			'check' => Configure::read('Cache.check'),
-			'disable' => Configure::read('Cache.disable'),
-		);
 		Configure::write('Cache.check', true);
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 
 		$this->loadFixtures('OverallFavorite');
 		$OverallFavorite = new OverallFavorite();
@@ -286,9 +282,6 @@ class ModelWriteTest extends ModelTestBase {
 
 		$this->assertFalse(file_exists(CACHE . 'views/some_dir_overallfavorites_index.php'));
 		$this->assertFalse(file_exists(CACHE . 'views/some_dir_overall_favorites_index.php'));
-
-		Configure::write('Cache.check', $_back['check']);
-		Configure::write('Cache.disable', $_back['disable']);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
+++ b/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
@@ -1128,7 +1128,7 @@ class EmailTest extends TestCase {
 				)
 			);
 
-		Log::config('email', ['engine' => $log]);
+		Log::config('email', $log);
 
 		$this->CakeEmail->transport('Debug');
 		$this->CakeEmail->to('me@cakephp.org');
@@ -1158,9 +1158,7 @@ class EmailTest extends TestCase {
 				)
 			);
 
-		Log::config('email', [
-			'engine' => $log,
-		]);
+		Log::config('email', $log);
 
 		$this->CakeEmail->transport('Debug');
 		$this->CakeEmail->to('me@cakephp.org');

--- a/lib/Cake/Test/TestCase/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/TestCase/Routing/DispatcherTest.php
@@ -18,6 +18,7 @@
  */
 namespace Cake\Test\TestCase\Routing;
 
+use Cake\Cache\Cache;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -266,17 +267,13 @@ class DispatcherTest extends TestCase {
 		parent::setUp();
 		$_GET = array();
 
-		$this->_app = Configure::read('App');
 		Configure::write('App.base', false);
 		Configure::write('App.baseUrl', false);
 		Configure::write('App.dir', 'app');
 		Configure::write('App.webroot', 'webroot');
 		Configure::write('App.namespace', 'TestApp');
 
-		$this->_cache = Configure::read('Cache');
-		Configure::write('Cache.disable', true);
-
-		$this->_debug = Configure::read('debug');
+		Cache::disable();
 
 		App::build();
 		App::objects('Plugin', null, false);
@@ -944,6 +941,7 @@ class DispatcherTest extends TestCase {
  * @return void
  */
 	public function testFullPageCachingDispatch($url) {
+		Cache::enable();
 		Configure::write('Cache.disable', false);
 		Configure::write('Cache.check', true);
 		Configure::write('debug', 2);

--- a/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/CacheHelperTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\View\Helper;
 
+use Cake\Cache\Cache;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -85,7 +86,7 @@ class CacheHelperTest extends TestCase {
 		$View = new View($this->Controller);
 		$this->Cache = new CacheHelper($View);
 		Configure::write('Cache.check', true);
-		Configure::write('Cache.disable', false);
+		Cache::enable();
 		App::build([
 			'View' => [CAKE . 'Test/TestApp/View/']
 		], App::RESET);

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -19,6 +19,7 @@
  * @since         CakePHP(tm) v 0.2.9
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\I18n\I18n;
 use Cake\Log\Log;
@@ -417,7 +418,7 @@ if (!function_exists('cache')) {
  * @deprecated Will be removed in 3.0. Please use Cache::write() instead.
  */
 	function cache($path, $data = null, $expires = '+1 day', $target = 'cache') {
-		if (Configure::read('Cache.disable')) {
+		if (!Cache::enabled()) {
 			return null;
 		}
 		$now = time();


### PR DESCRIPTION
After @lorenzo 's comments on my last pull request (#1517) I've added the ability to read config data back out of Cache and Log. In addition to that I've done a few other things.
- Made it simpler to inject built objects into Cache/Log.
- Made it simple to use a factory function to help with more complicated engine construction.
- Renamed 'engine' to 'className'. This is more conformant to the rest of CakePHP. `engine` will continue working though for now.

I also removed `Cache.disable` from Configure. I've always disliked this configure value. It is now part of the Cache class so it doesn't need to interact with Configure making the check cheaper, simpler and Cache more self contained.

I think there is an opportunity to extract `config()` and `drop()` into a trait if there are a few more similar uses. With only two uses it doesn't make much sense right now. But if another class re-uses the same pattern it will be useful.

I spent some time and [drafted up some ideas](https://github.com/markstory/cakephp/wiki/Config-methods) on how config methods on other classes could work as well. Any feedback on that is more than welcome.
