### PR TITLE
Accept 'connectOptions' in Router::mapResources()

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -500,11 +500,14 @@ class Router {
 	public static function mapResources($controller, $options = array()) {
 		$hasPrefix = isset($options['prefix']);
 		$options = array_merge(array(
+			'connectOptions' => array(),
 			'prefix' => '/',
 			'id' => self::ID . '|' . self::UUID
 		), $options);
 
 		$prefix = $options['prefix'];
+		$connectOptions = $options['connectOptions'];
+		unset($options['connectOptions']);
 
 		foreach ((array)$controller as $name) {
 			list($plugin, $name) = pluginSplit($name);
@@ -524,7 +527,10 @@ class Router {
 						'action' => $params['action'],
 						'[method]' => $params['method']
 					),
-					array('id' => $options['id'], 'pass' => array('id'))
+					array_merge(
+						array('id' => $options['id'], 'pass' => array('id')),
+						$connectOptions
+					)
 				);
 			}
 			self::$_resourceMapped[] = $urlName;

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -180,6 +180,28 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * testMapResources with custom connectOptions
+ */
+	public function testMapResourcesConnectOptions() {
+		App::build(array(
+			'Plugin' => array(
+				CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS
+			)
+		));
+		CakePlugin::load('TestPlugin');
+		App::uses('TestRoute', 'TestPlugin.Routing/Route');
+		$resources = Router::mapResources('Posts', array(
+			'connectOptions' => array(
+				'routeClass' => 'TestPlugin.TestRoute',
+				'foo' => '^(bar)$',
+			),
+		));
+		$route = end(Router::$routes);
+		$this->assertInstanceOf('TestRoute', $route);
+		$this->assertEquals('^(bar)$', $route->options['foo']);
+	}
+
+/**
  * Test mapResources with a plugin and prefix.
  *
  * @return void


### PR DESCRIPTION
Expansion of #1452 with test: Instead of allowing only 'routeClass', we pass 'connectOptions' in its entirety into Router::connect().
