### PR TITLE
3.0 email config

### DIFF
--- a/App/Config/email.default.php
+++ b/App/Config/email.default.php
@@ -14,13 +14,20 @@
  */
 namespace App\Config;
 
-use Cake\Core\Configure;
+use Cake\Network\Email\Email;
 /**
  * Email configuration.
  *
+ * You can configure email transports and email delivery profiles here.
+ *
+ * By defining transports separately from delivery profiles you can eaisly re-use transport
+ * configuration across multiple profiles.
+ *
  * You can specify multiple configurations for production, development and testing.
  *
- * transport => The name of a supported transport; valid options are as follows:
+ * ### Configuring transports
+ *
+ * Each transport needs a `className`. Valid options are as follows:
  *
  *  Mail   - Send using PHP mail function
  *  Smtp   - Send using SMTP
@@ -30,24 +37,29 @@ use Cake\Core\Configure;
  * appropriate file to app/Network/Email.  Transports should be named 'YourTransport.php',
  * where 'Your' is the name of the transport.
  *
- * from =>
- * The origin email. See Cake\Network\Email\Email::from() about the valid values
+ * ### Configuring delivery profiles
+ *
+ * Delivery profiles allow you to predefine various properties about email messages
+ * from your application and give the settings a name. This saves duplication across your
+ * application and makes maintenance and development easier. Each profile accepts a number of keys
+ * See Cake\Network\Email\Email for more information.
  */
-Configure::write('Email.default', [
-	'transport' => 'Mail',
-	'from' => 'you@localhost',
-	//'charset' => 'utf-8',
-	//'headerCharset' => 'utf-8',
-]);
-
-Configure::write('Email.smtp', [
-	'transport' => 'Smtp',
+Email::configTransport('default', [
+	'className' => 'Mail',
+	// The following keys are used in SMTP transports
 	'host' => 'localhost',
 	'port' => 25,
 	'timeout' => 30,
 	'username' => 'user',
 	'password' => 'secret',
 	'client' => null,
+	'tls' => null,
+]);
+
+Email::config('default', [
+	'transport' => 'default',
+	'charset' => 'utf-8',
+	'headerCharset' => 'utf-8',
 	'from' => ['site@localhost' => 'My Site'],
 	'sender' => null,
 	'to' => null,
@@ -67,6 +79,4 @@ Configure::write('Email.smtp', [
 	'attachments' => null,
 	'emailFormat' => null,
 	'log' => true,
-	//'charset' => 'utf-8',
-	//'headerCharset' => 'utf-8',
 ]);

--- a/lib/Cake/Network/Email/AbstractTransport.php
+++ b/lib/Cake/Network/Email/AbstractTransport.php
@@ -13,7 +13,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Network.Email
  * @since         CakePHP(tm) v 2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -22,7 +21,6 @@ namespace Cake\Network\Email;
 /**
  * Abstract transport for sending email
  *
- * @package       Cake.Network.Email
  */
 abstract class AbstractTransport {
 

--- a/lib/Cake/Network/Email/AbstractTransport.php
+++ b/lib/Cake/Network/Email/AbstractTransport.php
@@ -42,6 +42,15 @@ abstract class AbstractTransport {
 	abstract public function send(Email $email);
 
 /**
+ * Constructor
+ *
+ * @param array $config The configuration data for the transport.
+ */
+	public function __construct($config = null) {
+		$this->config($config);
+	}
+
+/**
  * Set the config
  *
  * @param array $config

--- a/lib/Cake/Network/Email/DebugTransport.php
+++ b/lib/Cake/Network/Email/DebugTransport.php
@@ -13,7 +13,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Network.Email
  * @since         CakePHP(tm) v 2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -23,7 +22,6 @@ namespace Cake\Network\Email;
  * Debug Transport class, useful for emulate the email sending process and inspect the resulted
  * email message before actually send it during development
  *
- * @package       Cake.Network.Email
  */
 class DebugTransport extends AbstractTransport {
 

--- a/lib/Cake/Network/Email/Email.php
+++ b/lib/Cake/Network/Email/Email.php
@@ -301,7 +301,7 @@ class Email {
 
 /**
  * A copy of the configuration profile for this
- * instance. This copy can be modified with Email::useConfig().
+ * instance. This copy can be modified with Email::profile().
  *
  * @var array
  */
@@ -347,7 +347,7 @@ class Email {
 		}
 
 		if ($config) {
-			$this->useConfig($config);
+			$this->profile($config);
 		}
 		if (empty($this->headerCharset)) {
 			$this->headerCharset = $this->charset;
@@ -1173,7 +1173,7 @@ class Email {
  *    an array with config or null to return current config.
  * @return string|array|Cake\Network\Email\Email
  */
-	public function useConfig($config = null) {
+	public function profile($config = null) {
 		if ($config === null) {
 			return $this->_profile;
 		}
@@ -1249,7 +1249,7 @@ class Email {
 		if (is_array($message)) {
 			$instance->viewVars($message);
 			$message = null;
-		} elseif ($message === null && array_key_exists('message', $config = $instance->useConfig())) {
+		} elseif ($message === null && array_key_exists('message', $config = $instance->profile())) {
 			$message = $config['message'];
 		}
 

--- a/lib/Cake/Network/Email/Email.php
+++ b/lib/Cake/Network/Email/Email.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Network.Email
  * @since         CakePHP(tm) v 2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -29,10 +28,8 @@ use Cake\View\View;
 /**
  * Cake e-mail class.
  *
- * This class is used for handling Internet Message Format based
- * based on the standard outlined in http://www.rfc-editor.org/rfc/rfc2822.txt
- *
- * @package       Cake.Network.Email
+ * This class is used for sending Internet Message Format based
+ * on the standard outlined in http://www.rfc-editor.org/rfc/rfc2822.txt
  */
 class Email {
 

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -13,7 +13,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Network.Email
  * @since         CakePHP(tm) v 2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -24,7 +23,6 @@ use Cake\Error;
 /**
  * Send mail using mail() function
  *
- * @package       Cake.Network.Email
  */
 class MailTransport extends AbstractTransport {
 

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -13,7 +13,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Network.Email
  * @since         CakePHP(tm) v 2.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -24,8 +23,6 @@ use Cake\Network\Socket;
 
 /**
  * Send mail using SMTP protocol
- *
- * @package       Cake.Network.Email
  */
 class SmtpTransport extends AbstractTransport {
 

--- a/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
+++ b/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
@@ -863,19 +863,19 @@ class EmailTest extends TestCase {
 	}
 
 /**
- * test useConfig method
+ * test profile method
  *
  * @return void
  */
-	public function testUseConfig() {
+	public function testProfile() {
 		$config = array('test' => 'ok', 'test2' => true);
-		$this->CakeEmail->useConfig($config);
-		$this->assertSame($this->CakeEmail->useConfig(), $config);
+		$this->CakeEmail->profile($config);
+		$this->assertSame($this->CakeEmail->profile(), $config);
 
 		$config = array('test' => 'test@example.com');
-		$this->CakeEmail->useConfig($config);
+		$this->CakeEmail->profile($config);
 		$expected = array('test' => 'test@example.com', 'test2' => true);
-		$this->assertSame($expected, $this->CakeEmail->useConfig());
+		$this->assertSame($expected, $this->CakeEmail->profile());
 	}
 
 /**
@@ -893,7 +893,7 @@ class EmailTest extends TestCase {
 			'helpers' => array('Html', 'Form'),
 		];
 		Email::config('test', $config);
-		$this->CakeEmail->useConfig('test');
+		$this->CakeEmail->profile('test');
 
 		$result = $this->CakeEmail->to();
 		$this->assertEquals($config['to'], $result);
@@ -925,7 +925,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 
 		$result = $this->CakeEmail->send("Here is my body, with multi lines.\nThis is the second line.\r\n\r\nAnd the last.");
 		$expected = array('headers', 'message');
@@ -948,7 +948,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$result = $this->CakeEmail->send(array('Sending content', 'As array'));
 		$expected = "Sending content\r\nAs array\r\n\r\n\r\n";
 		$this->assertSame($result['message'], $expected);
@@ -963,7 +963,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->setExpectedException('Cake\Error\SocketException');
 		$this->CakeEmail->send("Forgot to set From");
 	}
@@ -977,7 +977,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->setExpectedException('Cake\Error\SocketException');
 		$this->CakeEmail->send("Forgot to set To");
 	}
@@ -1216,7 +1216,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->to('me@cakephp.org');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('log' => 'debug'));
+		$this->CakeEmail->profile(array('log' => 'debug'));
 		$result = $this->CakeEmail->send($message);
 	}
 
@@ -1246,7 +1246,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->to('me@cakephp.org');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('log' => array('scope' => 'email')));
+		$this->CakeEmail->profile(array('log' => array('scope' => 'email')));
 		$this->CakeEmail->send($message);
 	}
 
@@ -1262,7 +1262,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('default', 'default');
 		$result = $this->CakeEmail->send();
 
@@ -1283,7 +1283,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('default', 'japanese');
 		$this->CakeEmail->charset = 'ISO-2022-JP';
 		$result = $this->CakeEmail->send();
@@ -1306,7 +1306,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->theme('TestTheme');
 		$this->CakeEmail->template('themed', 'default');
 		$result = $this->CakeEmail->send();
@@ -1328,7 +1328,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->emailFormat('html');
 		$this->CakeEmail->template('html', 'default');
 		$result = $this->CakeEmail->send();
@@ -1349,7 +1349,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('custom', 'default');
 		$this->CakeEmail->viewVars(array('value' => 12345));
 		$result = $this->CakeEmail->send();
@@ -1369,7 +1369,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('japanese', 'default');
 		$this->CakeEmail->viewVars(array('value' => '日本語の差し込み123'));
 		$this->CakeEmail->charset = 'ISO-2022-JP';
@@ -1392,7 +1392,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('custom_helper', 'default');
 		$this->CakeEmail->viewVars(array('time' => $timestamp));
 
@@ -1418,7 +1418,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('image');
 		$this->CakeEmail->emailFormat('html');
 		$server = env('SERVER_NAME') ? env('SERVER_NAME') : 'localhost';
@@ -1448,7 +1448,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 
 		$result = $this->CakeEmail->template('TestPlugin.test_plugin_tpl', 'default')->send();
 		$this->assertContains('Into TestPlugin.', $result['message']);
@@ -1490,7 +1490,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->template('custom', 'default');
-		$this->CakeEmail->useConfig(array());
+		$this->CakeEmail->profile(array());
 		$this->CakeEmail->viewVars(array('value' => 12345));
 		$this->CakeEmail->emailFormat('both');
 		$this->CakeEmail->send();
@@ -1526,7 +1526,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array());
+		$this->CakeEmail->profile(array());
 		$this->CakeEmail->attachments(array(CAKE . 'basics.php'));
 		$result = $this->CakeEmail->send('body');
 		$expected = "Content-Disposition: attachment; filename=\"basics.php\"\r\n" .
@@ -1603,7 +1603,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->template('default', 'default');
 		$this->CakeEmail->emailFormat('both');
 		$this->CakeEmail->send();
@@ -2129,7 +2129,7 @@ class EmailTest extends TestCase {
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$result = $this->CakeEmail->send($message);
 		$expected = "<a\r\n" . 'href="http://cakephp.org">' . str_repeat('x', Email::LINE_LENGTH_MUST - 26) . "\r\n" .
 			str_repeat('x', 26) . "\r\n</a>\r\n\r\n";
@@ -2176,7 +2176,7 @@ HTML;
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$result = $this->CakeEmail->send($message);
 		$message = str_replace("\r\n", "\n", substr($message, 0, -9));
 		$message = str_replace("\n", "\r\n", $message);
@@ -2195,7 +2195,7 @@ HTML;
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$result = $this->CakeEmail->send($message);
 		$message = substr($message, 0, -1);
 		$expected = "{$message}\r\nx\r\n\r\n";
@@ -2213,7 +2213,7 @@ HTML;
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
-		$this->CakeEmail->useConfig(array('empty'));
+		$this->CakeEmail->profile(array('empty'));
 		$this->CakeEmail->charset('iso-2022-jp');
 		$this->CakeEmail->headerCharset('iso-2022-jp');
 		$result = $this->CakeEmail->send($message);

--- a/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
+++ b/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
@@ -73,19 +73,8 @@ class TestEmail extends Email {
 
 }
 
-/*
- * ExtendTransport class
- * test class to ensure the class has send() method
- *
- */
-class ExtendTransport {
-
-}
-
 /**
  * EmailTest class
- *
- * @package       Cake.Test.Case.Network.Email
  */
 class EmailTest extends TestCase {
 
@@ -733,27 +722,33 @@ class EmailTest extends TestCase {
  * @return void
  */
 	public function testTransport() {
-		$result = $this->CakeEmail->transport('Debug');
+		$result = $this->CakeEmail->transport('debug');
 		$this->assertSame($this->CakeEmail, $result);
-		$this->assertSame($this->CakeEmail->transport(), 'Debug');
 
-		$result = $this->CakeEmail->transportClass();
+		$result = $this->CakeEmail->transport();
 		$this->assertInstanceOf('Cake\Network\Email\DebugTransport', $result);
 
-		$this->setExpectedException('Cake\Error\SocketException');
-		$this->CakeEmail->transport('Invalid');
-		$result = $this->CakeEmail->transportClass();
+		$instance = $this->getMock('Cake\Network\Email\DebugTransport');
+		$this->CakeEmail->transport($instance);
+		$this->assertSame($instance, $this->CakeEmail->transport());
 	}
 
 /**
- * testExtendTransport method
+ * Test that using unknown transports fails.
  *
- * @expectedException Cake\Error\SocketException
- * @return void
+ * @expectedException Cake\Error\Exception
  */
-	public function testExtendTransport() {
-		$this->CakeEmail->transport('Extend');
-		$this->CakeEmail->transportClass();
+	public function testTransportInvalid() {
+		$this->CakeEmail->transport('Invalid');
+	}
+
+/**
+ * Test that using classes with no send method fails.
+ *
+ * @expectedException Cake\Error\Exception
+ */
+	public function testTransportInstanceInvalid() {
+		$this->CakeEmail->transport(new \StdClass());
 	}
 
 /**
@@ -868,29 +863,14 @@ class EmailTest extends TestCase {
 	}
 
 /**
- * Test that specifying a transport that doesn't exist causes an error.
- *
- * @return void
- */
-	public function testConfigErrorOnMissingTransport() {
-		$this->markTestIncomplete();
-	}
-
-/**
  * test useConfig method
  *
  * @return void
  */
 	public function testUseConfig() {
-		$transportClass = $this->CakeEmail->transport('debug')->transportClass();
-
 		$config = array('test' => 'ok', 'test2' => true);
 		$this->CakeEmail->useConfig($config);
-		$this->assertSame($transportClass->config(), $config);
 		$this->assertSame($this->CakeEmail->useConfig(), $config);
-
-		$this->CakeEmail->useConfig(array());
-		$this->assertSame($transportClass->config(), array());
 
 		$config = array('test' => 'test@example.com');
 		$this->CakeEmail->useConfig($config);
@@ -908,7 +888,7 @@ class EmailTest extends TestCase {
 			'from' => array('some@example.com' => 'My website'),
 			'to' => array('test@example.com' => 'Testname'),
 			'subject' => 'Test mail subject',
-			'transport' => 'Debug',
+			'transport' => 'debug',
 			'theme' => 'TestTheme',
 			'helpers' => array('Html', 'Form'),
 		];
@@ -928,9 +908,6 @@ class EmailTest extends TestCase {
 		$this->assertEquals($config['theme'], $result);
 
 		$result = $this->CakeEmail->transport();
-		$this->assertEquals($config['transport'], $result);
-
-		$result = $this->CakeEmail->transportClass();
 		$this->assertInstanceOf('Cake\Network\Email\DebugTransport', $result);
 
 		$result = $this->CakeEmail->helpers();
@@ -944,7 +921,7 @@ class EmailTest extends TestCase {
  */
 	public function testSendWithContent() {
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
@@ -967,7 +944,7 @@ class EmailTest extends TestCase {
 		$this->assertTrue((bool)strpos($result['headers'], 'To: '));
 
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
 		$this->CakeEmail->subject('My title');
@@ -983,7 +960,7 @@ class EmailTest extends TestCase {
  * @return void
  */
 	public function testSendWithoutFrom() {
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->useConfig(array('empty'));
@@ -997,7 +974,7 @@ class EmailTest extends TestCase {
  * @return void
  */
 	public function testSendWithoutTo() {
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
 		$this->CakeEmail->useConfig(array('empty'));
@@ -1235,7 +1212,7 @@ class EmailTest extends TestCase {
 
 		Log::config('email', $log);
 
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->to('me@cakephp.org');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
@@ -1265,7 +1242,7 @@ class EmailTest extends TestCase {
 
 		Log::config('email', $log);
 
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->to('me@cakephp.org');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->subject('My title');
@@ -1436,7 +1413,7 @@ class EmailTest extends TestCase {
  */
 	public function testSendRenderWithImage() {
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to(array('you@cakephp.org' => 'You'));
@@ -1609,7 +1586,7 @@ class EmailTest extends TestCase {
 		$this->assertSame($instance->viewVars(), array('value' => 123, 'name' => 'CakePHP'));
 		$this->assertSame($instance->cc(), array('cake@cakephp.org' => 'Myself'));
 
-		$configs = array('from' => 'root@cakephp.org', 'message' => 'Message from configs', 'transport' => 'Debug');
+		$configs = array('from' => 'root@cakephp.org', 'message' => 'Message from configs', 'transport' => 'debug');
 		$instance = Email::deliver('all@cakephp.org', 'About', null, $configs, true);
 		$message = $instance->message();
 		$this->assertEquals($configs['message'], $message[0]);
@@ -1776,7 +1753,7 @@ class EmailTest extends TestCase {
 			'from' => array('some@example.com' => 'My website'),
 			'to' => 'test@example.com',
 			'subject' => 'Test mail subject',
-			'transport' => 'Debug',
+			'transport' => 'debug',
 		);
 		$this->CakeEmail = new Email($configs);
 
@@ -1790,9 +1767,6 @@ class EmailTest extends TestCase {
 		$this->assertEquals($configs['subject'], $result);
 
 		$result = $this->CakeEmail->transport();
-		$this->assertEquals($configs['transport'], $result);
-
-		$result = $this->CakeEmail->transportClass();
 		$this->assertInstanceOf('Cake\Network\Email\DebugTransport', $result);
 
 		$result = $this->CakeEmail->send('This is the message');
@@ -1811,7 +1785,7 @@ class EmailTest extends TestCase {
 			'from' => array('some@example.com' => 'My website'),
 			'to' => 'test@example.com',
 			'subject' => 'Test mail subject',
-			'transport' => 'Debug',
+			'transport' => 'debug',
 		);
 		Email::config('test', $configs);
 
@@ -1827,9 +1801,6 @@ class EmailTest extends TestCase {
 		$this->assertEquals($configs['subject'], $result);
 
 		$result = $this->CakeEmail->transport();
-		$this->assertEquals($configs['transport'], $result);
-
-		$result = $this->CakeEmail->transportClass();
 		$this->assertInstanceOf('Cake\Network\Email\DebugTransport', $result);
 
 		$result = $this->CakeEmail->send('This is the message');
@@ -1902,7 +1873,7 @@ class EmailTest extends TestCase {
  * @return void
  */
 	public function testHeaderEncoding() {
-		$email = new Email(array('headerCharset' => 'iso-2022-jp-ms', 'transport' => 'Debug'));
+		$email = new Email(array('headerCharset' => 'iso-2022-jp-ms', 'transport' => 'debug'));
 		$email->subject('あれ？もしかしての前と');
 		$headers = $email->getHeaders(array('subject'));
 		$expected = "?ISO-2022-JP?B?GyRCJCIkbCEpJGIkNyQrJDckRiROQTAkSBsoQg==?=";
@@ -1922,7 +1893,7 @@ class EmailTest extends TestCase {
 		$email = new Email(array(
 			'charset' => 'iso-2022-jp',
 			'headerCharset' => 'iso-2022-jp-ms',
-			'transport' => 'Debug'
+			'transport' => 'debug'
 		));
 		$email->subject('あれ？もしかしての前と');
 		$headers = $email->getHeaders(array('subject'));
@@ -1944,7 +1915,7 @@ class EmailTest extends TestCase {
 		$email = new Email(array(
 			'charset' => 'iso-2022-jp',
 			'headerCharset' => 'iso-2022-jp',
-			'transport' => 'Debug'
+			'transport' => 'debug'
 		));
 		$email->subject('あれ？もしかしての前と');
 		$headers = $email->getHeaders(array('subject'));
@@ -1967,7 +1938,7 @@ class EmailTest extends TestCase {
 		$email = new Email(array(
 			'charset' => 'iso-2022-jp-ms',
 			'headerCharset' => 'iso-2022-jp-ms',
-			'transport' => 'Debug'
+			'transport' => 'debug'
 		));
 		$email->subject('あれ？もしかしての前と');
 		$headers = $email->getHeaders(array('subject'));
@@ -2113,7 +2084,7 @@ class EmailTest extends TestCase {
 	}
 
 	protected function _getEmailByOldStyleCharset($charset, $headerCharset) {
-		$email = new Email(array('transport' => 'Debug'));
+		$email = new Email(array('transport' => 'debug'));
 
 		if (! empty($charset)) {
 			$email->charset = $charset;
@@ -2132,7 +2103,7 @@ class EmailTest extends TestCase {
 	}
 
 	protected function _getEmailByNewStyleCharset($charset, $headerCharset) {
-		$email = new Email(array('transport' => 'Debug'));
+		$email = new Email(array('transport' => 'debug'));
 
 		if (! empty($charset)) {
 			$email->charset($charset);
@@ -2154,7 +2125,7 @@ class EmailTest extends TestCase {
 		$message = '<a href="http://cakephp.org">' . str_repeat('x', Email::LINE_LENGTH_MUST) . "</a>";
 
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
@@ -2201,7 +2172,7 @@ HTML;
 		$message = $str . str_repeat('x', Email::LINE_LENGTH_MUST + 1);
 
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
@@ -2220,7 +2191,7 @@ HTML;
 		$message = $str . str_repeat('x', Email::LINE_LENGTH_MUST - $length + 1);
 
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');
@@ -2238,7 +2209,7 @@ HTML;
 		$message = mb_convert_encoding('受け付けました', 'iso-2022-jp', 'UTF-8');
 
 		$this->CakeEmail->reset();
-		$this->CakeEmail->transport('Debug');
+		$this->CakeEmail->transport('debug');
 		$this->CakeEmail->from('cake@cakephp.org');
 		$this->CakeEmail->to('cake@cakephp.org');
 		$this->CakeEmail->subject('Wordwrap Test');


### PR DESCRIPTION
Move Email configuration into 2 separate methods and no longer rely on Configure. Following the [proposal from earlier this week](https://github.com/markstory/cakephp/wiki/Config-methods) I've update the Email class. Transport and delivery configuration are now independent and follow the conventions started in `Cache` and `Log`.

I'm not entirely sure `useConfig()` is the correct method name, but I'm open to suggestions.
