### PR TITLE
BugFix: 2.4 mock components with config

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -211,6 +211,28 @@ class ControllerTestCaseTest extends CakeTestCase {
 	}
 
 /**
+ * testGenerateWithComponentConfig
+ */
+	public function testGenerateWithComponentConfig() {
+		$Tests = $this->Case->generate('TestConfigs', array(
+		));
+
+		$expected = array('some' => 'config');
+		$settings = array_intersect_key($Tests->RequestHandler->settings, array('some' => 'foo'));
+		$this->assertSame($expected, $settings, 'A mocked component should have the same config as an unmocked component');
+
+		$Tests = $this->Case->generate('TestConfigs', array(
+			'components' => array(
+				'RequestHandler' => array('isPut')
+			)
+		));
+
+		$expected = array('some' => 'config');
+		$settings = array_intersect_key($Tests->RequestHandler->settings, array('some' => 'foo'));
+		$this->assertSame($expected, $settings, 'A mocked component should have the same config as an unmocked component');
+	}
+
+/**
  * Tests ControllerTestCase::generate() using classes from plugins
  */
 	public function testGenerateWithPlugin() {

--- a/lib/Cake/Test/test_app/Controller/TestConfigsController.php
+++ b/lib/Cake/Test/test_app/Controller/TestConfigsController.php
@@ -1,0 +1,13 @@
+<?php
+
+App::uses('CakeErrorController', 'Controller');
+
+class TestConfigsController extends CakeErrorController {
+
+	public $components = array(
+		'RequestHandler' => array(
+			'some' => 'config'
+		)
+	);
+
+}

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -364,7 +364,8 @@ abstract class ControllerTestCase extends CakeTestCase {
 					'class' => $componentClass
 				));
 			}
-			$componentObj = $this->getMock($componentClass, $methods, array($controllerObj->Components));
+			$config = isset($controllerObj->components[$component]) ? $controllerObj->components[$component] : array();
+			$componentObj = $this->getMock($componentClass, $methods, array($controllerObj->Components, $config));
 			$controllerObj->Components->set($name, $componentObj);
 			$controllerObj->Components->enable($name);
 		}


### PR DESCRIPTION
At the moment, anything in `Controller::$components` is lost as soon as you mock a component. This makes using testAction with any controller where `Controller::$components` contains settings pertinent to the test - confusing and difficult (as you must not mock the component, to get the relevant config). 
