### PR TITLE
assets dirs may be defined elsewhere bootstrap.php

### DIFF
--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -62,18 +62,22 @@ if (!defined('APP')) {
 /**
  * Path to the public CSS directory.
  */
+if (!defined('CSS')) {
 	define('CSS', WWW_ROOT . 'css' . DS);
+}
 
 /**
  * Path to the public JavaScript directory.
  */
+if (!defined('JS')) {
 	define('JS', WWW_ROOT . 'js' . DS);
-
+}
 /**
  * Path to the public images directory.
  */
+if (!defined('IMAGES')) {
 	define('IMAGES', WWW_ROOT . 'img' . DS);
-
+}
 /**
  * Path to the tests directory.
  */


### PR DESCRIPTION
{CSS,JS,IMAGES}_URL can be defined elsewhere, but not {CSS,JS,IMAGES} . I think it's a miss.
