### PR TITLE
sync and correct generic css

### DIFF
--- a/app/webroot/css/cake.generic.css
+++ b/app/webroot/css/cake.generic.css
@@ -109,6 +109,9 @@ p {
 	padding: 6px 10px;
 	text-align: right;
 }
+#header a, #footer a {
+	color: #fff;
+}
 
 /** containers **/
 div.form,

--- a/lib/Cake/Console/Templates/skel/webroot/css/cake.generic.css
+++ b/lib/Cake/Console/Templates/skel/webroot/css/cake.generic.css
@@ -13,7 +13,6 @@
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.webroot.css
- * @since         CakePHP(tm)
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
@@ -109,6 +108,9 @@ p {
 	clear: both;
 	padding: 6px 10px;
 	text-align: right;
+}
+#header a, #footer a {
+	color: #fff;
 }
 
 /** containers **/


### PR DESCRIPTION
Currently, the default color for text in header and footer is badly set (as it will not be visible).
This corrects it.
I found that out building the cakefest app - which I had to tweak the way described here in order to make the text visible again.

The skeleton one is now also in sync again with the app one.
