### PR TITLE
3.0 remove cache set

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -427,8 +427,7 @@ class Cache {
 			return false;
 		}
 
-		$success = $engine->delete($settings['prefix'] . $key);
-		return $success;
+		return $engine->delete($settings['prefix'] . $key);
 	}
 
 /**
@@ -444,8 +443,7 @@ class Cache {
 			return false;
 		}
 
-		$success = $engine->clear($check);
-		return $success;
+		return $engine->clear($check);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -68,7 +68,6 @@ class CacheTest extends TestCase {
 		Cache::write('no_save', 'Noooo!', 'tests');
 		Cache::read('no_save', 'tests');
 		Cache::delete('no_save', 'tests');
-		Cache::set('duration', '+10 minutes');
 	}
 
 /**
@@ -415,85 +414,6 @@ class CacheTest extends TestCase {
 
 		$this->assertFalse(Cache::write('key_6', 'hello', 'test_cache_disable_2'));
 		$this->assertFalse(Cache::read('key_6', 'test_cache_disable_2'));
-	}
-
-/**
- * testSet method
- *
- * @return void
- */
-	public function testSet() {
-		$this->_configCache();
-
-		Cache::set(array('duration' => '+1 year'), 'tests');
-		$data = Cache::read('test_cache', 'tests');
-		$this->assertFalse($data);
-
-		$data = 'this is just a simple test of the cache system';
-		$write = Cache::write('test_cache', $data, 'tests');
-		$this->assertTrue($write);
-
-		Cache::set(array('duration' => '+1 year'), 'tests');
-		$data = Cache::read('test_cache', 'tests');
-		$this->assertEquals('this is just a simple test of the cache system', $data);
-
-		Cache::delete('test_cache', 'tests');
-	}
-
-/**
- * Test that set() modifies settings, which can be read back with
- * settings().
- *
- * @return void
- */
-	public function testSetModifySettings() {
-		Cache::config('tests', [
-			'engine' => 'File',
-			'duration' => '+1 minute'
-		]);
-
-		$result = Cache::set(['duration' => '+1 year'], 'tests');
-		$this->assertEquals(strtotime('+1 year') - time(), $result['duration']);
-
-		$result = Cache::set('duration', '+1 month', 'tests');
-		$this->assertEquals(strtotime('+1 month') - time(), $result['duration']);
-
-		$settings = Cache::settings('tests');
-		$this->assertEquals($result, $settings, 'set() and settings() should be the same.');
-	}
-
-/**
- * Test that calling set() with null, config restores old settings.
- *
- * @return void
- */
-	public function testSetModifyAndResetSettings() {
-		Cache::config('tests', [
-			'engine' => 'File',
-			'duration' => '+1 minute'
-		]);
-		$result = Cache::set('duration', '+1 year', 'tests');
-		$this->assertEquals(strtotime('+1 year') - time(), $result['duration']);
-
-		$result = Cache::set(null, 'tests');
-		$this->assertEquals(strtotime('+1 minute') - time(), $result['duration']);
-	}
-
-/**
- * test set() parameter handling for user cache configs.
- *
- * @return void
- */
-	public function testSetOnAlternateConfigs() {
-		Cache::config('file_config', [
-			'engine' => 'File',
-			'prefix' => 'test_file_'
-		]);
-		Cache::set(['duration' => '+1 year'], 'file_config');
-		$settings = Cache::settings('file_config');
-
-		$this->assertEquals('test_file_', $settings['prefix']);
-		$this->assertEquals(strtotime('+1 year') - time(), $settings['duration']);
 	}
 
 /**

--- a/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
@@ -43,7 +43,7 @@ class ApcEngineTest extends TestCase {
 		}
 
 		Cache::enable();
-		Cache::config('apc', ['engine' => 'Apc', 'prefix' => 'cake_']);
+		$this->_configCache();
 	}
 
 /**
@@ -58,12 +58,26 @@ class ApcEngineTest extends TestCase {
 	}
 
 /**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'Apc',
+			'prefix' => 'cake_',
+		];
+		Cache::drop('apc');
+		Cache::config('apc', array_merge($defaults, $settings));
+	}
+
+/**
  * testReadAndWriteCache method
  *
  * @return void
  */
 	public function testReadAndWriteCache() {
-		Cache::set(['duration' => 1], 'apc');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'apc');
 		$expecting = '';
@@ -101,7 +115,7 @@ class ApcEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(['duration' => 1], 'apc');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'apc');
 		$this->assertFalse($result);
@@ -114,7 +128,7 @@ class ApcEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'apc');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => 1], 'apc');
+		$this->_configCache();
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'apc');

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -45,11 +45,7 @@ class FileEngineTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Cache::enable();
-		Cache::drop('file_test');
-		Cache::config('file_test', [
-			'engine' => 'File',
-			'path' => TMP . 'tests',
-		]);
+		$this->_configCache();
 		Cache::clear(false, 'file_test');
 	}
 
@@ -67,16 +63,45 @@ class FileEngineTest extends TestCase {
 	}
 
 /**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'File',
+			'path' => TMP . 'tests',
+		];
+		Cache::drop('file_test');
+		Cache::config('file_test', array_merge($defaults, $settings));
+	}
+
+/**
  * testReadAndWriteCache method
  *
  * @return void
  */
-	public function testReadAndWriteCache() {
+	public function testReadAndWriteCacheExpired() {
+		Cache::drop('file_test');
+		Cache::config('file_test', [
+			'engine' => 'File',
+			'path' => TMP . 'tests',
+			'duration' => 1,
+		]);
 		$result = Cache::write(null, 'here', 'file_test');
 		$this->assertFalse($result);
 
-		Cache::set(array('duration' => 1), 'file_test');
+		$result = Cache::read('test', 'file_test');
+		$expecting = '';
+		$this->assertEquals($expecting, $result);
+	}
 
+/**
+ * Test reading and writing to the cache.
+ *
+ * @return void
+ */
+	public function testReadAndwrite() {
 		$result = Cache::read('test', 'file_test');
 		$expecting = '';
 		$this->assertEquals($expecting, $result);
@@ -115,7 +140,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(array('duration' => 1), 'file_test');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'file_test');
 		$this->assertFalse($result);
@@ -128,7 +153,7 @@ class FileEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'file_test');
 		$this->assertFalse($result);
 
-		Cache::set(array('duration' => "+1 second"), 'file_test');
+		$this->_configCache(['duration' => '+1 second']);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'file_test');
@@ -163,13 +188,12 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testSerialize() {
-		Cache::drop('file_test');
-		Cache::config('file_test', ['engine' => 'File', 'serialize' => true]);
+		$this->_configCache(['serialize' => true]);
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test', $data, 'file_test');
 		$this->assertTrue($write);
 
-		Cache::set(['serialize' => false], 'file_test');
+		$this->_configCache(['serialize' => false]);
 		$read = Cache::read('serialize_test', 'file_test');
 
 		$delete = Cache::delete('serialize_test', 'file_test');
@@ -183,30 +207,30 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testClear() {
-		Cache::drop('file_test');
-		Cache::config('file_test', ['engine' => 'File', 'duration' => 1]);
+		$this->_configCache(['duration' => 1]);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test1', $data, 'file_test');
 		$write = Cache::write('serialize_test2', $data, 'file_test');
 		$write = Cache::write('serialize_test3', $data, 'file_test');
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test1'));
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test2'));
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test3'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test1'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test2'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test3'));
+
 		sleep(2);
 		$result = Cache::clear(true, 'file_test');
 		$this->assertTrue($result);
-		$this->assertFalse(file_exists(CACHE . 'cake_serialize_test1'));
-		$this->assertFalse(file_exists(CACHE . 'cake_serialize_test2'));
-		$this->assertFalse(file_exists(CACHE . 'cake_serialize_test3'));
+		$this->assertFalse(file_exists(TMP . 'tests/cake_serialize_test1'));
+		$this->assertFalse(file_exists(TMP . 'tests/cake_serialize_test2'));
+		$this->assertFalse(file_exists(TMP . 'tests/cake_serialize_test3'));
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$write = Cache::write('serialize_test1', $data, 'file_test');
 		$write = Cache::write('serialize_test2', $data, 'file_test');
 		$write = Cache::write('serialize_test3', $data, 'file_test');
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test1'));
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test2'));
-		$this->assertTrue(file_exists(CACHE . 'cake_serialize_test3'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test1'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test2'));
+		$this->assertTrue(file_exists(TMP . 'tests/cake_serialize_test3'));
 
 		$result = Cache::clear(false, 'file_test');
 		$this->assertTrue($result);

--- a/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -82,12 +82,7 @@ class FileEngineTest extends TestCase {
  * @return void
  */
 	public function testReadAndWriteCacheExpired() {
-		Cache::drop('file_test');
-		Cache::config('file_test', [
-			'engine' => 'File',
-			'path' => TMP . 'tests',
-			'duration' => 1,
-		]);
+		$this->_configCache(['duration' => 1]);
 		$result = Cache::write(null, 'here', 'file_test');
 		$this->assertFalse($result);
 

--- a/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/MemcacheEngineTest.php
@@ -62,11 +62,7 @@ class MemcacheEngineTest extends TestCase {
 		$this->skipIf(!class_exists('Memcache'), 'Memcache is not installed or configured properly.');
 
 		Cache::enable();
-		Cache::config('memcache', array(
-			'className' => 'Memcache',
-			'prefix' => 'cake_',
-			'duration' => 3600
-		));
+		$this->_configCache();
 	}
 
 /**
@@ -80,6 +76,22 @@ class MemcacheEngineTest extends TestCase {
 		Cache::drop('memcache_groups');
 		Cache::drop('memcache_helper');
 	}
+
+/**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'Memcache',
+			'prefix' => 'cake_',
+			'duration' => 3600
+		];
+		Cache::drop('memcache');
+		Cache::config('memcache', array_merge($defaults, $settings));
+	}
+
 
 /**
  * testSettings method
@@ -212,7 +224,7 @@ class MemcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(['duration' => 1], 'memcache');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'memcache');
 		$this->assertFalse($result);
@@ -225,7 +237,7 @@ class MemcacheEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'memcache');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => "+1 second"], 'memcache');
+		$this->_configCache(['duration' => '+1 second']);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'memcache');
@@ -235,12 +247,12 @@ class MemcacheEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'memcache');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => '+1 second'], 'memcache');
+		$this->_configCache(['duration' => '+1 second']);
 
 		$result = Cache::read('other_test', 'memcache');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => '+29 days'], 'memcache');
+		$this->_configCache(['duration' => '+29 days']);
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('long_expiry_test', $data, 'memcache');
 		$this->assertTrue($result);

--- a/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
@@ -36,11 +36,7 @@ class RedisEngineTest extends TestCase {
 		$this->skipIf(!class_exists('Redis'), 'Redis is not installed or configured properly.');
 
 		Cache::enable();
-		Cache::config('redis', array(
-			'engine' => 'Cake\Cache\Engine\RedisEngine',
-			'prefix' => 'cake_',
-			'duration' => 3600
-		));
+		$this->_configCache();
 	}
 
 /**
@@ -53,6 +49,21 @@ class RedisEngineTest extends TestCase {
 		Cache::drop('redis');
 		Cache::drop('redis_groups');
 		Cache::drop('redis_helper');
+	}
+
+/**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'Redis',
+			'prefix' => 'cake_',
+			'duration' => 3600
+		];
+		Cache::drop('redis');
+		Cache::config('redis', array_merge($defaults, $settings));
 	}
 
 /**
@@ -92,7 +103,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testReadAndWriteCache() {
-		Cache::set(['duration' => 1], 'redis');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'redis');
 		$expecting = '';
@@ -119,7 +130,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(array('duration' => 1), 'redis');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'redis');
 		$this->assertFalse($result);
@@ -132,7 +143,7 @@ class RedisEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'redis');
 		$this->assertFalse($result);
 
-		Cache::set(array('duration' => "+1 second"), 'redis');
+		$this->_configCache(['duration' => '+1 second']);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'redis');
@@ -142,13 +153,12 @@ class RedisEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'redis');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => '+1 second'], 'redis');
 		sleep(2);
 
 		$result = Cache::read('other_test', 'redis');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => '+29 days'], 'redis');
+		$this->_configCache(['duration' => '+29 days']);
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('long_expiry_test', $data, 'redis');
 		$this->assertTrue($result);
@@ -248,7 +258,7 @@ class RedisEngineTest extends TestCase {
  * @return void
  */
 	public function testZeroDuration() {
-		Cache::set(['duration' => 0], 'redis');
+		$this->_configCache(['duration' => 0]);
 		$result = Cache::write('test_key', 'written!', 'redis');
 
 		$this->assertTrue($result);

--- a/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -39,7 +39,7 @@ class WincacheEngineTest extends TestCase {
 		parent::setUp();
 		$this->skipIf(!function_exists('wincache_ucache_set'), 'Wincache is not installed or configured properly.');
 		Cache::enable();
-		Cache::config('wincache', ['engine' => 'Wincache', 'prefix' => 'cake_']);
+		$this->_configCache();
 	}
 
 /**
@@ -54,12 +54,27 @@ class WincacheEngineTest extends TestCase {
 	}
 
 /**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'Wincache',
+			'prefix' => 'cake_'
+		];
+		Cache::drop('wincache');
+		Cache::config('wincache', array_merge($defaults, $settings));
+	}
+
+
+/**
  * testReadAndWriteCache method
  *
  * @return void
  */
 	public function testReadAndWriteCache() {
-		Cache::set(['duration' => 1], 'wincache');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'wincache');
 		$expecting = '';
@@ -82,7 +97,7 @@ class WincacheEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(['duration' => 1], 'wincache');
+		$this->_configCache(['duration' => 1]);
 
 		$result = Cache::read('test', 'wincache');
 		$this->assertFalse($result);
@@ -95,15 +110,9 @@ class WincacheEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'wincache');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => 1], 'wincache');
-
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'wincache');
 		$this->assertTrue($result);
-
-		sleep(2);
-		$result = Cache::read('other_test', 'wincache');
-		$this->assertFalse($result);
 
 		sleep(2);
 		$result = Cache::read('other_test', 'wincache');

--- a/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -44,6 +44,21 @@ class XcacheEngineTest extends TestCase {
 	}
 
 /**
+ * Helper method for testing.
+ *
+ * @return void
+ */
+	protected function _configCache($settings = []) {
+		$defaults = [
+			'className' => 'Xcache',
+			'prefix' => 'cake_',
+		];
+		Cache::drop('xcache');
+		Cache::config('xcache', array_merge($defaults, $settings));
+	}
+
+
+/**
  * tearDown method
  *
  * @return void
@@ -79,8 +94,6 @@ class XcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testReadAndWriteCache() {
-		Cache::set(['duration' => 1], 'xcache');
-
 		$result = Cache::read('test', 'xcache');
 		$expecting = '';
 		$this->assertEquals($expecting, $result);
@@ -102,7 +115,7 @@ class XcacheEngineTest extends TestCase {
  * @return void
  */
 	public function testExpiry() {
-		Cache::set(['duration' => 1], 'xcache');
+		$this->_configCache(['duration' => 1]);
 		$result = Cache::read('test', 'xcache');
 		$this->assertFalse($result);
 
@@ -114,7 +127,7 @@ class XcacheEngineTest extends TestCase {
 		$result = Cache::read('other_test', 'xcache');
 		$this->assertFalse($result);
 
-		Cache::set(['duration' => "+1 second"], 'xcache');
+		$this->_configCache(['duration' => '+1 second']);
 
 		$data = 'this is a test of the emergency broadcasting system';
 		$result = Cache::write('other_test', $data, 'xcache');


### PR DESCRIPTION
This method has been a pain since its introduction. It causes a number  of negative things to happen:
- It leaks configuration information into all calling code. Making maintenance harder.
- It can easily cause nasty side-effects. Since Cache is a global facade, an unbalanced set() call can screw up cache writes elsewhere in the application.
- It is prone to error as developers have to remember to balance all the set() calls.
- It complicates the internals of Cache.

Instead of set developers can easily create multiple cache configurations for the various settings they need. This keeps both the calling code and CakePHP clean and simple.
