### PR TITLE
remove code, class names and paths from translation strings.

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -174,7 +174,7 @@ class Cache {
 		}
 		$cacheClass = $class . 'Engine';
 		if (!is_subclass_of($cacheClass, 'CacheEngine')) {
-			throw new CacheException(__d('cake_dev', 'Cache engines must use CacheEngine as a base class.'));
+			throw new CacheException(__d('cake_dev', 'Cache engines must use %s as a base class.', 'CacheEngine'));
 		}
 		self::$_engines[$name] = new $cacheClass();
 		if (!self::$_engines[$name]->init($config)) {

--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -71,7 +71,7 @@ class PhpReader implements ConfigReaderInterface {
 
 		include $file;
 		if (!isset($config)) {
-			throw new ConfigureException(__d('cake_dev', 'No variable $config found in %s', $file));
+			throw new ConfigureException(__d('cake_dev', 'No variable %s found in %s', '$config', $file));
 		}
 		return $config;
 	}

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -122,7 +122,7 @@ class ServerShell extends AppShell {
  */
 	public function main() {
 		if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-			$this->out(__d('cake_console', '<warning>This command is available on PHP5.4 or above</warning>'));
+			$this->out(__d('cake_console', '<warning>This command is available on %s or above</warning>', 'PHP5.4'));
 			return;
 		}
 

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -117,8 +117,8 @@ class ProjectTask extends AppShell {
 			}
 			$success = $this->corePath($path, $hardCode) === true;
 			if ($success) {
-				$this->out(__d('cake_console', ' * CAKE_CORE_INCLUDE_PATH set to %s in webroot/index.php', CAKE_CORE_INCLUDE_PATH));
-				$this->out(__d('cake_console', ' * CAKE_CORE_INCLUDE_PATH set to %s in webroot/test.php', CAKE_CORE_INCLUDE_PATH));
+				$this->out(__d('cake_console', ' * CAKE_CORE_INCLUDE_PATH set to %s in %s', CAKE_CORE_INCLUDE_PATH, 'webroot/index.php'));
+				$this->out(__d('cake_console', ' * CAKE_CORE_INCLUDE_PATH set to %s in %s', CAKE_CORE_INCLUDE_PATH, 'webroot/test.php'));
 			} else {
 				$this->err(__d('cake_console', 'Unable to set CAKE_CORE_INCLUDE_PATH, you should change it in %s', $path . 'webroot' . DS . 'index.php'));
 				$success = false;

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -59,11 +59,11 @@ endif;
 		$settings = Cache::settings();
 		if (!empty($settings)):
 			echo '<span class="notice success">';
-				echo __d('cake_dev', 'The %s is being used for core caching. To change the config edit APP/Config/core.php ', '<em>'. $settings['engine'] . 'Engine</em>');
+				echo __d('cake_dev', 'The %s is being used for core caching. To change the config edit %s', '<em>'. $settings['engine'] . 'Engine</em>', 'APP/Config/core.php');
 			echo '</span>';
 		else:
 			echo '<span class="notice">';
-				echo __d('cake_dev', 'Your cache is NOT working. Please check the settings in APP/Config/core.php');
+				echo __d('cake_dev', 'Your cache is NOT working. Please check the settings in %s', 'APP/Config/core.php');
 			echo '</span>';
 		endif;
 	?>
@@ -80,7 +80,7 @@ endif;
 			echo '<span class="notice">';
 				echo __d('cake_dev', 'Your database configuration file is NOT present.');
 				echo '<br/>';
-				echo __d('cake_dev', 'Rename APP/Config/database.php.default to APP/Config/database.php');
+				echo __d('cake_dev', 'Rename %s to %s', 'APP/Config/database.php.default', 'APP/Config/database.php');
 			echo '</span>';
 		endif;
 	?>
@@ -123,7 +123,7 @@ if (isset($filePresent)):
 		echo '<p><span class="notice">';
 			echo __d('cake_dev', 'PCRE has not been compiled with Unicode support.');
 			echo '<br/>';
-			echo __d('cake_dev', 'Recompile PCRE with Unicode support by adding <code>--enable-unicode-properties</code> when configuring');
+			echo __d('cake_dev', 'Recompile PCRE with Unicode support by adding %s when configuring', '<code>--enable-unicode-properties</code>');
 		echo '</span></p>';
 	}
 ?>
@@ -147,9 +147,10 @@ if (isset($filePresent)):
 <h3><?php echo __d('cake_dev', 'Editing this Page'); ?></h3>
 <p>
 <?php
-echo __d('cake_dev', 'To change the content of this page, edit: APP/View/Pages/home.ctp.<br />
-To change its layout, edit: APP/View/Layouts/default.ctp.<br />
-You can also add some CSS styles for your pages at: APP/webroot/css.');
+echo __d('cake_dev', 'To change the content of this page, edit: %s.<br />
+To change its layout, edit: %s.<br />
+You can also add some CSS styles for your pages at: %s.',
+	'APP/View/Pages/home.ctp', 'APP/View/Layouts/default.ctp', 'APP/webroot/css');
 ?>
 </p>
 

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -48,7 +48,7 @@ class ControllerAuthorize extends BaseAuthorize {
 	public function controller(Controller $controller = null) {
 		if ($controller) {
 			if (!method_exists($controller, 'isAuthorized')) {
-				throw new CakeException(__d('cake_dev', '$controller does not implement an isAuthorized() method.'));
+				throw new CakeException(__d('cake_dev', '$controller does not implement an %s method.', 'isAuthorized()'));
 			}
 		}
 		return parent::controller($controller);

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -495,7 +495,7 @@ class AuthComponent extends Component {
 				throw new CakeException(__d('cake_dev', 'Authorization adapter "%s" was not found.', $class));
 			}
 			if (!method_exists($className, 'authorize')) {
-				throw new CakeException(__d('cake_dev', 'Authorization objects must implement an %s method.', 'authorize'));
+				throw new CakeException(__d('cake_dev', 'Authorization objects must implement an %s method.', 'authorize()'));
 			}
 			$settings = array_merge($global, (array)$settings);
 			$this->_authorizeObjects[] = new $className($this->_Collection, $settings);
@@ -784,7 +784,7 @@ class AuthComponent extends Component {
 				throw new CakeException(__d('cake_dev', 'Authentication adapter "%s" was not found.', $class));
 			}
 			if (!method_exists($className, 'authenticate')) {
-				throw new CakeException(__d('cake_dev', 'Authentication objects must implement an %s method.', 'authenticate'));
+				throw new CakeException(__d('cake_dev', 'Authentication objects must implement an %s method.', 'authenticate()'));
 			}
 			$settings = array_merge($global, (array)$settings);
 			$this->_authenticateObjects[] = new $className($this->_Collection, $settings);

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -340,7 +340,7 @@ class Configure {
 			throw new ConfigureException(__d('cake_dev', 'There is no "%s" adapter.', $config));
 		}
 		if (!method_exists($reader, 'dump')) {
-			throw new ConfigureException(__d('cake_dev', 'The "%s" adapter, does not have a dump() method.', $config));
+			throw new ConfigureException(__d('cake_dev', 'The "%s" adapter, does not have a %s method.', $config, 'dump()'));
 		}
 		$values = self::$_values;
 		if (!empty($keys) && is_array($keys)) {

--- a/lib/Cake/Model/Behavior/AclBehavior.php
+++ b/lib/Cake/Model/Behavior/AclBehavior.php
@@ -65,7 +65,7 @@ class AclBehavior extends ModelBehavior {
 			$model->{$type} = ClassRegistry::init($type);
 		}
 		if (!method_exists($model, 'parentNode')) {
-			trigger_error(__d('cake_dev', 'Callback parentNode() not defined in %s', $model->alias), E_USER_WARNING);
+			trigger_error(__d('cake_dev', 'Callback %s not defined in %s', 'parentNode()', $model->alias), E_USER_WARNING);
 		}
 	}
 

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -228,7 +228,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
 		$method = $this->hasMethod($method, true);
 
 		if ($strict && empty($method)) {
-			trigger_error(__d('cake_dev', "BehaviorCollection::dispatchMethod() - Method %s not found in any attached behavior", $method), E_USER_WARNING);
+			trigger_error(__d('cake_dev', '%s - Method %s not found in any attached behavior', 'BehaviorCollection::dispatchMethod()', $method), E_USER_WARNING);
 			return null;
 		}
 		if (empty($method)) {

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -81,7 +81,7 @@ class Permission extends AppModel {
  * @param string $action Action (defaults to *)
  * @return boolean Success (true if ARO has access to action in ACO, false otherwise)
  */
-	public function check($aro, $aco, $action = "*") {
+	public function check($aro, $aco, $action = '*') {
 		if (!$aro || !$aco) {
 			return false;
 		}
@@ -92,7 +92,8 @@ class Permission extends AppModel {
 
 		if (!$aroPath || !$acoPath) {
 			trigger_error(__d('cake_dev',
-					"DbAcl::check() - Failed ARO/ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
+					"%s - Failed ARO/ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
+					'DbAcl::check()',
 					print_r($aro, true),
 					print_r($aco, true)),
 				E_USER_WARNING
@@ -102,7 +103,8 @@ class Permission extends AppModel {
 
 		if (!$acoPath) {
 			trigger_error(__d('cake_dev',
-					"DbAcl::check() - Failed ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
+					"%s - Failed ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
+					'DbAcl::check()',
 					print_r($aro, true),
 					print_r($aco, true)),
 				E_USER_WARNING
@@ -111,7 +113,7 @@ class Permission extends AppModel {
 		}
 
 		if ($action !== '*' && !in_array('_' . $action, $permKeys)) {
-			trigger_error(__d('cake_dev', "ACO permissions key %s does not exist in DbAcl::check()", $action), E_USER_NOTICE);
+			trigger_error(__d('cake_dev', "ACO permissions key %s does not exist in %s", $action, 'DbAcl::check()'), E_USER_NOTICE);
 			return false;
 		}
 
@@ -176,20 +178,20 @@ class Permission extends AppModel {
  * @return boolean Success
  * @throws AclException on Invalid permission key.
  */
-	public function allow($aro, $aco, $actions = "*", $value = 1) {
+	public function allow($aro, $aco, $actions = '*', $value = 1) {
 		$perms = $this->getAclLink($aro, $aco);
 		$permKeys = $this->getAcoKeys($this->schema());
 		$save = array();
 
 		if (!$perms) {
-			trigger_error(__d('cake_dev', 'DbAcl::allow() - Invalid node'), E_USER_WARNING);
+			trigger_error(__d('cake_dev', '%s - Invalid node', 'DbAcl::allow()'), E_USER_WARNING);
 			return false;
 		}
 		if (isset($perms[0])) {
 			$save = $perms[0][$this->alias];
 		}
 
-		if ($actions === "*") {
+		if ($actions === '*') {
 			$save = array_combine($permKeys, array_pad(array(), count($permKeys), $value));
 		} else {
 			if (!is_array($actions)) {

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -846,11 +846,11 @@ class Debugger {
  */
 	public static function checkSecurityKeys() {
 		if (Configure::read('Security.salt') === 'DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi') {
-			trigger_error(__d('cake_dev', 'Please change the value of \'Security.salt\' in app/Config/core.php to a salt value specific to your application'), E_USER_NOTICE);
+			trigger_error(__d('cake_dev', 'Please change the value of %s in %s to a salt value specific to your application.', '\'Security.salt\'', 'APP/Config/core.php'), E_USER_NOTICE);
 		}
 
 		if (Configure::read('Security.cipherSeed') === '76859309657453542496749683645') {
-			trigger_error(__d('cake_dev', 'Please change the value of \'Security.cipherSeed\' in app/Config/core.php to a numeric (digits only) seed value specific to your application'), E_USER_NOTICE);
+			trigger_error(__d('cake_dev', 'Please change the value of %s in %s to a numeric (digits only) seed value specific to your application.', '\'Security.cipherSeed\'', 'APP/Config/core.php'), E_USER_NOTICE);
 		}
 	}
 

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -254,7 +254,7 @@ class Validation {
 				}
 				break;
 			default:
-				self::$errors[] = __d('cake_dev', 'You must define the $operator parameter for Validation::comparison()');
+				self::$errors[] = __d('cake_dev', 'You must define the $operator parameter for %s', 'Validation::comparison()');
 		}
 		return false;
 	}
@@ -272,7 +272,7 @@ class Validation {
 			extract(self::_defaults($check));
 		}
 		if ($regex === null) {
-			self::$errors[] = __d('cake_dev', 'You must define a regular expression for Validation::custom()');
+			self::$errors[] = __d('cake_dev', 'You must define a regular expression for %s', 'Validation::custom()');
 			return false;
 		}
 		return self::_check($check, $regex);

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -308,7 +308,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
 	public function drop($options = array()) {
 		if (empty($options['drag'])) {
 			trigger_error(
-				__d('cake_dev', 'MootoolsEngine::drop() requires a "drag" option to properly function'), E_USER_WARNING
+				__d('cake_dev', '%s requires a "drag" option to properly function'), 'MootoolsEngine::drop()', E_USER_WARNING
 			);
 			return false;
 		}

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -96,7 +96,7 @@ class PaginatorHelper extends AppHelper {
 		$classname = $ajaxProvider . 'Helper';
 		if (!class_exists($classname) || !method_exists($classname, 'link')) {
 			throw new CakeException(
-				__d('cake_dev', '%s does not implement a link() method, it is incompatible with PaginatorHelper', $classname)
+				__d('cake_dev', '%s does not implement a %s method, it is incompatible with %s', $classname, 'link()', 'PaginatorHelper')
 			);
 		}
 		parent::__construct($View, $settings);


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/1532 and https://github.com/cakephp/cakephp/pull/1526 .

Paths, Classes and their methods should not be part of the translation. It only creates a risk of misspelling them. Also, changing those should not necessarily have to affect the translation itself.

Also unifies methods - having () appended.
