### PR TITLE
3.0 simplify errorhandling

### DIFF
--- a/App/Config/error.php
+++ b/App/Config/error.php
@@ -32,6 +32,7 @@ use Cake\Console\ConsoleErrorHandler;
  * - `errorLevel` - int - The level of errors you are interested in capturing.
  * - `trace` - boolean - Whether or not backtraces should be included in
  *   logged errors/exceptions.
+ * - `log` - boolean - Whether or not you want exceptions logged.
  * - `exceptionRenderer` - string - The class responsible for rendering
  *   uncaught exceptions.  If you choose a custom class you should place
  *   the file for that class in app/Lib/Error. This class needs to implement a render method.

--- a/App/Config/error.php
+++ b/App/Config/error.php
@@ -8,64 +8,50 @@
  *
  * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       app.Config
  * @since         CakePHP(tm) v3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 namespace App\Config;
 
-use Cake\Core\Configure;
+use Cake\Error\ErrorHandler;
+use Cake\Console\ConsoleErrorHandler;
 
 /**
- * Configure the Error handler used to handle errors for your application.  By default
- * ErrorHandler::handleError() is used.  It will display errors using Debugger, when debug > 0
- * and log errors with Cake Log when debug = 0.
+ * Configure the Error and Exception handlers used by your application.
+ *
+ * By default errors are displayed using Debugger, when debug > 0 and logged by
+ * Cake\Log\Log when debug = 0.
+ *
+ * In CLI environments exceptions will be printed to stderr with a backtrace.
+ * In web environments an HTML page will be displayed for the exception.
+ * While debug > 0, framework errors like Missing Controller will be displayed.
+ * When debug = 0, framework errors will be coerced into generic HTTP errors.
  *
  * Options:
  *
- * - `handler` - callback - The callback to handle errors. You can set this to any callable type,
- *    including anonymous functions.
- * - `consoleHandler` - callback - The callback to handle errors. You can set this to any callable type,
- *    including anonymous functions.
- * - `level` - int - The level of errors you are interested in capturing.
- * - `trace` - boolean - Include stack traces for errors in log files.
- *
- * @see ErrorHandler for more information on error handling and configuration.
- */
-	Configure::write('Error', [
-		'handler' => 'Cake\Error\ErrorHandler::handleError',
-		'consoleHandler' => 'Cake\Console\ConsoleErrorHandler::handleError',
-		'level' => E_ALL & ~E_DEPRECATED,
-		'trace' => true
-	]);
-
-/**
- * Configure the Exception handler used for uncaught exceptions.  By default,
- * ErrorHandler::handleException() is used. It will display a HTML page for the exception, and
- * while debug > 0, framework errors like Missing Controller will be displayed.  When debug = 0,
- * framework errors will be coerced into generic HTTP errors.
- *
- * Options:
- *
- * - `handler` - callback - The callback to handle exceptions. You can set this to any callback type,
- *   including anonymous functions.
- * - `renderer` - string - The class responsible for rendering uncaught exceptions.  If you choose a custom class you
- *   should place the file for that class in app/Lib/Error. This class needs to implement a render method.
- * - `log` - boolean - Should Exceptions be logged?
- * - `skipLog` - array - list of exceptions to skip for logging. Exceptions that
+ * - `errorLevel` - int - The level of errors you are interested in capturing.
+ * - `trace` - boolean - Whether or not backtraces should be included in
+ *   logged errors/exceptions.
+ * - `exceptionRenderer` - string - The class responsible for rendering
+ *   uncaught exceptions.  If you choose a custom class you should place
+ *   the file for that class in app/Lib/Error. This class needs to implement a render method.
+ * - `skipLog` - array - List of exceptions to skip for logging. Exceptions that
  *   extend one of the listed exceptions will also be skipped for logging.
  *   Example: `'skipLog' => array('Cake\Error\NotFoundException', 'Cake\Error\UnauthorizedException')`
  *
- * @see ErrorHandler for more information on exception handling and configuration.
+ * @see ErrorHandler for more information on error handling and configuration.
  */
-	Configure::write('Exception', [
-		'handler' => 'Cake\Error\ErrorHandler::handleException',
-		'consoleHandler' => 'Cake\Console\ConsoleErrorHandler::handleException',
-		'renderer' => 'Cake\Error\ExceptionRenderer',
-		'log' => true
-	]);
+$options = [
+	'errorLevel' => E_ALL & ~E_DEPRECATED,
+	'exceptionRenderer' => 'Cake\Error\ExceptionRenderer',
+	'skipLog' => [],
+	'log' => true,
+	'trace' => true,
+];
 
-/**
- * Once configured, set the error/exception handlers to PHP's default handlers.
- */
-	Configure::setErrorHandlers();
+if (php_sapi_name() == 'cli') {
+	$errorHandler = new ConsoleErrorHandler($options);
+} else {
+	$errorHandler = new ErrorHandler($options);
+}
+$errorHandler->register();

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Console;
 
-use Cake\Error\FatalErrorException;
 use Cake\Error\BaseErrorHandler;
+use Cake\Error\FatalErrorException;
 
 /**
  * Error Handler for Cake console. Does simple printing of the
@@ -87,7 +87,7 @@ class ConsoleErrorHandler extends BaseErrorHandler {
 			$error['file'],
 			$error['line']
 		);
-		$message = __d('cake_console', "<error>%s Error:</error> %s\n", 
+		$message = __d('cake_console', "<error>%s Error:</error> %s\n",
 			$error['error'],
 			$message
 		);

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -57,17 +57,16 @@ class ConsoleErrorHandler extends BaseErrorHandler {
  * @return void
  */
 	protected function _displayException($exception) {
-		$errorName = __d('cake_console', 'Error:');
+		$errorName = __d('cake_console', 'Exception:');
 		if ($exception instanceof FatalErrorException) {
 			$errorName = __d('cake_console', 'Fatal Error:');
 		}
 		$message = sprintf(
-			"<error>%s</error> %s in [%s, line %s]\n%s",
+			"<error>%s</error> %s in [%s, line %s]",
 			$errorName,
 			$exception->getMessage(),
 			$exception->getFile(),
-			$exception->getLine(),
-			$exception->getTraceAsString()
+			$exception->getLine()
 		);
 		$this->_stderr->write($message);
 	}

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -94,4 +94,13 @@ class ConsoleErrorHandler extends BaseErrorHandler {
 		$this->_stderr->write($message);
 	}
 
+/**
+ * Stop the execution and set the exit code for the process.
+ *
+ * @param integer $code The exit code.
+ */
+	protected function _stop($code) {
+		exit($code);
+	}
+
 }

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -14,10 +14,8 @@
  */
 namespace Cake\Console;
 
-use Cake\Core\Configure;
 use Cake\Error\FatalErrorException;
 use Cake\Error\BaseErrorHandler;
-use Cake\Error\ErrorHandler;
 
 /**
  * Error Handler for Cake console. Does simple printing of the
@@ -53,12 +51,12 @@ class ConsoleErrorHandler extends BaseErrorHandler {
 	}
 
 /**
- * Handle a exception in the console environment. Prints a message to stderr.
+ * Prints an exception to stderr.
  *
  * @param Exception $exception The exception to handle
- * @return integer Exit code from exception caught.
+ * @return void
  */
-	public function handleException(\Exception $exception) {
+	protected function _displayException($exception) {
 		$errorName = __d('cake_console', 'Error:');
 		if ($exception instanceof FatalErrorException) {
 			$errorName = __d('cake_console', 'Fatal Error:');
@@ -72,10 +70,6 @@ class ConsoleErrorHandler extends BaseErrorHandler {
 			$exception->getTraceAsString()
 		);
 		$this->_stderr->write($message);
-		return $exception->getCode() ?: 1;
-	}
-
-	protected function _displayException($exception) {
 	}
 
 /**

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -51,7 +51,7 @@ class ConsoleErrorHandler {
 	}
 
 /**
- * Register the error and exception handlers
+ * Register the error and exception handlers.
  *
  * @return void
  */

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -112,8 +112,6 @@ class ShellDispatcher {
  * @return boolean Success.
  */
 	protected function _bootstrap() {
-		$this->setErrorHandlers();
-
 		if (!Configure::read('App.fullBaseUrl')) {
 			Configure::write('App.fullBaseUrl', 'http://localhost');
 		}
@@ -122,46 +120,13 @@ class ShellDispatcher {
 	}
 
 /**
- * Set the error/exception handlers for the console
- *
- * @return void
- */
-	public function setErrorHandlers() {
-		$error = Configure::read('Error');
-		$exception = Configure::read('Exception');
-
-		$errorHandler = new ConsoleErrorHandler();
-		if (empty($error['consoleHandler'])) {
-			$error['consoleHandler'] = array($errorHandler, 'handleError');
-			Configure::write('Error', $error);
-		}
-		if (empty($exception['consoleHandler'])) {
-			$exception['consoleHandler'] = array($errorHandler, 'handleException');
-			Configure::write('Exception', $exception);
-		}
-		set_error_handler($error['consoleHandler'], Configure::read('Error.level'));
-	}
-
-/**
  * Dispatches a CLI request
  *
  * @return integer The cli command exit code. 0 is success.
  */
 	public function dispatch() {
-		try {
-			$exit = 0;
-			$this->_dispatch();
-		} catch (\Exception $e) {
-			$handler = Configure::read('Exception.consoleHandler');
-			if (is_callable($handler)) {
-				$exit = call_user_func($handler, $e);
-			} else {
-				echo __d('cake_console', "An exception occured\n");
-				echo __d('cake_console', "But the configured Exception.consoleHandler is not callable\n");
-				echo $e->getMessage() . "\n";
-				echo $e->getTraceAsString() . "\n";
-			}
-		}
+		$exit = 0;
+		$this->_dispatch();
 		return $exit;
 	}
 

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -125,9 +125,7 @@ class ShellDispatcher {
  * @return integer The cli command exit code. 0 is success.
  */
 	public function dispatch() {
-		$exit = 0;
-		$this->_dispatch();
-		return $exit;
+		return $this->_dispatch() === true ? 0 : 1;
 	}
 
 /**
@@ -160,6 +158,7 @@ class ShellDispatcher {
 			$Shell->loadTasks();
 			return $Shell->runCommand($command, $this->args);
 		}
+
 		$methods = array_diff(get_class_methods($Shell), get_class_methods('Cake\Console\Shell'));
 		$added = in_array($command, $methods);
 		$private = $command[0] === '_' && method_exists($Shell, $command);

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -21,8 +21,6 @@ use Cake\Utility\Inflector;
 
 /**
  * Shell dispatcher handles dispatching cli commands.
- *
- * @package       Cake.Console
  */
 class ShellDispatcher {
 

--- a/lib/Cake/Core/Configure.php
+++ b/lib/Cake/Core/Configure.php
@@ -348,27 +348,4 @@ class Configure {
 		return true;
 	}
 
-/**
- * Set the error and exception handlers using the native default handlers.
- *
- * Uses data already stored in Configure.
- *
- * @return void
- */
-	public static function setErrorHandlers() {
-		$level = -1;
-		$error = static::read('Error');
-		if (isset($error['level'])) {
-			error_reporting($error['level']);
-			$level = $error['level'];
-		}
-		if (!empty($error['handler'])) {
-			set_error_handler($error['handler'], $level);
-		}
-		$exception = static::read('Exception');
-		if (!empty($exception['handler'])) {
-			set_exception_handler($exception['handler']);
-		}
-	}
-
 }

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -254,39 +254,33 @@ abstract class BaseErrorHandler {
  * @return array Array of error word, and log location.
  */
 	public static function mapErrorCode($code) {
-		$error = $log = null;
-		switch ($code) {
-			case E_PARSE:
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-				$error = 'Fatal Error';
-				$log = LOG_ERR;
-				break;
-			case E_WARNING:
-			case E_USER_WARNING:
-			case E_COMPILE_WARNING:
-			case E_RECOVERABLE_ERROR:
-				$error = 'Warning';
-				$log = LOG_WARNING;
-				break;
-			case E_NOTICE:
-			case E_USER_NOTICE:
-				$error = 'Notice';
-				$log = LOG_NOTICE;
-				break;
-			case E_STRICT:
-				$error = 'Strict';
-				$log = LOG_NOTICE;
-				break;
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				$error = 'Deprecated';
-				$log = LOG_NOTICE;
-				break;
-		}
-		return array($error, $log);
+		$levelMap = [
+			E_PARSE => 'error',
+			E_ERROR => 'error',
+			E_CORE_ERROR => 'error',
+			E_COMPILE_ERROR => 'error',
+			E_USER_ERROR => 'error',
+			E_WARNING => 'warning',
+			E_USER_WARNING => 'warning',
+			E_COMPILE_WARNING => 'warning',
+			E_RECOVERABLE_ERROR => 'warning',
+			E_NOTICE => 'notice',
+			E_USER_NOTICE => 'notice',
+			E_STRICT => 'strict',
+			E_DEPRECATED => 'deprecated',
+			E_USER_DEPRECATED => 'deprecated',
+		];
+		$logMap = [
+			'error' => LOG_ERR,
+			'warning' => LOG_WARNING,
+			'notice' => LOG_NOTICE,
+			'strict' => LOG_NOTICE,
+			'deprecated' => LOG_NOTICE,
+		];
+
+		$error = $levelMap[$code];
+		$log = $logMap[$error];
+		return [ucfirst($error), $log];
 	}
 
 }

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -93,6 +93,37 @@ abstract class BaseErrorHandler {
 	}
 
 /**
+ * Display/Log a fatal error.
+ *
+ * @param integer $code Code of error
+ * @param string $description Error description
+ * @param string $file File on which error occurred
+ * @param integer $line Line that triggered the error
+ * @return boolean
+ */
+	public function handleFatalError($code, $description, $file, $line) {
+		$data = [
+			'code' => $code,
+			'description' => $description,
+			'file' => $file,
+			'line' => $line,
+			'error' => 'Fatal Error',
+		];
+		$this->_logError(LOG_ERR, $data);
+
+		if (ob_get_level()) {
+			ob_end_clean();
+		}
+
+		if (Configure::read('debug')) {
+			$this->handleException(new FatalErrorException($description, 500, $file, $line));
+		} else {
+			$this->handleException(new InternalErrorException());
+		}
+		return false;
+	}
+
+/**
  * Log an error.
  *
  * @param string $level The level name of the log.

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Error;
+
+use Cake\Core\Configure;
+use Cake\Log\Log;
+use Cake\Utility\Debugger;
+
+/**
+ * Base error handler that provides logic common to the CLI + web
+ * error/exception handlers.
+ *
+ * Subclasses are required to implement the template methods to handle displaying
+ * the errors in their environment.
+ */
+abstract class BaseErrorHandler {
+
+	abstract protected function _displayError($error, $debug);
+
+	abstract protected function _displayException($exception);
+
+/**
+ * Register the error and exception handlers.
+ *
+ * @return void
+ */
+	public function register() {
+		$level = -1;
+		if (isset($this->_options['errorLevel'])) {
+			$level = $this->_options['errorLevel'];
+		}
+		error_reporting($level);
+		set_error_handler([$this, 'handleError'], $level);
+		set_exception_handler([$this, 'handleException']);
+	}
+
+/**
+ * Set as the default error handler by CakePHP.
+ *
+ * Use App/Config/error.php to customize or replace this error handler.
+ * This function will use Debugger to display errors when debug > 0. And
+ * will log errors to Log, when debug == 0.
+ *
+ * You can use the 'errorLevel' option to set what type of errors will be handled.
+ * Stack traces for errors can be enabled with the 'trace' option.
+ *
+ * @param integer $code Code of error
+ * @param string $description Error description
+ * @param string $file File on which error occurred
+ * @param integer $line Line that triggered the error
+ * @param array $context Context
+ * @return boolean true if error was handled
+ */
+	public function handleError($code, $description, $file = null, $line = null, $context = null) {
+		if (error_reporting() === 0) {
+			return false;
+		}
+		list($error, $log) = $this->mapErrorCode($code);
+		if ($log === LOG_ERR) {
+			return $this->handleFatalError($code, $description, $file, $line);
+		}
+		$data = array(
+			'level' => $log,
+			'code' => $code,
+			'error' => $error,
+			'description' => $description,
+			'file' => $file,
+			'line' => $line,
+		);
+
+		$debug = Configure::read('debug');
+		if ($debug) {
+			$data += [
+				'context' => $context,
+				'start' => 2,
+				'path' => Debugger::trimPath($file)
+			];
+		}
+		$this->_displayError($data, $debug);
+		$this->_logError($log, $data);
+	}
+
+/**
+ * Log an error.
+ *
+ * @param string $level The level name of the log.
+ * @param array $data Array of error data.
+ * @return void
+ */
+	protected function _logError($level, $data) {
+		$message = sprintf('%s (%s): %s in [%s, line %s]',
+			$data['error'],
+			$data['code'],
+			$data['description'],
+			$data['file'],
+			$data['line']
+		);
+		if (!empty($this->_options['trace'])) {
+			$trace = Debugger::trace(array(
+				'start' => 1,
+				'format' => 'log'
+			));
+			$message .= "\nTrace:\n" . $trace . "\n";
+		}
+		return Log::write($level, $message);
+	}
+
+/**
+ * Map an error code into an Error word, and log location.
+ *
+ * @param integer $code Error code to map
+ * @return array Array of error word, and log location.
+ */
+	public static function mapErrorCode($code) {
+		$error = $log = null;
+		switch ($code) {
+			case E_PARSE:
+			case E_ERROR:
+			case E_CORE_ERROR:
+			case E_COMPILE_ERROR:
+			case E_USER_ERROR:
+				$error = 'Fatal Error';
+				$log = LOG_ERR;
+				break;
+			case E_WARNING:
+			case E_USER_WARNING:
+			case E_COMPILE_WARNING:
+			case E_RECOVERABLE_ERROR:
+				$error = 'Warning';
+				$log = LOG_WARNING;
+				break;
+			case E_NOTICE:
+			case E_USER_NOTICE:
+				$error = 'Notice';
+				$log = LOG_NOTICE;
+				break;
+			case E_STRICT:
+				$error = 'Strict';
+				$log = LOG_NOTICE;
+				break;
+			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
+				$error = 'Deprecated';
+				$log = LOG_NOTICE;
+				break;
+		}
+		return array($error, $log);
+	}
+
+
+}

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -107,6 +107,19 @@ abstract class BaseErrorHandler {
 	public function handleException($exception) {
 		$this->_displayException($exception);
 		$this->_logException($exception);
+		$this->_stop($exception->getCode() ?: 1);
+	}
+
+/**
+ * Stop the process.
+ *
+ * Implemented in subclasses that need it.
+ *
+ * @param integer $code Exit code.
+ * @return void
+ */
+	protected function _stop($code) {
+		// Do nothing.
 	}
 
 /**

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -28,8 +28,27 @@ use Cake\Utility\Debugger;
  */
 abstract class BaseErrorHandler {
 
+/**
+ * Display an error message in an environment specific way.
+ *
+ * Subclasses should implement this method to display the error as
+ * desired for the runtime they operate in.
+ *
+ * @param array $error An array of error data.
+ * @param boolean $debug Whether or not the app is in debug mode.
+ * @return void
+ */
 	abstract protected function _displayError($error, $debug);
 
+/**
+ * Display an exception in an environment specific way.
+ *
+ * Subclasses should implement this method to display an uncaught exception as
+ * desired for the runtime they operate in.
+ *
+ * @param \Exceptino $exception The uncaught exception.
+ * @return void
+ */
 	abstract protected function _displayException($exception);
 
 /**

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -110,6 +110,7 @@ abstract class BaseErrorHandler {
 		}
 		$this->_displayError($data, $debug);
 		$this->_logError($log, $data);
+		return false;
 	}
 
 /**

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Error handler
- *
- * Provides Error Capturing for Framework errors.
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
@@ -15,7 +11,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Error
  * @since         CakePHP(tm) v 0.10.5.1732
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -42,28 +37,27 @@ use Cake\Utility\Debugger;
  * You can implement application specific exception handling in one of a few ways. Each approach
  * gives you different amounts of control over the exception handling process.
  *
- * - Set Configure::write('Exception.handler', 'YourClass::yourMethod');
+ * - Modify App/Config/error.php and setup custom exception handling.
  * - Create AppController::appError();
- * - Set Configure::write('Exception.renderer', 'YourClass');
+ * - Use the `exceptionRenderer` option to inject an Exception renderer. This will
+ *   let you keep the existing handling logic but override the rendering logic.
  *
- * #### Create your own Exception handler with `Exception.handler`
+ * #### Create your own Exception handler
  *
  * This gives you full control over the exception handling process. The class you choose should be
- * loaded in your app/Config/bootstrap.php, so its available to handle any exceptions. You can
- * define the handler as any callback type. Using Exception.handler overrides all other exception
- * handling settings and logic.
+ * loaded in your app/Config/error.php and registered as the default exception handler.
  *
  * #### Using `AppController::appError();`
  *
  * This controller method is called instead of the default exception rendering. It receives the
  * thrown exception as its only argument. You should implement your error handling in that method.
- * Using AppController::appError(), will supersede any configuration for Exception.renderer.
+ * Using AppController::appError(), will supersede any default exception handlers.
  *
- * #### Using a custom renderer with `Exception.renderer`
+ * #### Using a custom renderer with `exceptionRenderer`
  *
  * If you don't want to take control of the exception handling, but want to change how exceptions are
- * rendered you can use `Exception.renderer` to choose a class to render exception pages. By default
- * `ExceptionRenderer` is used. Your custom exception renderer class should be placed in app/Lib/Error.
+ * rendered you can use `exceptionRenderer` option to choose a class to render exception pages. By default
+ * `Cake\Error\ExceptionRenderer` is used. Your custom exception renderer class should be placed in app/Error.
  *
  * Your custom renderer should expect an exception in its constructor, and implement a render method.
  * Failing to do so will cause additional errors.
@@ -71,7 +65,7 @@ use Cake\Utility\Debugger;
  * #### Logging exceptions
  *
  * Using the built-in exception handling, you can log all the exceptions
- * that are dealt with by ErrorHandler by setting `Exception.log` to true in your App/Config/error.php.
+ * that are dealt with by ErrorHandler by setting `log` option to true in your App/Config/error.php.
  * Enabling this will log every exception to Log and the configured loggers.
  *
  * ### PHP errors
@@ -79,19 +73,19 @@ use Cake\Utility\Debugger;
  * Error handler also provides the built in features for handling php errors (trigger_error).
  * While in debug mode, errors will be output to the screen using debugger. While in production mode,
  * errors will be logged to Log.  You can control which errors are logged by setting
- * `Error.level` in your App/Config/error.php.
+ * `errorLevel` option in App/Config/error.php.
  *
  * #### Logging errors
  *
- * When ErrorHandler is used for handling errors, you can enable error logging by setting `Error.log` to true.
- * This will log all errors to the configured log handlers.
+ * When ErrorHandler is used for handling errors, you can enable error logging by setting the `log`
+ * option to true. This will log all errors to the configured log handlers.
  *
  * #### Controlling what errors are logged/displayed
  *
- * You can control which errors are logged / displayed by ErrorHandler by setting `Error.level`. Setting this
+ * You can control which errors are logged / displayed by ErrorHandler by setting `errorLevel`. Setting this
  * to one or a combination of a few of the E_* constants will only enable the specified errors.
  *
- * e.g. `Configure::write('Error.level', E_ALL & ~E_NOTICE);`
+ * $options['log'] = E_ALL & ~E_NOTICE;
  *
  * Would enable handling for all non Notice errors.
  *

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -127,6 +127,7 @@ class ErrorHandler extends BaseErrorHandler {
  *
  * @param \Exception $exception The exception to display
  * @return void
+ * @throws \Exception When the chosen exception renderer is invalid.
  */
 	protected function _displayException($exception) {
 		$renderer = App::classname($this->_options['exceptionRenderer'], 'Error');

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -73,9 +73,9 @@ use Cake\Utility\Debugger;
  * #### Controlling what errors are logged/displayed
  *
  * You can control which errors are logged / displayed by ErrorHandler by setting `errorLevel`. Setting this
- * to one or a combination of a few of the E_* constants will only enable the specified errors.
+ * to one or a combination of a few of the E_* constants will only enable the specified errors:
  *
- * $options['log'] = E_ALL & ~E_NOTICE;
+ * `$options['errorLevel'] = E_ALL & ~E_NOTICE;`
  *
  * Would enable handling for all non Notice errors.
  *

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -38,7 +38,6 @@ use Cake\Utility\Debugger;
  * gives you different amounts of control over the exception handling process.
  *
  * - Modify App/Config/error.php and setup custom exception handling.
- * - Create AppController::appError();
  * - Use the `exceptionRenderer` option to inject an Exception renderer. This will
  *   let you keep the existing handling logic but override the rendering logic.
  *
@@ -46,12 +45,6 @@ use Cake\Utility\Debugger;
  *
  * This gives you full control over the exception handling process. The class you choose should be
  * loaded in your app/Config/error.php and registered as the default exception handler.
- *
- * #### Using `AppController::appError();`
- *
- * This controller method is called instead of the default exception rendering. It receives the
- * thrown exception as its only argument. You should implement your error handling in that method.
- * Using AppController::appError(), will supersede any default exception handlers.
  *
  * #### Using a custom renderer with `exceptionRenderer`
  *

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -25,6 +25,7 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
+use Cake\View\View;
 
 /**
  * Exception Renderer.

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -25,7 +25,6 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
-use Cake\View\View;
 
 /**
  * Exception Renderer.

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -1,10 +1,5 @@
 <?php
 /**
- * Exception Renderer
- *
- * Provides Exception rendering features. Which allow exceptions to be rendered
- * as HTML pages.
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
@@ -16,7 +11,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Error
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -31,7 +25,6 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
-use Cake\Utility\Sanitize;
 use Cake\View\View;
 
 /**
@@ -43,23 +36,13 @@ use Cake\View\View;
  *
  * ### Implementing application specific exception rendering
  *
- * You can implement application specific exception handling in one of a few ways:
- *
- * - Create a AppController::appError();
- * - Create a subclass of ExceptionRenderer and configure it to be the `Exception.renderer`
- *
- * #### Using AppController::appError();
- *
- * This controller method is called instead of the default exception handling. It receives the
- * thrown exception as its only argument. You should implement your error handling in that method.
+ * You can implement application specific exception handling by creating a subclass of
+ * ExceptionRenderer and configure it to be the `exceptionRenderer` in App/Config/error.php
  *
  * #### Using a subclass of ExceptionRenderer
  *
  * Using a subclass of ExceptionRenderer gives you full control over how Exceptions are rendered, you
- * can configure your class in your App/Config/error.php, with `Configure::write('Exception.renderer', 'MyClass');`
- * You should place any custom exception renderers in `app/Lib/Error`.
- *
- * @package       Cake.Error
+ * can configure your class in your App/Config/error.php.
  */
 class ExceptionRenderer {
 
@@ -97,14 +80,11 @@ class ExceptionRenderer {
  * code error depending on the code used to construct the error.
  *
  * @param \Exception $exception Exception
- * @return mixed Return void or value returned by controller's `appError()` function
+ * @return void
  */
 	public function __construct(\Exception $exception) {
 		$this->controller = $this->_getController($exception);
 
-		if (method_exists($this->controller, 'apperror')) {
-			return $this->controller->appError($exception);
-		}
 		list(, $baseClass) = namespaceSplit(get_class($exception));
 		$baseClass = substr($baseClass, 0, -9);
 		$method = $template = Inflector::variable($baseClass);

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -65,9 +65,10 @@ class ConsoleErrorHandlerTest extends TestCase {
  * @return void
  */
 	public function testHandleFatalError() {
-		$content = "<error>Fatal Error Error:</error> This is a fatal error in [/some/file, line 275]\n";
+		ob_start();
+		$content = "<error>Fatal Error:</error> This is a fatal error in [/some/file, line 275]\n";
 		$this->stderr->expects($this->once())->method('write')
-			->with($content);
+			->with($this->stringContains($content));
 
 		$this->Error->handleError(E_USER_ERROR, 'This is a fatal error', '/some/file', 275);
 	}
@@ -79,8 +80,9 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function testCakeErrors() {
 		$exception = new Error\MissingActionException('Missing action');
+		$message = sprintf('Missing action in [%s, line %s]', $exception->getFile(), $exception->getLine());
 		$this->stderr->expects($this->once())->method('write')
-			->with($this->stringContains('Missing action'));
+			->with($this->stringContains($message));
 
 		$result = $this->Error->handleException($exception);
 		$this->assertEquals(404, $result);

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -68,7 +68,7 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function testHandleFatalError() {
 		ob_start();
-		$content = "<error>Fatal Error:</error> This is a fatal error in [/some/file, line 275]\n";
+		$content = "<error>Fatal Error:</error> This is a fatal error in [/some/file, line 275]";
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains($content));
 

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -84,8 +84,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains($message));
 
-		$result = $this->Error->handleException($exception);
-		$this->assertEquals(404, $result);
+		$this->Error->handleException($exception);
 	}
 
 /**
@@ -99,8 +98,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('Too many parameters.'));
 
-		$result = $this->Error->handleException($exception);
-		$this->assertEquals(1, $result);
+		$this->Error->handleException($exception);
 	}
 
 /**
@@ -114,8 +112,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('dont use me in cli.'));
 
-		$result = $this->Error->handleException($exception);
-		$this->assertEquals(404, $result);
+		$this->Error->handleException($exception);
 	}
 
 /**
@@ -129,8 +126,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('dont use me in cli.'));
 
-		$result = $this->Error->handleException($exception);
-		$this->assertEquals(500, $result);
+		$this->Error->handleException($exception);
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ConsoleErrorHandler Test case
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
@@ -24,8 +22,6 @@ use Cake\TestSuite\TestCase;
 
 /**
  * ConsoleErrorHandler Test case.
- *
- * @package       Cake.Test.Case.Console
  */
 class ConsoleErrorHandlerTest extends TestCase {
 

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -36,8 +36,8 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->Error = $this->getMock('Cake\Console\ConsoleErrorHandler', ['_stop']);
-		ConsoleErrorHandler::$stderr = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
+		$this->stderr = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
+		$this->Error = new ConsoleErrorHandler(['stderr' => $this->stderr]);
 	}
 
 /**
@@ -57,7 +57,7 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function testHandleError() {
 		$content = "<error>Notice Error:</error> This is a notice error in [/some/file, line 275]\n";
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($content);
 
 		$this->Error->handleError(E_NOTICE, 'This is a notice error', '/some/file', 275);
@@ -70,7 +70,7 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function testHandleFatalError() {
 		$content = "<error>Fatal Error Error:</error> This is a fatal error in [/some/file, line 275]\n";
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($content);
 
 		$this->Error->handleError(E_USER_ERROR, 'This is a fatal error', '/some/file', 275);
@@ -83,7 +83,7 @@ class ConsoleErrorHandlerTest extends TestCase {
  */
 	public function testCakeErrors() {
 		$exception = new Error\MissingActionException('Missing action');
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('Missing action'));
 
 		$result = $this->Error->handleException($exception);
@@ -98,7 +98,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 	public function testNonCakeExceptions() {
 		$exception = new \InvalidArgumentException('Too many parameters.');
 
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('Too many parameters.'));
 
 		$result = $this->Error->handleException($exception);
@@ -113,7 +113,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 	public function testError404Exception() {
 		$exception = new Error\NotFoundException('dont use me in cli.');
 
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('dont use me in cli.'));
 
 		$result = $this->Error->handleException($exception);
@@ -128,7 +128,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 	public function testError500Exception() {
 		$exception = new Error\InternalErrorException('dont use me in cli.');
 
-		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains('dont use me in cli.'));
 
 		$result = $this->Error->handleException($exception);

--- a/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Console/ConsoleErrorHandlerTest.php
@@ -33,7 +33,7 @@ class ConsoleErrorHandlerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->stderr = $this->getMock('Cake\Console\ConsoleOutput', [], [], '', false);
-		$this->Error = new ConsoleErrorHandler(['stderr' => $this->stderr]);
+		$this->Error = $this->getMock('Cake\Console\ConsoleErrorHandler', ['_stop'], [['stderr' => $this->stderr]]);
 	}
 
 /**
@@ -55,6 +55,8 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$content = "<error>Notice Error:</error> This is a notice error in [/some/file, line 275]\n";
 		$this->stderr->expects($this->once())->method('write')
 			->with($content);
+		$this->Error->expects($this->never())
+			->method('_stop');
 
 		$this->Error->handleError(E_NOTICE, 'This is a notice error', '/some/file', 275);
 	}
@@ -83,6 +85,9 @@ class ConsoleErrorHandlerTest extends TestCase {
 		$message = sprintf('Missing action in [%s, line %s]', $exception->getFile(), $exception->getLine());
 		$this->stderr->expects($this->once())->method('write')
 			->with($this->stringContains($message));
+
+		$this->Error->expects($this->once())
+			->method('_stop');
 
 		$this->Error->handleException($exception);
 	}

--- a/lib/Cake/Test/TestCase/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/TestCase/Error/ErrorHandlerTest.php
@@ -43,6 +43,7 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
+
 		App::build(array(
 			'View' => array(
 				CAKE . 'Test/TestApp/View/'
@@ -154,7 +155,7 @@ class ErrorHandlerTest extends TestCase {
 
 		$this->_logger->expects($this->once())
 			->method('write')
-			->with('notice', 'Notice (8): Undefined variable: out in [' . __FILE__ . ', line 159]');
+			->with('notice', 'Notice (8): Undefined variable: out in [' . __FILE__ . ', line ' . (__LINE__ + 2) . ']');
 
 		$out .= '';
 	}
@@ -168,6 +169,7 @@ class ErrorHandlerTest extends TestCase {
 		Configure::write('debug', 0);
 		$errorHandler = new ErrorHandler(['trace' => true]);
 		$errorHandler->register();
+		$this->_restoreError = true;
 
 		$this->_logger->expects($this->once())
 			->method('write')
@@ -176,7 +178,6 @@ class ErrorHandlerTest extends TestCase {
 				$this->stringContains('Trace:'),
 				$this->stringContains(__NAMESPACE__ . '\ErrorHandlerTest::testHandleErrorLoggingTrace()')
 			));
-		$this->_restoreError = true;
 
 		$out .= '';
 	}
@@ -203,7 +204,6 @@ class ErrorHandlerTest extends TestCase {
  */
 	public function testHandleExceptionLog() {
 		$errorHandler = new ErrorHandler(['log' => true]);
-		$errorHandler->register();
 
 		$error = new Error\NotFoundException('Kaboom!');
 
@@ -240,7 +240,6 @@ class ErrorHandlerTest extends TestCase {
 			'log' => true,
 			'skipLog' => ['Cake\Error\NotFoundException']
 		]);
-		$errorHandler->register();
 
 		ob_start();
 		$errorHandler->handleException($notFound);
@@ -315,7 +314,7 @@ class ErrorHandlerTest extends TestCase {
 		$this->_logger->expects($this->at(0))
 			->method('write')
 			->with('error', $this->logicalAnd(
-				$this->stringContains(__FILE__ . ', line 328'),
+				$this->stringContains(__FILE__ . ', line 327'),
 				$this->stringContains('Fatal Error (1)'),
 				$this->stringContains('Something wrong')
 			));


### PR DESCRIPTION
Simplify the error/exception handling in 3.0. Instead of all static methods the error handlers are now all instance methods and there are fewer configuration options overall. I didn't think the handling classes needed to be 'configurable' as they are application logic that should be part of the application code. However logging, and error levels are still configuration data as before.

The changes around error handlers have allowed duplicated code and out of place code to be removed from both `Configure` and `ShellDispatcher` which I see as a win.

There is a small bit of duplication between `ErrorHandler` and `ConsoleErrorHandler`, if it really bothers anyone I'm happy to extract it out into a base class.
