### PR TITLE
Sqlite::truncate(): Verify `sqlite_sequence` exists before _execute()

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -230,7 +230,9 @@ class Sqlite extends DboSource {
  * @return boolean SQL TRUNCATE TABLE statement, false if not applicable.
  */
 	public function truncate($table) {
-		$this->_execute('DELETE FROM sqlite_sequence where name=' . $this->startQuote . $this->fullTableName($table, false, false) . $this->endQuote);
+		if (in_array('sqlite_sequence', $this->listSources())) {
+			$this->_execute('DELETE FROM sqlite_sequence where name=' . $this->startQuote . $this->fullTableName($table, false, false) . $this->endQuote);
+		}
 		return $this->execute('DELETE FROM ' . $this->fullTableName($table));
 	}
 


### PR DESCRIPTION
`sqlite_sequence` is a dynamic table that's only available when a table in
the database use an auto increment field.  For some cases, eg: databases that
exclusively use uuid for primary keys, this table won't exist and
truncate() call will fail with:

>  Error: SQLSTATE[HY000]: General error: 1 no such table: sqlite_sequence
