### PR TITLE
CakeSchema/SchemaShell: Propagate 'exclude' argument to CakeSchema

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -148,6 +148,14 @@ class SchemaShell extends AppShell {
 		$cacheDisable = Configure::read('Cache.disable');
 		Configure::write('Cache.disable', true);
 
+		if (!empty($this->params['exclude'])) {
+			$excludeModels = array_map(
+				array('Inflector', 'classify'),
+				explode(',', $this->params['exclude'])
+			);
+			$this->Schema->excludes += $excludeModels;
+		}
+
 		$content = $this->Schema->read($options);
 		$content['file'] = $this->params['file'];
 

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -392,7 +392,7 @@ class CakeSchema extends Object {
 		$out .= "}\n";
 
 		$file = new File($path . DS . $file, true);
-		$content = "<?php \n{$out}";
+		$content = "<?php\n\n{$out}";
 		if ($file->write($content)) {
 			return $content;
 		}

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -73,6 +73,13 @@ class CakeSchema extends Object {
 	public $tables = array();
 
 /**
+ * Set of excluded models
+ *
+ * @var array
+ */
+	public $excludes = array();
+
+/**
  * Constructor
  *
  * @param array $options optional load object properties
@@ -227,7 +234,7 @@ class CakeSchema extends Object {
 			foreach ($models as $model) {
 				$importModel = $model;
 				$plugin = null;
-				if ($model === 'AppModel') {
+				if ($model === 'AppModel' || in_array($model, $this->excludes)) {
 					continue;
 				}
 

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -414,6 +414,7 @@ class SchemaShellTest extends CakeTestCase {
 			'overwrite' => true,
 			'exclude' => 'acos, aros',
 		);
+		$excludeModels = array('Aco', 'Aro');
 		$this->Shell->startup();
 		$this->Shell->Schema->path = TMP . 'tests' . DS;
 
@@ -421,6 +422,7 @@ class SchemaShellTest extends CakeTestCase {
 		$this->file = new File(TMP . 'tests' . DS . 'schema.php');
 		$contents = $this->file->read();
 
+		$this->assertEquals($excludeModels, $this->Shell->Schema->excludes);
 		$this->assertNotContains('public $acos = array(', $contents);
 		$this->assertNotContains('public $aros = array(', $contents);
 		$this->assertContains('public $aros_acos = array(', $contents);


### PR DESCRIPTION
For models that extend from a plugin model (eg. UsersAppModel model), the schema shell will get a missing table error. This is due to CakeSchema trying to introspect users_app_models table.

This patch fixes this by allowing CakeSchema to skip processing table/models specified in the `--exclude` argument.
