### PR TITLE
Making env('HTTPS') respect HTTP_X_FORWARDED_PROTO

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -151,6 +151,12 @@ class BasicsTest extends CakeTestCase {
 		$_SERVER['HTTPS'] = '';
 		$this->assertFalse(env('HTTPS'));
 
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'http'
+		$this->assertFalse(env('HTTPS'));
+
+		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https'
+		$this->assertTrue(env('HTTPS'));
+
 		$_SERVER = array();
 
 		$_ENV['SCRIPT_URI'] = 'https://domain.test/a/test.php';

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -292,6 +292,11 @@ if (!function_exists('env')) {
 			if (isset($_SERVER['HTTPS'])) {
 				return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 			}
+
+			if(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+				return true;
+			}
+
 			return (strpos(env('SCRIPT_URI'), 'https://') === 0);
 		}
 


### PR DESCRIPTION
Solves an issue with url generation when behind load balancers or proxies which do not set server env https but instead pass HTTP_X_FORWARDED_PROTO as https. 
