### PR TITLE
Fix for create statement in Sqlite where primary key is of type biginteger

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -407,7 +407,7 @@ class Sqlite extends DboSource {
 			return null;
 		}
 
-		if (isset($column['key']) && $column['key'] === 'primary' && $type === 'integer') {
+		if (isset($column['key']) && $column['key'] === 'primary' && ($type === 'integer' || $type === 'biginteger')) {
 			return $this->name($name) . ' ' . $this->columns['primary_key']['name'];
 		}
 		return parent::buildColumn($column);


### PR DESCRIPTION
Without this patch, the `create table` statement looks like:

```
CREATE TABLE "main"."vehicles" (
    "id" bigint(20) integer primary key autoincrement,
```

where `integer` causes a syntax error. This seems a little like sticking-plaster but I can't find out where the spurious `integer` type is coming from at the moment.
