### PR TITLE
2.4 unify name

### DIFF
--- a/app/Config/Schema/db_acl.php
+++ b/app/Config/Schema/db_acl.php
@@ -28,8 +28,6 @@
  */
 class DbAclSchema extends CakeSchema {
 
-	public $name = 'DbAcl';
-
 	public function before($event = array()) {
 		return true;
 	}

--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -32,13 +32,6 @@ App::uses('AppController', 'Controller');
 class PagesController extends AppController {
 
 /**
- * Controller name
- *
- * @var string
- */
-	public $name = 'Pages';
-
-/**
  * This controller does not use a model
  *
  * @var array

--- a/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
@@ -19,8 +19,6 @@
  */
 class DbAclSchema extends CakeSchema {
 
-	public $name = 'DbAcl';
-
 	public function before($event = array()) {
 		return true;
 	}

--- a/lib/Cake/Console/Templates/skel/Controller/PagesController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/PagesController.php
@@ -24,13 +24,6 @@ App::uses('AppController', 'Controller');
 class PagesController extends AppController {
 
 /**
- * Controller name
- *
- * @var string
- */
-	public $name = 'Pages';
-
-/**
  * This controller does not use a model
  *
  * @var array

--- a/lib/Cake/Controller/CakeErrorController.php
+++ b/lib/Cake/Controller/CakeErrorController.php
@@ -32,13 +32,6 @@ App::uses('AppController', 'Controller');
 class CakeErrorController extends AppController {
 
 /**
- * Controller name
- *
- * @var string
- */
-	public $name = 'CakeError';
-
-/**
  * Uses Property
  *
  * @var array

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -27,13 +27,6 @@ App::uses('AppModel', 'Model');
 class Permission extends AppModel {
 
 /**
- * Model name
- *
- * @var string
- */
-	public $name = 'Permission';
-
-/**
  * Explicitly disable in-memory query caching
  *
  * @var boolean


### PR DESCRIPTION
We can drop those lines as they are unnecessary. Unifies it across 2.x.
Less lines of code = more readability for the useful code.
Also makes the remaining $name properties more meaningful as they actually serve a purpose (re-aliasing etc).
