### PR TITLE
3.0 extract config() methods into a trait

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -9,7 +9,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Cache
  * @since         CakePHP(tm) v 1.2.0.4933
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -17,6 +16,7 @@ namespace Cake\Cache;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\StaticConfigTrait;
 use Cake\Error;
 use Cake\Utility\Inflector;
 
@@ -82,6 +82,8 @@ use Cake\Utility\Inflector;
  */
 class Cache {
 
+	use StaticConfigTrait;
+
 /**
  * Flag for tracking whether or not caching is enabled.
  *
@@ -121,66 +123,6 @@ class Cache {
 	protected static $_registry;
 
 /**
- * This method can be used to define cache adapters for an application
- * or read existing configuration.
- *
- * To change an adapter's configuration at runtime, first drop the adapter and then
- * reconfigure it.
- *
- * Adapters will not be constructed until the first operation is done.
- *
- * ### Usage
- *
- * Reading config data back:
- *
- * `Cache::config('default');`
- *
- * Setting a cache engine up.
- *
- * `Cache::config('default', $settings);`
- *
- * Injecting a constructed adapter in:
- *
- * `Cache::config('default', $instance);`
- *
- * Using a factory function to get an adapter:
- *
- * `Cache::config('default', function () { return new FileEngine(); });`
- *
- * Configure multiple adapters at once:
- *
- * `Cache::config($arrayOfConfig);`
- *
- * @param string|array $key The name of the cache config, or an array of multiple configs.
- * @param array $config An array of name => config data for adapter.
- * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws Cake\Error\Exception When trying to modify an existing config.
- */
-	public static function config($key, $config = null) {
-		// Read config.
-		if ($config === null && is_string($key)) {
-			return isset(static::$_config[$key]) ? static::$_config[$key] : null;
-		}
-		if ($config === null && is_array($key)) {
-			foreach ($key as $name => $settings) {
-				static::config($name, $settings);
-			}
-			return;
-		}
-		if (isset(static::$_config[$key])) {
-			throw new Error\Exception(__d('cake_dev', 'Cannot reconfigure existing adapter "%s"', $key));
-		}
-		if (is_object($config)) {
-			$config = ['className' => $config];
-		}
-		if (isset($config['engine']) && empty($config['className'])) {
-			$config['className'] = $config['engine'];
-			unset($config['engine']);
-		}
-		static::$_config[$key] = $config;
-	}
-
-/**
  * Finds and builds the instance of the required engine class.
  *
  * @param string $name Name of the config array that needs an engine instance built
@@ -204,32 +146,6 @@ class Cache {
 				sort(static::$_groups[$group]);
 			}
 		}
-	}
-
-/**
- * Returns an array containing the configured Cache engines.
- *
- * @return array Array of configured Cache config names.
- */
-	public static function configured() {
-		return array_keys(static::$_config);
-	}
-
-/**
- * Drops a constructed cache engine.
- *
- * If you wish to re-configure a cache engine you should drop it,
- * change configuration and then re-use it.
- *
- * @param string $config A currently configured cache config you wish to remove.
- * @return boolean success of the removal, returns false when the config does not exist.
- */
-	public static function drop($config) {
-		if (isset(static::$_registry->{$config})) {
-			static::$_registry->unload($config);
-		}
-		unset(static::$_config[$config]);
-		return true;
 	}
 
 /**

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -58,17 +58,14 @@ class CacheRegistry extends ObjectRegistry {
  * Create the cache engine instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string|CacheEngine|Closure $class The classname or object to make, or a closure factory.
+ * @param string|CacheEngine $class The classname or object to make, or a closure factory.
  * @param array $settings An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
  * @throws Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $settings) {
-		$isObject = is_object($class);
-		if ($isObject && $class instanceof \Closure) {
-			$instance = $class();
-		} elseif ($isObject) {
+		if (is_object($class)) {
 			$instance = $class;
 		}
 

--- a/lib/Cake/Cache/CacheRegistry.php
+++ b/lib/Cake/Cache/CacheRegistry.php
@@ -58,7 +58,7 @@ class CacheRegistry extends ObjectRegistry {
  * Create the cache engine instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string|CacheEngine $class The classname or object to make, or a closure factory.
+ * @param string|CacheEngine $class The classname or object to make.
  * @param array $settings An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
  * @throws Cake\Error\Exception when an object doesn't implement

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * App class
- *
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)

--- a/lib/Cake/Core/StaticConfigTrait.php
+++ b/lib/Cake/Core/StaticConfigTrait.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Core;
+
+use Cake\Error;
+
+/**
+ * A trait that provides a set of static methods to manage configuration
+ * for classes that provide an adapter facade or need to have sets of
+ * configuration data registered and manipulated.
+ *
+ * Implementing objects are expected to declare a static `$_config` property.
+ */
+trait StaticConfigTrait {
+
+/**
+ * This method can be used to define confguration adapters for an application
+ * or read existing configuration.
+ *
+ * To change an adapter's configuration at runtime, first drop the adapter and then
+ * reconfigure it.
+ *
+ * Adapters will not be constructed until the first operation is done.
+ *
+ * ### Usage
+ *
+ * Assuming that the class' name is `Cache` the following scenarios
+ * are supported:
+ *
+ * Reading config data back:
+ *
+ * `Cache::config('default');`
+ *
+ * Setting a cache engine up.
+ *
+ * `Cache::config('default', $settings);`
+ *
+ * Injecting a constructed adapter in:
+ *
+ * `Cache::config('default', $instance);`
+ *
+ * Configure multiple adapters at once:
+ *
+ * `Cache::config($arrayOfConfig);`
+ *
+ * @param string|array $key The name of the configuration, or an array of multiple configs.
+ * @param array $config An array of name => configuration data for adapter.
+ * @return mixed null when adding configuration and an array of configuration data when reading.
+ * @throws Cake\Error\Exception When trying to modify an existing config.
+ */
+	public static function config($key, $config = null) {
+		// Read config.
+		if ($config === null && is_string($key)) {
+			return isset(static::$_config[$key]) ? static::$_config[$key] : null;
+		}
+		if ($config === null && is_array($key)) {
+			foreach ($key as $name => $settings) {
+				static::config($name, $settings);
+			}
+			return;
+		}
+		if (isset(static::$_config[$key])) {
+			throw new Error\Exception(__d('cake_dev', 'Cannot reconfigure existing key "%s"', $key));
+		}
+		if (is_object($config)) {
+			$config = ['className' => $config];
+		}
+		if (isset($config['engine']) && empty($config['className'])) {
+			$config['className'] = $config['engine'];
+			unset($config['engine']);
+		}
+		static::$_config[$key] = $config;
+	}
+
+/**
+ * Drops a constructed adapter.
+ *
+ * If you wish to modify an existing configuration, you should drop it,
+ * change configuration and then re-add it.
+ *
+ * If the implementing objects supports a `$_registry` object the named configuration
+ * will also be unloaded from the registry.
+ *
+ * @param string $config An existing configuation you wish to remove.
+ * @return boolean success of the removal, returns false when the config does not exist.
+ */
+	public static function drop($config) {
+		if (!isset(static::$_config[$config])) {
+			return false;
+		}
+		if (isset(static::$_registry->{$config})) {
+			static::$_registry->unload($config);
+		}
+		unset(static::$_config[$config]);
+		return true;
+	}
+
+/**
+ * Returns an array containing the named configurations
+ *
+ * @return array Array of configurations.
+ */
+	public static function configured() {
+		return array_keys(static::$_config);
+	}
+
+}

--- a/lib/Cake/Core/StaticConfigTrait.php
+++ b/lib/Cake/Core/StaticConfigTrait.php
@@ -102,7 +102,7 @@ trait StaticConfigTrait {
 		if (!isset(static::$_config[$config])) {
 			return false;
 		}
-		if (isset(static::$_registry->{$config})) {
+		if (isset(static::$_registry) && isset(static::$_registry->{$config})) {
 			static::$_registry->unload($config);
 		}
 		unset(static::$_config[$config]);

--- a/lib/Cake/Log/Log.php
+++ b/lib/Cake/Log/Log.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Log;
 
+use Cake\Core\StaticConfigTrait;
 use Cake\Error;
 use Cake\Log\Engine\BaseLog;
 
@@ -102,6 +103,10 @@ use Cake\Log\Engine\BaseLog;
  * of your application and also use standard log levels.
  */
 class Log {
+
+	use StaticConfigTrait {
+		config as protected _config;
+	}
 
 /**
  * Internal flag for tracking whether or not configuration has been changed.
@@ -204,16 +209,6 @@ class Log {
 	}
 
 /**
- * Returns the keynames of the currently active streams
- *
- * @return array Array of configured log streams.
- */
-	public static function configured() {
-		static::_init();
-		return static::$_registry->loaded();
-	}
-
-/**
  * Gets log levels
  *
  * Call this method to obtain current
@@ -263,44 +258,11 @@ class Log {
  * @see App/Config/logging.php
  */
 	public static function config($key, $config = null) {
-		// Read config.
-		if ($config === null && is_string($key)) {
-			return isset(static::$_config[$key]) ? static::$_config[$key] : null;
-		}
-		if ($config === null && is_array($key)) {
-			foreach ($key as $name => $settings) {
-				static::config($name, $settings);
-			}
-			return;
-		}
-		if (isset(static::$_config[$key])) {
-			throw new Error\Exception(__d('cake_dev', 'Cannot reconfigure existing adapter "%s"', $key));
+		$return = static::_config($key, $config);
+		if ($return !== null) {
+			return $return;
 		}
 		static::$_dirtyConfig = true;
-		if (is_object($config)) {
-			$config = ['className' => $config];
-		}
-		if (isset($config['engine']) && empty($config['className'])) {
-			$config['className'] = $config['engine'];
-			unset($config['engine']);
-		}
-		static::$_config[$key] = $config;
-	}
-
-/**
- * Removes a stream from the active streams.
- *
- * Once a stream has been removed it will no longer have messages sent to it.
- * The original configuration data will also be removed. You can use this method
- * when reconfiguring a logger or when you want to remove a logger.
- *
- * @param string $streamName Key name of a configured logger to remove.
- * @return void
- */
-	public static function drop($streamName) {
-		static::_init();
-		static::$_registry->unload($streamName);
-		unset(static::$_config[$streamName]);
 	}
 
 /**

--- a/lib/Cake/Log/LogEngineRegistry.php
+++ b/lib/Cake/Log/LogEngineRegistry.php
@@ -57,17 +57,14 @@ class LogEngineRegistry extends ObjectRegistry {
  * Create the logger instance.
  *
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
- * @param string|LogInterface|Closure $class The classname or object to make, or a closure factory
+ * @param string|LogInterface $class The classname or object to make.
  * @param array $settings An array of settings to use for the logger.
  * @return LogEngine The constructed logger class.
  * @throws Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $settings) {
-		$isObject = is_object($class);
-		if ($isObject && $class instanceof \Closure) {
-			$instance = $class();
-		} elseif ($isObject) {
+		if (is_object($class)) {
 			$instance = $class;
 		}
 

--- a/lib/Cake/Network/Email/Email.php
+++ b/lib/Cake/Network/Email/Email.php
@@ -16,6 +16,7 @@ namespace Cake\Network\Email;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\StaticConfigTrait;
 use Cake\Error;
 use Cake\Log\Log;
 use Cake\Network\Http\FormData\Part;
@@ -30,8 +31,18 @@ use Cake\View\View;
  *
  * This class is used for sending Internet Message Format based
  * on the standard outlined in http://www.rfc-editor.org/rfc/rfc2822.txt
+ *
+ * ### Configuration
+ *
+ * Configuration for Email is managed by Email::config() and Email::configTransport().
+ * Email::config() can be used to add or read a configuration profile for Email instances.
+ * Once made configuration profiles can be used to re-use across various email messages your
+ * application sends.
+ *
  */
 class Email {
+
+	use StaticConfigTrait;
 
 /**
  * Default X-Mailer
@@ -1130,46 +1141,6 @@ class Email {
  */
 	public static function dropTransport($key) {
 		unset(static::$_transportConfig[$key]);
-	}
-
-/**
- * Add or read a configuration profile for Email instances.
- *
- * This method is used to read or define configuration profiles for
- * Email. Once made configuration profiles can be used to re-use the same
- * sets of configuration across multiple email messages.
- *
- * @param string|array $key The name of the configuration profile to read/create
- *    or an array of multiple configuration profiles to set
- * @param null|array $config Null to read config data, an array to set data.
- * @return array|void
- * @throws Cake\Error\Exception When modifying an existing configuration.
- */
-	public static function config($key, $config = null) {
-		// Read config.
-		if ($config === null && is_string($key)) {
-			return isset(static::$_config[$key]) ? static::$_config[$key] : null;
-		}
-		if ($config === null && is_array($key)) {
-			foreach ($key as $name => $settings) {
-				static::config($name, $settings);
-			}
-			return;
-		}
-		if (isset(static::$_config[$key])) {
-			throw new Error\Exception(__d('cake_dev', 'Cannot modify an existing config "%s"', $key));
-		}
-		static::$_config[$key] = $config;
-	}
-
-/**
- * Drop a configured profile.
- *
- * @param string $key The profile to drop.
- * @return void
- */
-	public static function drop($key) {
-		unset(static::$_config[$key]);
 	}
 
 /**

--- a/lib/Cake/Network/Email/Email.php
+++ b/lib/Cake/Network/Email/Email.php
@@ -1238,29 +1238,20 @@ class Email {
 	}
 
 /**
- * Read the configuration profile for a given name.
- *
- * @param string $name The name to read.
- * @return array
- * @throws Cake\Error\Exception When using a configuration that doesn't exist.
- */
-	protected function _getConfig($name) {
-		$config = static::config($name);
-		if (empty($config)) {
-			throw new Error\Exception(__d('cake_dev', 'Unknown email configuration "%s".', $name));
-		}
-		return $config;
-	}
-
-/**
  * Apply the config to an instance
  *
  * @param string|array $config
  * @return void
+ * @throws Cake\Error\Exception When using a configuration that doesn't exist.
  */
 	protected function _applyConfig($config) {
 		if (is_string($config)) {
-			$config = $this->_getConfig($config);
+			$name = $config;
+			$config = static::config($name);
+			if (empty($config)) {
+				throw new Error\Exception(__d('cake_dev', 'Unknown email configuration "%s".', $name));
+			}
+			unset($name);
 		}
 		$this->_profile = array_merge($this->_profile, $config);
 		if (!empty($config['charset'])) {

--- a/lib/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/lib/Cake/Test/TestCase/Cache/CacheTest.php
@@ -147,9 +147,6 @@ class CacheTest extends TestCase {
 				'prefix' => 'cake_test_'
 			]],
 			'Direct instance' => [new FileEngine()],
-			'Closure factory' => [function () {
-				return new FileEngine();
-			}],
 		];
 	}
 
@@ -308,7 +305,7 @@ class CacheTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 
 		$result = Cache::drop('some_config_that_does_not_exist');
-		$this->assertTrue($result, 'Drop should succeed.');
+		$this->assertFalse($result, 'Drop should not succeed when config is missing.');
 
 		Cache::config('unconfigTest', [
 			'engine' => 'TestAppCache'

--- a/lib/Cake/Test/TestCase/Database/ConnectionManagerTest.php
+++ b/lib/Cake/Test/TestCase/Database/ConnectionManagerTest.php
@@ -42,10 +42,6 @@ class ConnectionManagerTest extends TestCase {
  */
 	public static function configProvider() {
 		return [
-			'Array of data using datasource key.' => [[
-				'datasource' => 'Cake\Database\Driver\Sqlite',
-				'database' => ':memory:',
-			]],
 			'Array of data using classname key.' => [[
 				'className' => 'Sqlite',
 				'database' => ':memory:',
@@ -85,7 +81,7 @@ class ConnectionManagerTest extends TestCase {
  * Test for errors on duplicate config.
  *
  * @expectedException Cake\Error\Exception
- * @expectedExceptionMessage Cannot reconfigure existing adapter "test_variant"
+ * @expectedExceptionMessage Cannot reconfigure existing key "test_variant"
  * @return void
  */
 	public function testConfigDuplicateConfig() {
@@ -173,7 +169,7 @@ class ConnectionManagerTest extends TestCase {
 		$result = ConnectionManager::configured();
 		$this->assertNotContains('test_variant', $result);
 
-		$this->assertTrue(ConnectionManager::drop('probably_does_not_exist'), 'Should always return true.');
+		$this->assertFalse(ConnectionManager::drop('probably_does_not_exist'), 'Should return false on failure.');
 	}
 
 }

--- a/lib/Cake/Test/TestCase/Database/QueryTest.php
+++ b/lib/Cake/Test/TestCase/Database/QueryTest.php
@@ -35,7 +35,7 @@ class QueryTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->connection = ConnectionManager::getDataSource('test');
+		$this->connection = ConnectionManager::get('test');
 	}
 
 	public function tearDown() {

--- a/lib/Cake/Test/TestCase/Log/LogTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTest.php
@@ -136,9 +136,6 @@ class LogTest extends TestCase {
 				'path' => TMP . 'tests',
 			]],
 			'Direct instance' => [new FileLog()],
-			'Closure factory' => [function () {
-				return new FileLog();
-			}],
 		];
 	}
 

--- a/lib/Cake/Test/TestCase/Log/LogTest.php
+++ b/lib/Cake/Test/TestCase/Log/LogTest.php
@@ -114,7 +114,8 @@ class LogTest extends TestCase {
 		$result = Log::configured();
 		$this->assertContains('file', $result);
 
-		Log::drop('file');
+		$this->assertTrue(Log::drop('file'), 'Should be dropped');
+		$this->assertFalse(Log::drop('file'), 'Already gone');
 
 		$result = Log::configured();
 		$this->assertNotContains('file', $result);

--- a/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
+++ b/lib/Cake/Test/TestCase/Network/Email/EmailTest.php
@@ -879,6 +879,17 @@ class EmailTest extends TestCase {
 	}
 
 /**
+ * Test that using an invalid profile fails.
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage Unknown email configuration "derp".
+ */
+	public function testProfileInvalid() {
+		$email = new Email();
+		$email->profile('derp');
+	}
+
+/**
  * testConfigString method
  *
  * @return void


### PR DESCRIPTION
I've extracted the `config()`, `drop()` and `configured()` methods into a trait. I'm not sure it has the best name yet, but at least we can discuss it now. I decided to move those 3 methods as they are all related to the configuration management of a class.

I've removed the `Closure` factory function versions of config() as well. I don't have a solid use case for them right now, and would rather not have code included 'just in case'. If we can come up with some good use cases I'd be happy to re-include it.

I've not de-duplicated the tests yet, but I can see a few options for that:
- Make a unit test for the trait, and then assert that each class uses the trait.
- Make a trait of tests for the trait methods. Include the testing trait into each test suite. This feels like odd as it makes the tests harder to follow/understand.

Any ideas on how to de-duplicate the tests would be great.
