### PR TITLE
Allow 'options' to be given as array when adding a param detector - similar to env / options.

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -512,8 +512,13 @@ class CakeRequest implements ArrayAccess {
 		}
 		if (isset($detect['param'])) {
 			$key = $detect['param'];
-			$value = $detect['value'];
-			return isset($this->params[$key]) ? $this->params[$key] == $value : false;
+		        if (isset($detect['value'])) {
+		            $value = $detect['value'];
+		            return isset($this->params[$key]) ? $this->params[$key] == $value : false;
+		        }
+		        if (isset($detect['options'])) {
+		            return isset($this->params[$key]) ? in_array($this->params[$key],$detect['options']) : false;
+		        }
 		}
 		if (isset($detect['callback']) && is_callable($detect['callback'])) {
 			return call_user_func($detect['callback'], $this);


### PR DESCRIPTION
Allow the following when adding request detectors using CakeRequest::addDetector():

```
array('param'=>'{param-name}', 'options'=>array())
```
