### PR TITLE
Aliased stock helpers in a custom view load stock helpers, not aliased h...

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -345,6 +345,11 @@ class View extends Object {
 		} else {
 			$this->response = new CakeResponse();
 		}
+
+		if (isset($controller->helpers)) {
+			$this->helpers = $controller->helpers;
+		}
+
 		$this->Helpers = new HelperCollection($this);
 		$this->Blocks = new ViewBlock();
 		parent::__construct();
@@ -830,6 +835,13 @@ class View extends Object {
 			case 'output':
 				return $this->Blocks->get('content');
 		}
+
+		//  don't auto load aliased stock helpers
+		if (isset($this->helpers[$name])) {
+			$this->Helpers->load($name,$this->helpers[$name]);
+			return $this->Helpers->{$name};
+		}
+
 		if (isset($this->Helpers->{$name})) {
 			$this->{$name} = $this->Helpers->{$name};
 			return $this->Helpers->{$name};


### PR DESCRIPTION
When using aliased stock helpers (CustomHtmlHelper.php) in a custom view class, any reference to $this->Html or $this->Form attempts to auto the stock helpers, ignoring the aliases that were assigned.

Refers to this ticket: https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/4030-custom-views-dont-load-aliased-helpers-when-they-instantiate
