### PR TITLE
Load helpers at View construction.

### DIFF
--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -334,6 +334,8 @@ object(View) {
 	response => object(CakeResponse) {}
 	elementCache => 'default'
 	elementCacheSettings => array()
+	Html => object(HtmlHelper) {}
+	Form => object(FormHelper) {}
 	int => (int) 2
 	float => (float) 1.333
 
@@ -358,7 +360,6 @@ TEXT;
 	)
 	[protected] _scripts => array()
 	[protected] _paths => array()
-	[protected] _helpersLoaded => false
 	[protected] _parents => array()
 	[protected] _current => null
 	[protected] _currentType => ''

--- a/lib/Cake/Test/Case/View/HelperTest.php
+++ b/lib/Cake/Test/Case/View/HelperTest.php
@@ -972,7 +972,7 @@ class HelperTest extends CakeTestCase {
 		$Helper->OtherHelper;
 
 		$result = $this->View->Helpers->enabled();
-		$expected = array();
+		$expected = array('Html');
 		$this->assertEquals($expected, $result, 'Helper helpers were attached to the collection.');
 	}
 

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -49,6 +49,25 @@ class JsonViewTest extends CakeTestCase {
 	}
 
 /**
+ * Test that rendering with _serialize does not load helpers
+ *
+ * @return void
+ */
+	public function testRenderSerializeNoHelpers() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$Controller->helpers = array('Html');
+		$Controller->set(array(
+			'_serialize' => 'tags',
+			'tags' => array('cakephp', 'framework')
+		));
+		$View = new JsonView($Controller);
+		$View->render();
+		$this->assertFalse(isset($View->Html), 'No helper loaded.');
+	}
+
+/**
  * Test render with an array in _serialize
  *
  * @return void

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -92,8 +92,8 @@ class JsonViewTest extends CakeTestCase {
 			)
 		);
 		$Controller->set('user', $data);
+		$Controller->helpers = array('Paginator');
 		$View = new JsonView($Controller);
-		$View->helpers = array('Paginator');
 		$output = $View->render('index');
 
 		$expected = json_encode(array('user' => 'fake', 'list' => array('item1', 'item2'), 'paging' => array('page' => 2)));

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -75,6 +75,25 @@ class XmlViewTest extends CakeTestCase {
 	}
 
 /**
+ * Test that rendering with _serialize does not load helpers
+ *
+ * @return void
+ */
+	public function testRenderSerializeNoHelpers() {
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$Controller->helpers = array('Html');
+		$Controller->set(array(
+			'_serialize' => 'tags',
+			'tags' => array('cakephp', 'framework')
+		));
+		$View = new XmlView($Controller);
+		$View->render();
+		$this->assertFalse(isset($View->Html), 'No helper loaded.');
+	}
+
+/**
  * Test render with an array in _serialize
  *
  * @return void

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -70,6 +70,19 @@ class JsonView extends View {
 	}
 
 /**
+ * Skip loading helpers if this is a _serialize based view.
+ *
+ * @return void
+ */
+	public function loadHelpers() {
+		if (isset($this->viewVars['_serialize'])) {
+			return;
+		}
+		parent::loadHelpers();
+	}
+
+
+/**
  * Render a JSON view.
  *
  * Uses the special '_serialize' parameter to convert a set of

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -254,13 +254,6 @@ class View extends Object {
 	protected $_paths = array();
 
 /**
- * Indicate that helpers have been loaded.
- *
- * @var boolean
- */
-	protected $_helpersLoaded = false;
-
-/**
  * The names of views and their parents used with View::extend();
  *
  * @var array
@@ -347,6 +340,7 @@ class View extends Object {
 		}
 		$this->Helpers = new HelperCollection($this);
 		$this->Blocks = new ViewBlock();
+		$this->loadHelpers();
 		parent::__construct();
 	}
 
@@ -460,9 +454,6 @@ class View extends Object {
 		if ($this->hasRendered) {
 			return true;
 		}
-		if (!$this->_helpersLoaded) {
-			$this->loadHelpers();
-		}
 		$this->Blocks->set('content', '');
 
 		if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
@@ -511,9 +502,6 @@ class View extends Object {
 			return $this->Blocks->get('content');
 		}
 
-		if (!$this->_helpersLoaded) {
-			$this->loadHelpers();
-		}
 		if (empty($content)) {
 			$content = $this->Blocks->get('content');
 		}
@@ -881,7 +869,6 @@ class View extends Object {
 			list(, $class) = pluginSplit($properties['class']);
 			$this->{$class} = $this->Helpers->load($properties['class'], $properties['settings']);
 		}
-		$this->_helpersLoaded = true;
 	}
 
 /**
@@ -1194,9 +1181,6 @@ class View extends Object {
  * @return string
  */
 	protected function _renderElement($file, $data, $options) {
-		if (!$this->_helpersLoaded) {
-			$this->loadHelpers();
-		}
 		if ($options['callbacks']) {
 			$this->getEventManager()->dispatch(new CakeEvent('View.beforeRender', $this, array($file)));
 		}

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -73,6 +73,18 @@ class XmlView extends View {
 	}
 
 /**
+ * Skip loading helpers if this is a _serialize based view.
+ *
+ * @return void
+ */
+	public function loadHelpers() {
+		if (isset($this->viewVars['_serialize'])) {
+			return;
+		}
+		parent::loadHelpers();
+	}
+
+/**
  * Render a XML view.
  *
  * Uses the special '_serialize' parameter to convert a set of


### PR DESCRIPTION
Loading helpers earlier in View's lifecycle allows for the removal of many duplicated code segments and a now useless property. It slightly modifies how View behaves in a test case, but that issue is easily remedied by calling loadHelpers() a second time.

This primarily fixes issues where helpers may not be loaded in View subclasses if they override any of View's methods. This is particularly problematic when aliased helpers are involved.

Related to #1564
