### PR TITLE
Allow 'options' to be given as array when adding a param detector - similar to env / options.

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -516,8 +516,13 @@ class CakeRequest implements ArrayAccess {
 		}
 		if (isset($detect['param'])) {
 			$key = $detect['param'];
-			$value = $detect['value'];
-			return isset($this->params[$key]) ? $this->params[$key] == $value : false;
+			if (isset($detect['value'])) {
+				$value = $detect['value'];
+				return isset($this->params[$key]) ? $this->params[$key] == $value : false;
+			}
+			if (isset($detect['options'])) {
+				return isset($this->params[$key]) ? in_array($this->params[$key],$detect['options']) : false;
+			}
 		}
 		if (isset($detect['callback']) && is_callable($detect['callback'])) {
 			return call_user_func($detect['callback'], $this);

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -521,7 +521,7 @@ class CakeRequest implements ArrayAccess {
 				return isset($this->params[$key]) ? $this->params[$key] == $value : false;
 			}
 			if (isset($detect['options'])) {
-				return isset($this->params[$key]) ? in_array($this->params[$key],$detect['options']) : false;
+				return isset($this->params[$key]) ? in_array($this->params[$key], $detect['options']) : false;
 			}
 		}
 		if (isset($detect['callback']) && is_callable($detect['callback'])) {

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1050,6 +1050,13 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request->return = false;
 		$this->assertFalse($request->isCallMe());
+		
+		$request->addDetector('extension', array('param' => 'ext', 'options' => array('pdf','png','txt')));
+		$request->params['ext'] = 'pdf';
+		$this->assertTrue($request->is('extension'));
+		
+		$request->params['ext'] = 'exe';
+		$this->assertFalse($request->isExtension());
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1050,11 +1050,11 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request->return = false;
 		$this->assertFalse($request->isCallMe());
-		
-		$request->addDetector('extension', array('param' => 'ext', 'options' => array('pdf','png','txt')));
+
+		$request->addDetector('extension', array('param' => 'ext', 'options' => array('pdf', 'png', 'txt')));
 		$request->params['ext'] = 'pdf';
 		$this->assertTrue($request->is('extension'));
-		
+
 		$request->params['ext'] = 'exe';
 		$this->assertFalse($request->isExtension());
 	}


### PR DESCRIPTION
Allow the following when adding request detectors using CakeRequest::addDetector():

```
array('param'=>'{param-name}', 'options'=>array())
```
