### PR TITLE
2.5 - Add Security::encrypt() and Security::decrypt()

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -132,7 +132,9 @@ class CookieComponent extends Component {
  * Type of encryption to use.
  *
  * Currently two methods are available: cipher and rijndael
- * Defaults to Security::cipher();
+ * Defaults to Security::cipher(). Cipher is horribly insecure and only
+ * the default because of backwards compatibility. In new applications you should
+ * always change this to 'aes' or 'rijndael'.
  *
  * @var string
  */
@@ -364,10 +366,11 @@ class CookieComponent extends Component {
 	public function type($type = 'cipher') {
 		$availableTypes = array(
 			'cipher',
-			'rijndael'
+			'rijndael',
+			'aes'
 		);
 		if (!in_array($type, $availableTypes)) {
-			trigger_error(__d('cake_dev', 'You must use cipher or rijndael for cookie encryption type'), E_USER_WARNING);
+			trigger_error(__d('cake_dev', 'You must use cipher, rijndael or aes for cookie encryption type'), E_USER_WARNING);
 			$type = 'cipher';
 		}
 		$this->_type = $type;
@@ -455,12 +458,20 @@ class CookieComponent extends Component {
 		if (is_array($value)) {
 			$value = $this->_implode($value);
 		}
-
-		if ($this->_encrypted === true) {
-			$type = $this->_type;
-			$value = "Q2FrZQ==." . base64_encode(Security::$type($value, $this->key, 'encrypt'));
+		if (!$this->_encrypted) {
+			return $value;
 		}
-		return $value;
+		$prefix = "Q2FrZQ==.";
+		if ($this->_type === 'rijndael') {
+			$cipher = Security::rijndael($value, $this->key, 'encrypt');
+		}
+		if ($this->_type === 'cipher') {
+			$cipher = Security::cipher($value, $this->key);
+		}
+		if ($this->_type === 'aes') {
+			$cipher = Security::encrypt($value, $this->key);
+		}
+		return $prefix . base64_encode($cipher);
 	}
 
 /**
@@ -476,25 +487,38 @@ class CookieComponent extends Component {
 		foreach ((array)$values as $name => $value) {
 			if (is_array($value)) {
 				foreach ($value as $key => $val) {
-					$pos = strpos($val, 'Q2FrZQ==.');
-					$decrypted[$name][$key] = $this->_explode($val);
-
-					if ($pos !== false) {
-						$val = substr($val, 8);
-						$decrypted[$name][$key] = $this->_explode(Security::$type(base64_decode($val), $this->key, 'decrypt'));
-					}
+					$decrypted[$name][$key] = $this->_decode($val);
 				}
 			} else {
-				$pos = strpos($value, 'Q2FrZQ==.');
-				$decrypted[$name] = $this->_explode($value);
-
-				if ($pos !== false) {
-					$value = substr($value, 8);
-					$decrypted[$name] = $this->_explode(Security::$type(base64_decode($value), $this->key, 'decrypt'));
-				}
+				$decrypted[$name] = $this->_decode($value);
 			}
 		}
 		return $decrypted;
+	}
+
+/**
+ * Decodes and decrypts a single value.
+ *
+ * @param string $value The value to decode & decrypt.
+ * @return string Decoded value.
+ */
+	protected function _decode($value) {
+		$prefix = 'Q2FrZQ==.';
+		$pos = strpos($value, $prefix);
+		if ($pos === false) {
+			return $this->_explode($value);
+		}
+		$value = base64_decode(substr($value, strlen($prefix)));
+		if ($this->_type === 'rijndael') {
+			$plain = Security::rijndael($value, $this->key, 'decrypt');
+		}
+		if ($this->_type === 'cipher') {
+			$plain = Security::cipher($value, $this->key);
+		}
+		if ($this->_type === 'aes') {
+			$plain = Security::decrypt($value, $this->key);
+		}
+		return $this->_explode($plain);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -317,6 +317,51 @@ class SecurityTest extends CakeTestCase {
 	}
 
 /**
+ * Test that changing the key causes decryption to fail.
+ *
+ * @return void
+ */
+	public function testDecryptKeyFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is longer than 32 bytes long.';
+		$result = Security::encrypt($txt, $key);
+
+		$key = 'Not the same key. This one will fail';
+		$this->assertFalse(Security::decrypt($txt, $key), 'Modified key will fail.');
+	}
+
+/**
+ * Test that decrypt fails when there is an hmac error.
+ *
+ * @return void
+ */
+	public function testDecryptHmacFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is quite long and works well.';
+		$salt = 'this is a delicious salt!';
+		$result = Security::encrypt($txt, $key, $salt);
+
+		// Change one of the bytes in the hmac.
+		$result[10] = 'x';
+		$this->assertFalse(Security::decrypt($result, $key, $salt), 'Modified hmac causes failure.');
+	}
+
+/**
+ * Test that changing the hmac salt will cause failures.
+ *
+ * @return void
+ */
+	public function testDecryptHmacSaltFailure() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is quite long and works well.';
+		$salt = 'this is a delicious salt!';
+		$result = Security::encrypt($txt, $key, $salt);
+
+		$salt = 'humpty dumpty had a great fall.';
+		$this->assertFalse(Security::decrypt($result, $key, $salt), 'Modified salt causes failure.');
+	}
+
+/**
  * Test that short keys cause errors
  *
  * @expectedException CakeException

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -342,7 +342,6 @@ class SecurityTest extends CakeTestCase {
 		Security::encrypt($txt, $key);
 	}
 
-
 /**
  * Test that short keys cause errors
  *

--- a/lib/Cake/Test/Case/Utility/SecurityTest.php
+++ b/lib/Cake/Test/Case/Utility/SecurityTest.php
@@ -302,4 +302,71 @@ class SecurityTest extends CakeTestCase {
 		Security::rijndael($txt, $key, 'encrypt');
 	}
 
+/**
+ * Test encrypt/decrypt.
+ *
+ * @return void
+ */
+	public function testEncryptDecrypt() {
+		$txt = 'The quick brown fox';
+		$key = 'This key is longer than 32 bytes long.';
+		$result = Security::encrypt($txt, $key);
+		$this->assertNotEquals($txt, $result, 'Should be encrypted.');
+		$this->assertNotEquals($result, Security::encrypt($txt, $key), 'Each result is unique.');
+		$this->assertEquals($txt, Security::decrypt($result, $key));
+	}
+
+/**
+ * Test that short keys cause errors
+ *
+ * @expectedException CakeException
+ * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
+ * @return void
+ */
+	public function testEncryptInvalidKey() {
+		$txt = 'The quick brown fox jumped over the lazy dog.';
+		$key = 'this is too short';
+		Security::encrypt($txt, $key);
+	}
+
+/**
+ * Test that empty data cause errors
+ *
+ * @expectedException CakeException
+ * @expectedExceptionMessage The data to encrypt cannot be empty.
+ * @return void
+ */
+	public function testEncryptInvalidData() {
+		$txt = '';
+		$key = 'This is a key that is long enough to be ok.';
+		Security::encrypt($txt, $key);
+	}
+
+
+/**
+ * Test that short keys cause errors
+ *
+ * @expectedException CakeException
+ * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
+ * @return void
+ */
+	public function testDecryptInvalidKey() {
+		$txt = 'The quick brown fox jumped over the lazy dog.';
+		$key = 'this is too short';
+		Security::decrypt($txt, $key);
+	}
+
+/**
+ * Test that empty data cause errors
+ *
+ * @expectedException CakeException
+ * @expectedExceptionMessage The data to decrypt cannot be empty.
+ * @return void
+ */
+	public function testDecryptInvalidData() {
+		$txt = '';
+		$key = 'This is a key that is long enough to be ok.';
+		Security::decrypt($txt, $key);
+	}
+
 }

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -319,7 +319,7 @@ class Security {
 
 		$ivSize = mcrypt_get_iv_size($algorithm, $mode);
 		$iv = mcrypt_create_iv($ivSize, MCRYPT_DEV_URANDOM);
-		$ciphertext =  $iv . mcrypt_encrypt($algorithm, $key, $plain, $mode, $iv);
+		$ciphertext = $iv . mcrypt_encrypt($algorithm, $key, $plain, $mode, $iv);
 		$hmac = hash_hmac('sha256', $ciphertext, $key);
 		return $hmac . $ciphertext;
 	}

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -302,7 +302,7 @@ class Security {
  * @throws CakeException On invalid data or key.
  */
 	public static function encrypt($plain, $key) {
-		static::_checkKey($key, 'encrypt()');
+		self::_checkKey($key, 'encrypt()');
 		if (empty($plain)) {
 			throw new CakeException(__d('cake_dev', 'The data to encrypt cannot be empty.'));
 		}
@@ -338,7 +338,7 @@ class Security {
  * @throws CakeException On invalid data or key.
  */
 	public static function decrypt($cipher, $key) {
-		static::_checkKey($key, 'decrypt()');
+		self::_checkKey($key, 'decrypt()');
 		if (empty($cipher)) {
 			throw new CakeException(__d('cake_dev', 'The data to decrypt cannot be empty.'));
 		}


### PR DESCRIPTION
Add new methods to simplify access to AES-256. After talking with @lorenzo we agreed that `rijndael` is hard to remember, and has a funky signature taking the mode as a string. These new methods have simple names and use a more broadly accepted cipher set (AES-256).

You might notice that the algorithm is `MCRYPT_RIJNDAEL_128`, after reading both the PHP docs and [zf2 source code](https://github.com/zendframework/zf2/blob/master/library/Zend/Crypt/Symmetric/Mcrypt.php#L74) I'm fairly sure this is correct constant to use and that the key length changes the strength of the encryption.
