### PR TITLE
Add y/yes option to schema create and update subcommands

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -333,7 +333,7 @@ class SchemaShell extends AppShell {
 		$this->out("\n" . __d('cake_console', 'The following table(s) will be dropped.'));
 		$this->out(array_keys($drop));
 
-		if ($this->in(__d('cake_console', 'Are you sure you want to drop the table(s)?'), array('y', 'n'), 'n') === 'y') {
+		if (!empty($this->params['yes']) || $this->in(__d('cake_console', 'Are you sure you want to drop the table(s)?'), array('y', 'n'), 'n') === 'y') {
 			$this->out(__d('cake_console', 'Dropping table(s).'));
 			$this->_run($drop, 'drop', $Schema);
 		}
@@ -341,7 +341,7 @@ class SchemaShell extends AppShell {
 		$this->out("\n" . __d('cake_console', 'The following table(s) will be created.'));
 		$this->out(array_keys($create));
 
-		if ($this->in(__d('cake_console', 'Are you sure you want to create the table(s)?'), array('y', 'n'), 'y') === 'y') {
+		if (!empty($this->params['yes']) || $this->in(__d('cake_console', 'Are you sure you want to create the table(s)?'), array('y', 'n'), 'y') === 'y') {
 			$this->out(__d('cake_console', 'Creating table(s).'));
 			$this->_run($create, 'create', $Schema);
 		}
@@ -392,7 +392,7 @@ class SchemaShell extends AppShell {
 
 		$this->out("\n" . __d('cake_console', 'The following statements will run.'));
 		$this->out(array_map('trim', $contents));
-		if ($this->in(__d('cake_console', 'Are you sure you want to alter the tables?'), array('y', 'n'), 'n') === 'y') {
+		if (!empty($this->params['yes']) || $this->in(__d('cake_console', 'Are you sure you want to alter the tables?'), array('y', 'n'), 'n') === 'y') {
 			$this->out();
 			$this->out(__d('cake_console', 'Updating Database...'));
 			$this->_run($contents, 'update', $Schema);
@@ -496,6 +496,11 @@ class SchemaShell extends AppShell {
 		$exclude = array(
 			'help' => __d('cake_console', 'Tables to exclude as comma separated list.')
 		);
+		$yes = array(
+			'short' => 'y',
+			'help' => __d('cake_console', 'Do not prompt for confirmation. Be careful!'),
+			'boolean' => true
+		);
 
 		$parser = parent::getOptionParser();
 		$parser->description(
@@ -523,7 +528,7 @@ class SchemaShell extends AppShell {
 		))->addSubcommand('create', array(
 			'help' => __d('cake_console', 'Drop and create tables based on the schema file.'),
 			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot'),
+				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'yes'),
 				'args' => array(
 					'name' => array(
 						'help' => __d('cake_console', 'Name of schema to use.')
@@ -536,7 +541,7 @@ class SchemaShell extends AppShell {
 		))->addSubcommand('update', array(
 			'help' => __d('cake_console', 'Alter the tables based on the schema file.'),
 			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'force'),
+				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'force', 'yes'),
 				'args' => array(
 					'name' => array(
 						'help' => __d('cake_console', 'Name of schema to use.')

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -427,6 +427,29 @@ class SchemaShellTest extends CakeTestCase {
 	}
 
 /**
+ * Test schema run create with --yes option
+ *
+ * @return void
+ */
+	public function testCreateOptionYes() {
+		$this->Shell = $this->getMock(
+			'SchemaShell',
+			array('in', 'out', 'hr', 'createFile', 'error', 'err', '_stop', '_run'),
+			array(&$this->Dispatcher)
+		);
+
+		$this->Shell->params = array(
+			'connection' => 'test',
+			'yes' => true,
+		);
+		$this->Shell->args = array('i18n');
+		$this->Shell->expects($this->never())->method('in');
+		$this->Shell->expects($this->exactly(2))->method('_run');
+		$this->Shell->startup();
+		$this->Shell->create();
+	}
+
+/**
  * Test schema run create with no table args.
  *
  * @return void
@@ -532,6 +555,33 @@ class SchemaShellTest extends CakeTestCase {
 		$r = $this->Shell->expects($this->once())
 			->method('_run')
 			->with($this->arrayHasKey('newone'), 'update', $this->isInstanceOf('CakeSchema'));
+
+		$this->Shell->update();
+	}
+
+/**
+ * test run update with --yes option
+ *
+ * @return void
+ */
+	public function testUpdateWithOptionYes() {
+		$this->Shell = $this->getMock(
+			'SchemaShell',
+			array('in', 'out', 'hr', 'createFile', 'error', 'err', '_stop', '_run'),
+			array(&$this->Dispatcher)
+		);
+
+		$this->Shell->params = array(
+			'connection' => 'test',
+			'force' => true,
+			'yes' => true,
+		);
+		$this->Shell->args = array('SchemaShellTest', 'articles');
+		$this->Shell->startup();
+		$this->Shell->expects($this->never())->method('in');
+		$this->Shell->expects($this->once())
+			->method('_run')
+			->with($this->arrayHasKey('articles'), 'update', $this->isInstanceOf('CakeSchema'));
 
 		$this->Shell->update();
 	}


### PR DESCRIPTION
In addition to the closed pull request https://github.com/cakephp/cakephp/pull/1569.
- rebased onto latest commit of 2.5 branch
- changed option name to `-y` and `--yes`
- Travis is passing
