### PR TITLE
2.5 logging - deprecate/disallow magic logging

### DIFF
--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -372,18 +372,6 @@ class CakeLog {
 	}
 
 /**
- * Configures the automatic/default stream a FileLog.
- *
- * @return void
- */
-	protected static function _autoConfig() {
-		self::$_Collection->load('default', array(
-			'engine' => 'File',
-			'path' => LOGS,
-		));
-	}
-
-/**
  * Writes the given message and type to all of the configured log adapters.
  * Configured adapters are passed both the $type and $message variables. $type
  * is one of the following strings/values.
@@ -454,11 +442,7 @@ class CakeLog {
 				$logged = true;
 			}
 		}
-		if (!$logged) {
-			self::_autoConfig();
-			self::stream('default')->write($type, $message);
-		}
-		return true;
+		return $logged;
 	}
 
 /**

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -126,27 +126,20 @@ class CakeLogTest extends CakeTestCase {
 	}
 
 /**
- * Test that CakeLog autoconfigures itself to use a FileLogger with the LOGS dir.
- * When no streams are there.
+ * Test that CakeLog does not auto create logs when no streams are there to listen.
  *
  * @return void
  */
-	public function testAutoConfig() {
+	public function testNoStreamListenting() {
 		if (file_exists(LOGS . 'error.log')) {
 			unlink(LOGS . 'error.log');
 		}
-		CakeLog::write(LOG_WARNING, 'Test warning');
-		$this->assertTrue(file_exists(LOGS . 'error.log'));
+		$res = CakeLog::write(LOG_WARNING, 'Test warning');
+		$this->assertFalse($res);
+		$this->assertFalse(file_exists(LOGS . 'error.log'));
 
 		$result = CakeLog::configured();
-		$this->assertEquals(array('default'), $result);
-
-		$testMessage = 'custom message';
-		CakeLog::write('custom', $testMessage);
-		$content = file_get_contents(LOGS . 'custom.log');
-		$this->assertContains($testMessage, $content);
-		unlink(LOGS . 'error.log');
-		unlink(LOGS . 'custom.log');
+		$this->assertEquals(array(), $result);
 	}
 
 /**
@@ -197,6 +190,10 @@ class CakeLogTest extends CakeTestCase {
  * @return void
  */
 	public function testLogFileWriting() {
+		CakeLog::config('file', array(
+			'engine' => 'File',
+			'path' => LOGS
+		));
 		if (file_exists(LOGS . 'error.log')) {
 			unlink(LOGS . 'error.log');
 		}
@@ -502,6 +499,11 @@ class CakeLogTest extends CakeTestCase {
 	public function testBogusTypeAndScope() {
 		$this->_resetLogConfig();
 		$this->_deleteLogs();
+
+		CakeLog::config('file', array(
+			'engine' => 'File',
+			'path' => LOGS
+		));
 
 		CakeLog::write('bogus', 'bogus message');
 		$this->assertTrue(file_exists(LOGS . 'bogus.log'));


### PR DESCRIPTION
More suble approach on the "swallowing issue" from https://github.com/cakephp/debug_kit/pull/85

Just deprecate/disallow the magic logging to avoid such issues.
