### PR TITLE
Feature/configure engine

### DIFF
--- a/lib/Cake/Configure/ConfigEngineInterface.php
+++ b/lib/Cake/Configure/ConfigEngineInterface.php
@@ -17,10 +17,8 @@ namespace Cake\Configure;
 
 /**
  * An interface for creating objects compatible with Configure::load()
- *
- * @package       Cake.Core
  */
-interface ConfigReaderInterface {
+interface ConfigEngineInterface {
 
 /**
  * Read method is used for reading configuration information from sources.

--- a/lib/Cake/Configure/Engine/IniConfig.php
+++ b/lib/Cake/Configure/Engine/IniConfig.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * IniReader
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -13,12 +9,12 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @package       Cake.Configure
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Configure;
+namespace Cake\Configure\Engine;
 
+use Cake\Configure\ConfigEngineInterface;
 use Cake\Core\App;
 use Cake\Error;
 use Cake\Utility\Hash;
@@ -26,10 +22,10 @@ use Cake\Utility\Hash;
 /**
  * Ini file configuration engine.
  *
- * Since IniReader uses parse_ini_file underneath, you should be aware that this
+ * Since IniConfig uses parse_ini_file underneath, you should be aware that this
  * class shares the same behavior, especially with regards to boolean and null values.
  *
- * In addition to the native `parse_ini_file` features, IniReader also allows you
+ * In addition to the native `parse_ini_file` features, IniConfig also allows you
  * to create nested array structures through usage of `.` delimited names. This allows
  * you to create nested arrays structures in an ini config file. For example:
  *
@@ -50,14 +46,13 @@ use Cake\Utility\Hash;
  * You can combine `.` separated values with sections to create more deeply
  * nested structures.
  *
- * IniReader also manipulates how the special ini values of
+ * IniConfig also manipulates how the special ini values of
  * 'yes', 'no', 'on', 'off', 'null' are handled. These values will be
  * converted to their boolean equivalents.
  *
- * @package       Cake.Configure
  * @see http://php.net/parse_ini_file
  */
-class IniReader implements ConfigReaderInterface {
+class IniConfig implements ConfigEngineInterface {
 
 /**
  * The path to read ini files from.
@@ -95,7 +90,7 @@ class IniReader implements ConfigReaderInterface {
  * For backwards compatibility, acl.ini.php will be treated specially until 3.0.
  *
  * @param string $key The identifier to read from. If the key has a . it will be treated
- *  as a plugin prefix. The chosen file must be on the reader's path.
+ *  as a plugin prefix. The chosen file must be on the engine's path.
  * @return array Parsed configuration values.
  * @throws Cake\Error\ConfigureException when files don't exist.
  *  Or when files contain '..' as this could lead to abusive reads.

--- a/lib/Cake/Configure/Engine/PhpConfig.php
+++ b/lib/Cake/Configure/Engine/PhpConfig.php
@@ -1,39 +1,34 @@
 <?php
 /**
- * PhpReader file
- *
- * PHP 5
- *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt
- * Redistributions of files must retain the above copyright notice
+ * Redistributions of files must retain the above copyright notice.
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
- * @link          http://book.cakephp.org/2.0/en/development/configuration.html#loading-configuration-files CakePHP(tm) Configuration
- * @package       Cake.Configure
+ * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Configure;
+namespace Cake\Configure\Engine;
 
+use Cake\Configure\ConfigEngineInterface;
 use Cake\Core\App;
 use Cake\Error;
 
 /**
- * PHP Reader allows Configure to load configuration values from
+ * PHP engine allows Configure to load configuration values from
  * files containing simple PHP arrays.
  *
- * Files compatible with PhpReader should define a `$config` variable, that
+ * Files compatible with PhpConfig should define a `$config` variable, that
  * contains all of the configuration data contained in the file.
- *
- * @package       Cake.Configure
  */
-class PhpReader implements ConfigReaderInterface {
+class PhpConfig implements ConfigEngineInterface {
 
 /**
- * The path this reader finds files on.
+ * The path this engine finds files on.
  *
  * @var string
  */

--- a/lib/Cake/Controller/Component/Acl/IniAcl.php
+++ b/lib/Cake/Controller/Component/Acl/IniAcl.php
@@ -15,7 +15,7 @@
  */
 namespace Cake\Controller\Component\Acl;
 
-use Cake\Configure\IniReader;
+use Cake\Configure\Engine\IniConfig;
 use Cake\Controller\Component;
 use Cake\Core\Object;
 use Cake\Utility\Hash;
@@ -156,7 +156,7 @@ class IniAcl extends Object implements AclInterface {
  * @return array INI section structure
  */
 	public function readConfigFile($filename) {
-		$iniFile = new IniReader(dirname($filename) . DS);
+		$iniFile = new IniConfig(dirname($filename) . DS);
 		return $iniFile->read(basename($filename));
 	}
 

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Controller\Component\Acl;
 
-use Cake\Configure\PhpReader;
+use Cake\Configure\Engine\PhpConfig;
 use Cake\Controller\Component;
 use Cake\Core\Object;
 use Cake\Error;
@@ -85,8 +85,8 @@ class PhpAcl extends Object implements AclInterface {
 			$this->options = array_merge($this->options, $Component->settings['adapter']);
 		}
 
-		$Reader = new PhpReader(dirname($this->options['config']) . DS);
-		$config = $Reader->read(basename($this->options['config']));
+		$engine = new PhpConfig(dirname($this->options['config']) . DS);
+		$config = $engine->read(basename($this->options['config']));
 		$this->build($config);
 		$Component->Aco = $this->Aco;
 		$Component->Aro = $this->Aro;

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Controller\Component;
 
-use Cake\Configure\IniReader;
+use Cake\Configure\Engine\IniConfig;
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Component\Acl\AclInterface;

--- a/lib/Cake/Test/TestCase/Configure/Engine/IniConfig.php
+++ b/lib/Cake/Test/TestCase/Configure/Engine/IniConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * IniReaderTest
+ * IniEngineTest
  *
  * PHP 5
  *
@@ -17,19 +17,19 @@
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Configure;
+namespace Cake\Test\TestCase\Configure\Engine;
 
-use Cake\Configure\IniReader;
+use Cake\Configure\IniEngine;
 use Cake\Core\App;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 
 /**
- * Class IniReaderTest
+ * Class IniEngineTest
  *
  * @package       Cake.Test.Case.Configure
  */
-class IniReaderTest extends TestCase {
+class IniEngineTest extends TestCase {
 
 /**
  * Test data to serialize and unserialize.
@@ -67,8 +67,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testConstruct() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('acl.ini');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('acl.ini');
 
 		$this->assertTrue(isset($config['admin']));
 		$this->assertTrue(isset($config['paul']['groups']));
@@ -81,11 +81,11 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testRead() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('nested');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('nested');
 		$this->assertTrue($config['bools']['test_on']);
 
-		$config = $reader->read('nested.ini');
+		$config = $engine->read('nested.ini');
 		$this->assertTrue($config['bools']['test_on']);
 	}
 
@@ -95,8 +95,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadOnlyOneSection() {
-		$reader = new IniReader($this->path, 'admin');
-		$config = $reader->read('acl.ini');
+		$engine = new IniEngine($this->path, 'admin');
+		$config = $engine->read('acl.ini');
 
 		$this->assertTrue(isset($config['groups']));
 		$this->assertEquals('administrators', $config['groups']);
@@ -108,8 +108,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadSpecialAclIniPhp() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('acl.ini.php');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('acl.ini.php');
 
 		$this->assertTrue(isset($config['admin']));
 		$this->assertTrue(isset($config['paul']['groups']));
@@ -122,8 +122,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithoutSection() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('no_section.ini');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('no_section.ini');
 
 		$expected = array(
 			'some_key' => 'some_value',
@@ -138,8 +138,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadValuesWithDots() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('nested.ini');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('nested.ini');
 
 		$this->assertTrue(isset($config['database']['db']['username']));
 		$this->assertEquals('mark', $config['database']['db']['username']);
@@ -154,8 +154,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testBooleanReading() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('nested.ini');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('nested.ini');
 
 		$this->assertTrue($config['bools']['test_on']);
 		$this->assertFalse($config['bools']['test_off']);
@@ -176,8 +176,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
-		$reader = new IniReader($this->path);
-		$reader->read('no_ini_extension');
+		$engine = new IniEngine($this->path);
+		$engine->read('no_ini_extension');
 	}
 
 /**
@@ -187,8 +187,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithNonExistentFile() {
-		$reader = new IniReader($this->path);
-		$reader->read('fake_values');
+		$engine = new IniEngine($this->path);
+		$engine->read('fake_values');
 	}
 
 /**
@@ -197,8 +197,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadEmptyFile() {
-		$reader = new IniReader($this->path);
-		$config = $reader->read('empty');
+		$engine = new IniEngine($this->path);
+		$config = $engine->read('empty');
 		$this->assertEquals(array(), $config);
 	}
 
@@ -209,8 +209,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithDots() {
-		$reader = new IniReader($this->path);
-		$reader->read('../empty');
+		$engine = new IniEngine($this->path);
+		$engine->read('../empty');
 	}
 
 /**
@@ -223,15 +223,15 @@ class IniReaderTest extends TestCase {
 			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
 		), App::RESET);
 		Plugin::load('TestPlugin');
-		$reader = new IniReader($this->path);
-		$result = $reader->read('TestPlugin.nested');
+		$engine = new IniEngine($this->path);
+		$result = $engine->read('TestPlugin.nested');
 
 		$this->assertTrue(isset($result['database']['db']['username']));
 		$this->assertEquals('bar', $result['database']['db']['username']);
 		$this->assertFalse(isset($result['database.db.username']));
 		$this->assertFalse(isset($result['database']['db.username']));
 
-		$result = $reader->read('TestPlugin.nested.ini');
+		$result = $engine->read('TestPlugin.nested.ini');
 		$this->assertEquals('foo', $result['database']['db']['password']);
 		Plugin::unload();
 	}
@@ -246,8 +246,8 @@ class IniReaderTest extends TestCase {
 			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
 		), App::RESET);
 		Plugin::load('TestPlugin');
-		$reader = new IniReader($this->path);
-		$result = $reader->read('TestPlugin.acl.ini.php');
+		$engine = new IniEngine($this->path);
+		$result = $engine->read('TestPlugin.acl.ini.php');
 
 		$this->assertTrue(isset($result['admin']));
 		$this->assertTrue(isset($result['paul']['groups']));
@@ -261,8 +261,8 @@ class IniReaderTest extends TestCase {
  * @return void
  */
 	public function testDump() {
-		$reader = new IniReader(TMP);
-		$result = $reader->dump('test.ini', $this->testData);
+		$engine = new IniEngine(TMP);
+		$result = $engine->dump('test.ini', $this->testData);
 		$this->assertTrue($result > 0);
 
 		$expected = <<<INI
@@ -282,7 +282,7 @@ INI;
 
 		$this->assertTextEquals($expected, $result);
 
-		$result = $reader->dump('test', $this->testData);
+		$result = $engine->dump('test', $this->testData);
 		$this->assertTrue($result > 0);
 
 		$contents = file_get_contents($file);
@@ -296,9 +296,9 @@ INI;
  * @return void
  */
 	public function testDumpRead() {
-		$reader = new IniReader(TMP);
-		$reader->dump('test.ini', $this->testData);
-		$result = $reader->read('test.ini');
+		$engine = new IniEngine(TMP);
+		$engine->dump('test.ini', $this->testData);
+		$result = $engine->read('test.ini');
 		unlink(TMP . 'test.ini');
 
 		$expected = $this->testData;

--- a/lib/Cake/Test/TestCase/Configure/Engine/PhpConfig.php
+++ b/lib/Cake/Test/TestCase/Configure/Engine/PhpConfig.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PhpConfigReaderTest
+ * PhpConfigEngineTest
  *
  * PHP 5
  *
@@ -17,19 +17,19 @@
  * @since         CakePHP(tm) v 2.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\TestCase\Configure;
+namespace Cake\Test\TestCase\Configure\Engine;
 
-use Cake\Configure\PhpReader;
+use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\App;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 
 /**
- * Class PhpReaderTest
+ * Class PhpConfigTest
  *
  * @package       Cake.Test.Case.Configure
  */
-class PhpReaderTest extends TestCase {
+class PhpConfigTest extends TestCase {
 
 /**
  * Test data to serialize and unserialize.
@@ -67,12 +67,12 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testRead() {
-		$reader = new PhpReader($this->path);
-		$values = $reader->read('var_test');
+		$engine = new PhpConfig($this->path);
+		$values = $engine->read('var_test');
 		$this->assertEquals('value', $values['Read']);
 		$this->assertEquals('buried', $values['Deep']['Deeper']['Deepest']);
 
-		$values = $reader->read('var_test.php');
+		$values = $engine->read('var_test.php');
 		$this->assertEquals('value', $values['Read']);
 	}
 
@@ -83,8 +83,8 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
-		$reader = new PhpReader($this->path);
-		$reader->read('no_php_extension');
+		$engine = new PhpConfig($this->path);
+		$engine->read('no_php_extension');
 	}
 
 /**
@@ -94,8 +94,8 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithNonExistentFile() {
-		$reader = new PhpReader($this->path);
-		$reader->read('fake_values');
+		$engine = new PhpConfig($this->path);
+		$engine->read('fake_values');
 	}
 
 /**
@@ -105,8 +105,8 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testReadEmptyFile() {
-		$reader = new PhpReader($this->path);
-		$reader->read('empty');
+		$engine = new PhpConfig($this->path);
+		$engine->read('empty');
 	}
 
 /**
@@ -116,8 +116,8 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testReadWithDots() {
-		$reader = new PhpReader($this->path);
-		$reader->read('../empty');
+		$engine = new PhpConfig($this->path);
+		$engine->read('../empty');
 	}
 
 /**
@@ -130,11 +130,11 @@ class PhpReaderTest extends TestCase {
 			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
 		), App::RESET);
 		Plugin::load('TestPlugin');
-		$reader = new PhpReader($this->path);
-		$result = $reader->read('TestPlugin.load');
+		$engine = new PhpConfig($this->path);
+		$result = $engine->read('TestPlugin.load');
 		$this->assertTrue(isset($result['plugin_load']));
 
-		$result = $reader->read('TestPlugin.load.php');
+		$result = $engine->read('TestPlugin.load.php');
 		$this->assertTrue(isset($result['plugin_load']));
 		Plugin::unload();
 	}
@@ -145,8 +145,8 @@ class PhpReaderTest extends TestCase {
  * @return void
  */
 	public function testDump() {
-		$reader = new PhpReader(TMP);
-		$result = $reader->dump('test.php', $this->testData);
+		$engine = new PhpConfig(TMP);
+		$result = $engine->dump('test.php', $this->testData);
 		$this->assertTrue($result > 0);
 		$expected = <<<PHP
 <?php
@@ -174,7 +174,7 @@ PHP;
 		unlink($file);
 		$this->assertTextEquals($expected, $contents);
 
-		$result = $reader->dump('test', $this->testData);
+		$result = $engine->dump('test', $this->testData);
 		$this->assertTrue($result > 0);
 
 		$contents = file_get_contents($file);
@@ -188,9 +188,9 @@ PHP;
  * @return void
  */
 	public function testDumpRead() {
-		$reader = new PhpReader(TMP);
-		$reader->dump('test.php', $this->testData);
-		$result = $reader->read('test.php');
+		$engine = new PhpConfig(TMP);
+		$engine->dump('test.php', $this->testData);
+		$result = $engine->read('test.php');
 		unlink(TMP . 'test.php');
 
 		$this->assertEquals($this->testData, $result);

--- a/lib/Cake/Test/TestCase/Core/ConfigureTest.php
+++ b/lib/Cake/Test/TestCase/Core/ConfigureTest.php
@@ -22,7 +22,7 @@
 namespace Cake\Test\TestCase\Core;
 
 use Cake\Cache\Cache;
-use Cake\Configure\PhpReader;
+use Cake\Configure\Engine\PhpConfig;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
@@ -246,7 +246,7 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testLoadExceptionOnNonExistantFile() {
-		Configure::config('test', new PhpReader());
+		Configure::config('test', new PhpConfig());
 		Configure::load('non_existing_configuration_file', 'test');
 	}
 
@@ -270,7 +270,7 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testLoadWithMerge() {
-		Configure::config('test', new PhpReader(CAKE . 'Test/TestApp/Config/'));
+		Configure::config('test', new PhpConfig(CAKE . 'Test/TestApp/Config/'));
 
 		$result = Configure::load('var_test', 'test');
 		$this->assertTrue($result);
@@ -293,7 +293,7 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testLoadNoMerge() {
-		Configure::config('test', new PhpReader(CAKE . 'Test/TestApp/Config/'));
+		Configure::config('test', new PhpConfig(CAKE . 'Test/TestApp/Config/'));
 
 		$result = Configure::load('var_test', 'test');
 		$this->assertTrue($result);
@@ -317,7 +317,7 @@ class ConfigureTest extends TestCase {
 		App::build(array(
 			'Plugin' => array(CAKE . 'Test/TestApp/Plugin/')
 		), App::RESET);
-		Configure::config('test', new PhpReader());
+		Configure::config('test', new PhpConfig());
 		Plugin::load('TestPlugin');
 		$result = Configure::load('TestPlugin.load', 'test');
 		$this->assertTrue($result);
@@ -394,13 +394,13 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * test adding new readers.
+ * test adding new engines.
  *
  * @return void
  */
-	public function testReaderSetup() {
-		$reader = new PhpReader();
-		Configure::config('test', $reader);
+	public function testEngineSetup() {
+		$engine = new PhpConfig();
+		Configure::config('test', $engine);
 		$configured = Configure::configured();
 
 		$this->assertTrue(in_array('test', $configured));
@@ -413,14 +413,14 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * test reader() throwing exceptions on missing interface.
+ * test engine() throwing exceptions on missing interface.
  *
  * @expectedException PHPUnit_Framework_Error
  * @return void
  */
-	public function testReaderExceptionOnIncorrectClass() {
-		$reader = new \StdClass();
-		Configure::config('test', $reader);
+	public function testEngineExceptionOnIncorrectClass() {
+		$engine = new \StdClass();
+		Configure::config('test', $engine);
 	}
 
 /**
@@ -443,14 +443,14 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * test dump integrated with the PhpReader.
+ * test dump integrated with the PhpConfig.
  *
  * @return void
  */
 	public function testDump() {
-		Configure::config('test_reader', new PhpReader(TMP));
+		Configure::config('test_Engine', new PhpConfig(TMP));
 
-		$result = Configure::dump('config_test.php', 'test_reader');
+		$result = Configure::dump('config_test.php', 'test_Engine');
 		$this->assertTrue($result > 0);
 		$result = file_get_contents(TMP . 'config_test.php');
 		$this->assertContains('<?php', $result);
@@ -466,10 +466,10 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testDumpPartial() {
-		Configure::config('test_reader', new PhpReader(TMP));
+		Configure::config('test_Engine', new PhpConfig(TMP));
 		Configure::write('Error', ['test' => 'value']);
 
-		$result = Configure::dump('config_test.php', 'test_reader', ['Error']);
+		$result = Configure::dump('config_test.php', 'test_Engine', ['Error']);
 		$this->assertTrue($result > 0);
 		$result = file_get_contents(TMP . 'config_test.php');
 		$this->assertContains('<?php', $result);

--- a/lib/Cake/Test/TestCase/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/TestCase/View/Helper/HtmlHelperTest.php
@@ -2116,14 +2116,14 @@ class HtmlHelperTest extends TestCase {
 	}
 
 /**
- * testLoadConfigWrongReader method
+ * testLoadConfigWrongEngine method
  *
  * @return void
  * @expectedException Cake\Error\ConfigureException
  */
-	public function testLoadConfigWrongReader() {
+	public function testLoadConfigWrongEngine() {
 		$path = CAKE . 'Test/TestApp/Config/';
-		$this->Html->loadConfig(array('htmlhelper_tags', 'wrong_reader'), $path);
+		$this->Html->loadConfig(array('htmlhelper_tags', 'wrong_engine'), $path);
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -1171,7 +1171,7 @@ class HtmlHelper extends Helper {
  * Load Html tag configuration.
  *
  * Loads a file from APP/Config that contains tag data. By default the file is expected
- * to be compatible with PhpReader:
+ * to be compatible with PhpConfig:
  *
  * `$this->Html->loadConfig('tags.php');`
  *
@@ -1184,7 +1184,7 @@ class HtmlHelper extends Helper {
  * }}}
  *
  * If you wish to store tag definitions in another format you can give an array
- * containing the file name, and reader class name:
+ * containing the file name, and Engine class name:
  *
  * `$this->Html->loadConfig(array('tags.ini', 'ini'));`
  *
@@ -1202,7 +1202,7 @@ class HtmlHelper extends Helper {
  * - `attributeFormat` Format for long attributes e.g. `'%s="%s"'`
  * - `minimizedAttributeFormat` Format for minimized attributes e.g. `'%s="%s"'`
  *
- * @param string|array $configFile String with the config file (load using PhpReader) or an array with file and reader name
+ * @param string|array $configFile String with the config file (load using PhpConfig) or an array with file and engine name
  * @param string $path Path with config file
  * @return mixed False to error or loaded configs
  * @throws Cake\Error\ConfigureException
@@ -1213,26 +1213,26 @@ class HtmlHelper extends Helper {
 			$path = APP . 'Config/';
 		}
 		$file = null;
-		$reader = 'php';
+		$engine = 'php';
 
 		if (!is_array($configFile)) {
 			$file = $configFile;
 		} elseif (isset($configFile[0])) {
 			$file = $configFile[0];
 			if (isset($configFile[1])) {
-				$reader = $configFile[1];
+				$engine = $configFile[1];
 			}
 		} else {
 			throw new Error\ConfigureException(__d('cake_dev', 'Cannot load the configuration file. Wrong "configFile" configuration.'));
 		}
 
-		$readerClass = App::classname(Inflector::camelize($reader), 'Configure', 'Reader');
-		if (!$readerClass) {
-			throw new Error\ConfigureException(__d('cake_dev', 'Cannot load the configuration file. Unknown reader.'));
+		$engineClass = App::classname(Inflector::camelize($engine), 'Configure/Engine', 'Config');
+		if (!$engineClass) {
+			throw new Error\ConfigureException(__d('cake_dev', 'Cannot load the configuration file. Unknown engine.'));
 		}
 
-		$readerObj = new $readerClass($path);
-		$configs = $readerObj->read($file);
+		$engineObj = new $engineClass($path);
+		$configs = $engineObj->read($file);
 		if (isset($configs['tags']) && is_array($configs['tags'])) {
 			$this->_tags = array_merge($this->_tags, $configs['tags']);
 		}


### PR DESCRIPTION
Using suffix "Reader" felt wrong as the "readers" don't just read, they dump config vars to file too.
