### PR TITLE
enable test.php webrunner again and fix a missing namespace

### DIFF
--- a/App/webroot/index.php
+++ b/App/webroot/index.php
@@ -20,7 +20,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 // for built-in server
-if (php_sapi_name() == 'cli-server') {
+if (php_sapi_name() === 'cli-server') {
 	$_SERVER['PHP_SELF'] = '/' . basename(__FILE__);
 }
 require dirname(__DIR__) . '/Config/bootstrap.php';

--- a/App/webroot/test.php
+++ b/App/webroot/test.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Web Access Frontend for TestSuite
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html
+ * @package       app.webroot
+ * @since         CakePHP(tm) v 1.2.0.4433
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+set_time_limit(0);
+ini_set('display_errors', 1);
+
+require dirname(__DIR__) . '/Config/bootstrap.php';
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestSuiteDispatcher;
+
+if (Configure::read('debug') < 1) {
+	exit(__d('cake_dev', 'Debug setting does not allow access to this url.'));
+}
+
+TestSuiteDispatcher::run();

--- a/lib/Cake/TestSuite/Reporter/HtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/HtmlReporter.php
@@ -22,6 +22,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\TestSuite\Coverage\HtmlCoverageReport;
 use Cake\Utility\Inflector;
+use PHPUnit_Util_Diff;
 
 /**
  * HtmlReporter Reports Results of TestSuites and Test Cases

--- a/lib/Cake/TestSuite/templates/header.php
+++ b/lib/Cake/TestSuite/templates/header.php
@@ -17,6 +17,8 @@
  * @since         CakePHP(tm) v 1.2.0.4433
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
+use Cake\Core\Configure;
 ?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
A few months back the test.php testrunner file got removed during a 2.4 merge. Probably due to convenience during a merge conflict.
Anyway, during a discussion some including me saw the usefulness in 3.0 still supporting the webrunner as it eases the start into testing.

This moves the test.php webrunner back into 3.0.
For it to work I had to first add a missing use, though.

Note that this might not be the best approach regarding the current overhead in TestSuiteDispatcher::run() - also in light of its possible removal. Open for discussion on how to best proceed.
