### PR TITLE
Fix missing use

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -24,6 +24,7 @@ namespace Cake\Model;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Object;
+use Cake\Database\ConnectionManager;
 use Cake\Error;
 use Cake\Event\Event;
 use Cake\Event\EventListener;


### PR DESCRIPTION
I don't speak much English.

[![Build Status](https://travis-ci.org/gold1/cakephp.png?branch=3.0-model-missing-use)](https://travis-ci.org/gold1/cakephp/builds/10829558)
### Problem

Fatal error: Class 'Cake\Model\ConnectionManager' not found in /lib/Cake/Model/Model.php on line 3291
### Solution

Add `use ConnectionManager` to Model.php.
`use Cake\Database\ConnectionManager;`
### Memo

'Cake\Model\ConnectionManager' moves to 'Cake\Database\ConnectionManager'
### Comment

Since I do not understand specification well, I have a possibility of being wrong. 
