### PR TITLE
Fix typo in Database/ConnectionManager

### DIFF
--- a/lib/Cake/Database/ConnectionManager.php
+++ b/lib/Cake/Database/ConnectionManager.php
@@ -79,11 +79,11 @@ class ConnectionManager {
  *
  * @param string $name The connection name.
  * @return Connection A connection object.
- * @throws Cake\Error\MissingDataSourceConfigException When config data is missing.
+ * @throws Cake\Error\MissingDatasourceConfigException When config data is missing.
  */
 	public static function get($name) {
 		if (empty(static::$_config[$name])) {
-			throw new Error\MissingDataSourceConfigException(['name' => $name]);
+			throw new Error\MissingDatasourceConfigException(['name' => $name]);
 		}
 		if (empty(static::$_registry)) {
 			static::$_registry = new ConnectionRegistry();


### PR DESCRIPTION
I don't speak much English.

[![Build Status](https://travis-ci.org/gold1/cakephp.png?branch=3.0-connection-manager-fix-typo)](https://travis-ci.org/gold1/cakephp/builds/10830884)
#### Problem

Fatal error: Class 'Cake\Error\MissingDataSourceConfigException' not found in /lib/Cake/Database/ConnectionManager.php on line 86
#### Solution

https://github.com/cakephp/cakephp/blob/3.0/lib/Cake/Error/MissingDatasourceConfigException.php
'Datasource' is right.
Rename "DataSource" to "Datasource".
#### Comment

Since I do not understand specification well, I have a possibility of being wrong.
