### PR TITLE
3.0 find first

### DIFF
--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -558,7 +558,7 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Returns the first result out of executed this query, if the query has not been
+ * Returns the first result out of executing this query, if the query has not been
  * executed before, it will set the limit clause to 1 for performance reasons.
  *
  * ###Example:
@@ -573,7 +573,7 @@ class Query extends DatabaseQuery {
 		}
 		$this->bufferResults();
 		$this->_results = $this->execute();
-		// Calls foreach so we cursor is rewinded automatically
+		// Calls foreach so we cursor is rewound automatically
 		foreach ($this->_results as $row) {
 			// Just get the first result from the iterator
 			return $row;

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -390,7 +390,7 @@ class Query extends DatabaseQuery {
 			return $this->_results;
 		}
 		if ($this->_useBufferedResults) {
-			return $this->_applyFormatters(
+			return $this->_results = $this->_applyFormatters(
 				new BufferedResultSet($this, $this->executeStatement())
 			);
 		}
@@ -398,7 +398,7 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Compiles the SQL representation of this query ane executes it using
+ * Compiles the SQL representation of this query and executes it using
  * the provided connection object.
  *
  * @return Cake\Database\StatementInterface

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -558,6 +558,29 @@ class Query extends DatabaseQuery {
 	}
 
 /**
+ * Returns the first result out of executed this query, if the query has not been
+ * executed before, it will set the limit clause to 1 for performance reasons.
+ *
+ * ###Example:
+ *
+ * ``$singleUser = $query->select(['id', 'username'])->first()``
+ *
+ * @return mixed the first result from the ResultSet
+ */
+	public function first() {
+		if ($this->_dirty) {
+			$this->limit(1);
+		}
+		$this->bufferResults();
+		$this->_results = $this->execute();
+		// Calls foreach so we cursor is rewinded automatically
+		foreach ($this->_results as $row) {
+			// Just get the first result from the iterator
+			return $row;
+		}
+	}
+
+/**
  * Decorates the ResultSet iterator with MapReduce routines
  *
  * @param $results Cake\ORM\ResultCollectionTrait original results

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1023,4 +1023,53 @@ class QueryTest extends TestCase {
 		$this->assertEquals([2, 3], iterator_to_array($query->execute()));
 	}
 
+/**
+ * Tests first() method when the query has not been executed before
+ *
+ * @return void
+ */
+	public function testFirstDirtyQuery() {
+		$this->_createTables();
+		$table = Table::build('article', ['table' => 'articles']);
+		$query = new Query($this->connection, $table);
+		$result = $query->select(['id'])->first();
+		$this->assertEquals(['id' => 1], $result);
+		$this->assertEquals(1, $query->clause('limit'));
+		$result = $query->select(['id'])->first();
+		$this->assertEquals(['id' => 1], $result);
+	}
+
+/**
+ * Tests that first can be called again on an already executed query
+ *
+ * @return void
+ */
+	public function testFirstCleanQuery() {
+		$this->_createTables();
+		$table = Table::build('article', ['table' => 'articles']);
+		$query = new Query($this->connection, $table);
+		$query->select(['id'])->toArray();
+
+		$first = $query->first();
+		$this->assertEquals(['id' => 1], $first);
+		$this->assertNull($query->clause('limit'));
+	}
+
+/**
+ * Tests that first() will not execute the same query twice
+ *
+ * @return void
+ */
+	public function testFirstSameResult() {
+		$this->_createTables();
+		$table = Table::build('article', ['table' => 'articles']);
+		$query = new Query($this->connection, $table);
+		$query->select(['id'])->toArray();
+
+		$first = $query->first();
+		$resultSet = $query->execute();
+		$this->assertEquals(['id' => 1], $first);
+		$this->assertSame($resultSet, $query->execute());
+	}
+
 }


### PR DESCRIPTION
An implementation of find('first'). It is not built into the Table class because finders should always return a Query and not a result. This also allows to chain any finder and then call first to get the top result.
