### PR TITLE
Bugfix: Add scope for generateTreeList

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -375,6 +375,12 @@ class TreeBehavior extends ModelBehavior {
 		} else {
 			array_unshift($valuePath, '%s' . $valuePath[0], '{n}.tree_prefix');
 		}
+
+		$conditions = (array)$conditions;
+		if ($scope) {
+			$conditions[] = $scope;
+		}
+
 		$order = $Model->escapeField($left) . " asc";
 		$results = $Model->find('all', compact('conditions', 'fields', 'order', 'recursive'));
 		$stack = array();

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -340,4 +340,44 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		));
 		$this->assertEquals($expected, $result);
 	}
+
+/**
+ * testGenerateTreeListWithScope method
+ *
+ * @return void
+ */
+	public function testGenerateTreeListWithScope() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(2, 3);
+
+		$this->Tree->id = 1;
+		$this->Tree->saveField('flag', 1);
+		$this->Tree->id = 2;
+		$this->Tree->saveField('flag', 1);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
+
+		$result = $this->Tree->generateTreeList();
+		$expected = array(
+			1 => '1. Root',
+			2 => '_1.1'
+		);
+		$this->assertEquals($expected, $result);
+
+		// As string.
+		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
+
+		$result = $this->Tree->generateTreeList();
+		$this->assertEquals($expected, $result);
+
+		// Merging conditions.
+		$result = $this->Tree->generateTreeList(array('FlagTree.id >' => 1));
+		$expected = array(
+			2 => '1.1'
+		);
+		$this->assertEquals($expected, $result);
+	}
+
 }


### PR DESCRIPTION
Add missing scope to TreeBehavior's generateTreeList().
Resolves https://cakephp.lighthouseapp.com/projects/42648/tickets/4028-generatetreelist-scope-errors-cakephp-24-rc1rc2
