### PR TITLE
3.0 move before find

### DIFF
--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -16,10 +16,10 @@
  */
 namespace Cake\ORM;
 
-use Cake\Event\Event;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Database\Statement\CallbackStatement;
+use Cake\Event\Event;
 
 /**
  * Extends the base Query class to provide new methods related to association
@@ -543,7 +543,7 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Returns an array with the custom options that where applied to this query
+ * Returns an array with the custom options that were applied to this query
  * and that were not already processed by another method in this class.
  *
  * ###Example:

--- a/lib/Cake/ORM/Query.php
+++ b/lib/Cake/ORM/Query.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\ORM;
 
+use Cake\Event\Event;
 use Cake\Database\Query as DatabaseQuery;
 use Cake\Database\Statement\BufferedStatement;
 use Cake\Database\Statement\CallbackStatement;
@@ -107,6 +108,14 @@ class Query extends DatabaseQuery {
  * @var array
  */
 	protected $_mapReduce = [];
+
+/**
+ * Holds any custom options passed using applyOptions that could not be processed
+ * by any method in this class.
+ *
+ * @var array
+ */
+	protected $_options = [];
 
 /**
  * @param Cake\Database\Connection $connection
@@ -386,6 +395,9 @@ class Query extends DatabaseQuery {
  * @return Cake\ORM\ResultCollectionTrait
  */
 	public function execute() {
+		$table = $this->repository();
+		$event = new Event('Model.beforeFind', $table, [$this, $this->_options]);
+		$table->getEventManager()->dispatch($event);
 		if (isset($this->_results)) {
 			return $this->_results;
 		}
@@ -522,10 +534,31 @@ class Query extends DatabaseQuery {
 		foreach ($options as $option => $values) {
 			if (isset($valid[$option])) {
 				$this->{$valid[$option]}($values);
+			} else {
+				$this->_options[$option] = $values;
 			}
 		}
 
 		return $this;
+	}
+
+/**
+ * Returns an array with the custom options that where applied to this query
+ * and that were not already processed by another method in this class.
+ *
+ * ###Example:
+ *
+ * {{{
+ *	$query->applyOptions(['doABarrelRoll' => true, 'fields' => ['id', 'name']);
+ *	$query->getOptions(); // Returns ['doABarrelRoll' => true]
+ * }}}
+ *
+ * @see \Cake\ORM\Query::applyOptions() to read about the options that will
+ * be processed by this class and not returned by this function
+ * @return array
+ */
+	public function getOptions() {
+		return $this->_options;
 	}
 
 /**

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -16,9 +16,8 @@
  */
 namespace Cake\ORM;
 
-use Cake\Database\Schema\Table as Schema;
-use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\Database\Schema\Table as Schema;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
@@ -492,9 +491,7 @@ class Table {
  * ### Model.beforeFind event
  *
  * Each find() will trigger a `Model.beforeFind` event for all attached
- * listeners. Any listener can stop the event to prevent the default
- * find handler from being called. When a find() is stopped the Query
- * object will still be returned.
+ * listeners. Any listener can set a valid result set using $query
  *
  * @param string $type the type of query to perform
  * @param array $options
@@ -503,12 +500,6 @@ class Table {
 	public function find($type, $options = []) {
 		$query = $this->_buildQuery();
 		$query->select()->applyOptions($options);
-
-		$event = new Event('Model.beforeFind', $this, [$query, $options]);
-		$this->_eventManager->dispatch($event);
-		if ($event->isStopped()) {
-			return $query;
-		}
 		return $this->{'find' . ucfirst($type)}($query, $options);
 	}
 

--- a/lib/Cake/ORM/Table.php
+++ b/lib/Cake/ORM/Table.php
@@ -16,8 +16,8 @@
  */
 namespace Cake\ORM;
 
-use Cake\Event\EventManager;
 use Cake\Database\Schema\Table as Schema;
+use Cake\Event\EventManager;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;

--- a/lib/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/lib/Cake/Test/TestCase/ORM/QueryTest.php
@@ -904,6 +904,23 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests getOptions() method
+ *
+ * @return void
+ */
+	public function testGetOptions() {
+		$options = ['doABarrelRoll' => true, 'fields' => ['id', 'name']];
+		$query = new Query($this->connection, $this->table);
+		$query->applyOptions($options);
+		$expected = ['doABarrelRoll' => true];
+		$this->assertEquals($expected, $query->getOptions());
+
+		$expected = ['doABarrelRoll' => false, 'doAwesome' => true];
+		$query->applyOptions($expected);
+		$this->assertEquals($expected, $query->getOptions());
+	}
+
+/**
  * Tests registering mappers with mapReduce()
  *
  * @return void


### PR DESCRIPTION
Moving beforeFind to the Query class

This allows listeners to have as much information as possible before before acting. This also allows to carerctly stack finders without firing beforeFind callback per each finder that is stacked
