### PR TITLE
Fixes virtualField support for Model::escapeField().

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3200,6 +3200,9 @@ class Model extends Object implements CakeEventListener {
 		if (strpos($field, $db->name($alias) . '.') === 0) {
 			return $field;
 		}
+		if ($this->isVirtualField($field)) {
+			return $db->name($this->getVirtualField($field));
+		}
 		return $db->name($alias . '.' . $field);
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2298,6 +2298,12 @@ class ModelIntegrationTest extends BaseModelTest {
 		$expected = $db->name('Domain.DomainHandle');
 		$this->assertEquals($expected, $result);
 
+		$TestModel->virtualFields['my_field'] = 'Test.test_field';
+		$result = $TestModel->escapeField('my_field');
+		$expected = $db->name('Test.test_field');
+		$this->assertEquals($expected, $result);
+		unset($TestModel->virtualFields['my_field']);
+
 		ConnectionManager::create('mock', array('datasource' => 'DboMock'));
 		$TestModel->setDataSource('mock');
 		$db = $TestModel->getDataSource();


### PR DESCRIPTION
Adds a test for #1270 and fixes it. The fix provided there didn't escape the field. It just translated the virtualField. Also the changes to DboSource there weren't needed.

Or am I missing something? :confused:
