### PR TITLE
Use readline in console when supported

### DIFF
--- a/lib/Cake/Console/ConsoleInput.php
+++ b/lib/Cake/Console/ConsoleInput.php
@@ -41,7 +41,7 @@ class ConsoleInput {
  *
  * @var bool
  */
-	private $__canReadline;
+	protected $_canReadline;
 
 /**
  * Constructor
@@ -49,7 +49,7 @@ class ConsoleInput {
  * @param string $handle The location of the stream to use as input.
  */
 	public function __construct($handle = 'php://stdin') {
-		$this->__canReadline = extension_loaded('readline') && $handle == 'php://stdin' ? true : false;
+		$this->_canReadline = extension_loaded('readline') && $handle == 'php://stdin' ? true : false;
 		$this->_input = fopen($handle, 'r');
 	}
 
@@ -59,7 +59,7 @@ class ConsoleInput {
  * @return mixed The value of the stream
  */
 	public function read() {
-		if ($this->__canReadline) {
+		if ($this->_canReadline) {
 			$line = readline('');
 			if (!empty($line)) {
 				readline_add_history($line);

--- a/lib/Cake/Console/ConsoleInput.php
+++ b/lib/Cake/Console/ConsoleInput.php
@@ -31,6 +31,16 @@ class ConsoleInput {
  * @var resource
  */
 	protected $_input;
+/**
+ * Can this instance use readline?
+ * Two conditions must be met:
+ * 1. Readline support must be enabled.
+ * 2. Handle we are attached to must be stdin.
+ * Allows rich editing with arrow keys and history when inputting a string.
+ *
+ * @var bool
+ */
+	private $_can_readline;
 
 /**
  * Constructor
@@ -38,6 +48,7 @@ class ConsoleInput {
  * @param string $handle The location of the stream to use as input.
  */
 	public function __construct($handle = 'php://stdin') {
+		$this->_can_readline = extension_loaded('readline') && $handle == 'php://stdin' ? true : false;
 		$this->_input = fopen($handle, 'r');
 	}
 
@@ -47,6 +58,13 @@ class ConsoleInput {
  * @return mixed The value of the stream
  */
 	public function read() {
+		if ($this->_can_readline) {
+			$line = readline('');
+			if (!empty($line)) {
+				readline_add_history($line);
+			}
+			return $line;
+		}
 		return fgets($this->_input);
 	}
 

--- a/lib/Cake/Console/ConsoleInput.php
+++ b/lib/Cake/Console/ConsoleInput.php
@@ -31,6 +31,7 @@ class ConsoleInput {
  * @var resource
  */
 	protected $_input;
+
 /**
  * Can this instance use readline?
  * Two conditions must be met:
@@ -40,7 +41,7 @@ class ConsoleInput {
  *
  * @var bool
  */
-	private $_can_readline;
+	private $__canReadline;
 
 /**
  * Constructor
@@ -48,7 +49,7 @@ class ConsoleInput {
  * @param string $handle The location of the stream to use as input.
  */
 	public function __construct($handle = 'php://stdin') {
-		$this->_can_readline = extension_loaded('readline') && $handle == 'php://stdin' ? true : false;
+		$this->__canReadline = extension_loaded('readline') && $handle == 'php://stdin' ? true : false;
 		$this->_input = fopen($handle, 'r');
 	}
 
@@ -58,7 +59,7 @@ class ConsoleInput {
  * @return mixed The value of the stream
  */
 	public function read() {
-		if ($this->_can_readline) {
+		if ($this->__canReadline) {
 			$line = readline('');
 			if (!empty($line)) {
 				readline_add_history($line);


### PR DESCRIPTION
$this->stdin->read(); will use readline if the system is detected to
support it.  In linux, you will be able to use the left and right arrow
keys to edit the current line, use the up and down keys to navigate
history, press ^U to delete the entire line, etc.

Before this, using arrow keys in linux will just spam characters like
^[[C^[[A^[[D^[[C^[[A^.  Useful for "Console/cake console"
