### PR TITLE
Potential Fix for LightHouse Ticket #3936

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1520,11 +1520,7 @@ class FormHelper extends AppHelper {
 			);
 
 			if ($label) {
-				if (is_array($label)) {
-					$optTitle = $this->label($tagName, $optTitle, $label);
-				} else {
-					$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
-				}
+				$optTitle = $this->label($tagName, $optTitle, is_array($label) ? $label : null);
 			}
 			
 			if (is_array($between)) {

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1520,8 +1520,13 @@ class FormHelper extends AppHelper {
 			);
 
 			if ($label) {
-				$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
+				if(is_array($label)) {
+					$optTitle = $this->label($tagName, $optTitle, $label);
+				}else{
+					$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
+				}
 			}
+			
 			if (is_array($between)) {
 				$optTitle .= array_shift($between);
 			}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1520,9 +1520,9 @@ class FormHelper extends AppHelper {
 			);
 
 			if ($label) {
-				if(is_array($label)) {
+				if (is_array($label)) {
 					$optTitle = $this->label($tagName, $optTitle, $label);
-				}else{
+				} else {
 					$optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
 				}
 			}


### PR DESCRIPTION
I believe I found a fix for this issue. I am here at #CakeFest2013 and during the #HourOfContribution I ran across this issue.

https://cakephp.lighthouseapp.com/projects/42648/tickets/3936

Currently in CakePHP 2.4 on Line 1522 - 1524 you can see the following code:

``` php
if ($label) {
    $optTitle = $this->Html->useTag('label', $tagName, '', $optTitle);
}
```

The $label variable here the is the $label array passed into the input method in Sethathi example above. The problem is that the $label array is completely ignored and instead a label is created using the HtmlHelper->useTag method.

I have what I believe is a fix for this issue but it hasn't been extensively tested. I tested against Sethathi example in the ticket and it produced the correct result.

The fix is simple. We detect if an array is passed in and then send it to the FormHelper label method instead of the HtmlHelper useTag method. The FormHelper label methods accepts an options array, so we pass in the $label array.

This will probably need to be fixed for checkbox also

"ask":https://cakephp.lighthouseapp.com/users/235987 helped me with this fix
