### PR TITLE
Updated CDATA wrappers in script blocks when a non-xhtml doctype has been set.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1244,7 +1244,7 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Html->doctype('html5');
+		$this->Html->docType('html5');
 		$result = $this->Html->scriptBlock('window.foo = 2;');
 		$expected = array(
 			'script' => array('type' => 'text/javascript'),
@@ -1253,7 +1253,7 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Html->doctype('xhtml-strict');
+		$this->Html->docType('xhtml-strict');
 		$result = $this->Html->scriptBlock('window.foo = 2;');
 		$expected = array(
 			'script' => array('type' => 'text/javascript'),
@@ -1320,7 +1320,7 @@ class HtmlHelperTest extends CakeTestCase {
 		$result = $this->Html->scriptEnd();
 		$this->assertNull($result);
 
-		$this->Html->doctype('html4-strict');
+		$this->Html->docType('html4-strict');
 		$result = $this->Html->scriptStart();
 		$this->assertNull($result);
 		echo 'this is some javascript';
@@ -1333,7 +1333,7 @@ class HtmlHelperTest extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Html->doctype('xhtml-trans');
+		$this->Html->docType('xhtml-trans');
 		$result = $this->Html->scriptStart();
 		$this->assertNull($result);
 		echo 'this is some javascript';

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1243,6 +1243,26 @@ class HtmlHelperTest extends CakeTestCase {
 			'/script',
 		);
 		$this->assertTags($result, $expected);
+
+		$this->Html->doctype('html5');
+		$result = $this->Html->scriptBlock('window.foo = 2;');
+		$expected = array(
+			'script' => array('type' => 'text/javascript'),
+			'window.foo = 2;',
+			'/script',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Html->doctype('xhtml-strict');
+		$result = $this->Html->scriptBlock('window.foo = 2;');
+		$expected = array(
+			'script' => array('type' => 'text/javascript'),
+			$this->cDataStart,
+			'window.foo = 2;',
+			$this->cDataEnd,
+			'/script',
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**
@@ -1299,6 +1319,34 @@ class HtmlHelperTest extends CakeTestCase {
 
 		$result = $this->Html->scriptEnd();
 		$this->assertNull($result);
+
+		$this->Html->doctype('html4-strict');
+		$result = $this->Html->scriptStart();
+		$this->assertNull($result);
+		echo 'this is some javascript';
+
+		$result = $this->Html->scriptEnd();
+		$expected = array(
+			'script' => array('type' => 'text/javascript'),
+			'this is some javascript',
+			'/script'
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Html->doctype('xhtml-trans');
+		$result = $this->Html->scriptStart();
+		$this->assertNull($result);
+		echo 'this is some javascript';
+
+		$result = $this->Html->scriptEnd();
+		$expected = array(
+			'script' => array('type' => 'text/javascript'),
+			$this->cDataStart,
+			'this is some javascript',
+			$this->cDataEnd,
+			'/script'
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -119,6 +119,13 @@ class HtmlHelper extends AppHelper {
 	protected $_includedScripts = array();
 
 /**
+ * Default `safe` option for script blocks.
+ *
+ * @var boolean
+ */
+	protected $_cdataDefault = true;
+
+/**
  * Options for the currently opened script block buffer if any.
  *
  * @var array
@@ -202,6 +209,7 @@ class HtmlHelper extends AppHelper {
  */
 	public function docType($type = 'html5') {
 		if (isset($this->_docTypes[$type])) {
+			$this->_cdataDefault = strpos($type, 'xhtml') !== false;
 			return $this->_docTypes[$type];
 		}
 		return null;
@@ -578,7 +586,7 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::scriptBlock
  */
 	public function scriptBlock($script, $options = array()) {
-		$options += array('type' => 'text/javascript', 'safe' => true, 'inline' => true);
+		$options += array('type' => 'text/javascript', 'safe' => $this->_cdataDefault, 'inline' => true);
 		if ($options['safe']) {
 			$script = "\n" . '//<![CDATA[' . "\n" . $script . "\n" . '//]]>' . "\n";
 		}
@@ -611,7 +619,7 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::scriptStart
  */
 	public function scriptStart($options = array()) {
-		$options += array('safe' => true, 'inline' => true);
+		$options += array('safe' => $this->_cdataDefault, 'inline' => true);
 		$this->_scriptBlockOptions = $options;
 		ob_start();
 		return null;


### PR DESCRIPTION
CDATA wrappers in script blocks are only useful for CDATA in XHTML doctypes.  In non-XHTML doctypes, they are just noise.

With this change, if the HtmlHelper::docType method was called with a non-XHTML doctype, the CDATA wrapper will not be set by default (can still be turned on with the `safe` option set to true)
