### PR TITLE
Load helpers of email view

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1611,6 +1611,7 @@ class CakeEmail {
 		$View = new $viewClass(null);
 		$View->viewVars = $this->_viewVars;
 		$View->helpers = $this->_helpers;
+		$View->loadHelpers();
 
 		list($templatePlugin, $template) = pluginSplit($this->_template);
 		list($layoutPlugin, $layout) = pluginSplit($this->_layout);


### PR DESCRIPTION
Since View now loads its helpers only once we'll have to call View::loadHelpers() after setting it up in CakeEmail's rendering process.
