### PR TITLE
Update FormHelper.php : $this->Form->inputDefaults(array('error'=>array('class'=>'custom-class'))); was not working

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -996,7 +996,7 @@ class FormHelper extends AppHelper {
 
 		$out['error'] = null;
 		if ($type !== 'hidden' && $error !== false) {
-			$errMsg = $this->error($fieldName, $error);
+			$errMsg = $this->error($fieldName,null, $error);
 			if ($errMsg) {
 				$divOptions = $this->addClass($divOptions, 'error');
 				if ($errorMessage) {


### PR DESCRIPTION
Call to FormHelper::error does not comply with API specification http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::error
