### PR TITLE
correct use statements

### DIFF
--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -17,7 +17,7 @@ namespace Cake\Console\Command;
 use Cake\Cache\Cache;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Schema;
 use Cake\Utility\File;
 use Cake\Utility\Folder;

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -20,7 +20,7 @@ namespace Cake\Console\Command\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\App;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -10,7 +10,7 @@
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Error;
 use Cake\Utility\Debugger;
 use Cake\Utility\Validation;

--- a/lib/Cake/Controller/Scaffold.php
+++ b/lib/Cake/Controller/Scaffold.php
@@ -23,7 +23,7 @@ namespace Cake\Controller;
 
 use Cake\Core\Configure;
 use Cake\Error;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Network\Request;
 use Cake\Utility\Inflector;
 

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -18,7 +18,7 @@ namespace Cake\Model\Behavior;
 use Cake\Core\Configure;
 use Cake\Error;
 use Cake\I18n\I18n;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Model\ModelBehavior;
 use Cake\Utility\ClassRegistry;

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -21,7 +21,7 @@
  */
 namespace Cake\Model\Behavior;
 
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Model\ModelBehavior;
 use Cake\Utility\Hash;

--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -21,7 +21,7 @@ namespace Cake\Model\Datasource;
 
 use Cake\Cache\Cache;
 use Cake\Core\Object;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 
 /**

--- a/lib/Cake/Test/TestApp/View/Pages/home.ctp
+++ b/lib/Cake/Test/TestApp/View/Pages/home.ctp
@@ -2,7 +2,7 @@
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Error;
 use Cake\Utility\Debugger;
 use Cake\Utility\Validation;

--- a/lib/Cake/Test/TestApp/View/Posts/test_nocache_tags.ctp
+++ b/lib/Cake/Test/TestApp/View/Posts/test_nocache_tags.ctp
@@ -1,5 +1,5 @@
 <?php
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Core\Configure;
 ?>
 <p>

--- a/lib/Cake/Test/TestCase/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/SchemaShellTest.php
@@ -23,7 +23,7 @@ use Cake\Console\Command\SchemaShell;
 use Cake\Core\App;
 use Cake\Core\Object;
 use Cake\Core\Plugin;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\File;
 use Cake\Utility\Inflector;

--- a/lib/Cake/Test/TestCase/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/TestCase/Console/Command/Task/FixtureTaskTest.php
@@ -17,7 +17,7 @@ namespace Cake\Test\TestCase\Console\Command\Task;
 use Cake\Console\Command\Task\FixtureTask;
 use Cake\Console\Command\Task\TemplateTask;
 use Cake\Core\Plugin;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\ClassRegistry;
 

--- a/lib/Cake/Test/TestCase/Model/Datasource/DataSourceTest.php
+++ b/lib/Cake/Test/TestCase/Model/Datasource/DataSourceTest.php
@@ -18,7 +18,7 @@
  */
 namespace Cake\Test\TestCase\Model\Datasource;
 
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Datasource\DataSource;
 use Cake\Model\Model;
 use Cake\TestSuite\TestCase;

--- a/lib/Cake/Test/TestCase/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/TestCase/Model/ModelIntegrationTest.php
@@ -19,7 +19,7 @@
  */
 namespace Cake\Test\TestCase\Model;
 
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Model\ModelBehavior;
 use Cake\TestSuite\TestCase;

--- a/lib/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
+++ b/lib/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
@@ -15,7 +15,7 @@
 namespace Cake\Test\TestCase\TestSuite;
 
 use Cake\Core\Configure;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\Model\Model;
 use Cake\TestSuite\Fixture\TestFixture;
 use Cake\TestSuite\TestCase;

--- a/lib/Cake/Test/TestCase/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/TestCase/Utility/ClassRegistryTest.php
@@ -15,7 +15,7 @@
 namespace Cake\Test\TestCase\Utility;
 
 use Cake\Core\Plugin;
-use Cake\Model\ConnectionManager;
+use Cake\Database\ConnectionManager;
 use Cake\TestSuite\Fixture\TestModel;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\ClassRegistry;


### PR DESCRIPTION
as far as I know

```
use Cake\Model\ConnectionManager
```

is now

```
use Cake\Database\ConnectionManager
```
