### PR TITLE
Fix log classname in skeleton

### DIFF
--- a/lib/Cake/Console/Templates/skel/Config/bootstrap.php
+++ b/lib/Cake/Console/Templates/skel/Config/bootstrap.php
@@ -89,12 +89,12 @@ Configure::write('Dispatcher.filters', array(
  */
 App::uses('CakeLog', 'Log');
 CakeLog::config('debug', array(
-	'engine' => 'File',
+	'engine' => 'FileLog',
 	'types' => array('notice', 'info', 'debug'),
 	'file' => 'debug',
 ));
 CakeLog::config('error', array(
-	'engine' => 'File',
+	'engine' => 'FileLog',
 	'types' => array('warning', 'error', 'critical', 'alert', 'emergency'),
 	'file' => 'error',
 ));


### PR DESCRIPTION
Fixes "logger class File does not implement a write method."
It probably tries to use the utility File class instead of the logger
