### PR TITLE
Update Model/Behaviors callback signature to be PHP5.4+ compliant.

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -320,9 +320,11 @@ class TranslateBehavior extends ModelBehavior {
  * beforeValidate Callback
  *
  * @param Model $Model Model invalidFields was called on.
+ * @param array $options Options passed from Model::save().
  * @return boolean
+ * @see Model::save()
  */
-	public function beforeValidate(Model $Model) {
+	public function beforeValidate(Model $Model, $options = array()) {
 		unset($this->runtime[$Model->alias]['beforeSave']);
 		$this->_setRuntimeData($Model);
 		return true;
@@ -335,7 +337,9 @@ class TranslateBehavior extends ModelBehavior {
  * disabled. Or the runtime data hasn't been set yet.
  *
  * @param Model $Model Model save was called on.
+ * @param array $options Options passed from Model::save().
  * @return boolean true.
+ * @see Model::save()
  */
 	public function beforeSave(Model $Model, $options = array()) {
 		if (isset($options['validate']) && !$options['validate']) {

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -175,9 +175,11 @@ class TreeBehavior extends ModelBehavior {
  *
  * @since         1.2
  * @param Model $Model Model instance
+ * @param array $options Options passed from Model::save().
  * @return boolean true to continue, false to abort the save
+ * @see Model::save()
  */
-	public function beforeSave(Model $Model) {
+	public function beforeSave(Model $Model, $options = array()) {
 		extract($this->settings[$Model->alias]);
 
 		$this->_addToWhitelist($Model, array($left, $right));

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3460,9 +3460,10 @@ class Model extends Object implements CakeEventListener {
  * Called during validation operations, before validation. Please note that custom
  * validation rules can be defined in $validate.
  *
- * @param array $options Options passed from model::save(), see $options of model::save().
+ * @param array $options Options passed from Model::save().
  * @return boolean True if validate operation should continue, false to abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforevalidate
+ * @see Model::save()
  */
 	public function beforeValidate($options = array()) {
 		return true;

--- a/lib/Cake/Model/ModelBehavior.php
+++ b/lib/Cake/Model/ModelBehavior.php
@@ -141,9 +141,11 @@ class ModelBehavior extends Object {
  * will allow you to make the validation fail.
  *
  * @param Model $model Model using this behavior
+ * @param array $options Options passed from Model::save().
  * @return mixed False or null will abort the operation. Any other result will continue.
+ * @see Model::save()
  */
-	public function beforeValidate(Model $model) {
+	public function beforeValidate(Model $model, $options = array()) {
 		return true;
 	}
 
@@ -163,9 +165,11 @@ class ModelBehavior extends Object {
  * will abort the save operation.
  *
  * @param Model $model Model using this behavior
+ * @param array $options Options passed from Model::save().
  * @return mixed False if the operation should abort. Any other result will continue.
+ * @see Model::save()
  */
-	public function beforeSave(Model $model) {
+	public function beforeSave(Model $model, $options = array()) {
 		return true;
 	}
 

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -104,10 +104,12 @@ class TestBehavior extends ModelBehavior {
 /**
  * beforeSave method
  *
- * @param Model $model
- * @return void
+ * @param Model $model Model using this behavior
+ * @param array $options Options passed from Model::save().
+ * @return mixed False if the operation should abort. Any other result will continue.
+ * @see Model::save()
  */
-	public function beforeSave(Model $model) {
+	public function beforeSave(Model $model, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['beforeSave']) || $settings['beforeSave'] === 'off') {
 			return parent::beforeSave($model);
@@ -155,12 +157,14 @@ class TestBehavior extends ModelBehavior {
 	}
 
 /**
- * beforeValidate method
+ * beforeValidate Callback
  *
- * @param Model $model
- * @return void
+ * @param Model $Model Model invalidFields was called on.
+ * @param array $options Options passed from Model::save().
+ * @return boolean
+ * @see Model::save()
  */
-	public function beforeValidate(Model $model) {
+	public function beforeValidate(Model $model, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['validate']) || $settings['validate'] === 'off') {
 			return parent::beforeValidate($model);

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -2039,7 +2039,9 @@ class CallbackPostTestModel extends CakeTestModel {
 /**
  * beforeValidate callback
  *
- * @return boolean
+ * @param array $options Options passed from Model::save().
+ * @return boolean True if validate operation should continue, false to abort
+ * @see Model::save()
  */
 	public function beforeValidate($options = array()) {
 		return $this->beforeValidateReturn;
@@ -4980,7 +4982,9 @@ class CustomArticle extends AppModel {
 /**
  * Alters title data
  *
- * @return void
+ * @param array $options Options passed from Model::save().
+ * @return boolean True if validate operation should continue, false to abort
+ * @see Model::save()
  */
 	public function beforeValidate($options = array()) {
 		$this->data[$this->alias]['title'] = 'foo';


### PR DESCRIPTION
Since PHP 5.4, warnings are thrown when function signatures of inherited classes does not match their parents.
