### PR TITLE
JsonView should return null if no data is set, regardless of the type of '_serialize'.

### DIFF
--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -135,8 +135,11 @@ class JsonView extends View {
 				if (is_numeric($alias)) {
 					$alias = $key;
 				}
-				$data[$alias] = $this->viewVars[$key];
+				if (array_key_exists($key, $this->viewVars)) {
+					$data[$alias] = $this->viewVars[$key];
+				}
 			}
+			$data = !empty($data) ? $data : null;
 		} else {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 		}


### PR DESCRIPTION
It should also honor true/false/0/'' values.
Battery of tests added.

Right now when `'_serialize'` is an array, an empty array is created and JSON encoded later if no keys are added, resulting in an empty JSON encoded array.

Variables are read [only if set](https://github.com/cakephp/cakephp/pull/1613/files#L1R137).
