### PR TITLE
Teach LogError to accept arrays or objects + add $scope

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -615,8 +615,22 @@ class BasicsTest extends CakeTestCase {
 			CakeLog::disable('stderr');
 		}
 
+		$currencies = array(
+			array('code' => 'USD', 'name' => 'US Dollars'),
+			array('code' => 'IDR', 'title' => 'Indonesian Rupiah'),
+		);
+		$currenciesOutput = print_r($currencies, true);
+
+		$countries = json_decode(json_encode(array(
+			'Indonesia' => array('capital' => 'Jakarta'),
+			'Canada' => array('capital' => 'Toronto'),
+		)));
+		$countriesOutput = print_r($countries, true);
+
 		LogError('Testing LogError() basic function');
 		LogError("Testing with\nmulti-line\nstring");
+		LogError($currencies);
+		LogError($countries);
 
 		if (CakeLog::stream('stderr')) {
 			CakeLog::enable('stderr');
@@ -626,6 +640,8 @@ class BasicsTest extends CakeTestCase {
 		$this->assertRegExp('/Error: Testing LogError\(\) basic function/', $result);
 		$this->assertNotRegExp("/Error: Testing with\nmulti-line\nstring/", $result);
 		$this->assertRegExp('/Error: Testing with multi-line string/', $result);
+		$this->assertRegExp('/' . preg_quote($currenciesOutput) . '/', $result);
+		$this->assertRegExp('/' . preg_quote($countriesOutput) . '/', $result);
 	}
 
 /**

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -789,11 +789,16 @@ if (!function_exists('LogError')) {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#LogError
  */
-	function LogError($message) {
+	function LogError($message, $scope = array()) {
 		App::uses('CakeLog', 'Log');
 		$bad = array("\n", "\r", "\t");
 		$good = ' ';
-		CakeLog::write('error', str_replace($bad, $good, $message));
+		if (is_string($message)) {
+			$message = str_replace($bad, $good, $message);
+		} else {
+			$message = print_r($message, true);
+		}
+		CakeLog::write(LOG_ERR, $message, $scope);
 	}
 
 }


### PR DESCRIPTION
Tired of writing `CakeLog::error(print_r($someObject, true))`?

![url](https://f.cloud.github.com/assets/39490/1095101/dc15ebd6-16dc-11e3-81e3-191c1fb17486.jpeg)
