### PR TITLE
3.0 - Fix fatal error pages

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -664,34 +664,6 @@ class App {
 		if (static::$_objectCacheChange) {
 			Cache::write('object_map', static::$_objects, '_cake_core_');
 		}
-		static::_checkFatalError();
-	}
-
-/**
- * Check if a fatal error happened and trigger the configured handler if configured
- *
- * @return void
- */
-	protected static function _checkFatalError() {
-		$lastError = error_get_last();
-		if (!is_array($lastError)) {
-			return;
-		}
-
-		list(, $log) = ErrorHandler::mapErrorCode($lastError['type']);
-		if ($log !== LOG_ERR) {
-			return;
-		}
-
-		if (PHP_SAPI === 'cli') {
-			$errorHandler = Configure::read('Error.consoleHandler');
-		} else {
-			$errorHandler = Configure::read('Error.handler');
-		}
-		if (!is_callable($errorHandler)) {
-			return;
-		}
-		call_user_func($errorHandler, $lastError['type'], $lastError['message'], $lastError['file'], $lastError['line'], array());
 	}
 
 }

--- a/lib/Cake/Error/BaseErrorHandler.php
+++ b/lib/Cake/Error/BaseErrorHandler.php
@@ -64,6 +64,26 @@ abstract class BaseErrorHandler {
 		error_reporting($level);
 		set_error_handler([$this, 'handleError'], $level);
 		set_exception_handler([$this, 'handleException']);
+		register_shutdown_function(function () {
+			$error = error_get_last();
+			if (!is_array($error)) {
+				return;
+			}
+			$fatals = [
+				E_USER_ERROR,
+				E_ERROR,
+				E_PARSE,
+			];
+			if (!in_array($error['type'], $fatals, true)) {
+				return;
+			}
+			$this->handleFatalError(
+				$error['type'],
+				$error['message'],
+				$error['file'],
+				$error['line']
+			);
+		});
 	}
 
 /**


### PR DESCRIPTION
I totally broke fatal error handling with my recent changes to the error handlers. Since there are and can be no unit tests for this I missed it.

Fatal error handling used to reference configure values that no longer existed.

Move the fatal error handling in the error handling classes as it makes more sense there. Doing this also allows far more code re-use than before.
