### PR TITLE
Fixed handling null values in Sqlserver->value

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -571,7 +571,7 @@ class Sqlserver extends DboSource {
  * @return string Quoted and escaped data
  */
 	public function value($data, $column = null) {
-		if (is_array($data) || is_object($data)) {
+		if ($data === null || is_array($data) || is_object($data)) {
 			return parent::value($data, $column);
 		} elseif (in_array($data, array('{$__cakeID__$}', '{$__cakeForeignKey__$}'), true)) {
 			return $data;

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -311,6 +311,10 @@ class SqlserverTest extends CakeTestCase {
 		$expected = "''";
 		$result = $this->db->value('', 'binary');
 		$this->assertSame($expected, $result);
+		
+		$expected = 'NULL';
+		$result = $this->db->value(null, 'string');
+		$this->assertSame($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
The value function quoted a null value as N'' instead of NULL.
As a result is produced queries like [name] IS N'' instead of [name] IS NULL which resulted in an SQL error.
