### PR TITLE
Update Model/Behavior afterSave() callback signature to be PHP5.4+ compliant.

### DIFF
--- a/lib/Cake/Model/Behavior/AclBehavior.php
+++ b/lib/Cake/Model/Behavior/AclBehavior.php
@@ -97,9 +97,10 @@ class AclBehavior extends ModelBehavior {
  *
  * @param Model $model
  * @param boolean $created True if this is a new record
+ * @param array $options Options passed from Model::save().
  * @return void
  */
-	public function afterSave(Model $model, $created) {
+	public function afterSave(Model $model, $created, $options = array()) {
 		$types = $this->_typeMaps[$this->settings[$model->name]['type']];
 		if (!is_array($types)) {
 			$types = array($types);

--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -408,9 +408,10 @@ class TranslateBehavior extends ModelBehavior {
  *
  * @param Model $Model Model the callback is called on
  * @param boolean $created Whether or not the save created a record.
+ * @param array $options Options passed from Model::save().
  * @return void
  */
-	public function afterSave(Model $Model, $created) {
+	public function afterSave(Model $Model, $created, $options = array()) {
 		if (!isset($this->runtime[$Model->alias]['beforeValidate']) && !isset($this->runtime[$Model->alias]['beforeSave'])) {
 			return true;
 		}

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -88,9 +88,10 @@ class TreeBehavior extends ModelBehavior {
  *
  * @param Model $Model Model instance.
  * @param boolean $created indicates whether the node just saved was created or updated
+ * @param array $options Options passed from Model::save().
  * @return boolean true on success, false on failure
  */
-	public function afterSave(Model $Model, $created) {
+	public function afterSave(Model $Model, $created, $options = array()) {
 		extract($this->settings[$Model->alias]);
 		if ($created) {
 			if ((isset($Model->data[$Model->alias][$parent])) && $Model->data[$Model->alias][$parent]) {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3418,9 +3418,10 @@ class Model extends Object implements CakeEventListener {
  * Called before each save operation, after validation. Return a non-true result
  * to halt the save.
  *
- * @param array $options
+ * @param array $options Options passed from Model::save().
  * @return boolean True if the operation should continue, false if it should abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforesave
+ * @see Model::save()
  */
 	public function beforeSave($options = array()) {
 		return true;
@@ -3430,10 +3431,12 @@ class Model extends Object implements CakeEventListener {
  * Called after each successful save operation.
  *
  * @param boolean $created True if this save created a new record
+ * @param array $options Options passed from Model::save().
  * @return void
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#aftersave
+ * @see Model::save()
  */
-	public function afterSave($created) {
+	public function afterSave($created, $options = array()) {
 	}
 
 /**

--- a/lib/Cake/Model/ModelBehavior.php
+++ b/lib/Cake/Model/ModelBehavior.php
@@ -178,9 +178,11 @@ class ModelBehavior extends Object {
  *
  * @param Model $model Model using this behavior
  * @param boolean $created True if this save created a new record
+ * @param array $options Options passed from Model::save().
  * @return boolean
+ * @see Model::save()
  */
-	public function afterSave(Model $model, $created) {
+	public function afterSave(Model $model, $created, $options = array()) {
 		return true;
 	}
 

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -130,9 +130,10 @@ class TestBehavior extends ModelBehavior {
  *
  * @param Model $model
  * @param boolean $created
+ * @param array $options Options passed from Model::save().
  * @return void
  */
-	public function afterSave(Model $model, $created) {
+	public function afterSave(Model $model, $created, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['afterSave']) || $settings['afterSave'] === 'off') {
 			return parent::afterSave($model, $created);

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1336,5 +1336,5 @@ class DboSourceTest extends CakeTestCase {
 
 		$result = $db->insertMulti('articles', array_keys($data[0]), $data);
 		$this->assertTrue($result, 'Data was saved');
-    }
+	}
 }

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -2731,7 +2731,7 @@ class AfterTree extends NumberTree {
  */
 	public $actsAs = array('Tree');
 
-	public function afterSave($created) {
+	public function afterSave($created, $options = array()) {
 		if ($created && isset($this->data['AfterTree'])) {
 			$this->data['AfterTree']['name'] = 'Six and One Half Changed in AfterTree::afterSave() but not in database';
 		}
@@ -3473,7 +3473,7 @@ class TransactionTestModel extends CakeTestModel {
 
 	public $useTable = 'samples';
 
-	public function afterSave($created) {
+	public function afterSave($created, $options = array()) {
 		$data = array(
 			array('apple_id' => 1, 'name' => 'sample6'),
 		);
@@ -3488,7 +3488,7 @@ class TransactionManyTestModel extends CakeTestModel {
 
 	public $useTable = 'samples';
 
-	public function afterSave($created) {
+	public function afterSave($created, $options = array()) {
 		$data = array(
 			array('apple_id' => 1, 'name' => 'sample6'),
 		);


### PR DESCRIPTION
Completely forgot `$option` inside `afterSave()` callbacks.

This completes https://github.com/cakephp/cakephp/pull/1610
