### PR TITLE
add missing params for parent call

### DIFF
--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -112,7 +112,7 @@ class TestBehavior extends ModelBehavior {
 	public function beforeSave(Model $model, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['beforeSave']) || $settings['beforeSave'] === 'off') {
-			return parent::beforeSave($model);
+			return parent::beforeSave($model, $options);
 		}
 		switch ($settings['beforeSave']) {
 			case 'on':
@@ -136,7 +136,7 @@ class TestBehavior extends ModelBehavior {
 	public function afterSave(Model $model, $created, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['afterSave']) || $settings['afterSave'] === 'off') {
-			return parent::afterSave($model, $created);
+			return parent::afterSave($model, $created, $options);
 		}
 		$string = 'modified after';
 		if ($created) {
@@ -168,7 +168,7 @@ class TestBehavior extends ModelBehavior {
 	public function beforeValidate(Model $model, $options = array()) {
 		$settings = $this->settings[$model->alias];
 		if (!isset($settings['validate']) || $settings['validate'] === 'off') {
-			return parent::beforeValidate($model);
+			return parent::beforeValidate($model, $options);
 		}
 		switch ($settings['validate']) {
 			case 'on':


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/1623 , https://github.com/cakephp/cakephp/pull/1622, and https://github.com/cakephp/cakephp/pull/1610

According to my updated Upgrade shell command estrict these should be the last remaining occurrences.
