### PR TITLE
flushMethodCache not working if called before cacheMethod

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -771,7 +771,7 @@ class DboSource extends DataSource {
 		if ($this->cacheMethods === false) {
 			return $value;
 		}
-		if (empty(self::$methodCache)) {
+		if (!$this->_methodCacheChange && empty(self::$methodCache)) {
 			self::$methodCache = Cache::read('method_cache', '_cake_core_');
 		}
 		if ($value === null) {

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -684,6 +684,22 @@ class DboSourceTest extends CakeTestCase {
 	}
 
 /**
+ * Test that flushMethodCache works as expected
+ * 
+ * @return void
+ */
+	public function testFlushMethodCache() {
+		$this->testDb->cacheMethods = true;
+		$this->testDb->cacheMethod('name','some-key','stuff');
+
+		Cache::write('method_cache', DboTestSource::$methodCache, '_cake_core_');
+
+		$this->testDb->flushMethodCache();
+		$result = $this->testDb->cacheMethod('name','some-key');
+		$this->assertNull($result);
+	}
+
+/**
  * testLog method
  *
  * @outputBuffering enabled


### PR DESCRIPTION
When calling flushMethodCache it correctly empties self::$methodCache but if cacheMethod is called afterwards self::$methodCache gets populated with data from the Cache.
