### PR TITLE
Corrected a CakeLog example in a DocBlock about scopes and types

### DIFF
--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -169,6 +169,7 @@ class CakeLog {
  * {{{
  * CakeLog::config('payments', array(
  *     'engine' => 'File',
+ *     'types' => array('info', 'error', 'warning'),
  *     'scopes' => array('payment', 'order')
  * ));
  * }}}


### PR DESCRIPTION
> Its important to remember that
> when using scopes you must also define the `types` of log messages
>  that a logger will handle. Failing to do so will result in the logger
>  catching all log messages even if the scope is incorrect.

According to this the previous example would fail to log correctly.
