### PR TITLE
remove wrong trailing slash

### DIFF
--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -298,7 +298,7 @@ class ExceptionRenderer {
 	protected function _outputMessageSafe($template) {
 		$this->controller->layoutPath = null;
 		$this->controller->subDir = null;
-		$this->controller->viewPath = 'Errors/';
+		$this->controller->viewPath = 'Errors';
 		$this->controller->layout = 'error';
 		$this->controller->helpers = array('Form', 'Html', 'Session');
 


### PR DESCRIPTION
That trailing slash should not be there.
In case of an error the output would be:

```
/home/travis/build/.../View/Errors//error500.ctp" is missing
```
