### PR TITLE
Running PHP Built-in web server without providing a router script.

### DIFF
--- a/Cake/Console/Command/ServerShell.php
+++ b/Cake/Console/Command/ServerShell.php
@@ -124,11 +124,10 @@ class ServerShell extends Shell {
  * @return void
  */
 	public function main() {
-		$command = sprintf("php -S %s:%d -t %s %s",
+		$command = sprintf('php -S %s:%d -t %s',
 			$this->_host,
 			$this->_port,
-			escapeshellarg($this->_documentRoot),
-			escapeshellarg($this->_documentRoot . '/index.php')
+			escapeshellarg($this->_documentRoot)
 		);
 
 		$port = ($this->_port == static::DEFAULT_PORT) ? '' : ':' . $this->_port;


### PR DESCRIPTION
From PHP's documentation:

> If a PHP file is given on the command line when the web server is started it is treated as a "router" script. The script is run at the start of each HTTP request. If this script returns FALSE, then the requested resource is returned as-is. Otherwise the script's output is returned to the browser.

When providing a router script every single request will go through it, including asset files. We would need to `return false` in the router script for asset files.
Without it, the webserver will first try to serve the requested file. If the file does not exist, index.php will be served instead.
