### PR TITLE
2.5 inList(), multiple() and case sensitivity

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1945,8 +1945,15 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::inList('three', array('one', 'two')));
 		$this->assertFalse(Validation::inList('1one', array(0, 1, 2, 3)));
 		$this->assertFalse(Validation::inList('one', array(0, 1, 2, 3)));
-		$this->assertFalse(Validation::inList('2', array(1, 2, 3)));
-		$this->assertTrue(Validation::inList('2', array(1, 2, 3), false));
+		$this->assertTrue(Validation::inList('2', array(1, 2, 3)));
+		$this->assertFalse(Validation::inList('2x', array(1, 2, 3)));
+		$this->assertFalse(Validation::inList(2, array('1', '2x', '3')));
+		$this->assertFalse(Validation::inList('One', array('one', 'two')));
+
+		// case insensitive
+		$this->assertTrue(Validation::inList('one', array('One', 'Two'), true));
+		$this->assertTrue(Validation::inList('Two', array('one', 'two'), true));
+		$this->assertFalse(Validation::inList('three', array('one', 'two'), true));
 	}
 
 /**
@@ -2065,14 +2072,24 @@ class ValidationTest extends CakeTestCase {
 		$this->assertFalse(Validation::multiple(array('foo', 'bar', 'baz', 'squirrel'), array('min' => 10)));
 
 		$this->assertTrue(Validation::multiple(array(0, 5, 9), array('in' => range(0, 10), 'max' => 5)));
-		$this->assertFalse(Validation::multiple(array('0', '5', '9'), array('in' => range(0, 10), 'max' => 5)));
-		$this->assertTrue(Validation::multiple(array('0', '5', '9'), array('in' => range(0, 10), 'max' => 5), false));
+		$this->assertTrue(Validation::multiple(array('0', '5', '9'), array('in' => range(0, 10), 'max' => 5)));
+
 		$this->assertFalse(Validation::multiple(array(0, 5, 9, 8, 6, 2, 1), array('in' => range(0, 10), 'max' => 5)));
 		$this->assertFalse(Validation::multiple(array(0, 5, 9, 8, 11), array('in' => range(0, 10), 'max' => 5)));
 
 		$this->assertFalse(Validation::multiple(array(0, 5, 9), array('in' => range(0, 10), 'max' => 5, 'min' => 3)));
 		$this->assertFalse(Validation::multiple(array(0, 5, 9, 8, 6, 2, 1), array('in' => range(0, 10), 'max' => 5, 'min' => 2)));
 		$this->assertFalse(Validation::multiple(array(0, 5, 9, 8, 11), array('in' => range(0, 10), 'max' => 5, 'min' => 2)));
+
+		$this->assertFalse(Validation::multiple(array('2x', '3x'), array('in' => array(1, 2, 3, 4, 5))));
+		$this->assertFalse(Validation::multiple(array(2, 3), array('in' => array('1x', '2x', '3x', '4x'))));
+		$this->assertFalse(Validation::multiple(array('one'), array('in' => array('One', 'Two'))));
+		$this->assertFalse(Validation::multiple(array('Two'), array('in' => array('one', 'two'))));
+
+		// case insensitive
+		$this->assertTrue(Validation::multiple(array('one'), array('in' => array('One', 'Two')), true));
+		$this->assertTrue(Validation::multiple(array('Two'), array('in' => array('one', 'two')), true));
+		$this->assertFalse(Validation::multiple(array('three'), array('in' => array('one', 'two')), true));
 	}
 
 /**
@@ -2333,6 +2350,7 @@ class ValidationTest extends CakeTestCase {
 		$this->assertTrue(Validation::mimeType($image, array('image/gif')));
 		$this->assertTrue(Validation::mimeType(array('tmp_name' => $image), array('image/gif')));
 
+		$this->assertFalse(Validation::mimeType($image, array('image/GIF')));
 		$this->assertFalse(Validation::mimeType($image, array('image/png')));
 		$this->assertFalse(Validation::mimeType(array('tmp_name' => $image), array('image/png')));
 	}

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -540,7 +540,7 @@ class Validation {
 	}
 
 /**
- * Validate a multiple select.
+ * Validate a multiple select. Comparison is case sensitive by default.
  *
  * Valid Options
  *
@@ -550,12 +550,13 @@ class Validation {
  *
  * @param array $check Value to check
  * @param array $options Options for the check.
- * @param boolean $strict Defaults to true, set to false to disable strict type check
+ * @param boolean $caseInsensitive Set to true for case insensitive comparison.
  * @return boolean Success
  */
-	public static function multiple($check, $options = array(), $strict = true) {
+	public static function multiple($check, $options = array(), $caseInsensitive = false) {
 		$defaults = array('in' => null, 'max' => null, 'min' => null);
 		$options = array_merge($defaults, $options);
+
 		$check = array_filter((array)$check);
 		if (empty($check)) {
 			return false;
@@ -567,8 +568,15 @@ class Validation {
 			return false;
 		}
 		if ($options['in'] && is_array($options['in'])) {
+			if ($caseInsensitive) {
+				$options['in'] = array_map('mb_strtolower', $options['in']);
+			}
 			foreach ($check as $val) {
-				if (!in_array($val, $options['in'], $strict)) {
+				$strict = !is_numeric($val);
+				if ($caseInsensitive) {
+					$val = mb_strtolower($val);
+				}
+				if (!in_array((string)$val, $options['in'], $strict)) {
 					return false;
 				}
 			}
@@ -766,15 +774,22 @@ class Validation {
 	}
 
 /**
- * Checks if a value is in a given list.
+ * Checks if a value is in a given list. Comparison is case sensitive by default.
  *
- * @param string $check Value to check
- * @param array $list List to check against
- * @param boolean $strict Defaults to true, set to false to disable strict type check
- * @return boolean Success
+ * @param string $check Value to check.
+ * @param array $list List to check against.
+ * @param boolean $caseInsensitive Set to true for case insensitive comparison.
+ * @return boolean Success.
  */
-	public static function inList($check, $list, $strict = true) {
-		return in_array($check, $list, $strict);
+	public static function inList($check, $list, $caseInsensitive = false) {
+		$strict = !is_numeric($check);
+
+		if ($caseInsensitive) {
+			$list = array_map('mb_strtolower', $list);
+			$check = mb_strtolower($check);
+		}
+
+		return in_array((string)$check, $list, $strict);
 	}
 
 /**
@@ -896,7 +911,7 @@ class Validation {
 	}
 
 /**
- * Checks the mime type of a file
+ * Checks the mime type of a file. Comparison is case sensitive.
  *
  * @param string|array $check
  * @param array $mimeTypes to check for


### PR DESCRIPTION
Resolves https://cakephp.lighthouseapp.com/projects/42648/tickets/3521-case-insensitive-validation-inlist-option

Also fixes the issue that $strict would return too many false positives by removing it all-together and putting the focus on what actually needs a setting: case sensitivity.

Last but not least clarifies that mimetype validation/check is case sensitive.
