### PR TITLE
Fix casing of validation rules in bake

### DIFF
--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -380,7 +380,7 @@ class ModelTask extends BakeTask {
 		$default = 1;
 		foreach ($options as $option) {
 			if ($option{0} !== '_') {
-				$choices[$default] = strtolower($option);
+				$choices[$default] = $option;
 				$default++;
 			}
 		}
@@ -433,9 +433,9 @@ class ModelTask extends BakeTask {
 				} elseif ($metaData['type'] === 'string' && $metaData['length'] == 36) {
 					$guess = $methods['uuid'];
 				} elseif ($metaData['type'] === 'string') {
-					$guess = $methods['notempty'];
+					$guess = $methods['notEmpty'];
 				} elseif ($metaData['type'] === 'text') {
-					$guess = $methods['notempty'];
+					$guess = $methods['notEmpty'];
 				} elseif ($metaData['type'] === 'integer') {
 					$guess = $methods['numeric'];
 				} elseif ($metaData['type'] === 'boolean') {

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -269,7 +269,7 @@ class ModelTaskTest extends CakeTestCase {
  */
 	public function testInitValidations() {
 		$result = $this->Task->initValidations();
-		$this->assertTrue(in_array('notempty', $result));
+		$this->assertTrue(in_array('notEmpty', $result));
 	}
 
 /**
@@ -283,7 +283,7 @@ class ModelTaskTest extends CakeTestCase {
 		$this->Task->initValidations();
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notempty' => 'notempty');
+		$expected = array('notEmpty' => 'notEmpty');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'date', 'length' => 10, 'null' => false));
@@ -319,7 +319,7 @@ class ModelTaskTest extends CakeTestCase {
 			->will($this->onConsecutiveCalls('24', 'y', '18', 'n'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notempty' => 'notempty', 'maxlength' => 'maxlength');
+		$expected = array('notEmpty' => 'notEmpty', 'maxLength' => 'maxLength');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -340,7 +340,7 @@ class ModelTaskTest extends CakeTestCase {
 			->with($this->stringContains('make a valid'));
 
 		$result = $this->Task->fieldValidation('text', array('type' => 'string', 'length' => 10, 'null' => false));
-		$expected = array('notempty' => 'notempty');
+		$expected = array('notEmpty' => 'notEmpty');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -406,7 +406,7 @@ class ModelTaskTest extends CakeTestCase {
 		$result = $this->Task->doValidation($Model);
 		$expected = array(
 			'name' => array(
-				'notempty' => 'notempty'
+				'notEmpty' => 'notEmpty'
 			),
 			'email' => array(
 				'email' => 'email',
@@ -742,7 +742,7 @@ class ModelTaskTest extends CakeTestCase {
 	public function testBakeValidation() {
 		$validate = array(
 			'name' => array(
-				'notempty' => 'notempty'
+				'notempty' => 'notEmpty'
 			),
 			'email' => array(
 				'email' => 'email',
@@ -760,7 +760,7 @@ class ModelTaskTest extends CakeTestCase {
 		$expected = <<< STRINGEND
 array(
 			'notempty' => array(
-				'rule' => array('notempty'),
+				'rule' => array('notEmpty'),
 				//'message' => 'Your custom message here',
 				//'allowEmpty' => false,
 				//'required' => false,


### PR DESCRIPTION
This has been bothering me for a quite a while now.. I always had to manually rename the baked validation rules, as they did not match the actual method names.

Bake would simply lowercase all validation rules, and while this works due to PHP case insensitivity, this gets quite messy/unreadable at some point

```
'content' => array(
        'notempty' => array(
            'rule' => array('notempty'),
            ...
        ),
    ),
```

Same for maxLength, inList, ...
It is also a good practice to always name your called rules the same than their actual name.
Or bad casings like `nOtEmpTY` etc would also be valid and acceptable here :)

This bug-fix resolves this unnecessary lower-casing:

```
'content' => array(
        'notEmpty' => array(
            'rule' => array('notEmpty'),
            ...
        ),
    ),
```
