### PR TITLE
Fixed TreeBehavior::recover() when using scope. Fixes #4062.

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -676,7 +676,7 @@ class TreeBehavior extends ModelBehavior {
 
 		$scope = $this->settings[$Model->alias]['scope'];
 		if ($scope && ($scope !== '1 = 1' && $scope !== true)) {
-			$conditions[] = $scope;
+			$params['conditions'][] = $scope;
 		}
 
 		$children = $Model->find('all', $params);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -380,4 +380,185 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * testRecoverUsingParentMode method
+ *
+ * @return void
+ */
+	public function testRecoverUsingParentMode() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(2, 3);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
+		$this->Tree->Behaviors->disable('Tree');
+
+		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0, 'flag' => 1));
+		$node1 = $this->Tree->id;
+
+		$this->Tree->create();
+		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0, 'flag' => 1));
+		$node11 = $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0, 'flag' => 1));
+		$node12 = $this->Tree->id;
+		$this->Tree->create();
+		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0, 'flag' => 1));
+		$this->Tree->create();
+		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0, 'flag' => 1));
+
+		$this->Tree->Behaviors->enable('Tree');
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->verify();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->find('first', array(
+			'fields' => array('name', $parentField, $leftField, $rightField, 'flag'),
+			'conditions' => array('name' => 'Main'),
+			'recursive' => -1
+		));
+		$expected = array(
+			$modelClass => array(
+				'name' => 'Main',
+				$parentField => null,
+				$leftField => 1,
+				$rightField => 10,
+				'flag' => 1
+			)
+		);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testRecoverFromMissingParent method
+ *
+ * @return void
+ */
+	public function testRecoverFromMissingParent() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(2, 2);
+
+		$this->Tree->id = 1;
+		$this->Tree->saveField('flag', 1);
+		$this->Tree->id = 2;
+		$this->Tree->saveField('flag', 1);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
+
+		$result = $this->Tree->findByName('1.1');
+		$this->Tree->updateAll(array($parentField => 999999), array('id' => $result[$modelClass]['id']));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidParents method
+ *
+ * @return void
+ */
+	public function testDetectInvalidParents() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(2, 2);
+
+		$this->Tree->id = 1;
+		$this->Tree->saveField('flag', 1);
+		$this->Tree->id = 2;
+		$this->Tree->saveField('flag', 1);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
+
+		$this->Tree->updateAll(array($parentField => null));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertSame($result, true);
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * testDetectInvalidLftsRghts method
+ *
+ * @return void
+ */
+	public function testDetectInvalidLftsRghts() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(2, 2);
+
+		$this->Tree->id = 1;
+		$this->Tree->saveField('flag', 1);
+		$this->Tree->id = 2;
+		$this->Tree->saveField('flag', 1);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
+
+		$this->Tree->updateAll(array($leftField => 0, $rightField => 0));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$this->Tree->recover();
+
+		$result = $this->Tree->verify();
+		$this->assertSame($result, true);
+	}
+
+/**
+ * Reproduces a situation where a single node has lft= rght, and all other lft and rght fields follow sequentially
+ *
+ * @return void
+ */
+	public function testDetectEqualLftsRghts() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->initialize(1, 3);
+
+		$this->Tree->id = 1;
+		$this->Tree->saveField('flag', 1);
+		$this->Tree->id = 2;
+		$this->Tree->saveField('flag', 1);
+
+		$this->Tree->Behaviors->attach('Tree', array('scope' => array('FlagTree.flag' => 1)));
+
+		$result = $this->Tree->findByName('1.1');
+		$this->Tree->updateAll(array($rightField => $result[$modelClass][$leftField]), array('id' => $result[$modelClass]['id']));
+		$this->Tree->updateAll(array($leftField => $this->Tree->escapeField($leftField) . ' -1'),
+			array($leftField . ' >' => $result[$modelClass][$leftField]));
+		$this->Tree->updateAll(array($rightField => $this->Tree->escapeField($rightField) . ' -1'),
+			array($rightField . ' >' => $result[$modelClass][$leftField]));
+
+		$result = $this->Tree->verify();
+		$this->assertNotSame($result, true);
+
+		$result = $this->Tree->recover();
+		$this->assertTrue($result);
+
+		$result = $this->Tree->verify();
+		$this->assertTrue($result);
+	}
+
 }


### PR DESCRIPTION
Refs [#4062](https://cakephp.lighthouseapp.com/projects/42648-cakephp/tickets/4062-release-240-broke-tree-behavior-recover-function)
