### PR TITLE
correct and simplify tests

### DIFF
--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -372,13 +372,13 @@ class CacheTest extends CakeTestCase {
  */
 	public function testWriteEmptyValues() {
 		Cache::write('App.falseTest', false);
-		$this->assertSame(Cache::read('App.falseTest'), false);
+		$this->assertFalse(Cache::read('App.falseTest'));
 
 		Cache::write('App.trueTest', true);
-		$this->assertSame(Cache::read('App.trueTest'), true);
+		$this->assertTrue(Cache::read('App.trueTest'));
 
 		Cache::write('App.nullTest', null);
-		$this->assertSame(Cache::read('App.nullTest'), null);
+		$this->assertNull(Cache::read('App.nullTest'));
 
 		Cache::write('App.zeroTest', 0);
 		$this->assertSame(Cache::read('App.zeroTest'), 0);

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -377,16 +377,16 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->Paginator->paginate('PaginatorControllerPost');
 		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertFalse($Controller->params['paging']['PaginatorControllerPost']['prevPage']);
+		$this->assertTrue($Controller->params['paging']['PaginatorControllerPost']['nextPage']);
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => 'garbage!', 'maxLimit' => 10, 'paramType' => 'named');
 		$Controller->Paginator->paginate('PaginatorControllerPost');
 		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertFalse($Controller->params['paging']['PaginatorControllerPost']['prevPage']);
+		$this->assertTrue($Controller->params['paging']['PaginatorControllerPost']['nextPage']);
 
 		$Controller->request->params['named'] = array();
 		$Controller->Paginator->settings = array('limit' => '-1', 'maxLimit' => 10, 'paramType' => 'named');
@@ -395,8 +395,8 @@ class PaginatorComponentTest extends CakeTestCase {
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['limit'], 1);
 		$this->assertSame(1, $Controller->params['paging']['PaginatorControllerPost']['page']);
 		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['pageCount'], 3);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['prevPage'], false);
-		$this->assertSame($Controller->params['paging']['PaginatorControllerPost']['nextPage'], true);
+		$this->assertFalse($Controller->params['paging']['PaginatorControllerPost']['prevPage']);
+		$this->assertTrue($Controller->params['paging']['PaginatorControllerPost']['nextPage']);
 
 		$Controller->Paginator->settings = array('conditions' => array('PaginatorAuthor.user' => 'mariano'));
 		$Controller->Paginator->paginate('PaginatorControllerPost');

--- a/lib/Cake/Test/Case/Controller/ControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerTest.php
@@ -1321,8 +1321,8 @@ class ControllerTest extends CakeTestCase {
 		$Controller->paginate('ControllerPost');
 		$this->assertSame($Controller->params['paging']['ControllerPost']['page'], 1);
 		$this->assertSame($Controller->params['paging']['ControllerPost']['pageCount'], 3);
-		$this->assertSame($Controller->params['paging']['ControllerPost']['prevPage'], false);
-		$this->assertSame($Controller->params['paging']['ControllerPost']['nextPage'], true);
+		$this->assertFalse($Controller->params['paging']['ControllerPost']['prevPage']);
+		$this->assertTrue($Controller->params['paging']['ControllerPost']['nextPage']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -91,6 +91,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$save[$modelClass]['id'] = $result[$modelClass]['id'];
 		$save[$modelClass][$leftField] = 0;
 
+		$this->Tree->create();
 		$this->Tree->save($save);
 		$result = $this->Tree->verify();
 		$this->assertNotSame($result, true);
@@ -118,6 +119,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$save[$modelClass]['id'] = $result[$modelClass]['id'];
 		$save[$modelClass][$rightField] = 0;
 
+		$this->Tree->create();
 		$this->Tree->save($save);
 		$result = $this->Tree->verify();
 		$this->assertNotSame($result, true);
@@ -190,17 +192,21 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->order = null;
 		$this->Tree->Behaviors->disable('Tree');
 
+		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
 		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node11 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node12 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
 
@@ -242,19 +248,24 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->order = null;
 		$this->Tree->Behaviors->disable('Tree');
 
+		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0));
 		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node11 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0));
 		$node12 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0));
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0));
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Lost', $parentField => 9, $leftField => 0, $rightField => 0));
 
@@ -408,6 +419,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
+		$this->Tree->create();
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
 		$result = $this->Tree->find('first', array('fields' => array('name', $parentField), 'order' => $modelClass . '.' . $leftField . ' desc'));
 		$expected = array($modelClass => array('name' => 'testAddOrphan', $parentField => null));
@@ -495,6 +507,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$initialCount = $this->Tree->find('count');
 		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
 
+		$this->Tree->create();
 		$saveSuccess = $this->Tree->save(array($modelClass => array('name' => 'testAddInvalid', $parentField => 99999)));
 		$this->assertFalse($saveSuccess);
 
@@ -516,6 +529,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->order = null;
 		$this->Tree->initialize(2, 2);
 
+		$this->Tree->create();
 		$this->Tree->save(array('name' => 'testAddNotIndexed', $parentField => null));
 		$result = $this->Tree->find('first', array('fields' => array('name', $parentField), 'order' => $modelClass . '.' . $leftField . ' desc'));
 		$expected = array($modelClass => array('name' => 'testAddNotIndexed', $parentField => null));
@@ -592,6 +606,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->initialize(2, 2);
 
 		$this->Tree->whitelist = array('name', $parentField);
+		$this->Tree->create();
 		$this->Tree->save(array($modelClass => array('name' => 'testAddOrphan', $parentField => null)));
 		$result = $this->Tree->findByName('testAddOrphan', array('name', $parentField, $leftField, $rightField));
 		$expected = array('name' => 'testAddOrphan', $parentField => null, $leftField => '15', $rightField => 16);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -72,7 +72,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals(7, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -96,10 +96,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -123,10 +123,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -149,10 +149,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -173,10 +173,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover('MPTT');
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -318,10 +318,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -341,10 +341,10 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -366,7 +366,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->recover();
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -414,7 +414,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -446,7 +446,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertSame($children, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -496,13 +496,13 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		//$this->expectError('Trying to save a node under a none-existant node in TreeBehavior::beforeSave');
 
 		$saveSuccess = $this->Tree->save(array($modelClass => array('name' => 'testAddInvalid', $parentField => 99999)));
-		$this->assertSame($saveSuccess, false);
+		$this->assertFalse($saveSuccess);
 
 		$laterCount = $this->Tree->find('count');
 		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -522,7 +522,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -549,7 +549,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 			array($modelClass => array('id' => 3, 'name' => '1.1.1', $parentField => 1, $leftField => 12, $rightField => 13)));
 		$this->assertEquals($direct, $expects);
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -596,7 +596,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$result = $this->Tree->findByName('testAddOrphan', array('name', $parentField, $leftField, $rightField));
 		$expected = array('name' => 'testAddOrphan', $parentField => null, $leftField => '15', $rightField => 16);
 		$this->assertEquals($expected, $result[$modelClass]);
-		$this->assertSame($this->Tree->verify(), true);
+		$this->assertTrue($this->Tree->verify());
 	}
 
 /**
@@ -625,7 +625,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($expects, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -654,7 +654,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($expects, $result);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -687,7 +687,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($before, $after);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -712,7 +712,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -733,12 +733,12 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->id = $data[$modelClass]['id'];
 		$saveSuccess = $this->Tree->saveField($parentField, $this->Tree->id);
 
-		$this->assertSame($saveSuccess, false);
+		$this->assertFalse($saveSuccess);
 		$laterCount = $this->Tree->find('count');
 		$this->assertSame($initialCount, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1000,7 +1000,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->Tree->save(array($parentField => null));
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$this->Tree->moveUp();
 
@@ -1031,7 +1031,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($initialCount - 1, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 
 		$initialCount = $this->Tree->find('count');
 		$result = $this->Tree->findByName('1.1');
@@ -1043,7 +1043,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($initialCount - 2, $laterCount);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1089,7 +1089,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1123,7 +1123,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1158,7 +1158,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($nodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1193,7 +1193,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($topNodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -1226,7 +1226,7 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 		$this->assertEquals($nodes, $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -461,10 +461,10 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -491,10 +491,10 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->assertNotSame($result, true);
 
 		$result = $this->Tree->recover();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**
@@ -523,7 +523,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->Tree->recover();
 
 		$result = $this->Tree->verify();
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -178,6 +178,7 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->Tree->Behaviors->attach('Translate', array('title'));
 
 		//Save
+		$this->Tree->create();
 		$this->Tree->locale = 'eng';
 		$data = array('FlagTree' => array(
 			'title' => 'name #1',
@@ -394,17 +395,21 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 		$this->Tree->Behaviors->attach('Tree', array('scope' => 'FlagTree.flag = 1'));
 		$this->Tree->Behaviors->disable('Tree');
 
+		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Main', $parentField => null, $leftField => 0, $rightField => 0, 'flag' => 1));
 		$node1 = $this->Tree->id;
 
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'About Us', $parentField => $node1, $leftField => 0, $rightField => 0, 'flag' => 1));
 		$node11 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Programs', $parentField => $node1, $leftField => 0, $rightField => 0, 'flag' => 1));
 		$node12 = $this->Tree->id;
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Mission and History', $parentField => $node11, $leftField => 0, $rightField => 0, 'flag' => 1));
+
 		$this->Tree->create();
 		$this->Tree->save(array('name' => 'Overview', $parentField => $node12, $leftField => 0, $rightField => 0, 'flag' => 1));
 

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -114,7 +114,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 			array($modelClass => array('name' => '1.1.1', $leftField => 12, $rightField => 13)));
 		$this->assertEquals($direct, $expects);
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -177,7 +177,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$this->assertEquals(array_values($nodes), $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**
@@ -210,7 +210,7 @@ class TreeBehaviorUuidTest extends CakeTestCase {
 		$this->assertEquals(array_values($nodes), $expects);
 
 		$validTree = $this->Tree->verify();
-		$this->assertSame($validTree, true);
+		$this->assertTrue($validTree);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -629,11 +629,11 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Sample->Behaviors->attach('Test');
-		$this->assertSame($Apple->Sample->Behaviors->enabled('Test'), true);
+		$this->assertTrue($Apple->Sample->Behaviors->enabled('Test'));
 		$this->assertSame($Apple->Behaviors->enabled(), array());
 
 		$Apple->Behaviors->enable('Test');
-		$this->assertSame($Apple->Behaviors->loaded('Test'), true);
+		$this->assertTrue($Apple->Behaviors->loaded('Test'));
 		$this->assertSame($Apple->Behaviors->enabled(), array('Test'));
 
 		$Apple->Behaviors->disable('Test');
@@ -658,7 +658,7 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$expected = $Apple->find('all');
 
 		$Apple->Behaviors->attach('Test');
-		$this->assertSame($Apple->find('all'), null);
+		$this->assertNull($Apple->find('all'));
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off'));
 		$this->assertSame($expected, $Apple->find('all'));
@@ -929,28 +929,28 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 
 		$Apple->Behaviors->attach('Test', array('beforeFind' => 'off', 'beforeDelete' => 'off'));
-		$this->assertSame($Apple->delete(6), true);
+		$this->assertTrue($Apple->delete(6));
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'on'));
-		$this->assertSame($Apple->delete(4), false);
+		$this->assertFalse($Apple->delete(4));
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'test2'));
 
 		ob_start();
 		$results = $Apple->delete(4);
 		$this->assertSame(trim(ob_get_clean()), 'beforeDelete success (cascading)');
-		$this->assertSame($results, true);
+		$this->assertTrue($results);
 
 		ob_start();
 		$results = $Apple->delete(3, false);
 		$this->assertSame(trim(ob_get_clean()), 'beforeDelete success');
-		$this->assertSame($results, true);
+		$this->assertTrue($results);
 
 		$Apple->Behaviors->attach('Test', array('beforeDelete' => 'off', 'afterDelete' => 'on'));
 		ob_start();
 		$results = $Apple->delete(2, false);
 		$this->assertSame(trim(ob_get_clean()), 'afterDelete success');
-		$this->assertSame($results, true);
+		$this->assertTrue($results);
 	}
 
 /**
@@ -976,14 +976,14 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 
 		$Apple->Behaviors->attach('Test');
-		$this->assertSame($Apple->validates(), true);
+		$this->assertTrue($Apple->validates());
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'on'));
-		$this->assertSame($Apple->validates(), false);
+		$this->assertFalse($Apple->validates());
 		$this->assertSame($Apple->validationErrors, array('name' => array(true)));
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'stop'));
-		$this->assertSame($Apple->validates(), false);
+		$this->assertFalse($Apple->validates());
 		$this->assertSame($Apple->validationErrors, array('name' => array(true, true)));
 
 		$Apple->Behaviors->attach('Test', array('validate' => 'whitelist'));
@@ -1004,10 +1004,10 @@ class BehaviorCollectionTest extends CakeTestCase {
 		$Apple = new Apple();
 
 		$Apple->Behaviors->attach('Test');
-		$this->assertSame($Apple->validates(), true);
+		$this->assertTrue($Apple->validates());
 
 		$Apple->Behaviors->attach('Test', array('afterValidate' => 'on'));
-		$this->assertSame($Apple->validates(), true);
+		$this->assertTrue($Apple->validates());
 		$this->assertSame($Apple->validationErrors, array());
 
 		$Apple->Behaviors->attach('Test', array('afterValidate' => 'test'));

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -213,19 +213,19 @@ class MysqlTest extends CakeTestCase {
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 5, 'small_int' => 5)));
 		$result = $this->model->find('first');
-		$this->assertSame($result['Tinyint']['bool'], true);
+		$this->assertTrue($result['Tinyint']['bool']);
 		$this->assertSame($result['Tinyint']['small_int'], '5');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 0, 'small_int' => 100)));
 		$result = $this->model->find('first');
-		$this->assertSame($result['Tinyint']['bool'], false);
+		$this->assertFalse($result['Tinyint']['bool']);
 		$this->assertSame($result['Tinyint']['small_int'], '100');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => true, 'small_int' => 0)));
 		$result = $this->model->find('first');
-		$this->assertSame($result['Tinyint']['bool'], true);
+		$this->assertTrue($result['Tinyint']['bool']);
 		$this->assertSame($result['Tinyint']['small_int'], '0');
 		$this->model->deleteAll(true);
 

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -661,7 +661,7 @@ class ModelDeleteTest extends BaseModelTest {
 		$this->assertEquals(4, $result);
 
 		$result = $Article->delete(1, true);
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $Article->Comment->find('count', array(
 			'conditions' => array('Comment.article_id' => 1)

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -318,7 +318,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel2 = new Item();
 
 		$result = $TestModel->findById(1);
-		$this->assertSame($result['Syfile']['item_count'], null);
+		$this->assertNull($result['Syfile']['item_count']);
 
 		$TestModel2->save(array(
 			'name' => 'Item 7',
@@ -480,7 +480,7 @@ class ModelWriteTest extends BaseModelTest {
 		$TestModel2->belongsTo['Syfile']['counterScope'] = array('published' => true);
 
 		$result = $TestModel->findById(1);
-		$this->assertSame($result['Syfile']['item_count'], null);
+		$this->assertNull($result['Syfile']['item_count']);
 
 		$TestModel2->save(array(
 			'name' => 'Item 7',
@@ -4629,7 +4629,7 @@ class ModelWriteTest extends BaseModelTest {
 			array('validate' => 'first')
 		);
 
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $model->Comment->find('all');
 		$this->assertSame(count($result), 1);
@@ -6033,7 +6033,7 @@ class ModelWriteTest extends BaseModelTest {
 			array('validate' => 'first')
 		);
 
-		$this->assertSame($result, true);
+		$this->assertTrue($result);
 
 		$result = $model->Comment->find('all');
 		$this->assertSame(count($result), 1);

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -937,7 +937,7 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertEquals('posts', $request->controller);
 		$this->assertEquals('view', $request->action);
 		$this->assertEquals('blogs', $request->plugin);
-		$this->assertSame($request->banana, null);
+		$this->assertNull($request->banana);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -211,7 +211,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertSame($this->CakeEmail->sender(), $expected);
 
 		$headers = $this->CakeEmail->getHeaders(array('from' => true, 'sender' => true));
-		$this->assertSame($headers['From'], false);
+		$this->assertFalse($headers['From']);
 		$this->assertSame($headers['Sender'], 'Name <cake@cakephp.org>');
 
 		$this->CakeEmail->from('cake@cakephp.org', 'CakePHP');

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -143,7 +143,7 @@ class HttpResponseTest extends CakeTestCase {
 		$this->assertEquals('Bar', $this->HttpResponse->getHeader('FOO'));
 		$this->assertEquals('value', $this->HttpResponse->getHeader('header'));
 		$this->assertEquals('text/plain', $this->HttpResponse->getHeader('Content-Type'));
-		$this->assertSame($this->HttpResponse->getHeader(0), null);
+		$this->assertNull($this->HttpResponse->getHeader(0));
 
 		$this->assertEquals('Bar', $this->HttpResponse->getHeader('foo', false));
 		$this->assertEquals('not from class', $this->HttpResponse->getHeader('foo', array('foo' => 'not from class')));
@@ -578,7 +578,7 @@ class HttpResponseTest extends CakeTestCase {
 		$this->assertEquals($expected, $this->HttpResponse['cookies']);
 
 		$this->HttpResponse->raw = "HTTP/1.1 200 OK\r\n\r\nThis is a test!";
-		$this->assertSame($this->HttpResponse['raw']['header'], null);
+		$this->assertNull($this->HttpResponse['raw']['header']);
 	}
 
 }

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -310,11 +310,11 @@ class FileTest extends CakeTestCase {
 		} else {
 			$expected = "some\nvery\ncool\nteststring here\n\n\nfor\n\n\n\n\nhere";
 		}
-		$this->assertSame(File::prepare($string), $expected);
+		$this->assertSame($expected, File::prepare($string));
 
 		$expected = "some\r\nvery\r\ncool\r\nteststring here\r\n\r\n\r\n";
 		$expected .= "for\r\n\r\n\r\n\r\n\r\nhere";
-		$this->assertSame(File::prepare($string, true), $expected);
+		$this->assertSame($expected, File::prepare($string, true));
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -89,9 +89,9 @@ class PaginatorHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testHasPrevious() {
-		$this->assertSame($this->Paginator->hasPrev(), false);
+		$this->assertFalse($this->Paginator->hasPrev());
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
-		$this->assertSame($this->Paginator->hasPrev(), true);
+		$this->assertTrue($this->Paginator->hasPrev());
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
 	}
 
@@ -101,9 +101,9 @@ class PaginatorHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testHasNext() {
-		$this->assertSame($this->Paginator->hasNext(), true);
+		$this->assertTrue($this->Paginator->hasNext());
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = false;
-		$this->assertSame($this->Paginator->hasNext(), false);
+		$this->assertFalse($this->Paginator->hasNext());
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = true;
 	}
 


### PR DESCRIPTION
Some create() are missing - since we make users always use create() before save() for creating a new record, the tests should reflect the same behavior.

Also simplified some tests.
