### PR TITLE
3.0 - Start cleaning up the Pagination parameters

### DIFF
--- a/Cake/Controller/Component/PaginatorComponent.php
+++ b/Cake/Controller/Component/PaginatorComponent.php
@@ -223,7 +223,7 @@ class PaginatorComponent extends Component {
 			'pageCount' => $pageCount,
 			'sort' => key($order),
 			'direction' => current($order),
-			'limit' => $limit,
+			'limit' => $defaults['limit'] != $options['limit'] ? $options['limit'] : null,
 		);
 
 		if (!isset($this->Controller->request['paging'])) {

--- a/Cake/Controller/Component/PaginatorComponent.php
+++ b/Cake/Controller/Component/PaginatorComponent.php
@@ -212,16 +212,18 @@ class PaginatorComponent extends Component {
 			throw new Error\NotFoundException();
 		}
 
+		reset($order);
 		$paging = array(
+			'findType' => $type,
 			'page' => $page,
 			'current' => count($results),
 			'count' => $count,
 			'prevPage' => ($page > 1),
 			'nextPage' => ($count > ($page * $limit)),
 			'pageCount' => $pageCount,
-			'order' => $order,
+			'sort' => key($order),
+			'direction' => current($order),
 			'limit' => $limit,
-			'options' => Hash::diff($options, $defaults),
 		);
 
 		if (!isset($this->Controller->request['paging'])) {

--- a/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -254,7 +254,7 @@ class PaginatorComponentTest extends TestCase {
 		$paging = $Controller->request->params['paging']['PaginatorControllerPost'];
 
 		$this->assertEquals(12, $Controller->PaginatorControllerPost->lastQueries[1]['limit']);
-		$this->assertEquals(12, $paging['options']['limit']);
+		$this->assertEquals(12, $paging['limit']);
 
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('ControllerPaginateModel');
@@ -319,7 +319,7 @@ class PaginatorComponentTest extends TestCase {
 			$Controller->PaginatorControllerPost->lastQueries[1]['conditions'],
 			array('PaginatorControllerPost.id > ' => '1')
 		);
-		$this->assertFalse(isset($Controller->request->params['paging']['PaginatorControllerPost']['options'][0]));
+		$this->assertEquals('popular', $Controller->request->params['paging']['PaginatorControllerPost']['findType']);
 	}
 
 /**
@@ -367,7 +367,7 @@ class PaginatorComponentTest extends TestCase {
 		$this->assertEquals($expected, Hash::extract($result, '{n}.PaginatorControllerPost.created'));
 		$this->assertEquals(
 			$Controller->PaginatorControllerPost->order,
-			$Controller->request->paging['PaginatorControllerPost']['options']['order']
+			$Controller->request->paging['PaginatorControllerPost']['order']
 		);
 
 		$Controller->PaginatorControllerPost->order = array('PaginatorControllerPost.id');
@@ -867,26 +867,26 @@ class PaginatorComponentTest extends TestCase {
 			'contain' => array('ControllerComment'), 'limit' => '1000'
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals(100, $Controller->request->params['paging']['PaginatorControllerPost']['options']['limit']);
+		$this->assertEquals(100, $Controller->request->params['paging']['PaginatorControllerPost']['limit']);
 
 		$Controller->request->query = array(
 			'contain' => array('ControllerComment'), 'limit' => '1000', 'maxLimit' => 1000
 		);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals(100, $Controller->request->params['paging']['PaginatorControllerPost']['options']['limit']);
+		$this->assertEquals(100, $Controller->request->params['paging']['PaginatorControllerPost']['limit']);
 
 		$Controller->request->query = array('contain' => array('ControllerComment'), 'limit' => '10');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals(10, $Controller->request->params['paging']['PaginatorControllerPost']['options']['limit']);
+		$this->assertEquals(10, $Controller->request->params['paging']['PaginatorControllerPost']['limit']);
 
 		$Controller->request->query = array('contain' => array('ControllerComment'), 'limit' => '1000');
 		$Controller->paginate = array('maxLimit' => 2000);
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals(1000, $Controller->request->params['paging']['PaginatorControllerPost']['options']['limit']);
+		$this->assertEquals(1000, $Controller->request->params['paging']['PaginatorControllerPost']['limit']);
 
 		$Controller->request->query = array('contain' => array('ControllerComment'), 'limit' => '5000');
 		$result = $Controller->paginate('PaginatorControllerPost');
-		$this->assertEquals(2000, $Controller->request->params['paging']['PaginatorControllerPost']['options']['limit']);
+		$this->assertEquals(2000, $Controller->request->params['paging']['PaginatorControllerPost']['limit']);
 	}
 
 /**

--- a/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -25,7 +25,6 @@ use Cake\Utility\Hash;
 /**
  * PaginatorTestController class
  *
- * @package       Cake.Test.Case.Controller.Component
  */
 class PaginatorTestController extends Controller {
 
@@ -53,7 +52,6 @@ class PaginatorComponentTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->markTestIncomplete('Need to revisit once models work again.');
 
 		$this->_ns = Configure::read('App.namespace');
 		Configure::write('App.namespace', 'TestApp');
@@ -83,6 +81,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginate() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost', 'PaginatorControllerComment');
 		$Controller->request->params['pass'] = array('1');
@@ -179,6 +178,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPageParamCasting() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Controller->Post->expects($this->at(0))
 			->method('hasMethod')
 			->with('paginate')
@@ -209,6 +209,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateExtraParams() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 
 		$Controller->uses = array('PaginatorControllerPost', 'PaginatorControllerComment');
@@ -297,6 +298,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateSpecialType() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost', 'PaginatorControllerComment');
 		$Controller->request->params['pass'][] = '1';
@@ -326,6 +328,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testDefaultPaginateParams() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->modelClass = 'PaginatorControllerPost';
 		$Controller->request->query = [];
@@ -345,6 +348,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateOrderModelDefault() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost');
 		$Controller->params['url'] = array();
@@ -389,6 +393,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateOrderVirtualField() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost', 'PaginatorControllerComment');
 		$Controller->request->query = [];
@@ -416,6 +421,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateOrderVirtualFieldJoinedModel() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost');
 		$Controller->request->query = [];
@@ -439,6 +445,7 @@ class PaginatorComponentTest extends TestCase {
  * @expectedException Cake\Error\MissingModelException
  */
 	public function testPaginateMissingModel() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->constructClasses();
 		$Controller->Paginator->paginate('MissingModel');
@@ -622,6 +629,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testOutOfRangePageNumberGetsClamped() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost');
 		$Controller->request->query['page'] = 3000;
@@ -634,10 +642,11 @@ class PaginatorComponentTest extends TestCase {
  * Test that a really REALLY large page number gets clamped to the max page size.
  *
  *
- * @expectedException NotFoundException
+ * @expectedException Cake\Error\NotFoundException
  * @return void
  */
 	public function testOutOfVeryBigPageNumberGetsClamped() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost');
 		$Controller->params['named'] = array(
@@ -651,10 +660,11 @@ class PaginatorComponentTest extends TestCase {
 /**
  * testOutOfRangePageNumberAndPageCountZero
  *
- * @expectedException NotFoundException
+ * @expectedException Cake\Error\NotFoundException
  * @return void
  */
 	public function testOutOfRangePageNumberAndPageCountZero() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new PaginatorTestController($this->request);
 		$Controller->uses = array('PaginatorControllerPost');
 		$Controller->request->query['page'] = 3000;
@@ -698,7 +708,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testValidateSortWhitelistTrusted() {
-		$model = $this->getMock('Model');
+		$model = $this->getMock('Cake\Model\Model');
 		$model->alias = 'model';
 		$model->expects($this->never())->method('hasField');
 
@@ -740,9 +750,9 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testValidateSortSharedFields() {
-		$model = $this->getMock('Model');
+		$model = $this->getMock('Cake\Model\Model');
 		$model->alias = 'Parent';
-		$model->Child = $this->getMock('Model');
+		$model->Child = $this->getMock('Cake\Model\Model');
 		$model->Child->alias = 'Child';
 
 		$model->expects($this->never())
@@ -809,7 +819,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testValidateSortInvalidAlias() {
-		$model = $this->getMock('Model');
+		$model = $this->getMock('Cake\Model\Model');
 		$model->alias = 'Model';
 		$model->expects($this->any())->method('hasField')->will($this->returnValue(true));
 
@@ -846,6 +856,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateMaxLimit() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 
 		$Controller->uses = array('PaginatorControllerPost', 'ControllerComment');
@@ -884,6 +895,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateOrderVirtualFieldSharedWithRealField() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = array('PaginatorControllerPost', 'PaginatorControllerComment');
 		$Controller->constructClasses();
@@ -928,6 +940,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFind() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = ['PaginatorCustomPost'];
 
@@ -969,6 +982,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFindFieldsArray() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = array('PaginatorCustomPost');
 		$Controller->constructClasses();
@@ -1001,6 +1015,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFindWithCustomFindKey() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = array('PaginatorCustomPost');
 		$Controller->constructClasses();
@@ -1034,6 +1049,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFindGroupBy() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = array('PaginatorCustomPost');
 		$Controller->constructClasses();
@@ -1099,6 +1115,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFindCount() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
 		$Controller = new Controller($this->request);
 		$Controller->uses = array('PaginatorCustomPost');
 		$Controller->constructClasses();
@@ -1140,4 +1157,5 @@ class PaginatorComponentTest extends TestCase {
 		$this->assertTrue($result['nextPage']);
 		$this->assertFalse($result['prevPage']);
 	}
+
 }

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PaginatorHelperTest file
- *
  * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
@@ -13,7 +11,6 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @package       Cake.Test.Case.View.Helper
  * @since         CakePHP(tm) v 1.2.0.4206
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
@@ -32,7 +29,6 @@ use Cake\View\View;
 /**
  * PaginatorHelperTest class
  *
- * @package       Cake.Test.Case.View.Helper
  */
 class PaginatorHelperTest extends TestCase {
 
@@ -52,7 +48,7 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->addParams(array(
 			'paging' => array(
 				'Article' => array(
-					'page' => 2,
+					'page' => 1,
 					'current' => 9,
 					'count' => 62,
 					'prevPage' => false,
@@ -60,10 +56,6 @@ class PaginatorHelperTest extends TestCase {
 					'pageCount' => 7,
 					'order' => null,
 					'limit' => 20,
-					'options' => array(
-						'page' => 1,
-						'conditions' => array()
-					),
 				)
 			)
 		));
@@ -148,11 +140,9 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 7,
-				'options' => array(
-					'page' => 1,
-					'order' => array('date' => 'asc'),
-					'conditions' => array()
-				),
+				'sort' => 'date',
+				'direction' => 'asc',
+				'page' => 1,
 			)
 		);
 
@@ -188,7 +178,7 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = 'title';
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'title';
 		$result = $this->Paginator->sort('title', array('asc' => 'ascending', 'desc' => 'descending'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'),
@@ -197,8 +187,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'),
@@ -207,8 +197,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sort('title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'),
@@ -217,8 +207,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'),
@@ -227,8 +217,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=asc', 'class' => 'desc'),
@@ -237,8 +227,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'asc';
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'),
@@ -247,8 +237,9 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'),
@@ -257,8 +248,9 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
-		$this->Paginator->request->params['paging']['Article']['options']['sort'] = null;
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc', 'class' => 'foo'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'foo asc'),
@@ -278,7 +270,8 @@ class PaginatorHelperTest extends TestCase {
 			array('plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => array(), 'form' => array(), 'url' => array('url' => 'accounts/')),
 			array('base' => '', 'here' => '/accounts/', 'webroot' => '/')
 		));
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('full_name' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'full_name';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 
 		$result = $this->Paginator->sort('Article.full_name');
 		$expected = array(
@@ -296,7 +289,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('full_name' => 'desc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'full_name';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('Article.full_name');
 		$expected = array(
 			'a' => array('href' => '/accounts/index?sort=Article.full_name&amp;direction=asc', 'class' => 'desc'),
@@ -355,7 +349,8 @@ class PaginatorHelperTest extends TestCase {
 			array('base' => '', 'here' => '/accounts/', 'webroot' => '/')
 		));
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('Article.title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'),
@@ -364,7 +359,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sort('Article.title', 'Title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index?sort=Article.title&amp;direction=asc', 'class' => 'desc'),
@@ -373,7 +369,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sort('Article.title', 'Title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index?sort=Article.title&amp;direction=desc', 'class' => 'asc'),
@@ -382,7 +379,8 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Account.title' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Account.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sort('title');
 		$expected = array(
 			'a' => array('href' => '/accounts/index?sort=title&amp;direction=asc'),
@@ -445,65 +443,37 @@ class PaginatorHelperTest extends TestCase {
 	public function testSortDir() {
 		$result = $this->Paginator->sortDir();
 		$expected = 'asc';
-
 		$this->assertEquals($expected, $result);
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'desc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sortDir();
-		$expected = 'desc';
+		$this->assertEquals('desc', $result);
 
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sortDir();
-		$expected = 'asc';
+		$this->assertEquals('asc', $result);
 
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('title' => 'desc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'desc';
 		$result = $this->Paginator->sortDir();
-		$expected = 'desc';
+		$this->assertEquals('desc', $result);
 
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('title' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sortDir();
-		$expected = 'asc';
+		$this->assertEquals('asc', $result);
 
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
-		$this->Paginator->request->params['paging']['Article']['options']['direction'] = 'asc';
-		$result = $this->Paginator->sortDir();
-		$expected = 'asc';
-
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
-		$this->Paginator->request->params['paging']['Article']['options']['direction'] = 'desc';
-		$result = $this->Paginator->sortDir();
-		$expected = 'desc';
-
-		$this->assertEquals($expected, $result);
-
-		unset($this->Paginator->request->params['paging']['Article']['options']);
+		unset($this->Paginator->request->params['paging']['Article']['direction']);
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'asc'));
-		$expected = 'asc';
-
-		$this->assertEquals($expected, $result);
+		$this->assertEquals('asc', $result);
 
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'desc'));
-		$expected = 'desc';
-
-		$this->assertEquals($expected, $result);
+		$this->assertEquals('desc', $result);
 
 		$result = $this->Paginator->sortDir('Article', array('direction' => 'asc'));
-		$expected = 'asc';
-
-		$this->assertEquals($expected, $result);
+		$this->assertEquals('asc', $result);
 	}
 
 /**
@@ -513,18 +483,18 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testSortDirFallbackToParams() {
-		$this->Paginator->request->params['paging']['Article']['order'] = array(
-			'Article.body' => 'ASC'
-		);
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
+
 		$result = $this->Paginator->sortDir();
 		$this->assertEquals('asc', $result);
 
 		$result = $this->Paginator->sortDir('Article');
 		$this->assertEquals('asc', $result);
 
-		$this->Paginator->request->params['paging']['Article']['order'] = array(
-			'Article.body' => 'DESC'
-		);
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
+
 		$result = $this->Paginator->sortDir();
 		$this->assertEquals('desc', $result);
 
@@ -592,16 +562,16 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->url();
 		$this->assertEquals('/index', $result);
 
-		$this->Paginator->request->params['paging']['Article']['options']['page'] = 2;
+		$this->Paginator->request->params['paging']['Article']['page'] = 2;
 		$result = $this->Paginator->url();
 		$this->assertEquals('/index?page=2', $result);
 
-		$options = array('order' => array('Article' => 'desc'));
+		$options = array('sort' => 'Article', 'direction' => 'desc');
 		$result = $this->Paginator->url($options);
 		$this->assertEquals('/index?page=2&amp;sort=Article&amp;direction=desc', $result);
 
-		$this->Paginator->request->params['paging']['Article']['options']['page'] = 3;
-		$options = array('order' => array('Article.name' => 'desc'));
+		$this->Paginator->request->params['paging']['Article']['page'] = 3;
+		$options = array('sort' => 'Article.name', 'direction' => 'desc');
 		$result = $this->Paginator->url($options);
 		$this->assertEquals('/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 	}
@@ -622,7 +592,6 @@ class PaginatorHelperTest extends TestCase {
 			array('base' => '', 'here' => 'posts/index', 'webroot' => '/')
 		));
 
-		$this->Paginator->request->params['paging']['Article']['options']['page'] = 2;
 		$this->Paginator->request->params['paging']['Article']['page'] = 2;
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
 		$options = array('prefix' => 'members');
@@ -659,12 +628,12 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$options = array('prefix' => 'members', 'controller' => 'posts', 'order' => array('name' => 'desc'));
+		$options = array('prefix' => 'members', 'controller' => 'posts', 'sort' => 'name', 'direction' => 'desc');
 		$result = $this->Paginator->url($options);
 		$expected = '/members/posts/index?page=2&amp;sort=name&amp;direction=desc';
 		$this->assertEquals($expected, $result);
 
-		$options = array('controller' => 'posts', 'order' => array('Article.name' => 'desc'));
+		$options = array('controller' => 'posts', 'sort' => 'Article.name', 'direction' => 'desc');
 		$result = $this->Paginator->url($options);
 		$expected = '/posts/index?page=2&amp;sort=Article.name&amp;direction=desc';
 		$this->assertEquals($expected, $result);
@@ -680,13 +649,13 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params = array();
 
 		$options = array('paging' => array('Article' => array(
-			'order' => 'desc',
+			'direction' => 'desc',
 			'sort' => 'title'
 		)));
 		$this->Paginator->options($options);
 
 		$expected = array('Article' => array(
-			'order' => 'desc',
+			'direction' => 'desc',
 			'sort' => 'title'
 		));
 		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
@@ -695,20 +664,20 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params = array();
 
 		$options = array('Article' => array(
-			'order' => 'desc',
+			'direction' => 'desc',
 			'sort' => 'title'
 		));
 		$this->Paginator->options($options);
 		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
 
 		$options = array('paging' => array('Article' => array(
-			'order' => 'desc',
+			'direction' => 'desc',
 			'sort' => 'Article.title'
 		)));
 		$this->Paginator->options($options);
 
 		$expected = array('Article' => array(
-			'order' => 'desc',
+			'direction' => 'desc',
 			'sort' => 'Article.title'
 		));
 		$this->assertEquals($expected, $this->Paginator->request->params['paging']);
@@ -728,11 +697,7 @@ class PaginatorHelperTest extends TestCase {
 			'Article' => array(
 				'page' => 1, 'current' => 3, 'count' => 13,
 				'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
-				'options' => array(
-					'page' => 1,
-					'order' => array(),
-					'conditions' => array()
-				),
+				'sort' => null, 'direction' => null,
 			)
 		);
 
@@ -791,9 +756,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->prev('<< Previous', null, null, array('class' => 'disabled'));
@@ -903,9 +865,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 
@@ -976,11 +935,9 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-					'limit' => 3,
-					'order' => array('Client.name' => 'DESC'),
-				),
+				'sort' => 'Client.name',
+				'direction' => 'DESC',
+				'limit' => 3,
 			)
 		);
 
@@ -1020,12 +977,7 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => true,
 				'nextPage' => false,
 				'pageCount' => 2,
-				'options' => array(
-					'page' => 2,
-					'limit' => 10,
-					'order' => array(),
-					'conditions' => array()
-				),
+				'limit' => 10,
 			)
 		);
 		$result = $this->Paginator->prev('Prev');
@@ -1050,10 +1002,7 @@ class PaginatorHelperTest extends TestCase {
 			'Client' => array(
 				'page' => 2, 'current' => 1, 'count' => 13, 'prevPage' => true,
 				'nextPage' => false, 'pageCount' => 2,
-				'defaults' => array(),
-				'options' => array(
-					'page' => 2, 'limit' => 10, 'order' => array(), 'conditions' => array()
-				),
+				'limit' => 10,
 			)
 		);
 		$this->Paginator->options(array('url' => array(12, 'page' => 3)));
@@ -1083,9 +1032,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->prev('<< Previous', array('escape' => false));
@@ -1124,9 +1070,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-				),
 			),
 			'Server' => array(
 				'page' => 1,
@@ -1135,9 +1078,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => false,
 				'pageCount' => 5,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->next('Next', array('model' => 'Client'));
@@ -1171,7 +1111,7 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['page'] = 2;
+		$this->Paginator->request->params['paging']['Article']['page'] = 2;
 		$result = $this->Paginator->link('Sort by title', array('sort' => 'title', 'direction' => 'desc'));
 		$expected = array(
 			'a' => array('href' => '/index?page=2&amp;sort=title&amp;direction=desc'),
@@ -1180,7 +1120,7 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging']['Article']['options']['page'] = 4;
+		$this->Paginator->request->params['paging']['Article']['page'] = 4;
 		$result = $this->Paginator->link('Sort by title on page 4', array('sort' => 'Article.title', 'direction' => 'desc'));
 		$expected = array(
 			'a' => array('href' => '/index?page=4&amp;sort=Article.title&amp;direction=desc'),
@@ -1241,9 +1181,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->numbers();
@@ -1338,9 +1275,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->numbers();
@@ -1373,9 +1307,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$result = $this->Paginator->numbers();
@@ -1408,9 +1339,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 9,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 
@@ -1532,9 +1460,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 
@@ -1571,9 +1496,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 
@@ -1611,9 +1533,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => 1,
 				'nextPage' => 1,
 				'pageCount' => 42,
-				'options' => array(
-					'page' => 6,
-				),
 			)
 		);
 
@@ -1651,9 +1570,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => 1,
 				'nextPage' => 1,
 				'pageCount' => 42,
-				'options' => array(
-					'page' => 37,
-				),
 			)
 		);
 
@@ -1691,9 +1607,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 3,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$options = array('modulus' => 10);
@@ -1725,10 +1638,8 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => true,
 				'nextPage' => true,
 				'pageCount' => 4,
-				'options' => array(
-					'page' => 1,
-					'order' => array('Client.name' => 'DESC'),
-				),
+				'sort' => 'Client.name',
+				'direction' => 'DESC',
 			)
 		);
 		$result = $this->Paginator->numbers(array('class' => 'page-link'));
@@ -1751,9 +1662,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => 1,
 				'nextPage' => 1,
 				'pageCount' => 4897,
-				'options' => array(
-					'page' => 4894,
-				),
 			)
 		);
 
@@ -1968,9 +1876,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 3,
 				'pageCount' => 3,
-				'options' => array(
-					'page' => 1,
-				)
 			)
 		);
 
@@ -2058,7 +1963,8 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testFirstFullBaseUrl() {
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'DESC');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
 
 		$this->Paginator->options(array('url' => array('_full' => true)));
 
@@ -2192,10 +2098,8 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => 2,
 				'pageCount' => 15,
-				'options' => array(
-					'page' => 1,
-					'order' => array('Client.name' => 'DESC'),
-				),
+				'sort' => 'Client.name',
+				'direction' => 'DESC',
 			)
 		);
 
@@ -2262,10 +2166,8 @@ class PaginatorHelperTest extends TestCase {
 				'nextPage' => true,
 				'pageCount' => 5,
 				'limit' => 3,
-				'options' => array(
-					'page' => 1,
-					'order' => array('Client.name' => 'DESC'),
-				),
+				'sort' => 'Client.name',
+				'order' => 'DESC',
 			)
 		);
 		$input = 'Page %page% of %pages%, showing %current% records out of %count% total, ';
@@ -2380,7 +2282,8 @@ class PaginatorHelperTest extends TestCase {
 			array('base' => '', 'here' => '/accounts/', 'webroot' => '/')
 		));
 
-		$this->Paginator->request->params['paging']['Article']['options']['order'] = array('Article.title' => 'asc');
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$this->Paginator->request->params['paging']['Article']['page'] = 1;
 
 		$test = array('url' => array(
@@ -2441,9 +2344,6 @@ class PaginatorHelperTest extends TestCase {
 				'prevPage' => false,
 				'nextPage' => true,
 				'pageCount' => 1,
-				'options' => array(
-					'page' => 1,
-				),
 			)
 		);
 		$this->assertFalse($this->Paginator->numbers());
@@ -2466,10 +2366,6 @@ class PaginatorHelperTest extends TestCase {
 				'nextPage' => false,
 				'pageCount' => 0,
 				'limit' => 10,
-				'options' => array(
-					'page' => 0,
-					'conditions' => array()
-				),
 			)
 		);
 

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -54,8 +54,9 @@ class PaginatorHelperTest extends TestCase {
 					'prevPage' => false,
 					'nextPage' => true,
 					'pageCount' => 7,
-					'order' => null,
-					'limit' => 20,
+					'sort' => null,
+					'direction' => null,
+					'limit' => null,
 				)
 			)
 		));
@@ -228,7 +229,7 @@ class PaginatorHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-		$this->Paginator->request->params['paging']['Article']['sort'] = 'asc';
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
 		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'asc'));
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'asc'),
@@ -396,14 +397,6 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testSortKey() {
-		$result = $this->Paginator->sortKey(null, array(
-			'order' => array('Article.title' => 'desc'
-		)));
-		$this->assertEquals('Article.title', $result);
-
-		$result = $this->Paginator->sortKey('Article', array('order' => 'Article.title'));
-		$this->assertEquals('Article.title', $result);
-
 		$result = $this->Paginator->sortKey('Article', array('sort' => 'Article.title'));
 		$this->assertEquals('Article.title', $result);
 
@@ -418,16 +411,15 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testSortKeyFallbackToParams() {
-		$this->Paginator->request->params['paging']['Article']['order'] = 'Article.body';
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
 		$result = $this->Paginator->sortKey();
 		$this->assertEquals('Article.body', $result);
 
 		$result = $this->Paginator->sortKey('Article');
 		$this->assertEquals('Article.body', $result);
 
-		$this->Paginator->request->params['paging']['Article']['order'] = array(
-			'Article.body' => 'DESC'
-		);
+		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.body';
+		$this->Paginator->request->params['paging']['Article']['order'] = 'DESC';
 		$result = $this->Paginator->sortKey();
 		$this->assertEquals('Article.body', $result);
 
@@ -1906,6 +1898,7 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testFirstAndLastTag() {
+		$this->Paginator->request->params['paging']['Article']['page'] = 2;
 		$result = $this->Paginator->first('<<', array('tag' => 'li', 'class' => 'first'));
 		$expected = array(
 			'li' => array('class' => 'first'),
@@ -1963,6 +1956,8 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testFirstFullBaseUrl() {
+		$this->Paginator->request->params['paging']['Article']['page'] = 3;
+		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
 		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
 		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
 
@@ -1987,6 +1982,7 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testFirstBoundaries() {
+		$this->Paginator->request->params['paging']['Article']['page'] = 3;
 		$result = $this->Paginator->first();
 		$expected = array(
 			'<span',

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1959,7 +1959,6 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params['paging']['Article']['page'] = 3;
 		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
 		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-		$this->Paginator->request->params['paging']['Article']['direction'] = 'DESC';
 
 		$this->Paginator->options(array('url' => array('_full' => true)));
 

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -351,9 +351,9 @@ class PaginatorHelper extends Helper {
 		$paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 		$url = [
 			'page' => $paging['page'],
-			'sort' => $paging['sort'],
-			'direction' => $paging['sort'],
 			'limit' => $paging['limit'],
+			'sort' => $paging['sort'],
+			'direction' => $paging['direction'],
 		];
 		$url = array_merge(array_filter($url), $options);
 

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -25,7 +25,6 @@ use Cake\View\View;
  *
  * PaginationHelper encloses all methods needed when working with pagination.
  *
- * @package Cake.View.Helper
  * @property HtmlHelper $Html
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html
  */
@@ -57,9 +56,7 @@ class PaginatorHelper extends Helper {
  *
  * @var array
  */
-	public $options = array(
-		'convertKeys' => array('page', 'limit', 'sort', 'direction')
-	);
+	public $options = [];
 
 /**
  * Before render callback. Overridden to merge passed args with url options.
@@ -135,9 +132,6 @@ class PaginatorHelper extends Helper {
 			);
 			unset($options[$model]);
 		}
-		if (!empty($options['convertKeys'])) {
-			$options['convertKeys'] = array_merge($this->options['convertKeys'], $options['convertKeys']);
-		}
 		$this->options = array_filter(array_merge($this->options, $options));
 	}
 
@@ -168,17 +162,10 @@ class PaginatorHelper extends Helper {
  */
 	public function sortKey($model = null, $options = array()) {
 		if (empty($options)) {
-			$params = $this->params($model);
-			$options = $params['options'];
+			$options = $this->params($model);
 		}
-		if (isset($options['sort']) && !empty($options['sort'])) {
+		if (!empty($options['sort'])) {
 			return $options['sort'];
-		}
-		if (isset($options['order'])) {
-			return is_array($options['order']) ? key($options['order']) : $options['order'];
-		}
-		if (isset($params['order'])) {
-			return is_array($params['order']) ? key($params['order']) : $params['order'];
 		}
 		return null;
 	}
@@ -196,16 +183,11 @@ class PaginatorHelper extends Helper {
 		$dir = null;
 
 		if (empty($options)) {
-			$params = $this->params($model);
-			$options = $params['options'];
+			$options = $this->params($model);
 		}
 
 		if (isset($options['direction'])) {
 			$dir = strtolower($options['direction']);
-		} elseif (isset($options['order']) && is_array($options['order'])) {
-			$dir = strtolower(current($options['order']));
-		} elseif (isset($params['order']) && is_array($params['order'])) {
-			$dir = strtolower(current($params['order']));
 		}
 
 		if ($dir === 'desc') {
@@ -350,7 +332,6 @@ class PaginatorHelper extends Helper {
 			$url = array_merge((array)$options['url'], (array)$url);
 			unset($options['url']);
 		}
-		unset($options['convertKeys']);
 
 		$url = $this->url($url, true, $model);
 		return $this->Html->link($title, $url, $options);
@@ -367,16 +348,15 @@ class PaginatorHelper extends Helper {
  */
 	public function url($options = array(), $asArray = false, $model = null) {
 		$paging = $this->params($model);
-		$url = array_merge(array_filter($paging['options']), $options);
+		$paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
+		$url = [
+			'page' => $paging['page'],
+			'sort' => $paging['sort'],
+			'direction' => $paging['sort'],
+			'limit' => $paging['limit'],
+		];
+		$url = array_merge(array_filter($url), $options);
 
-		if (isset($url['order'])) {
-			$sort = $direction = null;
-			if (is_array($url['order'])) {
-				list($sort, $direction) = array($this->sortKey($model, $url), current($url['order']));
-			}
-			unset($url['order']);
-			$url = array_merge($url, compact('sort', 'direction'));
-		}
 		if (!empty($url['page']) && $url['page'] == 1) {
 			$url['page'] = null;
 		}


### PR DESCRIPTION
This is the first of a few pull requests to clean up and improve Pagination helper + component. I've started by reducing the number of parameters that are passed between the component + helper. 

There was a fair bit of duplication in the 'options' subkey that really doesn't need to exist. This change removes that duplication and also removes the 'order' key in favor of the sort/direction keys which is what the order was composed of. This makes internal access simpler and require fewer function calls.
