### PR TITLE
Added TreeBehavior::generateTreeArray(), the big brother of TreeBehavior::generateTreeList()

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -344,36 +344,35 @@ class TreeBehavior extends ModelBehavior {
  * @param Model $Model Model instance
  * @param array $records Initial list of records to start with (usually just a blank array())
  * @param string $spacer The character or characters which will be repeated
- * @param integer $parent_id The record id to start with (usually NULL to start from the root node)
+ * @param integer $ParentId The record id to start with (usually NULL to start from the root node)
  * @param string|array $fields Table fields as a string or as an array('Model.field1','Model.Field2',...)
  * @param string|array $order SQL conditions as a string or as an array('Model.field1' =>'ASC',...)
  * @param string|array $conditions SQL conditions as a string or as an array('field' =>'value',...)
- * @param string $parent_id_field_name The name of the parent_id column (e.g. parent_id)
+ * @param string $ParentIdFieldName The name of the parent_id column (e.g. parent_id)
  * @return array An associative array of records
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::generateTreeArray
  */
-	public function generateTreeArray(Model $model, $records=array(), $spacer="_", $parent_id=NULL, $fields=array(), $order= array(), $conditions=array(), $parent_id_field_name="parent_id"){
+	public function generateTreeArray(Model $model, $records=array(), $spacer="_", $ParentId=null, $fields=array(), $order= array(), $conditions=array(), $ParentIdFieldName="parent_id") {
+		$ParentIdColumnName = sprintf("%s.%s", $model->alias, $ParentIdFieldName);
+		$conditions[$ParentIdColumnName] = $ParentId;
 
-		$parent_id_column_name = sprintf("%s.%s", $model->alias, $parent_id_field_name);
-		$conditions[$parent_id_column_name] = $parent_id;
-
-		$spacer_to_use = "";
-		if($parent_id != NULL){
-			$spacer_to_use = $spacer; // the root records does not need a spacer
+		$SpacerToUse = "";
+		if ($ParentId != null) {
+			$SpacerToUse = $spacer; // the root records does not need a spacer
 		}
 		$model->recursive = -1;
-		$children = $model->find("all", compact("conditions","fields","order"));
-		if((bool)$children){
-			foreach($children as $child){
+		$children = $model->find("all", compact("conditions", "fields", "order"));
+		if ((bool)$children) {
+			foreach ($children as $child) {
 				// add the prefix to the child record
-				$child[$model->alias]['tree_prefix'] = $spacer_to_use;
+				$child[$model->alias]['tree_prefix'] = $SpacerToUse;
 
 				// add the child to the tree
 				$records[] = $child;
 
 				// find all the children under the current child
-				$child_record_id = $child[$model->alias][$model->primaryKey];
-				$records = $model->generateTreeArray($records, $spacer_to_use.$spacer, $child_record_id, $fields, $order, $conditions, $parent_id_field_name);
+				$ChildRecordId = $child[$model->alias][$model->primaryKey];
+				$records = $model->generateTreeArray($records, $SpacerToUse . $spacer, $ChildRecordId, $fields, $order, $conditions, $ParentIdFieldName);
 			}
 		}
 		return $records;

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -339,6 +339,47 @@ class TreeBehavior extends ModelBehavior {
 	}
 
 /**
+ * A convenience method for returning an associative hierarchical array of the tree
+ *
+ * @param Model $Model Model instance
+ * @param array $records Initial list of records to start with (usually just a blank array())
+ * @param string $spacer The character or characters which will be repeated
+ * @param integer $parent_id The record id to start with (usually NULL to start from the root node)
+ * @param string|array $fields Table fields as a string or as an array('Model.field1','Model.Field2',...)
+ * @param string|array $order SQL conditions as a string or as an array('Model.field1' =>'ASC',...)
+ * @param string|array $conditions SQL conditions as a string or as an array('field' =>'value',...)
+ * @param string $parent_id_field_name The name of the parent_id column (e.g. parent_id)
+ * @return array An associative array of records
+ * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::generateTreeArray
+ */
+	public function generateTreeArray(Model $model, $records=array(), $spacer="_", $parent_id=NULL, $fields=array(), $order= array(), $conditions=array(), $parent_id_field_name="parent_id"){
+
+		$parent_id_column_name = sprintf("%s.%s", $model->alias, $parent_id_field_name);
+		$conditions[$parent_id_column_name] = $parent_id;
+
+		$spacer_to_use = "";
+		if($parent_id != NULL){
+			$spacer_to_use = $spacer; // the root records does not need a spacer
+		}
+		$model->recursive = -1;
+		$children = $model->find("all", compact("conditions","fields","order"));
+		if((bool)$children){
+			foreach($children as $child){
+				// add the prefix to the child record
+				$child[$model->alias]['tree_prefix'] = $spacer_to_use;
+
+				// add the child to the tree
+				$records[] = $child;
+
+				// find all the children under the current child
+				$child_record_id = $child[$model->alias][$model->primaryKey];
+				$records = $model->generateTreeArray($records, $spacer_to_use.$spacer, $child_record_id, $fields, $order, $conditions, $parent_id_field_name);
+			}
+		}
+		return $records;
+	}
+
+/**
  * A convenience method for returning a hierarchical array used for HTML select boxes
  *
  * @param Model $Model Model instance

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -1428,6 +1428,95 @@ class TreeBehaviorNumberTest extends CakeTestCase {
 	}
 
 /**
+ * testGenerateTreeArray method
+ *
+ * @return void
+ */
+	public function testGenerateTreeArray() {
+		extract($this->settings);
+		$this->Tree = new $modelClass();
+		$this->Tree->order = null;
+		$this->Tree->bindModel(array('belongsTo' => array('Dummy' =>
+			array('className' => $modelClass, 'foreignKey' => $parentField, 'conditions' => array('Dummy.id' => null)))), false);
+		$this->Tree->initialize(2, 2);
+
+		$result = $this->Tree->generateTreeArray();
+		$expected = array(
+			array(
+				"NumberTree" => array(
+					'id' => '1',
+					'name' => '1. Root',
+					'parent_id' => null,
+					'lft' => '1',
+					'rght' => '14',
+					'tree_prefix' => ''
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '2',
+					'name' => '1.1',
+					'parent_id' => '1',
+					'lft' => '2',
+					'rght' => '7',
+					'tree_prefix' => '_'
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '3',
+					'name' => '1.1.1',
+					'parent_id' => '2',
+					'lft' => '3',
+					'rght' => '4',
+					'tree_prefix' => '__'
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '4',
+					'name' => '1.1.2',
+					'parent_id' => '2',
+					'lft' => '5',
+					'rght' => '6',
+					'tree_prefix' => '__'
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '5',
+					'name' => '1.2',
+					'parent_id' => '1',
+					'lft' => '8',
+					'rght' => '13',
+					'tree_prefix' => '_'
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '6',
+					'name' => '1.2.1',
+					'parent_id' => '5',
+					'lft' => '9',
+					'rght' => '10',
+					'tree_prefix' => '__'
+				)
+			),
+			array(
+				"NumberTree" => array(
+					'id' => '7',
+					'name' => '1.2.2',
+					'parent_id' => '5',
+					'lft' => '11',
+					'rght' => '12',
+					'tree_prefix' => '__'
+				)
+			)
+		);
+		$this->assertSame($expected, $result);
+	}
+
+/**
  * Test the formatting options of generateTreeList()
  *
  * @return void


### PR DESCRIPTION
The method TreeBehavior::generateTreeList() generates a simple array of only the record id and name of the node and its corresponding spacer to indicate its hierarchy. However, such list might limit you to the things you can do. 

So, I created a recursive method TreeBehavior::generateTreeArray(), which returns an associative array of the record. And the method also allows you to sort by any other custom fields or add other conditions if needed.

FYI commit a632769 has the codes that passes phpcs --standard=CakePHP tests.

You can see a screenshot of the final output below. The first array is from TreeBehavior::generateTreeList(), while the second array is from TreeBehavior::generateTreeArray().

![screen shot 2013-09-19 at 11 34 51 pm](https://f.cloud.github.com/assets/4078130/1178403/4c9f204e-21ae-11e3-96c9-2c59b8a00ba1.png)
