### PR TITLE
Do not assume CONTENT_TYPE is available, fall back to CakeResponse::type()

### DIFF
--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -518,6 +518,9 @@ class RequestHandlerComponent extends Component {
 		}
 
 		list($contentType) = explode(';', env('CONTENT_TYPE'));
+		if (is_null($contentType)) {
+			$contentType = $this->response->type();
+		}
 		if (!$type) {
 			return $this->mapType($contentType);
 		}

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -518,7 +518,7 @@ class RequestHandlerComponent extends Component {
 		}
 
 		list($contentType) = explode(';', env('CONTENT_TYPE'));
-		if ($contentType === null) {
+		if ($contentType === '') {
 			list($contentType) = explode(';', CakeRequest::header('CONTENT_TYPE'));
 		}
 		if (!$type) {

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -519,7 +519,7 @@ class RequestHandlerComponent extends Component {
 
 		list($contentType) = explode(';', env('CONTENT_TYPE'));
 		if ($contentType === null) {
-			$contentType = explode(';', CakeRequest::header('CONTENT_TYPE'));
+			list($contentType) = explode(';', CakeRequest::header('CONTENT_TYPE'));
 		}
 		if (!$type) {
 			return $this->mapType($contentType);

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -518,8 +518,8 @@ class RequestHandlerComponent extends Component {
 		}
 
 		list($contentType) = explode(';', env('CONTENT_TYPE'));
-		if (is_null($contentType)) {
-			$contentType = $this->response->type();
+		if ($contentType === null) {
+			$contentType = explode(';', CakeRequest::header('CONTENT_TYPE'));
 		}
 		if (!$type) {
 			return $this->mapType($contentType);

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -603,6 +603,16 @@ class RequestHandlerComponentTest extends CakeTestCase {
 		$result = $this->RequestHandler->requestedWith(array('rss', 'atom'));
 		$this->assertFalse($result);
 
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		unset($_SERVER['CONTENT_TYPE']);
+		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
+
+		$result = $this->RequestHandler->requestedWith(array('json', 'xml'));
+		$this->assertEquals('json', $result);
+
+		$result = $this->RequestHandler->requestedWith(array('rss', 'atom'));
+		$this->assertFalse($result);
+
 		$_SERVER['HTTP_ACCEPT'] = 'text/xml,application/xml,application/xhtml+xml,text/html,text/plain,image/png,*/*';
 		$this->assertTrue($this->RequestHandler->isXml());
 		$this->assertFalse($this->RequestHandler->isAtom());


### PR DESCRIPTION
Not all servers will provide a CONTENT_TYPE environment variable.

In such a situation, the user is required to decode POST data explicitly with CakeRequest::input().

This patch falls back to CakeResponse::type() to determine the content type when the existing check provides null.
