### PR TITLE
Added a method File::replace() to the File Utilities

### DIFF
--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -557,11 +557,7 @@ class FileTest extends CakeTestCase {
 
 		// Double check
 		$contents = $TmpFile->read();
-		if (strpos($contents, "public functionsdfsa testPassed") === false) {
-			$this->assertTrue(false);
-		} else {
-			$this->assertTrue(true);
-		}
+		$this->assertContains("* testReplace method passed", $contents);
 
 		$TmpFile->delete();
 	}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -541,6 +541,32 @@ class FileTest extends CakeTestCase {
 	}
 
 /**
+ * testReplace method
+ *
+ * @return void
+ */
+	public function testReplace() {
+		$TestFile = new File(__FILE__);
+		$TmpFile = new File(TMP . 'tests' . DS . 'cakephp.file.test.tmp');
+		// Copy the test file to the temporary location
+		$TestFile->copy($TmpFile->path, true);
+
+		// Replace the contents of the tempory file
+		$result = $TmpFile->replace("* testReplace method", "* testReplace method passed");
+		$this->assertTrue($result);
+
+		// Double check
+		$contents = $TmpFile->read();
+		if (strpos($contents, "public functionsdfsa testPassed") === false) {
+			$this->assertTrue(false);
+		} else {
+			$this->assertTrue(true);
+		}
+
+		$TmpFile->delete();
+	}
+
+/**
  * getTmpFile method
  *
  * @param boolean $paintSkip

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -574,7 +574,6 @@ class File {
  * @param  string $search
  * @param  string $replace
  * @return boolean Success
- * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::replace
  */
 	public function replace($search, $replace) {
 		if (!$this->exists()) {
@@ -585,7 +584,7 @@ class File {
 			return false;
 		}
 
-		$TemporaryFile = new File(TMP . DS . "temp_" . time(), true, 0666);
+		$TemporaryFile = new File(tempnam(TMP, "temp_"));
 
 		if (!$TemporaryFile->writable() || !$TemporaryFile->readable()) {
 			return false;

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -569,4 +569,45 @@ class File {
 		return false;
 	}
 
+/**
+ * Searches for a given text and replaces the text if found
+ * @param  string $search
+ * @param  string $replace
+ * @return boolean Success
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::replace
+ */
+	public function replace($search, $replace) {
+		if (!$this->exists()) {
+			return false;
+		}
+
+		if (!$this->readable() || !$this->writable()) {
+			return false;
+		}
+
+		$TemporaryFile = new File(TMP . DS . "temp_" . time(), true, 0666);
+
+		if (!$TemporaryFile->writable() || !$TemporaryFile->readable()) {
+			return false;
+		}
+
+		$this->open();
+		$TemporaryFile->open();
+
+		while (!feof($this->handle)) {
+			$data = fgets($this->handle, 4096);
+			$TemporaryFile->append(str_replace($search, $replace, $data), true);
+		}
+
+		$TemporaryFile->close();
+		$this->close();
+
+		// overwrite the original file
+		$replaced = $TemporaryFile->copy($this->path, true);
+
+		$TemporaryFile->delete();
+
+		return $replaced;
+	}
+
 }


### PR DESCRIPTION
This method allows you to search the current file for a specific string, and replace it with a given argument.

Very useful for custom shell scripts or any general file operation where you need to replace specific contents of a file.

FYI, I wrote the method in such a way that it can handle large files. General file_get_contents() method may not work well for large files, so I used fgets() to read the string in a buffer and then try the replacement operations.
