### PR TITLE
Added a method File::replace() to the File Utilities

### DIFF
--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -564,23 +564,23 @@ class FileTest extends CakeTestCase {
 	}
 
 /**
- * testReplace method
+ * testReplaceText method
  *
  * @return void
  */
-	public function testReplace() {
+	public function testReplaceText() {
 		$TestFile = new File(__FILE__);
 		$TmpFile = new File(TMP . 'tests' . DS . 'cakephp.file.test.tmp');
 		// Copy the test file to the temporary location
 		$TestFile->copy($TmpFile->path, true);
 
 		// Replace the contents of the tempory file
-		$result = $TmpFile->replace("* testReplace method", "* testReplace method passed");
+		$result = $TmpFile->replaceText("* testReplaceText method", "* testReplaceText method passed");
 		$this->assertTrue($result);
 
 		// Double check
 		$contents = $TmpFile->read();
-		$this->assertContains("* testReplace method passed", $contents);
+		$this->assertContains("* testReplaceText method passed", $contents);
 
 		$TmpFile->delete();
 	}

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -562,4 +562,26 @@ class FileTest extends CakeTestCase {
 		}
 		return false;
 	}
+
+/**
+ * testReplace method
+ *
+ * @return void
+ */
+	public function testReplace() {
+		$TestFile = new File(__FILE__);
+		$TmpFile = new File(TMP . 'tests' . DS . 'cakephp.file.test.tmp');
+		// Copy the test file to the temporary location
+		$TestFile->copy($TmpFile->path, true);
+
+		// Replace the contents of the tempory file
+		$result = $TmpFile->replace("* testReplace method", "* testReplace method passed");
+		$this->assertTrue($result);
+
+		// Double check
+		$contents = $TmpFile->read();
+		$this->assertContains("* testReplace method passed", $contents);
+
+		$TmpFile->delete();
+	}
 }

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -589,20 +589,15 @@ class File {
 
 /**
  * Searches for a given text and replaces the text if found
- * @param  string $search
- * @param  string $replace
+ * @param string $search
+ * @param string $replace
  * @return boolean Success
  */
 	public function replaceText($search, $replace) {
-		if (!$this->exists()) {
+		if (!$this->open("r+")) {
 			return false;
 		}
 
-		if (!$this->readable() || !$this->writable()) {
-			return false;
-		}
-
-		$this->open();
 		if ($this->lock !== null) {
 			if (flock($this->handle, LOCK_EX) === false) {
 				return false;

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -602,29 +602,19 @@ class File {
 			return false;
 		}
 
-		$TemporaryFile = new File(tempnam(TMP, "temp_"));
-
-		if (!$TemporaryFile->writable() || !$TemporaryFile->readable()) {
-			return false;
-		}
-
 		$this->open();
-		if (flock($this->handle, LOCK_EX) === false) {
-			return false;
+		if ($this->lock !== null) {
+			if (flock($this->handle, LOCK_EX) === false) {
+				return false;
+			}
 		}
 
-		$TemporaryFile->open();
-		$TemporaryFile->write(str_replace($search, $replace, $this->read()), "w", true);
-		$TemporaryFile->close();
-
-		$replaced = $TemporaryFile->copy($this->path, true);
+		$replaced = $this->write(str_replace($search, $replace, $this->read()), "w", true);
 
 		if ($this->lock !== null) {
 			flock($this->handle, LOCK_UN);
 		}
 		$this->close();
-
-		$TemporaryFile->delete();
 
 		return $replaced;
 	}

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -587,4 +587,39 @@ class File {
 		return clearstatcache();
 	}
 
+/**
+ * Searches for a given text and replaces the text if found
+ * @param  string $search
+ * @param  string $replace
+ * @return boolean Success
+ */
+	public function replace($search, $replace) {
+		if (!$this->exists()) {
+			return false;
+		}
+
+		if (!$this->readable() || !$this->writable()) {
+			return false;
+		}
+
+		$TemporaryFile = new File(tempnam(TMP, "temp_"));
+
+		if (!$TemporaryFile->writable() || !$TemporaryFile->readable()) {
+			return false;
+		}
+
+		$this->open();
+		$TemporaryFile->open();
+		$TemporaryFile->write(str_replace($search, $replace, $this->read()), "w", true);
+		$TemporaryFile->close();
+		$this->close();
+
+		// overwrite the original file
+		$replaced = $TemporaryFile->copy($this->path, true);
+
+		$TemporaryFile->delete();
+
+		return $replaced;
+	}
+
 }


### PR DESCRIPTION
Reopened Against Branch 2.5.

This method allows you to search the current file for a specific string, and replace it with a given argument. Very useful for custom shell scripts or any general file operation where you need to replace specific contents of a file.

My apologizes to markstory. The original pull requests can be found here: https://github.com/cakephp/cakephp/pull/1663 and https://github.com/cakephp/cakephp/pull/1664. My original cakephp repository was faulty because the branch I was using was custom created and it was not an actual upstream/master branch. Anyways, here are some of the answers from the original pull request.

1) I realized that if the file is too big to process then it makes sense for the developer to use the terminal or increasing the memory limit. Because if we read a file piece by piece and run the replacement against one piece at a time and the string you are searching for gets split between the bytes, it will fail to replace the text. So, I changed the code to use CakePHP's $file->read() method.

Thanks :)
