### PR TITLE
3.0 - Paginator templates part 1

### DIFF
--- a/Cake/Test/TestApp/Config/test_templates.php
+++ b/Cake/Test/TestApp/Config/test_templates.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Template strings for testing.
+ */
+$config = [
+	'link' => '<a href="{{url}}">{{text}}</a>',
+];

--- a/Cake/Test/TestApp/Plugin/TestPlugin/Config/test_templates.php
+++ b/Cake/Test/TestApp/Plugin/TestPlugin/Config/test_templates.php
@@ -1,0 +1,4 @@
+<?php
+$config = [
+	'italic' => '<em>{{text}}</em>',
+];

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -101,9 +101,9 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testHasPrevious() {
-		$this->assertFalse($this->Paginator->hasPrev());
+		$this->assertSame($this->Paginator->hasPrev(), false);
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
-		$this->assertTrue($this->Paginator->hasPrev());
+		$this->assertSame($this->Paginator->hasPrev(), true);
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
 	}
 
@@ -113,9 +113,9 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testHasNext() {
-		$this->assertTrue($this->Paginator->hasNext());
+		$this->assertSame($this->Paginator->hasNext(), true);
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = false;
-		$this->assertFalse($this->Paginator->hasNext());
+		$this->assertSame($this->Paginator->hasNext(), false);
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = true;
 	}
 
@@ -914,7 +914,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->prev('Prev', [
 			'model' => 'Client'
 		]);
-		$expected ='<li class="prev disabled"><span>Prev</span></li>';
+		$expected = '<li class="prev disabled"><span>Prev</span></li>';
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->next('Next', [

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -128,15 +128,13 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = false;
 		$this->Paginator->request->params['paging']['Article']['page'] = 1;
 		$result = $this->Paginator->next('Next', array(), true);
-		$expected = '<span class="next">Next</span>';
+		$expected = '<li class="next"><span>Next</span>';
 		$this->assertEquals($expected, $result);
 
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
-		$result = $this->Paginator->prev('prev', array('url' => array('controller' => 'posts')), null, array('class' => 'disabled', 'tag' => 'span'));
-		$expected = array(
-			'span' => array('class' => 'disabled'), 'prev', '/span'
-		);
-		$this->assertTags($result, $expected);
+		$result = $this->Paginator->prev('prev', array('url' => array('controller' => 'posts')));
+		$expected = '<li class="prev"><span>prev</span>';
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -619,21 +617,21 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->next('next', array('url' => $options));
 		$expected = array(
-			'span' => array('class' => 'next'),
+			'li' => array('class' => 'next'),
 			'a' => array('href' => '/members/posts/index?page=3', 'rel' => 'next'),
 			'next',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->prev('prev', array('url' => $options));
 		$expected = array(
-			'span' => array('class' => 'prev'),
+			'li' => array('class' => 'prev'),
 			'a' => array('href' => '/members/posts/index', 'rel' => 'prev'),
 			'prev',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
@@ -752,11 +750,11 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * testPagingLinks method
+ * Test the prev() method.
  *
  * @return void
  */
-	public function testPagingLinks() {
+	public function testPrev() {
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
 				'page' => 1,
@@ -767,246 +765,48 @@ class PaginatorHelperTest extends TestCase {
 				'pageCount' => 5,
 			)
 		);
-		$result = $this->Paginator->prev('<< Previous', null, null, array('class' => 'disabled'));
+		$result = $this->Paginator->prev('<< Previous');
 		$expected = array(
-			'span' => array('class' => 'disabled'),
-			'&lt;&lt; Previous',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', null, null, array('class' => 'disabled', 'tag' => 'div'));
-		$expected = array(
-			'div' => array('class' => 'disabled'),
-			'&lt;&lt; Previous',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging']['Client']['page'] = 2;
-		$this->Paginator->request->params['paging']['Client']['prevPage'] = true;
-		$result = $this->Paginator->prev('<< Previous', null, null, array('class' => 'disabled'));
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/index', 'rel' => 'prev'),
-			'&lt;&lt; Previous',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', array('tag' => false), null, array('class' => 'disabled'));
-		$expected = array(
-			'a' => array('href' => '/index', 'rel' => 'prev', 'class' => 'prev'),
-			'&lt;&lt; Previous',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev(
-			'<< Previous',
-			array(),
-			null,
-			array('disabledTag' => 'span', 'class' => 'disabled')
-		);
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/index', 'rel' => 'prev'),
-			'&lt;&lt; Previous',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->next('Next');
-		$expected = array(
-			'span' => array('class' => 'next'),
-			'a' => array('href' => '/index?page=3', 'rel' => 'next'),
-			'Next',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->next('Next', array('tag' => 'li'));
-		$expected = array(
-			'li' => array('class' => 'next'),
-			'a' => array('href' => '/index?page=3', 'rel' => 'next'),
-			'Next',
-			'/a',
-			'/li'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->next('Next', array('tag' => false));
-		$expected = array(
-			'a' => array('href' => '/index?page=3', 'rel' => 'next', 'class' => 'next'),
-			'Next',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', array('escape' => true));
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/index', 'rel' => 'prev'),
-			'&lt;&lt; Previous',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', array('escape' => false));
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/index', 'rel' => 'prev'),
-			'preg:/<< Previous/',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 1,
-				'current' => 1,
-				'count' => 13,
-				'prevPage' => false,
-				'nextPage' => true,
-				'pageCount' => 5,
-			)
-		);
-
-		$result = $this->Paginator->prev('<< Previous', null, '<strong>Disabled</strong>');
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'&lt;strong&gt;Disabled&lt;/strong&gt;',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', null, '<strong>Disabled</strong>', array('escape' => true));
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'&lt;strong&gt;Disabled&lt;/strong&gt;',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', null, '<strong>Disabled</strong>', array('escape' => false));
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'<strong', 'Disabled', '/strong',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev('<< Previous', array('tag' => false), '<strong>Disabled</strong>');
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'&lt;strong&gt;Disabled&lt;/strong&gt;',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->prev(
-			'<< Previous',
-			array('tag' => 'li'),
-			null,
-			array('tag' => 'li', 'disabledTag' => 'span', 'class' => 'disabled')
-		);
-		$expected = array(
-			'li' => array('class' => 'disabled'),
+			'li' => array('class' => 'prev disabled'),
 			'span' => array(),
 			'&lt;&lt; Previous',
 			'/span',
 			'/li'
 		);
 		$this->assertTags($result, $expected);
-		$result = $this->Paginator->prev(
-			'<< Previous',
-			array(),
-			null,
-			array('tag' => false, 'disabledTag' => 'span', 'class' => 'disabled')
-		);
+
+		$result = $this->Paginator->prev('<< Previous', ['disabledTitle' => 'Prev']);
 		$expected = array(
-			'span' => array('class' => 'disabled'),
-			'&lt;&lt; Previous',
+			'li' => array('class' => 'prev disabled'),
+			'span' => array(),
+			'Prev',
 			'/span',
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 1,
-				'current' => 3,
-				'count' => 13,
-				'prevPage' => false,
-				'nextPage' => true,
-				'pageCount' => 5,
-				'sort' => 'Client.name',
-				'direction' => 'DESC',
-				'limit' => 3,
-			)
-		);
+		$result = $this->Paginator->prev('<< Previous', ['disabledTitle' => false]);
+		$this->assertEquals('', $result, 'disabled + no text = no link');
 
 		$this->Paginator->request->params['paging']['Client']['page'] = 2;
 		$this->Paginator->request->params['paging']['Client']['prevPage'] = true;
-		$result = $this->Paginator->prev('<< Previous', null, null, array('class' => 'disabled'));
+		$result = $this->Paginator->prev('<< Previous');
 		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array(
-				'href' => '/index?limit=3&amp;sort=Client.name&amp;direction=DESC',
-				'rel' => 'prev'
-			),
+			'li' => array('class' => 'prev'),
+			'a' => array('href' => '/index', 'rel' => 'prev'),
 			'&lt;&lt; Previous',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
+	}
 
-		$result = $this->Paginator->next('Next');
-		$expected = array(
-			'span' => array('class' => 'next'),
-			'a' => array(
-				'href' => '/index?page=3&amp;limit=3&amp;sort=Client.name&amp;direction=DESC',
-				'rel' => 'next'
-			),
-			'Next',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 1,
-				'count' => 13,
-				'prevPage' => true,
-				'nextPage' => false,
-				'pageCount' => 2,
-				'limit' => 10,
-			)
-		);
-		$result = $this->Paginator->prev('Prev');
-		$expected = array(
-			'span' => array('class' => 'prev'),
-			'a' => array('href' => '/index?limit=10', 'rel' => 'prev'),
-			'Prev',
-			'/a',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->next('Next', array(), null, array('tag' => false));
-		$expected = array(
-			'span' => array('class' => 'next'),
-			'Next',
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
+/**
+ * Test that prev() and the shared implementation underneath picks up from optins
+ *
+ * @return void
+ */
+	public function testPrevWithOptions() {
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
 				'page' => 2, 'current' => 1, 'count' => 13, 'prevPage' => true,
@@ -1017,11 +817,73 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->options(array('url' => array(12, 'page' => 3)));
 		$result = $this->Paginator->prev('Prev', array('url' => array('foo' => 'bar')));
 		$expected = array(
-			'span' => array('class' => 'prev'),
+			'li' => array('class' => 'prev'),
 			'a' => array('href' => '/index/12?limit=10&amp;foo=bar', 'rel' => 'prev'),
 			'Prev',
 			'/a',
-			'/span'
+			'/li'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * test the next() method.
+ *
+ * @return void
+ */
+	public function testNext() {
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 5,
+				'current' => 3,
+				'count' => 13,
+				'prevPage' => true,
+				'nextPage' => false,
+				'pageCount' => 5,
+			)
+		);
+		$result = $this->Paginator->next('Next >>');
+		$expected = array(
+			'li' => array('class' => 'next disabled'),
+			'span' => array(),
+			'Next &gt;&gt;',
+			'/span',
+			'/li'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->next('Next >>', ['disabledTitle' => 'Next']);
+		$expected = array(
+			'li' => array('class' => 'next disabled'),
+			'span' => array(),
+			'Next',
+			'/span',
+			'/li'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->next('Next >>', ['disabledTitle' => false]);
+		$this->assertEquals('', $result, 'disabled + no text = no link');
+
+		$this->Paginator->request->params['paging']['Client']['page'] = 3;
+		$this->Paginator->request->params['paging']['Client']['nextPage'] = true;
+		$result = $this->Paginator->next('Next >>');
+		$expected = array(
+			'li' => array('class' => 'next'),
+			'a' => array('href' => '/index?page=4', 'rel' => 'next'),
+			'Next &gt;&gt;',
+			'/a',
+			'/li'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->next('Next >>', ['escape' => false]);
+		$expected = array(
+			'li' => array('class' => 'next'),
+			'a' => array('href' => '/index?page=4', 'rel' => 'next'),
+			'preg:/Next >>/',
+			'/a',
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 	}

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -101,9 +101,9 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testHasPrevious() {
-		$this->assertSame($this->Paginator->hasPrev(), false);
+		$this->assertFalse($this->Paginator->hasPrev());
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
-		$this->assertSame($this->Paginator->hasPrev(), true);
+		$this->assertTrue($this->Paginator->hasPrev());
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = false;
 	}
 
@@ -113,9 +113,9 @@ class PaginatorHelperTest extends TestCase {
  * @return void
  */
 	public function testHasNext() {
-		$this->assertSame($this->Paginator->hasNext(), true);
+		$this->assertTrue($this->Paginator->hasNext());
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = false;
-		$this->assertSame($this->Paginator->hasNext(), false);
+		$this->assertFalse($this->Paginator->hasNext());
 		$this->Paginator->request->params['paging']['Article']['nextPage'] = true;
 	}
 

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -79,6 +79,23 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
+ * Test the templates method.
+ *
+ * @return void
+ */
+	public function testTemplates() {
+		$result = $this->Paginator->templates([
+			'test' => 'val'
+		]);
+		$this->assertNull($result, 'Setting should return null');
+		$result = $this->Paginator->templates();
+		$this->assertArrayHasKey('test', $result);
+		$this->assertEquals('val', $result['test']);
+
+		$this->assertEquals('val', $this->Paginator->templates('test'));
+	}
+
+/**
  * testHasPrevious method
  *
  * @return void

--- a/Cake/Test/TestCase/View/StringTemplateTest.php
+++ b/Cake/Test/TestCase/View/StringTemplateTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Cake\Test\View;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\StringTemplate;
+
+class StringTemplateTest extends TestCase {
+
+/**
+ * setUp
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->template = new StringTemplate();
+	}
+
+/**
+ * test adding templates.
+ *
+ * @return void
+ */
+	public function testAdd() {
+		$templates = [
+			'link' => '<a href="{{url}}">{{text}}</a>'
+		];
+		$result = $this->template->add($templates);
+		$this->assertNull($result, 'No return');
+
+		$this->assertEquals($templates['link'], $this->template->get('link'));
+	}
+
+/**
+ * Test remove.
+ *
+ * @return void
+ */
+	public function testRemove() {
+		$templates = [
+			'link' => '<a href="{{url}}">{{text}}</a>'
+		];
+		$this->template->add($templates);
+		$this->assertNull($this->template->remove('link'), 'No return');
+		$this->assertNull($this->template->get('link'), 'Template should be gone.');
+	}
+
+/**
+ * Test formatting strings.
+ *
+ * @return void
+ */
+	public function testFormat() {
+		$templates = [
+			'link' => '<a href="{{url}}">{{text}}</a>'
+		];
+		$this->template->add($templates);
+
+		$result = $this->template->format('not there', []);
+		$this->assertSame('', $result);
+
+		$result = $this->template->format('link', [
+			'url' => '/',
+			'text' => 'example'
+		]);
+		$this->assertEquals('<a href="/">example</a>', $result);
+	}
+
+}

--- a/Cake/Test/TestCase/View/StringTemplateTest.php
+++ b/Cake/Test/TestCase/View/StringTemplateTest.php
@@ -1,5 +1,17 @@
 <?php
-
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\Test\View;
 
 use Cake\Core\Plugin;

--- a/Cake/Test/TestCase/View/StringTemplateTest.php
+++ b/Cake/Test/TestCase/View/StringTemplateTest.php
@@ -2,6 +2,7 @@
 
 namespace Cake\Test\View;
 
+use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
 
@@ -65,6 +66,38 @@ class StringTemplateTest extends TestCase {
 			'text' => 'example'
 		]);
 		$this->assertEquals('<a href="/">example</a>', $result);
+	}
+
+/**
+ * Test loading templates files in the app.
+ *
+ * @return void
+ */
+	public function testLoad() {
+		$this->assertEquals([], $this->template->get());
+		$this->assertNull($this->template->load('test_templates'));
+		$this->assertEquals('<a href="{{url}}">{{text}}</a>', $this->template->get('link'));
+	}
+
+/**
+ * Test loading templates files from a plugin
+ *
+ * @return void
+ */
+	public function testLoadPlugin() {
+		Plugin::load('TestPlugin');
+		$this->assertNull($this->template->load('TestPlugin.test_templates'));
+		$this->assertEquals('<em>{{text}}</em>', $this->template->get('italic'));
+	}
+
+/**
+ * Test that loading non-existing templates causes errors.
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage Could not load configuration file
+ */
+	public function testLoadErrorNoFile() {
+		$this->template->load('no_such_file');
 	}
 
 }

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -18,6 +18,7 @@ use Cake\Core\App;
 use Cake\Error;
 use Cake\Utility\Inflector;
 use Cake\View\Helper;
+use Cake\View\StringTemplate;
 use Cake\View\View;
 
 /**
@@ -35,7 +36,7 @@ class PaginatorHelper extends Helper {
  *
  * @var array
  */
-	public $helpers = array('Html');
+	public $helpers = ['Html'];
 
 /**
  * Holds the default options for pagination links
@@ -57,6 +58,52 @@ class PaginatorHelper extends Helper {
  * @var array
  */
 	public $options = [];
+
+/**
+ * StringTemplate instance.
+ *
+ * @var Cake\View\StringTemplate
+ */
+	protected $_templater;
+
+/**
+ * The default templates used by PaginatorHelper.
+ *
+ * @var array
+ */
+	protected $_defaultTemplates = [
+
+	];
+
+/**
+ * Constructor
+ *
+ * @param View $View The View this helper is being attached to.
+ * @param array $settings Configuration settings for the helper.
+ */
+	public function __construct(View $View, $settings = []) {
+		parent::__construct($View, $settings);
+
+		$this->_templater = new StringTemplate();
+		$this->_templater->add($this->_defaultTemplates);
+		if (isset($settings['templates'])) {
+			$this->_templater->load($settings['templates']);
+		}
+	}
+
+/**
+ * Get/set templates to use.
+ *
+ * @param string|null|array $templates null or string allow reading templates. An array 
+ *   allows templates to be added.
+ * @return void|string|array
+ */
+	public function templates($templates = null) {
+		if ($templates === null || is_string($templates)) {
+			return $this->_templater->get($templates);
+		}
+		return $this->_templater->add($templates);
+	}
 
 /**
  * Before render callback. Overridden to merge passed args with url options.

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -262,7 +262,7 @@ class PaginatorHelper extends Helper {
 			$template = $templates['disabled'];
 		}
 
-		if (!$enabled && $text == '') {
+		if (!$enabled && $text === false) {
 			return '';
 		}
 		$text = $options['escape'] ? h($text) : $text;
@@ -294,7 +294,7 @@ class PaginatorHelper extends Helper {
  * ### Options:
  *
  * - `disabledTitle` The text to used when the link is disabled. This
- *   defaults to the same text at the active link. Setting to null or '' will cause
+ *   defaults to the same text at the active link. Setting to false will cause
  *   this method to return ''.
  * - `escape` Whether you want the contents html entity encoded, defaults to true
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
@@ -329,7 +329,7 @@ class PaginatorHelper extends Helper {
  * ### Options:
  *
  * - `disabledTitle` The text to used when the link is disabled. This
- *   defaults to the same text at the active link. Setting to null or '' will cause
+ *   defaults to the same text at the active link. Setting to false will cause
  *   this method to return ''.
  * - `escape` Whether you want the contents html entity encoded, defaults to true
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -248,6 +248,12 @@ class PaginatorHelper extends Helper {
 
 /**
  * Generate an active/inactive link for next/prev methods.
+ *
+ * @param string $text The enabled text for the link.
+ * @param boolean $enabled Whether or not the enabled/disabled version should be created.
+ * @param array $options An array of options from the calling method.
+ * @param array $templates An array of templates with the 'active' and 'disabled' keys.
+ * @return string Generated HTML
  */
 	protected function _toggledLink($text, $enabled, $options, $templates) {
 		$template = $templates['active'];
@@ -312,7 +318,7 @@ class PaginatorHelper extends Helper {
 		$enabled = $this->hasPrev($options['model']);
 		$templates = [
 			'active' => 'prevActive',
-			'disabled' =>  'prevDisabled'
+			'disabled' => 'prevDisabled'
 		];
 		return $this->_toggledLink($title, $enabled, $options, $templates);
 	}

--- a/Cake/View/StringTemplate.php
+++ b/Cake/View/StringTemplate.php
@@ -1,6 +1,10 @@
 <?php
 namespace Cake\View;
 
+use Cake\Core\Plugin;
+use Cake\Configure\Engine\PhpConfig;
+use Cake\Error;
+
 /**
  * Provides a interface for registering and inserting
  * content into simple logic-less string templates.
@@ -16,6 +20,27 @@ class StringTemplate {
  * @var array
  */
 	protected $_templates = [];
+
+/**
+ * Load a config file containing templates.
+ *
+ * Template files should define a `$config` variable containing
+ * all the templates to load. Loaded templates will be merged with existing
+ * templates.
+ *
+ * @param string $file The file to load
+ * @return void
+ */
+	public function load($file) {
+		list($plugin, $file) = pluginSplit($file);
+		$path = APP . 'Config/';
+		if ($plugin !== null) {
+			$path = Plugin::path($plugin) . 'Config/';
+		}
+		$loader = new PhpConfig($path);
+		$templates = $loader->read($file);
+		$this->add($templates);
+	}
 
 /**
  * Add one or more template strings.

--- a/Cake/View/StringTemplate.php
+++ b/Cake/View/StringTemplate.php
@@ -1,4 +1,17 @@
 <?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
 namespace Cake\View;
 
 use Cake\Core\Plugin;

--- a/Cake/View/StringTemplate.php
+++ b/Cake/View/StringTemplate.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\View;
 
-use Cake\Core\Plugin;
 use Cake\Configure\Engine\PhpConfig;
+use Cake\Core\Plugin;
 use Cake\Error;
 
 /**

--- a/Cake/View/StringTemplate.php
+++ b/Cake/View/StringTemplate.php
@@ -1,0 +1,76 @@
+<?php
+namespace Cake\View;
+
+/**
+ * Provides a interface for registering and inserting
+ * content into simple logic-less string templates.
+ *
+ * Used by several helpers to provide simple flexible templates
+ * for generating HTML and other content.
+ */
+class StringTemplate {
+
+/**
+ * The templates this instance holds.
+ *
+ * @var array
+ */
+	protected $_templates = [];
+
+/**
+ * Add one or more template strings.
+ *
+ * @param array $templates The templates to add.
+ * @return void
+ */
+	public function add(array $templates) {
+		$this->_templates = array_merge($this->_templates, $templates);
+	}
+
+/**
+ * Get one or all templates.
+ *
+ * @param string $name Leave null to get all templates, provide a name to get a single template.
+ * @return string|array|null Either the template(s) or null
+ */
+	public function get($name = null) {
+		if ($name === null) {
+			return $this->_templates;
+		}
+		if (!isset($this->_templates[$name])) {
+			return null;
+		}
+		return $this->_templates[$name];
+	}
+
+/**
+ * Remove the named template.
+ *
+ * @param string $name The template to remove.
+ * @return void
+ */
+	public function remove($name) {
+		unset($this->_templates[$name]);
+	}
+
+/**
+ * Format a template string with $data
+ *
+ * @param string $name The template name.
+ * @param array $data The data to insert.
+ * @return string
+ */
+	public function format($name, array $data) {
+		$template = $this->get($name);
+		if ($template === null) {
+			return '';
+		}
+		$replace = [];
+		$keys = array_keys($data);
+		foreach ($keys as $key) {
+			$replace['{{' . $key . '}}'] = $data[$key];
+		}
+		return strtr($template, $replace);
+	}
+
+}


### PR DESCRIPTION
This is the first part of the [proposed changes](https://github.com/markstory/cakephp/wiki/Paginatorhelper-cleanup) for PaginatorHelper and ultimately the other core helpers. I've only update `next()` and `prev()` so far as I wanted to get feedback, make sure I was on the right path before doing the other methods. I've made the default templates use `<li>` elements, this makes it really easy to use with both bootstrap and foundation. Other methods would need to start using li elements as well for everything to work. Some specific things I'd like feedback on:
- I've switched from `{foo}` to `{{foo}}` for placeholders. I thought reusing mustache/twig output braces. This syntax means there would be one fewer placeholder styles to learn/use. Another option is to use `{:foo}` that `String::insert()` already uses. Alternatively, we could make `String` consistent with everything else.
- Almost all of the HTML attribute generation has been removed, this should work well for PaginatorHelper. In other helpers we may still need to have generated attributes that go into a `attributes` placeholder.
- I'm not totally sold on the class name of `StringTemplate`, any suggestions would be great.
- Are there any options that were removed that would still be useful?
- I've intentionally left template options out of next/prev as I generally make all my pagination elements the same, which is what having one set of templates would make easy.

After this is merged, I'm going to start working on the other methods in PaginatorHelper.
