### PR TITLE
Fix minor issue with autoLinkUrls()

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -241,6 +241,10 @@ class TextHelperTest extends CakeTestCase {
 				'Text with a url http://www.not--work.com and more',
 				'Text with a url <a href="http://www.not--work.com">http://www.not--work.com</a> and more',
 			),
+			array(
+				'Text with a url wwww.invalid.com and more',
+				'Text with a url wwww.invalid.com and more',
+			),
 		);
 	}
 

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -112,7 +112,7 @@ class TextHelper extends AppHelper {
 			$text
 		);
 		$text = preg_replace_callback(
-			'#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)www.[^\n\%\ <]+[^<\n\%\,\.\ <](?<!\))#i',
+			'#(?<!href="|">)(?<!\b[[:punct:]])(?<!http://|https://|ftp://|nntp://)\bwww\b.[^\n\%\ <]+[^<\n\%\,\.\ <](?<!\))#i',
 			array(&$this, '_insertPlaceHolder'),
 			$text
 		);


### PR DESCRIPTION
When using invalid URLs such as wwww.example.com

Not even sure that modifying the regex is the best way to go about this, not a strong point unfortunately. This probably won't fix URLs like http://wwww.example.com so suggestions are welcome.

First pull request submitted and just getting used to git so if I've done anything incorrect please let me know.
