### PR TITLE
3.0 testcase

### DIFF
--- a/Cake/Console/Command/UpgradeShell.php
+++ b/Cake/Console/Command/UpgradeShell.php
@@ -53,7 +53,7 @@ class UpgradeShell extends Shell {
 	}
 
 /**
- * Run all upgrade steps one at a time
+ * Run all upgrade steps one at a time.
  *
  * @return void
  */
@@ -69,7 +69,7 @@ class UpgradeShell extends Shell {
 	}
 
 /**
- * Move files and folders to their new homes
+ * Move files and folders to their new homes.
  *
  * @return void
  */
@@ -201,7 +201,7 @@ class UpgradeShell extends Shell {
 	}
 
 /**
- * Replace all the App::uses() calls with `use`
+ * Replace all the App::uses() calls with `use`.
  *
  * @param string $file The file to search and replace.
  * @param boolean $dryRun Whether or not to do the thing.
@@ -351,7 +351,7 @@ class UpgradeShell extends Shell {
 			}
 			foreach ($values as $key => $val) {
 				if (is_array($val)) {
-					$vals[] = "'{$key}' => [" . implode(", ", $export($val)) . "]";
+					$vals[] = "'{$key}' => [" . implode(', ', $export($val)) . ']';
 				} else {
 					$val = var_export($val, true);
 					if ($val === 'NULL') {
@@ -453,22 +453,22 @@ class UpgradeShell extends Shell {
 				[
 					'Rename ComponentCollection',
 					'#ComponentCollection#',
-					"ComponentRegistry",
+					'ComponentRegistry',
 				],
 				[
 					'Rename HelperCollection',
 					'#HelperCollection#',
-					"HelperRegistry",
+					'HelperRegistry',
 				],
 				[
 					'Rename TaskCollection',
 					'#TaskCollection#',
-					"TaskRegistry",
+					'TaskRegistry',
 				],
 			];
 			$this->_updateFileRegexp($filePath, $patterns);
 		}
-		$this->out(__d('cake_console', '<success>Collection class uses rename successfully.</success>'));
+		$this->out(__d('cake_console', '<success>Collection class uses renamed successfully.</success>'));
 	}
 
 /**
@@ -532,11 +532,11 @@ class UpgradeShell extends Shell {
 			];
 			$this->_updateFileRegexp($filePath, $patterns);
 		}
-		$this->out(__d('cake_console', '<success>Collection class uses rename successfully.</success>'));
+		$this->out(__d('cake_console', '<success>Assertion methods renamed successfully.</success>'));
 	}
 
 /**
- * Filter paths to remove webroot, Plugin, tmp directories
+ * Filter paths to remove webroot, Plugin, tmp directories.
  *
  * @return array
  */
@@ -566,7 +566,7 @@ class UpgradeShell extends Shell {
 		if (preg_match('/namespace\s+[a-z0-9\\\]+;/', $contents)) {
 			$this->out(__d(
 				'cake_console',
-				"<warning>Skipping %s as it already has a namespace.</warning>",
+				'<warning>Skipping %s as it already has a namespace.</warning>',
 				$shortPath
 			));
 			return;
@@ -653,7 +653,7 @@ class UpgradeShell extends Shell {
 	}
 
 /**
- * get the option parser
+ * Get the option parser.
  *
  * @return ConsoleOptionParser
  */
@@ -712,7 +712,11 @@ class UpgradeShell extends Shell {
 				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')],
 			])
 			->addSubcommand('rename_collections', [
-				'help' => __d('cake_console', "Rename HelperCollection, ComponentCollection, and TaskCollection. Will also rename component constructor arguments and _Collection properties on all objects."),
+				'help' => __d('cake_console', 'Rename HelperCollection, ComponentCollection, and TaskCollection. Will also rename component constructor arguments and _Collection properties on all objects.'),
+				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')]
+			])
+			->addSubcommand('tests', [
+				'help' => __d('cake_console', 'Rename test case assertion methods.'),
 				'parser' => ['options' => compact('plugin', 'dryRun'), 'arguments' => compact('path')]
 			]);
 	}

--- a/Cake/Console/Command/UpgradeShell.php
+++ b/Cake/Console/Command/UpgradeShell.php
@@ -149,7 +149,7 @@ class UpgradeShell extends Shell {
 			$contents,
 			$count
 		);
-		if ($count == 0) {
+		if ($count === 0) {
 			$this->out(
 				__d('cake_console', '<info>Skip %s as there are no renames to do.</info>', $path),
 				1,
@@ -322,7 +322,7 @@ class UpgradeShell extends Shell {
 		$path = $this->_getPath();
 
 		$app = rtrim(APP, DS);
-		if ($path == $app || !empty($this->params['plugin'])) {
+		if ($path === $app || !empty($this->params['plugin'])) {
 			$path .= DS . 'Test' . DS . 'Fixture' . DS;
 		}
 		$this->out(__d('cake_console', 'Processing fixtures on %s', $path));
@@ -441,30 +441,94 @@ class UpgradeShell extends Shell {
 		foreach ($this->_files as $filePath) {
 			$patterns = [
 				[
-					' Replace $this->_Collection with $this->_registry',
+					'Replace $this->_Collection with $this->_registry',
 					'#\$this->_Collection#',
 					'$this->_registry',
 				],
 				[
-					' Replace ComponentCollection arguments',
+					'Replace ComponentCollection arguments',
 					'#ComponentCollection\s+\$collection#',
 					'ComponentRegistry $registry',
 				],
 				[
-					' Rename ComponentCollection',
+					'Rename ComponentCollection',
 					'#ComponentCollection#',
 					"ComponentRegistry",
 				],
 				[
-					' Rename HelperCollection',
+					'Rename HelperCollection',
 					'#HelperCollection#',
 					"HelperRegistry",
 				],
 				[
-					' Rename TaskCollection',
+					'Rename TaskCollection',
 					'#TaskCollection#',
 					"TaskRegistry",
 				],
+			];
+			$this->_updateFileRegexp($filePath, $patterns);
+		}
+		$this->out(__d('cake_console', '<success>Collection class uses rename successfully.</success>'));
+	}
+
+/**
+ * Update test case assertion methods.
+ *
+ * @return void
+ */
+	public function tests() {
+		$path = $this->_getPath();
+
+		$Folder = new Folder($path);
+		$this->_paths = $Folder->tree(null, false, 'dir');
+		$this->_findFiles('php');
+		foreach ($this->_files as $filePath) {
+			$patterns = [
+				[
+					'Replace assertEqual() with assertEquals()',
+					'#\$this-\>assertEqual\(\#i',
+					'$this->assertEquals(',
+				],
+				[
+					'Replace assertNotEqual() with assertNotEquals()',
+					'#\$this-\>assertNotEqual\(\#i',
+					'$this->assertNotEquals(',
+				],
+				[
+					'Replace assertIdentical() with assertSame()',
+					'#\$this-\>assertIdentical\(\#i',
+					'$this->assertSame(',
+				],
+				[
+					'Replace assertNotIdentical() with assertNotSame()',
+					'#\$this-\>assertNotIdentical\(\#i',
+					'$this->assertNotSame(',
+				],
+				[
+					'Replace assertPattern() with assertRegExp()',
+					'#\$this-\>assertPattern\(\#i',
+					'$this->assertRegExp(',
+				],
+				[
+					'Replace assertNoPattern() with assertNotRegExp()',
+					'#\$this-\>assertNoPattern\(\#i',
+					'$this->assertNotRegExp(',
+				],
+				[
+					'Replace assertReference() with assertSame()',
+					'#\$this-\>assertReference\(\$(.*?),\s*\'(.*?)\'\)#i',
+					'$this->assertSame($\1, $\2)',
+				],
+				[
+					'Replace assertIsA() with assertInstanceOf()',
+					'#\$this-\>assertIsA\(\$(.*?),\s*\'(.*?)\'\)#i',
+					'$this->assertInstanceOf(\'\2\', $\1)',
+				],
+				[
+					'Replace assert*($is, $expected) with assert*($expected, $is) - except for assertTags()',
+					'/\bassert((?!tags)\w+)\(\$(\w+),\s*\$expected\)/i',
+					'assert\1($expected, $\2)'
+				]
 			];
 			$this->_updateFileRegexp($filePath, $patterns);
 		}
@@ -510,7 +574,7 @@ class UpgradeShell extends Shell {
 		$namespace = trim($ns . str_replace(DS, '\\', dirname($shortPath)), '\\');
 		$patterns = [
 			[
-				' namespace to ' . $namespace,
+				'namespace to ' . $namespace,
 				'#^(<\?(?:php)?\s+(?:\/\*.*?\*\/\s{0,1})?)#s',
 				"\\1namespace " . $namespace . ";\n",
 			]

--- a/Cake/Test/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/Cake/Test/TestCase/Database/Type/DateTimeTypeTest.php
@@ -46,12 +46,12 @@ class DateTimeTypeTest extends TestCase {
 
 		$result = $this->type->toPHP('2001-01-04 12:13:14', $this->driver);
 		$this->assertInstanceOf('DateTime', $result);
-		$this->assertEqual('2001', $result->format('Y'));
-		$this->assertEqual('01', $result->format('m'));
-		$this->assertEqual('04', $result->format('d'));
-		$this->assertEqual('12', $result->format('H'));
-		$this->assertEqual('13', $result->format('i'));
-		$this->assertEqual('14', $result->format('s'));
+		$this->assertEquals('2001', $result->format('Y'));
+		$this->assertEquals('01', $result->format('m'));
+		$this->assertEquals('04', $result->format('d'));
+		$this->assertEquals('12', $result->format('H'));
+		$this->assertEquals('13', $result->format('i'));
+		$this->assertEquals('14', $result->format('s'));
 	}
 
 /**

--- a/Cake/Test/TestCase/Database/Type/DateTypeTest.php
+++ b/Cake/Test/TestCase/Database/Type/DateTypeTest.php
@@ -46,9 +46,9 @@ class DateTypeTest extends TestCase {
 
 		$result = $this->type->toPHP('2001-01-04', $this->driver);
 		$this->assertInstanceOf('DateTime', $result);
-		$this->assertEqual('2001', $result->format('Y'));
-		$this->assertEqual('01', $result->format('m'));
-		$this->assertEqual('04', $result->format('d'));
+		$this->assertEquals('2001', $result->format('Y'));
+		$this->assertEquals('01', $result->format('m'));
+		$this->assertEquals('04', $result->format('d'));
 
 		$result = $this->type->toPHP('2001-01-04 10:11:12', $this->driver);
 		$this->assertFalse($result);

--- a/Cake/Test/TestCase/Model/ModelCrossSchemaHabtmTest.php
+++ b/Cake/Test/TestCase/Model/ModelCrossSchemaHabtmTest.php
@@ -149,7 +149,7 @@ class ModelCrossSchemaHabtmTest extends ModelTestBase {
 		));
 
 		$results = $Player->saveAll($player, array('validate' => 'first'));
-		$this->assertNotEqual(false, $results);
+		$this->assertNotSame(false, $results);
 		$count = $Player->find('count');
 		$this->assertEquals(5, $count);
 

--- a/Cake/Test/TestCase/View/Helper/FormHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/FormHelperTest.php
@@ -9275,7 +9275,7 @@ class FormHelperTest extends TestCase {
 			'div' => false,
 			'label' => false,
 		);
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 }

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2027,7 +2027,7 @@ class PaginatorHelperTest extends TestCase {
  */
 	public function testParam() {
 		$result = $this->Paginator->param('count');
-		$this->assertIdentical(62, $result);
+		$this->assertSame(62, $result);
 
 		$result = $this->Paginator->param('imaginary');
 		$this->assertNull($result);

--- a/Cake/Test/TestCase/View/ViewTest.php
+++ b/Cake/Test/TestCase/View/ViewTest.php
@@ -1349,7 +1349,7 @@ class ViewTest extends TestCase {
 	public function testBlockSetDecimal() {
 		$this->View->assign('testWithDecimal', 1.23456789);
 		$result = $this->View->fetch('testWithDecimal');
-		$this->assertEqual('1.23456789', $result);
+		$this->assertEquals('1.23456789', $result);
 	}
 
 /**

--- a/Cake/TestSuite/TestCase.php
+++ b/Cake/TestSuite/TestCase.php
@@ -525,79 +525,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 // @codingStandardsIgnoreStart
 
 /**
- * Compatibility wrapper function for assertEquals
- *
- *
- * @param mixed $result
- * @param mixed $expected
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertEqual($result, $expected, $message = '') {
-		return static::assertEquals($expected, $result, $message);
-	}
-
-/**
- * Compatibility wrapper function for assertNotEquals
- *
- * @param mixed $result
- * @param mixed $expected
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertNotEqual($result, $expected, $message = '') {
-		return static::assertNotEquals($expected, $result, $message);
-	}
-
-/**
- * Compatibility wrapper function for assertRegexp
- *
- * @param mixed $pattern a regular expression
- * @param string $string the text to be matched
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertPattern($pattern, $string, $message = '') {
-		return static::assertRegExp($pattern, $string, $message);
-	}
-
-/**
- * Compatibility wrapper function for assertEquals
- *
- * @param mixed $actual
- * @param mixed $expected
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertIdentical($actual, $expected, $message = '') {
-		return static::assertSame($expected, $actual, $message);
-	}
-
-/**
- * Compatibility wrapper function for assertNotEquals
- *
- * @param mixed $actual
- * @param mixed $expected
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertNotIdentical($actual, $expected, $message = '') {
-		return static::assertNotSame($expected, $actual, $message);
-	}
-
-/**
- * Compatibility wrapper function for assertNotRegExp
- *
- * @param mixed $pattern a regular expression
- * @param string $string the text to be matched
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertNoPattern($pattern, $string, $message = '') {
-		return static::assertNotRegExp($pattern, $string, $message);
-	}
-
-/**
  * assert no errors
  */
 	protected function assertNoErrors() {
@@ -629,30 +556,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 /**
- * Compatibility wrapper function for assertSame
- *
- * @param mixed $first
- * @param mixed $second
- * @param string $message the text to display if the assertion is not correct
- * @return void
- */
-	protected static function assertReference(&$first, &$second, $message = '') {
-		return static::assertSame($first, $second, $message);
-	}
-
-/**
- * Compatibility wrapper for assertIsA
- *
- * @param string $object
- * @param string $type
- * @param string $message
- * @return void
- */
-	protected static function assertIsA($object, $type, $message = '') {
-		return static::assertInstanceOf($type, $object, $message);
-	}
-
-/**
  * Compatibility function to test if value is between an acceptable range
  *
  * @param mixed $result
@@ -680,7 +583,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 		return $condition;
 	}
-	// @codingStandardsIgnoreEnd
+
+// @codingStandardsIgnoreEnd
 
 /**
  * Mock a model, maintain fixtures and table association


### PR DESCRIPTION
Some compatibility wrappers might still be useful, e.g. assertWithinMargin() or , as it simplifies asserts.
This improves readability.
But same are leftovers mainly from the SimpleUnit suite and are 100% redundant to the existing PHPUnit ones.

So removing
- assertEqual() in favor of assertEquals()
- assertNotEqual() in favor of assertNotEquals()
- assertIdentical() in favor of assertSame()
- assertNotIdentical() in favor of assertNotSame()
- assertPattern() in favor of assertRegExp()
- assertNoPattern() in favor of assertNotRegExp()
- assertReference() if favor of assertSame()
- assertIsA() in favor of assertInstanceOf()

Note:
My [Upgrade shell task for tests](https://github.com/dereuromark/upgrade/blob/master/Console/Command/UpgradeShell.php#L867) contains those replacements.
Maybe we can add this in as an improved version (doesn't check for message param yet) for the 3.x upgrade shell?
