### PR TITLE
Don't use comp. wrappers anymore.

### DIFF
--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -703,7 +703,7 @@ class CakeSchemaTest extends CakeTestCase {
 		);
 		$result = $this->Schema->generateTable('fields', $posts);
 		$this->assertRegExp('/public \$fields/', $result);
-		$this->assertPattern('/\'type\' \=\> \'fulltext\'/', $result);
+		$this->assertRegExp('/\'type\' \=\> \'fulltext\'/', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
+++ b/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
@@ -147,7 +147,7 @@ class ModelCrossSchemaHabtmTest extends BaseModelTest {
 		));
 
 		$results = $Player->saveAll($player, array('validate' => 'first'));
-		$this->assertNotEqual(false, $results);
+		$this->assertNotSame(false, $results);
 		$count = $Player->find('count');
 		$this->assertEquals(5, $count);
 

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -6754,7 +6754,7 @@ class FormHelperTest extends CakeTestCase {
 
 		$result = $matches[1];
 		$expected = range(date('Y') + 20, 1930);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$this->Form->request->data['Project']['release'] = '2050-10-10';
 		$result = $this->Form->year('Project.release');
@@ -6762,7 +6762,7 @@ class FormHelperTest extends CakeTestCase {
 
 		$result = $matches[1];
 		$expected = range(2050, date('Y') - 20);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 
 		$this->Form->request->data['Project']['release'] = '1881-10-10';
 		$result = $this->Form->year('Project.release', 1890, 1900);
@@ -6770,7 +6770,7 @@ class FormHelperTest extends CakeTestCase {
 
 		$result = $matches[1];
 		$expected = range(1900, 1881);
-		$this->assertEquals($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -9312,7 +9312,7 @@ class FormHelperTest extends CakeTestCase {
 			'div' => false,
 			'label' => false,
 		);
-		$this->assertEqual($result, $expected);
+		$this->assertEquals($expected, $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1844,13 +1844,13 @@ class HtmlHelperTest extends CakeTestCase {
 		$this->assertTags($result, array('div' => array('class' => 'class-name'), '&lt;text&gt;', '/div'));
 
 		$result = $this->Html->tag(false, '<em>stuff</em>');
-		$this->assertEquals($result, '<em>stuff</em>');
+		$this->assertEquals('<em>stuff</em>', $result);
 
 		$result = $this->Html->tag(null, '<em>stuff</em>');
-		$this->assertEquals($result, '<em>stuff</em>');
+		$this->assertEquals('<em>stuff</em>', $result);
 
 		$result = $this->Html->tag('', '<em>stuff</em>');
-		$this->assertEquals($result, '<em>stuff</em>');
+		$this->assertEquals('<em>stuff</em>', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2233,7 +2233,7 @@ class PaginatorHelperTest extends CakeTestCase {
  */
 	public function testParam() {
 		$result = $this->Paginator->param('count');
-		$this->assertIdentical(62, $result);
+		$this->assertSame(62, $result);
 
 		$result = $this->Paginator->param('imaginary');
 		$this->assertNull($result);

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -1388,7 +1388,7 @@ class ViewTest extends CakeTestCase {
 	public function testBlockSetDecimal() {
 		$this->View->assign('testWithDecimal', 1.23456789);
 		$result = $this->View->fetch('testWithDecimal');
-		$this->assertEqual('1.23456789', $result);
+		$this->assertEquals('1.23456789', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Fixture/AssertTagsTestCase.php
+++ b/lib/Cake/Test/Fixture/AssertTagsTestCase.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This class helpes in indirectly testing the functionaliteies of CakeTestCase::assertTags
+ * This class helpes in indirectly testing the functionalities of CakeTestCase::assertTags
  *
  * @package       Cake.Test.Fixture
  */


### PR DESCRIPTION
We don't use the SimpleTest wrappers anymore except for those few occurrences.
This unifies it.
Also preparation for https://github.com/cakephp/cakephp/pull/1678
