### PR TITLE
Enable Router::reverse() to accept CakeRequest-formatted arrays

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -1064,7 +1064,7 @@ class Router {
 			$url = $params->query;
 			$params = $params->params;
 		} else {
-			$url = $params['url'];
+			$url = isset($params['url']) ? $params['url'] : null;
 		}
 		$pass = isset($params['pass']) ? $params['pass'] : array();
 		$named = isset($params['named']) ? $params['named'] : array();


### PR DESCRIPTION
Router::reverse() can currently create a string URL from a CakeRequest instance or an array in the CakeRequest format, but if an array is submitted it currently throws a Notice error looking for $params['url'].

Simple change that ignores the $params['url'], if it's not present.
