### PR TITLE
Bugfix: Assert own tasks are loaded before trying to access taskNames.

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -201,6 +201,7 @@ class Shell extends Object {
  */
 	public function initialize() {
 		$this->_loadModels();
+		$this->loadTasks();
 	}
 
 /**

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -206,7 +206,6 @@ class ShellDispatcher {
 
 		if ($Shell instanceof Shell) {
 			$Shell->initialize();
-			$Shell->loadTasks();
 			return $Shell->runCommand($command, $this->args);
 		}
 		$methods = array_diff(get_class_methods($Shell), get_class_methods('Shell'));

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -441,7 +441,6 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Mock = $this->getMock('Shell', array(), array(), 'MockWithMainShell');
 
 		$Mock->expects($this->once())->method('initialize');
-		$Mock->expects($this->once())->method('loadTasks');
 		$Mock->expects($this->once())->method('runCommand')
 			->with(null, array())
 			->will($this->returnValue(true));
@@ -467,7 +466,6 @@ class ShellDispatcherTest extends CakeTestCase {
 		$this->mockObjects[] = $Shell;
 
 		$Shell->expects($this->once())->method('initialize');
-		$Shell->expects($this->once())->method('loadTasks');
 		$Shell->expects($this->once())->method('runCommand')
 			->with('initdb', array('initdb'))
 			->will($this->returnValue(true));
@@ -491,7 +489,6 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Shell = $this->getMock('Object', $methods, array(), 'MockWithMainNotAShell');
 
 		$Shell->expects($this->never())->method('initialize');
-		$Shell->expects($this->never())->method('loadTasks');
 		$Shell->expects($this->once())->method('startup');
 		$Shell->expects($this->once())->method('main')->will($this->returnValue(true));
 		$Dispatcher->TestShell = $Shell;
@@ -524,7 +521,6 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Shell = $this->getMock('Object', $methods, array(&$Dispatcher), 'MockWithoutMainNotAShell');
 
 		$Shell->expects($this->never())->method('initialize');
-		$Shell->expects($this->never())->method('loadTasks');
 		$Shell->expects($this->once())->method('startup');
 		$Shell->expects($this->once())->method('main')->will($this->returnValue(true));
 		$Dispatcher->TestShell = $Shell;

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -195,6 +195,7 @@ class ShellTest extends CakeTestCase {
 		), App::RESET);
 
 		CakePlugin::load('TestPlugin');
+		$this->Shell->tasks = array('DbConfig' => array('one', 'two'));
 		$this->Shell->uses = array('TestPlugin.TestPluginPost');
 		$this->Shell->initialize();
 
@@ -208,6 +209,7 @@ class ShellTest extends CakeTestCase {
 		$this->assertTrue(isset($this->Shell->Comment));
 		$this->assertInstanceOf('Comment', $this->Shell->Comment);
 		$this->assertEquals('Comment', $this->Shell->modelClass);
+		$this->assertInstanceOf('DbConfigTask', $this->Shell->DbConfig);
 
 		App::build();
 	}


### PR DESCRIPTION
$this->taskNames will only contain sth after loadTasks() has been triggered.
So if it tries to autoload a task before that it will fail.
