### PR TITLE
Test to prove that autoLink has issues with umlauts.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -241,6 +241,14 @@ class TextHelperTest extends CakeTestCase {
 				'Text with a url http://www.not--work.com and more',
 				'Text with a url <a href="http://www.not--work.com">http://www.not--work.com</a> and more',
 			),
+			array(
+				'Text with a partial www.küchenschöhn-not-working.de URL',
+				'Text with a partial <a href="http://www.küchenschöhn-not-working.de">www.küchenschöhn-not-working.de</a> URL'
+			),
+			array(
+				'Text with a partial http://www.küchenschöhn-not-working.de URL',
+				'Text with a partial <a href="http://www.küchenschöhn-not-working.de">http://www.küchenschöhn-not-working.de</a> URL'
+			)
 		);
 	}
 
@@ -383,7 +391,7 @@ TEXT;
 
 TEXT;
 		$result = $this->Text->autoParagraph($text);
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 		$result = $this->Text->autoParagraph($text);
 		$text = 'This is a <BR id="test"/><br class="test"> test text';
 		$expected = <<<TEXT
@@ -392,7 +400,7 @@ TEXT;
 
 TEXT;
 		$result = $this->Text->autoParagraph($text);
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 		$text = <<<TEXT
 This is a test text.
 This is a line return.
@@ -403,7 +411,7 @@ This is a line return.</p>
 
 TEXT;
 		$result = $this->Text->autoParagraph($text);
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 		$text = <<<TEXT
 This is a test text.
 
@@ -415,7 +423,7 @@ TEXT;
 
 TEXT;
 		$result = $this->Text->autoParagraph($text);
-		$this->assertEquals($expected, $result);
+		$this->assertTextEquals($expected, $result);
 	}
 
 }

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -364,6 +364,11 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'Text with <a href="mailto:düsentrieb@küchenschöhn-not-working.de">düsentrieb@küchenschöhn-not-working.de</a> address';
 		$result = $this->Text->autoLinkEmails($text);
 		$this->assertRegExp('#^' . $expected . '$#', $result);
+
+		$text = 'Text with me@subdomain.küchenschöhn.de address';
+		$expected = 'Text with <a href="mailto:me@subdomain.küchenschöhn.de">me@subdomain.küchenschöhn.de</a> address';
+		$result = $this->Text->autoLinkEmails($text);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -359,6 +359,11 @@ class TextHelperTest extends CakeTestCase {
 		$expected = 'Text with <a href="mailto:email@example.com" \s*class="link">email@example.com</a> address';
 		$result = $this->Text->autoLinkEmails($text, array('class' => 'link'));
 		$this->assertRegExp('#^' . $expected . '$#', $result);
+
+		$text = 'Text with düsentrieb@küchenschöhn-not-working.de address';
+		$expected = 'Text with <a href="mailto:düsentrieb@küchenschöhn-not-working.de">düsentrieb@küchenschöhn-not-working.de</a> address';
+		$result = $this->Text->autoLinkEmails($text);
+		$this->assertRegExp('#^' . $expected . '$#', $result);
 	}
 
 /**

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -186,9 +186,9 @@ class TextHelper extends AppHelper {
 		$options += array('escape' => true);
 		$this->_placeholders = array();
 
-		$atom = '[a-z0-9!#$%&\'*+\/=?^_`{|}~-]';
+		$atom = '[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]';
 		$text = preg_replace_callback(
-			'/(' . $atom . '+(?:\.' . $atom . '+)*@[a-z0-9-]+(?:\.[a-z0-9-]+)+)/i',
+			'/(' . $atom . '+(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[a-z0-9-]+)+)/ui',
 			array(&$this, '_insertPlaceholder'),
 			$text
 		);

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -188,7 +188,7 @@ class TextHelper extends AppHelper {
 
 		$atom = '[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]';
 		$text = preg_replace_callback(
-			'/(' . $atom . '+(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[a-z0-9-]+)+)/ui',
+			'/(' . $atom . '+(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[\p{L}0-9-]+)+)/ui',
 			array(&$this, '_insertPlaceholder'),
 			$text
 		);

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -105,7 +105,7 @@ class TextHelper extends AppHelper {
 		$this->_placeholders = array();
 		$options += array('escape' => true);
 
-		$pattern = '#(?<!href="|src="|">)((?:https?|ftp|nntp)://[a-z0-9.\-:]+(?:[/?][^\s<]*)?)#i';
+		$pattern = '#(?<!href="|src="|">)((?:https?|ftp|nntp)://[\p{L}0-9.\-:]+(?:[/?][^\s<]*)?)#ui';
 		$text = preg_replace_callback(
 			$pattern,
 			array(&$this, '_insertPlaceHolder'),


### PR DESCRIPTION
Current result:

```
Text with a partial <a href="http://www.k">http://www.k</a>üchenschöhn-not-working.de URL
```

Note that without the protocol (just `www.küchenschöhn-not-working.de`) it works. 
So the regexp only breaks for the complete protocol including url. 

Any quick ideas what is missing?

Also makes the other tests work for windows.
