### PR TITLE
3.0 - Paginator templates part 2

### DIFF
--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -718,17 +718,11 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers();
 		$expected = array(
 			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=2&amp;foo=bar&amp;x=y')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=3&amp;foo=bar&amp;x=y')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=4&amp;foo=bar&amp;x=y')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=5&amp;foo=bar&amp;x=y')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=6&amp;foo=bar&amp;x=y')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=7&amp;foo=bar&amp;x=y')), '7', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1037,21 +1031,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers();
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '8', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1061,21 +1047,13 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array('class' => 'first')), array('a' => array('href' => '/index', 'rel' => 'first')), 'first', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '8', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array('class' => 'last')), array('a' => array('href' => '/index?page=15', 'rel' => 'last')), 'last', '/a', '/li',
@@ -1095,21 +1073,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers();
 		$expected = array(
 			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1127,21 +1097,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers();
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '14', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1160,21 +1122,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1182,21 +1136,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('last' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1217,21 +1163,13 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '15', '/span', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1252,23 +1190,14 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '10', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1287,23 +1216,14 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '6', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/li',
@@ -1326,23 +1246,14 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=33')), '33', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=34')), '34', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=35')), '35', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=36')), '36', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '37', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=38')), '38', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=39')), '39', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=40')), '40', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=41')), '41', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1368,9 +1279,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers($options);
 		$expected = array(
 			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1378,9 +1287,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('modulus' => 3));
 		$expected = array(
 			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1399,15 +1306,11 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span',  '4895', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1417,15 +1320,11 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1433,15 +1332,11 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1449,25 +1344,16 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 5, 'last' => 5));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1476,27 +1362,17 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4891')), '4891', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4892')), '4892', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '4893', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1505,33 +1381,21 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=56')), '56', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=57')), '57', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '58', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=59')), '59', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=60')), '60', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1540,27 +1404,17 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '5', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1569,15 +1423,11 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1613,9 +1463,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers();
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/clients/index')), '1', '/a', '/li',
-			' | ',
 			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
-			' | ',
 			array('li' => array()), array('a' => array('href' => '/clients/index?page=3')), '3', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1643,7 +1491,6 @@ class PaginatorHelperTest extends TestCase {
 			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
 			'/li',
-			' | ',
 			'<li',
 			array('a' => array('href' => '/index?page=7')), '7', '/a',
 			'/li',
@@ -1725,7 +1572,6 @@ class PaginatorHelperTest extends TestCase {
 			'<li',
 			array('a' => array('href' => '/index')), '1', '/a',
 			'/li',
-			' | ',
 			'<li',
 			array('a' => array('href' => '/index?page=2')), '2', '/a',
 			'/li'
@@ -1794,7 +1640,6 @@ class PaginatorHelperTest extends TestCase {
 			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
 			'/li',
-			' | ',
 			'<li',
 			array('a' => array('href' => '/index?page=7')), '7', '/a',
 			'/li',
@@ -1849,7 +1694,6 @@ class PaginatorHelperTest extends TestCase {
 			'<li',
 			array('a' => array('href' => '/index?page=14&amp;sort=Client.name&amp;direction=DESC')), '14', '/a',
 			'/li',
-			' | ',
 			'<li',
 			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
 			'/li',

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -942,75 +942,6 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
-/**
- * testGenericLinks method
- *
- * @return void
- */
-	public function testGenericLinks() {
-		$result = $this->Paginator->link('Sort by title on page 5', array('sort' => 'title', 'page' => 5, 'direction' => 'desc'));
-		$expected = array(
-			'a' => array('href' => '/index?page=5&amp;sort=title&amp;direction=desc'),
-			'Sort by title on page 5',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging']['Article']['page'] = 2;
-		$result = $this->Paginator->link('Sort by title', array('sort' => 'title', 'direction' => 'desc'));
-		$expected = array(
-			'a' => array('href' => '/index?page=2&amp;sort=title&amp;direction=desc'),
-			'Sort by title',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging']['Article']['page'] = 4;
-		$result = $this->Paginator->link('Sort by title on page 4', array('sort' => 'Article.title', 'direction' => 'desc'));
-		$expected = array(
-			'a' => array('href' => '/index?page=4&amp;sort=Article.title&amp;direction=desc'),
-			'Sort by title on page 4',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
-	}
-
-/**
- * Tests generation of generic links with preset options
- *
- * @return void
- */
-	public function testGenericLinksWithPresetOptions() {
-		$result = $this->Paginator->link('Foo!', array('page' => 1));
-		$this->assertTags($result, array('a' => array('href' => '/index'), 'Foo!', '/a'));
-
-		$this->Paginator->options(array('sort' => 'title', 'direction' => 'desc'));
-		$result = $this->Paginator->link('Foo!', array('page' => 1));
-		$this->assertTags($result, array(
-			'a' => array(
-				'href' => '/index',
-				'sort' => 'title',
-				'direction' => 'desc'
-			),
-			'Foo!',
-			'/a'
-		));
-
-		$this->Paginator->options(array('sort' => null, 'direction' => null));
-		$result = $this->Paginator->link('Foo!', array('page' => 1));
-		$this->assertTags($result, array('a' => array('href' => '/index'), 'Foo!', '/a'));
-
-		$this->Paginator->options(array('url' => array(
-			'sort' => 'title',
-			'direction' => 'desc'
-		)));
-		$result = $this->Paginator->link('Foo!', array('page' => 1));
-		$this->assertTags($result, array(
-			'a' => array('href' => '/index?sort=title&amp;direction=desc'),
-			'Foo!',
-			'/a'
-		));
-	}
 
 /**
  * testNumbers method
@@ -1757,55 +1688,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->hasPage(2);
 		$this->assertTrue($result);
-	}
-
-/**
- * testWithPlugin method
- *
- * @return void
- */
-	public function testWithPlugin() {
-		Router::setRequestInfo(array(
-			array(
-				'pass' => array(), 'prefix' => null,
-				'controller' => 'magazines', 'plugin' => 'my_plugin', 'action' => 'index',
-			),
-			array('base' => '', 'here' => '/my_plugin/magazines', 'webroot' => '/')
-		));
-
-		$result = $this->Paginator->link('Page 3', array('page' => 3));
-		$expected = array(
-			'a' => array('href' => '/my_plugin/magazines/index?page=3'), 'Page 3', '/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->options(array('url' => array('action' => 'another_index')));
-		$result = $this->Paginator->link('Page 3', array('page' => 3));
-		$expected = array(
-			'a' => array('href' => '/my_plugin/magazines/another_index?page=3'), 'Page 3', '/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->options(array('url' => array('controller' => 'issues')));
-		$result = $this->Paginator->link('Page 3', array('page' => 3));
-		$expected = array(
-			'a' => array('href' => '/my_plugin/issues/index?page=3'), 'Page 3', '/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->options(array('url' => array('plugin' => null)));
-		$result = $this->Paginator->link('Page 3', array('page' => 3));
-		$expected = array(
-			'a' => array('href' => '/magazines/index?page=3'), 'Page 3', '/a'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->options(array('url' => array('plugin' => null, 'controller' => 'issues')));
-		$result = $this->Paginator->link('Page 3', array('page' => 3));
-		$expected = array(
-			'a' => array('href' => '/issues/index?page=3'), 'Page 3', '/a'
-		);
-		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1745,7 +1745,7 @@ class PaginatorHelperTest extends TestCase {
  */
 	public function testFirstAndLastTag() {
 		$this->Paginator->request->params['paging']['Article']['page'] = 2;
-		$result = $this->Paginator->first('<<', array('tag' => 'li', 'class' => 'first'));
+		$result = $this->Paginator->first('<<');
 		$expected = array(
 			'li' => array('class' => 'first'),
 			'a' => array('href' => '/index', 'rel' => 'first'),
@@ -1755,14 +1755,14 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->last(2, array('tag' => 'li', 'class' => 'last'));
+		$result = $this->Paginator->last(2);
 		$expected = array(
 			'...',
-			'li' => array('class' => 'last'),
+			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
 			'/li',
 			' | ',
-			array('li' => array('class' => 'last')),
+			'<li',
 			array('a' => array('href' => '/index?page=7')), '7', '/a',
 			'/li',
 		);
@@ -1887,22 +1887,22 @@ class PaginatorHelperTest extends TestCase {
 	public function testLast() {
 		$result = $this->Paginator->last();
 		$expected = array(
-			'<span',
+			'li' => ['class' => 'last'],
 			'a' => array('href' => '/index?page=7', 'rel' => 'last'),
 			'last &gt;&gt;',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->last(1);
 		$expected = array(
 			'...',
-			'<span',
+			'<li',
 			'a' => array('href' => '/index?page=7'),
 			'7',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
@@ -1911,13 +1911,13 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->last(2);
 		$expected = array(
 			'...',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
-			'/span',
+			'/li',
 			' | ',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=7')), '7', '/a',
-			'/span',
+			'/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1926,7 +1926,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * undocumented function
+ * test the options for last()
  *
  * @return void
  */
@@ -1946,48 +1946,35 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last();
 		$expected = array(
-			'<span',
-			array('a' => array(
+			'li' => ['class' => 'last'],
+			'a' => array(
 				'href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC',
 				'rel' => 'last'
-			)),
+			),
 				'last &gt;&gt;', '/a',
-			'/span',
+			'/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->last(1);
 		$expected = array(
 			'...',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
-			'/span',
+			'/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->last(2);
 		$expected = array(
 			'...',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=14&amp;sort=Client.name&amp;direction=DESC')), '14', '/a',
-			'/span',
+			'/li',
 			' | ',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
-			'/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->last(2, array('ellipsis' => '<span class="ellipsis">...</span>'));
-		$expected = array(
-			array('span' => array('class' => 'ellipsis')), '...', '/span',
-			'<span',
-			array('a' => array('href' => '/index?page=14&amp;sort=Client.name&amp;direction=DESC')), '14', '/a',
-			'/span',
-			' | ',
-			'<span',
-			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
-			'/span',
+			'/li',
 		);
 		$this->assertTags($result, $expected);
 	}

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -245,17 +245,6 @@ class PaginatorHelperTest extends TestCase {
 			'/a'
 		);
 		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging']['Article']['sort'] = 'Article.title';
-		$this->Paginator->request->params['paging']['Article']['direction'] = 'asc';
-
-		$result = $this->Paginator->sort('title', 'Title', array('direction' => 'desc', 'class' => 'foo'));
-		$expected = array(
-			'a' => array('href' => '/accounts/index/param?sort=title&amp;direction=desc', 'class' => 'foo asc'),
-			'Title',
-			'/a'
-		);
-		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1401,6 +1401,39 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
+ * Test that numbers() works with the non default model.
+ *
+ * @return void
+ */
+	public function testNumbersNonDefaultModel() {
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 1,
+				'current' => 3,
+				'count' => 13,
+				'prevPage' => false,
+				'nextPage' => true,
+				'pageCount' => 5,
+			),
+			'Server' => array(
+				'page' => 5,
+				'current' => 1,
+				'count' => 5,
+				'prevPage' => true,
+				'nextPage' => false,
+				'pageCount' => 5,
+			)
+		);
+		$result = $this->Paginator->numbers(['model' => 'Server']);
+		$this->assertContains('<li class="active"><span>5</span></li>', $result);
+		$this->assertNotContains('<li class="active"><span>1</span></li>', $result);
+
+		$result = $this->Paginator->numbers(['model' => 'Client']);
+		$this->assertContains('<li class="active"><span>1</span></li>', $result);
+		$this->assertNotContains('<li class="active"><span>5</span></li>', $result);
+	}
+
+/**
  * test first() and last() with tag options
  *
  * @return void
@@ -1441,6 +1474,37 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->last();
 		$expected = '';
 		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test first() with a the model parameter.
+ *
+ * @return void
+ */
+	public function testFirstNonDefaultModel() {
+		$this->Paginator->request->params['paging']['Article']['page'] = 1;
+		$this->Paginator->request->params['paging']['Client'] = array(
+			'page' => 3,
+			'current' => 3,
+			'count' => 13,
+			'prevPage' => false,
+			'nextPage' => true,
+			'pageCount' => 5,
+		);
+
+		
+		$result = $this->Paginator->first('first', ['model' => 'Article:']);
+		$this->assertEquals('', $result);
+
+		$result = $this->Paginator->first('first', ['model' => 'Client']);
+		$expected = array(
+			'li' => array('class' => 'first'),
+			'a' => array('href' => '/index', 'rel' => 'first'),
+			'first',
+			'/a',
+			'/li'
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**
@@ -1628,6 +1692,36 @@ class PaginatorHelperTest extends TestCase {
 			'<li',
 			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
 			'/li',
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * test last() with a the model parameter.
+ *
+ * @return void
+ */
+	public function testLastNonDefaultModel() {
+		$this->Paginator->request->params['paging']['Article']['page'] = 7;
+		$this->Paginator->request->params['paging']['Client'] = array(
+			'page' => 3,
+			'current' => 3,
+			'count' => 13,
+			'prevPage' => false,
+			'nextPage' => true,
+			'pageCount' => 5,
+		);
+
+		$result = $this->Paginator->last('last', ['model' => 'Article:']);
+		$this->assertEquals('', $result);
+
+		$result = $this->Paginator->last('last', ['model' => 'Client']);
+		$expected = array(
+			'li' => array('class' => 'last'),
+			'a' => array('href' => '/index?page=5', 'rel' => 'last'),
+			'last',
+			'/a',
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 	}

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1810,13 +1810,13 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->first();
 		$expected = array(
-			'<span',
+			'li' => ['class' => 'first'],
 			array('a' => array(
 				'href' => Configure::read('App.fullBaseUrl') . '/index?sort=Article.title&amp;direction=DESC', 'rel' => 'first'
 			)),
 			'&lt;&lt; first',
 			'/a',
-			'/span',
+			'/li',
 		);
 		$this->assertTags($result, $expected);
 	}
@@ -1830,23 +1830,23 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params['paging']['Article']['page'] = 3;
 		$result = $this->Paginator->first();
 		$expected = array(
-			'<span',
+			'li' => ['class' => 'first'],
 			'a' => array('href' => '/index', 'rel' => 'first'),
 			'&lt;&lt; first',
 			'/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->first(2);
 		$expected = array(
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index')), '1', '/a',
-			'/span',
+			'/li',
 			' | ',
-			'<span',
+			'<li',
 			array('a' => array('href' => '/index?page=2')), '2', '/a',
-			'/span'
+			'/li'
 		);
 		$this->assertTags($result, $expected);
 

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -248,6 +248,30 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
+ * test sort() with escape option
+ */
+	public function testSortEscape() {
+		$result = $this->Paginator->sort('title', 'TestTitle >');
+		$expected = array(
+			'a' => array('href' => '/index?sort=title&amp;direction=asc'),
+			'TestTitle &gt;',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->sort('title', 'TestTitle >', ['escape' => true]);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->sort('title', 'TestTitle >', ['escape' => false]);
+		$expected = array(
+			'a' => array('href' => '/index?sort=title&amp;direction=asc'),
+			'TestTitle >',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * test that sort() works with virtual field order options.
  *
  * @return void

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1770,7 +1770,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last(2);
 		$expected = array(
-			'...',
 			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
 			'/li',
@@ -1910,7 +1909,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last(1);
 		$expected = array(
-			'...',
 			'<li',
 			'a' => array('href' => '/index?page=7'),
 			'7',
@@ -1923,7 +1921,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last(2);
 		$expected = array(
-			'...',
 			'<li',
 			array('a' => array('href' => '/index?page=6')), '6', '/a',
 			'/li',
@@ -1971,7 +1968,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last(1);
 		$expected = array(
-			'...',
 			'<li',
 			array('a' => array('href' => '/index?page=15&amp;sort=Client.name&amp;direction=DESC')), '15', '/a',
 			'/li',
@@ -1980,7 +1976,6 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->last(2);
 		$expected = array(
-			'...',
 			'<li',
 			array('a' => array('href' => '/index?page=14&amp;sort=Client.name&amp;direction=DESC')), '14', '/a',
 			'/li',

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -2011,20 +2011,12 @@ class PaginatorHelperTest extends TestCase {
 				'order' => 'DESC',
 			)
 		);
-		$input = 'Page {:page} of {:pages}, showing {:current} records out of {:count} total, ';
-		$input .= 'starting on record {:start}, ending on {:end}';
+		$input = 'Page {{page}} of {{pages}}, showing {{current}} records out of {{count}} total, ';
+		$input .= 'starting on record {{start}}, ending on {{end}}';
+
 		$expected = 'Page 1 of 5, showing 3 records out of 13 total, starting on record 1, ';
 		$expected .= 'ending on 3';
 		$result = $this->Paginator->counter($input);
-		$this->assertEquals($expected, $result);
-
-		$input = 'Page {:page} of {:pages}';
-		$result = $this->Paginator->counter($input);
-		$expected = 'Page 1 of 5';
-		$this->assertEquals($expected, $result);
-
-		$result = $this->Paginator->counter(array('format' => $input));
-		$expected = 'Page 1 of 5';
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->counter(array('format' => 'pages'));
@@ -2035,7 +2027,7 @@ class PaginatorHelperTest extends TestCase {
 		$expected = '1 - 3 of 13';
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Paginator->counter('Showing {:page} of {:pages} {:model}');
+		$result = $this->Paginator->counter('Showing {{page}} of {{pages}} {{model}}');
 		$this->assertEquals('Showing 1 of 5 clients', $result);
 	}
 

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -717,19 +717,19 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers();
 		$expected = array(
-			array('span' => array('class' => 'current')), '1', '/span',
+			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=2&amp;foo=bar&amp;x=y')), '2', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=2&amp;foo=bar&amp;x=y')), '2', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=3&amp;foo=bar&amp;x=y')), '3', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=3&amp;foo=bar&amp;x=y')), '3', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=4&amp;foo=bar&amp;x=y')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=4&amp;foo=bar&amp;x=y')), '4', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=5&amp;foo=bar&amp;x=y')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=5&amp;foo=bar&amp;x=y')), '5', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=6&amp;foo=bar&amp;x=y')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=6&amp;foo=bar&amp;x=y')), '6', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/articles/index/2?page=7&amp;foo=bar&amp;x=y')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/articles/index/2?page=7&amp;foo=bar&amp;x=y')), '7', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1036,28 +1036,6 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$result = $this->Paginator->numbers();
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current')), '8', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('tag' => 'li'));
-		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
@@ -1066,7 +1044,7 @@ class PaginatorHelperTest extends TestCase {
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('li' => array('class' => 'current')), '8', '/li',
+			array('li' => array('class' => 'active')), '<span', '8', '/span', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
@@ -1074,47 +1052,33 @@ class PaginatorHelperTest extends TestCase {
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
-			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('tag' => 'li', 'separator' => false));
-		$expected = array(
-			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			array('li' => array('class' => 'current')), '8', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->numbers(true);
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index', 'rel' => 'first')), 'first', '/a', '/span',
+			array('li' => array('class' => 'first')), array('a' => array('href' => '/index', 'rel' => 'first')), 'first', '/a', '/li',
+			'...',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array('class' => 'active')), '<span', '8', '/span', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '8', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=15', 'rel' => 'last')), 'last', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
+			'...',
+			array('li' => array('class' => 'last')), array('a' => array('href' => '/index?page=15', 'rel' => 'last')), 'last', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1130,118 +1094,9 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$result = $this->Paginator->numbers();
 		$expected = array(
-			array('span' => array('class' => 'current')), '1', '/span',
+			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 14,
-				'current' => 3,
-				'count' => 30,
-				'prevPage' => false,
-				'nextPage' => 2,
-				'pageCount' => 15,
-			)
-		);
-		$result = $this->Paginator->numbers();
-		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current')), '14', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 3,
-				'count' => 27,
-				'prevPage' => false,
-				'nextPage' => 2,
-				'pageCount' => 9,
-			)
-		);
-
-		$result = $this->Paginator->numbers(array('first' => 1, 'class' => 'page-link'));
-		$expected = array(
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'current page-link')), '2', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('first' => 1, 'currentClass' => 'active'));
-		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'active')), '2', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('first' => 1, 'tag' => 'li', 'currentClass' => 'active', 'currentTag' => 'a'));
-		$expected = array(
-			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			' | ',
-			array('li' => array('class' => 'active')), array('a' => array()), '2', '/a', '/li',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 			' | ',
@@ -1259,47 +1114,90 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->numbers(array('first' => 1, 'class' => 'page-link', 'currentClass' => 'active'));
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 14,
+				'current' => 3,
+				'count' => 30,
+				'prevPage' => false,
+				'nextPage' => 2,
+				'pageCount' => 15,
+			)
+		);
+		$result = $this->Paginator->numbers();
 		$expected = array(
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'active page-link')), '2', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
+			array('li' => array('class' => 'active')), '<span', '14', '/span', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/li',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->request->params['paging'] = array(
+			'Client' => array(
+				'page' => 2,
+				'current' => 3,
+				'count' => 27,
+				'prevPage' => false,
+				'nextPage' => 2,
+				'pageCount' => 9,
+			)
+		);
+
+		$result = $this->Paginator->numbers(array('first' => 1));
+		$expected = array(
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Paginator->numbers(array('last' => 1));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '2', '/span',
+			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1316,26 +1214,25 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 1));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '15', '/span',
-
+			array('li' => array('class' => 'active')), '<span', '15', '/span', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1352,27 +1249,27 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '10', '/span',
+			array('li' => array('class' => 'active')), '<span', '10', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=13')), '13', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=14')), '14', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=15')), '15', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1389,27 +1286,27 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '6', '/span',
+			array('li' => array('class' => 'active')), '<span', '6', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1426,30 +1323,37 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=33')), '33', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=33')), '33', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=34')), '34', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=34')), '34', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=35')), '35', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=35')), '35', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=36')), '36', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=36')), '36', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '37', '/span',
+			array('li' => array('class' => 'active')), '<span', '37', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=38')), '38', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=38')), '38', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=39')), '39', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=39')), '39', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=40')), '40', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=40')), '40', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=41')), '41', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=41')), '41', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
+	}
 
+/**
+ * Test modulus option for numbers()
+ *
+ * @return void
+ */
+	public function testNumbersModulus() {
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
 				'page' => 1,
@@ -1463,17 +1367,7 @@ class PaginatorHelperTest extends TestCase {
 		$options = array('modulus' => 10);
 		$result = $this->Paginator->numbers($options);
 		$expected = array(
-			array('span' => array('class' => 'current')), '1', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Paginator->numbers(array('modulus' => 3, 'currentTag' => 'span', 'tag' => 'li'));
-		$expected = array(
-			array('li' => array('class' => 'current')), array('span' => array()), '1', '/span', '/li',
+			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			' | ',
@@ -1481,27 +1375,13 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Paginator->request->params['paging'] = array(
-			'Client' => array(
-				'page' => 2,
-				'current' => 10,
-				'count' => 31,
-				'prevPage' => true,
-				'nextPage' => true,
-				'pageCount' => 4,
-				'sort' => 'Client.name',
-				'direction' => 'DESC',
-			)
-		);
-		$result = $this->Paginator->numbers(array('class' => 'page-link'));
+		$result = $this->Paginator->numbers(array('modulus' => 3));
 		$expected = array(
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?sort=Client.name&amp;direction=DESC')), '1', '/a', '/span',
+			array('li' => array('class' => 'active')), '<span', '1', '/span', '/li',
 			' | ',
-			array('span' => array('class' => 'current page-link')), '2', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=3&amp;sort=Client.name&amp;direction=DESC')), '3', '/a', '/span',
-			' | ',
-			array('span' => array('class' => 'page-link')), array('a' => array('href' => '/index?page=4&amp;sort=Client.name&amp;direction=DESC')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1518,17 +1398,17 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '4895', '/span',
+			array('li' => array('class' => 'active')), '<span',  '4895', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
@@ -1536,189 +1416,179 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '3', '/span',
+			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2, 'separator' => ' - '));
+		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '3', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 5, 'last' => 5, 'separator' => ' - '));
+		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 5, 'last' => 5));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '3', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$this->Paginator->request->params['paging']['Client']['page'] = 4893;
-		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5, 'separator' => ' - '));
+		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4891')), '4891', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4892')), '4892', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '4893', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4891')), '4891', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4892')), '4892', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '4893', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$this->Paginator->request->params['paging']['Client']['page'] = 58;
-		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5, 'separator' => ' - '));
+		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=56')), '56', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=57')), '57', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '58', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=59')), '59', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=60')), '60', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=56')), '56', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=57')), '57', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '58', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=59')), '59', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=60')), '60', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$this->Paginator->request->params['paging']['Client']['page'] = 5;
-		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5, 'separator' => ' - '));
+		$result = $this->Paginator->numbers(array('first' => 5, 'modulus' => 4, 'last' => 5));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '5', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=3')), '3', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '5', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			'...',
-			array('span' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4895')), '4895', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 
 		$this->Paginator->request->params['paging']['Client']['page'] = 3;
-		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2, 'separator' => ' - ', 'ellipsis' => ' ~~~ '));
+		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2));
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '3', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			' ~~~ ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
+			' | ',
+			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
+			'...',
+			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
+			' | ',
+			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
+	}
 
-		$this->Paginator->request->params['paging']['Client']['page'] = 3;
-		$result = $this->Paginator->numbers(array('first' => 2, 'modulus' => 2, 'last' => 2, 'separator' => ' - ', 'ellipsis' => '<span class="ellipsis">...</span>'));
-		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/index')), '1', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/span',
-			' - ',
-			array('span' => array('class' => 'current')), '3', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/span',
-			array('span' => array('class' => 'ellipsis')), '...', '/span',
-			array('span' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/span',
-			' - ',
-			array('span' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/span',
-		);
-		$this->assertTags($result, $expected);
-
+/**
+ * test numbers() with routing parameters.
+ *
+ * @return void
+ */
+	public function testNumbersRouting() {
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
 				'page' => 2,
@@ -1742,11 +1612,11 @@ class PaginatorHelperTest extends TestCase {
 
 		$result = $this->Paginator->numbers();
 		$expected = array(
-			array('span' => array()), array('a' => array('href' => '/clients/index')), '1', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/clients/index')), '1', '/a', '/li',
 			' | ',
-			array('span' => array('class' => 'current')), '2', '/span',
+			array('li' => array('class' => 'active')), '<span', '2', '/span', '/li',
 			' | ',
-			array('span' => array()), array('a' => array('href' => '/clients/index?page=3')), '3', '/a', '/span',
+			array('li' => array()), array('a' => array('href' => '/clients/index?page=3')), '3', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
 	}

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -20,9 +20,6 @@ use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
-use Cake\View\Helper\FormHelper;
-use Cake\View\Helper\HtmlHelper;
-use Cake\View\Helper\JsHelper;
 use Cake\View\Helper\PaginatorHelper;
 use Cake\View\View;
 
@@ -60,7 +57,6 @@ class PaginatorHelperTest extends TestCase {
 				)
 			)
 		));
-		$this->Paginator->Html = new HtmlHelper($this->View);
 
 		Configure::write('Routing.prefixes', array());
 		Router::reload();

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1059,7 +1059,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(true);
 		$expected = array(
 			array('li' => array('class' => 'first')), array('a' => array('href' => '/index', 'rel' => 'first')), 'first', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
@@ -1077,7 +1077,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=11')), '11', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=12')), '12', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array('class' => 'last')), array('a' => array('href' => '/index?page=15', 'rel' => 'last')), 'last', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1215,7 +1215,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=8')), '8', '/a', '/li',
@@ -1250,7 +1250,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
@@ -1305,7 +1305,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=9')), '9', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=10')), '10', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=42')), '42', '/a', '/li',
 		);
 		$this->assertTags($result, $expected);
@@ -1324,7 +1324,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->numbers(array('first' => 1, 'last' => 1));
 		$expected = array(
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=33')), '33', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=34')), '34', '/a', '/li',
@@ -1401,7 +1401,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index')), '1', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
 			' | ',
 			array('li' => array('class' => 'active')), '<span',  '4895', '/span', '/li',
@@ -1423,7 +1423,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
@@ -1439,7 +1439,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
@@ -1459,7 +1459,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
@@ -1484,7 +1484,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4891')), '4891', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4892')), '4892', '/a', '/li',
@@ -1513,7 +1513,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=5')), '5', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=56')), '56', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=57')), '57', '/a', '/li',
@@ -1523,7 +1523,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=59')), '59', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=60')), '60', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
@@ -1552,7 +1552,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=6')), '6', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=7')), '7', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4893')), '4893', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
@@ -1575,7 +1575,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array('class' => 'active')), '<span', '3', '/span', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4')), '4', '/a', '/li',
-			'...',
+			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			' | ',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -432,37 +432,6 @@ class PaginatorHelper extends Helper {
 	}
 
 /**
- * Generates a link with pagination parameters
- *
- * ### Options
- *
- * - `escape` Whether you want the contents html entity encoded, defaults to true
- * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
- *
- * @param string $title Title for the link.
- * @param string|array $url Url for the action. See Router::url()
- * @param array $options Options for the link. See #options for list of keys.
- * @return string A link with pagination parameters.
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::link
- */
-	public function link($title, $url = array(), $options = array()) {
-		$options = array_merge(array('model' => null, 'escape' => true), $options);
-		$model = $options['model'];
-		unset($options['model']);
-
-		if (!empty($this->options)) {
-			$options = array_merge($this->options, $options);
-		}
-		if (isset($options['url'])) {
-			$url = array_merge((array)$options['url'], (array)$url);
-			unset($options['url']);
-		}
-
-		$url = $this->url($url, true, $model);
-		return $this->Html->link($title, $url, $options);
-	}
-
-/**
  * Merges passed URL options with current pagination state to generate a pagination URL.
  *
  * @param array $options Pagination/URL options array
@@ -471,7 +440,7 @@ class PaginatorHelper extends Helper {
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
  */
-	public function url($options = array(), $asArray = false, $model = null) {
+	public function url($options = array(), $model = null) {
 		$paging = $this->params($model);
 		$paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 		$url = [
@@ -488,9 +457,6 @@ class PaginatorHelper extends Helper {
 
 		if (!empty($url['page']) && $url['page'] == 1) {
 			$url['page'] = null;
-		}
-		if ($asArray) {
-			return $url;
 		}
 		return parent::url($url);
 	}

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -82,7 +82,7 @@ class PaginatorHelper extends Helper {
 		'last' => '<li class="last"><a rel="last" href="{{url}}">{{text}}</a></li>',
 		'number' => '<li><a href="{{url}}">{{text}}</a></li>',
 		'current' => '<li class="active"><span>{{text}}</span></li>',
-		'ellipsis' => '...',
+		'ellipsis' => '<li class="ellipsis">...</li>',
 		'separator' => ' | ',
 		'sort' => '<a href="{{url}}">{{text}}</a>',
 		'sortAsc' => '<a class="asc" href="{{url}}">{{text}}</a>',

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -83,6 +83,9 @@ class PaginatorHelper extends Helper {
 		'number' => '<li><a href="{{url}}">{{text}}</a></li>',
 		'ellipsis' => '...',
 		'separator' => ' | ',
+		'sort' => '<a href="{{url}}">{{text}}</a>',
+		'sortAsc' => '<a class="asc" href="{{url}}">{{text}}</a>',
+		'sortDesc' => '<a class="desc" href="{{url}}">{{text}}</a>',
 	];
 
 /**
@@ -405,21 +408,25 @@ class PaginatorHelper extends Helper {
 			$key === $defaultModel . '.' . $sortKey
 		);
 
+		$template = 'sort';
 		if ($isSorted) {
 			$dir = $this->sortDir($options['model']) === 'asc' ? 'desc' : 'asc';
-			$class = $dir === 'asc' ? 'desc' : 'asc';
-			if (!empty($options['class'])) {
-				$options['class'] .= ' ' . $class;
-			} else {
-				$options['class'] = $class;
-			}
+			$template = $dir === 'asc' ? 'sortDesc' : 'sortAsc';
 		}
 		if (is_array($title) && array_key_exists($dir, $title)) {
 			$title = $title[$dir];
 		}
 
-		$url = array_merge(array('sort' => $key, 'direction' => $dir), $url, array('order' => null));
-		return $this->link($title, $url, $options);
+		$url = array_merge(
+			['sort' => $key, 'direction' => $dir],
+			$url,
+			['order' => null]
+		);
+		$vars = [
+			'text' => $title,
+			'url' => $this->url($url),
+		];
+		return $this->_templater->format($template, $vars);
 	}
 
 /**

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -383,8 +383,11 @@ class PaginatorHelper extends Helper {
  *  key the returned link will sort by 'desc'.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sort
  */
-	public function sort($key, $title = null, $options = array()) {
-		$options = array_merge(array('url' => array(), 'model' => null), $options);
+	public function sort($key, $title = null, $options = []) {
+		$options = array_merge(
+			['url' => array(), 'model' => null, 'escape' => true],
+			$options
+		);
 		$url = $options['url'];
 		unset($options['url']);
 
@@ -423,7 +426,7 @@ class PaginatorHelper extends Helper {
 			['order' => null]
 		);
 		$vars = [
-			'text' => $title,
+			'text' => $options['escape'] ? h($title) : $title,
 			'url' => $this->url($url),
 		];
 		return $this->_templater->format($template, $vars);

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -588,8 +588,8 @@ class PaginatorHelper extends Helper {
  *
  * ### Options
  *
- * - `before` Content to be inserted before the numbers
- * - `after` Content to be inserted after the numbers
+ * - `before` Content to be inserted before the numbers, but after the first links.
+ * - `after` Content to be inserted after the numbers, but before the last links.
  * - `model` Model to create numbers for, defaults to PaginatorHelper::defaultModel()
  * - `modulus` how many numbers to include on either side of the current page, defaults to 8.
  * - `first` Whether you want first links generated, set to an integer to define the number of 'first'
@@ -598,8 +598,8 @@ class PaginatorHelper extends Helper {
  *    links to generate.
  *
  * The generated number links will include the 'ellipsis' template when the `first` and `last` options
- * are used and a range of page links will not be generated because they fall outside the range defined
- * by modulus.
+ * and the number of pages exceed the modulus. For example if you have 25 pages, and use the first/last
+ * options and a modulus of 8, ellipsis content will be inserted after the first and last link sets.
  *
  * @param array $options Options for the numbers, (before, after, model, modulus)
  * @return string numbers string.

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -275,19 +275,19 @@ class PaginatorHelper extends Helper {
 			return '';
 		}
 		$text = $options['escape'] ? h($text) : $text;
-		$paging = $this->params($options['model']);
 
 		if (!$enabled) {
 			return $this->_templater->format($template, [
 				'text' => $text,
 			]);
 		}
+		$paging = $this->params($options['model']);
 
 		$url = array_merge(
 			$options['url'],
 			['page' => $paging['page'] + $options['step']]
 		);
-		$url = $this->url($url);
+		$url = $this->url($url, $options['model']);
 		return $this->_templater->format($template, [
 			'url' => $url,
 			'text' => $text,
@@ -426,7 +426,7 @@ class PaginatorHelper extends Helper {
 		);
 		$vars = [
 			'text' => $options['escape'] ? h($title) : $title,
-			'url' => $this->url($url),
+			'url' => $this->url($url, $options['model']),
 		];
 		return $this->_templater->format($template, $vars);
 	}
@@ -435,7 +435,6 @@ class PaginatorHelper extends Helper {
  * Merges passed URL options with current pagination state to generate a pagination URL.
  *
  * @param array $options Pagination/URL options array
- * @param boolean $asArray Return the url as an array, or a URI string
  * @param string $model Which model to paginate on
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
@@ -631,7 +630,6 @@ class PaginatorHelper extends Helper {
 		$options += $defaults;
 
 		$params = (array)$this->params($options['model']) + array('page' => 1);
-		unset($options['model']);
 
 		if ($params['pageCount'] <= 1) {
 			return false;
@@ -666,21 +664,21 @@ class PaginatorHelper extends Helper {
 			for ($i = $start; $i < $params['page']; $i++) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $i]),
+					'url' => $this->url(['page' => $i], $options['model']),
 				];
 				$out .= $this->_templater->format('number', $vars);
 			}
 
 			$out .= $this->_templater->format('current', [
 				'text' => $params['page'],
-				'url' => $this->url(['page' => $params['page']]),
+				'url' => $this->url(['page' => $params['page']], $options['model']),
 			]);
 
 			$start = $params['page'] + 1;
 			for ($i = $start; $i < $end; $i++) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $i]),
+					'url' => $this->url(['page' => $i], $options['model']),
 				];
 				$out .= $this->_templater->format('number', $vars);
 			}
@@ -688,7 +686,7 @@ class PaginatorHelper extends Helper {
 			if ($end != $params['page']) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $end]),
+					'url' => $this->url(['page' => $end], $options['model']),
 				];
 				$out .= $this->_templater->format('number', $vars);
 			}
@@ -710,12 +708,12 @@ class PaginatorHelper extends Helper {
 				if ($i == $params['page']) {
 					$out .= $this->_templater->format('current', [
 						'text' => $params['page'],
-						'url' => $this->url(['page' => $params['page']]),
+						'url' => $this->url(['page' => $params['page']], $options['model']),
 					]);
 				} else {
 					$vars = [
 						'text' => $i,
-						'url' => $this->url(['page' => $i]),
+						'url' => $this->url(['page' => $i], $options['model']),
 					];
 					$out .= $this->_templater->format('number', $vars);
 				}
@@ -756,11 +754,7 @@ class PaginatorHelper extends Helper {
 			(array)$options
 		);
 
-		$params = array_merge(
-			['page' => 1],
-			(array)$this->params($options['model'])
-		);
-		unset($options['model']);
+		$params = $this->params($options['model']);
 
 		if ($params['pageCount'] <= 1) {
 			return false;
@@ -771,14 +765,14 @@ class PaginatorHelper extends Helper {
 		if (is_int($first) && $params['page'] >= $first) {
 			for ($i = 1; $i <= $first; $i++) {
 				$out .= $this->_templater->format('number', [
-					'url' => $this->url(['page' => $i]),
+					'url' => $this->url(['page' => $i], $options['model']),
 					'text' => $i
 				]);
 			}
 		} elseif ($params['page'] > 1 && is_string($first)) {
 			$first = $options['escape'] ? h($first) : $first;
 			$out .= $this->_templater->format('first', [
-				'url' => $this->url(['page' => 1]),
+				'url' => $this->url(['page' => 1], $options['model']),
 				'text' => $first
 			]);
 		}
@@ -812,11 +806,7 @@ class PaginatorHelper extends Helper {
 			(array)$options
 		);
 
-		$params = array_merge(
-			['page' => 1],
-			(array)$this->params($options['model'])
-		);
-		unset($options['model']);
+		$params = $this->params($options['model']);
 
 		if ($params['pageCount'] <= 1) {
 			return false;
@@ -828,14 +818,14 @@ class PaginatorHelper extends Helper {
 		if (is_int($last) && $params['page'] <= $lower) {
 			for ($i = $lower; $i <= $params['pageCount']; $i++) {
 				$out .= $this->_templater->format('number', [
-					'url' => $this->url(['page' => $i]),
+					'url' => $this->url(['page' => $i], $options['model']),
 					'text' => $i
 				]);
 			}
 		} elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
 			$last = $options['escape'] ? h($last) : $last;
 			$out .= $this->_templater->format('last', [
-				'url' => $this->url(['page' => $params['pageCount']]),
+				'url' => $this->url(['page' => $params['pageCount']], $options['model']),
 				'text' => $last
 			]);
 		}

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -660,7 +660,7 @@ class PaginatorHelper extends Helper {
 
 		$defaults = array(
 			'before' => null, 'after' => null, 'model' => $this->defaultModel(),
-			'modulus' => '8', 'first' => null, 'last' => null,
+			'modulus' => 8, 'first' => null, 'last' => null,
 		);
 		$options += $defaults;
 

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -76,6 +76,8 @@ class PaginatorHelper extends Helper {
 		'nextDisabled' => '<li class="next disabled"><span>{{text}}</span></li>',
 		'prevActive' => '<li class="prev"><a rel="prev" href="{{url}}">{{text}}</a></li>',
 		'prevDisabled' => '<li class="prev disabled"><span>{{text}}</span></li>',
+		'counterRange' => '{{start}} - {{end}} of {{count}}',
+		'counterPages' => '{{page}} of {{pages}}',
 	];
 
 /**
@@ -554,25 +556,23 @@ class PaginatorHelper extends Helper {
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel();
  * - `format` The format string you want to use, defaults to 'pages' Which generates output like '1 of 5'
  *    set to 'range' to generate output like '1 - 3 of 13'. Can also be set to a custom string, containing
- *    the following placeholders `{:page}`, `{:pages}`, `{:current}`, `{:count}`, `{:model}`, `{:start}`, `{:end}` and any
+ *    the following placeholders `{{page}}`, `{{pages}}`, `{{current}}`, `{{count}}`, `{{model}}`, `{{start}}`, `{{end}}` and any
  *    custom content you would like.
- * - `separator` The separator string to use, default to ' of '
  *
  * @param array $options Options for the counter string. See #options for list of keys.
  * @return string Counter string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
  */
-	public function counter($options = array()) {
+	public function counter($options = []) {
 		if (is_string($options)) {
 			$options = array('format' => $options);
 		}
 
 		$options = array_merge(
-			array(
+			[
 				'model' => $this->defaultModel(),
 				'format' => 'pages',
-				'separator' => __d('cake', ' of ')
-			),
+			],
 		$options);
 
 		$paging = $this->params($options['model']);
@@ -590,28 +590,23 @@ class PaginatorHelper extends Helper {
 
 		switch ($options['format']) {
 			case 'range':
-				if (!is_array($options['separator'])) {
-					$options['separator'] = array(' - ', $options['separator']);
-				}
-				$out = $start . $options['separator'][0] . $end . $options['separator'][1];
-				$out .= $paging['count'];
-				break;
 			case 'pages':
-				$out = $paging['page'] . $options['separator'] . $paging['pageCount'];
+				$template = 'counter' . ucfirst($options['format']);
 				break;
 			default:
-				$map = array(
-					'{:page}' => $paging['page'],
-					'{:pages}' => $paging['pageCount'],
-					'{:current}' => $paging['current'],
-					'{:count}' => $paging['count'],
-					'{:start}' => $start,
-					'{:end}' => $end,
-					'{:model}' => strtolower(Inflector::humanize(Inflector::tableize($options['model'])))
-				);
-				$out = str_replace(array_keys($map), array_values($map), $options['format']);
+				$template = 'counterCustom';
+				$this->_templater->add([$template => $options['format']]);
 		}
-		return $out;
+		$map = [
+			'page' => $paging['page'],
+			'pages' => $paging['pageCount'],
+			'current' => $paging['current'],
+			'count' => $paging['count'],
+			'start' => $start,
+			'end' => $end,
+			'model' => strtolower(Inflector::humanize(Inflector::tableize($options['model'])))
+		];
+		return $this->_templater->format($template, $map);
 	}
 
 /**

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -47,7 +47,6 @@ class PaginatorHelper extends Helper {
  *    and custom (default). In the default mode the supplied string is parsed and constants are replaced
  *    by their actual values.
  *    placeholders: %page%, %pages%, %current%, %count%, %start%, %end% .
- * - `separator` The separator of the actual page and number of pages (default: ' of ').
  * - `url` Url of the action. See Router::url()
  * - `url['sort']`  the key that the recordset is sorted.
  * - `url['direction']` Direction of the sorting (default: 'asc').
@@ -83,7 +82,6 @@ class PaginatorHelper extends Helper {
 		'number' => '<li><a href="{{url}}">{{text}}</a></li>',
 		'current' => '<li class="active"><span>{{text}}</span></li>',
 		'ellipsis' => '<li class="ellipsis">...</li>',
-		'separator' => ' | ',
 		'sort' => '<a href="{{url}}">{{text}}</a>',
 		'sortAsc' => '<a class="asc" href="{{url}}">{{text}}</a>',
 		'sortDesc' => '<a class="desc" href="{{url}}">{{text}}</a>',
@@ -674,7 +672,6 @@ class PaginatorHelper extends Helper {
 		}
 
 		$out = '';
-		$separator = $this->_templater->format('separator', []);
 		$ellipsis = $this->_templater->format('ellipsis', []);
 
 		if ($options['modulus'] && $params['pageCount'] > $options['modulus']) {
@@ -695,8 +692,6 @@ class PaginatorHelper extends Helper {
 				$out .= $this->first($offset);
 				if ($offset < $start - 1) {
 					$out .= $ellipsis;
-				} else {
-					$out .= $separator;
 				}
 			}
 
@@ -707,7 +702,7 @@ class PaginatorHelper extends Helper {
 					'text' => $i,
 					'url' => $this->url(['page' => $i]),
 				];
-				$out .= $this->_templater->format('number', $vars) . $separator;
+				$out .= $this->_templater->format('number', $vars);
 			}
 
 			$out .= $this->_templater->format('current', [
@@ -715,17 +710,13 @@ class PaginatorHelper extends Helper {
 				'url' => $this->url(['page' => $params['page']]),
 			]);
 
-			if ($i != $params['pageCount']) {
-				$out .= $separator;
-			}
-
 			$start = $params['page'] + 1;
 			for ($i = $start; $i < $end; $i++) {
 				$vars = [
 					'text' => $i,
 					'url' => $this->url(['page' => $i]),
 				];
-				$out .= $this->_templater->format('number', $vars) . $separator;
+				$out .= $this->_templater->format('number', $vars);
 			}
 
 			if ($end != $params['page']) {
@@ -742,8 +733,6 @@ class PaginatorHelper extends Helper {
 				$offset = ($params['pageCount'] < $end + (int)$options['last']) ? $params['pageCount'] - $end : $options['last'];
 				if ($offset <= $options['last'] && $params['pageCount'] - $end > $offset) {
 					$out .= $ellipsis;
-				} else {
-					$out .= $separator;
 				}
 				$out .= $this->last($offset);
 			}
@@ -763,9 +752,6 @@ class PaginatorHelper extends Helper {
 						'url' => $this->url(['page' => $i]),
 					];
 					$out .= $this->_templater->format('number', $vars);
-				}
-				if ($i != $params['pageCount']) {
-					$out .= $separator;
 				}
 			}
 
@@ -817,15 +803,11 @@ class PaginatorHelper extends Helper {
 		$out = '';
 
 		if (is_int($first) && $params['page'] >= $first) {
-			$separator = $this->_templater->format('separator', []);
 			for ($i = 1; $i <= $first; $i++) {
 				$out .= $this->_templater->format('number', [
 					'url' => $this->url(['page' => $i]),
 					'text' => $i
 				]);
-				if ($i != $first) {
-					$out .= $separator;
-				}
 			}
 		} elseif ($params['page'] > 1 && is_string($first)) {
 			$first = $options['escape'] ? h($first) : $first;
@@ -878,15 +860,11 @@ class PaginatorHelper extends Helper {
 		$lower = $params['pageCount'] - $last + 1;
 
 		if (is_int($last) && $params['page'] <= $lower) {
-			$separator = $this->_templater->format('separator', []);
 			for ($i = $lower; $i <= $params['pageCount']; $i++) {
 				$out .= $this->_templater->format('number', [
 					'url' => $this->url(['page' => $i]),
 					'text' => $i
 				]);
-				if ($i != $params['pageCount']) {
-					$out .= $separator;
-				}
 			}
 		} elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
 			$last = $options['escape'] ? h($last) : $last;

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -812,7 +812,6 @@ class PaginatorHelper extends Helper {
 		$out = '';
 
 		if (is_int($first) && $params['page'] >= $first) {
-			$ellipsis = $this->_templater->format('ellipsis', []);
 			$separator = $this->_templater->format('separator', []);
 			for ($i = 1; $i <= $first; $i++) {
 				$out .= $this->_templater->format('number', [
@@ -874,7 +873,6 @@ class PaginatorHelper extends Helper {
 		$lower = $params['pageCount'] - $last + 1;
 
 		if (is_int($last) && $params['page'] <= $lower) {
-			$ellipsis = $this->_templater->format('ellipsis', []);
 			$separator = $this->_templater->format('separator', []);
 			for ($i = $lower; $i <= $params['pageCount']; $i++) {
 				$out .= $this->_templater->format('number', [
@@ -885,7 +883,6 @@ class PaginatorHelper extends Helper {
 					$out .= $separator;
 				}
 			}
-			$out = $ellipsis . $out;
 		} elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
 			$last = $options['escape'] ? h($last) : $last;
 			$out .= $this->_templater->format('last', [

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -14,9 +14,6 @@
  */
 namespace Cake\View\Helper;
 
-use Cake\Core\App;
-use Cake\Error;
-use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplate;
 use Cake\View\View;

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -26,17 +26,9 @@ use Cake\View\View;
  *
  * PaginationHelper encloses all methods needed when working with pagination.
  *
- * @property HtmlHelper $Html
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html
  */
 class PaginatorHelper extends Helper {
-
-/**
- * Helper dependencies
- *
- * @var array
- */
-	public $helpers = ['Html'];
 
 /**
  * Holds the default options for pagination links


### PR DESCRIPTION
This is the second set of change for converting PaginatorHelper to use template strings instead of option-itis to generate HTML. I've converted all of the methods except link() to use templates. I've got a few open questions/todo's left, and any feedback you folks have on them or the changes in general would be great.
### TODO
- [x] Better HTML for the `ellipsis` and `separator` elements.
- [x] Is `separator` useful given how modern CSS frameworks handle pagination CSS. Looking at both bootstrap and zurb makes me think this element is totally useless now.
- [x] Does link() need to exist at all anymore?
- [x] Address missing model parameter in various methods.
