### PR TITLE
Make BaseSchema abstract and add abstract methods to it.

### DIFF
--- a/Cake/Database/Driver.php
+++ b/Cake/Database/Driver.php
@@ -16,8 +16,6 @@
  */
 namespace Cake\Database;
 
-use \Cake\Database\SqlDialectTrait;
-
 /**
  * Represents a database diver containing all specificities for
  * a database engine including its SQL dialect

--- a/Cake/Database/Schema/BaseSchema.php
+++ b/Cake/Database/Schema/BaseSchema.php
@@ -16,13 +16,33 @@
  */
 namespace Cake\Database\Schema;
 
+use Cake\Database\Driver;
+use Cake\Database\Schema\Table;
+
 /**
  * Base class for schema implementations.
  *
  * This class contains methods that are common across
  * the various SQL dialects.
  */
-class BaseSchema {
+abstract class BaseSchema {
+
+/**
+ * The driver instance being used.
+ *
+ * @var Cake\Database\Driver
+ */
+	protected $_driver;
+
+/**
+ * Constructor
+ *
+ * @param Cake\Database\Driver $driver The driver to use.
+ * @return void
+ */
+	public function __construct(Driver $driver) {
+		$this->_driver = $driver;
+	}
 
 /**
  * Generate an ON clause for a foreign key.
@@ -65,7 +85,7 @@ class BaseSchema {
  * Generate the SQL to drop a table.
  *
  * @param Cake\Database\Schema\Table $table Table instance
- * @return array SQL statements to drop DROP a table.
+ * @return array SQL statements to drop a table.
  */
 	public function dropTableSql(Table $table) {
 		$sql = sprintf(
@@ -74,5 +94,116 @@ class BaseSchema {
 		);
 		return [$sql];
 	}
+
+/**
+ * Generate the SQL to list the tables.
+ *
+ * @param array $config The connection configuration to use for
+ *    getting tables from.
+ * @return array An array of (sql, params) to execute.
+ */
+	abstract public function listTablesSql($config);
+
+/**
+ * Generate the SQL to describe a table.
+ *
+ * @param string $name The table name to get information on.
+ * @param array $config The connection configuration.
+ * @return array An array of (sql, params) to execute.
+ */
+	abstract public function describeTableSql($name, $config);
+
+/**
+ * Generate the SQL to describe the indexes in a table.
+ *
+ * @param string $table The table name to get information on.
+ * @param array $config The connection configuration.
+ * @return array An array of (sql, params) to execute.
+ */
+	abstract public function describeIndexSql($table, $config);
+
+/**
+ * Generate the SQL to describe the foreign keys in a table.
+ *
+ * @param string $table The table name to get information on.
+ * @param array $config The connection configuration.
+ * @return array An array of (sql, params) to execute.
+ */
+	abstract public function describeForeignKeySql($table, $config);
+
+/**
+ * Convert field description results into abstract schema fields.
+ *
+ * @param Cake\Database\Schema\Table $table The table object to append fields to.
+ * @param array $row The row data from `describeTableSql`.
+ * @return void
+ */
+	abstract public function convertFieldDescription(Table $table, $row);
+
+/**
+ * Convert an index description results into abstract schema indexes or constraints.
+ *
+ * @param Cake\Database\Schema\Table $table The table object to append
+ *    an index or constraint to.
+ * @param array $row The row data from `describeIndexSql`.
+ * @return void
+ */
+	abstract public function convertIndexDescription(Table $table, $row);
+
+/**
+ * Convert a foreign key description into constraints on the Table object.
+ *
+ * @param Cake\Database\Schema\Table $table The table object to append
+ *    a constraint to.
+ * @param array $row The row data from `describeForeignKeySql`.
+ * @return void
+ */
+	abstract public function convertForeignKeyDescription(Table $table, $row);
+
+/**
+ * Generate the SQL to create a table.
+ *
+ * @param Cake\Database\Schema\Table $table Table instance.
+ * @param array $columns The columns to go inside the table.
+ * @param array $constraints The constraints for the table.
+ * @param array $indexes The indexes for the table.
+ * @return array SQL statements to create a table.
+ */
+	abstract public function createTableSql(Table $table, $columns, $constraints, $indexes);
+
+/**
+ * Generate the SQL fragment for a single column in a table.
+ *
+ * @param Cake\Database\Schema\Table $table The table instance the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	abstract public function columnSql(Table $table, $name);
+
+/**
+ * Generate the SQL fragments for defining table constraints.
+ *
+ * @param Cake\Database\Schema\Table $table The table instance the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	abstract public function constraintSql(Table $table, $name);
+
+/**
+ * Generate the SQL fragment for a single index in a table.
+ *
+ * @param Cake\Database\Schema\Table $table The table object the column is in.
+ * @param string $name The name of the column.
+ * @return string SQL fragment.
+ */
+	abstract public function indexSql(Table $table, $name);
+
+/**
+ * Generate the SQL to truncate a table.
+ *
+ * @param Cake\Database\Schema\Table $table Table instance.
+ * @return array SQL statements to truncate a table.
+ */
+	abstract public function truncateTableSql(Table $table);
 
 }

--- a/Cake/Database/Schema/Collection.php
+++ b/Cake/Database/Schema/Collection.php
@@ -71,14 +71,13 @@ class Collection {
  * Get the column metadata for a table.
  *
  * @param string $name The name of the table to describe.
- * @return Cake\Schema\Table|null Object with column metadata, or null.
+ * @return Cake\Database\Schema\Table Object with column metadata.
  * @throws Cake\Database\Exception when table cannot be described.
  */
 	public function describe($name) {
-		list($sql, $params) = $this->_dialect->describeTableSql(
-			$name,
-			$this->_connection->config()
-		);
+		$config = $this->_connection->config();
+
+		list($sql, $params) = $this->_dialect->describeTableSql($name, $config);
 		$statement = $this->_executeSql($sql, $params);
 		if (count($statement) === 0) {
 			throw new Exception(__d('cake_dev', 'Cannot describe %s. It has 0 columns.', $name));
@@ -89,22 +88,16 @@ class Collection {
 			$this->_dialect->convertFieldDescription($table, $row);
 		}
 
-		list($sql, $params) = $this->_dialect->describeIndexSql(
-			$name,
-			$this->_connection->config()
-		);
+		list($sql, $params) = $this->_dialect->describeIndexSql($name, $config);
 		$statement = $this->_executeSql($sql, $params);
 		foreach ($statement->fetchAll('assoc') as $row) {
 			$this->_dialect->convertIndexDescription($table, $row);
 		}
 
-		list($sql, $params) = $this->_dialect->describeForeignKeySql(
-			$name,
-			$this->_connection->config()
-		);
+		list($sql, $params) = $this->_dialect->describeForeignKeySql($name, $config);
 		$statement = $this->_executeSql($sql, $params);
 		foreach ($statement->fetchAll('assoc') as $row) {
-			$this->_dialect->convertForeignKey($table, $row);
+			$this->_dialect->convertForeignKeyDescription($table, $row);
 		}
 		return $table;
 	}

--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -31,7 +31,7 @@ class SqliteSchema extends BaseSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @throws Cake\Database\Exception
+ * @throws Cake\Database\Exception when unable to parse column type
  * @return array Array of column information.
  */
 	protected function _convertColumn($column) {
@@ -191,6 +191,7 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritdoc}
  *
+ * @throws Cake\Database\Exception when the column type is unknown
  */
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);

--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -25,23 +25,6 @@ use Cake\Database\Schema\Table;
 class SqliteSchema extends BaseSchema {
 
 /**
- * The driver instance being used.
- *
- * @var Cake\Database\Driver\Sqlite
- */
-	protected $_driver;
-
-/**
- * Constructor
- *
- * @param Cake\Database\Driver\Sqlite $driver Driver to use.
- * @return void
- */
-	public function __construct($driver) {
-		$this->_driver = $driver;
-	}
-
-/**
  * Convert a column definition to the abstract types.
  *
  * The returned type will be a type that
@@ -51,7 +34,7 @@ class SqliteSchema extends BaseSchema {
  * @throws Cake\Database\Exception
  * @return array Array of column information.
  */
-	public function convertColumn($column) {
+	protected function _convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?/i', $column, $matches);
 		if (empty($matches)) {
 			throw new Exception(__d('cake_dev', 'Unable to parse column type from "%s"', $column));
@@ -94,34 +77,31 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Get the SQL to list the tables in Sqlite
+ * {@inheritdoc}
  *
- * @param array $config The connection configuration to use for
- *    getting tables from.
- * @return array An array of (sql, params) to execute.
  */
-	public function listTablesSql() {
-		return ["SELECT name FROM sqlite_master WHERE type='table' ORDER BY name", []];
+	public function listTablesSql($config) {
+		return ['SELECT name FROM sqlite_master WHERE type="table" ORDER BY name', []];
 	}
 
 /**
- * Get the SQL to describe a table in Sqlite.
+ * {@inheritdoc}
  *
- * @param string $table The table name to describe
- * @return array An array of (sql, params) to execute.
  */
-	public function describeTableSql($table) {
-		return ["PRAGMA table_info(" . $this->_driver->quoteIdentifier($table) . ")", []];
+	public function describeTableSql($name, $config) {
+		$sql = sprintf(
+			'PRAGMA table_info(%s)',
+			$this->_driver->quoteIdentifier($name)
+		);
+		return [$sql, []];
 	}
 
 /**
- * Convert field description results into abstract schema fields.
+ * {@inheritdoc}
  *
- * @param Cake\Database\Schema\Table $table The table object to append fields to.
- * @param array $row The row data from describeTableSql
  */
 	public function convertFieldDescription(Table $table, $row) {
-		$field = $this->convertColumn($row['type']);
+		$field = $this->_convertColumn($row['type']);
 		$field += [
 			'null' => !$row['notnull'],
 			'default' => $row['dflt_value'] === null ? null : trim($row['dflt_value'], "'"),
@@ -139,12 +119,10 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Get the SQL to describe the indexes in a table.
+ * {@inheritdoc}
  *
- * @param string $table The table name to get information on.
- * @return array An array of (sql, params) to execute.
  */
-	public function describeIndexSql($table) {
+	public function describeIndexSql($table, $config) {
 		$sql = sprintf(
 			'PRAGMA index_list(%s)',
 			$this->_driver->quoteIdentifier($table)
@@ -153,17 +131,13 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Convert an index into the abstract description.
+ * {@inheritdoc}
  *
  * Since SQLite does not have a way to get metadata about all indexes at once,
  * additional queries are done here. Sqlite constraint names are not
  * stable, and the names for constraints will not match those used to create
  * the table. This is a limitation in Sqlite's metadata features.
  *
- * @param Cake\Database\Schema\Table $table The table object to append
- *    an index or constraint to.
- * @param array $row The row data from describeIndexSql
- * @return void
  */
 	public function convertIndexDescription(Table $table, $row) {
 		$sql = sprintf(
@@ -190,23 +164,19 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL to describe the foreign keys on a table.
+ * {@inheritdoc}
  *
- * @return array List of sql, params
  */
-	public function describeForeignKeySql($table) {
+	public function describeForeignKeySql($table, $config) {
 		$sql = sprintf('PRAGMA foreign_key_list(%s)', $this->_driver->quoteIdentifier($table));
 		return [$sql, []];
 	}
 
 /**
- * Convert a foreign key description into constraints on the Table object.
+ * {@inheritdoc}
  *
- * @param Cake\Database\Table $table The table instance to populate.
- * @param array $row The row of data.
- * @return void
  */
-	public function convertForeignKey(Table $table, $row) {
+	public function convertForeignKeyDescription(Table $table, $row) {
 		$data = [
 			'type' => Table::CONSTRAINT_FOREIGN,
 			'columns' => [$row['from']],
@@ -219,12 +189,8 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL fragment for a single column in Sqlite
+ * {@inheritdoc}
  *
- * @param Cake\Database\Schema\Table $table The table object the column is in.
- * @param string $name The name of the column.
- * @return string SQL fragment.
- * @throws Cake\Database\Exception On unknown column types.
  */
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);
@@ -277,14 +243,11 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL fragments for defining table constraints.
+ * {@inheritdoc}
  *
  * Note integer primary keys will return ''. This is intentional as Sqlite requires
  * that integer primary keys be defined in the column definition.
  *
- * @param Cake\Database\Schema\Table $table The table object the column is in.
- * @param string $name The name of the column.
- * @return string SQL fragment.
  */
 	public function constraintSql(Table $table, $name) {
 		$data = $table->constraint($name);
@@ -325,11 +288,8 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL fragment for a single index.
+ * {@inheritdoc}
  *
- * @param Cake\Database\Schema\Table $table The table object the column is in.
- * @param string $name The name of the column.
- * @return string SQL fragment.
  */
 	public function indexSql(Table $table, $name) {
 		$data = $table->index($name);
@@ -345,15 +305,10 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL to create a table.
+ * {@inheritdoc}
  *
- * @param Table $table Cake\Database\Schema\Table instance
- * @param array $columns The columns to go inside the table.
- * @param array $constraints The constraints for the table.
- * @param array $indexes The indexes for the table.
- * @return array Complete CREATE TABLE statement(s)S
  */
-	public function createTableSql($table, $columns, $constraints, $indexes) {
+	public function createTableSql(Table $table, $columns, $constraints, $indexes) {
 		$lines = array_merge($columns, $constraints);
 		$content = implode(",\n", array_filter($lines));
 		$table = sprintf("CREATE TABLE \"%s\" (\n%s\n)", $table->name(), $content);
@@ -365,10 +320,8 @@ class SqliteSchema extends BaseSchema {
 	}
 
 /**
- * Generate the SQL to truncate a table.
+ * {@inheritdoc}
  *
- * @param Cake\Database\Schema\Table $table Table instance
- * @return array SQL statements to drop truncate a table.
  */
 	public function truncateTableSql(Table $table) {
 		$name = $table->name();

--- a/Cake/Database/Schema/Table.php
+++ b/Cake/Database/Schema/Table.php
@@ -118,6 +118,18 @@ class Table {
 		self::CONSTRAINT_FOREIGN,
 	];
 
+/**
+ * Names of the valid foreign key actions.
+ *
+ * @var array
+ */
+	protected $_validForeignKeyActions = [
+		self::ACTION_CASCADE,
+		self::ACTION_SET_NULL,
+		self::ACTION_NO_ACTION,
+		self::ACTION_RESTRICT,
+	];
+
 	const CONSTRAINT_PRIMARY = 'primary';
 	const CONSTRAINT_UNIQUE = 'unique';
 	const CONSTRAINT_FOREIGN = 'foreign';
@@ -358,12 +370,11 @@ class Table {
 		if (count($attrs['references']) < 2) {
 			throw new Exception(__d('cake_dev', 'References must contain a table and column.'));
 		}
-		$validActions = [static::ACTION_CASCADE, static::ACTION_RESTRICT, static::ACTION_SET_NULL, static::ACTION_NO_ACTION];
-		if (!in_array($attrs['update'], $validActions)) {
-			throw new Exception(__d('cake_dev', 'Update action is invalid. Must be one of %s', implode(',', $validActions)));
+		if (!in_array($attrs['update'], $this->_validForeignKeyActions)) {
+			throw new Exception(__d('cake_dev', 'Update action is invalid. Must be one of %s', implode(',', $this->_validForeignKeyActions)));
 		}
-		if (!in_array($attrs['delete'], $validActions)) {
-			throw new Exception(__d('cake_dev', 'Delete action is invalid. Must be one of %s', implode(',', $validActions)));
+		if (!in_array($attrs['delete'], $this->_validForeignKeyActions)) {
+			throw new Exception(__d('cake_dev', 'Delete action is invalid. Must be one of %s', implode(',', $this->_validForeignKeyActions)));
 		}
 		return $attrs;
 	}

--- a/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -39,11 +39,11 @@ class MysqlSchemaTest extends TestCase {
 	}
 
 /**
- * Dataprovider for column testing
+ * Data provider for convert column testing
  *
  * @return array
  */
-	public static function columnProvider() {
+	public static function convertColumnProvider() {
 		return [
 			[
 				'DATETIME',
@@ -117,15 +117,34 @@ class MysqlSchemaTest extends TestCase {
 	}
 
 /**
- * Test parsing MySQL column types.
+ * Test parsing MySQL column types form field description.
  *
- * @dataProvider columnProvider
+ * @dataProvider convertColumnProvider
  * @return void
  */
-	public function testConvertColumnType($input, $expected) {
+	public function testConvertColumn($type, $expected) {
+		$field = [
+			'Field' => 'field',
+			'Type' => $type,
+			'Null' => 'YES',
+			'Default' => 'Default value',
+			'Collation' => 'Collate information',
+			'Comment' => 'Comment section',
+		];
+		$expected += [
+			'null' => true,
+			'default' => 'Default value',
+			'collate' => 'Collate information',
+			'comment' => 'Comment section',
+		];
+
 		$driver = $this->getMock('Cake\Database\Driver\Mysql');
 		$dialect = new MysqlSchema($driver);
-		$this->assertEquals($expected, $dialect->convertColumn($input));
+
+		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
+
+		$dialect->convertFieldDescription($table, $field);
 	}
 
 /**

--- a/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -70,7 +70,7 @@ published BOOLEAN DEFAULT false,
 views SMALLINT DEFAULT 0,
 created TIMESTAMP,
 CONSTRAINT "content_idx" UNIQUE ("title", "body"),
-CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE 
+CONSTRAINT "author_idx" FOREIGN KEY ("author_id") REFERENCES "schema_authors" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
 )
 SQL;
 		$connection->execute($table);
@@ -79,11 +79,11 @@ SQL;
 	}
 
 /**
- * Dataprovider for column testing
+ * Data provider for convert column testing
  *
  * @return array
  */
-	public static function columnProvider() {
+	public static function convertColumnProvider() {
 		return [
 			[
 				'TIMESTAMP',
@@ -185,15 +185,33 @@ SQL;
 	}
 
 /**
- * Test parsing Postgres column types.
+ * Test parsing Postgres column types from field description.
  *
- * @dataProvider columnProvider
+ * @dataProvider convertColumnProvider
  * @return void
  */
-	public function testConvertColumnType($input, $expected) {
+	public function testConvertColumn($type, $expected) {
+		$field = [
+			'name' => 'field',
+			'type' => $type,
+			'null' => 'YES',
+			'default' => 'Default value',
+			'comment' => 'Comment section',
+			'char_length' => null,
+		];
+		$expected += [
+			'null' => true,
+			'default' => 'Default value',
+			'comment' => 'Comment section',
+		];
+
 		$driver = $this->getMock('Cake\Database\Driver\Postgres');
 		$dialect = new PostgresSchema($driver);
-		$this->assertEquals($expected, $dialect->convertColumn($input));
+
+		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
+
+		$dialect->convertFieldDescription($table, $field);
 	}
 
 /**

--- a/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -39,11 +39,11 @@ class SqliteSchemaTest extends TestCase {
 	}
 
 /**
- * Dataprovider for column testing
+ * Data provider for convert column testing
  *
  * @return array
  */
-	public static function columnProvider() {
+	public static function convertColumnProvider() {
 		return [
 			[
 				'DATETIME',
@@ -109,15 +109,31 @@ class SqliteSchemaTest extends TestCase {
 	}
 
 /**
- * Test parsing SQLite column types.
+ * Test parsing SQLite column types from field description.
  *
- * @dataProvider columnProvider
+ * @dataProvider convertColumnProvider
  * @return void
  */
-	public function testConvertColumnType($input, $expected) {
+	public function testConvertColumn($type, $expected) {
+		$field = [
+			'pk' => false,
+			'name' => 'field',
+			'type' => $type,
+			'notnull' => false,
+			'dflt_value' => 'Default value',
+		];
+		$expected += [
+			'null' => true,
+			'default' => 'Default value',
+		];
+
 		$driver = $this->getMock('Cake\Database\Driver\Sqlite');
 		$dialect = new SqliteSchema($driver);
-		$this->assertEquals($expected, $dialect->convertColumn($input));
+
+		$table = $this->getMock('Cake\Database\Schema\Table', [], ['table']);
+		$table->expects($this->at(0))->method('addColumn')->with('field', $expected);
+
+		$dialect->convertFieldDescription($table, $field);
 	}
 
 /**


### PR DESCRIPTION
This PR focus on making easier to implement other driver schemas by making BaseSchema abstract and adding abstract methods to it.

`_convertColumn` is now protected, all schema implementations now only exposes public methods as defined in the BaseSchema.

The last point can be a bit opinionated and I don't remember having a discussion about it.
I introduced `{@inheritdoc}` into our codebase. When looking at the docblocks of the schema implementations all of them were pretty much alike. I thought it was just way too much repetition and decided to give it a try.

Some pros and cons I can think are:
- Pros:
  - They are all equal and extra descriptions can be 'appended'.
  - Focus on documenting one and documenting it well.
  - Typo? Better wording? Just update one place.
  - ApiGen (used for generating our api.cakephp.org) supports it
- Cons:
  - Since they are pretty much all equals if there is any typo or better wording we will have to go through four files.
  - Understanding what the code does may become more difficult, althught some editors make it easy to see the inherited documentation.

Thoughts?
