### PR TITLE
3.0 CS fixes

### DIFF
--- a/Cake/Console/Command/SchemaShell.php
+++ b/Cake/Console/Command/SchemaShell.php
@@ -49,17 +49,26 @@ class SchemaShell extends Shell {
 	protected $_dry = null;
 
 /**
- * Override startup
+ * Override _welcome
  *
  * @return void
  * @throws \Cake\Error\Exception
+ */
+	protected function _welcome() {
+		parent::_welcome();
+
+		throw new \Cake\Error\Exception('Schema shell is not working at this time.');
+	}
+
+/**
+ * Override startup
+ *
+ * @return void
  */
 	public function startup() {
 		$this->_welcome();
 		$this->out('Cake Schema Shell');
 		$this->hr();
-
-		throw new \Cake\Error\Exception('Schema shell is not working at this time.');
 
 		Cache::disable();
 

--- a/Cake/Console/Command/UpgradeShell.php
+++ b/Cake/Console/Command/UpgradeShell.php
@@ -369,7 +369,10 @@ class UpgradeShell extends Shell {
 
 		// Process field property.
 		$processor = function ($matches) use ($export) {
+			//@codingStandardsIgnoreStart
 			eval('$data = [' . $matches[2] . '];');
+			//@codingStandardsIgnoreEnd
+
 			$constraints = [];
 			$out = [];
 			foreach ($data as $field => $properties) {

--- a/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/Cake/Test/TestCase/View/Helper/PaginatorHelperTest.php
@@ -923,7 +923,7 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->next('Next', [
 			'model' => 'Server'
 		]);
-		$expected ='<li class="next disabled"><span>Next</span></li>';
+		$expected = '<li class="next disabled"><span>Next</span></li>';
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Paginator->prev('Prev', [
@@ -1236,7 +1236,7 @@ class PaginatorHelperTest extends TestCase {
 			array('li' => array()), array('a' => array('href' => '/index?page=2')), '2', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4894')), '4894', '/a', '/li',
-			array('li' => array('class' => 'active')), '<span',  '4895', '/span', '/li',
+			array('li' => array('class' => 'active')), '<span', '4895', '/span', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4896')), '4896', '/a', '/li',
 			array('li' => array()), array('a' => array('href' => '/index?page=4897')), '4897', '/a', '/li',
 		);
@@ -1488,7 +1488,6 @@ class PaginatorHelperTest extends TestCase {
 			'pageCount' => 5,
 		);
 
-		
 		$result = $this->Paginator->first('first', ['model' => 'Article:']);
 		$this->assertEquals('', $result);
 

--- a/Cake/Test/TestCase/View/StringTemplateTest.php
+++ b/Cake/Test/TestCase/View/StringTemplateTest.php
@@ -12,7 +12,7 @@
  * @since         CakePHP(tm) v3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Test\View;
+namespace Cake\Test\TestCase\View;
 
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;

--- a/Cake/View/Helper/PaginatorHelper.php
+++ b/Cake/View/Helper/PaginatorHelper.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\View\Helper;
 
+use Cake\Utility\Inflector;
 use Cake\View\Helper;
 use Cake\View\StringTemplate;
 use Cake\View\View;
-use Cake\Utility\Inflector;
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -349,7 +349,7 @@ class PaginatorHelper extends Helper {
 		$enabled = $this->hasNext($options['model']);
 		$templates = [
 			'active' => 'nextActive',
-			'disabled' =>  'nextDisabled'
+			'disabled' => 'nextDisabled'
 		];
 		return $this->_toggledLink($title, $enabled, $options, $templates);
 	}


### PR DESCRIPTION
This fixes most of the current CS errors we are having.

Remaining errors are:
- Useless method overriding detected
- Variable "_sort" is not in valid camel caps format
- Public method name "and_" is not in camel caps format
- PHP4 style constructors are not allowed; use "__construct()" instead

For those errors I think some adjustments on the Coding Standard repository should be made.
I will create a PR for that later on.
