### PR TITLE
2.5 - Add Cache::remember()

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -549,9 +549,20 @@ class Cache {
  * will be invoked. The results will then be stored into the cache config
  * at key.
  *
+ * Examples:
+ *
+ * Using a Closure to provide data, assume $this is a Model:
+ *
+ * {{{
+ * $model = $this;
+ * $results = Cache::remember('all_articles', function () use ($model) {
+ *      return $model->find('all');
+ * });
+ * }}}
+ *
  * @param string $key The cache key to read/store data at.
  * @param callable $callable The callable that provides data in the case when
- *   the cache key is empty.
+ *   the cache key is empty. Can be any callable type supported by your PHP.
  * @param string $config The cache configuration to use for this operation.
  *   Defaults to default.
  */

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -542,4 +542,27 @@ class Cache {
 		throw new CacheException(__d('cake_dev', 'Invalid cache group %s', $group));
 	}
 
+/**
+ * Provides the ability to easily do read-through caching.
+ *
+ * When called if the $key is not set in $config, the $callable function
+ * will be invoked. The results will then be stored into the cache config
+ * at key.
+ *
+ * @param string $key The cache key to read/store data at.
+ * @param callable $callable The callable that provides data in the case when
+ *   the cache key is empty.
+ * @param string $config The cache configuration to use for this operation.
+ *   Defaults to default.
+ */
+	public static function remember($key, $callable, $config = 'default') {
+		$existing = self::read($key, $config);
+		if ($existing !== false) {
+			return $existing;
+		}
+		$results = call_user_func($callable);
+		self::write($key, $results, $config);
+		return $results;
+	}
+
 }

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -555,7 +555,7 @@ class Cache {
  *
  * {{{
  * $model = $this;
- * $results = Cache::remember('all_articles', function () use ($model) {
+ * $results = Cache::remember('all_articles', function() use ($model) {
  *      return $model->find('all');
  * });
  * }}}

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -501,11 +501,11 @@ class CacheTest extends CakeTestCase {
  */
 	public function testRemember() {
 		$expected = 'This is some data 0';
-		$result = Cache::remember('test_key', [$this, 'cacher'], 'default');
+		$result = Cache::remember('test_key', array($this, 'cacher'), 'default');
 		$this->assertEquals($expected, $result);
 
 		$this->_count = 1;
-		$result = Cache::remember('test_key', [$this, 'cacher'], 'default');
+		$result = Cache::remember('test_key', array($this, 'cacher'), 'default');
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -27,6 +27,8 @@ App::uses('Cache', 'Cache');
  */
 class CacheTest extends CakeTestCase {
 
+	protected $_count = 0;
+
 /**
  * setUp method
  *
@@ -490,5 +492,29 @@ class CacheTest extends CakeTestCase {
 
 		$this->assertEquals('test_file_', $settings['prefix']);
 		$this->assertEquals(strtotime('+1 year') - time(), $settings['duration']);
+	}
+
+/**
+ * test remember method.
+ *
+ * @return void
+ */
+	public function testRemember() {
+		$expected = 'This is some data 0';
+		$result = Cache::remember('test_key', [$this, 'cacher'], 'default');
+		$this->assertEquals($expected, $result);
+
+		$this->_count = 1;
+		$result = Cache::remember('test_key', [$this, 'cacher'], 'default');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Method for testing Cache::remember()
+ *
+ * @return string
+ */
+	public function cacher() {
+		return 'This is some data ' . $this->_count;
 	}
 }


### PR DESCRIPTION
I frequently use read-through caching strategies in my applications. This often ends up being repetitive code, that gets pushed into a helper function. I thought it might be useful to have this as a pre-baked workflow in Cache.

This new method allows you to provide callables that provide data for a cache key should the cache key not exist.

For example a model function could easily be used to cache results. Assuming you are using PHP 5.4 or later.

``` php
<?php
class Articles extends AppModel {

  function all() {
    return Cache::remember('all_articles', function () {
      return $this->find('all');
    });
  }
}
```
