### PR TITLE
fixes FileLog doesn't delete on rotation if count(files) is greater 'rotate'

### DIFF
--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -206,7 +206,7 @@ class FileLog extends BaseLog {
 
 		if ($this->_config['rotate']) {
 			$files = glob($filepath . '.*');
-			if (count($files) === $this->_config['rotate']) {
+			while (count($files) >= $this->_config['rotate']) {
 				unlink(array_shift($files));
 			}
 		}

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -201,17 +201,21 @@ class FileLog extends BaseLog {
 		}
 
 		if ($this->_config['rotate'] === 0) {
-			return unlink($filepath);
+			$result = unlink($filepath);
+		} else {
+			$result = rename($filepath, $filepath . '.' . time());
 		}
 
-		if ($this->_config['rotate']) {
-			$files = glob($filepath . '.*');
-			while (count($files) >= $this->_config['rotate']) {
+		$files = glob($filepath . '.*');
+		if ($files) {
+			$filesToDelete = count($files) - $this->_config['rotate'];
+			while ($filesToDelete > 0) {
 				unlink(array_shift($files));
+				$filesToDelete--;
 			}
 		}
 
-		return rename($filepath, $filepath . '.' . time());
+		return $result;
 	}
 
 }

--- a/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
@@ -142,6 +142,7 @@ class FileLogTest extends CakeTestCase {
 			'size' => 35,
 			'rotate' => 0
 		));
+		file_put_contents($path . 'debug.log.0000000000', "The oldest log file with over 35 bytes.\n");
 		$log->write('debug', 'Test debug');
 		$this->assertTrue(file_exists($path . 'debug.log'));
 

--- a/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
@@ -117,6 +117,8 @@ class FileLogTest extends CakeTestCase {
 		$result = file_get_contents($files[1]);
 		$this->assertRegExp('/Warning: Test warning second/', $result);
 
+		file_put_contents($path . 'error.log.0000000000', "The oldest log file with over 35 bytes.\n");
+
 		sleep(1);
 		clearstatcache();
 		$log->write('warning', 'Test warning fourth');


### PR DESCRIPTION
If for whatever reason there were more log files than should according 
to the rotate parameter the log files weren't deleted at all.
