### PR TITLE
Fix return value of save() to only return actually saved fields.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1789,6 +1789,8 @@ class Model extends Object implements CakeEventListener {
 				$this->getEventManager()->dispatch($event);
 			}
 			if (!empty($this->data)) {
+				$this->data[$this->alias] = array_combine($fields, $values);
+				$this->data[$this->alias][$this->primaryKey] = $this->id;
 				$success = $this->data;
 			}
 			$this->data = false;

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -292,6 +292,39 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
+ * Test that save() only returns the actually saved fields when whitelisting is used.
+ * The primary key is always returned, though.
+ */
+	public function testSaveWithFieldList() {
+		$this->loadFixtures('Bidding');
+		$model = new Bidding();
+
+		$data = array('bid' => 'foo', 'name' => 'bar');
+		$model->create();
+		$result = $model->save(
+			$data,
+			array('fieldList' => array('bid'))
+		);
+		$expected = array(
+			'bid' => 'foo',
+			'id' => $model->id
+		);
+		$this->assertEquals($expected, $result['Bidding']);
+
+		$data['id'] = $model->id;
+		$model->create();
+		$result = $model->save(
+			$data,
+			array('fieldList' => array('name'))
+		);
+		$expected = array(
+			'name' => 'bar',
+			'id' => $model->id
+		);
+		$this->assertEquals($expected, $result['Bidding']);
+	}
+
+/**
  * test that save() resets whitelist on failed save
  */
 	public function testSaveFieldListResetsWhitelistOnFailedSave() {


### PR DESCRIPTION
The current return value of save() contains also fields that have been ignored due to whitelisting.
This is quite confusing as the return value should reflect the actually modified fields IMO.
Otherwise the only way to know for sure would be to query again and compare the results.

This should resolve it.
