### PR TITLE
Fix whitelist to be modifiable from behaviors to work with validate.

### DIFF
--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -249,7 +249,11 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 			return $model->validationErrors;
 		}
 
-		$fieldList = isset($options['fieldList']) ? $options['fieldList'] : array();
+		$fieldList = $model->whitelist;
+		if (empty($fieldList) && !empty($options['fieldList'])) {
+			$fieldList = $options['fieldList'];
+		}
+
 		$exists = $model->exists();
 		$methods = $this->getMethods();
 		$fields = $this->_validationList($fieldList);

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -622,12 +622,10 @@ class ModelValidationTest extends BaseModelTest {
 		$TestModel = new ValidationTest1();
 		$TestModel->validate = array(
 			'title' => array(
-				'rule' => 'alphaNumeric',
-				'required' => true
+				'rule' => 'notEmpty',
 			),
 			'name' => array(
-				'rule' => 'alphaNumeric',
-				'required' => true
+				'rule' => 'notEmpty',
 		));
 		$TestModel->Behaviors->attach('ValidationRule', array('fields' => array('name')));
 

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -612,6 +612,12 @@ class ModelValidationTest extends BaseModelTest {
 		$this->assertEquals(0, $joinRecords, 'Records were saved on the join table. %s');
 	}
 
+/**
+ * Test that if a behavior modifies the model's whitelist validation gets triggered
+ * properly for those fields.
+ *
+ * @return void
+ */
 	public function testValidateWithFieldListAndBehavior() {
 		$TestModel = new ValidationTest1();
 		$TestModel->validate = array(


### PR DESCRIPTION
Allows behaviors to modify/extend the whitelist when adding new fields.
Otherwise those will be disregarded for validation - which is quite a deficiency in behavior functionality IMO.

Initially I thought of this as a bugfix. 
But it seems the behaviors have not been able to modify the whitelist so far in 2.x - so this might be more a change of behavior for some.

Actually, I wanted to keep the ValidationRuleBehavior test class separate in the test_app folder, but it wasn't loaded.
Anything missing there?
