### PR TITLE
Use App.base when there are no requests to generate URL's

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -803,6 +803,9 @@ class Router {
 			$params = $request->params;
 			$path = array('base' => $request->base, 'here' => $request->here);
 		}
+		if (empty($path['base'])) {
+			$path['base'] = Configure::read('App.base');
+		}
 
 		$base = $path['base'];
 		$extension = $output = $q = $frag = null;

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -81,6 +81,18 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * Test that Router uses App.base to build URL's when there are no stored
+ * request objects.
+ *
+ * @return void
+ */
+	public function testBaseUrlWithBasePath() {
+		Configure::write('App.base', '/cakephp');
+		Router::fullBaseUrl('http://example.com');
+		$this->assertEquals('http://example.com/cakephp/tasks', Router::url('/tasks', true));
+	}
+
+/**
  * testRouteDefaultParams method
  *
  * @return void


### PR DESCRIPTION
Setting App.fullBaseUrl to a non-host value causes issues generating URL's in a web context. However, not including the base path generates incorrect URL's in a CLI context. This change allows the use of App.base to populate the base path which is used as a fallback when there are no requests, or when the base path is empty.

Refs [2931](https://cakephp.lighthouseapp.com/projects/42648/tickets/2931-htmlhelperimage-does-not-work-from-within-email-templates)
