### PR TITLE
Remove deprecated methods.

### DIFF
--- a/Cake/Controller/Component/AclComponent.php
+++ b/Cake/Controller/Component/AclComponent.php
@@ -155,32 +155,4 @@ class AclComponent extends Component {
 		return $this->_Instance->inherit($aro, $aco, $action);
 	}
 
-/**
- * Pass-thru function for ACL grant instance. An alias for AclComponent::allow()
- *
- * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
- * @param string $action Action (defaults to *)
- * @return boolean Success
- * @deprecated Will be removed in 3.0.
- */
-	public function grant($aro, $aco, $action = "*") {
-		trigger_error(__d('cake_dev', '%s is deprecated, use %s instead', 'AclComponent::grant()', 'allow()'), E_USER_WARNING);
-		return $this->_Instance->allow($aro, $aco, $action);
-	}
-
-/**
- * Pass-thru function for ACL grant instance. An alias for AclComponent::deny()
- *
- * @param array|string|Model $aro ARO The requesting object identifier. See `AclNode::node()` for possible formats
- * @param array|string|Model $aco ACO The controlled object identifier. See `AclNode::node()` for possible formats
- * @param string $action Action (defaults to *)
- * @return boolean Success
- * @deprecated Will be removed in 3.0.
- */
-	public function revoke($aro, $aco, $action = "*") {
-		trigger_error(__d('cake_dev', '%s is deprecated, use %s instead', 'AclComponent::revoke()', 'deny()'), E_USER_WARNING);
-		return $this->_Instance->deny($aro, $aco, $action);
-	}
-
 }

--- a/Cake/Controller/Component/CookieComponent.php
+++ b/Cake/Controller/Component/CookieComponent.php
@@ -477,9 +477,6 @@ class CookieComponent extends Component {
 		if ($this->_type === 'rijndael') {
 			$cipher = Security::rijndael($value, $this->key, 'encrypt');
 		}
-		if ($this->_type === 'cipher') {
-			$cipher = Security::cipher($value, $this->key);
-		}
 		if ($this->_type === 'aes') {
 			$cipher = Security::encrypt($value, $this->key);
 		}
@@ -523,9 +520,6 @@ class CookieComponent extends Component {
 		$value = base64_decode(substr($value, strlen($prefix)));
 		if ($this->_type === 'rijndael') {
 			$plain = Security::rijndael($value, $this->key, 'decrypt');
-		}
-		if ($this->_type === 'cipher') {
-			$plain = Security::cipher($value, $this->key);
 		}
 		if ($this->_type === 'aes') {
 			$plain = Security::decrypt($value, $this->key);

--- a/Cake/Model/BehaviorCollection.php
+++ b/Cake/Model/BehaviorCollection.php
@@ -73,18 +73,6 @@ class BehaviorCollection extends ObjectCollection implements EventListener {
 	}
 
 /**
- * Backwards compatible alias for load()
- *
- * @param string $behavior
- * @param array $config
- * @return void
- * @deprecated Will be removed in 3.0. Replaced with load().
- */
-	public function attach($behavior, $config = array()) {
-		return $this->load($behavior, $config);
-	}
-
-/**
  * Loads a behavior into the collection. You can use use `$config['enabled'] = false`
  * to load a behavior with callbacks disabled. By default callbacks are enabled. Disable behaviors
  * can still be used as normal.
@@ -199,17 +187,6 @@ class BehaviorCollection extends ObjectCollection implements EventListener {
 				unset($this->_methods[$m]);
 			}
 		}
-	}
-
-/**
- * Backwards compatible alias for unload()
- *
- * @param string $name Name of behavior
- * @return void
- * @deprecated Will be removed in 3.0. Use unload instead.
- */
-	public function detach($name) {
-		return $this->unload($name);
 	}
 
 /**

--- a/Cake/Test/TestCase/Utility/SecurityTest.php
+++ b/Cake/Test/TestCase/Utility/SecurityTest.php
@@ -25,29 +25,6 @@ use Cake\Utility\Security;
 class SecurityTest extends TestCase {
 
 /**
- * sut property
- *
- * @var mixed null
- */
-	public $sut = null;
-
-/**
- * testInactiveMins method
- *
- * @return void
- */
-	public function testInactiveMins() {
-		Configure::write('Security.level', 'high');
-		$this->assertEquals(10, Security::inactiveMins());
-
-		Configure::write('Security.level', 'medium');
-		$this->assertEquals(100, Security::inactiveMins());
-
-		Configure::write('Security.level', 'low');
-		$this->assertEquals(300, Security::inactiveMins());
-	}
-
-/**
  * testGenerateAuthkey method
  *
  * @return void

--- a/Cake/Utility/ObjectCollection.php
+++ b/Cake/Utility/ObjectCollection.php
@@ -268,19 +268,6 @@ abstract class ObjectCollection {
 	}
 
 /**
- * Gets the list of attached objects, or, whether the given object is attached
- *
- * @param string $name Optional. The name of the object to check the status of. If omitted,
- *   returns an array of currently-attached objects
- * @return mixed If $name is specified, returns the boolean status of the corresponding object.
- *    Otherwise, returns an array of all attached objects.
- * @deprecated Will be removed in 3.0. Use loaded instead.
- */
-	public function attached($name = null) {
-		return $this->loaded($name);
-	}
-
-/**
  * Gets the list of loaded objects, or, whether the given object is loaded
  *
  * @param string $name Optional. The name of the object to check the status of. If omitted,

--- a/Cake/Utility/Security.php
+++ b/Cake/Utility/Security.php
@@ -42,24 +42,6 @@ class Security {
 	public static $hashCost = '10';
 
 /**
- * Get allowed minutes of inactivity based on security level.
- *
- * @deprecated Exists for backwards compatibility only, not used by the core
- * @return integer Allowed inactivity in minutes
- */
-	public static function inactiveMins() {
-		switch (Configure::read('Security.level')) {
-			case 'high':
-				return 10;
-			case 'medium':
-				return 100;
-			case 'low':
-			default:
-				return 300;
-		}
-	}
-
-/**
  * Generate authorization hash.
  *
  * @return string Hash
@@ -165,17 +147,6 @@ class Security {
 			));
 		}
 		static::$hashCost = $cost;
-	}
-
-/**
- * Deprecated method. Does nothing.
- * @param string $text Encrypted string to decrypt, normal string to encrypt
- * @param string $key Key to use
- * @throws Cake\Error\Exception
- * @deprecated This method will be removed in 3.x
- */
-	public static function cipher($text, $key) {
-		throw new Error\Exception(__d('cake_dev', 'Security::cipher() has been removed. Use Security::rijndael() to encrypt data'));
 	}
 
 /**


### PR DESCRIPTION
The following deprecated methods have been removed:
- Security::cipher()
- Security::inactiveMins()
- BehaviorCollection::attach()
- BehaviorCollection::detach()
- ObjectCollection::attached()
- AclComponent::grant()
- AclComponent::revoke()

As they have long been deprecated in 2.x and should have been upgraded to 2.3/2.4 code respectively.
