### PR TITLE
Ability to use PaginatorHelper::sort() with only one direction.

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -234,6 +234,53 @@ class PaginatorHelperTest extends CakeTestCase {
 	}
 
 /**
+ * testSortLinksWithLockOption method
+ *
+ * @return void
+ */
+	public function testSortLinksWithLockOption() {
+		Router::reload();
+		Router::parse('/');
+		Router::setRequestInfo(array(
+			array('plugin' => null, 'controller' => 'accounts', 'action' => 'index', 'pass' => array(), 'url' => array('url' => 'accounts/')),
+			array('base' => '/officespace', 'here' => '/officespace/accounts/', 'webroot' => '/officespace/')
+		));
+		$this->Paginator->options(array('url' => array('param')));
+		$this->Paginator->request['paging'] = array(
+			'Article' => array(
+				'current' => 9,
+				'count' => 62,
+				'prevPage' => false,
+				'nextPage' => true,
+				'pageCount' => 7,
+				'options' => array(
+					'page' => 1,
+					'order' => array('date' => 'asc'),
+					'conditions' => array()
+				),
+				'paramType' => 'named'
+			)
+		);
+
+		$result = $this->Paginator->sort('distance', null, array('lock' => true));
+		$expected = array(
+			'a' => array('href' => '/officespace/accounts/index/param/sort:distance/direction:asc'),
+			'Distance',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Paginator->request->params['paging']['Article']['options']['sort'] = 'distance';
+		$result = $this->Paginator->sort('distance', null, array('lock' => true));
+		$expected = array(
+			'a' => array('href' => '/officespace/accounts/index/param/sort:distance/direction:asc', 'class' => 'asc locked'),
+			'Distance',
+			'/a'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * test that sort() works with virtual field order options.
  *
  * @return void

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -315,9 +315,10 @@ class PaginatorHelper extends AppHelper {
  *
  * ### Options:
  *
- * - `escape` Whether you want the contents html entity encoded, defaults to true
- * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
+ * - `escape` Whether you want the contents html entity encoded, defaults to true.
+ * - `model` The model to use, defaults to PaginatorHelper::defaultModel().
  * - `direction` The default direction to use when this link isn't active.
+ * - `lock` Lock direction. Will only use the default direction then, defaults to false.
  *
  * @param string $key The name of the key that the recordset should be sorted.
  * @param string $title Title for the link. If $title is null $key will be used
@@ -341,8 +342,11 @@ class PaginatorHelper extends AppHelper {
 
 			$title = __(Inflector::humanize(preg_replace('/_id$/', '', $title)));
 		}
-		$dir = isset($options['direction']) ? $options['direction'] : 'asc';
+		$defaultDir = isset($options['direction']) ? $options['direction'] : 'asc';
 		unset($options['direction']);
+
+		$locked = isset($options['lock']) ? $options['lock'] : false;
+		unset($options['lock']);
 
 		$sortKey = $this->sortKey($options['model']);
 		$defaultModel = $this->defaultModel();
@@ -352,6 +356,7 @@ class PaginatorHelper extends AppHelper {
 			$key === $defaultModel . '.' . $sortKey
 		);
 
+		$dir = $defaultDir;
 		if ($isSorted) {
 			$dir = $this->sortDir($options['model']) === 'asc' ? 'desc' : 'asc';
 			$class = $dir === 'asc' ? 'desc' : 'asc';
@@ -359,6 +364,10 @@ class PaginatorHelper extends AppHelper {
 				$options['class'] .= ' ' . $class;
 			} else {
 				$options['class'] = $class;
+			}
+			if ($locked) {
+				$dir = $defaultDir;
+				$options['class'] .= ' locked';
 			}
 		}
 		if (is_array($title) && array_key_exists($dir, $title)) {


### PR DESCRIPTION
In the past we sometimes had to use a little bit of view overhead to make sort links for fields
in the paginated table sortable in one direction only (check via sortKey() and dynamically adjust the output).

This functionality makes sense for distance, price, etc (where you only need/want ASC sorting).

But instead of a view workaround of multiple lines, I suggest the following enhancement for the paginator's sort() method:

Add `fixate` option (default false) to restrict direction to only default one.

So:

```
echo $this->Paginator->sort('price', null, 
    array('direction'=>'asc', 'fixate' => true));
```

It will then also add the class "fixated" in case it is sorted by this field (`class="asc fixated"`).

One can then adjust the link via CSS:

```
a.asc.fixated {
    color: grey;
}
```

And/or disable the click event via JS.

Other possible option keys: "fixed", "sticky", "freeze", "restrict".
As class name that is added we could also use "disabled": `class="asc disabled"`.

Speaking of: We could also use some kind of "disabled" modification here - similar to first/last page links transformed into non-clickable text. But this way we don't lose the default css styling of the pagination links (search arrow icon, marked as active) besides the link or don't have to necessarily add more styling.

CakePHP: 2.5 as feature
BC: yes, 100%
