### PR TITLE
Remove extra space around the brace in CakeSchema::_arrayDiffAssoc()

### DIFF
--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -551,7 +551,7 @@ class CakeSchema extends Object {
 				continue;
 			}
 			$correspondingValue = $array2[$key];
-			if (($value === null ) !== ($correspondingValue === null)) {
+			if (($value === null) !== ($correspondingValue === null)) {
 				$difference[$key] = $value;
 				continue;
 			}


### PR DESCRIPTION
Fixes extra space created in:  https://github.com/cakephp/cakephp/pull/2142
