### PR TITLE
Refactor frequently-changed config into separate files

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -63,14 +63,9 @@ Cache::config('default', array('engine' => 'File'));
  */
 
 /**
- * Plugins need to be loaded manually, you can either load them one by one or all of them in a single call
- * Uncomment one of the lines below, as you need. Make sure you read the documentation on CakePlugin to use more
- * advanced ways of loading plugins
- *
- * CakePlugin::loadAll(); // Loads all plugins at once
- * CakePlugin::load('DebugKit'); //Loads a single plugin named DebugKit
- *
+ * Plugins
  */
+include('plugins.php');
 
 /**
  * You can attach event listeners to the request lifecycle as Dispatcher Filter. By default CakePHP bundles two filters:

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -65,7 +65,7 @@ Cache::config('default', array('engine' => 'File'));
 /**
  * Plugins
  */
-include('plugins.php');
+include ('plugins.php');
 
 /**
  * You can attach event listeners to the request lifecycle as Dispatcher Filter. By default CakePHP bundles two filters:

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -20,7 +20,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-include( 'environment.php' );
+include ('environment.php');
 
 /**
  * CakePHP Debug Level:
@@ -35,7 +35,7 @@ include( 'environment.php' );
  * In production mode, flash messages redirect after a time interval.
  * In development mode, you need to click the flash message to continue.
  */
-if ( ENV_DEVELOPMENT ) {
+if (ENV_DEVELOPMENT) {
 	Configure::write('debug', 2);
 } else {
 	Configure::write('debug', 0);

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -20,6 +20,8 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+include( 'environment.php' );
+
 /**
  * CakePHP Debug Level:
  *
@@ -33,7 +35,11 @@
  * In production mode, flash messages redirect after a time interval.
  * In development mode, you need to click the flash message to continue.
  */
+if ( ENV_DEVELOPMENT ) {
 	Configure::write('debug', 2);
+} else {
+	Configure::write('debug', 0);
+}
 
 /**
  * Configure the Error handler used to handle errors for your application. By default

--- a/app/Config/environment.php
+++ b/app/Config/environment.php
@@ -1,0 +1,14 @@
+<?php
+$environmentAddresses = array(
+	'development' => array( 'localhost' ),
+	// 'staging'     => array( '<your_staging_site>.com' ),
+	'production'  => array( '<your_production_site>.com' ),
+	);
+
+// environments
+foreach ( $environmentAddresses as $environment => $addresses ) {
+	define( 'ENV_'.strtoupper($environment), isset($_SERVER['SERVER_NAME']) && in_array($_SERVER['SERVER_NAME'], $addresses) );
+}
+
+// sandbox
+define( 'SANDBOX', ENV_DEVELOPMENT || ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array('my_ip_address') ) ) );

--- a/app/Config/environment.php
+++ b/app/Config/environment.php
@@ -1,14 +1,14 @@
 <?php
 $environmentAddresses = array(
-	'development' => array( 'localhost' ),
-	// 'staging'     => array( '<your_staging_site>.com' ),
-	'production'  => array( '<your_production_site>.com' ),
+	'development' => array('localhost'),
+	// 'staging' => array('<your_staging_site>.com'),
+	'production' => array('<your_production_site>.com'),
 	);
 
 // environments
-foreach ( $environmentAddresses as $environment => $addresses ) {
-	define( 'ENV_'.strtoupper($environment), isset($_SERVER['SERVER_NAME']) && in_array($_SERVER['SERVER_NAME'], $addresses) );
+foreach ($environmentAddresses as $environment => $addresses) {
+	define('ENV_' . strtoupper($environment), isset($_SERVER['SERVER_NAME']) && in_array($_SERVER['SERVER_NAME'], $addresses));
 }
 
 // sandbox
-define( 'SANDBOX', ENV_DEVELOPMENT || ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array('my_ip_address') ) ) );
+define('SANDBOX', ENV_DEVELOPMENT || (isset($_SERVER['REMOTE_ADDR']) && in_array($_SERVER['REMOTE_ADDR'], array('my_ip_address'))));

--- a/app/Config/plugins.php
+++ b/app/Config/plugins.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Plugins need to be loaded manually, you can either load them one by one or all of them in a single call
+ * Uncomment one of the lines below, as you need. Make sure you read the documentation on CakePlugin to use more
+ * advanced ways of loading plugins
+ */
+// CakePlugin::loadAll(); // Loads all plugins at once
+// CakePlugin::load('DebugKit'); //Loads a single plugin named DebugKit


### PR DESCRIPTION
There is one config thing that changes a lot during the course of a CakePHP project - the plugins. I felt uncomfortable always editing bootstrap.php. Now all plugins are loaded in `plugins.php`.

Also, there was never any clean way to handle multiple environments. And when deployment times rolls around, remembering to change `debug = 0` can be easily forgotten.
