### PR TITLE
3.0 - Extract table registry

### DIFF
--- a/Cake/Database/ConnectionManager.php
+++ b/Cake/Database/ConnectionManager.php
@@ -46,6 +46,13 @@ class ConnectionManager {
 	protected static $_config = [];
 
 /**
+ * A map of connection aliases.
+ *
+ * @var array
+ */
+	protected static $_aliasMap = [];
+
+/**
  * The ConnectionRegistry used by the manager.
  *
  * @var Cake\Database\ConnectionRegistry
@@ -72,21 +79,70 @@ class ConnectionManager {
 	}
 
 /**
+ * Set one or more connection aliases.
+ *
+ * Connection aliases allow you to rename active connections without overwriting
+ * the aliased connection. This is most useful in the testsuite for replacing
+ * connections with their test variant.
+ *
+ * Defined aliases will take precedence over normal connection names. For example,
+ * if you alias 'default' to 'test', fetching 'default' will always return the 'test'
+ * connection as long as the alias is defined.
+ *
+ * You can remove aliases with ConnectionManager::dropAlias().
+ *
+ * @param string|array $from The connection to rename. Can also be a map of multiple
+ *   aliases to set.
+ * @param string $to The connection $from should return when loaded with get().
+ * @return void
+ */
+	public static function alias($from, $to = null) {
+		if (is_array($from)) {
+			foreach ($from as $source => $dest) {
+				static::alias($source, $dest);
+			}
+		}
+		if (empty(static::$_config[$from])) {
+			throw new Error\MissingDatasourceConfigException(
+				__d('cake_dev', 'Cannot alias connection "%s" as it does not exist.', $from)
+			);
+		}
+		static::$_aliasMap[$to] = $from;
+	}
+
+/**
+ * Drop an alias.
+ *
+ * Removes an alias from ConnectionManager. Fetching the aliased
+ * connection may fail if there is no other connection with that name.
+ *
+ * @param string $name The connection name to remove aliases for.
+ * @return void
+ */
+	public static function dropAlias($name) {
+		unset(static::$_aliasMap[$name]);
+	}
+
+/**
  * Get a connection.
  *
  * If the connection has not been constructed an instance will be added
- * to the registry.
+ * to the registry. This method will use any aliases that have been
+ * defined. If you want the original unaliased connections use getOriginal()
  *
  * @param string $name The connection name.
  * @return Connection A connection object.
  * @throws Cake\Error\MissingDatasourceConfigException When config data is missing.
  */
 	public static function get($name) {
-		if (empty(static::$_config[$name])) {
+		if (empty(static::$_config[$name]) && empty(static::$_aliasMap[$name])) {
 			throw new Error\MissingDatasourceConfigException(['name' => $name]);
 		}
 		if (empty(static::$_registry)) {
 			static::$_registry = new ConnectionRegistry();
+		}
+		if (isset(static::$_aliasMap[$name])) {
+			$name = static::$_aliasMap[$name];
 		}
 		if (isset(static::$_registry->{$name})) {
 			return static::$_registry->{$name};

--- a/Cake/Database/ConnectionManager.php
+++ b/Cake/Database/ConnectionManager.php
@@ -131,18 +131,19 @@ class ConnectionManager {
  * defined. If you want the original unaliased connections use getOriginal()
  *
  * @param string $name The connection name.
+ * @param boolean $useAliases Set to false to not use aliased connections.
  * @return Connection A connection object.
  * @throws Cake\Error\MissingDatasourceConfigException When config data is missing.
  */
-	public static function get($name) {
-		if (empty(static::$_config[$name]) && empty(static::$_aliasMap[$name])) {
+	public static function get($name, $useAliases = true) {
+		if ($useAliases && isset(static::$_aliasMap[$name])) {
+			$name = static::$_aliasMap[$name];
+		}
+		if (empty(static::$_config[$name])) {
 			throw new Error\MissingDatasourceConfigException(['name' => $name]);
 		}
 		if (empty(static::$_registry)) {
 			static::$_registry = new ConnectionRegistry();
-		}
-		if (isset(static::$_aliasMap[$name])) {
-			$name = static::$_aliasMap[$name];
 		}
 		if (isset(static::$_registry->{$name})) {
 			return static::$_registry->{$name};

--- a/Cake/Database/ConnectionManager.php
+++ b/Cake/Database/ConnectionManager.php
@@ -91,20 +91,14 @@ class ConnectionManager {
  *
  * You can remove aliases with ConnectionManager::dropAlias().
  *
- * @param string|array $from The connection to rename. Can also be a map of multiple
- *   aliases to set.
- * @param string $to The connection $from should return when loaded with get().
+ * @param string $from The connection to add an alias to.
+ * @param string $to The alias to create. $from should return when loaded with get().
  * @return void
  */
 	public static function alias($from, $to = null) {
-		if (is_array($from)) {
-			foreach ($from as $source => $dest) {
-				static::alias($source, $dest);
-			}
-		}
-		if (empty(static::$_config[$from])) {
+		if (empty(static::$_config[$to]) && empty(static::$_config[$from])) {
 			throw new Error\MissingDatasourceConfigException(
-				__d('cake_dev', 'Cannot alias connection "%s" as it does not exist.', $from)
+				__d('cake_dev', 'Cannot create alias of "%s" as it does not exist.', $from)
 			);
 		}
 		static::$_aliasMap[$to] = $from;

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -16,6 +16,9 @@
  */
 namespace Cake\ORM;
 
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+
 /**
  * An Association is a relationship established between two tables and is used
  * to configure and customize the way interconnected records are retrieved.
@@ -210,7 +213,7 @@ abstract class Association {
 
 		if ($table === null) {
 			$className = $this->_className;
-			$this->_targetTable = Table::build($this->_name, compact('className'));
+			$this->_targetTable = TableRegistry::get($this->_name, compact('className'));
 		}
 		return $this->_targetTable;
 	}

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -212,8 +212,9 @@ abstract class Association {
 		}
 
 		if ($table === null) {
-			$className = $this->_className;
-			$this->_targetTable = TableRegistry::get($this->_name, compact('className'));
+			$this->_targetTable = TableRegistry::get($this->_name, [
+				'className' => $this->_className,
+			]);
 		}
 		return $this->_targetTable;
 	}

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -19,6 +19,7 @@ namespace Cake\ORM\Association;
 use Cake\ORM\Association;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 
 /**
@@ -93,8 +94,7 @@ class BelongsToMany extends Association {
 			if (empty($this->_pivotTable)) {
 				$tableName = $this->_joinTableName();
 				$tableAlias = Inflector::classify(Inflector::singularize($tableName));
-				$table = Table::instance($tableAlias);
-				$table = $table ?: Table::build($tableAlias, [
+				$table = TableRegistry::get($tableAlias, [
 					'table' => $tableName
 				]);
 			} else {
@@ -103,7 +103,7 @@ class BelongsToMany extends Association {
 		}
 
 		if (is_string($table)) {
-			$table = Table::build($table);
+			$table = TableRegistry::get($table);
 		}
 
 		if (!$table->association($sAlias)) {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -261,7 +261,7 @@ class Table {
 			if ($this->_schema === null) {
 				$this->_schema = $this->connection()
 					->schemaCollection()
-					->describe($this->_table);
+					->describe($this->table());
 			}
 			return $this->_schema;
 		}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -146,6 +146,9 @@ class Table {
  * @return void
  */
 	public function __construct(array $config = []) {
+		if (empty($config['table'])) {
+			$config['table'] = Inflector::tableize(get_class($this));
+		}
 		if (!empty($config['table'])) {
 			$this->table($config['table']);
 		}
@@ -173,6 +176,7 @@ class Table {
 			$eventManager = $config['eventManager'];
 		}
 		$this->_eventManager = $eventManager ?: new EventManager();
+<<<<<<< HEAD
 		$this->initialize($config);
 	}
 
@@ -215,25 +219,7 @@ class Table {
  * @return Table
  */
 	public static function build($alias, array $options = []) {
-		if (isset(static::$_instances[$alias])) {
-			return static::$_instances[$alias];
-		}
-
-		list($plugin, $baseClass) = pluginSplit($alias);
-		$options = ['alias' => $baseClass] + $options;
-
-		if (empty($options['className'])) {
-			$options['className'] = get_called_class();
-		}
-
-		if ($options['className'] === __CLASS__ || $plugin) {
-			$class = $options['className'];
-			$classified = Inflector::classify($alias);
-			$class = App::classname($classified, 'Model\Repository', 'Table') ?: $class;
-			$options['className'] = $class;
-		}
-
-		return static::$_instances[$alias] = new $options['className']($options);
+		return TableRegistry::get($alias, $options);
 	}
 
 /**
@@ -247,46 +233,9 @@ class Table {
  */
 	public static function instance($alias, self $object = null) {
 		if ($object === null) {
-			return isset(static::$_instances[$alias]) ? static::$_instances[$alias] : null;
+			return TableRegistry::get($alias);
 		}
-		return static::$_instances[$alias] = $object;
-	}
-
-/**
- * Stores a list of options to be used when instantiating an object for the table
- * with the same name as $table. The options that can be stored are those that
- * are recognized by `build()`
- *
- * If second argument is omitted, it will return the current settings for $table
- *
- * If no arguments are passed it will return the full configuration array for
- * all tables
- *
- * @param string $table name of the table
- * @param array $options list of options for the table
- * @return array
- */
-	public static function config($table = null, array $options = null) {
-		if ($table === null) {
-			return static::$_tablesMap;
-		}
-		if (!is_string($table)) {
-			return static::$_tablesMap = $table;
-		}
-		if ($options === null) {
-			return isset(static::$_tablesMap[$table]) ? static::$_tablesMap[$table] : [];
-		}
-		return static::$_tablesMap[$table] = $options;
-	}
-
-/**
- * Clears the registry of instantiated tables and default configurations
- *
- * @return void
- */
-	public static function clearRegistry() {
-		static::$_instances = [];
-		static::$_tablesMap = [];
+		return TableRegistry::set($alias, $object);
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -27,11 +27,22 @@ use Cake\ORM\Entity;
 use Cake\Utility\Inflector;
 
 /**
- * Represents a single database table. Exposes methods for retrieving data out
- * of it and manages the associations it has to other tables. Multiple
- * instances of this class can be created for the same database table with
- * different aliases, this allows you to address your database structure in a
- * richer and more expressive way.
+ * Represents a single database table.
+ *
+ * Exposes methods for retrieving data out of it, and manages the associations
+ * this table has to other tables. Multiple instances of this class can be created
+ * for the same database table with different aliases, this allows you to address 
+ * your database structure in a richer and more expressive way.
+ *
+ * ### Retrieving data
+ *
+ * The primary way to retreive data is using Table::find(). See that method
+ * for more information.
+ *
+ * ### Bulk updates/deletes
+ *
+ * You can use Table::updateAll() and Table::deleteAll() to do bulk updates/deletes.
+ * You should be aware that events will *not* be fired for bulk updates/deletes.
  *
  * ### Callbacks/events
  *

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -46,14 +46,6 @@ use Cake\Utility\Inflector;
 class Table {
 
 /**
- * A list of all table instances that has been built using the factory
- * method. Instances are indexed by alias
- *
- * @var array
- */
-	protected static $_instances = [];
-
-/**
  * Name of the table as it can be found in the database
  *
  * @var string

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -36,12 +36,13 @@ use Cake\Utility\Inflector;
  * ### Callbacks/events
  *
  * Table objects provide a few callbacks/events you can hook into to augment/replace
- * find operations. Each event uses the standard Event subsystem in CakePHP
+ * find operations. Each event uses the standard event subsystem in CakePHP
  *
  * - beforeFind($event, $query, $options) - Fired before each find operation. By stopping
  *   the event and supplying a return value you can bypass the find operation entirely. Any
  *   changes done to the $query instance will be retained for the rest of the find.
  *
+ * @see Cake\Event\EventManager for reference on the events system.
  */
 class Table {
 

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -54,14 +54,6 @@ class Table {
 	protected static $_instances = [];
 
 /**
- * A collection of default options to apply to each table built with the
- * factory method. Indexed by table name
- *
- * @var array
- */
-	protected static $_tablesMap = [];
-
-/**
  * Name of the table as it can be found in the database
  *
  * @var string
@@ -149,19 +141,10 @@ class Table {
 		if (empty($config['table'])) {
 			$config['table'] = Inflector::tableize(get_class($this));
 		}
-		if (!empty($config['table'])) {
-			$this->table($config['table']);
-		}
-
+		$this->table($config['table']);
 		if (!empty($config['alias'])) {
 			$this->alias($config['alias']);
 		}
-
-		$table = $this->table();
-		if (isset(static::$_tablesMap[$table])) {
-			$config = array_merge(static::$_tablesMap[$table], $config);
-		}
-
 		if (!empty($config['connection'])) {
 			$this->connection($config['connection']);
 		}
@@ -198,44 +181,6 @@ class Table {
  * @return void
  */
 	public function initialize(array $config) {
-	}
-
-/**
- * A factory method to build a new Table instance. Once created, the instance
- * will be registered so it can be re-used if tried to build again for the same
- * alias.
- *
- * The options that can be passed are the same as in `__construct()`, but the
- * key `className` is also recognized.
- *
- * When $options contains `className` this method will try to instantiate an
- * object of that class instead of this default Table class.
- *
- * If no `table` option is passed, the table name will be the tableized version
- * of the provided $alias.
- *
- * @param string $alias the alias for the table
- * @param array $options a list of options as accepted by `__construct()`
- * @return Table
- */
-	public static function build($alias, array $options = []) {
-		return TableRegistry::get($alias, $options);
-	}
-
-/**
- * Returns the Table object associated to the provided alias, if any.
- * If a Table is passed as second parameter it will be associated to the
- * passed $alias even if another object was associated before.
- *
- * @param string $alias
- * @param Table $object
- * @return Table
- */
-	public static function instance($alias, self $object = null) {
-		if ($object === null) {
-			return TableRegistry::get($alias);
-		}
-		return TableRegistry::set($alias, $object);
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -130,10 +130,9 @@ class Table {
  * @return void
  */
 	public function __construct(array $config = []) {
-		if (empty($config['table'])) {
-			$config['table'] = Inflector::tableize(get_class($this));
+		if (!empty($config['table'])) {
+			$this->table($config['table']);
 		}
-		$this->table($config['table']);
 		if (!empty($config['alias'])) {
 			$this->alias($config['alias']);
 		}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -151,15 +151,27 @@ class Table {
 			$eventManager = $config['eventManager'];
 		}
 		$this->_eventManager = $eventManager ?: new EventManager();
-<<<<<<< HEAD
 		$this->initialize($config);
 	}
 
 /**
- * This method is meant to be overridden by subclasses so that any initial setting
- * up for associations, validation rules or any custom logic can be done.
+ * Get the default connection name.
  *
- * ### Example:
+ * This method is used to get the fallback connection name if an
+ * instance is created through the TableRegistry without a connection.
+ *
+ * @return string
+ * @see Cake\ORM\TableRegistry::get()
+ */
+	public static function defaultConnectionName() {
+		return 'default';
+	}
+
+/**
+ * Initialize a table instance. Called after the constructor.
+ *
+ * You can use this method to define associations, attach behaviors
+ * define validation and do any other initialization logic you need.
  *
  * {{{
  *	public function initialize(array $config) {

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -1,0 +1,104 @@
+<?php
+namespace Cake\ORM;
+
+use Cake\Utility\Inflector;
+
+/**
+ * Provides a registry/factory for Table gateways.
+ *
+ * This registry allows you to centralize the configuration for tables
+ * their connections and other meta-data.
+ */
+class TableRegistry {
+
+	protected static $_config = [];
+
+	protected static $_instances = [];
+
+/**
+ * Stores a list of options to be used when instantiating an object for the table
+ * with the same name as $table. The options that can be stored are those that
+ * are recognized by `build()`
+ *
+ * If second argument is omitted, it will return the current settings for $table
+ *
+ * If no arguments are passed it will return the full configuration array for
+ * all tables
+ *
+ * @param string $table name of the table
+ * @param array $options list of options for the table
+ * @return array
+ */
+	public static function config($table, $data) {
+		if ($table === null) {
+			return static::$_config;
+		}
+		if (!is_string($table)) {
+			return static::$_config = $table;
+		}
+		if ($options === null) {
+			return isset(static::$_config[$table]) ? static::$_tablesMap[$table] : [];
+		}
+		return static::$_config[$table] = $options;
+	}
+
+/**
+ * Get a table instance from the registry.
+ *
+ * Tables are only created once until the registry is flushed.
+ * This means that aliases must be unique across your application.
+ * This is important because table associations are resolved at runtime
+ * and cyclic references need to be handled correctly.
+ *
+ * The options that can be passed are the same as in `__construct()`, but the
+ * key `className` is also recognized.
+ *
+ * When $options contains `className` this method will try to instantiate an
+ * object of that class instead of this default Table class.
+ *
+ * If no `table` option is passed, the table name will be the tableized version
+ * of the provided $alias.
+ *
+ * @param string $alias The alias you want to get.
+ * @param array $options The options you want to build the table with.
+ *   If a table has already been loaded the options will be ignored.
+ * @return Cake\Database\Table
+ */
+	public static function get($alias, $options = []) {
+		if (isset(static::$_instances[$alias])) {
+			return static::$_instances[$alias];
+		}
+
+
+		list($plugin, $baseClass) = pluginSplit($alias);
+		$options = ['alias' => $baseClass] + $options;
+
+		if (empty($options['className'])) {
+			$class = Inflector::classify($alias);
+			$className = App::classname($class, 'Model\Repository', 'Table');
+			$options['className'] = $className ?: 'Cake\ORM\Table';
+			$options['className'] = $className;
+		}
+
+		return static::$_instances[$alias] = new $options['className']($options);
+	}
+
+/**
+ * Set an instance, this should be temporary.
+ *
+ */
+	public static function set($alias, $object) {
+		return static::$_instances[$alias] = $object;
+	}
+
+/**
+ * Clears the registry of configuration and instances.
+ *
+ * @return void
+ */
+	public static function clear() {
+		static::$_instances = [];
+		static::$_config = [];
+	}
+
+}

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -21,10 +21,36 @@ use Cake\Database\ConnectionManager;
 use Cake\Utility\Inflector;
 
 /**
- * Provides a registry/factory for Table gateways.
+ * Provides a registry/factory for Table objects.
  *
  * This registry allows you to centralize the configuration for tables
  * their connections and other meta-data.
+ *
+ * ## Configuring instances
+ *
+ * You may need to configure your table objects, using TableRegistry you can
+ * centralize configuration. Any configuration set before instances are created
+ * will be used when creating instances. If you modify configuration after
+ * an instance is made, the instances *will not* be updated.
+ *
+ * {{{
+ * TableRegistry::config('User', ['table' => 'my_users']);
+ * }}}
+ *
+ * Configuration data is stored *per alias* if you use the same table with
+ * multiple aliases you will need to set configuration multiple times.
+ *
+ * ## Getting instances
+ *
+ * You can fetch instances out of the registry using get(). One instance is stored
+ * per alias. Once an alias is populated the same instance will always be returned.
+ * This is used to make the ORM use less memory and help make cyclic references easier
+ * to solve.
+ *
+ * {{{
+ * $table = TableRegistry::get('User', $config);
+ * }}}
+ *
  */
 class TableRegistry {
 
@@ -78,11 +104,15 @@ class TableRegistry {
  * This is important because table associations are resolved at runtime
  * and cyclic references need to be handled correctly.
  *
- * The options that can be passed are the same as in `__construct()`, but the
+ * The options that can be passed are the same as in `Table::__construct()`, but the
  * key `className` is also recognized.
  *
- * When $options contains `className` this method will try to instantiate an
- * object of that class instead of this default Table class.
+ * If $options does not contain `className` CakePHP will attempt to inflect the
+ * class name based on the alias. For example 'User' would result in
+ * `App\Model\Repository\UserTable` being attempted. If this class does not exist,
+ * then the default `Cake\ORM\Table` class will be used. By setting the `className`
+ * option you can define the specific class to use. This className can
+ * use a short class reference.
  *
  * If no `table` option is passed, the table name will be the tableized version
  * of the provided $alias.

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -1,6 +1,7 @@
 <?php
 namespace Cake\ORM;
 
+use Cake\Core\App;
 use Cake\Utility\Inflector;
 
 /**
@@ -26,10 +27,10 @@ class TableRegistry {
  * all tables
  *
  * @param string $table name of the table
- * @param array $options list of options for the table
+ * @param null|array $options list of options for the table
  * @return array
  */
-	public static function config($table, $data) {
+	public static function config($table = null, $options = null) {
 		if ($table === null) {
 			return static::$_config;
 		}
@@ -37,7 +38,7 @@ class TableRegistry {
 			return static::$_config = $table;
 		}
 		if ($options === null) {
-			return isset(static::$_config[$table]) ? static::$_tablesMap[$table] : [];
+			return isset(static::$_config[$table]) ? static::$_config[$table] : [];
 		}
 		return static::$_config[$table] = $options;
 	}
@@ -80,6 +81,9 @@ class TableRegistry {
 			$options['className'] = $className;
 		}
 
+		if (isset(static::$_config[$alias])) {
+			$options = array_merge(static::$_config[$alias], $options);
+		}
 		return static::$_instances[$alias] = new $options['className']($options);
 	}
 

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -108,7 +108,6 @@ class TableRegistry {
 			$class = Inflector::classify($alias);
 			$className = App::classname($class, 'Model\Repository', 'Table');
 			$options['className'] = $className ?: 'Cake\ORM\Table';
-			$options['className'] = $className;
 		}
 
 		if (isset(static::$_config[$alias])) {

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -100,7 +100,6 @@ class TableRegistry {
 			return static::$_instances[$alias];
 		}
 
-
 		list($plugin, $baseClass) = pluginSplit($alias);
 		$options = ['alias' => $baseClass] + $options;
 

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
 namespace Cake\ORM;
 
 use Cake\Core\App;
@@ -12,8 +27,18 @@ use Cake\Utility\Inflector;
  */
 class TableRegistry {
 
+/**
+ * Configuration for aliases.
+ *
+ * @var array
+ */
 	protected static $_config = [];
 
+/**
+ * Instances that belong to the registry.
+ *
+ * @var array
+ */
 	protected static $_instances = [];
 
 /**
@@ -88,10 +113,13 @@ class TableRegistry {
 	}
 
 /**
- * Set an instance, this should be temporary.
+ * Set an instance.
  *
+ * @param string $alias The alias to set.
+ * @param Cake\ORM\Table The table to set.
+ * @return void
  */
-	public static function set($alias, $object) {
+	public static function set($alias, Table $object) {
 		return static::$_instances[$alias] = $object;
 	}
 

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -42,30 +42,31 @@ class TableRegistry {
 	protected static $_instances = [];
 
 /**
- * Stores a list of options to be used when instantiating an object for the table
- * with the same name as $table. The options that can be stored are those that
- * are recognized by `build()`
+ * Stores a list of options to be used when instantiating an object
+ * with a matching alias.
  *
- * If second argument is omitted, it will return the current settings for $table
+ * The options that can be stored are those that are recognized by `build()`
+ * If second argument is omitted, it will return the current settings
+ * for $alias.
  *
  * If no arguments are passed it will return the full configuration array for
- * all tables
+ * all aliases
  *
- * @param string $table name of the table
- * @param null|array $options list of options for the table
- * @return array
+ * @param string $alias Name of the alias
+ * @param null|array $options list of options for the alias
+ * @return array The config data.
  */
-	public static function config($table = null, $options = null) {
-		if ($table === null) {
+	public static function config($alias = null, $options = null) {
+		if ($alias === null) {
 			return static::$_config;
 		}
-		if (!is_string($table)) {
-			return static::$_config = $table;
+		if (!is_string($alias)) {
+			return static::$_config = $alias;
 		}
 		if ($options === null) {
-			return isset(static::$_config[$table]) ? static::$_config[$table] : [];
+			return isset(static::$_config[$alias]) ? static::$_config[$alias] : [];
 		}
-		return static::$_config[$table] = $options;
+		return static::$_config[$alias] = $options;
 	}
 
 /**

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -17,6 +17,7 @@
 namespace Cake\ORM;
 
 use Cake\Core\App;
+use Cake\Database\ConnectionManager;
 use Cake\Utility\Inflector;
 
 /**
@@ -86,6 +87,9 @@ class TableRegistry {
  * If no `table` option is passed, the table name will be the tableized version
  * of the provided $alias.
  *
+ * If no `connection` option is passed the table's defaultConnectionName() method
+ * will be called to get the default connection name to use.
+ *
  * @param string $alias The alias you want to get.
  * @param array $options The options you want to build the table with.
  *   If a table has already been loaded the options will be ignored.
@@ -109,6 +113,10 @@ class TableRegistry {
 
 		if (isset(static::$_config[$alias])) {
 			$options = array_merge(static::$_config[$alias], $options);
+		}
+		if (empty($options['connection'])) {
+			$connectionName = $options['className']::defaultConnectionName();
+			$options['connection'] = ConnectionManager::get($connectionName);
 		}
 		return static::$_instances[$alias] = new $options['className']($options);
 	}

--- a/Cake/Test/TestCase/Database/ConnectionManagerTest.php
+++ b/Cake/Test/TestCase/Database/ConnectionManagerTest.php
@@ -121,6 +121,21 @@ class ConnectionManagerTest extends TestCase {
 	}
 
 /**
+ * Test loading connections without aliases
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage The datasource configuration "other_name" was not found.
+ * @return void
+ */
+	public function testGetNoAlias() {
+		$config = ConnectionManager::config('test');
+		$this->skipIf(empty($config), 'No test config, skipping');
+
+		ConnectionManager::alias('test', 'other_name');
+		ConnectionManager::get('other_name', false);
+	}
+
+/**
  * Test that configured() finds configured sources.
  *
  * @return void

--- a/Cake/Test/TestCase/Database/ConnectionManagerTest.php
+++ b/Cake/Test/TestCase/Database/ConnectionManagerTest.php
@@ -33,6 +33,7 @@ class ConnectionManagerTest extends TestCase {
 		parent::tearDown();
 		Plugin::unload();
 		ConnectionManager::drop('test_variant');
+		ConnectionManager::dropAlias('other_name');
 	}
 
 /**
@@ -156,8 +157,8 @@ class ConnectionManagerTest extends TestCase {
  */
 	public function testDrop() {
 		ConnectionManager::config('test_variant', [
-			'datasource' => 'Sqlite',
-			'database' => 'memory'
+			'className' => 'Sqlite',
+			'database' => ':memory:'
 		]);
 		$result = ConnectionManager::configured();
 		$this->assertContains('test_variant', $result);
@@ -167,6 +168,32 @@ class ConnectionManagerTest extends TestCase {
 		$this->assertNotContains('test_variant', $result);
 
 		$this->assertFalse(ConnectionManager::drop('probably_does_not_exist'), 'Should return false on failure.');
+	}
+
+/**
+ * Test aliasing connections.
+ *
+ * @return void
+ */
+	public function testAlias() {
+		ConnectionManager::config('test_variant', [
+			'className' => 'Sqlite',
+			'database' => ':memory:'
+		]);
+		ConnectionManager::alias('test_variant', 'other_name');
+		$result = ConnectionManager::get('test_variant');
+		$this->assertSame($result, ConnectionManager::get('other_name'));
+	}
+
+/**
+ * Test alias() raises an error when aliasing an undefined connection.
+ *
+ * @expectedException Cake\Error\MissingDatasourceConfigException
+ * @return void
+ */
+	public function testAliasError() {
+		$this->assertNotContains('test_kaboom', ConnectionManager::configured());
+		ConnectionManager::alias('test_kaboom', 'other_name');
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -19,12 +19,14 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
 
 /**
  * Tests BelongsToMany class
  *
  */
-class BelongsToManyTest extends \Cake\TestSuite\TestCase {
+class BelongsToManyTest extends TestCase {
 
 /**
  * Set up
@@ -47,7 +49,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
 		]);
-		Table::instance('Article', $this->article);
+		TableRegistry::set('Article', $this->article);
 	}
 
 /**
@@ -57,7 +59,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**
@@ -126,7 +128,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 		$this->assertInstanceOf($hasMany, $this->tag->association('ArticlesTag'));
 
 		$this->assertSame($pivot, $assoc->pivot());
-		$pivot2 = Table::build('Foo');
+		$pivot2 = TableRegistry::get('Foo');
 		$assoc->pivot($pivot2);
 		$this->assertSame($pivot2, $assoc->pivot());
 
@@ -163,7 +165,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->tag,
 			'conditions' => ['Tag.name' => 'cake']
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -213,7 +215,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->tag,
 			'conditions' => ['Tag.name' => 'cake']
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -254,7 +256,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -310,7 +312,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Tag.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -362,7 +364,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Tag.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -432,7 +434,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Tag.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
@@ -468,7 +470,7 @@ class BelongsToManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Tag.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		Table::build('ArticlesTag', [
+		TableRegistry::get('ArticlesTag', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 
 /**
  * Tests BelongsTo class
@@ -33,13 +34,13 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->company = Table::build('Company', [
+		$this->company = TableRegistry::get('Company', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'company_name' => ['type' => 'string'],
 			]
 		]);
-		$this->client = Table::build('Client', [
+		$this->client = TableRegistry::get('Client', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'client_name' => ['type' => 'string'],
@@ -55,7 +56,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 
 /**
  * Tests HasMany class
@@ -33,7 +34,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->author = Table::build('Author', [
+		$this->author = TableRegistry::get('Author', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
@@ -56,7 +57,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -19,6 +19,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 
 /**
  * Tests HasOne class
@@ -33,13 +34,13 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->user = Table::build('User', [
+		$this->user = TableRegistry::get('User', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
 			]
 		]);
-		$this->profile = Table::build('Profile', [
+		$this->profile = TableRegistry::get('Profile', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'first_name' => ['type' => 'string'],
@@ -55,7 +56,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/AssociationTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationTest.php
@@ -18,11 +18,12 @@ namespace Cake\Test\TestCase\ORM;
 
 use Cake\ORM\Association;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 
 /**
  * A Test double used to assert that default tables are created
  *
- **/
+ */
 class TestTable extends Table {
 
 }
@@ -63,7 +64,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -313,8 +313,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHasManyEagerLoadingNoHydration($strategy) {
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		TableRegistry::get('article');
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'strategy' => $strategy,
@@ -388,8 +388,8 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testHasManyEagerLoadingFieldsAndOrderNoHydration($strategy) {
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		TableRegistry::get('article');
 		$table->hasMany('article', ['property' => 'articles'] + compact('strategy'));
 
 		$query = new Query($this->connection, $table);
@@ -437,8 +437,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHasManyEagerLoadingDeep($strategy) {
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		$article = TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		$article = TableRegistry::get('article');
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'stratgey' => $strategy,
@@ -509,9 +509,9 @@ class QueryTest extends TestCase {
  **/
 	public function testHasManyEagerLoadingFromSecondaryTable($strategy) {
 
-		$author = TableRegistry::get('author', ['connection' => $this->connection]);
-		$article = TableRegistry::get('article', ['connection' => $this->connection]);
-		$post = TableRegistry::get('post', ['connection' => $this->connection]);
+		$author = TableRegistry::get('author');
+		$article = TableRegistry::get('article');
+		$post = TableRegistry::get('post');
 
 		$author->hasMany('post', ['property' => 'posts'] + compact('strategy'));
 		$article->belongsTo('author');
@@ -611,10 +611,9 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testBelongsToManyEagerLoadingNoHydration($strategy) {
-		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
-		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		$table = TableRegistry::get('Article');
+		TableRegistry::get('Tag');
 		TableRegistry::get('ArticleTag', [
-			'connection' => $this->connection,
 			'table' => 'articles_tags'
 		]);
 		$table->belongsToMany('Tag', ['property' => 'tags', 'strategy' => $strategy]);
@@ -715,8 +714,8 @@ class QueryTest extends TestCase {
  */
 	public function testFilteringByHasManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		TableRegistry::get('article');
 		$table->hasMany('article', ['property' => 'articles']);
 
 		$results = $query->repository($table)
@@ -752,10 +751,9 @@ class QueryTest extends TestCase {
  **/
 	public function testFilteringByBelongsToManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
-		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		$table = TableRegistry::get('Article');
+		TableRegistry::get('Tag');
 		TableRegistry::get('ArticleTag', [
-			'connection' => $this->connection,
 			'table' => 'articles_tags'
 		]);
 		$table->belongsToMany('Tag', ['property' => 'tags']);
@@ -825,7 +823,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testBufferResults() {
-		$table = TableRegistry::get('article', ['connection' => $this->connection, 'table' => 'articles']);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 
 		$result = $query->select()->bufferResults();
@@ -1094,8 +1092,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateWithHasMany() {
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		TableRegistry::get('article');
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'sort' => ['article.id' => 'asc']
@@ -1135,10 +1133,9 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateBelongsToMany() {
-		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
-		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		$table = TableRegistry::get('Article');
+		TableRegistry::get('Tag');
 		TableRegistry::get('ArticlesTag', [
-			'connection' => $this->connection,
 			'table' => 'articles_tags'
 		]);
 		$table->belongsToMany('Tag', ['property' => 'tags']);
@@ -1177,7 +1174,7 @@ class QueryTest extends TestCase {
  */
 	public function testHydrateBelongsTo() {
 		$table = TableRegistry::get('article', ['table' => 'articles']);
-		TableRegistry::get('author', ['connection' => $this->connection]);
+		TableRegistry::get('author');
 		$table->belongsTo('author');
 
 		$query = new Query($this->connection, $table);
@@ -1199,8 +1196,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateDeep() {
-		$table = TableRegistry::get('author', ['connection' => $this->connection]);
-		$article = TableRegistry::get('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author');
+		$article = TableRegistry::get('article');
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'sort' => ['article.id' => 'asc']
@@ -1257,11 +1254,9 @@ class QueryTest extends TestCase {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
 		$articleEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
 		$table = TableRegistry::get('author', [
-			'connection' => $this->connection,
 			'entityClass' => '\\' . $authorEntity
 		]);
 		TableRegistry::get('article', [
-			'connection' => $this->connection,
 			'entityClass' => '\\' . $articleEntity
 		]);
 		$table->hasMany('article', [
@@ -1299,7 +1294,6 @@ class QueryTest extends TestCase {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
 		$table = TableRegistry::get('article', ['table' => 'articles']);
 		TableRegistry::get('author', [
-			'connection' => $this->connection,
 			'entityClass' => '\\' . $authorEntity
 		]);
 		$table->belongsTo('author');

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -23,6 +23,7 @@ use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -59,14 +60,14 @@ class QueryTest extends TestCase {
 			'placed' => ['type' => 'datetime']
 		];
 
-		$this->table = $table = Table::build('foo', ['schema' => $schema]);
-		$clients = Table::build('client', ['schema' => $schema1]);
-		$orders = Table::build('order', ['schema' => $schema2]);
-		$companies = Table::build('company', ['schema' => $schema, 'table' => 'organizations']);
-		$orderTypes = Table::build('orderType', ['schema' => $schema]);
-		$stuff = Table::build('stuff', ['schema' => $schema, 'table' => 'things']);
-		$stuffTypes = Table::build('stuffType', ['schema' => $schema]);
-		$categories = Table::build('category', ['schema' => $schema]);
+		$this->table = $table = TableRegistry::get('foo', ['schema' => $schema]);
+		$clients = TableRegistry::get('client', ['schema' => $schema1]);
+		$orders = TableRegistry::get('order', ['schema' => $schema2]);
+		$companies = TableRegistry::get('company', ['schema' => $schema, 'table' => 'organizations']);
+		$orderTypes = TableRegistry::get('orderType', ['schema' => $schema]);
+		$stuff = TableRegistry::get('stuff', ['schema' => $schema, 'table' => 'things']);
+		$stuffTypes = TableRegistry::get('stuffType', ['schema' => $schema]);
+		$categories = TableRegistry::get('category', ['schema' => $schema]);
 
 		$table->belongsTo('client');
 		$clients->hasOne('order');
@@ -84,7 +85,7 @@ class QueryTest extends TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		Table::clearRegistry();
+		TableRegistry::clear();
 	}
 
 /**
@@ -184,7 +185,7 @@ class QueryTest extends TestCase {
 			]
 		];
 
-		$table = Table::build('foo', ['schema' => ['id' => ['type' => 'integer']]]);
+		$table = TableRegistry::get('foo', ['schema' => ['id' => ['type' => 'integer']]]);
 		$query = new Query($this->connection, $table);
 
 		$query->select('foo.id')->contain($contains)->sql();
@@ -244,9 +245,9 @@ class QueryTest extends TestCase {
  * and results are not hydrated
  *
  * @return void
- **/
-	public function testContainResultFetchingOneLevelNoHydration() {
-		$table = Table::build('article', ['table' => 'articles']);
+ */
+	public function testContainResultFetchingOneLevel() {
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$table->belongsTo('author');
 
 		$query = new Query($this->connection, $table);
@@ -310,10 +311,10 @@ class QueryTest extends TestCase {
  *
  * @dataProvider strategiesProvider
  * @return void
- **/
+ */
 	public function testHasManyEagerLoadingNoHydration($strategy) {
-		$table = Table::build('author', ['connection' => $this->connection]);
-		Table::build('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'strategy' => $strategy,
@@ -387,8 +388,8 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testHasManyEagerLoadingFieldsAndOrderNoHydration($strategy) {
-		$table = Table::build('author', ['connection' => $this->connection]);
-		Table::build('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', ['property' => 'articles'] + compact('strategy'));
 
 		$query = new Query($this->connection, $table);
@@ -434,10 +435,10 @@ class QueryTest extends TestCase {
  *
  * @dataProvider strategiesProvider
  * @return void
- **/
-	public function testHasManyEagerLoadingDeepNoHydration($strategy) {
-		$table = Table::build('author');
-		$article = Table::build('article');
+ */
+	public function testHasManyEagerLoadingDeep($strategy) {
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		$article = TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'stratgey' => $strategy,
@@ -507,9 +508,10 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testHasManyEagerLoadingFromSecondaryTable($strategy) {
-		$author = Table::build('author');
-		$article = Table::build('article');
-		$post = Table::build('post');
+
+		$author = TableRegistry::get('author', ['connection' => $this->connection]);
+		$article = TableRegistry::get('article', ['connection' => $this->connection]);
+		$post = TableRegistry::get('post', ['connection' => $this->connection]);
 
 		$author->hasMany('post', ['property' => 'posts'] + compact('strategy'));
 		$article->belongsTo('author');
@@ -609,7 +611,12 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testBelongsToManyEagerLoadingNoHydration($strategy) {
-		$table = Table::build('Article');
+		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
+		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		TableRegistry::get('ArticleTag', [
+			'connection' => $this->connection,
+			'table' => 'articles_tags'
+		]);
 		$table->belongsToMany('Tag', ['property' => 'tags', 'strategy' => $strategy]);
 		$query = new Query($this->connection, $table);
 
@@ -708,7 +715,8 @@ class QueryTest extends TestCase {
  */
 	public function testFilteringByHasManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = Table::build('author');
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', ['property' => 'articles']);
 
 		$results = $query->repository($table)
@@ -744,7 +752,12 @@ class QueryTest extends TestCase {
  **/
 	public function testFilteringByBelongsToManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = Table::build('Article');
+		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
+		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		TableRegistry::get('ArticleTag', [
+			'connection' => $this->connection,
+			'table' => 'articles_tags'
+		]);
 		$table->belongsToMany('Tag', ['property' => 'tags']);
 
 		$results = $query->repository($table)->select()
@@ -812,7 +825,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testBufferResults() {
-		$table = Table::build('article');
+		$table = TableRegistry::get('article', ['connection' => $this->connection, 'table' => 'articles']);
 		$query = new Query($this->connection, $table);
 
 		$result = $query->select()->bufferResults();
@@ -1012,7 +1025,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstDirtyQuery() {
-		$table = Table::build('article', ['table' => 'articles']);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$result = $query->select(['id'])->hydrate(false)->first();
 		$this->assertEquals(['id' => 1], $result);
@@ -1027,7 +1040,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstCleanQuery() {
-		$table = Table::build('article', ['table' => 'articles']);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$query->select(['id'])->toArray();
 
@@ -1042,7 +1055,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstSameResult() {
-		$table = Table::build('article', ['table' => 'articles']);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$query->select(['id'])->toArray();
 
@@ -1058,7 +1071,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateSimple() {
-		$table = Table::build('article', ['table' => 'articles']);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$results = $query->select()->execute()->toArray();
 
@@ -1081,8 +1094,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateWithHasMany() {
-		$table = Table::build('author', ['connection' => $this->connection]);
-		Table::build('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'sort' => ['article.id' => 'asc']
@@ -1122,9 +1135,9 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateBelongsToMany() {
-		$table = Table::build('Article', ['connection' => $this->connection]);
-		Table::build('Tag', ['connection' => $this->connection]);
-		Table::build('ArticlesTag', [
+		$table = TableRegistry::get('Article', ['connection' => $this->connection]);
+		TableRegistry::get('Tag', ['connection' => $this->connection]);
+		TableRegistry::get('ArticlesTag', [
 			'connection' => $this->connection,
 			'table' => 'articles_tags'
 		]);
@@ -1163,8 +1176,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateBelongsTo() {
-		$table = Table::build('article', ['table' => 'articles']);
-		Table::build('author', ['connection' => $this->connection]);
+		$table = TableRegistry::get('article', ['table' => 'articles']);
+		TableRegistry::get('author', ['connection' => $this->connection]);
 		$table->belongsTo('author');
 
 		$query = new Query($this->connection, $table);
@@ -1186,8 +1199,8 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateDeep() {
-		$table = Table::build('author', ['connection' => $this->connection]);
-		$article = Table::build('article', ['connection' => $this->connection]);
+		$table = TableRegistry::get('author', ['connection' => $this->connection]);
+		$article = TableRegistry::get('article', ['connection' => $this->connection]);
 		$table->hasMany('article', [
 			'property' => 'articles',
 			'sort' => ['article.id' => 'asc']
@@ -1214,7 +1227,7 @@ class QueryTest extends TestCase {
  */
 	public function testHydrateCustomObject() {
 		$class = $this->getMockClass('\Cake\ORM\Entity', ['fakeMethod']);
-		$table = Table::build('article', [
+		$table = TableRegistry::get('article', [
 			'table' => 'articles',
 			'entityClass' => '\\' . $class
 		]);
@@ -1243,11 +1256,11 @@ class QueryTest extends TestCase {
 	public function testHydrateWithHasManyCustomEntity() {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
 		$articleEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
-		$table = Table::build('author', [
+		$table = TableRegistry::get('author', [
 			'connection' => $this->connection,
 			'entityClass' => '\\' . $authorEntity
 		]);
-		Table::build('article', [
+		TableRegistry::get('article', [
 			'connection' => $this->connection,
 			'entityClass' => '\\' . $articleEntity
 		]);
@@ -1284,8 +1297,8 @@ class QueryTest extends TestCase {
  */
 	public function testHydrateBelongsToCustomEntity() {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
-		$table = Table::build('article', ['table' => 'articles']);
-		Table::build('author', [
+		$table = TableRegistry::get('article', ['table' => 'articles']);
+		TableRegistry::get('author', [
 			'connection' => $this->connection,
 			'entityClass' => '\\' . $authorEntity
 		]);

--- a/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -33,7 +33,10 @@ class ResultSetTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->connection = ConnectionManager::get('test');
-		$this->table = new Table(['table' => 'articles']);
+		$this->table = new Table([
+			'table' => 'articles',
+			'connection' => $this->connection,
+		]);
 
 		$this->fixtureData = [
 			['id' => 1, 'author_id' => 1, 'title' => 'First Article', 'body' => 'First Article Body', 'published' => 'Y'],

--- a/Cake/Test/TestCase/ORM/TableRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/TableRegistryTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Test case for TableRegistry
+ */
+class TableRegistryTest extends TestCase {
+
+/**
+ * tear down
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		TableRegistry::clear();
+	}
+
+/**
+ * Test config() method.
+ *
+ * @return void
+ */
+	public function testConfig() {
+		$this->assertEquals([], TableRegistry::config('Test'));
+
+		$data = [
+			'connection' => 'testing',
+			'entityClass' => 'TestApp\Model\Entity\Article',
+		];
+		$result = TableRegistry::config('Test', $data);
+		$this->assertEquals($data, $result, 'Returns config data.');
+
+		$result = TableRegistry::config();
+		$expected = ['Test' => $data];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test getting instances from the registry.
+ *
+ * @return void
+ */
+	public function testGet() {
+		$result = TableRegistry::get('Article', ['table' => 'my_articles']);
+		$this->assertInstanceOf('Cake\ORM\Table', $result);
+		$this->assertEquals('my_articles', $result->table());
+
+		$result2 = TableRegistry::get('Article', ['table' => 'herp_derp']);
+		$this->assertSame($result, $result2);
+		$this->assertEquals('my_articles', $result->table());
+	}
+
+/**
+ * Test that get() uses config data set with config()
+ *
+ * @return void
+ */
+	public function testGetWithConfig() {
+		TableRegistry::config('Article', ['table' => 'my_articles']);
+		$result = TableRegistry::get('Article');
+		$this->assertEquals('my_articles', $result->table(), 'Should use config() data.');
+	}
+
+/**
+ * Test setting an instance.
+ *
+ * @return void
+ */
+	public function testSet() {
+		$mock = $this->getMock('Cake\ORM\Table');
+		$this->assertSame($mock, TableRegistry::set('Article', $mock));
+		$this->assertSame($mock, TableRegistry::get('Article'));
+	}
+
+}

--- a/Cake/Test/TestCase/ORM/TableRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/TableRegistryTest.php
@@ -61,11 +61,15 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testGet() {
-		$result = TableRegistry::get('Article', ['table' => 'my_articles']);
+		$result = TableRegistry::get('Article', [
+			'table' => 'my_articles',
+		]);
 		$this->assertInstanceOf('Cake\ORM\Table', $result);
 		$this->assertEquals('my_articles', $result->table());
 
-		$result2 = TableRegistry::get('Article', ['table' => 'herp_derp']);
+		$result2 = TableRegistry::get('Article', [
+			'table' => 'herp_derp',
+		]);
 		$this->assertSame($result, $result2);
 		$this->assertEquals('my_articles', $result->table());
 	}
@@ -76,7 +80,9 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testGetWithConfig() {
-		TableRegistry::config('Article', ['table' => 'my_articles']);
+		TableRegistry::config('Article', [
+			'table' => 'my_articles',
+		]);
 		$result = TableRegistry::get('Article');
 		$this->assertEquals('my_articles', $result->table(), 'Should use config() data.');
 	}

--- a/Cake/Test/TestCase/ORM/TableRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/TableRegistryTest.php
@@ -16,14 +16,41 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Core\Configure;
+use Cake\Database\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
 /**
+ * Used to test correct class is instantiated when using TableRegistry::get();
+ */
+class MyUsersTable extends Table {
+
+/**
+ * Overrides default table name
+ *
+ * @var string
+ */
+	protected $_table = 'users';
+
+}
+
+
+/**
  * Test case for TableRegistry
  */
 class TableRegistryTest extends TestCase {
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		Configure::write('App.namespace', 'TestApp');
+	}
 
 /**
  * tear down
@@ -85,6 +112,74 @@ class TableRegistryTest extends TestCase {
 		]);
 		$result = TableRegistry::get('Article');
 		$this->assertEquals('my_articles', $result->table(), 'Should use config() data.');
+	}
+
+/**
+ * Tests that tables can be instantiated based on conventions
+ * and using plugin notation
+ *
+ * @return void
+ */
+	public function testBuildConvention() {
+		$table = TableRegistry::get('article');
+		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
+		$table = TableRegistry::get('Article');
+		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
+
+		$table = TableRegistry::get('author');
+		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
+		$table = TableRegistry::get('Author');
+		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
+
+		$class = $this->getMockClass('\Cake\ORM\Table');
+		$class::staticExpects($this->once())
+			->method('defaultConnectionName')
+			->will($this->returnValue('test'));
+
+		class_alias($class, 'MyPlugin\Model\Repository\SuperTestTable');
+		$table = TableRegistry::get('MyPlugin.SuperTest');
+		$this->assertInstanceOf($class, $table);
+	}
+
+/**
+ * Tests that table options can be pre-configured for the factory method
+ *
+ * @return void
+ */
+	public function testConfigAndBuild() {
+		TableRegistry::clear();
+		$map = TableRegistry::config();
+		$this->assertEquals([], $map);
+
+		$connection = ConnectionManager::get('test', false);
+		$options = ['connection' => $connection];
+		TableRegistry::config('users', $options);
+		$map = TableRegistry::config();
+		$this->assertEquals(['users' => $options], $map);
+		$this->assertEquals($options, TableRegistry::config('users'));
+
+		$schema = ['id' => ['type' => 'rubbish']];
+		$options += ['schema' => $schema];
+		TableRegistry::config('users', $options);
+
+		$table = TableRegistry::get('users', ['table' => 'users']);
+		$this->assertInstanceOf('Cake\ORM\Table', $table);
+		$this->assertEquals('users', $table->table());
+		$this->assertEquals('users', $table->alias());
+		$this->assertSame($connection, $table->connection());
+		$this->assertEquals(array_keys($schema), $table->schema()->columns());
+		$this->assertEquals($schema['id']['type'], $table->schema()->column('id')['type']);
+
+		TableRegistry::clear();
+		$this->assertEmpty(TableRegistry::config());
+
+		TableRegistry::config('users', $options);
+		$table = TableRegistry::get('users', ['className' => __NAMESPACE__ . '\MyUsersTable']);
+		$this->assertInstanceOf(__NAMESPACE__ . '\MyUsersTable', $table);
+		$this->assertEquals('users', $table->table());
+		$this->assertEquals('users', $table->alias());
+		$this->assertSame($connection, $table->connection());
+		$this->assertEquals(array_keys($schema), $table->schema()->columns());
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -879,7 +879,9 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalBelongsToMany() {
-		$table = new \TestApp\Model\Repository\ArticleTable;
+		$table = new \TestApp\Model\Repository\ArticleTable([
+			'connection' => $this->connection,
+		]);
 		$result = $table->find('all')->contain(['tag'])->first();
 		$this->assertInstanceOf('TestApp\Model\Entity\Tag', $result->tags[0]);
 		$this->assertInstanceOf('TestApp\Model\Entity\ArticlesTag', $result->tags[0]->extraInfo);
@@ -897,7 +899,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'created' => new \DateTime('2013-10-10 00:00'),
 			'updated' => new \DateTime('2013-10-10 00:00')
 		]);
-		$table = Table::build('user');
+		$table = TableRegistry::get('user');
 		$this->assertSame($entity, $table->save($entity));
 		$this->assertEquals($entity->id, 5);
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -486,7 +486,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['b' => 'c'],
 			'sort' => ['foo' => 'asc']
 		];
-		$table = new Table(['table' => 'authors']);
+		$table = new Table(['table' => 'authors', 'connection' => $this->connection]);
 		$belongsToMany = $table->belongsToMany('tag', $options);
 		$this->assertInstanceOf('\Cake\ORM\Association\BelongsToMany', $belongsToMany);
 		$this->assertSame($belongsToMany, $table->association('tag'));
@@ -582,7 +582,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindApplyOptions() {
-		$table = $this->getMock('Cake\ORM\Table', ['_buildQuery'], [['table' => 'users']]);
+		$table = $this->getMock(
+			'Cake\ORM\Table',
+			['_buildQuery'],
+			[['table' => 'users', 'connection' => $this->connection]]
+		);
 		$query = $this->getMock('Cake\ORM\Query', [], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('_buildQuery')
@@ -708,7 +712,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testCallingFindersDirectly() {
-		$table = $this->getMock('\Cake\ORM\Table', ['find']);
+		$table = $this->getMock('\Cake\ORM\Table', ['find'], [], '', false);
 		$query = $this->getMock('\Cake\ORM\Query', [], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('find')
@@ -716,7 +720,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 		$this->assertSame($query, $table->list());
 
-		$table = $this->getMock('\Cake\ORM\Table', ['find']);
+		$table = $this->getMock('\Cake\ORM\Table', ['find'], [], '', false);
 		$table->expects($this->once())
 			->method('find')
 			->with('threaded', ['order' => ['name' => 'ASC']])
@@ -730,7 +734,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testStackingFinders() {
-		$table = $this->getMock('\Cake\ORM\Table', ['find', 'findList']);
+		$table = $this->getMock('\Cake\ORM\Table', ['find', 'findList'], [], '', false);
 		$params = [$this->connection, $table];
 		$query = $this->getMock('\Cake\ORM\Query', ['addDefaultTypes'], $params);
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -29,20 +29,6 @@ class UsersTable extends Table {
 }
 
 /**
- * Used to test correct class is instantiated when using TableRegistry::get();
- */
-class MyUsersTable extends Table {
-
-/**
- * Overrides default table name
- *
- * @var string
- */
-	protected $_table = 'users';
-
-}
-
-/**
  * Tests Table class
  *
  */
@@ -62,68 +48,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		TableRegistry::clear();
-	}
-/**
- * Tests that table options can be pre-configured for the factory method
- *
- * @return void
- */
-	public function testConfigAndBuild() {
-		TableRegistry::clear();
-		$map = TableRegistry::config();
-		$this->assertEquals([], $map);
-
-		$options = ['connection' => $this->connection];
-		TableRegistry::config('users', $options);
-		$map = TableRegistry::config();
-		$this->assertEquals(['users' => $options], $map);
-		$this->assertEquals($options, TableRegistry::config('users'));
-
-		$schema = ['id' => ['type' => 'rubbish']];
-		$options += ['schema' => $schema];
-		TableRegistry::config('users', $options);
-
-		$table = TableRegistry::get('users', ['table' => 'users']);
-		$this->assertInstanceOf('Cake\ORM\Table', $table);
-		$this->assertEquals('users', $table->table());
-		$this->assertEquals('users', $table->alias());
-		$this->assertSame($this->connection, $table->connection());
-		$this->assertEquals(array_keys($schema), $table->schema()->columns());
-		$this->assertEquals($schema['id']['type'], $table->schema()->column('id')['type']);
-
-		TableRegistry::clear();
-		$this->assertEmpty(TableRegistry::config());
-
-		TableRegistry::config('users', $options);
-		$table = TableRegistry::get('users', ['className' => __NAMESPACE__ . '\MyUsersTable']);
-		$this->assertInstanceOf(__NAMESPACE__ . '\MyUsersTable', $table);
-		$this->assertEquals('users', $table->table());
-		$this->assertEquals('users', $table->alias());
-		$this->assertSame($this->connection, $table->connection());
-		$this->assertEquals(array_keys($schema), $table->schema()->columns());
-	}
-
-/**
- * Tests that tables can be instantiated based on conventions
- * and using plugin notation
- *
- * @return void
- */
-	public function testBuildConvention() {
-		$table = TableRegistry::get('article');
-		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
-		$table = TableRegistry::get('Article');
-		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
-
-		$table = TableRegistry::get('author');
-		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
-		$table = TableRegistry::get('Author');
-		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
-
-		$class = $this->getMockClass('\Cake\ORM\Table');
-		class_alias($class, 'MyPlugin\Model\Repository\SuperTestTable');
-		$table = TableRegistry::get('MyPlugin.SuperTest');
-		$this->assertInstanceOf($class, $table);
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -182,7 +182,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testConnection() {
-		Table::clearRegistry();
 		$table = new Table(['table' => 'users']);
 		$this->assertNull($table->connection());
 		$table->connection($this->connection);
@@ -274,7 +273,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testSchema() {
 		$schema = $this->connection->schemaCollection()->describe('users');
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$this->assertEquals($schema, $table->schema());
 
 		$table = new Table(['table' => 'stuff']);
@@ -297,7 +299,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindAllNoFieldsAndNoHydration() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$results = $table
 			->find('all')
 			->where(['id IN' => [1, 2]])
@@ -329,7 +334,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindAllSomeFieldsNoHydration() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$results = $table->find('all')
 			->select(['username', 'password'])
 			->hydrate(false)
@@ -363,7 +371,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindAllConditionAutoTypes() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$query = $table->find('all')
 			->select(['id', 'username'])
 			->where(['created >=' => new \DateTime('2010-01-22 00:00')])
@@ -390,7 +401,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindBeforeFindEventMutateQuery() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$table->getEventManager()->attach(function ($event, $query, $options) {
 			$query->limit(1);
 		}, 'Model.beforeFind');
@@ -406,7 +420,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindBeforeFindEventOverrideReturn() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$expected = ['One', 'Two', 'Three'];
 		$table->getEventManager()->attach(function ($event, $query, $options) use ($expected) {
 			$query->setResult($expected);
@@ -504,7 +521,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testUpdateAll() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$fields = ['username' => 'mark'];
 		$result = $table->updateAll($fields, ['id <' => 4]);
 		$this->assertTrue($result);
@@ -546,7 +566,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDeleteAll() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$result = $table->deleteAll(['id <' => 4]);
 		$this->assertTrue($result);
 
@@ -608,7 +631,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindListNoHydration() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$table->displayField('username');
 		$query = $table->find('list', ['fields' => ['id', 'username']])
 			->hydrate(false)
@@ -644,7 +670,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindThreadedNoHydration() {
-		$table = new Table(['table' => 'categories']);
+		$table = new Table([
+			'table' => 'categories',
+			'connection' => $this->connection,
+		]);
 		$expected = [
 			[
 				'id' => 1,
@@ -760,7 +789,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindThreadedHydrated() {
-		$table = new Table(['table' => 'categories']);
+		$table = new Table([
+			'table' => 'categories',
+			'connection' => $this->connection,
+		]);
 		$results = $table->find('all')
 			->threaded()
 			->select(['id', 'parent_id', 'name'])
@@ -782,7 +814,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindListHydrated() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'connection' => $this->connection,
+		]);
 		$table->displayField('username');
 		$query = $table
 			->find('list', ['fields' => ['id', 'username']])
@@ -889,7 +924,9 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalBelongsToLoading() {
-		$table = new \TestApp\Model\Repository\ArticleTable;
+		$table = new \TestApp\Model\Repository\ArticleTable([
+			'connection' => $this->connection,
+		]);
 		$result = $table->find('all')->contain(['author'])->first();
 		$this->assertInstanceOf('TestApp\Model\Entity\Author', $result->author);
 	}
@@ -901,7 +938,9 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalHasManyLoading() {
-		$table = new \TestApp\Model\Repository\ArticleTable;
+		$table = new \TestApp\Model\Repository\ArticleTable([
+			'connection' => $this->connection,
+		]);
 		$result = $table->find('all')->contain(['author' => ['article']])->first();
 		$this->assertCount(2, $result->author->article);
 		foreach ($result->author->article as $article) {

--- a/Cake/TestSuite/Fixture/FixtureManager.php
+++ b/Cake/TestSuite/Fixture/FixtureManager.php
@@ -98,7 +98,7 @@ class FixtureManager {
 		if ($this->_initialized) {
 			return;
 		}
-		$db = ConnectionManager::getDataSource('test');
+		$db = ConnectionManager::get('test', false);
 		$db->cacheSources = false;
 		$this->_db = $db;
 		$this->_initialized = true;
@@ -155,7 +155,7 @@ class FixtureManager {
 		if (!$db) {
 			$db = $this->_db;
 			if (!empty($fixture->connection)) {
-				$db = ConnectionManager::getDataSource($fixture->connection);
+				$db = ConnectionManager::get($fixture->connection, false);
 			}
 		}
 		if (!empty($fixture->created) && in_array($db->configName(), $fixture->created)) {
@@ -203,7 +203,7 @@ class FixtureManager {
 		}
 		try {
 			foreach ($dbs as $db => $fixtures) {
-				$db = ConnectionManager::getDataSource($fixture->connection);
+				$db = ConnectionManager::get($fixture->connection, false);
 				$db->begin();
 				foreach ($fixtures as $fixture) {
 					$this->_setupTable($fixture, $db, $test->dropTables);

--- a/Cake/TestSuite/Fixture/FixtureManager.php
+++ b/Cake/TestSuite/Fixture/FixtureManager.php
@@ -88,14 +88,20 @@ class FixtureManager {
 	protected function _aliasConnections() {
 		$connections = ConnectionManager::configured();
 		ConnectionManager::alias('test', 'default');
+		$map = [
+			'test' => 'default',
+		];
 		foreach ($connections as $connection) {
-			if ($connection === 'default') {
+			if (isset($map[$connection])) {
 				continue;
 			}
-			if (strpos($connection, 'test') === 0) {
-				continue;
+			if (strpos($connection, 'test_') === 0) {
+				$map[$connection] = substr($connection, 5);
+			} else {
+				$map['test_' . $connection] = $connection;
 			}
-			$alias = 'test_' . $connection;
+		}
+		foreach ($map as $alias => $connection) {
 			ConnectionManager::alias($alias, $connection);
 		}
 	}

--- a/Cake/TestSuite/Fixture/FixtureManager.php
+++ b/Cake/TestSuite/Fixture/FixtureManager.php
@@ -42,13 +42,6 @@ class FixtureManager {
 	protected $_initialized = false;
 
 /**
- * Default datasource to use
- *
- * @var DataSource
- */
-	protected $_db = null;
-
-/**
  * Holds the fixture classes that where instantiated
  *
  * @var array
@@ -69,11 +62,11 @@ class FixtureManager {
  * @return void
  */
 	public function fixturize($test) {
+		$this->_initDb();
 		if (empty($test->fixtures) || !empty($this->_processed[get_class($test)])) {
 			return;
 		}
-		$this->_initDb();
-		$test->db = $this->_db;
+		$test->db = ConnectionManager::get('test', false);
 		if (!is_array($test->fixtures)) {
 			$test->fixtures = array_map('trim', explode(',', $test->fixtures));
 		}
@@ -117,8 +110,6 @@ class FixtureManager {
 			return;
 		}
 		$this->_aliasConnections();
-		$db = ConnectionManager::get('test', false);
-		$this->_db = $db;
 		$this->_initialized = true;
 	}
 
@@ -171,9 +162,11 @@ class FixtureManager {
  */
 	protected function _setupTable(TestFixture $fixture, Connection $db = null, $drop = true) {
 		if (!$db) {
-			$db = $this->_db;
 			if (!empty($fixture->connection)) {
 				$db = ConnectionManager::get($fixture->connection, false);
+			}
+			if (!$db) {
+				$db = ConnectionManager::get('test', false);
 			}
 		}
 		if (!empty($fixture->created) && in_array($db->configName(), $fixture->created)) {

--- a/Cake/TestSuite/Fixture/TestFixture.php
+++ b/Cake/TestSuite/Fixture/TestFixture.php
@@ -21,7 +21,6 @@ use Cake\Database\Schema\Collection as SchemaCollection;
 use Cake\Database\Schema\Table;
 use Cake\Error;
 use Cake\Log\Log;
-use Cake\ORM\Table as Repository;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
@@ -274,8 +273,6 @@ class TestFixture {
  * @return boolean on success or if there are no records to insert, or false on failure
  */
 	public function insert(Connection $db) {
-		Repository::config($this->table, ['connection' => $db]);
-
 		if (isset($this->records) && !empty($this->records)) {
 			list($fields, $values, $types) = $this->_getRecords();
 			$query = $db->newQuery()

--- a/Cake/TestSuite/TestCase.php
+++ b/Cake/TestSuite/TestCase.php
@@ -594,7 +594,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  * @return Model
  */
 	public function getMockForModel($model, $methods = array(), $config = array()) {
-		$config += ClassRegistry::config('Model');
+		$config += (array)ClassRegistry::config('Model');
 
 		$modelClass = App::className($model, 'Model');
 		list(, $name) = namespaceSplit($modelClass);


### PR DESCRIPTION
This set of changes separates the static and non-static features of `Table` into a separate Registry. The registry provides a similar interface as the other static registries, and allows Table to remain simpler.  `TableRegistry` also makes it simple to resolve tables lazily, and doesn't prevent cross connection associations if we want to avoid them in the future..

I've added a feature to automatically force all table objects to use test connections instead of the 'real' ones. I've called it connection aliasing, and while the name may be a bit wonky, I think it provides a nicer solution to this problem than we used in 2.x. By making it much harder to access the 'real' connections it is less likely that a developer will accidentally hit the wrong database in testing.
### Alternative approaches

One alternative I considered was to make connection instances have a `getTable()` method. This would remove the need for yet another static class and allow the following type of usage:

``` php
<?php
$db = ConnectionManager::get('default');
$tasks = $db->getTable('tasks');
$q = $tasks->find('all');
```

All tables would inherit the connection, and any associated tables would inherit the connection of the table they are connected to. This has the benefit of not requiring any static classes, but obviously prevents associations between connections. 

I'm not sure we really want to support cross connection associations as they have always been problematic and buggy in the past. This approach might also complicate accessing models from a controller as you'd need to define both the connection and table you want. These are the reasons I didn't pursue this approach. However, if we can come up with an elegant way to expose table getters in controllers I think it is worth having fewer static classes.
