### PR TITLE
Don't set Response::expires() in Response::cache()

### DIFF
--- a/Cake/Network/Response.php
+++ b/Cake/Network/Response.php
@@ -800,7 +800,6 @@ class Response {
 			'Date' => gmdate("D, j M Y G:i:s ", time()) . 'GMT'
 		));
 		$this->modified($since);
-		$this->expires($time);
 		$this->sharable(true);
 		$this->maxAge($time - time());
 	}

--- a/Cake/Test/TestCase/Network/ResponseTest.php
+++ b/Cake/Test/TestCase/Network/ResponseTest.php
@@ -304,11 +304,9 @@ class ResponseTest extends TestCase {
 		$response = new Response();
 		$since = time();
 		$time = new \DateTime('+1 day', new \DateTimeZone('UTC'));
-		$response->expires('+1 day');
 		$expected = array(
 			'Date' => gmdate("D, j M Y G:i:s ", $since) . 'GMT',
 			'Last-Modified' => gmdate("D, j M Y H:i:s ", $since) . 'GMT',
-			'Expires' => $time->format('D, j M Y H:i:s') . ' GMT',
 			'Cache-Control' => 'public, max-age=' . ($time->format('U') - time())
 		);
 		$response->cache($since);
@@ -320,7 +318,6 @@ class ResponseTest extends TestCase {
 		$expected = array(
 			'Date' => gmdate("D, j M Y G:i:s ", $since) . 'GMT',
 			'Last-Modified' => gmdate("D, j M Y H:i:s ", $since) . 'GMT',
-			'Expires' => gmdate("D, j M Y H:i:s", strtotime($time)) . " GMT",
 			'Cache-Control' => 'public, max-age=' . (strtotime($time) - time())
 		);
 		$response->cache($since, $time);
@@ -332,7 +329,6 @@ class ResponseTest extends TestCase {
 		$expected = array(
 			'Date' => gmdate("D, j M Y G:i:s ", $since) . 'GMT',
 			'Last-Modified' => gmdate("D, j M Y H:i:s ", $since) . 'GMT',
-			'Expires' => gmdate("D, j M Y H:i:s", $time) . " GMT",
 			'Cache-Control' => 'public, max-age=0'
 		);
 		$response->cache($since, $time);


### PR DESCRIPTION
According to the rfc2616,

If a response includes both an Expires header and a max-age directive, the max-age directive overrides the Expires header, even if the Expires header is more restrictive.

So, it's pretty much useless to set Response::expires().
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
