### PR TITLE
Removed DS termination

### DIFF
--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -79,10 +79,6 @@ class TemplateTask extends AppShell {
 
 		$paths[] = $core;
 
-		foreach ($paths as $i => $path) {
-			$paths[$i] = rtrim($path, DS) . DS;
-		}
-
 		$themes = array();
 		foreach ($paths as $path) {
 			$Folder = new Folder($path . 'Templates', false);


### PR DESCRIPTION
Out of curiosity, I removed the lines marked in issue #2021.
The tests still pass, so I assume the mentioned paths are all terminated with a DS now.

Does anybody know of some paths which aren't terminated correclty yet?

Resolves #2021
