### PR TITLE
Simplify Join Workflow

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1055,6 +1055,9 @@ class DboSource extends DataSource {
 			unset($_associations[2], $_associations[3]);
 		}
 
+		$saveOriginalQueryDataJoins = $queryData['joins'];
+		$queryData['joins'] = array();
+
 		foreach ($_associations as $type) {
 			foreach ($model->{$type} as $assoc => $assocData) {
 				$linkModel = $model->{$assoc};
@@ -1070,6 +1073,10 @@ class DboSource extends DataSource {
 					}
 				}
 			}
+		}
+
+		foreach ($saveOriginalQueryDataJoins as $originalJoin) {
+			array_push($queryData['joins'], $originalJoin);
 		}
 
 		$query = trim($this->generateAssociationQuery($model, null, null, null, null, $queryData, false, $null));


### PR DESCRIPTION
Currently all automatically generated joins from model relationships are added AFTER joins passed to the find function.

This means I have to respecify some existing joins and ALIAS the tables in order to pass custom joins to the find function.

Adding the custom joins from find options after model joins would solve the problem.
![cake-join-diff](https://f.cloud.github.com/assets/2997424/1384880/d8cf8566-3b55-11e3-8388-bf7800e2b4e9.png)

In reference to ticket: https://github.com/cakephp/cakephp/issues/2162
