### PR TITLE
Added a .gitattributes file to set the line ending behavior when checkin...

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.php text
+*.default text
+*.ctp text
+*.sql text
+*.md text
+*.mo text
+*.po text
+*.js text
+*.css text
+*.ini text
+*.properties text
+*.txt text
+*.xml text
+*.yml text
+.htaccess text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
...g out/committing

I think I've covered all important file extensions

I did find some other's which I didn't cover explicitly:
1 x .editorconfig
1 x .gitignore
1 x .gitattributes (the new file itself)

And some special fiiles under Test somewhere:
2 x *.swf
1 x *.text
1 x *.htc

Not sure whether *.pem couldn't be moved to the "text" ones above.

Under binary there could be many more file extensions but only these I have found within the current repo.

Kudos to @shama for pointing this out in [his comment](https://github.com/cakephp/docs/pull/842#issuecomment-27058191).
