### PR TITLE
3.0 - Replace time() with DateTime's getTimestamp()

### DIFF
--- a/Cake/Utility/Time.php
+++ b/Cake/Utility/Time.php
@@ -496,7 +496,7 @@ class Time {
 	public static function isPast($dateString, $timezone = null) {
 		$timestamp = static::fromString($dateString, $timezone);
 		$dateTime = new \DateTime;
-		return $timestamp > $dateTime->getTimestamp();
+		return $timestamp < $dateTime->getTimestamp();
 	}
 
 /**

--- a/Cake/Utility/Time.php
+++ b/Cake/Utility/Time.php
@@ -136,7 +136,8 @@ class Time {
  */
 	public static function convertSpecifiers($format, $time = null) {
 		if (!$time) {
-			$time = time();
+			$dateTime = new \DateTime;
+			$time = $dateTime->getTimestamp();
 		}
 		static::$_time = $time;
 		return preg_replace_callback('/\%(\w+)/', array(__CLASS__, '_translateSpecifier'), $format);
@@ -356,7 +357,8 @@ class Time {
  */
 	public static function nice($dateString = null, $timezone = null, $format = null) {
 		if (!$dateString) {
-			$dateString = time();
+			$dateTime = new \DateTime;
+			$dateString = $dateTime->getTimestamp();
 		}
 		$date = static::fromString($dateString, $timezone);
 
@@ -383,7 +385,8 @@ class Time {
  */
 	public static function niceShort($dateString = null, $timezone = null) {
 		if (!$dateString) {
-			$dateString = time();
+			$dateTime = new \DateTime;
+			$dateString = $dateTime->getTimestamp();
 		}
 		$date = static::fromString($dateString, $timezone);
 
@@ -478,7 +481,8 @@ class Time {
  */
 	public static function isFuture($dateString, $timezone = null) {
 		$timestamp = static::fromString($dateString, $timezone);
-		return $timestamp > time();
+		$dateTime = new \DateTime;
+		return $timestamp > $dateTime->getTimestamp();
 	}
 
 /**
@@ -491,7 +495,8 @@ class Time {
  */
 	public static function isPast($dateString, $timezone = null) {
 		$timestamp = static::fromString($dateString, $timezone);
-		return $timestamp < time();
+		$dateTime = new \DateTime;
+		return $timestamp > $dateTime->getTimestamp();
 	}
 
 /**
@@ -982,7 +987,8 @@ class Time {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::gmt
  */
 	public static function gmt($dateString = null) {
-		$time = time();
+		$dateTime = new \DateTime;
+		$time = $dateTime->getTimestamp();
 		if ($dateString) {
 			$time = static::fromString($dateString);
 		}


### PR DESCRIPTION
While this doesn't address the overall architectural issues (https://github.com/cakephp/cakephp/issues/2226) in the Time utility, it's a small step in the right direction for the time being (pun intended, :smile: ).
