### PR TITLE
Pass depth through for Debugger::dump().

### DIFF
--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -510,6 +510,21 @@ TEXT;
 ){$close}
 TEXT;
 		$this->assertTextEquals($expected, $result);
+
+		ob_start();
+		Debugger::dump($var, 1);
+		$result = ob_get_clean();
+
+		$open = php_sapi_name() == 'cli' ? "\n" : '<pre>';
+		$close = php_sapi_name() == 'cli' ? "\n" : '</pre>';
+		$expected = <<<TEXT
+{$open}array(
+	'People' => array(
+		[maximum depth reached]
+	)
+){$close}
+TEXT;
+		$this->assertTextEquals($expected, $result);
 	}
 
 /**

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -172,12 +172,13 @@ class Debugger {
  *
  *
  * @param mixed $var the variable to dump
+ * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @see Debugger::exportVar()
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::dump
  */
-	public static function dump($var) {
-		pr(self::exportVar($var));
+	public static function dump($var, $depth = 3) {
+		pr(self::exportVar($var, $depth));
 	}
 
 /**


### PR DESCRIPTION
Currently, dump() cannot set the depth. This resolves it.
