### PR TITLE
Parse cookie values "{}" & "[]" as array

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -534,7 +534,7 @@ class CookieComponent extends Component {
 		$first = substr($string, 0, 1);
 		if ($first === '{' || $first === '[') {
 			$ret = json_decode($string, true);
-			return ($ret) ? $ret : $string;
+			return ($ret !== null) ? $ret : $string;
 		}
 		$array = array();
 		foreach (explode(',', $string) as $pair) {

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -601,12 +601,14 @@ class CookieComponentTest extends CakeTestCase {
 		$_COOKIE['CakeTestCookie'] = array(
 			'JSON' => '{"name":"value"}',
 			'Empty' => '',
-			'String' => '{"somewhat:"broken"}'
+			'String' => '{"somewhat:"broken"}',
+			'Array' => '{}'
 		);
 		$this->assertEquals(array('name' => 'value'), $this->Cookie->read('JSON'));
 		$this->assertEquals('value', $this->Cookie->read('JSON.name'));
 		$this->assertEquals('', $this->Cookie->read('Empty'));
 		$this->assertEquals('{"somewhat:"broken"}', $this->Cookie->read('String'));
+		$this->assertEquals(array(), $this->Cookie->read('Array'));
 	}
 
 /**


### PR DESCRIPTION
Cookies set to values  "{}" & "[]" directly in a HTTP Client (e.g. a browser) are not being parsed as PHP arrays. I think we should only discard the cases [where](http://php.net/manual/en/function.json-decode.php#refsect1-function.json-decode-returnvalues) "..the json cannot be decoded or if the encoded data is deeper than the recursion limit."
