### PR TITLE
Make default fractionSymbol to false

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -775,4 +775,17 @@ class CakeNumberTest extends CakeTestCase {
 		);
 	}
 
+/**
+ * testDefaultFractionSymbol
+ * Setting this to false prevents auto conversion of 0.2 to 20
+ *
+ * @ return void
+ */
+	public function testDefaultFractionSymbolIsFalse() {
+		$this->assertFalse(
+			$this->Number->defaultFractionSymbol(), 
+			'The default fractionSymbol must be set to false'
+		);
+	}
+
 }

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -776,16 +776,22 @@ class CakeNumberTest extends CakeTestCase {
 	}
 
 /**
- * testDefaultFractionSymbol
- * Setting this to false prevents auto conversion of 0.2 to 20
- *
+ * testFractionToCurrency
+ * Even if the fractionSymbol is not specified, 0.2 should remain as 0.2
+ * not change to 20
+ * 
  * @ return void
  */
-	public function testDefaultFractionSymbolIsFalse() {
-		$this->assertFalse(
-			$this->Number->defaultFractionSymbol(), 
-			'The default fractionSymbol must be set to false'
+	public function testFractionToCurrency() {
+		// Using the default USD currency doesn't help because it already sets the
+		// fractionSymbol.
+		// Testing with currency = ''
+		$val = 0.2;
+		$this->assertEquals(
+			number_format($val, 2, '.', ','),
+			$this->Number->currency($val, '', array(
+				'places' => 2, 'decimals' => '.', 'thousands' => ','
+			))
 		);
 	}
-
 }

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -414,14 +414,5 @@ class CakeNumber {
 		}
 		return self::$_defaultCurrency;
 	}
-	
-/**
- * Getter for default fractionSymbol
- *
- * @ return string
- */
-	public function defaultFractionSymbol() {
-		return self::$_currencyDefaults['fractionSymbol'];
-	}
 
 }

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -414,5 +414,14 @@ class CakeNumber {
 		}
 		return self::$_defaultCurrency;
 	}
+	
+/**
+ * Getter for default fractionSymbol
+ *
+ * @ return string
+ */
+	public function defaultFractionSymbol() {
+		return self::$_currencyDefaults['fractionSymbol'];
+	}
 
 }

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -75,7 +75,7 @@ class CakeNumber {
  * @var array
  */
 	protected static $_currencyDefaults = array(
-		'wholeSymbol' => '', 'wholePosition' => 'before', 'fractionSymbol' => '', 'fractionPosition' => 'after',
+		'wholeSymbol' => '', 'wholePosition' => 'before', 'fractionSymbol' => false, 'fractionPosition' => 'after',
 		'zero' => '0', 'places' => 2, 'thousands' => ',', 'decimals' => '.', 'negative' => '()', 'escape' => true,
 		'fractionExponent' => 2
 	);


### PR DESCRIPTION
The default value of '' will change:
0.2 = 20
But it should be $0.20 if nothing is specified as fractionSymbol. 

Of course, adding this in every use will solve this issue:
'fractionSymbol' => false

But this option is rarely mentioned in the docs. And the default '' doesn't seem to have any particular use.
