### PR TITLE
3.0 - Table delete

### DIFF
--- a/Cake/Database/Statement/CallbackStatement.php
+++ b/Cake/Database/Statement/CallbackStatement.php
@@ -16,21 +16,55 @@
  */
 namespace Cake\Database\Statement;
 
+/**
+ * Wraps a statement in a callback that allows row results
+ * to be modified when being fetched.
+ *
+ * This is used by CakePHP to eagerly load association data.
+ */
 class CallbackStatement extends StatementDecorator {
 
+/**
+ * A callback function to be applied to results.
+ *
+ * @var callable
+ */
 	protected $_callback;
 
+/**
+ * Constructor
+ *
+ * @param Cake\Database\StatementInterface $statement The statement to decorate.
+ * @param Cake\Database\Driver $driver The driver instance used by the statement.
+ * @param callable $callback The callback to apply to results before they are returned.
+ */
 	public function __construct($statement, $driver, $callback) {
 		parent::__construct($statement, $driver);
 		$this->_callback = $callback;
 	}
 
+/**
+ * Fetch a row from the statement.
+ *
+ * The result will be procssed by the callback when it is not `false.
+ *
+ * @param string $type Either 'num' or 'assoc' to indicate the result format you would like.
+ * @return mixed
+ */
 	public function fetch($type = 'num') {
 		$callback = $this->_callback;
 		$row = $this->_statement->fetch($type);
 		return $row === false ? $row : $callback($row);
 	}
 
+/**
+ * Fetch all rows from the statement.
+ *
+ * Each row in the result will be procssed by the callback when it is not `false.
+ *
+ * @param string $type Either 'num' or 'assoc' to indicate the result format you would like.
+ * @return mixed
+ */
 	public function fetchAll($type = 'num') {
 		return array_map($this->_callback, $this->_statement->fetchAll($type));
 	}

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -249,9 +249,11 @@ abstract class Association {
 	}
 
 /**
- * Sets Whether the records on the target table are dependent on the source table,
- * often used to indicate that records should be removed is the owning record in
+ * Sets whether the records on the target table are dependent on the source table.
+ *
+ * This is primarily used to indicate that records should be removed is the owning record in
  * the source table is deleted.
+ *
  * If no parameters are passed current setting is returned.
  *
  * @param boolean $dependent

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\ORM;
 
+use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 
@@ -415,4 +416,16 @@ abstract class Association {
  * @return string|array|boolean
  */
 	protected abstract function _joinCondition(array $options);
+
+/**
+ * Handles cascading a delete from an associated model.
+ *
+ * Each implementing class should handle the cascaded delete as
+ * required.
+ *
+ * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @return boolean Success
+ */
+	public abstract function cascadeDelete(Entity $entity);
+
 }

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -95,6 +95,13 @@ abstract class Association {
 	protected $_dependent = false;
 
 /**
+ * Whether or not cascaded deletes should also fire callbacks.
+ *
+ * @var string
+ */
+	protected $_cascadeCallbacks = false;
+
+/**
  * Source table instance
  *
  * @var Cake\ORM\Table
@@ -145,6 +152,7 @@ abstract class Association {
 			'foreignKey',
 			'conditions',
 			'dependent',
+			'cascadeCallbacks',
 			'sourceTable',
 			'targetTable',
 			'joinType',

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -424,8 +424,9 @@ abstract class Association {
  * required.
  *
  * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param array $options The options for the original delete.
  * @return boolean Success
  */
-	public abstract function cascadeDelete(Entity $entity);
+	public abstract function cascadeDelete(Entity $entity, $options = []);
 
 }

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -59,9 +59,10 @@ class BelongsTo extends Association {
  * BelongsTo associations are never cleared in a cascading delete scenario.
  *
  * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param array $options The options for the original delete.
  * @return boolean Success.
  */
-	public function cascadeDelete(Entity $entity) {
+	public function cascadeDelete(Entity $entity, $options = []) {
 		return true;
 	}
 

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -17,6 +17,7 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 
@@ -50,6 +51,18 @@ class BelongsTo extends Association {
 			return $this->_foreignKey;
 		}
 		return parent::foreignKey($key);
+	}
+
+/**
+ * Handle cascading deletes.
+ *
+ * BelongsTo associations are never cleared in a cascading delete scenario.
+ *
+ * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @return boolean Success.
+ */
+	public function cascadeDelete(Entity $entity) {
+		return true;
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -235,7 +235,13 @@ class BelongsToMany extends Association {
 		$conditions = array_merge($conditions, $this->conditions());
 
 		$table = $this->pivot();
-		return $table->deleteAll($conditions);
+		if ($this->_cascadeCallbacks) {
+			foreach ($table->find('all')->where($conditions) as $related) {
+				$table->delete($related, $options);
+			}
+		} else {
+			return $table->deleteAll($conditions);
+		}
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -234,7 +234,7 @@ class BelongsToMany extends Association {
 		$conditions = array_merge($conditions, $this->conditions());
 
 		$table = $this->pivot();
-		$table->deleteAll($conditions);
+		return $table->deleteAll($conditions);
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -17,6 +17,7 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -215,6 +216,25 @@ class BelongsToMany extends Association {
 		}
 
 		return $this->_resultInjector($fetchQuery, $resultMap);
+	}
+
+/**
+ * Clear out the data in the join/pivot table for a given entity.
+ *
+ * @param Cake\ORM\Entity $entity The entity that started the cascading delete.
+ * @return boolean Success.
+ */
+	public function cascadeDelete(Entity $entity) {
+		$foreignKey = $this->foreignKey();
+		$primaryKey = $this->source()->primaryKey();
+		$conditions = [
+			$foreignKey => $entity->get($primaryKey)
+		];
+		// TODO fix multi-column primary keys.
+		$conditions = array_merge($conditions, $this->conditions());
+
+		$table = $this->pivot();
+		$table->deleteAll($conditions);
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -239,9 +239,9 @@ class BelongsToMany extends Association {
 			foreach ($table->find('all')->where($conditions) as $related) {
 				$table->delete($related, $options);
 			}
-		} else {
-			return $table->deleteAll($conditions);
+			return true;
 		}
+		return $table->deleteAll($conditions);
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -222,9 +222,10 @@ class BelongsToMany extends Association {
  * Clear out the data in the join/pivot table for a given entity.
  *
  * @param Cake\ORM\Entity $entity The entity that started the cascading delete.
+ * @param array $options The options for the original delete.
  * @return boolean Success.
  */
-	public function cascadeDelete(Entity $entity) {
+	public function cascadeDelete(Entity $entity, $options = []) {
 		$foreignKey = $this->foreignKey();
 		$primaryKey = $this->source()->primaryKey();
 		$conditions = [

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM\Association;
+
+use Cake\ORM\Entity;
+
+/**
+ * Implements cascading deletes for dependent associations.
+ *
+ * Included by HasOne and HasMany association classes.
+ */
+trait DependentDeleteTrait {
+
+/**
+ * Cascade a delete to remove dependent records.
+ *
+ * This method does nothing if the association is not dependent.
+ *
+ * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @return boolean Success.
+ */
+	public function cascadeDelete(Entity $entity) {
+		if (!$this->dependent()) {
+			return true;
+		}
+		$table = $this->target();
+		$foreignKey = $this->foreignKey();
+		$primaryKey = $this->source()->primaryKey();
+
+		$conditions = [
+			$foreignKey => $entity->get($primaryKey)
+		];
+		// TODO fix multi-column primary keys.
+		$conditions = array_merge($conditions, $this->conditions());
+
+		$query = $table->find('all')->where($conditions);
+		foreach ($query as $related) {
+			$table->delete($related, ['atomic' => false]);
+		}
+		return true;
+	}
+}

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -31,9 +31,10 @@ trait DependentDeleteTrait {
  * This method does nothing if the association is not dependent.
  *
  * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param array $options The options for the original delete.
  * @return boolean Success.
  */
-	public function cascadeDelete(Entity $entity) {
+	public function cascadeDelete(Entity $entity, $options = []) {
 		if (!$this->dependent()) {
 			return true;
 		}

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -48,9 +48,12 @@ trait DependentDeleteTrait {
 		// TODO fix multi-column primary keys.
 		$conditions = array_merge($conditions, $this->conditions());
 
-		$query = $table->find('all')->where($conditions);
-		foreach ($query as $related) {
-			$table->delete($related, $options);
+		if ($this->_cascadeCallbacks) {
+			foreach ($table->find('all')->where($conditions) as $related) {
+				$table->delete($related, $options);
+			}
+		} else {
+			$table->deleteAll($conditions);
 		}
 		return true;
 	}

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -52,9 +52,8 @@ trait DependentDeleteTrait {
 			foreach ($table->find('all')->where($conditions) as $related) {
 				$table->delete($related, $options);
 			}
-		} else {
-			$table->deleteAll($conditions);
+			return true;
 		}
-		return true;
+		return $table->deleteAll($conditions);
 	}
 }

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -50,7 +50,7 @@ trait DependentDeleteTrait {
 
 		$query = $table->find('all')->where($conditions);
 		foreach ($query as $related) {
-			$table->delete($related, ['atomic' => false]);
+			$table->delete($related, $options);
 		}
 		return true;
 	}

--- a/Cake/ORM/Association/ExternalAssociationTrait.php
+++ b/Cake/ORM/Association/ExternalAssociationTrait.php
@@ -212,7 +212,7 @@ trait ExternalAssociationTrait {
  * @return \Cake\ORM\Query
  */
 	protected function _addFilteringCondition($query, $key, $filter) {
-		return $query->andWhere([$key . ' in' => $filter]);
+		return $query->andWhere([$key . ' IN' => $filter]);
 	}
 
 /**

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -17,6 +17,8 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association;
+use Cake\ORM\Association\DependentDeleteTrait;
+use Cake\ORM\Association\ExternalAssociationTrait;
 use Cake\ORM\Query;
 
 /**
@@ -28,6 +30,7 @@ use Cake\ORM\Query;
 class HasMany extends Association {
 
 	use ExternalAssociationTrait;
+	use DependentDeleteTrait;
 
 /**
  * The type of join to be used when adding the association to a query

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -17,6 +17,7 @@
 namespace Cake\ORM\Association;
 
 use Cake\ORM\Association;
+use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 
@@ -27,6 +28,8 @@ use Cake\Utility\Inflector;
  * An example of a HasOne association would be User has one Profile.
  */
 class HasOne extends Association {
+
+	use DependentDeleteTrait;
 
 /**
  * Whether this association can be expressed directly in a query join

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -664,10 +664,12 @@ class Query extends DatabaseQuery {
 
 /**
  * Applies some defaults to the query object before it is executed.
- * Specifically add the FROM clause, adds default table fields if none is
+ *
+ * Specifically add the FROM clause, adds default table fields if none are
  * specified and applies the joins required to eager load associations defined
  * using `contain`
  *
+ * @see Cake\Database\Query::execute()
  * @return Query
  */
 	protected function _transformQuery() {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -989,57 +989,9 @@ class Table {
 		}
 
 		foreach ($this->_associations as $assoc) {
-			// TODO Perhaps refactor the deletion into the association class?
-			if ($assoc->dependent()) {
-				$this->_deleteDependent($assoc, $entity);
-			} elseif ($assoc instanceof BelongsToMany) {
-				$this->_deletePivotRecords($assoc, $entity);
-			}
+			$assoc->cascadeDelete($entity);
 		}
 		return $success;
-	}
-
-/**
- * Delete data in any associations that are marked 'dependent'
- *
- * @param Cake\ORM\Association $assoc The association to clear.
- * @param Cake\ORM\Entity $entity The entity to delete dependent data for.
- * @return void
- */
-	protected function _deleteDependent(Association $assoc, Entity $entity) {
-		$table = $assoc->target();
-		$foreignKey = $assoc->foreignKey();
-		$primaryKey = $this->primaryKey();
-
-		$conditions = [
-			$foreignKey => $entity->get($primaryKey)
-		];
-		// TODO fix multi-column primary keys.
-		$conditions = array_merge($conditions, $assoc->conditions());
-
-		$query = $table->find('all')->where($conditions);
-		foreach ($query as $related) {
-			$table->delete($related, ['atomic' => false]);
-		}
-	}
-
-/**
- * Clear the data out of a BelongsToMany join table.
- *
- * @param Cake\ORM\Association\BelongsToMany $assoc The association to clear.
- * @param Cake\ORM\Entity $entity The entity to remove pivot records for.
- * @return void
- */
-	protected function _deletePivotRecords(BelongsToMany $assoc, Entity $entity) {
-		$foreignKey = $assoc->foreignKey();
-		$primaryKey = $this->primaryKey();
-		$conditions = [
-			$foreignKey => $entity->get($primaryKey)
-		];
-		// TODO fix multi-column primary keys.
-		$conditions = array_merge($conditions, $assoc->conditions());
-		$table = $assoc->pivot();
-		$table->deleteAll($conditions);
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -938,6 +938,7 @@ class Table {
 		$process = function () use ($entity, $options) {
 			return $this->_processDelete($entity, $options);
 		};
+
 		if ($options['atomic']) {
 			$success = $this->connection()->transactional($process);
 		} else {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -989,7 +989,7 @@ class Table {
 		}
 
 		foreach ($this->_associations as $assoc) {
-			$assoc->cascadeDelete($entity);
+			$assoc->cascadeDelete($entity, $options);
 		}
 		return $success;
 	}

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -160,6 +161,27 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		]);
 		$query->expects($this->never())->method('select');
 		$association->attachTo($query, ['includeFields' => false]);
+	}
+
+/**
+ * Test the cascading delete of BelongsTo.
+ *
+ * @return void
+ */
+	public function testCascadeDelete() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->client,
+			'targetTable' => $mock,
+		];
+		$mock->expects($this->never())
+			->method('find');
+		$mock->expects($this->never())
+			->method('delete');
+
+		$association = new BelongsTo('Company', $config);
+		$entity = new Entity(['company_name' => 'CakePHP', 'id' => 1]);
+		$this->assertTrue($association->cascadeDelete($entity));
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -170,7 +170,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id in' => $keys])
+			->with(['Article.author_id IN' => $keys])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -215,7 +215,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id in' => $keys])
+			->with(['Article.author_id IN' => $keys])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -318,7 +318,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->select('Article.author_id', true)
 			->join($joins, [], true);
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id in' => $expected])
+			->with(['Article.author_id IN' => $expected])
 			->will($this->returnValue($query));
 
 		$callable = $association->eagerLoader([

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -469,10 +469,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$this->article->expects($this->at(1))
 			->method('delete')
-			->with($articleOne, ['atomic' => false]);
+			->with($articleOne, []);
 		$this->article->expects($this->at(2))
 			->method('delete')
-			->with($articleTwo, ['atomic' => false]);
+			->with($articleTwo, []);
 
 		$entity = new Entity(['id' => 1, 'name' => 'mark']);
 		$this->assertTrue($association->cascadeDelete($entity));

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -42,7 +42,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			]
 		]);
 		$this->article = $this->getMock(
-			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Article', 'table' => 'articles']]
+			'Cake\ORM\Table', ['find', 'deleteAll', 'delete'], [['alias' => 'Article', 'table' => 'articles']]
 		);
 		$this->article->schema([
 			'id' => ['type' => 'integer'],
@@ -434,7 +434,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test cascading delete with has many.
+ * Test cascading deletes.
  *
  * @return void
  */
@@ -443,7 +443,33 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'dependent' => true,
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true]
+			'conditions' => ['Article.is_active' => true],
+		];
+		$association = new HasMany('Article', $config);
+
+		$this->article->expects($this->once())
+			->method('deleteAll')
+			->with([
+				'Article.is_active' => true,
+				'author_id' => 1
+			]);
+
+		$entity = new Entity(['id' => 1, 'name' => 'PHP']);
+		$association->cascadeDelete($entity);
+	}
+
+/**
+ * Test cascading delete with has many.
+ *
+ * @return void
+ */
+	public function testCascadeDeleteCallbacks() {
+		$config = [
+			'dependent' => true,
+			'sourceTable' => $this->author,
+			'targetTable' => $this->article,
+			'conditions' => ['Article.is_active' => true],
+			'cascadeCallbacks' => true,
 		];
 		$association = new HasMany('Article', $config);
 

--- a/Cake/Test/TestCase/ORM/AssociationTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationTest.php
@@ -52,7 +52,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
 		];
 		$this->association = $this->getMock(
 			'\Cake\ORM\Association',
-			['_options', 'attachTo', '_joinCondition'],
+			['_options', 'attachTo', '_joinCondition', 'cascadeDelete'],
 			['Foo', $config]
 		);
 	}

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1603,20 +1603,20 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test delete with dependent records and cascade = false
+ * Test delete with dependent = false does not cascade.
  *
  * @return void
  */
-	public function testDeleteDependentCascadeFalse() {
+	public function testDeleteNoDependentNoCascade() {
 		$table = TableRegistry::get('author');
-		$table->hasOne('article', [
+		$table->hasMany('article', [
 			'foreignKey' => 'author_id',
-			'dependent' => true,
+			'dependent' => false,
 		]);
 
 		$query = $table->find('all')->where(['id' => 1]);
 		$entity = $query->first();
-		$result = $table->delete($entity, ['cascade' => false]);
+		$result = $table->delete($entity);
 
 		$articles = $table->association('article')->target();
 		$query = $articles->find('all')->where(['author_id' => $entity->id]);
@@ -1644,33 +1644,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test delete with belongsToMany and cascade = false
- *
- * @return void
- */
-	public function testDeleteCascadeFalseBelongsToMany() {
-		$table = TableRegistry::get('article');
-		$table->belongsToMany('tag', [
-			'foreignKey' => 'article_id',
-			'joinTable' => 'articles_tags'
-		]);
-		$query = $table->find('all')->where(['id' => 1]);
-		$entity = $query->first();
-		$table->delete($entity, ['cascade' => false]);
-
-		$pivot = $table->association('tag')->pivot();
-		$query = $pivot->find('all')->where(['article_id' => 1]);
-		$this->assertCount(2, $query->execute(), 'Should find rows.');
-	}
-
-/**
  * Test delete callbacks
  *
  * @return void
  */
 	public function testDeleteCallbacks() {
 		$entity = new \Cake\ORM\Entity(['id' => 1, 'name' => 'mark']);
-		$options = new \ArrayObject(['atomic' => true, 'cascade' => true]);
+		$options = new \ArrayObject(['atomic' => true]);
 
 		$mock = $this->getMock('Cake\Event\EventManager');
 		$mock->expects($this->at(0))

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1554,4 +1554,67 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertSame($entity, $table->save($entity));
 	}
 
+/**
+ * Test simple delete.
+ *
+ * @return void
+ */
+	public function testDelete() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test delete with dependent records
+ *
+ * @return void
+ */
+	public function testDeleteDependent() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test delete with BelongsToMany
+ *
+ * @return void
+ */
+	public function testDeleteBelongsToMany() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test delete callbacks
+ *
+ * @return void
+ */
+	public function testDeleteCallbacks() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test delete beforeDelete can abort the delete.
+ *
+ * @return void
+ */
+	public function testDeleteBeforeDeleteAbort() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test delete beforeDelete return result
+ *
+ * @return void
+ */
+	public function testDeleteBeforeDeleteReturnResult() {
+		$this->markTestIncomplete('not done');
+	}
+
+/**
+ * Test deleting new entities does nothing.
+ *
+ * @return void
+ */
+	public function testDeleteIsNew() {
+		$this->markTestIncomplete('not done');
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1710,7 +1710,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$mock = $this->getMock('Cake\Event\EventManager');
 		$mock->expects($this->once())
 			->method('dispatch')
-			->will($this->returnCallback(function ($event) {
+			->will($this->returnCallback(function($event) {
 				$event->stopPropagation();
 			}));
 
@@ -1732,7 +1732,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$mock = $this->getMock('Cake\Event\EventManager');
 		$mock->expects($this->once())
 			->method('dispatch')
-			->will($this->returnCallback(function ($event) {
+			->will($this->returnCallback(function($event) {
 				$event->stopPropagation();
 				$event->result = 'got stopped';
 			}));

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1560,7 +1560,21 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDelete() {
-		$this->markTestIncomplete('not done');
+		$table = TableRegistry::get('user');
+		$conditions = [
+			'limit' => 1,
+			'conditions' => [
+				'username' => 'nate'
+			]
+		];
+		$query = $table->find('all', $conditions);
+		$entity = $query->first();
+		$result = $table->delete($entity);
+		$this->assertTrue($result);
+
+		$query = $table->find('all', $conditions);
+		$results = $query->execute();
+		$this->assertCount(0, $results, 'Find should fail.');
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1583,7 +1583,23 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDeleteDependent() {
-		$this->markTestIncomplete('not done');
+		$table = TableRegistry::get('author');
+		$table->hasOne('article', [
+			'foreignKey' => 'author_id',
+			'dependent' => true,
+		]);
+
+		$query = $table->find('all')->where(['id' => 1]);
+		$entity = $query->first();
+		$result = $table->delete($entity);
+
+		$articles = $table->association('article')->target();
+		$query = $articles->find('all', [
+			'conditions' => [
+				'author_id' => $entity->id
+			]
+		]);
+		$this->assertNull($query->execute()->one());
 	}
 
 /**


### PR DESCRIPTION
Implement the requirements outlined in #2259.  This set of changes adds entity deletion to the ORM for 3.0. Right now pivot table records are removed using deleteAll(). I could see an argument for loading and deleting the entities instead, and I'm happy to change the code around. Some questions I had:
- Should the association classes now how to delete associated records? For example should `HasOne`, `HasMany` and `BelongsToMany` contain the logic for removing dependent/join table records instead of putting it all in `Table`. I think having it in the association allows user-land associations more flexibility in the future.
- I'm not sure the code will work with multi-column primary keys yet.

I think we will need to add a fixture set that includes multi-column primary keys so we can ensure saving & deleting associations with multi-column primary keys works. This may be the next logical block of work.
