### PR TITLE
Allow behavior method aliasing

### DIFF
--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -56,18 +56,6 @@ class TimestampBehavior extends Behavior {
 	protected $_ts;
 
 /**
- * Constructor
- *
- * Merge settings with the default and store in the settings property
- *
- * @param Table $table The table this behavior is attached to.
- * @param array $settings The settings for this behavior.
- */
-	public function __construct(Table $table, array $settings = []) {
-		$this->_settings = $settings + $this->_defaultSettings;
-	}
-
-/**
  * handleEvent
  *
  * There is only one event handler, it can be configured to be called for any event

--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -111,6 +111,32 @@ class TimestampBehavior extends Behavior {
 	}
 
 /**
+ * implementedFinders
+ *
+ * This behavior does not implement any finders
+ *
+ * @return array
+ */
+	public function implementedFinders() {
+		return [];
+	}
+
+/**
+ * implementedMethods
+ *
+ * Only the timestamp method is callable from a table.
+ *
+ * @return void
+ */
+	public function implementedMethods() {
+		if (isset($this->_settings['implementedMethods'])) {
+			return $this->_settings['implementedMethods'];
+		}
+
+		return ['timestamp' => 'timestamp'];
+	}
+
+/**
  * Get or set the timestamp to be used
  *
  * Set the timestamp to the given DateTime object, or if not passed a new DateTime object

--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -37,6 +37,8 @@ class TimestampBehavior extends Behavior {
  * @var array
  */
 	protected $_defaultSettings = [
+		'implementedFinders' => [],
+		'implementedMethods' => ['timestamp' => 'timestamp'],
 		'events' => [
 			'Model.beforeSave' => [
 				'created' => 'new',
@@ -108,32 +110,6 @@ class TimestampBehavior extends Behavior {
  */
 	public function implementedEvents() {
 		return array_fill_keys(array_keys($this->_settings['events']), 'handleEvent');
-	}
-
-/**
- * implementedFinders
- *
- * This behavior does not implement any finders
- *
- * @return array
- */
-	public function implementedFinders() {
-		return [];
-	}
-
-/**
- * implementedMethods
- *
- * Only the timestamp method is callable from a table.
- *
- * @return void
- */
-	public function implementedMethods() {
-		if (isset($this->_settings['implementedMethods'])) {
-			return $this->_settings['implementedMethods'];
-		}
-
-		return ['timestamp' => 'timestamp'];
 	}
 
 /**

--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -62,6 +62,7 @@ class TimestampBehavior extends Behavior {
  *
  * @param Event $event
  * @param Entity $entity
+ * @throws \UnexpectedValueException if a field's when value is misdefined
  * @return true (irrespective of the behavior logic, the save will not be prevented)
  * @throws \UnexpectedValueException When the value for an event is not 'new', 'existing' or true.
  */

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -102,6 +102,15 @@ class Behavior implements EventListener {
 	protected static $_reflectionMethods = [];
 
 /**
+ * Default settings
+ *
+ * These are merged with user-provided settings when the behavior is used.
+ *
+ * @var array
+ */
+	protected $_defaultSettings = [];
+
+/**
  * Contains configuration settings.
  *
  * @var array
@@ -111,14 +120,17 @@ class Behavior implements EventListener {
 /**
  * Constructor
  *
+ * Merge settings with the default and store in the settings property
+ *
  * Does not retain a reference to the Table object. If you need this
  * you should override the constructor.
+ *
  *
  * @param Table $table The table this behavior is attached to.
  * @param array $settings The settings for this behavior.
  */
 	public function __construct(Table $table, array $settings = []) {
-		$this->_settings = $settings;
+		$this->_settings = $settings + $this->_defaultSettings;
 	}
 
 /**

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -92,7 +92,7 @@ use Cake\Event\EventListener;
 class Behavior implements EventListener {
 
 /**
- * _reflectionMethods
+ * A cache of the methods provided by this class
  *
  * @var array
  */
@@ -207,7 +207,7 @@ class Behavior implements EventListener {
 		$events = $this->implementedEvents();
 		$eventMethods = [];
 		foreach ($events as $e => $binding) {
-			if (is_array($binding) && isset($binding['callable']) && isset($binding['callable'])) {
+			if (is_array($binding) && isset($binding['callable'])) {
 				$binding = $binding['callable'];
 			}
 			$eventMethods[$binding] = true;
@@ -231,8 +231,7 @@ class Behavior implements EventListener {
 			}
 			$methodName = strtolower($methodName);
 
-			$isFinder = substr($methodName, 0, 4) === 'find';
-			if ($isFinder) {
+			if (substr($methodName, 0, 4) === 'find') {
 				$return['finders'][substr($methodName, 4)] = $methodName;
 			} else {
 				$return['methods'][$methodName] = $methodName;

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -172,6 +172,10 @@ class Behavior implements EventListener {
  * @return array
  */
 	public function implementedFinders() {
+		if (isset($this->_settings['implementedFinders'])) {
+			return $this->_settings['implementedFinders'];
+		}
+
 		$reflectionMethods = $this->_reflectionMethods();
 		return $reflectionMethods['finders'];
 	}
@@ -182,6 +186,10 @@ class Behavior implements EventListener {
  * @return array
  */
 	public function implementedMethods() {
+		if (isset($this->_settings['implementedMethods'])) {
+			return $this->_settings['implementedMethods'];
+		}
+
 		$reflectionMethods = $this->_reflectionMethods();
 		return $reflectionMethods['methods'];
 	}
@@ -225,9 +233,9 @@ class Behavior implements EventListener {
 
 			$isFinder = substr($methodName, 0, 4) === 'find';
 			if ($isFinder) {
-				$return['finders'][] = $methodName;
+				$return['finders'][substr($methodName, 4)] = $methodName;
 			} else {
-				$return['methods'][] = $methodName;
+				$return['methods'][$methodName] = $methodName;
 			}
 		}
 

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -210,10 +210,12 @@ class Behavior implements EventListener {
  *
  * provides and alias->methodname map of which finders a behavior implements. Example:
  *
- *   [
- *     'this' => 'findThis',
- *     'alias' => 'findMethodName'
- *   ]
+ * {{{
+ *  [
+ *    'this' => 'findThis',
+ *    'alias' => 'findMethodName'
+ *  ]
+ * }}}
  *
  * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
  * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
@@ -236,12 +238,14 @@ class Behavior implements EventListener {
 /**
  * implementedMethods
  *
- * provides and alias->methodname map of which methods a behavior implements. Example:
+ * provides an alias->methodname map of which methods a behavior implements. Example:
  *
- *   [
- *     'method' => 'method',
- *     'aliasedmethod' => 'somethingElse'
- *   ]
+ * {{{
+ *  [
+ *    'method' => 'method',
+ *    'aliasedmethod' => 'somethingElse'
+ *  ]
+ * }}}
  *
  * With the above example, a call to `$Table->method()` will call `$Behavior->method()`
  * and a call to `$Table->aliasedmethod()` will call `$Behavior->somethingElse()`

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -126,7 +126,6 @@ class Behavior implements EventListener {
  * Does not retain a reference to the Table object. If you need this
  * you should override the constructor.
  *
- *
  * @param Table $table The table this behavior is attached to.
  * @param array $settings The settings for this behavior.
  */

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -99,7 +99,7 @@ class Behavior implements EventListener {
  *
  * @var array
  */
-	protected static $_reflectionMethods;
+	protected static $_reflectionMethods = [];
 
 /**
  * Contains configuration settings.
@@ -176,7 +176,7 @@ class Behavior implements EventListener {
  *
  *   [
  *     'this' => 'findThis',
- *     'alias' => 'findMmethodName'
+ *     'alias' => 'findMethodName'
  *   ]
  *
  * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
@@ -226,7 +226,11 @@ class Behavior implements EventListener {
 	}
 
 /**
- * _reflectionmethods
+ * Get the methods implemented by this behavior
+ *
+ * Use the implementedEvents() method to exclude callback methods.
+ * Methods starting with `_` will be ignored, as will methods
+ * declared on Cake\ORM\Behavior
  *
  * @return array
  */

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ORM;
 
+use Cake\Error\Exception;
 use Cake\Event\EventListener;
 
 /**
@@ -131,6 +132,7 @@ class Behavior implements EventListener {
  */
 	public function __construct(Table $table, array $settings = []) {
 		$this->_settings = $settings + $this->_defaultSettings;
+		$this->verifySettings();
 	}
 
 /**
@@ -140,6 +142,29 @@ class Behavior implements EventListener {
  */
 	public function settings() {
 		return $this->_settings;
+	}
+
+/**
+ * verifySettings
+ *
+ * Check that implemented* keys contain values pointing at callable
+ *
+ * @return void
+ * @throws Cake\Error\Exception if settings are invalid
+ */
+	public function verifySettings() {
+		$keys = ['implementedFinders', 'implementedMethods'];
+		foreach ($keys as $key) {
+			if (!isset($this->_settings[$key])) {
+				continue;
+			}
+
+			foreach ($this->_settings[$key] as $method) {
+				if (!is_callable([$this, $method])) {
+					throw new Exception(__d('cake_dev', 'The method %s is not callable on class %s', $method, get_class($this)));
+				}
+			}
+		}
 	}
 
 /**

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -169,6 +169,20 @@ class Behavior implements EventListener {
 /**
  * implementedFinders
  *
+ * provides and alias->methodname map of which finders a behavior implements. Example:
+ *
+ *   [
+ *     'this' => 'findThis',
+ *     'alias' => 'findMmethodName'
+ *   ]
+ *
+ * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
+ * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
+ *
+ * It is recommended, though not required,  to override this method in child classes such that
+ * it is not necessary to use reflections to derive the available method list. See core
+ * behaviors for an example
+ *
  * @return array
  */
 	public function implementedFinders() {
@@ -182,6 +196,20 @@ class Behavior implements EventListener {
 
 /**
  * implementedMethods
+ *
+ * provides and alias->methodname map of which methods a behavior implements. Example:
+ *
+ *   [
+ *     'method' => 'method',
+ *     'aliasedmethod' => 'somethingElse'
+ *   ]
+ *
+ * With the above example, a call to `$Table->method()` will call `$Behavior->method()`
+ * and a call to `$Table->aliasedmethod()` will call `$Behavior->somethingElse()`
+ *
+ * It is recommended, though not required,  to override this method in child classes such that
+ * it is not necessary to use reflections to derive the available method list. See core
+ * behaviors for an example
  *
  * @return array
  */
@@ -229,10 +257,9 @@ class Behavior implements EventListener {
 			if (strpos($methodName, '_') === 0 || isset($eventMethods[$methodName])) {
 				continue;
 			}
-			$methodName = strtolower($methodName);
 
 			if (substr($methodName, 0, 4) === 'find') {
-				$return['finders'][substr($methodName, 4)] = $methodName;
+				$return['finders'][lcfirst(substr($methodName, 4))] = $methodName;
 			} else {
 				$return['methods'][$methodName] = $methodName;
 			}

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -182,9 +182,9 @@ class Behavior implements EventListener {
  * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
  * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
  *
- * It is recommended, though not required,  to override this method in child classes such that
- * it is not necessary to use reflections to derive the available method list. See core
- * behaviors for an example
+ * It is recommended, though not required, to define implementedFinders in the settings property
+ * of child classes such that it is not necessary to use reflections to derive the available
+ * method list. See core behaviors for examples
  *
  * @return array
  */
@@ -210,9 +210,9 @@ class Behavior implements EventListener {
  * With the above example, a call to `$Table->method()` will call `$Behavior->method()`
  * and a call to `$Table->aliasedmethod()` will call `$Behavior->somethingElse()`
  *
- * It is recommended, though not required,  to override this method in child classes such that
- * it is not necessary to use reflections to derive the available method list. See core
- * behaviors for an example
+ * It is recommended, though not required, to define implementedFinders in the settings property
+ * of child classes such that it is not necessary to use reflections to derive the available
+ * method list. See core behaviors for examples
  *
  * @return array
  */

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -96,7 +96,7 @@ class Behavior implements EventListener {
  *
  * @var array
  */
-	protected $_reflectionMethods;
+	protected static $_reflectionMethods;
 
 /**
  * Contains configuration settings.
@@ -200,8 +200,8 @@ class Behavior implements EventListener {
  * @return array
  */
 	protected function _reflectionMethods() {
-		if (isset($this->_reflectionMethods)) {
-			return $this->_reflectionMethods;
+		if (isset(static::$_reflectionMethods)) {
+			return static::$_reflectionMethods;
 		}
 
 		$events = $this->implementedEvents();
@@ -239,7 +239,7 @@ class Behavior implements EventListener {
 			}
 		}
 
-		return $this->_reflectionMethods = $return;
+		return static::$_reflectionMethods = $return;
 	}
 
 }

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -131,7 +131,6 @@ class Behavior implements EventListener {
  */
 	public function __construct(Table $table, array $settings = []) {
 		$this->_settings = $settings + $this->_defaultSettings;
-		$this->verifySettings();
 	}
 
 /**

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -92,7 +92,10 @@ use Cake\Event\EventListener;
 class Behavior implements EventListener {
 
 /**
- * A cache of the methods provided by this class
+ * Method cache for behaviors.
+ *
+ * Stores the reflected method + finder methods per class.
+ * This prevents reflecting the same class multiple times in a single process.
  *
  * @var array
  */
@@ -228,8 +231,9 @@ class Behavior implements EventListener {
  * @return array
  */
 	protected function _reflectionMethods() {
-		if (isset(static::$_reflectionMethods)) {
-			return static::$_reflectionMethods;
+		$class = get_class($this);
+		if (isset(self::$_reflectionMethods[$class])) {
+			return self::$_reflectionMethods[$class];
 		}
 
 		$events = $this->implementedEvents();
@@ -265,7 +269,7 @@ class Behavior implements EventListener {
 			}
 		}
 
-		return static::$_reflectionMethods = $return;
+		return self::$_reflectionMethods[$class] = $return;
 	}
 
 }

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -196,7 +196,7 @@ class BehaviorRegistry extends ObjectRegistry {
 	}
 
 /**
- * Invoke a method or finder on a behavior.
+ * Invoke a method on a behavior.
  *
  * @param string $method The method to invoke.
  * @param array $args The arguments you want to invoke the method with.
@@ -210,12 +210,26 @@ class BehaviorRegistry extends ObjectRegistry {
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}
 
-		if ($this->hasFinder($method)) {
-			list($behavior, $callMethod) = $this->_finderMap[$method];
+		throw new Error\Exception(__d('cake_dev', 'Cannot call "%s" it does not belong to any attached behaviors.', $method));
+	}
+
+/**
+ * Invoke a finder on a behavior.
+ *
+ * @param string $type The finder type to invoke.
+ * @param array $args The arguments you want to invoke the method with.
+ * @return mixed The return value depends on the underlying behavior method.
+ * @throws Cake\Error\Exception When the method is unknown.
+ */
+	public function callFinder($type, array $args = []) {
+		$type = strtolower($type);
+
+		if ($this->hasFinder($type)) {
+			list($behavior, $callMethod) = $this->_finderMap[$type];
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}
 
-		throw new Error\Exception(__d('cake_dev', 'Cannot call "%s" it does not belong to any attached behaviors.', $method));
+		throw new Error\Exception(__d('cake_dev', 'Cannot call finder "%s" it does not belong to any attached behaviors.', $type));
 	}
 
 }

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -134,7 +134,7 @@ class BehaviorRegistry extends ObjectRegistry {
 		$finders = array_change_key_case($instance->implementedFinders());
 		$methods = array_change_key_case($instance->implementedMethods());
 
-		foreach($finders as $finder => &$methodName) {
+		foreach($finders as $finder => $methodName) {
 			if (isset($this->_finderMap[$finder])) {
 				$duplicate = $this->_finderMap[$finder];
 				$error = __d(
@@ -146,10 +146,10 @@ class BehaviorRegistry extends ObjectRegistry {
 				);
 				throw new Error\Exception($error);
 			}
-			$methodName = [$alias, $methodName];
+			$finders[$finder] = [$alias, $methodName];
 		}
 
-		foreach($methods as $method => &$methodName) {
+		foreach($methods as $method => $methodName) {
 			if (isset($this->_methodMap[$method])) {
 				$duplicate = $this->_methodMap[$method];
 				$error = __d(
@@ -161,7 +161,7 @@ class BehaviorRegistry extends ObjectRegistry {
 				);
 				throw new Error\Exception($error);
 			}
-			$methodName = [$alias, $methodName];
+			$methods[$method] = [$alias, $methodName];
 		}
 
 		return compact('methods', 'finders');

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -134,7 +134,7 @@ class BehaviorRegistry extends ObjectRegistry {
 		$finders = array_change_key_case($instance->implementedFinders());
 		$methods = array_change_key_case($instance->implementedMethods());
 
-		foreach($finders as $finder => $methodName) {
+		foreach ($finders as $finder => $methodName) {
 			if (isset($this->_finderMap[$finder])) {
 				$duplicate = $this->_finderMap[$finder];
 				$error = __d(
@@ -149,7 +149,7 @@ class BehaviorRegistry extends ObjectRegistry {
 			$finders[$finder] = [$alias, $methodName];
 		}
 
-		foreach($methods as $method => $methodName) {
+		foreach ($methods as $method => $methodName) {
 			if (isset($this->_methodMap[$method])) {
 				$duplicate = $this->_methodMap[$method];
 				$error = __d(

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -210,7 +210,7 @@ class BehaviorRegistry extends ObjectRegistry {
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}
 
-		throw new Error\Exception(__d('cake_dev', 'Cannot call "%s" it does not belong to any attached behaviors.', $method));
+		throw new Error\Exception(__d('cake_dev', 'Cannot call "%s" it does not belong to any attached behavior.', $method));
 	}
 
 /**
@@ -229,7 +229,7 @@ class BehaviorRegistry extends ObjectRegistry {
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}
 
-		throw new Error\Exception(__d('cake_dev', 'Cannot call finder "%s" it does not belong to any attached behaviors.', $type));
+		throw new Error\Exception(__d('cake_dev', 'Cannot call finder "%s" it does not belong to any attached behavior.', $type));
 	}
 
 }

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -59,16 +59,6 @@ class BehaviorRegistry extends ObjectRegistry {
 	protected $_finderMap = [];
 
 /**
- * Method cache for behaviors.
- *
- * Stores the reflected method + finder methods per class.
- * This prevents reflecting the same class multiple times in a single process.
- *
- * @var array
- */
-	protected static $_methodCache = [];
-
-/**
  * Constructor
  *
  * @param Cake\ORM\Table $table
@@ -124,8 +114,8 @@ class BehaviorRegistry extends ObjectRegistry {
 			$this->_eventManager->attach($instance);
 		}
 		$methods = $this->_getMethods($instance, $class, $alias);
-		$this->_methodMap = array_merge($this->_methodMap, $methods['methods']);
-		$this->_finderMap = array_merge($this->_finderMap, $methods['finders']);
+		$this->_methodMap += $methods['methods'];
+		$this->_finderMap += $methods['finders'];
 		return $instance;
 	}
 
@@ -141,11 +131,10 @@ class BehaviorRegistry extends ObjectRegistry {
  * @throws Cake\Error\Exception when duplicate methods are connected.
  */
 	protected function _getMethods(Behavior $instance, $class, $alias) {
-		$finders = $instance->implementedFinders();
-		$methods = $instance->implementedMethods();
+		$finders = array_change_key_case($instance->implementedFinders());
+		$methods = array_change_key_case($instance->implementedMethods());
 
 		foreach($finders as $finder => &$methodName) {
-			$finder = strtolower($finder);
 			if (isset($this->_finderMap[$finder])) {
 				$duplicate = $this->_finderMap[$finder];
 				$error = __d(
@@ -161,8 +150,6 @@ class BehaviorRegistry extends ObjectRegistry {
 		}
 
 		foreach($methods as $method => &$methodName) {
-			$method = strtolower($method);
-
 			if (isset($this->_methodMap[$method])) {
 				$duplicate = $this->_methodMap[$method];
 				$error = __d(

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1026,12 +1026,12 @@ class Table {
 			return $this->{$finder}($query, $options);
 		}
 
-		if ($this->_behaviors && $this->_behaviors->hasFinder($finder)) {
-			return $this->_behaviors->call($finder, [$query, $options]);
+		if ($this->_behaviors && $this->_behaviors->hasFinder($type)) {
+			return $this->_behaviors->callFinder($type, [$query, $options]);
 		}
 
 		throw new \BadMethodCallException(
-			__d('cake_dev', 'Unknown finder method "%s"', $finder)
+			__d('cake_dev', 'Unknown finder method "%s"', $type)
 		);
 	}
 

--- a/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
@@ -150,7 +150,7 @@ class BehaviorRegistryTest extends TestCase {
 
 		$this->assertFalse($this->Behaviors->hasMethod('nope'));
 		$this->assertFalse($this->Behaviors->hasMethod('beforeFind'));
-		$this->assertFalse($this->Behaviors->hasMethod('findNoSlug'));
+		$this->assertFalse($this->Behaviors->hasMethod('noSlug'));
 	}
 
 /**
@@ -161,9 +161,9 @@ class BehaviorRegistryTest extends TestCase {
 	public function testHasFinder() {
 		$this->Behaviors->load('Sluggable');
 
-		$this->assertTrue($this->Behaviors->hasFinder('findNoSlug'));
-		$this->assertTrue($this->Behaviors->hasFinder('findnoslug'));
-		$this->assertTrue($this->Behaviors->hasFinder('FINDNOSLUG'));
+		$this->assertTrue($this->Behaviors->hasFinder('noSlug'));
+		$this->assertTrue($this->Behaviors->hasFinder('noslug'));
+		$this->assertTrue($this->Behaviors->hasFinder('NOSLUG'));
 
 		$this->assertFalse($this->Behaviors->hasFinder('slugify'));
 		$this->assertFalse($this->Behaviors->hasFinder('beforeFind'));
@@ -181,7 +181,7 @@ class BehaviorRegistryTest extends TestCase {
 		$this->assertEquals('some_value', $result);
 
 		$query = $this->getMock('Cake\ORM\Query', [], [null, null]);
-		$result = $this->Behaviors->call('findNoSlug', [$query]);
+		$result = $this->Behaviors->call('noSlug', [$query]);
 		$this->assertEquals($query, $result);
 	}
 

--- a/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
@@ -173,12 +173,23 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * test call
  *
+ * Setup a behavior, then replace it with a mock to verify methods are called.
+ * use dummy return values to verify the return value makes it back
+ *
  * @return void
  */
 	public function testCall() {
 		$this->Behaviors->load('Sluggable');
-		$result = $this->Behaviors->call('slugify', ['some value']);
-		$this->assertEquals('some_value', $result);
+		$mockedBehavior = $this->getMock('Behavior', ['slugify']);
+		$this->Behaviors->set('Sluggable', $mockedBehavior);
+
+		$mockedBehavior
+			->expects($this->once())
+			->method('slugify')
+			->with(['some value'])
+			->will($this->returnValue('some-thing'));
+		$return = $this->Behaviors->call('slugify', [['some value']]);
+		$this->assertSame('some-thing', $return);
 	}
 
 /**
@@ -195,16 +206,24 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * test call finder
  *
+ * Setup a behavior, then replace it with a mock to verify methods are called.
+ * use dummy return values to verify the return value makes it back
+ *
  * @return void
  */
 	public function testCallFinder() {
 		$this->Behaviors->load('Sluggable');
-		$result = $this->Behaviors->call('slugify', ['some value']);
-		$this->assertEquals('some_value', $result);
+		$mockedBehavior = $this->getMock('Behavior', ['findNoSlug']);
+		$this->Behaviors->set('Sluggable', $mockedBehavior);
 
 		$query = $this->getMock('Cake\ORM\Query', [], [null, null]);
-		$result = $this->Behaviors->callFinder('noSlug', [$query]);
-		$this->assertEquals($query, $result);
+		$mockedBehavior
+			->expects($this->once())
+			->method('findNoSlug')
+			->with($query, [])
+			->will($this->returnValue('example'));
+		$return = $this->Behaviors->callFinder('noSlug', [$query, []]);
+		$this->assertSame('example', $return);
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
@@ -179,10 +179,6 @@ class BehaviorRegistryTest extends TestCase {
 		$this->Behaviors->load('Sluggable');
 		$result = $this->Behaviors->call('slugify', ['some value']);
 		$this->assertEquals('some_value', $result);
-
-		$query = $this->getMock('Cake\ORM\Query', [], [null, null]);
-		$result = $this->Behaviors->call('noSlug', [$query]);
-		$this->assertEquals($query, $result);
 	}
 
 /**
@@ -194,6 +190,32 @@ class BehaviorRegistryTest extends TestCase {
 	public function testCallError() {
 		$this->Behaviors->load('Sluggable');
 		$this->Behaviors->call('nope');
+	}
+
+/**
+ * test call finder
+ *
+ * @return void
+ */
+	public function testCallFinder() {
+		$this->Behaviors->load('Sluggable');
+		$result = $this->Behaviors->call('slugify', ['some value']);
+		$this->assertEquals('some_value', $result);
+
+		$query = $this->getMock('Cake\ORM\Query', [], [null, null]);
+		$result = $this->Behaviors->callFinder('noSlug', [$query]);
+		$this->assertEquals($query, $result);
+	}
+
+/**
+ * Test errors on unknown methods.
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage Cannot call finder "nope"
+ */
+	public function testCallFinderError() {
+		$this->Behaviors->load('Sluggable');
+		$this->Behaviors->callFinder('nope');
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -152,6 +152,23 @@ class BehaviorTest extends TestCase {
 	}
 
 /**
+ * testImplementedMethodsInvalid
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
+ *
+ * @return void
+ */
+	public function testImplementedMethodsInvalid() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedMethods' => [
+				'aliased' => 'iDoNotExist'
+			]
+		]);
+	}
+
+/**
  * testImplementedFinders
  *
  * @return void
@@ -197,4 +214,20 @@ class BehaviorTest extends TestCase {
 		$this->assertEquals($expected, $behavior->implementedFinders());
 	}
 
+/**
+ * testImplementedFinderInvalid
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
+ *
+ * @return void
+ */
+	public function testImplementedFinderInvalid() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedFinders' => [
+				'aliased' => 'findNotDefined'
+			]
+		]);
+	}
 }

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -31,6 +31,24 @@ class TestBehavior extends Behavior {
 }
 
 /**
+ * Test Stub.
+ */
+class Test2Behavior extends Behavior {
+
+/**
+ * Test for event bindings.
+ */
+	public function beforeFind() {
+	}
+
+	public function findFoo() {
+	}
+
+	public function doSomething() {
+	}
+
+}
+/**
  * Behavior test case
  */
 class BehaviorTest extends TestCase {
@@ -85,6 +103,98 @@ class BehaviorTest extends TestCase {
 			]
 		];
 		$this->assertEquals($expected, $behavior->implementedEvents());
+	}
+
+/**
+ * testImplementedMethods
+ *
+ * @return void
+ */
+	public function testImplementedMethods() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table);
+		$expected = [
+			'dosomething' => 'dosomething'
+		];
+		$this->assertEquals($expected, $behavior->implementedMethods());
+	}
+
+/**
+ * testImplementedMethodsAliased
+ *
+ * @return void
+ */
+	public function testImplementedMethodsAliased() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedMethods' => [
+				'aliased' => 'dosomething'
+			]
+		]);
+		$expected = [
+			'aliased' => 'dosomething'
+		];
+		$this->assertEquals($expected, $behavior->implementedMethods());
+	}
+
+/**
+ * testImplementedMethodsDisabled
+ *
+ * @return void
+ */
+	public function testImplementedMethodsDisabled() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedMethods' => []
+		]);
+		$expected = [];
+		$this->assertEquals($expected, $behavior->implementedMethods());
+	}
+
+/**
+ * testImplementedFinders
+ *
+ * @return void
+ */
+	public function testImplementedFinders() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table);
+		$expected = [
+			'foo' => 'findfoo'
+		];
+		$this->assertEquals($expected, $behavior->implementedFinders());
+	}
+
+/**
+ * testImplementedFindersAliased
+ *
+ * @return void
+ */
+	public function testImplementedFindersAliased() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedFinders' => [
+				'aliased' => 'findfoo'
+			]
+		]);
+		$expected = [
+			'aliased' => 'findfoo'
+		];
+		$this->assertEquals($expected, $behavior->implementedFinders());
+	}
+
+/**
+ * testImplementedFindersDisabled
+ *
+ * @return void
+ */
+	public function testImplementedFindersDisabled() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedFinders' => []
+		]);
+		$expected = [];
+		$this->assertEquals($expected, $behavior->implementedFinders());
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -230,23 +230,6 @@ class BehaviorTest extends TestCase {
 	}
 
 /**
- * testImplementedMethodsInvalid
- *
- * @expectedException Cake\Error\Exception
- * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
- *
- * @return void
- */
-	public function testImplementedMethodsInvalid() {
-		$table = $this->getMock('Cake\ORM\Table');
-		$behavior = new Test2Behavior($table, [
-			'implementedMethods' => [
-				'aliased' => 'iDoNotExist'
-			]
-		]);
-	}
-
-/**
  * testImplementedFinders
  *
  * @return void
@@ -308,4 +291,54 @@ class BehaviorTest extends TestCase {
 			]
 		]);
 	}
+
+/**
+ * testImplementedMethods
+ *
+ * Simply don't expect an exception to be thrown
+ *
+ * @return void
+ */
+	public function testVerifySettings() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table);
+		$behavior->verifySettings();
+	}
+
+/**
+ * testImplementedMethodsOverriden
+ *
+ * Simply don't expect an exception to be thrown
+ *
+ * @return void
+ */
+	public function testVerifySettingsOverriden() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table);
+		$behavior = new Test2Behavior($table, [
+			'implementedMethods' => [
+				'aliased' => 'doSomething'
+			]
+		]);
+		$behavior->verifySettings();
+	}
+
+/**
+ * testImplementedMethodsInvalid
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
+ *
+ * @return void
+ */
+	public function testVerifySettingsInvalid() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedMethods' => [
+				'aliased' => 'iDoNotExist'
+			]
+		]);
+		$behavior->verifySettings();
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -41,13 +41,83 @@ class Test2Behavior extends Behavior {
 	public function beforeFind() {
 	}
 
+/**
+ * Test finder
+ */
 	public function findFoo() {
 	}
 
+/**
+ * Test method
+ */
 	public function doSomething() {
 	}
 
 }
+
+ */
+class Test3Behavior extends Behavior {
+
+/**
+ * Test for event bindings.
+ */
+	public function beforeFind() {
+	}
+
+/**
+ * Test finder
+ */
+	public function findFoo() {
+	}
+
+/**
+ * Test method
+ */
+	public function doSomething() {
+	}
+
+/**
+ * verifySettings
+ */
+	public function verifySettings() {
+	}
+
+/**
+ * implementedEvents
+ *
+ * This class does pretend to implement beforeFind
+ *
+ * @return void
+ */
+	public function implementedEvents() {
+		return ['Model.beforeFind' => 'beforeFind'];
+	}
+
+/**
+ * implementedFinders
+ */
+	public function implementedFinders() {
+	}
+
+/**
+ * implementedMethods
+ */
+	public function implementedMethods() {
+	}
+
+/**
+ * Expose protected method for testing
+ *
+ * Since this is public - it'll show up as callable which is a side-effect
+ *
+ * @return array
+ */
+	public function testReflectionCache() {
+		return $this->_reflectionCache();
+	}
+
+}
+
 /**
  * Behavior test case
  */
@@ -72,6 +142,21 @@ class BehaviorTest extends TestCase {
 		$settings = ['key' => 'value'];
 		$behavior = new TestBehavior($table, $settings);
 		$this->assertEquals($settings, $behavior->settings());
+	}
+
+	public function testReflectionCache() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test3Behavior($table);
+		$expected = [
+			'finders' => [
+				'foo' => 'findFoo'
+			],
+			'methods' => [
+				'doSomething' => 'doSomething',
+				'testReflectionCache' => 'testReflectionCache'
+			]
+		];
+		$this->assertEquals($expected, $behavior->testReflectionCache());
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -82,6 +82,7 @@ class Test3Behavior extends Behavior {
  * verifySettings
  */
 	public function verifySettings() {
+		parent::verifySettings();
 	}
 
 /**
@@ -276,26 +277,9 @@ class BehaviorTest extends TestCase {
 	}
 
 /**
- * testImplementedFinderInvalid
+ * testVerifySettings
  *
- * @expectedException Cake\Error\Exception
- * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
- *
- * @return void
- */
-	public function testImplementedFinderInvalid() {
-		$table = $this->getMock('Cake\ORM\Table');
-		$behavior = new Test2Behavior($table, [
-			'implementedFinders' => [
-				'aliased' => 'findNotDefined'
-			]
-		]);
-	}
-
-/**
- * testImplementedMethods
- *
- * Simply don't expect an exception to be thrown
+ * Don't expect an exception to be thrown
  *
  * @return void
  */
@@ -303,16 +287,53 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$behavior->verifySettings();
+		$this->assertTrue(true, 'No exception thrown');
 	}
 
 /**
- * testImplementedMethodsOverriden
+ * testVerifySettingsImplementedFindersOverriden
  *
  * Simply don't expect an exception to be thrown
  *
  * @return void
  */
-	public function testVerifySettingsOverriden() {
+	public function testVerifySettingsImplementedFindersOverriden() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedFinders' => [
+				'aliased' => 'findFoo'
+			]
+		]);
+		$behavior->verifySettings();
+		$this->assertTrue(true, 'No exception thrown');
+	}
+
+/**
+ * testVerifyImplementedFindersInvalid
+ *
+ * @expectedException Cake\Error\Exception
+ * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
+ *
+ * @return void
+ */
+	public function testVerifyImplementedFindersInvalid() {
+		$table = $this->getMock('Cake\ORM\Table');
+		$behavior = new Test2Behavior($table, [
+			'implementedFinders' => [
+				'aliased' => 'findNotDefined'
+			]
+		]);
+		$behavior->verifySettings();
+	}
+
+/**
+ * testVerifySettingsImplementedMethodsOverriden
+ *
+ * Don't expect an exception to be thrown
+ *
+ * @return void
+ */
+	public function testVerifySettingsImplementedMethodsOverriden() {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$behavior = new Test2Behavior($table, [
@@ -321,17 +342,18 @@ class BehaviorTest extends TestCase {
 			]
 		]);
 		$behavior->verifySettings();
+		$this->assertTrue(true, 'No exception thrown');
 	}
 
 /**
- * testImplementedMethodsInvalid
+ * testVerifyImplementedMethodsInvalid
  *
  * @expectedException Cake\Error\Exception
  * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void
  */
-	public function testVerifySettingsInvalid() {
+	public function testVerifyImplementedMethodsInvalid() {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table, [
 			'implementedMethods' => [

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -114,7 +114,7 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$expected = [
-			'dosomething' => 'dosomething'
+			'doSomething' => 'doSomething'
 		];
 		$this->assertEquals($expected, $behavior->implementedMethods());
 	}
@@ -128,11 +128,11 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table, [
 			'implementedMethods' => [
-				'aliased' => 'dosomething'
+				'aliased' => 'doSomething'
 			]
 		]);
 		$expected = [
-			'aliased' => 'dosomething'
+			'aliased' => 'doSomething'
 		];
 		$this->assertEquals($expected, $behavior->implementedMethods());
 	}
@@ -160,7 +160,7 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$expected = [
-			'foo' => 'findfoo'
+			'foo' => 'findFoo'
 		];
 		$this->assertEquals($expected, $behavior->implementedFinders());
 	}
@@ -174,11 +174,11 @@ class BehaviorTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table, [
 			'implementedFinders' => [
-				'aliased' => 'findfoo'
+				'aliased' => 'findFoo'
 			]
 		]);
 		$expected = [
-			'aliased' => 'findfoo'
+			'aliased' => 'findFoo'
 		];
 		$this->assertEquals($expected, $behavior->implementedFinders());
 	}

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -126,15 +126,6 @@ class Test3Behavior extends Behavior {
 class BehaviorTest extends TestCase {
 
 /**
- * setup
- *
- * @return void
- */
-	public function setUp() {
-		parent::setUp();
-	}
-
-/**
  * Test the side effects of the constructor.
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -55,6 +55,8 @@ class Test2Behavior extends Behavior {
 
 }
 
+/**
+ * Test3Behavior
  */
 class Test3Behavior extends Behavior {
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1015,12 +1015,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testCallBehaviorAliasedFinder() {
-		$table = TableRegistry::get('article');
+		$table = TableRegistry::get('articles');
 		$table->addBehavior('Sluggable', ['implementedFinders' => ['special' => 'findNoSlug']]);
-
-		$query = $table->special();
-		$this->assertInstanceOf('Cake\ORM\Query', $query);
-		$this->assertNotEmpty($query->clause('where'));
 
 		$query = $table->find('special');
 		$this->assertInstanceOf('Cake\ORM\Query', $query);

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -985,6 +985,17 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test you can alias a behavior method
+ *
+ * @return void
+ */
+	public function testCallBehaviorAliasedMethod() {
+		$table = TableRegistry::get('article');
+		$table->addBehavior('Sluggable', ['implementedMethods' => ['wednesday' => 'slugify']]);
+		$this->assertEquals('some_value', $table->wednesday('some value'));
+	}
+
+/**
  * Test finder methods from behaviors.
  *
  * @return void
@@ -994,6 +1005,24 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->addBehavior('Sluggable');
 
 		$query = $table->find('noSlug');
+		$this->assertInstanceOf('Cake\ORM\Query', $query);
+		$this->assertNotEmpty($query->clause('where'));
+	}
+
+/**
+ * testCallBehaviorAliasedFinder
+ *
+ * @return void
+ */
+	public function testCallBehaviorAliasedFinder() {
+		$table = TableRegistry::get('article');
+		$table->addBehavior('Sluggable', ['implementedFinders' => ['special' => 'findNoSlug']]);
+
+		$query = $table->special();
+		$this->assertInstanceOf('Cake\ORM\Query', $query);
+		$this->assertNotEmpty($query->clause('where'));
+
+		$query = $table->find('special');
 		$this->assertInstanceOf('Cake\ORM\Query', $query);
 		$this->assertNotEmpty($query->clause('where'));
 	}

--- a/Cake/Utility/ObjectRegistry.php
+++ b/Cake/Utility/ObjectRegistry.php
@@ -44,7 +44,7 @@ abstract class ObjectRegistry {
  * If a subclass provides event support, you can use `$settings['enabled'] = false`
  * to exclude constructed objects from being registered for events.
  *
- * Using Cake\Controller\Controller::$components as an example. You can alias 
+ * Using Cake\Controller\Controller::$components as an example. You can alias
  * an object by setting the 'className' key, i.e.,
  *
  * {{{
@@ -174,6 +174,20 @@ abstract class ObjectRegistry {
  */
 	public function reset() {
 		$this->_loaded = [];
+	}
+
+/**
+ * set an object directly into the registry by name
+ *
+ * This is primarily to aide testing
+ *
+ * @param string $objectName
+ * @param object $object instance to store in the registry
+ * @return void
+ */
+	public function set($objectName, $object) {
+		list($plugin, $name) = pluginSplit($objectName);
+		$this->_loaded[$name] = $object;
 	}
 
 }


### PR DESCRIPTION
Some restructuring to the behavior registry to permit behavior method aliasing, and configuring on a per-table basis which behavior methods are exposed. It's important to be able to alias/configure behavior methods to avoid hitting road-block exceptions when behavior foo and behavior bar both implement the same method.
