### PR TITLE
remove short-syntax finder delegation

### DIFF
--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1039,13 +1039,6 @@ class Table {
  * Magic method to be able to call scoped finders & behaviors
  * without the find prefix.
  *
- * ## Finder delegation
- *
- * You can use this feature to invoke finder methods, without
- * adding the 'find' prefix or preparing a query ahead of time.
- * For example, if your Table provided a `findRecent` finder, you
- * could call `$table->recent()` instead.
- *
  * ## Behavior delegation
  *
  * If your Table uses any behaviors you can call them as if
@@ -1061,15 +1054,9 @@ class Table {
 			return $this->_behaviors->call($method, $args);
 		}
 
-		$query = null;
-		if (isset($args[0]) && $args[0] instanceof Query) {
-			$query = array_shift($args);
-		}
-		$options = array_shift($args) ?: [];
-		if ($query === null) {
-			return $this->find($method, $options);
-		}
-		return $this->callFinder($method, $query, $options);
+		throw new \BadMethodCallException(
+			__d('cake_dev', 'Unknown method "%s"', $method)
+		);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -669,28 +669,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Tests that finders can be called directly
- *
- * @return void
- */
-	public function testCallingFindersDirectly() {
-		$table = $this->getMock('\Cake\ORM\Table', ['find'], [], '', false);
-		$query = $this->getMock('\Cake\ORM\Query', [], [$this->connection, $table]);
-		$table->expects($this->once())
-			->method('find')
-			->with('list', [])
-			->will($this->returnValue($query));
-		$this->assertSame($query, $table->list());
-
-		$table = $this->getMock('\Cake\ORM\Table', ['find'], [], '', false);
-		$table->expects($this->once())
-			->method('find')
-			->with('threaded', ['order' => ['name' => 'ASC']])
-			->will($this->returnValue($query));
-		$this->assertSame($query, $table->threaded(['order' => ['name' => 'ASC']]));
-	}
-
-/**
  * Tests that finders can be stacked
  *
  * @return void
@@ -711,7 +689,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$result = $table
-			->threaded(['order' => ['name' => 'ASC']])
+			->find('threaded', ['order' => ['name' => 'ASC']])
 			->list(['keyPath' => 'id']);
 		$this->assertSame($query, $result);
 	}
@@ -1013,10 +991,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testCallBehaviorFinder() {
 		$table = TableRegistry::get('article');
 		$table->addBehavior('Sluggable');
-
-		$query = $table->noSlug();
-		$this->assertInstanceOf('Cake\ORM\Query', $query);
-		$this->assertNotEmpty($query->clause('where'));
 
 		$query = $table->find('noSlug');
 		$this->assertInstanceOf('Cake\ORM\Query', $query);


### PR DESCRIPTION
There's a significant risk of creating ambiguity whereby `Table->foo()` means any of:

```
$Table->foo(); // implemented on the table class, expected, but is probably not a finder
$Table->find('foo'); // table finder, expected
$Behavior->find('foo'); // behavior finder, expected
$Behavior->foo(); // implemented on a loaded behavior, UNexpected
```

While it would be convenient most of the time, it creates the following possibility:

```
$Table->foo()->bar()->zum();
$Table->addBehavior('Something'); (a behavior implementing function foo)
$Table->foo()->bar()->zum();
Fatal Error call to method bar on a none object/not-a-query object
```

Whereas this does not:

```
$Table->find('foo')->bar()->zum();
$Table->addBehavior('Something'); (a behavior implementing function foo)
$Table->find('foo')->bar()->zum();
```

Therefore it's best IMO to nip this in the bud and remove this feature.
