### PR TITLE
3.0 - Relaxing naming conventions for Table classess

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -19,6 +19,7 @@ namespace Cake\ORM;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 
 /**
  * An Association is a relationship established between two tables and is used
@@ -167,10 +168,6 @@ abstract class Association {
 		$this->_name = $name;
 		$this->_options($options);
 
-		if (empty($this->_property)) {
-			$this->property($name);
-		}
-
 		if (!empty($options['strategy'])) {
 			$this->strategy($options['strategy']);
 		}
@@ -310,6 +307,9 @@ abstract class Association {
 	public function property($name = null) {
 		if ($name !== null) {
 			$this->_property = $name;
+		}
+		if ($name === null && !$this->_property) {
+			$this->_property = Inflector::underscore($this->_name);
 		}
 		return $this->_property;
 	}

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -47,7 +47,8 @@ class BelongsTo extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$this->_foreignKey = Inflector::underscore($this->target()->alias()) . '_id';
+				$key = Inflector::singularize($this->target()->alias());
+				$this->_foreignKey = Inflector::underscore($key) . '_id';
 			}
 			return $this->_foreignKey;
 		}

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -69,6 +69,24 @@ class BelongsTo extends Association {
 	}
 
 /**
+ * Sets the property name that should be filled with data from the target table
+ * in the source table record.
+ * If no arguments are passed, currently configured type is returned.
+ *
+ * @param string $name
+ * @return string
+ */
+	public function property($name = null) {
+		if ($name !== null) {
+			return parent::property($name);
+		}
+		if ($name === null && !$this->_property) {
+			$this->_property = Inflector::underscore(Inflector::singularize($this->_name));
+		}
+		return $this->_property;
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -94,7 +94,7 @@ class BelongsToMany extends Association {
 		if ($table === null) {
 			if (empty($this->_pivotTable)) {
 				$tableName = $this->_joinTableName();
-				$tableAlias = Inflector::classify(Inflector::singularize($tableName));
+				$tableAlias = Inflector::camelize($tableName);
 				$table = TableRegistry::get($tableAlias, [
 					'table' => $tableName
 				]);
@@ -300,7 +300,7 @@ class BelongsToMany extends Association {
 	protected function _joinTableName($name = null) {
 		if ($name === null) {
 			if (empty($this->_joinTable)) {
-				$aliases = array_map('\Cake\Utility\Inflector::tableize', [
+				$aliases = array_map('\Cake\Utility\Inflector::underscore', [
 					$sAlias = $this->source()->alias(),
 					$tAlias = $this->target()->alias()
 				]);

--- a/Cake/ORM/Association/ExternalAssociationTrait.php
+++ b/Cake/ORM/Association/ExternalAssociationTrait.php
@@ -54,7 +54,8 @@ trait ExternalAssociationTrait {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$this->_foreignKey = Inflector::tableize($this->source()->alias()) . '_id';
+				$key = Inflector::singularize($this->source()->alias());
+				$this->_foreignKey = Inflector::underscore($key) . '_id';
 			}
 			return $this->_foreignKey;
 		}

--- a/Cake/ORM/Association/ExternalAssociationTrait.php
+++ b/Cake/ORM/Association/ExternalAssociationTrait.php
@@ -54,7 +54,7 @@ trait ExternalAssociationTrait {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$this->_foreignKey = Inflector::underscore($this->source()->alias()) . '_id';
+				$this->_foreignKey = Inflector::tableize($this->source()->alias()) . '_id';
 			}
 			return $this->_foreignKey;
 		}

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -56,7 +56,8 @@ class HasOne extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$this->_foreignKey = Inflector::tableize($this->source()->alias()) . '_id';
+				$key = Inflector::singularize($this->source()->alias());
+				$this->_foreignKey = Inflector::underscore($key) . '_id';
 			}
 			return $this->_foreignKey;
 		}

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -65,6 +65,24 @@ class HasOne extends Association {
 	}
 
 /**
+ * Sets the property name that should be filled with data from the target table
+ * in the source table record.
+ * If no arguments are passed, currently configured type is returned.
+ *
+ * @param string $name
+ * @return string
+ */
+	public function property($name = null) {
+		if ($name !== null) {
+			return parent::property($name);
+		}
+		if ($name === null && !$this->_property) {
+			$this->_property = Inflector::underscore(Inflector::singularize($this->_name));
+		}
+		return $this->_property;
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -56,7 +56,7 @@ class HasOne extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$this->_foreignKey = Inflector::underscore($this->source()->alias()) . '_id';
+				$this->_foreignKey = Inflector::tableize($this->source()->alias()) . '_id';
 			}
 			return $this->_foreignKey;
 		}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -354,7 +354,7 @@ class Table {
 				return $this->_entityClass = $default;
 			}
 
-			$alias = substr(array_pop($parts), 0, -5);
+			$alias = Inflector::singularize(substr(array_pop($parts), 0, -5));
 			$name = implode('\\', array_slice($parts, 0, -1)) . '\Entity\\' . $alias;
 			if (!class_exists($name)) {
 				return $this->_entityClass = $default;

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -200,8 +200,8 @@ class Table {
  *
  * {{{
  *	public function initialize(array $config) {
- *		$this->belongsTo('User');
- *		$this->belongsToMany('Tagging.Tag');
+ *		$this->belongsTo('Users');
+ *		$this->belongsToMany('Tagging.Tags');
  *		$this->primaryKey('something_else');
  *	}
  * }}}
@@ -228,7 +228,7 @@ class Table {
 			if (empty($table)) {
 				$table = $this->alias();
 			}
-			$this->_table = Inflector::tableize($table);
+			$this->_table = Inflector::underscore($table);
 		}
 		return $this->_table;
 	}

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -34,7 +34,7 @@ use Cake\Utility\Inflector;
  * an instance is made, the instances *will not* be updated.
  *
  * {{{
- * TableRegistry::config('User', ['table' => 'my_users']);
+ * TableRegistry::config('Users', ['table' => 'my_users']);
  * }}}
  *
  * Configuration data is stored *per alias* if you use the same table with
@@ -48,7 +48,7 @@ use Cake\Utility\Inflector;
  * to solve.
  *
  * {{{
- * $table = TableRegistry::get('User', $config);
+ * $table = TableRegistry::get('Users', $config);
  * }}}
  *
  */
@@ -107,14 +107,14 @@ class TableRegistry {
  * The options that can be passed are the same as in `Table::__construct()`, but the
  * key `className` is also recognized.
  *
- * If $options does not contain `className` CakePHP will attempt to inflect the
- * class name based on the alias. For example 'User' would result in
- * `App\Model\Repository\UserTable` being attempted. If this class does not exist,
+ * If $options does not contain `className` CakePHP will attempt to construct the
+ * class name based on the alias. For example 'Users' would result in
+ * `App\Model\Repository\UsersTable` being attempted. If this class does not exist,
  * then the default `Cake\ORM\Table` class will be used. By setting the `className`
  * option you can define the specific class to use. This className can
  * use a short class reference.
  *
- * If no `table` option is passed, the table name will be the tableized version
+ * If no `table` option is passed, the table name will be the underscored version
  * of the provided $alias.
  *
  * If no `connection` option is passed the table's defaultConnectionName() method
@@ -134,7 +134,7 @@ class TableRegistry {
 		$options = ['alias' => $baseClass] + $options;
 
 		if (empty($options['className'])) {
-			$class = Inflector::classify($alias);
+			$class = Inflector::camelize($alias);
 			$className = App::classname($class, 'Model\Repository', 'Table');
 			$options['className'] = $className ?: 'Cake\ORM\Table';
 		}

--- a/Cake/Test/TestApp/Model/Repository/ArticlesTable.php
+++ b/Cake/Test/TestApp/Model/Repository/ArticlesTable.php
@@ -20,11 +20,9 @@ use Cake\ORM\Table;
 class ArticlesTable extends Table {
 
 	public function initialize(array $config) {
-		$this->belongsTo('author');
-		$this->belongsToMany('tag', [
-			'property' => 'tags'
-		]);
-		$this->hasMany('articlesTag');
+		$this->belongsTo('authors');
+		$this->belongsToMany('tags');
+		$this->hasMany('articlesTags');
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/ArticlesTable.php
+++ b/Cake/Test/TestApp/Model/Repository/ArticlesTable.php
@@ -14,14 +14,17 @@ namespace TestApp\Model\Repository;
 use Cake\ORM\Table;
 
 /**
- * Tag table class
+ * Article table class
  *
  */
-class ArticlesTagTable extends Table {
+class ArticlesTable extends Table {
 
 	public function initialize(array $config) {
-		$this->belongsTo('article');
-		$this->belongsTo('tag');
+		$this->belongsTo('author');
+		$this->belongsToMany('tag', [
+			'property' => 'tags'
+		]);
+		$this->hasMany('articlesTag');
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/ArticlesTagsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/ArticlesTagsTable.php
@@ -17,12 +17,11 @@ use Cake\ORM\Table;
  * Tag table class
  *
  */
-class TagTable extends Table {
+class ArticlesTagsTable extends Table {
 
 	public function initialize(array $config) {
-		$this->belongsTo('author');
-		$this->belongsToMany('tag', ['property' => 'tags']);
-		$this->hasMany('articlesTag', ['property' => 'extraInfo']);
+		$this->belongsTo('article');
+		$this->belongsTo('tag');
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/ArticlesTagsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/ArticlesTagsTable.php
@@ -20,8 +20,8 @@ use Cake\ORM\Table;
 class ArticlesTagsTable extends Table {
 
 	public function initialize(array $config) {
-		$this->belongsTo('article');
-		$this->belongsTo('tag');
+		$this->belongsTo('articles');
+		$this->belongsTo('tags');
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/AuthorsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/AuthorsTable.php
@@ -20,7 +20,7 @@ use Cake\ORM\Table;
 class AuthorsTable extends Table {
 
 	public function initialize(array $config) {
-		$this->hasMany('article');
+		$this->hasMany('articles');
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/AuthorsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/AuthorsTable.php
@@ -17,7 +17,7 @@ use Cake\ORM\Table;
  * Author table class
  *
  */
-class AuthorTable extends Table {
+class AuthorsTable extends Table {
 
 	public function initialize(array $config) {
 		$this->hasMany('article');

--- a/Cake/Test/TestApp/Model/Repository/TagsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/TagsTable.php
@@ -20,9 +20,9 @@ use Cake\ORM\Table;
 class TagsTable extends Table {
 
 	public function initialize(array $config) {
-		$this->belongsTo('author');
-		$this->belongsToMany('tag', ['property' => 'tags']);
-		$this->hasMany('articlesTag', ['property' => 'extraInfo']);
+		$this->belongsTo('authors');
+		$this->belongsToMany('tags');
+		$this->hasMany('articlesTags', ['property' => 'extraInfo']);
 	}
 
 }

--- a/Cake/Test/TestApp/Model/Repository/TagsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/TagsTable.php
@@ -14,17 +14,15 @@ namespace TestApp\Model\Repository;
 use Cake\ORM\Table;
 
 /**
- * Article table class
+ * Tag table class
  *
  */
-class ArticleTable extends Table {
+class TagsTable extends Table {
 
 	public function initialize(array $config) {
 		$this->belongsTo('author');
-		$this->belongsToMany('tag', [
-			'property' => 'tags'
-		]);
-		$this->hasMany('articlesTag');
+		$this->belongsToMany('tag', ['property' => 'tags']);
+		$this->hasMany('articlesTag', ['property' => 'extraInfo']);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -279,8 +279,8 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
@@ -298,14 +298,14 @@ class BelongsToManyTest extends TestCase {
 		$row = ['Articles__id' => 1, 'title' => 'article 1'];
 		$result = $callable($row);
 		$row['Tags__Tags'] = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]]
 		];
 		$this->assertEquals($row, $result);
 
 		$row = ['Articles__id' => 2, 'title' => 'article 2'];
 		$result = $callable($row);
 		$row['Tags__Tags'] = [
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$this->assertEquals($row, $result);
 	}
@@ -336,8 +336,8 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
@@ -388,8 +388,8 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
@@ -501,8 +501,8 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
@@ -538,14 +538,14 @@ class BelongsToManyTest extends TestCase {
 		]);
 
 		$row['Tags__Tags'] = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]]
+			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]]
 		];
 		$row['Articles__id'] = 1;
 		$result = $callable($row);
 		$this->assertEquals($row, $result);
 
 		$row['Tags__Tags'] = [
-			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
+			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
 		$row['Articles__id'] = 2;
 		$result = $callable($row);

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -38,20 +38,20 @@ class BelongsToManyTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->tag = $this->getMock(
-			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Tag', 'table' => 'tags']]
+			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Tags', 'table' => 'tags']]
 		);
 		$this->tag->schema([
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
 		]);
 		$this->article = $this->getMock(
-			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Article', 'table' => 'articles']]
+			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Articles', 'table' => 'articles']]
 		);
 		$this->article->schema([
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
 		]);
-		TableRegistry::set('Article', $this->article);
+		TableRegistry::set('Articles', $this->article);
 	}
 
 /**
@@ -112,29 +112,29 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$pivot = $assoc->pivot();
 		$this->assertInstanceOf('\Cake\ORM\Table', $pivot);
-		$this->assertEquals('ArticlesTag', $pivot->alias());
+		$this->assertEquals('ArticlesTags', $pivot->alias());
 		$this->assertEquals('articles_tags', $pivot->table());
-		$this->assertSame($this->article, $pivot->association('Article')->target());
-		$this->assertSame($this->tag, $pivot->association('Tag')->target());
+		$this->assertSame($this->article, $pivot->association('Articles')->target());
+		$this->assertSame($this->tag, $pivot->association('Tags')->target());
 
 		$belongsTo = '\Cake\ORM\Association\BelongsTo';
-		$this->assertInstanceOf($belongsTo, $pivot->association('Article'));
-		$this->assertInstanceOf($belongsTo, $pivot->association('Tag'));
+		$this->assertInstanceOf($belongsTo, $pivot->association('Articles'));
+		$this->assertInstanceOf($belongsTo, $pivot->association('Tags'));
 
-		$this->assertSame($pivot, $this->tag->association('ArticlesTag')->target());
-		$this->assertSame($this->article, $this->tag->association('Article')->target());
+		$this->assertSame($pivot, $this->tag->association('ArticlesTags')->target());
+		$this->assertSame($this->article, $this->tag->association('Articles')->target());
 
 		$hasMany = '\Cake\ORM\Association\HasMany';
 		$belongsToMany = '\Cake\ORM\Association\BelongsToMany';
-		$this->assertInstanceOf($belongsToMany, $this->tag->association('Article'));
-		$this->assertInstanceOf($hasMany, $this->tag->association('ArticlesTag'));
+		$this->assertInstanceOf($belongsToMany, $this->tag->association('Articles'));
+		$this->assertInstanceOf($hasMany, $this->tag->association('ArticlesTags'));
 
 		$this->assertSame($pivot, $assoc->pivot());
-		$pivot2 = TableRegistry::get('Foo');
+		$pivot2 = TableRegistry::get('Foos');
 		$assoc->pivot($pivot2);
 		$this->assertSame($pivot2, $assoc->pivot());
 
-		$assoc->pivot('ArticlesTag');
+		$assoc->pivot('ArticlesTags');
 		$this->assertSame($pivot, $assoc->pivot());
 	}
 
@@ -150,7 +150,7 @@ class BelongsToManyTest extends TestCase {
 			'joinTable' => 'tags_articles'
 		]);
 		$pivot = $assoc->pivot();
-		$this->assertEquals('TagsArticle', $pivot->alias());
+		$this->assertEquals('TagsArticles', $pivot->alias());
 		$this->assertEquals('tags_articles', $pivot->table());
 	}
 
@@ -165,46 +165,46 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'cake']
+			'conditions' => ['Tags.name' => 'cake']
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$query->expects($this->at(0))->method('join')->with([
-			'Tag' => [
+			'Tags' => [
 				'conditions' => [
-					'Tag.name' => 'cake'
+					'Tags.name' => 'cake'
 				],
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
 		]);
 
-		$field1 = new IdentifierExpression('ArticlesTag.article_id');
-		$field2 = new IdentifierExpression('ArticlesTag.tag_id');
+		$field1 = new IdentifierExpression('ArticlesTags.article_id');
+		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
 		$query->expects($this->at(2))->method('join')->with([
-			'ArticlesTag' => [
+			'ArticlesTags' => [
 				'conditions' => [
-					['Article.id' => $field1],
-					['Tag.id' => $field2]
+					['Articles.id' => $field1],
+					['Tags.id' => $field2]
 				],
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
 		]);
 		$query->expects($this->at(1))->method('select')->with([
-			'Tag__id' => 'Tag.id',
-			'Tag__name' => 'Tag.name',
+			'Tags__id' => 'Tags.id',
+			'Tags__name' => 'Tags.name',
 		]);
 		$query->expects($this->at(3))->method('select')->with([
-			'ArticlesTag__article_id' => 'ArticlesTag.article_id',
-			'ArticlesTag__tag_id' => 'ArticlesTag.tag_id',
+			'ArticlesTags__article_id' => 'ArticlesTags.article_id',
+			'ArticlesTags__tag_id' => 'ArticlesTags.tag_id',
 		]);
 		$association->attachTo($query);
 	}
@@ -219,34 +219,34 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'cake']
+			'conditions' => ['Tags.name' => 'cake']
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$query->expects($this->at(0))->method('join')->with([
-			'Tag' => [
+			'Tags' => [
 				'conditions' => [
-					'Tag.name' => 'cake'
+					'Tags.name' => 'cake'
 				],
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
 		]);
 
-		$field1 = new IdentifierExpression('ArticlesTag.article_id');
-		$field2 = new IdentifierExpression('ArticlesTag.tag_id');
+		$field1 = new IdentifierExpression('ArticlesTags.article_id');
+		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
 		$query->expects($this->at(1))->method('join')->with([
-			'ArticlesTag' => [
+			'ArticlesTags' => [
 				'conditions' => [
-					['Article.id' => $field1],
-					['Tag.id' => $field2]
+					['Articles.id' => $field1],
+					['Tags.id' => $field2]
 				],
 				'type' => 'INNER',
 				'table' => 'articles_tags'
@@ -266,46 +266,46 @@ class BelongsToManyTest extends TestCase {
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock('Cake\ORM\Query', ['execute', 'contain'], [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('contain')
 			->with([
-				'ArticlesTag' => [
-					'conditions' => ['ArticlesTag.article_id in' => $keys],
+				'ArticlesTags' => [
+					'conditions' => ['ArticlesTags.article_id in' => $keys],
 					'matching' => true
 				]
 			])
 			->will($this->returnSelf());
 
 		$callable = $association->eagerLoader(compact('keys', 'query'));
-		$row = ['Article__id' => 1, 'title' => 'article 1'];
+		$row = ['Articles__id' => 1, 'title' => 'article 1'];
 		$result = $callable($row);
-		$row['Tag__Tag'] = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]]
+		$row['Tags__Tags'] = [
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]]
 		];
 		$this->assertEquals($row, $result);
 
-		$row = ['Article__id' => 2, 'title' => 'article 2'];
+		$row = ['Articles__id' => 2, 'title' => 'article 2'];
 		$result = $callable($row);
-		$row['Tag__Tag'] = [
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+		$row['Tags__Tags'] = [
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
 		$this->assertEquals($row, $result);
 	}
@@ -319,40 +319,40 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('contain')
 			->with([
-				'ArticlesTag' => [
-					'conditions' => ['ArticlesTag.article_id in' => $keys],
+				'ArticlesTags' => [
+					'conditions' => ['ArticlesTags.article_id in' => $keys],
 					'matching' => true
 				]
 			])
 			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('where')
-			->with(['Tag.name' => 'foo'])
+			->with(['Tags.name' => 'foo'])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -371,33 +371,33 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order', 'select'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('contain')
 			->with([
-				'ArticlesTag' => [
-					'conditions' => ['ArticlesTag.article_id in' => $keys],
+				'ArticlesTags' => [
+					'conditions' => ['ArticlesTags.article_id in' => $keys],
 					'matching' => true
 				]
 			])
@@ -405,8 +405,8 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->once())->method('where')
 			->with([
-				'Tag.name' => 'foo',
-				'Tag.id !=' => 3
+				'Tags.name' => 'foo',
+				'Tags.id !=' => 3
 			])
 			->will($this->returnValue($query));
 
@@ -416,15 +416,15 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->once())->method('select')
 			->with([
-				'Tag__name' => 'Tag.name',
-				'ArticlesTag__article_id' => 'ArticlesTag.article_id'
+				'Tags__name' => 'Tags.name',
+				'ArticlesTags__article_id' => 'ArticlesTags.article_id'
 			])
 			->will($this->returnValue($query));
 
 		$association->eagerLoader([
-			'conditions' => ['Tag.id !=' => 3],
+			'conditions' => ['Tags.id !=' => 3],
 			'sort' => ['name' => 'DESC'],
-			'fields' => ['name', 'ArticlesTag.article_id'],
+			'fields' => ['name', 'ArticlesTags.article_id'],
 			'keys' => $keys,
 			'query' => $query
 		]);
@@ -434,24 +434,24 @@ class BelongsToManyTest extends TestCase {
  * Test the eager loader method with default query clauses
  *
  * @expectedException \InvalidArgumentException
- * @expectedExceptionMessage You are required to select the "ArticlesTag.article_id"
+ * @expectedExceptionMessage You are required to select the "ArticlesTags.article_id"
  * @return void
  */
 	public function testEagerLoaderFieldsException() {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['execute', 'contain', 'where', 'order', 'select'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
@@ -477,17 +477,17 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		TableRegistry::get('ArticlesTag', [
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
 				'tag_id' => ['type' => 'integer']
 			]
 		]);
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$parent = (new Query(null, null))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
@@ -501,14 +501,14 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]],
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]],
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('where')
-			->with(['Tag.name' => 'foo'])
+			->with(['Tags.name' => 'foo'])
 			->will($this->returnSelf());
 
 		$expected = clone $parent;
@@ -516,17 +516,17 @@ class BelongsToManyTest extends TestCase {
 		unset($joins[1]);
 		$expected
 			->contain([], true)
-			->select('ArticlesTag.article_id', true)
+			->select('ArticlesTags.article_id', true)
 			->join($joins, [], true);
 
 		$query->expects($this->once())->method('where')
-			->with(['Tag.name' => 'foo'])
+			->with(['Tags.name' => 'foo'])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('contain')
 			->with([
-				'ArticlesTag' => [
-					'conditions' => ['ArticlesTag.article_id in' => $expected],
+				'ArticlesTags' => [
+					'conditions' => ['ArticlesTags.article_id in' => $expected],
 					'matching' => true
 				]
 			])
@@ -537,17 +537,17 @@ class BelongsToManyTest extends TestCase {
 			'keys' => []
 		]);
 
-		$row['Tag__Tag'] = [
-			['id' => 1, 'name' => 'foo', 'ArticlesTag' => ['article_id' => 1]]
+		$row['Tags__Tags'] = [
+			['id' => 1, 'name' => 'foo', 'ArticlesTags' => ['article_id' => 1]]
 		];
-		$row['Article__id'] = 1;
+		$row['Articles__id'] = 1;
 		$result = $callable($row);
 		$this->assertEquals($row, $result);
 
-		$row['Tag__Tag'] = [
-			['id' => 2, 'name' => 'bar', 'ArticlesTag' => ['article_id' => 2]]
+		$row['Tags__Tags'] = [
+			['id' => 2, 'name' => 'bar', 'ArticlesTags' => ['article_id' => 2]]
 		];
-		$row['Article__id'] = 2;
+		$row['Articles__id'] = 2;
 		$result = $callable($row);
 		$this->assertEquals($row, $result);
 	}
@@ -562,16 +562,16 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'sort' => ['id' => 'ASC'],
 		];
-		$association = new BelongsToMany('Tag', $config);
+		$association = new BelongsToMany('Tags', $config);
 		$association->pivot($articleTag);
 
 		$articleTag->expects($this->once())
 			->method('deleteAll')
 			->with([
-				'Tag.name' => 'foo',
+				'Tags.name' => 'foo',
 				'article_id' => 1
 			]);
 
@@ -589,7 +589,7 @@ class BelongsToManyTest extends TestCase {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
-			'conditions' => ['Tag.name' => 'foo'],
+			'conditions' => ['Tags.name' => 'foo'],
 			'cascadeCallbacks' => true,
 		];
 		$association = new BelongsToMany('Tag', $config);
@@ -605,7 +605,7 @@ class BelongsToManyTest extends TestCase {
 		$query = $this->getMock('\Cake\ORM\Query', [], [], '', false);
 		$query->expects($this->once())
 			->method('where')
-			->with(['Tag.name' => 'foo', 'article_id' => 1])
+			->with(['Tags.name' => 'foo', 'article_id' => 1])
 			->will($this->returnSelf());
 
 		$query->expects($this->any())

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -36,13 +36,13 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->company = TableRegistry::get('Company', [
+		$this->company = TableRegistry::get('Companies', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'company_name' => ['type' => 'string'],
 			]
 		]);
-		$this->client = TableRegistry::get('Client', [
+		$this->client = TableRegistry::get('Clients', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'client_name' => ['type' => 'string'],
@@ -83,23 +83,23 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
 			'targetTable' => $this->company,
-			'conditions' => ['Company.is_active' => true]
+			'conditions' => ['Companies.is_active' => true]
 		];
-		$association = new BelongsTo('Company', $config);
-		$field = new IdentifierExpression('Client.company_id');
+		$association = new BelongsTo('Companies', $config);
+		$field = new IdentifierExpression('Clients.company_id');
 		$query->expects($this->once())->method('join')->with([
-			'Company' => [
+			'Companies' => [
 				'conditions' => [
-					'Company.is_active' => true,
-					['Company.id' => $field]
+					'Companies.is_active' => true,
+					['Companies.id' => $field]
 				],
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Company__id' => 'Company.id',
-			'Company__company_name' => 'Company.company_name'
+			'Companies__id' => 'Companies.id',
+			'Companies__company_name' => 'Companies.company_name'
 		]);
 		$association->attachTo($query);
 	}
@@ -114,24 +114,24 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
-			'conditions' => ['Company.is_active' => true]
+			'conditions' => ['Companies.is_active' => true]
 		];
-		$association = new BelongsTo('Company', $config);
+		$association = new BelongsTo('Companies', $config);
 		$query->expects($this->once())->method('join')->with([
-			'Company' => [
+			'Companies' => [
 				'conditions' => [
-					'Company.is_active' => false
+					'Companies.is_active' => false
 				],
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Company__company_name' => 'Company.company_name'
+			'Companies__company_name' => 'Companies.company_name'
 		]);
 
 		$override = [
-			'conditions' => ['Company.is_active' => false],
+			'conditions' => ['Companies.is_active' => false],
 			'foreignKey' => false,
 			'fields' => ['company_name']
 		];
@@ -148,15 +148,15 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->client,
 			'targetTable' => $this->company,
-			'conditions' => ['Company.is_active' => true]
+			'conditions' => ['Companies.is_active' => true]
 		];
-		$association = new BelongsTo('Company', $config);
-		$field = new IdentifierExpression('Client.company_id');
+		$association = new BelongsTo('Companies', $config);
+		$field = new IdentifierExpression('Clients.company_id');
 		$query->expects($this->once())->method('join')->with([
-			'Company' => [
+			'Companies' => [
 				'conditions' => [
-					'Company.is_active' => true,
-					['Company.id' => $field]
+					'Companies.is_active' => true,
+					['Companies.id' => $field]
 				],
 				'type' => 'LEFT',
 				'table' => 'companies',
@@ -182,7 +182,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$mock->expects($this->never())
 			->method('delete');
 
-		$association = new BelongsTo('Company', $config);
+		$association = new BelongsTo('Companies', $config);
 		$entity = new Entity(['company_name' => 'CakePHP', 'id' => 1]);
 		$this->assertTrue($association->cascadeDelete($entity));
 	}

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -36,14 +36,16 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->author = TableRegistry::get('Author', [
+		$this->author = TableRegistry::get('Authors', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
 			]
 		]);
 		$this->article = $this->getMock(
-			'Cake\ORM\Table', ['find', 'deleteAll', 'delete'], [['alias' => 'Article', 'table' => 'articles']]
+			'Cake\ORM\Table',
+			['find', 'deleteAll', 'delete'],
+			[['alias' => 'Articles', 'table' => 'articles']]
 		);
 		$this->article->schema([
 			'id' => ['type' => 'integer'],
@@ -109,7 +111,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->article,
 			'strategy' => 'select'
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock('Cake\ORM\Query', ['execute'], [null, null]);
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -122,16 +124,16 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($results));
 
 		$callable = $association->eagerLoader(compact('keys', 'query'));
-		$row = ['Author__id' => 1, 'username' => 'author 1'];
+		$row = ['Authors__id' => 1, 'username' => 'author 1'];
 		$result = $callable($row);
-		$row['Article__Article'] = [
+		$row['Articles__Articles'] = [
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 			];
 		$this->assertEquals($row, $result);
 
-		$row = ['Author__id' => 2, 'username' => 'author 2'];
+		$row = ['Authors__id' => 2, 'username' => 'author 2'];
 		$result = $callable($row);
-		$row['Article__Article'] = [
+		$row['Articles__Articles'] = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2]
 			];
 		$this->assertEquals($row, $result);
@@ -146,11 +148,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true],
+			'conditions' => ['Articles.is_active' => true],
 			'sort' => ['id' => 'ASC'],
 			'strategy' => 'select'
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
@@ -168,11 +170,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('where')
-			->with(['Article.is_active' => true])
+			->with(['Articles.is_active' => true])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id IN' => $keys])
+			->with(['Articles.author_id IN' => $keys])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -191,11 +193,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true],
+			'conditions' => ['Articles.is_active' => true],
 			'sort' => ['id' => 'ASC'],
 			'strategy' => 'select'
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
@@ -213,11 +215,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('where')
-			->with(['Article.is_active' => true, 'Article.id !=' => 3])
+			->with(['Articles.is_active' => true, 'Articles.id !=' => 3])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id IN' => $keys])
+			->with(['Articles.author_id IN' => $keys])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -226,22 +228,22 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$query->expects($this->once())->method('select')
 			->with([
-				'Article__title' => 'Article.title',
-				'Article__author_id' => 'Article.author_id'
+				'Articles__title' => 'Articles.title',
+				'Articles__author_id' => 'Articles.author_id'
 			])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('contain')
 			->with([
-				'Category' => ['fields' => ['a', 'b']],
+				'Categories' => ['fields' => ['a', 'b']],
 			])
 			->will($this->returnValue($query));
 
 		$association->eagerLoader([
-			'conditions' => ['Article.id !=' => 3],
+			'conditions' => ['Articles.id !=' => 3],
 			'sort' => ['title' => 'DESC'],
 			'fields' => ['title', 'author_id'],
-			'contain' => ['Category' => ['fields' => ['a', 'b']]],
+			'contain' => ['Categories' => ['fields' => ['a', 'b']]],
 			'keys' => $keys,
 			'query' => $query
 		]);
@@ -252,7 +254,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * exception
  *
  * @expectedException \InvalidArgumentException
- * @expectedExceptionMessage You are required to select the "Article.author_id"
+ * @expectedExceptionMessage You are required to select the "Articles.author_id"
  * @return void
  */
 	public function testEagerLoaderFieldsException() {
@@ -261,7 +263,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->article,
 			'strategy' => 'select'
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
@@ -288,7 +290,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$parent = (new Query(null, null))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
@@ -317,25 +319,25 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		unset($joins[1]);
 		$expected
 			->contain([], true)
-			->select('Article.author_id', true)
+			->select('Articles.author_id', true)
 			->join($joins, [], true);
 		$query->expects($this->once())->method('andWhere')
-			->with(['Article.author_id IN' => $expected])
+			->with(['Articles.author_id IN' => $expected])
 			->will($this->returnValue($query));
 
 		$callable = $association->eagerLoader([
 			'query' => $parent, 'strategy' => HasMany::STRATEGY_SUBQUERY, 'keys' => []
 		]);
-		$row = ['Author__id' => 1, 'username' => 'author 1'];
+		$row = ['Authors__id' => 1, 'username' => 'author 1'];
 		$result = $callable($row);
-		$row['Article__Article'] = [
+		$row['Articles__Articles'] = [
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
 		$this->assertEquals($row, $result);
 
-		$row = ['Author__id' => 2, 'username' => 'author 2'];
+		$row = ['Authors__id' => 2, 'username' => 'author 2'];
 		$result = $callable($row);
-		$row['Article__Article'] = [
+		$row['Articles__Articles'] = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2]
 		];
 		$this->assertEquals($row, $result);
@@ -352,25 +354,25 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true]
+			'conditions' => ['Articles.is_active' => true]
 		];
 
-		$field = new IdentifierExpression('Article.author_id');
-		$association = new HasMany('Article', $config);
+		$field = new IdentifierExpression('Articles.author_id');
+		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
-			'Article' => [
+			'Articles' => [
 				'conditions' => [
-					'Article.is_active' => true,
-					['Author.id' => $field]
+					'Articles.is_active' => true,
+					['Authors.id' => $field]
 				],
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Article__id' => 'Article.id',
-			'Article__title' => 'Article.title',
-			'Article__author_id' => 'Article.author_id'
+			'Articles__id' => 'Articles.id',
+			'Articles__title' => 'Articles.title',
+			'Articles__author_id' => 'Articles.author_id'
 		]);
 		$association->attachTo($query);
 	}
@@ -385,24 +387,24 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true]
+			'conditions' => ['Articles.is_active' => true]
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
-			'Article' => [
+			'Articles' => [
 				'conditions' => [
-					'Article.is_active' => false
+					'Articles.is_active' => false
 				],
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Article__title' => 'Article.title'
+			'Articles__title' => 'Articles.title'
 		]);
 
 		$override = [
-			'conditions' => ['Article.is_active' => false],
+			'conditions' => ['Articles.is_active' => false],
 			'foreignKey' => false,
 			'fields' => ['title']
 		];
@@ -419,15 +421,15 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true]
+			'conditions' => ['Articles.is_active' => true]
 		];
-		$field = new IdentifierExpression('Article.author_id');
-		$association = new HasMany('Article', $config);
+		$field = new IdentifierExpression('Articles.author_id');
+		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
-			'Article' => [
+			'Articles' => [
 				'conditions' => [
-					'Article.is_active' => true,
-					['Author.id' => $field]
+					'Articles.is_active' => true,
+					['Authors.id' => $field]
 				],
 				'type' => 'INNER',
 				'table' => 'articles'
@@ -447,14 +449,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'dependent' => true,
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true],
+			'conditions' => ['Articles.is_active' => true],
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 
 		$this->article->expects($this->once())
 			->method('deleteAll')
 			->with([
-				'Article.is_active' => true,
+				'Articles.is_active' => true,
 				'author_id' => 1
 			]);
 
@@ -472,10 +474,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'dependent' => true,
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
-			'conditions' => ['Article.is_active' => true],
+			'conditions' => ['Articles.is_active' => true],
 			'cascadeCallbacks' => true,
 		];
-		$association = new HasMany('Article', $config);
+		$association = new HasMany('Articles', $config);
 
 		$articleOne = new Entity(['id' => 2, 'title' => 'test']);
 		$articleTwo = new Entity(['id' => 3, 'title' => 'testing']);
@@ -487,7 +489,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock('\Cake\ORM\Query', [], [], '', false);
 		$query->expects($this->once())
 			->method('where')
-			->with(['Article.is_active' => true, 'author_id' => 1])
+			->with(['Articles.is_active' => true, 'author_id' => 1])
 			->will($this->returnSelf());
 		$query->expects($this->any())
 			->method('getIterator')

--- a/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -35,13 +35,13 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->user = TableRegistry::get('User', [
+		$this->user = TableRegistry::get('Users', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
 			]
 		]);
-		$this->profile = TableRegistry::get('Profile', [
+		$this->profile = TableRegistry::get('Profiles', [
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'first_name' => ['type' => 'string'],
@@ -82,24 +82,24 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
-			'conditions' => ['Profile.is_active' => true]
+			'conditions' => ['Profiles.is_active' => true]
 		];
-		$association = new HasOne('Profile', $config);
-		$field = new IdentifierExpression('Profile.user_id');
+		$association = new HasOne('Profiles', $config);
+		$field = new IdentifierExpression('Profiles.user_id');
 		$query->expects($this->once())->method('join')->with([
-			'Profile' => [
+			'Profiles' => [
 				'conditions' => [
-					'Profile.is_active' => true,
-					['User.id' => $field],
+					'Profiles.is_active' => true,
+					['Users.id' => $field],
 				],
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Profile__id' => 'Profile.id',
-			'Profile__first_name' => 'Profile.first_name',
-			'Profile__user_id' => 'Profile.user_id'
+			'Profiles__id' => 'Profiles.id',
+			'Profiles__first_name' => 'Profiles.first_name',
+			'Profiles__user_id' => 'Profiles.user_id'
 		]);
 		$association->attachTo($query);
 	}
@@ -115,24 +115,24 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
-			'conditions' => ['Profile.is_active' => true]
+			'conditions' => ['Profiles.is_active' => true]
 		];
-		$association = new HasOne('Profile', $config);
+		$association = new HasOne('Profiles', $config);
 		$query->expects($this->once())->method('join')->with([
-			'Profile' => [
+			'Profiles' => [
 				'conditions' => [
-					'Profile.is_active' => false
+					'Profiles.is_active' => false
 				],
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
 		]);
 		$query->expects($this->once())->method('select')->with([
-			'Profile__first_name' => 'Profile.first_name'
+			'Profiles__first_name' => 'Profiles.first_name'
 		]);
 
 		$override = [
-			'conditions' => ['Profile.is_active' => false],
+			'conditions' => ['Profiles.is_active' => false],
 			'foreignKey' => false,
 			'fields' => ['first_name']
 		];
@@ -149,15 +149,15 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
-			'conditions' => ['Profile.is_active' => true]
+			'conditions' => ['Profiles.is_active' => true]
 		];
-		$association = new HasOne('Profile', $config);
-		$field = new IdentifierExpression('Profile.user_id');
+		$association = new HasOne('Profiles', $config);
+		$field = new IdentifierExpression('Profiles.user_id');
 		$query->expects($this->once())->method('join')->with([
-			'Profile' => [
+			'Profiles' => [
 				'conditions' => [
-					'Profile.is_active' => true,
-					['User.id' => $field],
+					'Profiles.is_active' => true,
+					['Users.id' => $field],
 				],
 				'type' => 'INNER',
 				'table' => 'profiles'

--- a/Cake/Test/TestCase/ORM/AssociationTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationTest.php
@@ -167,7 +167,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testProperty() {
-		$this->assertEquals('Foo', $this->association->property());
+		$this->assertEquals('foo', $this->association->property());
 		$this->association->property('thing');
 		$this->assertEquals('thing', $this->association->property());
 	}

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -62,21 +62,21 @@ class QueryTest extends TestCase {
 		];
 
 		$this->table = $table = TableRegistry::get('foo', ['schema' => $schema]);
-		$clients = TableRegistry::get('client', ['schema' => $schema1]);
-		$orders = TableRegistry::get('order', ['schema' => $schema2]);
-		$companies = TableRegistry::get('company', ['schema' => $schema, 'table' => 'organizations']);
-		$orderTypes = TableRegistry::get('orderType', ['schema' => $schema]);
+		$clients = TableRegistry::get('clients', ['schema' => $schema1]);
+		$orders = TableRegistry::get('orders', ['schema' => $schema2]);
+		$companies = TableRegistry::get('companies', ['schema' => $schema, 'table' => 'organizations']);
+		$orderTypes = TableRegistry::get('orderTypes', ['schema' => $schema]);
 		$stuff = TableRegistry::get('stuff', ['schema' => $schema, 'table' => 'things']);
-		$stuffTypes = TableRegistry::get('stuffType', ['schema' => $schema]);
-		$categories = TableRegistry::get('category', ['schema' => $schema]);
+		$stuffTypes = TableRegistry::get('stuffTypes', ['schema' => $schema]);
+		$categories = TableRegistry::get('categories', ['schema' => $schema]);
 
-		$table->belongsTo('client');
-		$clients->hasOne('order');
-		$clients->belongsTo('company');
-		$orders->belongsTo('orderType');
+		$table->belongsTo('clients');
+		$clients->hasOne('orders');
+		$clients->belongsTo('companies');
+		$orders->belongsTo('orderTypes');
 		$orders->hasOne('stuff');
-		$stuff->belongsTo('stuffType');
-		$companies->belongsTo('category');
+		$stuff->belongsTo('stuffTypes');
+		$companies->belongsTo('categories');
 	}
 
 /**
@@ -96,14 +96,14 @@ class QueryTest extends TestCase {
  **/
 	public function testContainToJoinsOneLevel() {
 		$contains = [
-			'client' => [
-			'order' => [
-					'orderType',
-					'stuff' => ['stuffType']
+			'clients' => [
+			'orders' => [
+					'orderTypes',
+					'stuff' => ['stuffTypes']
 				],
-				'company' => [
+				'companies' => [
 					'foreignKey' => 'organization_id',
-					'category'
+					'categories'
 				]
 			]
 		];
@@ -111,31 +111,31 @@ class QueryTest extends TestCase {
 		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
 
 		$query->expects($this->at(0))->method('join')
-			->with(['client' => [
+			->with(['clients' => [
 				'table' => 'clients',
 				'type' => 'LEFT',
 				'conditions' => [
-					['client.id' => new IdentifierExpression('foo.client_id')]
+					['clients.id' => new IdentifierExpression('foo.client_id')]
 				]
 			]])
 			->will($this->returnValue($query));
 
 		$query->expects($this->at(1))->method('join')
-			->with(['order' => [
+			->with(['orders' => [
 				'table' => 'orders',
 				'type' => 'INNER',
 				'conditions' => [
-					['client.id' => new IdentifierExpression('order.client_id')]
+					['clients.id' => new IdentifierExpression('orders.client_id')]
 				]
 			]])
 			->will($this->returnValue($query));
 
 		$query->expects($this->at(2))->method('join')
-			->with(['orderType' => [
+			->with(['orderTypes' => [
 				'table' => 'order_types',
 				'type' => 'LEFT',
 				'conditions' => [
-					['orderType.id' => new IdentifierExpression('order.order_type_id')]
+					['orderTypes.id' => new IdentifierExpression('orders.order_type_id')]
 				]
 			]])
 			->will($this->returnValue($query));
@@ -145,37 +145,37 @@ class QueryTest extends TestCase {
 				'table' => 'things',
 				'type' => 'INNER',
 				'conditions' => [
-					['order.id' => new IdentifierExpression('stuff.order_id')]
+					['orders.id' => new IdentifierExpression('stuff.order_id')]
 				]
 			]])
 			->will($this->returnValue($query));
 
 		$query->expects($this->at(4))->method('join')
-			->with(['stuffType' => [
+			->with(['stuffTypes' => [
 				'table' => 'stuff_types',
 				'type' => 'LEFT',
 				'conditions' => [
-					['stuffType.id' => new IdentifierExpression('stuff.stuff_type_id')]
+					['stuffTypes.id' => new IdentifierExpression('stuff.stuff_type_id')]
 				]
 			]])
 			->will($this->returnValue($query));
 
 		$query->expects($this->at(5))->method('join')
-			->with(['company' => [
+			->with(['companies' => [
 				'table' => 'organizations',
 				'type' => 'LEFT',
 				'conditions' => [
-					['company.id' => new IdentifierExpression('client.organization_id')]
+					['companies.id' => new IdentifierExpression('clients.organization_id')]
 				]
 			]])
 			->will($this->returnValue($query));
 
 		$query->expects($this->at(6))->method('join')
-			->with(['category' => [
+			->with(['categories' => [
 				'table' => 'categories',
 				'type' => 'LEFT',
 				'conditions' => [
-					['category.id' => new IdentifierExpression('company.category_id')]
+					['categories.id' => new IdentifierExpression('companies.category_id')]
 				]
 			]])
 			->will($this->returnValue($query));
@@ -192,9 +192,9 @@ class QueryTest extends TestCase {
  **/
 	public function testContainToFieldsPredefined() {
 		$contains = [
-			'client' => [
-				'fields' => ['name', 'company_id', 'client.telephone'],
-				'order' => [
+			'clients' => [
+				'fields' => ['name', 'company_id', 'clients.telephone'],
+				'orders' => [
 					'fields' => ['total', 'placed']
 				]
 			]
@@ -206,10 +206,10 @@ class QueryTest extends TestCase {
 		$query->select('foo.id')->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
-			'foo__id' => 'foo.id', 'client__name' => 'client.name',
-			'client__company_id' => 'client.company_id',
-			'client__telephone' => 'client.telephone',
-			'order__total' => 'order.total', 'order__placed' => 'order.placed'
+			'foo__id' => 'foo.id', 'clients__name' => 'clients.name',
+			'clients__company_id' => 'clients.company_id',
+			'clients__telephone' => 'clients.telephone',
+			'orders__total' => 'orders.total', 'orders__placed' => 'orders.placed'
 		];
 		$expected = $this->_quoteArray($expected);
 		$this->assertEquals($expected, $select);
@@ -222,38 +222,38 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testContainToFieldsDefault() {
-		$contains = ['client' => ['order']];
+		$contains = ['clients' => ['orders']];
 
 		$query = new Query($this->connection, $this->table);
 		$query->select()->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
-			'foo__id' => 'foo.id', 'client__name' => 'client.name',
-			'client__id' => 'client.id', 'client__phone' => 'client.phone',
-			'order__id' => 'order.id', 'order__total' => 'order.total',
-			'order__placed' => 'order.placed'
+			'foo__id' => 'foo.id', 'clients__name' => 'clients.name',
+			'clients__id' => 'clients.id', 'clients__phone' => 'clients.phone',
+			'orders__id' => 'orders.id', 'orders__total' => 'orders.total',
+			'orders__placed' => 'orders.placed'
 		];
 		$expected = $this->_quoteArray($expected);
 		$this->assertEquals($expected, $select);
 
-		$contains['client']['fields'] = ['name'];
+		$contains['clients']['fields'] = ['name'];
 		$query = new Query($this->connection, $this->table);
 		$query->select('foo.id')->contain($contains)->sql();
 		$select = $query->clause('select');
-		$expected = ['foo__id' => 'foo.id', 'client__name' => 'client.name'];
+		$expected = ['foo__id' => 'foo.id', 'clients__name' => 'clients.name'];
 		$expected = $this->_quoteArray($expected);
 		$this->assertEquals($expected, $select);
 
-		$contains['client']['fields'] = [];
-		$contains['client']['order']['fields'] = false;
+		$contains['clients']['fields'] = [];
+		$contains['clients']['orders']['fields'] = false;
 		$query = new Query($this->connection, $this->table);
 		$query->select()->contain($contains)->sql();
 		$select = $query->clause('select');
 		$expected = [
 			'foo__id' => 'foo.id',
-			'client__id' => 'client.id',
-			'client__name' => 'client.name',
-			'client__phone' => 'client.phone',
+			'clients__id' => 'clients.id',
+			'clients__name' => 'clients.name',
+			'clients__phone' => 'clients.phone',
 		];
 		$expected = $this->_quoteArray($expected);
 		$this->assertEquals($expected, $select);
@@ -286,14 +286,14 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testContainResultFetchingOneLevel() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
-		$table->belongsTo('author');
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
+		$table->belongsTo('authors');
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain('author')
+			->contain('authors')
 			->hydrate(false)
-			->order(['article.id' => 'asc'])
+			->order(['articles.id' => 'asc'])
 			->toArray();
 		$expected = [
 			[
@@ -352,17 +352,17 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHasManyEagerLoadingNoHydration($strategy) {
-		$table = TableRegistry::get('author');
-		TableRegistry::get('article');
-		$table->hasMany('article', [
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles', [
 			'property' => 'articles',
 			'strategy' => $strategy,
-			'sort' => ['article.id' => 'asc']
+			'sort' => ['articles.id' => 'asc']
 		]);
 		$query = new Query($this->connection, $table);
 
 		$results = $query->select()
-			->contain('article')
+			->contain('articles')
 			->hydrate(false)
 			->toArray();
 		$expected = [
@@ -412,12 +412,12 @@ class QueryTest extends TestCase {
 
 		$results = $query->repository($table)
 			->select()
-			->contain(['article' => ['conditions' => ['id' => 2]]])
+			->contain(['articles' => ['conditions' => ['id' => 2]]])
 			->hydrate(false)
 			->toArray();
 		unset($expected[0]['articles']);
 		$this->assertEquals($expected, $results);
-		$this->assertEquals($table->association('article')->strategy(), $strategy);
+		$this->assertEquals($table->association('articles')->strategy(), $strategy);
 	}
 
 /**
@@ -427,14 +427,14 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testHasManyEagerLoadingFieldsAndOrderNoHydration($strategy) {
-		$table = TableRegistry::get('author');
-		TableRegistry::get('article');
-		$table->hasMany('article', ['property' => 'articles'] + compact('strategy'));
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles', ['property' => 'articles'] + compact('strategy'));
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
 			->contain([
-				'article' => [
+				'articles' => [
 					'fields' => ['title', 'author_id'],
 					'sort' => ['id' => 'DESC']
 				]
@@ -476,18 +476,18 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHasManyEagerLoadingDeep($strategy) {
-		$table = TableRegistry::get('author');
-		$article = TableRegistry::get('article');
-		$table->hasMany('article', [
+		$table = TableRegistry::get('authors');
+		$article = TableRegistry::get('articles');
+		$table->hasMany('articles', [
 			'property' => 'articles',
 			'stratgey' => $strategy,
-			'sort' => ['article.id' => 'asc']
+			'sort' => ['articles.id' => 'asc']
 		]);
-		$article->belongsTo('author');
+		$article->belongsTo('authors');
 		$query = new Query($this->connection, $table);
 
 		$results = $query->select()
-			->contain(['article' => ['author']])
+			->contain(['articles' => ['authors']])
 			->hydrate(false)
 			->toArray();
 		$expected = [
@@ -547,18 +547,18 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHasManyEagerLoadingFromSecondaryTable($strategy) {
-		$author = TableRegistry::get('author');
-		$article = TableRegistry::get('article');
-		$post = TableRegistry::get('post');
+		$author = TableRegistry::get('authors');
+		$article = TableRegistry::get('articles');
+		$post = TableRegistry::get('posts');
 
-		$author->hasMany('post', ['property' => 'posts'] + compact('strategy'));
-		$article->belongsTo('author');
+		$author->hasMany('posts', compact('strategy'));
+		$article->belongsTo('authors');
 
 		$query = new Query($this->connection, $article);
 
 		$results = $query->select()
-			->contain(['author' => ['post']])
-			->order(['article.id' => 'ASC'])
+			->contain(['authors' => ['posts']])
+			->order(['articles.id' => 'ASC'])
 			->hydrate(false)
 			->toArray();
 		$expected = [
@@ -649,15 +649,15 @@ class QueryTest extends TestCase {
  * @return void
  **/
 	public function testBelongsToManyEagerLoadingNoHydration($strategy) {
-		$table = TableRegistry::get('Article');
-		TableRegistry::get('Tag');
-		TableRegistry::get('ArticleTag', [
+		$table = TableRegistry::get('Articles');
+		TableRegistry::get('Tags');
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags'
 		]);
-		$table->belongsToMany('Tag', ['property' => 'tags', 'strategy' => $strategy]);
+		$table->belongsToMany('Tags', ['strategy' => $strategy]);
 		$query = new Query($this->connection, $table);
 
-		$results = $query->select()->contain('Tag')->hydrate(false)->toArray();
+		$results = $query->select()->contain('Tags')->hydrate(false)->toArray();
 		$expected = [
 			[
 				'id' => 1,
@@ -669,12 +669,12 @@ class QueryTest extends TestCase {
 					[
 						'id' => 1,
 						'name' => 'tag1',
-						'ArticlesTag' => ['article_id' => 1, 'tag_id' => 1]
+						'articles_tags' => ['article_id' => 1, 'tag_id' => 1]
 					],
 					[
 						'id' => 2,
 						'name' => 'tag2',
-						'ArticlesTag' => ['article_id' => 1, 'tag_id' => 2]
+						'articles_tags' => ['article_id' => 1, 'tag_id' => 2]
 					]
 				]
 			],
@@ -688,12 +688,12 @@ class QueryTest extends TestCase {
 					[
 						'id' => 1,
 						'name' => 'tag1',
-						'ArticlesTag' => ['article_id' => 2, 'tag_id' => 1]
+						'articles_tags' => ['article_id' => 2, 'tag_id' => 1]
 					],
 					[
 						'id' => 3,
 						'name' => 'tag3',
-						'ArticlesTag' => ['article_id' => 2, 'tag_id' => 3]
+						'articles_tags' => ['article_id' => 2, 'tag_id' => 3]
 					]
 				]
 			],
@@ -708,7 +708,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals($expected, $results);
 
 		$results = $query->select()
-			->contain(['Tag' => ['conditions' => ['id' => 3]]])
+			->contain(['Tags' => ['conditions' => ['id' => 3]]])
 			->hydrate(false)
 			->toArray();
 		$expected = [
@@ -729,7 +729,7 @@ class QueryTest extends TestCase {
 					[
 						'id' => 3,
 						'name' => 'tag3',
-						'ArticlesTag' => ['article_id' => 2, 'tag_id' => 3]
+						'articles_tags' => ['article_id' => 2, 'tag_id' => 3]
 					]
 				]
 			],
@@ -742,7 +742,7 @@ class QueryTest extends TestCase {
 			],
 		];
 		$this->assertEquals($expected, $results);
-		$this->assertEquals($table->association('Tag')->strategy(), $strategy);
+		$this->assertEquals($table->association('Tags')->strategy(), $strategy);
 	}
 
 /**
@@ -752,16 +752,16 @@ class QueryTest extends TestCase {
  */
 	public function testFilteringByHasManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = TableRegistry::get('author');
-		TableRegistry::get('article');
-		$table->hasMany('article', ['property' => 'articles']);
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles');
 
 		$results = $query->repository($table)
 			->select()
 			->hydrate(false)
-			->contain(['article' => [
+			->contain(['articles' => [
 				'matching' => true,
-				'conditions' => ['article.id' => 2]
+				'conditions' => ['articles.id' => 2]
 			]])
 			->toArray();
 		$expected = [
@@ -789,17 +789,17 @@ class QueryTest extends TestCase {
  **/
 	public function testFilteringByBelongsToManyNoHydration() {
 		$query = new Query($this->connection, $this->table);
-		$table = TableRegistry::get('Article');
-		TableRegistry::get('Tag');
-		TableRegistry::get('ArticleTag', [
+		$table = TableRegistry::get('Articles');
+		TableRegistry::get('Tags');
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags'
 		]);
-		$table->belongsToMany('Tag', ['property' => 'tags']);
+		$table->belongsToMany('Tags');
 
 		$results = $query->repository($table)->select()
-			->contain(['Tag' => [
+			->contain(['Tags' => [
 				'matching' => true,
-				'conditions' => ['Tag.id' => 3]
+				'conditions' => ['Tags.id' => 3]
 			]])
 			->hydrate(false)
 			->toArray();
@@ -820,9 +820,9 @@ class QueryTest extends TestCase {
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain(['Tag' => [
+			->contain(['Tags' => [
 				'matching' => true,
-				'conditions' => ['Tag.name' => 'tag2']]
+				'conditions' => ['Tags.name' => 'tag2']]
 			])
 			->hydrate(false)
 			->toArray();
@@ -861,7 +861,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testBufferResults() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 
 		$result = $query->select()->bufferResults();
@@ -1062,7 +1062,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstDirtyQuery() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$result = $query->select(['id'])->hydrate(false)->first();
 		$this->assertEquals(['id' => 1], $result);
@@ -1077,7 +1077,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstCleanQuery() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$query->select(['id'])->toArray();
 
@@ -1092,7 +1092,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testFirstSameResult() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$query->select(['id'])->toArray();
 
@@ -1108,7 +1108,7 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateSimple() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
 		$results = $query->select()->execute()->toArray();
 
@@ -1131,15 +1131,15 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateWithHasMany() {
-		$table = TableRegistry::get('author');
-		TableRegistry::get('article');
-		$table->hasMany('article', [
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles', [
 			'property' => 'articles',
-			'sort' => ['article.id' => 'asc']
+			'sort' => ['articles.id' => 'asc']
 		]);
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain('article')
+			->contain('articles')
 			->toArray();
 
 		$first = $results[0];
@@ -1172,17 +1172,17 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateBelongsToMany() {
-		$table = TableRegistry::get('Article');
-		TableRegistry::get('Tag');
-		TableRegistry::get('ArticlesTag', [
+		$table = TableRegistry::get('Articles');
+		TableRegistry::get('Tags');
+		TableRegistry::get('ArticlesTags', [
 			'table' => 'articles_tags'
 		]);
-		$table->belongsToMany('Tag', ['property' => 'tags']);
+		$table->belongsToMany('Tags');
 		$query = new Query($this->connection, $table);
 
 		$results = $query
 			->select()
-			->contain('Tag')
+			->contain('Tags')
 			->toArray();
 
 		$first = $results[0];
@@ -1196,7 +1196,7 @@ class QueryTest extends TestCase {
 		$expected = [
 			'id' => 1,
 			'name' => 'tag1',
-			'ArticlesTag' => $articleTag
+			'articles_tags' => $articleTag
 		];
 		$this->assertEquals($expected, $first->tags[0]->toArray());
 
@@ -1205,7 +1205,7 @@ class QueryTest extends TestCase {
 		$expected = [
 			'id' => 2,
 			'name' => 'tag2',
-			'ArticlesTag' => $articleTag
+			'articles_tags' => $articleTag
 		];
 		$this->assertEquals($expected, $first->tags[1]->toArray());
 	}
@@ -1216,14 +1216,14 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateBelongsTo() {
-		$table = TableRegistry::get('article', ['table' => 'articles']);
-		TableRegistry::get('author');
-		$table->belongsTo('author');
+		$table = TableRegistry::get('articles');
+		TableRegistry::get('authors');
+		$table->belongsTo('authors');
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain('author')
-			->order(['article.id' => 'asc'])
+			->contain('authors')
+			->order(['articles.id' => 'asc'])
 			->toArray();
 
 		$this->assertCount(3, $results);
@@ -1239,17 +1239,17 @@ class QueryTest extends TestCase {
  * @return void
  */
 	public function testHydrateDeep() {
-		$table = TableRegistry::get('author');
-		$article = TableRegistry::get('article');
-		$table->hasMany('article', [
+		$table = TableRegistry::get('authors');
+		$article = TableRegistry::get('articles');
+		$table->hasMany('articles', [
 			'property' => 'articles',
-			'sort' => ['article.id' => 'asc']
+			'sort' => ['articles.id' => 'asc']
 		]);
-		$article->belongsTo('author');
+		$article->belongsTo('authors');
 		$query = new Query($this->connection, $table);
 
 		$results = $query->select()
-			->contain(['article' => ['author']])
+			->contain(['articles' => ['authors']])
 			->toArray();
 
 		$this->assertCount(4, $results);
@@ -1267,7 +1267,7 @@ class QueryTest extends TestCase {
  */
 	public function testHydrateCustomObject() {
 		$class = $this->getMockClass('\Cake\ORM\Entity', ['fakeMethod']);
-		$table = TableRegistry::get('article', [
+		$table = TableRegistry::get('articles', [
 			'table' => 'articles',
 			'entityClass' => '\\' . $class
 		]);
@@ -1296,19 +1296,19 @@ class QueryTest extends TestCase {
 	public function testHydrateWithHasManyCustomEntity() {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
 		$articleEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
-		$table = TableRegistry::get('author', [
+		$table = TableRegistry::get('authors', [
 			'entityClass' => '\\' . $authorEntity
 		]);
-		TableRegistry::get('article', [
+		TableRegistry::get('articles', [
 			'entityClass' => '\\' . $articleEntity
 		]);
-		$table->hasMany('article', [
+		$table->hasMany('articles', [
 			'property' => 'articles',
-			'sort' => ['article.id' => 'asc']
+			'sort' => ['articles.id' => 'asc']
 		]);
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain('article')
+			->contain('articles')
 			->toArray();
 
 		$first = $results[0];
@@ -1335,16 +1335,16 @@ class QueryTest extends TestCase {
  */
 	public function testHydrateBelongsToCustomEntity() {
 		$authorEntity = $this->getMockClass('\Cake\ORM\Entity', ['foo']);
-		$table = TableRegistry::get('article', ['table' => 'articles']);
-		TableRegistry::get('author', [
+		$table = TableRegistry::get('articles');
+		TableRegistry::get('authors', [
 			'entityClass' => '\\' . $authorEntity
 		]);
-		$table->belongsTo('author');
+		$table->belongsTo('authors');
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain('author')
-			->order(['article.id' => 'asc'])
+			->contain('authors')
+			->order(['articles.id' => 'asc'])
 			->toArray();
 
 		$first = $results[0];

--- a/Cake/Test/TestCase/ORM/TableRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/TableRegistryTest.php
@@ -68,17 +68,17 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testConfig() {
-		$this->assertEquals([], TableRegistry::config('Test'));
+		$this->assertEquals([], TableRegistry::config('Tests'));
 
 		$data = [
 			'connection' => 'testing',
 			'entityClass' => 'TestApp\Model\Entity\Article',
 		];
-		$result = TableRegistry::config('Test', $data);
+		$result = TableRegistry::config('Tests', $data);
 		$this->assertEquals($data, $result, 'Returns config data.');
 
 		$result = TableRegistry::config();
-		$expected = ['Test' => $data];
+		$expected = ['Tests' => $data];
 		$this->assertEquals($expected, $result);
 	}
 
@@ -88,13 +88,13 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testGet() {
-		$result = TableRegistry::get('Article', [
+		$result = TableRegistry::get('Articles', [
 			'table' => 'my_articles',
 		]);
 		$this->assertInstanceOf('Cake\ORM\Table', $result);
 		$this->assertEquals('my_articles', $result->table());
 
-		$result2 = TableRegistry::get('Article', [
+		$result2 = TableRegistry::get('Articles', [
 			'table' => 'herp_derp',
 		]);
 		$this->assertSame($result, $result2);
@@ -107,10 +107,10 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testGetWithConfig() {
-		TableRegistry::config('Article', [
+		TableRegistry::config('Articles', [
 			'table' => 'my_articles',
 		]);
-		$result = TableRegistry::get('Article');
+		$result = TableRegistry::get('Articles');
 		$this->assertEquals('my_articles', $result->table(), 'Should use config() data.');
 	}
 
@@ -121,26 +121,26 @@ class TableRegistryTest extends TestCase {
  * @return void
  */
 	public function testBuildConvention() {
-		$table = TableRegistry::get('article');
-		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
-		$table = TableRegistry::get('Article');
-		$this->assertInstanceOf('\TestApp\Model\Repository\ArticleTable', $table);
+		$table = TableRegistry::get('articles');
+		$this->assertInstanceOf('\TestApp\Model\Repository\ArticlesTable', $table);
+		$table = TableRegistry::get('Articles');
+		$this->assertInstanceOf('\TestApp\Model\Repository\ArticlesTable', $table);
 
-		$table = TableRegistry::get('author');
-		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
-		$table = TableRegistry::get('Author');
-		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorTable', $table);
+		$table = TableRegistry::get('authors');
+		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorsTable', $table);
+		$table = TableRegistry::get('Authors');
+		$this->assertInstanceOf('\TestApp\Model\Repository\AuthorsTable', $table);
 
 		$class = $this->getMockClass('\Cake\ORM\Table');
 		$class::staticExpects($this->once())
 			->method('defaultConnectionName')
 			->will($this->returnValue('test'));
 
-		if (!class_exists('MyPlugin\Model\Repository\SuperTestTable')) {
-			class_alias($class, 'MyPlugin\Model\Repository\SuperTestTable');
+		if (!class_exists('MyPlugin\Model\Repository\SuperTestsTable')) {
+			class_alias($class, 'MyPlugin\Model\Repository\SuperTestsTable');
 		}
 
-		$table = TableRegistry::get('MyPlugin.SuperTest');
+		$table = TableRegistry::get('MyPlugin.SuperTests');
 		$this->assertInstanceOf($class, $table);
 	}
 
@@ -192,8 +192,8 @@ class TableRegistryTest extends TestCase {
  */
 	public function testSet() {
 		$mock = $this->getMock('Cake\ORM\Table');
-		$this->assertSame($mock, TableRegistry::set('Article', $mock));
-		$this->assertSame($mock, TableRegistry::get('Article'));
+		$this->assertSame($mock, TableRegistry::set('Articles', $mock));
+		$this->assertSame($mock, TableRegistry::get('Articles'));
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -73,11 +73,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$table = $this->getMockBuilder('\Cake\ORM\Table')
 			->setMethods(['find'])
-			->setMockClassName('SpecialThingTable')
+			->setMockClassName('SpecialThingsTable')
 			->getMock();
 		$this->assertEquals('special_things', $table->table());
 
-		$table = new Table(['alias' => 'LoveBoat']);
+		$table = new Table(['alias' => 'LoveBoats']);
 		$this->assertEquals('love_boats', $table->table());
 
 		$table->table('other');
@@ -842,7 +842,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testRepositoryClassConventionForAPP() {
-		$table = new \TestApp\Model\Repository\ArticleTable;
+		$table = new \TestApp\Model\Repository\ArticlesTable;
 		$this->assertEquals('TestApp\Model\Entity\Article', $table->entityClass());
 	}
 
@@ -865,10 +865,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalBelongsToLoading() {
-		$table = new \TestApp\Model\Repository\ArticleTable([
+		$table = new \TestApp\Model\Repository\ArticlesTable([
 			'connection' => $this->connection,
 		]);
-		$result = $table->find('all')->contain(['author'])->first();
+		$result = $table->find('all')->contain(['authors'])->first();
 		$this->assertInstanceOf('TestApp\Model\Entity\Author', $result->author);
 	}
 
@@ -879,12 +879,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalHasManyLoading() {
-		$table = new \TestApp\Model\Repository\ArticleTable([
+		$table = new \TestApp\Model\Repository\ArticlesTable([
 			'connection' => $this->connection,
 		]);
-		$result = $table->find('all')->contain(['author' => ['article']])->first();
-		$this->assertCount(2, $result->author->article);
-		foreach ($result->author->article as $article) {
+		$result = $table->find('all')->contain(['authors' => ['articles']])->first();
+		$this->assertCount(2, $result->author->articles);
+		foreach ($result->author->articles as $article) {
 			$this->assertInstanceOf('TestApp\Model\Entity\Article', $article);
 		}
 	}
@@ -896,10 +896,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testReciprocalBelongsToMany() {
-		$table = new \TestApp\Model\Repository\ArticleTable([
+		$table = new \TestApp\Model\Repository\ArticlesTable([
 			'connection' => $this->connection,
 		]);
-		$result = $table->find('all')->contain(['tag'])->first();
+		$result = $table->find('all')->contain(['tags'])->first();
 		$this->assertInstanceOf('TestApp\Model\Entity\Tag', $result->tags[0]);
 		$this->assertInstanceOf(
 			'TestApp\Model\Entity\ArticlesTag',
@@ -913,10 +913,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindCleanEntities() {
-		$table = new \TestApp\Model\Repository\ArticleTable([
+		$table = new \TestApp\Model\Repository\ArticlesTable([
 			'connection' => $this->connection,
 		]);
-		$results = $table->find('all')->contain(['tag', 'author'])->toArray();
+		$results = $table->find('all')->contain(['tags', 'authors'])->toArray();
 		$this->assertCount(3, $results);
 		foreach ($results as $article) {
 			$this->assertFalse($article->dirty('id'));
@@ -940,10 +940,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testFindPersistedEntities() {
-		$table = new \TestApp\Model\Repository\ArticleTable([
+		$table = new \TestApp\Model\Repository\ArticlesTable([
 			'connection' => $this->connection,
 		]);
-		$results = $table->find('all')->contain(['tag', 'author'])->toArray();
+		$results = $table->find('all')->contain(['tags', 'authors'])->toArray();
 		$this->assertCount(3, $results);
 		foreach ($results as $article) {
 			$this->assertFalse($article->isNew());
@@ -1011,7 +1011,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testCallBehaviorFinder() {
-		$table = TableRegistry::get('article');
+		$table = TableRegistry::get('articles');
 		$table->addBehavior('Sluggable');
 
 		$query = $table->noSlug();
@@ -1613,8 +1613,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDeleteDependent() {
-		$table = TableRegistry::get('author');
-		$table->hasOne('article', [
+		$table = TableRegistry::get('authors');
+		$table->hasOne('articles', [
 			'foreignKey' => 'author_id',
 			'dependent' => true,
 		]);
@@ -1623,7 +1623,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$entity = $query->first();
 		$result = $table->delete($entity);
 
-		$articles = $table->association('article')->target();
+		$articles = $table->association('articles')->target();
 		$query = $articles->find('all', [
 			'conditions' => [
 				'author_id' => $entity->id
@@ -1638,7 +1638,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDeleteNoDependentNoCascade() {
-		$table = TableRegistry::get('author');
+		$table = TableRegistry::get('authors');
 		$table->hasMany('article', [
 			'foreignKey' => 'author_id',
 			'dependent' => false,
@@ -1648,7 +1648,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$entity = $query->first();
 		$result = $table->delete($entity);
 
-		$articles = $table->association('article')->target();
+		$articles = $table->association('articles')->target();
 		$query = $articles->find('all')->where(['author_id' => $entity->id]);
 		$this->assertCount(2, $query->execute(), 'Should find rows.');
 	}
@@ -1659,7 +1659,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testDeleteBelongsToMany() {
-		$table = TableRegistry::get('article');
+		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tag', [
 			'foreignKey' => 'article_id',
 			'joinTable' => 'articles_tags'
@@ -1668,7 +1668,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$entity = $query->first();
 		$table->delete($entity);
 
-		$pivot = $table->association('tag')->pivot();
+		$pivot = $table->association('tags')->pivot();
 		$query = $pivot->find('all')->where(['article_id' => 1]);
 		$this->assertNull($query->execute()->one(), 'Should not find any rows.');
 	}


### PR DESCRIPTION
This pull request addresses a couple issues by changing the way we require Table classes to be named. With this change, Table class names are not expected to be inflected anymore, any class should follow, by convention, the camelized version of the table, regardless of its pluralization. For example, for database table `articles`, you should create `ArticlesTable.php`.

The reasoning behind this is that Models, as they were conceived in 1.x, were supposed to represent a single row, thus the singular convention. Since Table classes are not meant to represent the row, but the collection, it make more sense to keep them in plural. On the other hand, Entity classes are expected to be in singular.

Additionally, this makes the Association classes a bit smarter so that the property name where results will be injected in a find will follow a more natural sigularization/pluralization of the alias name. For example if `Articles` belongsTo `Users` then the  Article entity will have a `user` property. Likewise, the `User` entity will contain an `articles` property since it is a one to many relationship.

Finally, this changes prevents accidental generation of aliases in queries that might be a reserved keyword in sql. Prime example is that cake was aliasing the `users` table to `user`, thus causing queries to fail in postgres. The amount of plural reserved keywords in SQL is rather insignificant, so chances of using a reserved names are even lower. This means that enabling automatic identifier quoting will not be required by default which is great news on the performance front :)
