### PR TITLE
3.0 - Convert Query::__call to a concrete method.

### DIFF
--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -867,16 +867,24 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Magic method to be able to call scoped finders in the default table
+ * Apply custom finds to against an existing query object.
  *
- * @param string $method name of the method to be invoked
- * @param array $args List of arguments passed to the function
- * @return mixed
- * @throws \BadMethodCallException
+ * Allows custom find methods to be combined and applied to each other.
+ *
+ * {{{
+ * $table->find('all')->find('recent');
+ * }}}
+ *
+ * The above is an example of stacking multiple finder methods onto
+ * a single query.
+ *
+ * @param string $finder The finder method to use.
+ * @param array $options The options for the finder.
+ * @return Cake\ORM\Query Returns a modified query.
+ * @see Cake\ORM\Table::find()
  */
-	public function __call($method, $args) {
-		$options = array_shift($args) ?: [];
-		return $this->repository()->callFinder($method, $this, $options);
+	public function find($finder, $options = []) {
+		return $this->repository()->callFinder($finder, $this, $options);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -663,8 +663,9 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$results = $table->find('all')
 			->select(['id', 'parent_id', 'name'])
 			->hydrate(false)
-			->threaded()
+			->find('threaded')
 			->toArray();
+
 		$this->assertEquals($expected, $results);
 	}
 
@@ -690,7 +691,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$result = $table
 			->find('threaded', ['order' => ['name' => 'ASC']])
-			->list(['keyPath' => 'id']);
+			->find('list', ['keyPath' => 'id']);
 		$this->assertSame($query, $result);
 	}
 
@@ -705,7 +706,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'connection' => $this->connection,
 		]);
 		$results = $table->find('all')
-			->threaded()
+			->find('threaded')
 			->select(['id', 'parent_id', 'name'])
 			->toArray();
 


### PR DESCRIPTION
Re-using the find() method makes Query and Table share the same interface.

Fixes #2293
