### PR TITLE
3.0 - Re-add automatic UUID generation when saving records

### DIFF
--- a/Cake/Database/Schema/MysqlSchema.php
+++ b/Cake/Database/Schema/MysqlSchema.php
@@ -258,6 +258,7 @@ class MysqlSchema extends BaseSchema {
 			'time' => ' TIME',
 			'datetime' => ' DATETIME',
 			'timestamp' => ' TIMESTAMP',
+			'uuid' => ' CHAR(36)',
 		];
 		$specialMap = [
 			'string' => true,

--- a/Cake/Database/Schema/MysqlSchema.php
+++ b/Cake/Database/Schema/MysqlSchema.php
@@ -87,6 +87,9 @@ class MysqlSchema extends BaseSchema {
 		if (strpos($col, 'int') !== false) {
 			return ['type' => 'integer', 'length' => $length];
 		}
+		if ($col === 'char' && $length === 36) {
+			return ['type' => 'uuid', 'length' => null];
+		}
 		if ($col === 'char') {
 			return ['type' => 'string', 'fixed' => true, 'length' => $length];
 		}

--- a/Cake/Database/Schema/PostgresSchema.php
+++ b/Cake/Database/Schema/PostgresSchema.php
@@ -98,7 +98,7 @@ class PostgresSchema extends BaseSchema {
 			return ['type' => 'string', 'length' => 39];
 		}
 		if ($col === 'uuid') {
-			return ['type' => 'string', 'fixed' => true, 'length' => 36];
+			return ['type' => 'uuid', 'length' => null];
 		}
 		if ($col === 'char' || $col === 'character') {
 			return ['type' => 'string', 'fixed' => true, 'length' => $length];

--- a/Cake/Database/Schema/PostgresSchema.php
+++ b/Cake/Database/Schema/PostgresSchema.php
@@ -294,6 +294,7 @@ class PostgresSchema extends BaseSchema {
 			'time' => ' TIME',
 			'datetime' => ' TIMESTAMP',
 			'timestamp' => ' TIMESTAMP',
+			'uuid' => ' UUID',
 		];
 
 		if (isset($typeMap[$data['type']])) {
@@ -314,9 +315,6 @@ class PostgresSchema extends BaseSchema {
 			$type = ' VARCHAR';
 			if ($isFixed) {
 				$type = ' CHAR';
-			}
-			if ($isFixed && isset($data['length']) && $data['length'] == 36) {
-				$type = ' UUID';
 			}
 			$out .= $type;
 			if (isset($data['length']) && $data['length'] != 36) {

--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -71,6 +71,9 @@ class SqliteSchema extends BaseSchema {
 		if (strpos($col, 'int') !== false) {
 			return ['type' => 'integer', 'length' => $length];
 		}
+		if ($col === 'char' && $length === 36) {
+			return ['type' => 'uuid', 'length' => null];
+		}
 		if ($col === 'char') {
 			return ['type' => 'string', 'fixed' => true, 'length' => $length];
 		}

--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -207,6 +207,7 @@ class SqliteSchema extends BaseSchema {
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);
 		$typeMap = [
+			'uuid' => ' CHAR(36)',
 			'string' => ' VARCHAR',
 			'integer' => ' INTEGER',
 			'biginteger' => ' BIGINT',

--- a/Cake/Database/Type.php
+++ b/Cake/Database/Type.php
@@ -221,7 +221,7 @@ class Type {
  * @return boolean
  */
 	public static function boolval($value) {
-		if (is_string($value)) {
+		if (is_string($value) && !is_numeric($value)) {
 			return strtolower($value) === 'true' ? true : false;
 		}
 		return !empty($value);

--- a/Cake/Database/Type.php
+++ b/Cake/Database/Type.php
@@ -38,7 +38,8 @@ class Type {
 		'date' => 'Cake\Database\Type\DateType',
 		'datetime' => 'Cake\Database\Type\DateTimeType',
 		'timestamp' => 'Cake\Database\Type\DateTimeType',
-		'time' => 'Cake\Database\Type\TimeType'
+		'time' => 'Cake\Database\Type\TimeType',
+		'uuid' => 'Cake\Database\Type\UuidType',
 	];
 
 /**
@@ -53,7 +54,6 @@ class Type {
 		'integer' => ['callback' => 'intval', 'pdo' => PDO::PARAM_INT],
 		'biginteger' => ['callback' => 'intval', 'pdo' => PDO::PARAM_INT],
 		'string' => ['callback' => 'strval'],
-		'uuid' => ['callback' => 'strval'],
 		'text' => ['callback' => 'strval'],
 		'boolean' => [
 			'callback' => ['\Cake\Database\Type', 'boolval'],
@@ -225,6 +225,19 @@ class Type {
 			return strtolower($value) === 'true' ? true : false;
 		}
 		return !empty($value);
+	}
+
+/**
+ * Generate a new primary key value for a given type.
+ *
+ * This method can be used by types to create new primary key values
+ * when entities are inserted.
+ *
+ * @return mixed A new primary key value.
+ * @see Cake\Database\Type\UuidType
+ */
+	public function newId() {
+		return null;
 	}
 
 }

--- a/Cake/Database/Type/UuidType.php
+++ b/Cake/Database/Type/UuidType.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Utility\String;
+use Exception;
+use PDO;
+
+/**
+ * Provides behavior for the uuid type
+ */
+class UuidType extends \Cake\Database\Type {
+
+/**
+ * Casts give value to Statement equivalent
+ *
+ * @param mixed $value value to be converted to PHP equivalent
+ * @param Driver $driver object from which database preferences and configuration will be extracted
+ * @return mixed
+ */
+	public function toStatement($value, Driver $driver) {
+		if (is_null($value)) {
+			return PDO::PARAM_NULL;
+		}
+		return PDO::PARAM_STR;
+	}
+
+/**
+ * Casts given value from a PHP type to one acceptable by database
+ *
+ * @param mixed $value value to be converted to database equivalent
+ * @param Driver $driver object from which database preferences and configuration will be extracted
+ * @return mixed
+ */
+	public function toDatabase($value, Driver $driver) {
+		if ($value === null) {
+			return null;
+		}
+		return strval($value);
+	}
+
+/**
+ * Casts given value from a database type to PHP equivalent
+ *
+ * @param mixed $value value to be converted to PHP equivalent
+ * @param Driver $driver object from which database preferences and configuration will be extracted
+ * @return mixed
+ */
+	public function toPHP($value, Driver $driver) {
+		if ($value === null) {
+			return null;
+		}
+		return strval($value);
+	}
+
+/**
+ * Generate a new UUID
+ *
+ * @return string A new primary key value.
+ */
+	public function newId() {
+		return String::uuid();
+	}
+
+}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -867,13 +867,8 @@ class Table {
 	protected function _insert($entity, $data) {
 		$query = $this->_buildQuery();
 
-		$id = null;
 		$primary = $this->primaryKey();
-		if ($primary) {
-			$typeName = $this->schema()->columnType($primary);
-			$type = Type::build($typeName);
-			$id = $type->newId();
-		}
+		$id = $this->_newId($primary);
 		if ($id !== null) {
 			$data[$primary] = $id;
 		}
@@ -895,6 +890,25 @@ class Table {
 		}
 		$statement->closeCursor();
 		return $success;
+	}
+
+/**
+ * Generate a primary key value for a new record.
+ *
+ * By default, this uses the type system to generate a new primary key
+ * value if possible. You can override this method if you have specific requirements
+ * for id generation.
+ *
+ * @param string $primary The primary key column to get a new ID for.
+ * @return null|mixed Either null or the new primary key value.
+ */
+	protected function _newId($primary) {
+		if (!$primary) {
+			return null;
+		}
+		$typeName = $this->schema()->columnType($primary);
+		$type = Type::build($typeName);
+		return $type->newId();
 	}
 
 /**

--- a/Cake/Test/Fixture/FruitsUuidTagFixture.php
+++ b/Cake/Test/Fixture/FruitsUuidTagFixture.php
@@ -32,8 +32,8 @@ class FruitsUuidTagFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'fruit_id' => ['type' => 'string', 'null' => false, 'length' => 36],
-		'uuid_tag_id' => ['type' => 'string', 'null' => false, 'length' => 36],
+		'fruit_id' => ['type' => 'uuid', 'null' => false],
+		'uuid_tag_id' => ['type' => 'uuid', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['uuid_tag_id']], 'unique_fruits_tags' => ['type' => 'unique', 'columns' => ['fruit_id', 'uuid_tag_id']]]
 	);
 

--- a/Cake/Test/Fixture/UuidFixture.php
+++ b/Cake/Test/Fixture/UuidFixture.php
@@ -32,7 +32,7 @@ class UuidFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
+		'id' => ['type' => 'uuid'],
 		'title' => 'string',
 		'count' => ['type' => 'integer', 'default' => 0],
 		'created' => 'datetime',

--- a/Cake/Test/Fixture/UuidTagFixture.php
+++ b/Cake/Test/Fixture/UuidTagFixture.php
@@ -32,7 +32,7 @@ class UuidTagFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
+		'id' => ['type' => 'uuid'],
 		'name' => ['type' => 'string', 'length' => 255],
 		'created' => ['type' => 'datetime'],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]

--- a/Cake/Test/Fixture/UuidTreeFixture.php
+++ b/Cake/Test/Fixture/UuidTreeFixture.php
@@ -33,9 +33,9 @@ class UuidTreeFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
+		'id' => ['type' => 'uuid'],
 		'name' => ['type' => 'string', 'null' => false],
-		'parent_id' => ['type' => 'string', 'length' => 36, 'null' => true],
+		'parent_id' => ['type' => 'uuid', 'null' => true],
 		'lft' => ['type' => 'integer', 'null' => false],
 		'rght' => ['type' => 'integer', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]

--- a/Cake/Test/Fixture/UuiditemFixture.php
+++ b/Cake/Test/Fixture/UuiditemFixture.php
@@ -32,7 +32,7 @@ class UuiditemFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
+		'id' => ['type' => 'uuid'],
 		'published' => ['type' => 'boolean', 'null' => false],
 		'name' => ['type' => 'string', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]

--- a/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
+++ b/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
@@ -32,9 +32,9 @@ class UuiditemsUuidportfolioFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
-		'uuiditem_id' => ['type' => 'string', 'length' => 36, 'null' => false],
-		'uuidportfolio_id' => ['type' => 'string', 'length' => 36, 'null' => false],
+		'id' => ['type' => 'uuid'],
+		'uuiditem_id' => ['type' => 'uuid', 'null' => false],
+		'uuidportfolio_id' => ['type' => 'uuid', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);
 

--- a/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
+++ b/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
@@ -33,8 +33,8 @@ class UuiditemsUuidportfolioNumericidFixture extends TestFixture {
  */
 	public $fields = array(
 		'id' => ['type' => 'integer', 'length' => 10],
-		'uuiditem_id' => ['type' => 'string', 'length' => 36, 'null' => false],
-		'uuidportfolio_id' => ['type' => 'string', 'length' => 36, 'null' => false],
+		'uuiditem_id' => ['type' => 'uuid', 'null' => false],
+		'uuidportfolio_id' => ['type' => 'uuid', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);
 

--- a/Cake/Test/Fixture/UuidportfolioFixture.php
+++ b/Cake/Test/Fixture/UuidportfolioFixture.php
@@ -32,7 +32,7 @@ class UuidportfolioFixture extends TestFixture {
  * @var array
  */
 	public $fields = array(
-		'id' => ['type' => 'string', 'length' => 36],
+		'id' => ['type' => 'uuid'],
 		'name' => ['type' => 'string', 'null' => false],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);

--- a/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -375,6 +375,11 @@ SQL;
 				['type' => 'string'],
 				'`title` VARCHAR(255)'
 			],
+			[
+				'id',
+				['type' => 'uuid'],
+				'`id` CHAR(36)'
+			],
 			// Text
 			[
 				'body',

--- a/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -82,6 +82,10 @@ class MysqlSchemaTest extends TestCase {
 				['type' => 'string', 'length' => 25, 'fixed' => true]
 			],
 			[
+				'CHAR(36)',
+				['type' => 'uuid', 'length' => null]
+			],
+			[
 				'TINYTEXT',
 				['type' => 'string', 'length' => null]
 			],

--- a/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -155,7 +155,7 @@ SQL;
 			],
 			[
 				'UUID',
-				['type' => 'string', 'fixed' => true, 'length' => 36]
+				['type' => 'uuid', 'length' => null]
 			],
 			[
 				'INET',

--- a/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -396,7 +396,7 @@ SQL;
 			],
 			[
 				'id',
-				['type' => 'string', 'length' => 36, 'fixed' => true, 'null' => false],
+				['type' => 'uuid', 'length' => 36, 'null' => false],
 				'"id" UUID NOT NULL'
 			],
 			[

--- a/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -74,6 +74,10 @@ class SqliteSchemaTest extends TestCase {
 				['type' => 'string', 'fixed' => true, 'length' => 25]
 			],
 			[
+				'CHAR(36)',
+				['type' => 'uuid', 'length' => null]
+			],
+			[
 				'BLOB',
 				['type' => 'binary', 'length' => null]
 			],

--- a/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -355,6 +355,11 @@ SQL;
 				['type' => 'string'],
 				'"title" VARCHAR'
 			],
+			[
+				'id',
+				['type' => 'uuid'],
+				'"id" CHAR(36)'
+			],
 			// Text
 			[
 				'body',

--- a/Cake/Test/TestCase/Database/Type/UuidTypeTest.php
+++ b/Cake/Test/TestCase/Database/Type/UuidTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Database\Type;
+
+use Cake\Database\Type;
+use Cake\Database\Type\UuidType;
+use Cake\TestSuite\TestCase;
+use \PDO;
+
+/**
+ * Test for the Uuid type.
+ */
+class UuidTypeTest extends TestCase {
+
+/**
+ * Setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->type = Type::build('uuid');
+		$this->driver = $this->getMock('Cake\Database\Driver');
+	}
+
+/**
+ * Test toPHP
+ *
+ * @return void
+ */
+	public function testToPHP() {
+		$this->assertNull($this->type->toPHP(null, $this->driver));
+
+		$result = $this->type->toPHP('some data', $this->driver);
+		$this->assertSame('some data', $result);
+
+		$result = $this->type->toPHP(2, $this->driver);
+		$this->assertSame('2', $result);
+	}
+
+/**
+ * Test converting to database format
+ *
+ * @return void
+ */
+	public function testToDatabase() {
+		$result = $this->type->toDatabase('some data', $this->driver);
+		$this->assertSame('some data', $result);
+
+		$result = $this->type->toDatabase(2, $this->driver);
+		$this->assertSame('2', $result);
+	}
+
+/**
+ * Test that the PDO binding type is correct.
+ *
+ * @return void
+ */
+	public function testToStatement() {
+		$this->assertEquals(PDO::PARAM_STR, $this->type->toStatement('', $this->driver));
+	}
+
+/**
+ * Test generating new ids
+ *
+ * @return void
+ */
+	public function testNewId() {
+		$one = $this->type->newId();
+		$two = $this->type->newId();
+
+		$this->assertNotEquals($one, $two, 'Should be different values');
+		$this->assertRegExp('/^[a-f0-9-]+$/', $one, 'Should quack like a uuid');
+		$this->assertRegExp('/^[a-f0-9-]+$/', $two, 'Should quack like a uuid');
+	}
+
+}

--- a/Cake/Test/TestCase/Database/TypeTest.php
+++ b/Cake/Test/TestCase/Database/TypeTest.php
@@ -295,6 +295,12 @@ class TypeTest extends \Cake\TestSuite\TestCase {
 
 		$driver = $this->getMock('\Cake\Database\Driver');
 		$this->assertFalse($type->toDatabase(0, $driver));
+
+		$driver = $this->getMock('\Cake\Database\Driver');
+		$this->assertTrue($type->toDatabase('1', $driver));
+
+		$driver = $this->getMock('\Cake\Database\Driver');
+		$this->assertFalse($type->toDatabase('0', $driver));
 	}
 
 /**
@@ -322,11 +328,13 @@ class TypeTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertTrue($type->toPHP(true, $driver));
 		$this->assertTrue($type->toPHP(1, $driver));
+		$this->assertTrue($type->toPHP('1', $driver));
 		$this->assertTrue($type->toPHP('TRUE', $driver));
 		$this->assertTrue($type->toPHP('true', $driver));
 
 		$this->assertFalse($type->toPHP(false, $driver));
 		$this->assertFalse($type->toPHP(0, $driver));
+		$this->assertFalse($type->toPHP('0', $driver));
 		$this->assertFalse($type->toPHP('FALSE', $driver));
 		$this->assertFalse($type->toPHP('false', $driver));
 	}

--- a/Cake/Test/TestCase/ORM/TableUuidTest.php
+++ b/Cake/Test/TestCase/ORM/TableUuidTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\Core\Configure;
+use Cake\Database\ConnectionManager;
+use Cake\Database\Expression\QueryExpression;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\String;
+
+/**
+ * Integration tests for Table class with uuid primary keys.
+ *
+ */
+class UuidTableTest extends \Cake\TestSuite\TestCase {
+
+/**
+ * Fixtures
+ *
+ * @var array
+ */
+	public $fixtures = [
+		'core.uuiditem', 'core.uuidportfolio'
+	];
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->connection = ConnectionManager::get('test');
+		Configure::write('App.namespace', 'TestApp');
+	}
+
+/**
+ * teardown
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		TableRegistry::clear();
+	}
+
+/**
+ * Test saving new records sets uuids
+ *
+ * @return void
+ */
+	public function testSaveNew() {
+		$entity = new \Cake\ORM\Entity([
+			'name' => 'shiny new',
+			'published' => true,
+		]);
+		$table = TableRegistry::get('uuiditems');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertRegExp('/^[a-f0-9-]{36}$/', $entity->id, 'Should be 36 characters');
+
+		$row = $table->find('all')->where(['id' => $entity->id])->first();
+		$this->assertEquals($entity->toArray(), $row->toArray());
+	}
+
+/**
+ * Test saving existing records works
+ *
+ * @return void
+ */
+	public function testSaveUpdate() {
+		$id = '481fc6d0-b920-43e0-a40d-6d1740cf8569';
+		$entity = new \Cake\ORM\Entity([
+			'id' => $id,
+			'name' => 'shiny update',
+			'published' => true,
+		]);
+
+		$table = TableRegistry::get('uuiditems');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertEquals($id, $entity->id, 'Should be 36 characters');
+
+		$row = $table->find('all')->where(['id' => $entity->id])->first();
+		$this->assertEquals($entity->toArray(), $row->toArray());
+	}
+
+/**
+ * Test delete with string pk.
+ *
+ * @return void
+ */
+	public function testDelete() {
+		$id = '481fc6d0-b920-43e0-a40d-6d1740cf8569';
+		$table = TableRegistry::get('uuiditems');
+		$entity = $table->find('all')->where(['id' => $id])->first();
+
+		$this->assertTrue($table->delete($entity));
+		$query = $table->find('all')->where(['id' => $id]);
+		$this->assertCount(0, $query->execute(), 'No rows left');
+	}
+
+}


### PR DESCRIPTION
Implement the features described in #2299. 
- Implement a new UUID abstract type, that works in reflection and schema generation. A new portable type allows the type system to be extended with a new type and features.
- I found a few small issues with SQLite type conversion and fixed those as well.

We'll need to re-visit this once cascading saves + multi-column primary keys are added.
