### PR TITLE
Add SSL support back to MySQL driver.

### DIFF
--- a/Cake/Database/Driver/Mysql.php
+++ b/Cake/Database/Driver/Mysql.php
@@ -59,12 +59,21 @@ class Mysql extends \Cake\Database\Driver {
 		}
 
 		$config['init'][] = sprintf("SET time_zone = '%s'", $config['timezone']);
+
 		$config['flags'] += [
 			PDO::ATTR_PERSISTENT => $config['persistent'],
 			PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 			PDO::MYSQL_ATTR_INIT_COMMAND => implode(';', (array)$config['init'])
 		];
+
+		if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {
+			$config['flags'][PDO::MYSQL_ATTR_SSL_KEY] = $config['ssl_key'];
+			$config['flags'][PDO::MYSQL_ATTR_SSL_CERT] = $config['ssl_cert'];
+		}
+		if (!empty($config['ssl_ca'])) {
+			$config['flags'][PDO::MYSQL_ATTR_SSL_CA] = $config['ssl_ca'];
+		}
 
 		if (empty($config['dsn'])) {
 			if (empty($config['unix_socket'])) {


### PR DESCRIPTION
This was lost in the 2.x -> 3.x migration. Re-add the documented options.

Fixes #2313
