### PR TITLE
Removed "PHP 5" from file header DocBlocks

### DIFF
--- a/app/Config/Schema/db_acl.php
+++ b/app/Config/Schema/db_acl.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for ACL
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/Schema/i18n.php
+++ b/app/Config/Schema/i18n.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for i18n
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/Schema/sessions.php
+++ b/app/Config/Schema/sessions.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for Sessions
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/acl.ini.php
+++ b/app/Config/acl.ini.php
@@ -2,9 +2,6 @@
 ;/**
 ; * ACL Configuration
 ; *
-; *
-; * PHP 5
-; *
 ; * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 ; * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 ; *

--- a/app/Config/acl.php
+++ b/app/Config/acl.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure access control of your CakePHP application.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -8,8 +8,6 @@
  * You should also use this file to include any files that provide global functions/constants
  * that your application uses.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure core behavior of Cake.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/Config/email.php.default
+++ b/app/Config/email.php.default
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -6,8 +6,6 @@
  * Routes are very important mechanism that allows you to freely connect
  * different URLs to chosen controllers and their actions (functions).
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Console/Command/AppShell.php
+++ b/app/Console/Command/AppShell.php
@@ -2,8 +2,6 @@
 /**
  * AppShell file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Console/cake
+++ b/app/Console/cake
@@ -2,7 +2,6 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/Console/cake.bat
+++ b/app/Console/cake.bat
@@ -1,7 +1,6 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::
 :: Bake is a shell script for running CakePHP bake script
-:: PHP 5
 ::
 :: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 :: Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -3,8 +3,6 @@
 /**
  * Command-line code generation utility to automate programmer chores.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -5,8 +5,6 @@
  * This file is application-wide controller file. You can put all
  * application-wide controller-related methods here.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Controller/PagesController.php
+++ b/app/Controller/PagesController.php
@@ -4,8 +4,6 @@
  *
  * This file will render views from views/pages/
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/Model/AppModel.php
+++ b/app/Model/AppModel.php
@@ -5,8 +5,6 @@
  * This file is application-wide model file. You can put all
  * application-wide model-related methods here.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Emails/html/default.ctp
+++ b/app/View/Emails/html/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Emails/text/default.ctp
+++ b/app/View/Emails/text/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Errors/error400.ctp
+++ b/app/View/Errors/error400.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Errors/error500.ctp
+++ b/app/View/Errors/error500.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Helper/AppHelper.php
+++ b/app/View/Helper/AppHelper.php
@@ -5,8 +5,6 @@
  * This file is application-wide helper file. You can put all
  * application-wide helper-related methods here.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/View/Layouts/Emails/html/default.ctp
+++ b/app/View/Layouts/Emails/html/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Layouts/Emails/text/default.ctp
+++ b/app/View/Layouts/Emails/text/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Layouts/ajax.ctp
+++ b/app/View/Layouts/ajax.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Layouts/error.ctp
+++ b/app/View/Layouts/error.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Layouts/flash.ctp
+++ b/app/View/Layouts/flash.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Pages

--- a/app/index.php
+++ b/app/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -4,8 +4,6 @@
  *
  * The Front Controller for handling every request
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/app/webroot/test.php
+++ b/app/webroot/test.php
@@ -2,8 +2,6 @@
 /**
  * Web Access Frontend for TestSuite
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/index.php
+++ b/index.php
@@ -7,8 +7,6 @@
  *  - requires App.baseUrl to be uncommented in app/Config/core.php
  *	- app/webroot is not set as a document root.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c), Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/ApcEngine.php
+++ b/lib/Cake/Cache/Engine/ApcEngine.php
@@ -2,9 +2,6 @@
 /**
  * APC storage engine for cache.
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -6,8 +6,6 @@
  *
  * You can configure a FileEngine cache, using Cache::config()
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/MemcacheEngine.php
+++ b/lib/Cake/Cache/Engine/MemcacheEngine.php
@@ -2,9 +2,6 @@
 /**
  * Memcache storage engine for cache
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -2,9 +2,6 @@
 /**
  * Redis storage engine for cache
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/WincacheEngine.php
+++ b/lib/Cake/Cache/Engine/WincacheEngine.php
@@ -4,8 +4,6 @@
  *
  * Supports wincache 1.1.0 and higher.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Cache/Engine/XcacheEngine.php
+++ b/lib/Cake/Cache/Engine/XcacheEngine.php
@@ -2,8 +2,6 @@
 /**
  * Xcache storage engine for cache.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/config.php
+++ b/lib/Cake/Config/config.php
@@ -2,8 +2,6 @@
 /**
  * Core Configurations.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/routes.php
+++ b/lib/Cake/Config/routes.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0080_00ff.php
+++ b/lib/Cake/Config/unicode/casefolding/0080_00ff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0100_017f.php
+++ b/lib/Cake/Config/unicode/casefolding/0100_017f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0180_024F.php
+++ b/lib/Cake/Config/unicode/casefolding/0180_024F.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0250_02af.php
+++ b/lib/Cake/Config/unicode/casefolding/0250_02af.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0370_03ff.php
+++ b/lib/Cake/Config/unicode/casefolding/0370_03ff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0400_04ff.php
+++ b/lib/Cake/Config/unicode/casefolding/0400_04ff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0500_052f.php
+++ b/lib/Cake/Config/unicode/casefolding/0500_052f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/0530_058f.php
+++ b/lib/Cake/Config/unicode/casefolding/0530_058f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/1e00_1eff.php
+++ b/lib/Cake/Config/unicode/casefolding/1e00_1eff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/1f00_1fff.php
+++ b/lib/Cake/Config/unicode/casefolding/1f00_1fff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2100_214f.php
+++ b/lib/Cake/Config/unicode/casefolding/2100_214f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2150_218f.php
+++ b/lib/Cake/Config/unicode/casefolding/2150_218f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2460_24ff.php
+++ b/lib/Cake/Config/unicode/casefolding/2460_24ff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2c00_2c5f.php
+++ b/lib/Cake/Config/unicode/casefolding/2c00_2c5f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2c60_2c7f.php
+++ b/lib/Cake/Config/unicode/casefolding/2c60_2c7f.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/2c80_2cff.php
+++ b/lib/Cake/Config/unicode/casefolding/2c80_2cff.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Config/unicode/casefolding/ff00_ffef.php
+++ b/lib/Cake/Config/unicode/casefolding/ff00_ffef.php
@@ -8,8 +8,6 @@
  * @see http://www.unicode.org/Public/UNIDATA/CaseFolding.txt
  * @see http://www.unicode.org/reports/tr21/tr21-5.html
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -2,8 +2,6 @@
 /**
  * IniReader
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -2,8 +2,6 @@
 /**
  * PhpReader file
  *
- * PHP 5
- *
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -2,8 +2,6 @@
 /**
  * Acl Shell provides Acl access in the CLI environment
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/ApiShell.php
+++ b/lib/Cake/Console/Command/ApiShell.php
@@ -4,8 +4,6 @@
  *
  * Implementation of a Cake Shell to show CakePHP core method signatures.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/AppShell.php
+++ b/lib/Cake/Console/Command/AppShell.php
@@ -2,8 +2,6 @@
 /**
  * AppShell file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -6,8 +6,6 @@
  * application development by writing fully functional skeleton controllers,
  * models, and views. Going further, Bake can also write Unit Tests for you.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/I18nShell.php
+++ b/lib/Cake/Console/Command/I18nShell.php
@@ -2,8 +2,6 @@
 /**
  * Internationalization Management Shell
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -2,8 +2,6 @@
 /**
  * built-in Server Shell
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/BakeTask.php
+++ b/lib/Cake/Console/Command/Task/BakeTask.php
@@ -2,8 +2,6 @@
 /**
  * Base class for Bake Tasks.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -2,8 +2,6 @@
 /**
  * The ControllerTask handles creating and updating controller files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -2,8 +2,6 @@
 /**
  * The DbConfig Task handles creating and updating the database.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -2,8 +2,6 @@
 /**
  * Language string extractor
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -2,8 +2,6 @@
 /**
  * The FixtureTask handles creating and updating fixture files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -2,8 +2,6 @@
 /**
  * The ModelTask handles creating and updating models files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -2,8 +2,6 @@
 /**
  * The Plugin Task handles creating an empty plugin, ready to be used
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -2,9 +2,6 @@
 /**
  * The Project Task handles creating the base application
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/TemplateTask.php
+++ b/lib/Cake/Console/Command/Task/TemplateTask.php
@@ -2,8 +2,6 @@
 /**
  * Template Task can generate templated output Used in other Tasks
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -2,8 +2,6 @@
 /**
  * The TestTask handles creating and updating test files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -2,8 +2,6 @@
 /**
  * The View Tasks handles creating and updating view files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -4,8 +4,6 @@
  *
  * This Shell allows the running of test suites via the cake command line
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/TestsuiteShell.php
+++ b/lib/Cake/Console/Command/TestsuiteShell.php
@@ -4,8 +4,6 @@
  *
  * This is a bc wrapper for the newer Test shell
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -2,8 +2,6 @@
 /**
  * Upgrade Shell
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -2,8 +2,6 @@
 /**
  * ErrorHandler for Console Shells
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleInput.php
+++ b/lib/Cake/Console/ConsoleInput.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleInput file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleInputArgument.php
+++ b/lib/Cake/Console/ConsoleInputArgument.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleArgumentOption file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleInputOption.php
+++ b/lib/Cake/Console/ConsoleInputOption.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleInputOption file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleInputSubcommand.php
+++ b/lib/Cake/Console/ConsoleInputSubcommand.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleInputSubcommand file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleOptionParser file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleOutput file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/HelpFormatter.php
+++ b/lib/Cake/Console/HelpFormatter.php
@@ -2,8 +2,6 @@
 /**
  * HelpFormatter
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -2,8 +2,6 @@
 /**
  * Base class for Shells
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -2,8 +2,6 @@
 /**
  * ShellDispatcher file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
+++ b/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
@@ -2,8 +2,6 @@
 /**
  * Bake Template for Controller action generation.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/classes/controller.ctp
+++ b/lib/Cake/Console/Templates/default/classes/controller.ctp
@@ -4,8 +4,6 @@
  *
  * Allows templating of Controllers generated from bake.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/classes/fixture.ctp
+++ b/lib/Cake/Console/Templates/default/classes/fixture.ctp
@@ -4,8 +4,6 @@
  *
  * Fixture Template used when baking fixtures with bake
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/classes/model.ctp
+++ b/lib/Cake/Console/Templates/default/classes/model.ctp
@@ -4,8 +4,6 @@
  *
  * Used by bake to create new Model files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -2,9 +2,6 @@
 /**
  * Test Case bake template
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/default/views/form.ctp
+++ b/lib/Cake/Console/Templates/default/views/form.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/default/views/index.ctp
+++ b/lib/Cake/Console/Templates/default/views/index.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/default/views/view.ctp
+++ b/lib/Cake/Console/Templates/default/views/view.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/db_acl.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for ACL
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/i18n.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for i18n
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
+++ b/lib/Cake/Console/Templates/skel/Config/Schema/sessions.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure database for Sessions
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config.Schema
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Config/acl.ini.php
+++ b/lib/Cake/Console/Templates/skel/Config/acl.ini.php
@@ -2,9 +2,6 @@
 ;/**
 ; * ACL Configuration
 ; *
-; *
-; * PHP 5
-; *
 ; * @link          http://cakephp.org CakePHP(tm) Project
 ; * @package       app.Config
 ; * @since         CakePHP(tm) v 0.10.0.1076

--- a/lib/Cake/Console/Templates/skel/Config/acl.php
+++ b/lib/Cake/Console/Templates/skel/Config/acl.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure access control of your CakePHP application.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 2.1

--- a/lib/Cake/Console/Templates/skel/Config/bootstrap.php
+++ b/lib/Cake/Console/Templates/skel/Config/bootstrap.php
@@ -8,8 +8,6 @@
  * You should also use this file to include any files that provide global functions/constants
  * that your application uses.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.10.8.2117

--- a/lib/Cake/Console/Templates/skel/Config/core.php
+++ b/lib/Cake/Console/Templates/skel/Config/core.php
@@ -4,8 +4,6 @@
  *
  * Use it to configure core behavior of Cake.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Config/database.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/database.php.default
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config

--- a/lib/Cake/Console/Templates/skel/Config/email.php.default
+++ b/lib/Cake/Console/Templates/skel/Config/email.php.default
@@ -4,8 +4,6 @@
  *
  * Use it to configure email transports of Cake.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 2.0.0

--- a/lib/Cake/Console/Templates/skel/Config/routes.php
+++ b/lib/Cake/Console/Templates/skel/Config/routes.php
@@ -6,8 +6,6 @@
  * Routes are very important mechanism that allows you to freely connect
  * different URLs to chosen controllers and their actions (functions).
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Config
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Console/Command/AppShell.php
+++ b/lib/Cake/Console/Templates/skel/Console/Command/AppShell.php
@@ -2,8 +2,6 @@
 /**
  * AppShell file
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 2.0
  */

--- a/lib/Cake/Console/Templates/skel/Console/cake
+++ b/lib/Cake/Console/Templates/skel/Console/cake
@@ -2,7 +2,6 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/Console/cake.bat
+++ b/lib/Cake/Console/Templates/skel/Console/cake.bat
@@ -1,7 +1,6 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::
 :: Bake is a shell script for running CakePHP bake script
-:: PHP 5
 ::
 :: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 :: Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/Console/cake.php
+++ b/lib/Cake/Console/Templates/skel/Console/cake.php
@@ -3,8 +3,6 @@
 /**
  * Command-line code generation utility to automate programmer chores.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Console/Templates/skel/Controller/AppController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/AppController.php
@@ -5,8 +5,6 @@
  * This file is application-wide controller file. You can put all
  * application-wide controller-related methods here.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Controller
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Controller/PagesController.php
+++ b/lib/Cake/Console/Templates/skel/Controller/PagesController.php
@@ -4,8 +4,6 @@
  *
  * This file will render views from views/pages/
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Controller
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/Model/AppModel.php
+++ b/lib/Cake/Console/Templates/skel/Model/AppModel.php
@@ -5,8 +5,6 @@
  * This file is application-wide model file. You can put all
  * application-wide model-related methods here.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.Model
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/View/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Emails/html/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/View/Emails/text/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Emails/text/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors

--- a/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Errors

--- a/lib/Cake/Console/Templates/skel/View/Helper/AppHelper.php
+++ b/lib/Cake/Console/Templates/skel/View/Helper/AppHelper.php
@@ -5,8 +5,6 @@
  * This file is application-wide helper file. You can put all
  * application-wide helper-related methods here.
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Helper
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts.Email.html

--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/text/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/text/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/ajax.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts

--- a/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts

--- a/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts

--- a/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/flash.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Layouts

--- a/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Pages/home.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.View.Pages

--- a/lib/Cake/Console/Templates/skel/index.php
+++ b/lib/Cake/Console/Templates/skel/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app

--- a/lib/Cake/Console/Templates/skel/webroot/index.php
+++ b/lib/Cake/Console/Templates/skel/webroot/index.php
@@ -4,8 +4,6 @@
  *
  * The Front Controller for handling every request
  *
- * PHP 5
- *
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       app.webroot
  * @since         CakePHP(tm) v 0.2.9

--- a/lib/Cake/Console/Templates/skel/webroot/test.php
+++ b/lib/Cake/Console/Templates/skel/webroot/test.php
@@ -2,8 +2,6 @@
 /**
  * Web Access Frontend for TestSuite
  *
- * PHP 5
- *
  * @link          http://book.cakephp.org/2.0/en/development/testing.html
  * @package       app.webroot
  * @since         CakePHP(tm) v 1.2.0.4433

--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -2,7 +2,6 @@
 ################################################################################
 #
 # Bake is a shell script for running CakePHP bake script
-# PHP 5
 #
 # CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
 # Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/cake.bat
+++ b/lib/Cake/Console/cake.bat
@@ -1,7 +1,6 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::
 :: Bake is a shell script for running CakePHP bake script
-:: PHP 5
 ::
 :: CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 :: Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Console/cake.php
+++ b/lib/Cake/Console/cake.php
@@ -3,8 +3,6 @@
 /**
  * Command-line code generation utility to automate programmer chores.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/CakeErrorController.php
+++ b/lib/Cake/Controller/CakeErrorController.php
@@ -4,8 +4,6 @@
  *
  * Controller used by ErrorHandler to render error views.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -2,8 +2,6 @@
 /**
  * PHP configuration based AclInterface implementation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/Auth/AbstractPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/AbstractPasswordHasher.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/ActionsAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ActionsAuthorize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BasicAuthenticate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishAuthenticate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/BlowfishPasswordHasher.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/CrudAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/CrudAuthorize.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/Auth/SimplePasswordHasher.php
+++ b/lib/Cake/Controller/Component/Auth/SimplePasswordHasher.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -4,8 +4,6 @@
  *
  * Manages user logins and permissions.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -2,8 +2,6 @@
 /**
  * Cookie Component
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/EmailComponent.php
+++ b/lib/Cake/Controller/Component/EmailComponent.php
@@ -2,8 +2,6 @@
 /**
  * Email Component
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -2,8 +2,6 @@
 /**
  * Paginator Component
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -2,8 +2,6 @@
 /**
  * Security Component
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Component/SessionComponent.php
+++ b/lib/Cake/Controller/Component/SessionComponent.php
@@ -2,8 +2,6 @@
 /**
  * SessionComponent. Provides access to Sessions from the Controller layer
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Controller/Scaffold.php
+++ b/lib/Cake/Controller/Scaffold.php
@@ -4,8 +4,6 @@
  *
  * Automatic forms and actions generation for rapid web application development.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -2,8 +2,6 @@
 /**
  * App class
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -2,8 +2,6 @@
 /**
  * CakePlugin class
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -4,8 +4,6 @@
  *
  * Provides Error Capturing for Framework errors.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -5,8 +5,6 @@
  * Provides Exception rendering features. Which allow exceptions to be rendered
  * as HTML pages.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -3,8 +3,6 @@
  * Exceptions file. Contains the various exceptions CakePHP will throw until they are
  * moved into their permanent location.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Event/CakeEventListener.php
+++ b/lib/Cake/Event/CakeEventListener.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -2,8 +2,6 @@
 /**
  * Internationalization
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/I18n/L10n.php
+++ b/lib/Cake/I18n/L10n.php
@@ -2,8 +2,6 @@
 /**
  * Localization
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/I18n/Multibyte.php
+++ b/lib/Cake/I18n/Multibyte.php
@@ -2,9 +2,6 @@
 /**
  * Multibyte handling methods.
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/CakeLog.php
+++ b/lib/Cake/Log/CakeLog.php
@@ -4,8 +4,6 @@
  *
  * Log messages to text files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/CakeLogInterface.php
+++ b/lib/Cake/Log/CakeLogInterface.php
@@ -2,8 +2,6 @@
 /**
  * CakeLogInterface
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/Engine/BaseLog.php
+++ b/lib/Cake/Log/Engine/BaseLog.php
@@ -2,8 +2,6 @@
 /**
  * Base Log Engine class
  *
- * PHP 5
- *
  * CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/Engine/ConsoleLog.php
+++ b/lib/Cake/Log/Engine/ConsoleLog.php
@@ -2,8 +2,6 @@
 /**
  * Console Logging
  *
- * PHP 5
- *
  * CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/Engine/FileLog.php
+++ b/lib/Cake/Log/Engine/FileLog.php
@@ -2,8 +2,6 @@
 /**
  * File Storage stream for Logging
  *
- * PHP 5
- *
  * CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/Engine/SyslogLog.php
+++ b/lib/Cake/Log/Engine/SyslogLog.php
@@ -2,8 +2,6 @@
 /**
  * Syslog logger engine for CakePHP
  *
- * PHP 5
- *
  * CakePHP(tm) :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Log/LogEngineCollection.php
+++ b/lib/Cake/Log/LogEngineCollection.php
@@ -2,8 +2,6 @@
 /**
  * Registry of loaded log engines
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/AclNode.php
+++ b/lib/Cake/Model/AclNode.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Aco.php
+++ b/lib/Cake/Model/Aco.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/AcoAction.php
+++ b/lib/Cake/Model/AcoAction.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Aro.php
+++ b/lib/Cake/Model/Aro.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Behavior/AclBehavior.php
+++ b/lib/Cake/Model/Behavior/AclBehavior.php
@@ -4,8 +4,6 @@
  *
  * Enables objects to easily tie into an ACL system
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -4,8 +4,6 @@
  *
  * Behavior to simplify manipulating a model's bindings when doing a find operation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -4,8 +4,6 @@
  *
  * Enables a model object to act as a node-based tree.
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -4,8 +4,6 @@
  *
  * Provides management and interface for interacting with collections of behaviors.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/CakeSchema.php
+++ b/lib/Cake/Model/CakeSchema.php
@@ -2,8 +2,6 @@
 /**
  * Schema database management for CakePHP.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -4,8 +4,6 @@
  *
  * Provides an interface for loading and enumerating connections defined in app/Config/database.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -7,8 +7,6 @@
  * This class is the implementation of those methods.
  * They are mostly used by the Session Component.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/DataSource.php
+++ b/lib/Cake/Model/Datasource/DataSource.php
@@ -2,8 +2,6 @@
 /**
  * DataSource base class
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -2,8 +2,6 @@
 /**
  * MySQL layer for DBO
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -2,8 +2,6 @@
 /**
  * PostgreSQL layer for DBO.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -2,8 +2,6 @@
 /**
  * SQLite layer for DBO
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -2,8 +2,6 @@
 /**
  * MS SQL Server layer for DBO
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2,8 +2,6 @@
 /**
  * Dbo Source
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Session/CacheSession.php
+++ b/lib/Cake/Model/Datasource/Session/CacheSession.php
@@ -2,8 +2,6 @@
 /**
  * Cache Session save handler. Allows saving session information into Cache.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Datasource/Session/DatabaseSession.php
+++ b/lib/Cake/Model/Datasource/Session/DatabaseSession.php
@@ -2,8 +2,6 @@
 /**
  * Database Session save handler. Allows saving session information into a model.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -4,8 +4,6 @@
  *
  * DBO-backed object data model, for mapping database tables to CakePHP objects.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/ModelBehavior.php
+++ b/lib/Cake/Model/ModelBehavior.php
@@ -4,8 +4,6 @@
  *
  * Adds methods and automagic functionality to CakePHP Models.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -4,8 +4,6 @@
  *
  * Provides the Model validation logic.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Model/Validator/CakeValidationRule.php
+++ b/lib/Cake/Model/Validator/CakeValidationRule.php
@@ -4,8 +4,6 @@
  *
  * Provides the Model validation logic.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -4,8 +4,6 @@
  *
  * Provides the Model validation logic.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -2,8 +2,6 @@
 /**
  * CakeRequest
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -2,8 +2,6 @@
 /**
  * CakeResponse
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -2,8 +2,6 @@
 /**
  * CakePHP Socket connection class.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Email/AbstractTransport.php
+++ b/lib/Cake/Network/Email/AbstractTransport.php
@@ -2,8 +2,6 @@
 /**
  * Abstract send email
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -2,8 +2,6 @@
 /**
  * CakePHP Email
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Email/DebugTransport.php
+++ b/lib/Cake/Network/Email/DebugTransport.php
@@ -2,8 +2,6 @@
 /**
  * Emulates the email sending process for testing purposes
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Email/MailTransport.php
+++ b/lib/Cake/Network/Email/MailTransport.php
@@ -2,8 +2,6 @@
 /**
  * Send mail using mail() function
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Email/SmtpTransport.php
+++ b/lib/Cake/Network/Email/SmtpTransport.php
@@ -2,8 +2,6 @@
 /**
  * Send mail using SMTP protocol
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Http/BasicAuthentication.php
+++ b/lib/Cake/Network/Http/BasicAuthentication.php
@@ -2,8 +2,6 @@
 /**
  * Basic authentication
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Http/DigestAuthentication.php
+++ b/lib/Cake/Network/Http/DigestAuthentication.php
@@ -2,8 +2,6 @@
 /**
  * Digest authentication
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Http/HttpResponse.php
+++ b/lib/Cake/Network/Http/HttpResponse.php
@@ -2,8 +2,6 @@
 /**
  * HTTP Response from HttpSocket.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -2,8 +2,6 @@
 /**
  * HTTP Socket connection class.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -2,8 +2,6 @@
 /**
  * HTTP Response from HttpSocket.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Routing/Dispatcher.php
+++ b/lib/Cake/Routing/Dispatcher.php
@@ -5,8 +5,6 @@
  *
  * This is the heart of CakePHP's operation.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Routing/DispatcherFilter.php
+++ b/lib/Cake/Routing/DispatcherFilter.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -2,8 +2,6 @@
 /**
  * Parses the request URL into controller, action, and parameters.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllBehaviorsTest.php
+++ b/lib/Cake/Test/Case/AllBehaviorsTest.php
@@ -2,8 +2,6 @@
 /**
  * AllBehaviorsTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllCacheTest.php
+++ b/lib/Cake/Test/Case/AllCacheTest.php
@@ -2,8 +2,6 @@
 /**
  * AllCacheTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllComponentsTest.php
+++ b/lib/Cake/Test/Case/AllComponentsTest.php
@@ -2,8 +2,6 @@
 /**
  * AllComponentsTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllConfigureTest.php
+++ b/lib/Cake/Test/Case/AllConfigureTest.php
@@ -2,8 +2,6 @@
 /**
  * AllConfigureTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllConsoleTest.php
+++ b/lib/Cake/Test/Case/AllConsoleTest.php
@@ -2,8 +2,6 @@
 /**
  * AllConsoleTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllControllerTest.php
+++ b/lib/Cake/Test/Case/AllControllerTest.php
@@ -2,8 +2,6 @@
 /**
  * AllControllersTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllCoreTest.php
+++ b/lib/Cake/Test/Case/AllCoreTest.php
@@ -2,8 +2,6 @@
 /**
  * AllCoreTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllDatabaseTest.php
+++ b/lib/Cake/Test/Case/AllDatabaseTest.php
@@ -2,8 +2,6 @@
 /**
  * AllDatabaseTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllDbRelatedTest.php
+++ b/lib/Cake/Test/Case/AllDbRelatedTest.php
@@ -2,8 +2,6 @@
 /**
  * AllDbRelatedTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllErrorTest.php
+++ b/lib/Cake/Test/Case/AllErrorTest.php
@@ -2,8 +2,6 @@
 /**
  * AllErrorTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllEventTest.php
+++ b/lib/Cake/Test/Case/AllEventTest.php
@@ -2,8 +2,6 @@
 /**
  * AllEventTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllHelpersTest.php
+++ b/lib/Cake/Test/Case/AllHelpersTest.php
@@ -2,8 +2,6 @@
 /**
  * HelpersGroupTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllI18nTest.php
+++ b/lib/Cake/Test/Case/AllI18nTest.php
@@ -2,8 +2,6 @@
 /**
  * AllLocalizationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllLogTest.php
+++ b/lib/Cake/Test/Case/AllLogTest.php
@@ -2,8 +2,6 @@
 /**
  * AllLogTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllNetworkTest.php
+++ b/lib/Cake/Test/Case/AllNetworkTest.php
@@ -2,8 +2,6 @@
 /**
  * AllNetworkTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllRoutingTest.php
+++ b/lib/Cake/Test/Case/AllRoutingTest.php
@@ -2,8 +2,6 @@
 /**
  * AllRoutingTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllTestSuiteTest.php
+++ b/lib/Cake/Test/Case/AllTestSuiteTest.php
@@ -2,8 +2,6 @@
 /**
  * AllTestSuiteTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllTestsTest.php
+++ b/lib/Cake/Test/Case/AllTestsTest.php
@@ -2,8 +2,6 @@
 /**
  * AllTests file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllUtilityTest.php
+++ b/lib/Cake/Test/Case/AllUtilityTest.php
@@ -2,8 +2,6 @@
 /**
  * AllUtilityTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/AllViewTest.php
+++ b/lib/Cake/Test/Case/AllViewTest.php
@@ -2,8 +2,6 @@
 /**
  * AllViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -2,8 +2,6 @@
 /**
  * BasicsTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/CacheTest.php
+++ b/lib/Cake/Test/Case/Cache/CacheTest.php
@@ -2,8 +2,6 @@
 /**
  * CacheTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/ApcEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * ApcEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/FileEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * FileEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcacheEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * MemcacheEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/RedisEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * RedisEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/WincacheEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * WincacheEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/XcacheEngineTest.php
@@ -2,8 +2,6 @@
 /**
  * XcacheEngineTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Configure/IniReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/IniReaderTest.php
@@ -2,8 +2,6 @@
 /**
  * IniReaderTest
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Configure/PhpReaderTest.php
+++ b/lib/Cake/Test/Case/Configure/PhpReaderTest.php
@@ -2,8 +2,6 @@
 /**
  * PhpConfigReaderTest
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/AllConsoleLibsTest.php
+++ b/lib/Cake/Test/Case/Console/AllConsoleLibsTest.php
@@ -2,8 +2,6 @@
 /**
  * AllConsoleLibsTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/AllConsoleTest.php
+++ b/lib/Cake/Test/Case/Console/AllConsoleTest.php
@@ -2,8 +2,6 @@
 /**
  * AllConsoleTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/AllShellsTest.php
+++ b/lib/Cake/Test/Case/Console/AllShellsTest.php
@@ -2,8 +2,6 @@
 /**
  * AllShellsTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/AllTasksTest.php
+++ b/lib/Cake/Test/Case/Console/AllTasksTest.php
@@ -2,8 +2,6 @@
 /**
  * AllTasksTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/AclShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/AclShellTest.php
@@ -2,8 +2,6 @@
 /**
  * AclShell Test file
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/ApiShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/ApiShellTest.php
@@ -2,8 +2,6 @@
 /**
  * ApiShellTest file
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/BakeShellTest.php
@@ -2,9 +2,6 @@
 /**
  * BakeShell Test Case
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/CommandListShellTest.php
@@ -2,8 +2,6 @@
 /**
  * CommandListShellTest file
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/SchemaShellTest.php
@@ -2,8 +2,6 @@
 /**
  * SchemaShellTest Test file
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ControllerTaskTest.php
@@ -2,8 +2,6 @@
 /**
  * ControllerTask Test Case
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/DbConfigTaskTest.php
@@ -2,8 +2,6 @@
 /**
  * DBConfigTask Test Case
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for i18n extraction shell task
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/FixtureTaskTest.php
@@ -2,8 +2,6 @@
 /**
  * FixtureTask Test case
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ModelTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for test generation shell task
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/PluginTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for plugin generation shell task
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ProjectTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for project generation shell task
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TemplateTaskTest.php
@@ -4,9 +4,6 @@
  *
  * Test Case for TemplateTask generation shell task
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for test generation shell task
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ViewTaskTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for view generation shell task
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/Command/TestShellTest.php
+++ b/lib/Cake/Test/Case/Console/Command/TestShellTest.php
@@ -2,8 +2,6 @@
 /**
  * TestSuiteShell test case
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleErrorHandler Test case
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOptionParserTest.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleOptionParserTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleOutputTest.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleOutputTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/HelpFormatterTest.php
+++ b/lib/Cake/Test/Case/Console/HelpFormatterTest.php
@@ -2,8 +2,6 @@
 /**
  * HelpFormatterTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -2,8 +2,6 @@
 /**
  * ShellDispatcherTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for Shell
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Console/TaskCollectionTest.php
+++ b/lib/Cake/Test/Case/Console/TaskCollectionTest.php
@@ -2,8 +2,6 @@
 /**
  * TaskCollectionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -2,8 +2,6 @@
 /**
  * DbAclTest file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Acl/IniAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/IniAclTest.php
@@ -2,8 +2,6 @@
 /**
  * IniAclTest file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Acl/PhpAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/PhpAclTest.php
@@ -2,8 +2,6 @@
 /**
  * PhpAclTest file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * AclComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/ActionsAuthorizeTest.php
@@ -2,8 +2,6 @@
 /**
  * ActionsAuthorizeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -2,8 +2,6 @@
 /**
  * BasicAuthenticateTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/BlowfishAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/BlowfishAuthenticateTest.php
@@ -2,8 +2,6 @@
 /**
  * BlowfishAuthenticateTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/ControllerAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/ControllerAuthorizeTest.php
@@ -2,8 +2,6 @@
 /**
  * ControllerAuthorizeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/CrudAuthorizeTest.php
@@ -2,8 +2,6 @@
 /**
  * CrudAuthorizeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -2,8 +2,6 @@
 /**
  * DigestAuthenticateTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/Auth/FormAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/FormAuthenticateTest.php
@@ -2,8 +2,6 @@
 /**
  * FormAuthenticateTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * AuthComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * CookieComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -4,8 +4,6 @@
  *
  * Series of tests for email component.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -4,8 +4,6 @@
  *
  * Series of tests for paginator component.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/RequestHandlerComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * RequestHandlerComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * SecurityComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * SessionComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentCollectionTest.php
@@ -2,8 +2,6 @@
 /**
  * ComponentCollectionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/ComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/ComponentTest.php
@@ -2,8 +2,6 @@
 /**
  * ComponentTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
+++ b/lib/Cake/Test/Case/Controller/ControllerMergeVarsTest.php
@@ -4,8 +4,6 @@
  *
  * Isolated from the Controller and Component test as to not pollute their AppController class
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/PagesControllerTest.php
+++ b/lib/Cake/Test/Case/Controller/PagesControllerTest.php
@@ -2,8 +2,6 @@
 /**
  * PagesControllerTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Controller/ScaffoldTest.php
+++ b/lib/Cake/Test/Case/Controller/ScaffoldTest.php
@@ -2,8 +2,6 @@
 /**
  * ScaffoldTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -2,8 +2,6 @@
 /**
  * AppTest file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Core/CakePluginTest.php
+++ b/lib/Cake/Test/Case/Core/CakePluginTest.php
@@ -2,8 +2,6 @@
 /**
  * CakePluginTest file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Core/ConfigureTest.php
+++ b/lib/Cake/Test/Case/Core/ConfigureTest.php
@@ -4,8 +4,6 @@
  *
  * Holds several tests
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Core/ObjectTest.php
+++ b/lib/Cake/Test/Case/Core/ObjectTest.php
@@ -2,8 +2,6 @@
 /**
  * ObjectTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Error/ErrorHandlerTest.php
@@ -2,8 +2,6 @@
 /**
  * ErrorHandlerTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -2,8 +2,6 @@
 /**
  * ExceptionRendererTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
+++ b/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Event/CakeEventTest.php
+++ b/lib/Cake/Test/Case/Event/CakeEventTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/I18n/I18nTest.php
+++ b/lib/Cake/Test/Case/I18n/I18nTest.php
@@ -2,8 +2,6 @@
 /**
  * I18nTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/I18n/L10nTest.php
+++ b/lib/Cake/Test/Case/I18n/L10nTest.php
@@ -2,8 +2,6 @@
 /**
  * L10nTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/I18n/MultibyteTest.php
+++ b/lib/Cake/Test/Case/I18n/MultibyteTest.php
@@ -2,8 +2,6 @@
 /**
  * MultibyteTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Log/CakeLogTest.php
+++ b/lib/Cake/Test/Case/Log/CakeLogTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeLogTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/ConsoleLogTest.php
@@ -2,8 +2,6 @@
 /**
  * ConsoleLogTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/FileLogTest.php
@@ -2,8 +2,6 @@
 /**
  * FileLogTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Log/LogEngineCollectionTest.php
+++ b/lib/Cake/Test/Case/Log/LogEngineCollectionTest.php
@@ -2,8 +2,6 @@
 /**
  * LogEngineCollectionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/AclNodeTest.php
+++ b/lib/Cake/Test/Case/Model/AclNodeTest.php
@@ -2,8 +2,6 @@
 /**
  * AclNodeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/AclBehaviorTest.php
@@ -4,8 +4,6 @@
  *
  * Test the Acl Behavior
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/ContainableBehaviorTest.php
@@ -2,8 +2,6 @@
 /**
  * ContainableBehaviorTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorAfterTest.php
@@ -2,8 +2,6 @@
 /**
  * TreeBehaviorAfterTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorNumberTest.php
@@ -4,8 +4,6 @@
  *
  * This is the basic Tree behavior test
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -4,8 +4,6 @@
  *
  * A tree test using scope
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorTest.php
@@ -2,8 +2,6 @@
 /**
  * Tree Behavior test file - runs all the tree behavior tests
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorUuidTest.php
@@ -4,8 +4,6 @@
  *
  * Tree test using UUIDs
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -4,8 +4,6 @@
  *
  * Long description for behavior.test.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/CakeSchemaTest.php
+++ b/lib/Cake/Test/Case/Model/CakeSchemaTest.php
@@ -2,9 +2,6 @@
 /**
  * Test for Schema database management
  *
- *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
+++ b/lib/Cake/Test/Case/Model/ConnectionManagerTest.php
@@ -2,8 +2,6 @@
 /**
  * Connection Manager tests
  *
- * PHP 5
- *
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -2,8 +2,6 @@
 /**
  * SessionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/DataSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DataSourceTest.php
@@ -2,8 +2,6 @@
 /**
  * DataSourceTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -2,8 +2,6 @@
 /**
  * DboMysqlTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -2,8 +2,6 @@
 /**
  * DboPostgresTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqliteTest.php
@@ -2,8 +2,6 @@
 /**
  * DboSqliteTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/SqlserverTest.php
@@ -2,8 +2,6 @@
 /**
  * SqlserverTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -2,8 +2,6 @@
 /**
  * DboSourceTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/CacheSessionTest.php
@@ -2,8 +2,6 @@
 /**
  * CacheSessionTest
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Session/DatabaseSessionTest.php
@@ -2,8 +2,6 @@
 /**
  * DatabaseSessionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
+++ b/lib/Cake/Test/Case/Model/ModelCrossSchemaHabtmTest.php
@@ -1,10 +1,10 @@
 <?php
 /**
+ *
+ *
  * Tests cross database HABTM. Requires $test and $test2 to both be set in DATABASE_CONFIG
  * NOTE: When testing on MySQL, you must set 'persistent' => false on *both* database connections,
  * or one connection will step on the other.
- *
- * PHP 5
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelDeleteTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelIntegrationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelReadTest.php
+++ b/lib/Cake/Test/Case/Model/ModelReadTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelReadTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelTest.php
+++ b/lib/Cake/Test/Case/Model/ModelTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelTestBase.php
+++ b/lib/Cake/Test/Case/Model/ModelTestBase.php
@@ -2,8 +2,6 @@
 /**
  * ModelTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelValidationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelValidationTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelValidationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -2,8 +2,6 @@
 /**
  * ModelWriteTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationRuleTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeValidationRuleTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
+++ b/lib/Cake/Test/Case/Model/Validator/CakeValidationSetTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeValidationSetTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -4,8 +4,6 @@
  *
  * Mock classes for use in Model and related test cases
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeRequest Test case file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -2,8 +2,6 @@
 /**
  * SocketTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeEmailTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
@@ -2,8 +2,6 @@
 /**
  * DebugTransportTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Email/MailTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/MailTransportTest.php
@@ -2,8 +2,6 @@
 /**
  * MailTransportTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -2,8 +2,6 @@
 /**
  * SmtpTransportTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/BasicAuthenticationTest.php
@@ -2,8 +2,6 @@
 /**
  * BasicAuthenticationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
+++ b/lib/Cake/Test/Case/Network/Http/DigestAuthenticationTest.php
@@ -2,8 +2,6 @@
 /**
  * DigestAuthenticationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpResponseTest.php
@@ -2,8 +2,6 @@
 /**
  * HttpResponseTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -2,8 +2,6 @@
 /**
  * HttpSocketTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -2,8 +2,6 @@
 /**
  * DispatcherTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeRequest Test case file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/PluginShortRouteTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeRequest Test case file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/RedirectRouteTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeRequest Test case file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -2,8 +2,6 @@
 /**
  * RouterTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestCaseTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for CakeTestCase class
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeTestFixture file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
+++ b/lib/Cake/Test/Case/TestSuite/ControllerTestCaseTest.php
@@ -4,8 +4,6 @@
  *
  * Test Case for ControllerTestCase class
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/CakeNumberTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeNumberTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeNumberTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -2,8 +2,6 @@
 /**
  * CakeTimeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
+++ b/lib/Cake/Test/Case/Utility/ClassRegistryTest.php
@@ -2,8 +2,6 @@
 /**
  * ClassRegistryTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -2,8 +2,6 @@
 /**
  * FileTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -2,8 +2,6 @@
 /**
  * FolderTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/InflectorTest.php
+++ b/lib/Cake/Test/Case/Utility/InflectorTest.php
@@ -4,8 +4,6 @@
  *
  * InflectorTest is used to test cases on the Inflector class
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -2,8 +2,6 @@
 /**
  * ObjectCollectionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/SanitizeTest.php
+++ b/lib/Cake/Test/Case/Utility/SanitizeTest.php
@@ -2,8 +2,6 @@
 /**
  * SanitizeTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/SetTest.php
+++ b/lib/Cake/Test/Case/Utility/SetTest.php
@@ -2,8 +2,6 @@
 /**
  * SetTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -2,8 +2,6 @@
 /**
  * StringTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2,8 +2,6 @@
 /**
  * ValidationTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/Utility/XmlTest.php
+++ b/lib/Cake/Test/Case/Utility/XmlTest.php
@@ -2,8 +2,6 @@
 /**
  * XmlTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * CacheHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * FormHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * HtmlHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JqueryEngineHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * JqueryEngineTestCase
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -4,8 +4,6 @@
  *
  * TestCase for the JsHelper
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/MootoolsEngineHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * MooEngineTestCase
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/NumberHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * NumberHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * PaginatorHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PrototypeEngineHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * PrototypeEngine TestCase
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/RssHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * RssHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/SessionHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * SessionHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * TextHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TimeHelperTest.php
@@ -2,8 +2,6 @@
 /**
  * TimeHelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/HelperCollectionTest.php
+++ b/lib/Cake/Test/Case/View/HelperCollectionTest.php
@@ -2,8 +2,6 @@
 /**
  * HelperCollectionTest file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/HelperTest.php
+++ b/lib/Cake/Test/Case/View/HelperTest.php
@@ -2,8 +2,6 @@
 /**
  * HelperTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/JsonViewTest.php
+++ b/lib/Cake/Test/Case/View/JsonViewTest.php
@@ -2,8 +2,6 @@
 /**
  * JsonViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/MediaViewTest.php
+++ b/lib/Cake/Test/Case/View/MediaViewTest.php
@@ -2,8 +2,6 @@
 /**
  * MediaViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/ScaffoldViewTest.php
+++ b/lib/Cake/Test/Case/View/ScaffoldViewTest.php
@@ -2,8 +2,6 @@
 /**
  * ScaffoldViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/ThemeViewTest.php
+++ b/lib/Cake/Test/Case/View/ThemeViewTest.php
@@ -2,8 +2,6 @@
 /**
  * ThemeViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -2,8 +2,6 @@
 /**
  * ViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Case/View/XmlViewTest.php
+++ b/lib/Cake/Test/Case/View/XmlViewTest.php
@@ -2,8 +2,6 @@
 /**
  * XmlViewTest file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AccountFixture.php
+++ b/lib/Cake/Test/Fixture/AccountFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AcoActionFixture.php
+++ b/lib/Cake/Test/Fixture/AcoActionFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AcoFixture.php
+++ b/lib/Cake/Test/Fixture/AcoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AcoTwoFixture.php
+++ b/lib/Cake/Test/Fixture/AcoTwoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AdFixture.php
+++ b/lib/Cake/Test/Fixture/AdFixture.php
@@ -4,8 +4,6 @@
  *
  * Long description for ad_fixture.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  *
  * Licensed under The MIT License

--- a/lib/Cake/Test/Fixture/AdvertisementFixture.php
+++ b/lib/Cake/Test/Fixture/AdvertisementFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AfterTreeFixture.php
+++ b/lib/Cake/Test/Fixture/AfterTreeFixture.php
@@ -4,8 +4,6 @@
  *
  * Long description for after_tree_fixture.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  *
  * Licensed under The MIT License

--- a/lib/Cake/Test/Fixture/AnotherArticleFixture.php
+++ b/lib/Cake/Test/Fixture/AnotherArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AppleFixture.php
+++ b/lib/Cake/Test/Fixture/AppleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArmorFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/ArmorsPlayerFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AroFixture.php
+++ b/lib/Cake/Test/Fixture/AroFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AroTwoFixture.php
+++ b/lib/Cake/Test/Fixture/AroTwoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArosAcoFixture.php
+++ b/lib/Cake/Test/Fixture/ArosAcoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArosAcoTwoFixture.php
+++ b/lib/Cake/Test/Fixture/ArosAcoTwoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFeaturedFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArticleFeaturedsTagsFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFeaturedsTagsFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArticleFixture.php
+++ b/lib/Cake/Test/Fixture/ArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ArticlesTagFixture.php
+++ b/lib/Cake/Test/Fixture/ArticlesTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AttachmentFixture.php
+++ b/lib/Cake/Test/Fixture/AttachmentFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserCustomFieldFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AuthUserFixture.php
+++ b/lib/Cake/Test/Fixture/AuthUserFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/AuthorFixture.php
+++ b/lib/Cake/Test/Fixture/AuthorFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BakeArticleFixture.php
+++ b/lib/Cake/Test/Fixture/BakeArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * BakeArticleFixture
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BakeArticlesBakeTagFixture.php
+++ b/lib/Cake/Test/Fixture/BakeArticlesBakeTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * BakeCommentFixture
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BakeCommentFixture.php
+++ b/lib/Cake/Test/Fixture/BakeCommentFixture.php
@@ -2,8 +2,6 @@
 /**
  * BakeCommentFixture
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BakeTagFixture.php
+++ b/lib/Cake/Test/Fixture/BakeTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * BakeTagFixture
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BasketFixture.php
+++ b/lib/Cake/Test/Fixture/BasketFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BidFixture.php
+++ b/lib/Cake/Test/Fixture/BidFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BiddingFixture.php
+++ b/lib/Cake/Test/Fixture/BiddingFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BiddingMessageFixture.php
+++ b/lib/Cake/Test/Fixture/BiddingMessageFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BinaryTestFixture.php
+++ b/lib/Cake/Test/Fixture/BinaryTestFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/BookFixture.php
+++ b/lib/Cake/Test/Fixture/BookFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CacheTestModelFixture.php
+++ b/lib/Cake/Test/Fixture/CacheTestModelFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CallbackFixture.php
+++ b/lib/Cake/Test/Fixture/CallbackFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CampaignFixture.php
+++ b/lib/Cake/Test/Fixture/CampaignFixture.php
@@ -4,8 +4,6 @@
  *
  * Long description for campaign_fixture.php
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  *
  * Licensed under The MIT License

--- a/lib/Cake/Test/Fixture/CategoryFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CategoryThreadFixture.php
+++ b/lib/Cake/Test/Fixture/CategoryThreadFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CdFixture.php
+++ b/lib/Cake/Test/Fixture/CdFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CommentFixture.php
+++ b/lib/Cake/Test/Fixture/CommentFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ContentAccountFixture.php
+++ b/lib/Cake/Test/Fixture/ContentAccountFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ContentFixture.php
+++ b/lib/Cake/Test/Fixture/ContentFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CounterCachePostFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCachePostFixture.php
@@ -2,8 +2,6 @@
 /**
  * Counter Cache Test Fixtures
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CounterCachePostNonstandardPrimaryKeyFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCachePostNonstandardPrimaryKeyFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CounterCacheUserFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCacheUserFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/CounterCacheUserNonstandardPrimaryKeyFixture.php
+++ b/lib/Cake/Test/Fixture/CounterCacheUserNonstandardPrimaryKeyFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DataTestFixture.php
+++ b/lib/Cake/Test/Fixture/DataTestFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DatatypeFixture.php
+++ b/lib/Cake/Test/Fixture/DatatypeFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DependencyFixture.php
+++ b/lib/Cake/Test/Fixture/DependencyFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DeviceFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DeviceTypeCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceTypeCategoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DeviceTypeFixture.php
+++ b/lib/Cake/Test/Fixture/DeviceTypeFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DocumentDirectoryFixture.php
+++ b/lib/Cake/Test/Fixture/DocumentDirectoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DocumentFixture.php
+++ b/lib/Cake/Test/Fixture/DocumentFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DomainFixture.php
+++ b/lib/Cake/Test/Fixture/DomainFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/DomainsSiteFixture.php
+++ b/lib/Cake/Test/Fixture/DomainsSiteFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ExteriorTypeCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/ExteriorTypeCategoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FeatureSetFixture.php
+++ b/lib/Cake/Test/Fixture/FeatureSetFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FeaturedFixture.php
+++ b/lib/Cake/Test/Fixture/FeaturedFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FilmFileFixture.php
+++ b/lib/Cake/Test/Fixture/FilmFileFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FlagTreeFixture.php
+++ b/lib/Cake/Test/Fixture/FlagTreeFixture.php
@@ -4,8 +4,6 @@
  *
  * Enables a model object to act as a node-based tree.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FruitFixture.php
+++ b/lib/Cake/Test/Fixture/FruitFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/FruitsUuidTagFixture.php
+++ b/lib/Cake/Test/Fixture/FruitsUuidTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/GroupUpdateAllFixture.php
+++ b/lib/Cake/Test/Fixture/GroupUpdateAllFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/GuildFixture.php
+++ b/lib/Cake/Test/Fixture/GuildFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
+++ b/lib/Cake/Test/Fixture/GuildsPlayerFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/HomeFixture.php
+++ b/lib/Cake/Test/Fixture/HomeFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ImageFixture.php
+++ b/lib/Cake/Test/Fixture/ImageFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/InnoFixture.php
+++ b/lib/Cake/Test/Fixture/InnoFixture.php
@@ -2,8 +2,6 @@
 /**
  * Fixture to test be tested exclusively with InnoDB tables
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/view/1196/Testing>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ItemFixture.php
+++ b/lib/Cake/Test/Fixture/ItemFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ItemsPortfolioFixture.php
+++ b/lib/Cake/Test/Fixture/ItemsPortfolioFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinABFixture.php
+++ b/lib/Cake/Test/Fixture/JoinABFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinACFixture.php
+++ b/lib/Cake/Test/Fixture/JoinACFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinAFixture.php
+++ b/lib/Cake/Test/Fixture/JoinAFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinBFixture.php
+++ b/lib/Cake/Test/Fixture/JoinBFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinCFixture.php
+++ b/lib/Cake/Test/Fixture/JoinCFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/JoinThingFixture.php
+++ b/lib/Cake/Test/Fixture/JoinThingFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MessageFixture.php
+++ b/lib/Cake/Test/Fixture/MessageFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MyCategoriesMyProductsFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoriesMyProductsFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MyCategoriesMyUsersFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoriesMyUsersFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MyCategoryFixture.php
+++ b/lib/Cake/Test/Fixture/MyCategoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MyProductFixture.php
+++ b/lib/Cake/Test/Fixture/MyProductFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/MyUserFixture.php
+++ b/lib/Cake/Test/Fixture/MyUserFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/NodeFixture.php
+++ b/lib/Cake/Test/Fixture/NodeFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/NumberTreeFixture.php
+++ b/lib/Cake/Test/Fixture/NumberTreeFixture.php
@@ -4,8 +4,6 @@
  *
  * Enables a model object to act as a node-based tree.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/NumberTreeTwoFixture.php
+++ b/lib/Cake/Test/Fixture/NumberTreeTwoFixture.php
@@ -4,8 +4,6 @@
  *
  * Enables a model object to act as a node-based tree.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/NumericArticleFixture.php
+++ b/lib/Cake/Test/Fixture/NumericArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/OverallFavoriteFixture.php
+++ b/lib/Cake/Test/Fixture/OverallFavoriteFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PersonFixture.php
+++ b/lib/Cake/Test/Fixture/PersonFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PlayerFixture.php
+++ b/lib/Cake/Test/Fixture/PlayerFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PortfolioFixture.php
+++ b/lib/Cake/Test/Fixture/PortfolioFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PostFixture.php
+++ b/lib/Cake/Test/Fixture/PostFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PostsTagFixture.php
+++ b/lib/Cake/Test/Fixture/PostsTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PrefixTestFixture.php
+++ b/lib/Cake/Test/Fixture/PrefixTestFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/PrimaryModelFixture.php
+++ b/lib/Cake/Test/Fixture/PrimaryModelFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ProductFixture.php
+++ b/lib/Cake/Test/Fixture/ProductFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ProductUpdateAllFixture.php
+++ b/lib/Cake/Test/Fixture/ProductUpdateAllFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ProjectFixture.php
+++ b/lib/Cake/Test/Fixture/ProjectFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SampleFixture.php
+++ b/lib/Cake/Test/Fixture/SampleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SecondaryModelFixture.php
+++ b/lib/Cake/Test/Fixture/SecondaryModelFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SessionFixture.php
+++ b/lib/Cake/Test/Fixture/SessionFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SiteFixture.php
+++ b/lib/Cake/Test/Fixture/SiteFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SomethingElseFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingElseFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SomethingFixture.php
+++ b/lib/Cake/Test/Fixture/SomethingFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/StoriesTagFixture.php
+++ b/lib/Cake/Test/Fixture/StoriesTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/StoryFixture.php
+++ b/lib/Cake/Test/Fixture/StoryFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/SyfileFixture.php
+++ b/lib/Cake/Test/Fixture/SyfileFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TagFixture.php
+++ b/lib/Cake/Test/Fixture/TagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
+++ b/lib/Cake/Test/Fixture/TestPluginCommentFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ThePaperMonkiesFixture.php
+++ b/lib/Cake/Test/Fixture/ThePaperMonkiesFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/ThreadFixture.php
+++ b/lib/Cake/Test/Fixture/ThreadFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslateArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslateFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslateTableFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateTableFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
+++ b/lib/Cake/Test/Fixture/TranslateWithPrefixFixture.php
@@ -4,8 +4,6 @@
  *
  * Long description for file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedArticleFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/TranslatedItemFixture.php
+++ b/lib/Cake/Test/Fixture/TranslatedItemFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UnconventionalTreeFixture.php
+++ b/lib/Cake/Test/Fixture/UnconventionalTreeFixture.php
@@ -2,8 +2,6 @@
 /**
  * Unconventional Tree behavior class test fixture.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UnderscoreFieldFixture.php
+++ b/lib/Cake/Test/Fixture/UnderscoreFieldFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UserFixture.php
+++ b/lib/Cake/Test/Fixture/UserFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuidFixture.php
+++ b/lib/Cake/Test/Fixture/UuidFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuidTagFixture.php
+++ b/lib/Cake/Test/Fixture/UuidTagFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuidTreeFixture.php
+++ b/lib/Cake/Test/Fixture/UuidTreeFixture.php
@@ -2,8 +2,6 @@
 /**
  * UUID Tree behavior fixture.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuiditemFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemsUuidportfolioFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
+++ b/lib/Cake/Test/Fixture/UuiditemsUuidportfolioNumericidFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/Fixture/UuidportfolioFixture.php
+++ b/lib/Cake/Test/Fixture/UuidportfolioFixture.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Config/acl.ini
+++ b/lib/Cake/Test/test_app/Config/acl.ini
@@ -3,9 +3,6 @@
 ;/**
 ; * Test App Ini Based Acl Config File
 ; *
-; *
-; * PHP 5
-; *
 ; * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 ; * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 ; *

--- a/lib/Cake/Test/test_app/Config/acl.ini.php
+++ b/lib/Cake/Test/test_app/Config/acl.ini.php
@@ -3,9 +3,6 @@
 ;/**
 ; * Test App Ini Based Acl Config File
 ; *
-; *
-; * PHP 5
-; *
 ; * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 ; * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 ; *

--- a/lib/Cake/Test/test_app/Config/acl.php
+++ b/lib/Cake/Test/test_app/Config/acl.php
@@ -2,9 +2,6 @@
 /*
  * Test App PHP Based Acl Config File
  *
- *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Config/routes.php
+++ b/lib/Cake/Test/test_app/Config/routes.php
@@ -4,8 +4,6 @@
  *
  * Routes for test app
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Console/Command/SampleShell.php
+++ b/lib/Cake/Test/test_app/Console/Command/SampleShell.php
@@ -2,8 +2,6 @@
 /**
  * SampleShell file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Controller/AppController.php
+++ b/lib/Cake/Test/test_app/Controller/AppController.php
@@ -5,8 +5,6 @@
  * This file is application-wide controller file. You can put all
  * application-wide controller-related methods here.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Controller/PagesController.php
+++ b/lib/Cake/Test/test_app/Controller/PagesController.php
@@ -4,8 +4,6 @@
  *
  * This file will render views from views/pages/
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Controller/TestsAppsController.php
+++ b/lib/Cake/Test/test_app/Controller/TestsAppsController.php
@@ -2,8 +2,6 @@
 /**
  * TestsAppsController file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Controller/TestsAppsPostsController.php
+++ b/lib/Cake/Test/test_app/Controller/TestsAppsPostsController.php
@@ -2,8 +2,6 @@
 /**
  * TestsAppsPostsController file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Lib/Cache/Engine/TestAppCacheEngine.php
+++ b/lib/Cake/Test/test_app/Lib/Cache/Engine/TestAppCacheEngine.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite Test App Cache Engine class.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Lib/Library.php
+++ b/lib/Cake/Test/test_app/Lib/Library.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite Library
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Lib/Log/Engine/TestAppLog.php
+++ b/lib/Cake/Test/test_app/Lib/Log/Engine/TestAppLog.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite Test App Logging stream class.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Lib/Utility/TestUtilityClass.php
+++ b/lib/Cake/Test/test_app/Lib/Utility/TestUtilityClass.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestUtilityClass Library
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/AppModel.php
+++ b/lib/Cake/Test/test_app/Model/AppModel.php
@@ -5,8 +5,6 @@
  * This file is application-wide model file. You can put all
  * application-wide model-related methods here.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/Behavior/PersisterOneBehaviorBehavior.php
+++ b/lib/Cake/Test/test_app/Model/Behavior/PersisterOneBehaviorBehavior.php
@@ -4,8 +4,6 @@
  *
  * Behavior to simplify manipulating a model's bindings when doing a find operation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/Behavior/PersisterTwoBehaviorBehavior.php
+++ b/lib/Cake/Test/test_app/Model/Behavior/PersisterTwoBehaviorBehavior.php
@@ -4,8 +4,6 @@
  *
  * Behavior to simplify manipulating a model's bindings when doing a find operation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/Comment.php
+++ b/lib/Cake/Test/test_app/Model/Comment.php
@@ -2,10 +2,6 @@
 /**
  * Test App Comment Model
  *
- *
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/PersisterOne.php
+++ b/lib/Cake/Test/test_app/Model/PersisterOne.php
@@ -2,10 +2,6 @@
 /**
  * Test App Comment Model
  *
- *
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/PersisterTwo.php
+++ b/lib/Cake/Test/test_app/Model/PersisterTwo.php
@@ -2,10 +2,6 @@
 /**
  * Test App Comment Model
  *
- *
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Model/Post.php
+++ b/lib/Cake/Test/test_app/Model/Post.php
@@ -2,10 +2,6 @@
 /**
  * Test App Comment Model
  *
- *
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/Schema/schema.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/Schema/schema.php
@@ -4,8 +4,6 @@
  *
  * Use for testing the loading of schema files from plugins.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/acl.ini.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/acl.ini.php
@@ -3,9 +3,6 @@
 ;/**
 ; * Test App Ini Based Acl Config File
 ; *
-; *
-; * PHP 5
-; *
 ; * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
 ; * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
 ; *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/load.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/load.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin config file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/more.load.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Config/more.load.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin config file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/ExampleShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/ExampleShell.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/Task/OtherTaskTask.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Console/Command/Task/OtherTaskTask.php
@@ -2,8 +2,6 @@
 /**
  * Testing task in a plugin
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/OtherComponent.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/OtherComponent.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/PluginsComponent.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/PluginsComponent.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginComponent.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginComponent.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginOtherComponent.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/Component/TestPluginOtherComponent.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestPluginAppController.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestPluginAppController.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin AppController
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestPluginController.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestPluginController.php
@@ -2,8 +2,6 @@
 /**
  * TestPluginController used by Dispatcher test to test plugin shortcut URLs.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestsController.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Controller/TestsController.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Cache/Engine/TestPluginCacheEngine.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Cache/Engine/TestPluginCacheEngine.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite Test Plugin Cache Engine class.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Custom/Package/CustomLibClass.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Custom/Package/CustomLibClass.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite CustomLibClass Library
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Error/TestPluginExceptionRenderer.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Error/TestPluginExceptionRenderer.php
@@ -5,8 +5,6 @@
  * Provides Exception rendering features. Which allow exceptions to be rendered
  * as HTML pages.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Log/Engine/TestPluginLog.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Log/Engine/TestPluginLog.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite Test Plugin Logging stream class.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/Test2DispatcherFilter.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/Test2DispatcherFilter.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/TestDispatcherFilter.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/Routing/Filter/TestDispatcherFilter.php
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/TestPluginLibrary.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/TestPluginLibrary.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin Library
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/TestPluginOtherLibrary.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Lib/TestPluginOtherLibrary.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin Other Library
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Behavior/TestPluginPersisterOneBehavior.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Behavior/TestPluginPersisterOneBehavior.php
@@ -4,8 +4,6 @@
  *
  * Behavior to simplify manipulating a model's bindings when doing a find operation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Behavior/TestPluginPersisterTwoBehavior.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/Behavior/TestPluginPersisterTwoBehavior.php
@@ -4,8 +4,6 @@
  *
  * Behavior to simplify manipulating a model's bindings when doing a find operation
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAppModel.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAppModel.php
@@ -2,8 +2,6 @@
 /**
  * Test Suite TestPlugin AppModel
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthUser.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthUser.php
@@ -2,8 +2,6 @@
 /**
  * Test Plugin Auth User Model
  *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthors.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginAuthors.php
@@ -2,8 +2,6 @@
 /**
  * Test App Comment Model
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginComment.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginComment.php
@@ -2,8 +2,6 @@
 /**
  * Test App Comment Model
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginPost.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Model/TestPluginPost.php
@@ -2,10 +2,6 @@
 /**
  * Test Plugin Post Model
  *
- *
- *
- * PHP 5
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Vendor/sample/sample_plugin.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Vendor/sample/sample_plugin.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/Vendor/welcome.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/Vendor/welcome.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/View/Helper/OtherHelperHelper.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/View/Helper/OtherHelperHelper.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPlugin/View/Helper/PluggedHelperHelper.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPlugin/View/Helper/PluggedHelperHelper.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPluginTwo/Console/Command/ExampleShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPluginTwo/Console/Command/ExampleShell.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Plugin/TestPluginTwo/Console/Command/WelcomeShell.php
+++ b/lib/Cake/Test/test_app/Plugin/TestPluginTwo/Console/Command/WelcomeShell.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Vendor/Test/MyTest.php
+++ b/lib/Cake/Test/test_app/Vendor/Test/MyTest.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Vendor/Test/hello.php
+++ b/lib/Cake/Test/test_app/Vendor/Test/hello.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Vendor/sample/configure_test_vendor_sample.php
+++ b/lib/Cake/Test/test_app/Vendor/sample/configure_test_vendor_sample.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Vendor/somename/some.name.php
+++ b/lib/Cake/Test/test_app/Vendor/somename/some.name.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Test/test_app/Vendor/welcome.php
+++ b/lib/Cake/Test/test_app/Vendor/welcome.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestCase.php
+++ b/lib/Cake/TestSuite/CakeTestCase.php
@@ -2,8 +2,6 @@
 /**
  * CakeTestCase file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestLoader.php
+++ b/lib/Cake/TestSuite/CakeTestLoader.php
@@ -4,8 +4,6 @@
  *
  * Turns partial paths used on the testsuite console and web UI into full file paths.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestRunner.php
+++ b/lib/Cake/TestSuite/CakeTestRunner.php
@@ -2,8 +2,6 @@
 /**
  * TestRunner for CakePHP Test suite.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestSuite.php
+++ b/lib/Cake/TestSuite/CakeTestSuite.php
@@ -2,8 +2,6 @@
 /**
  * A class to contain test cases and run them with shared fixtures
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestSuiteCommand.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteCommand.php
@@ -2,8 +2,6 @@
 /**
  * TestRunner for CakePHP Test suite.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -2,8 +2,6 @@
 /**
  * CakeTestSuiteDispatcher controls dispatching TestSuite web based requests.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -2,8 +2,6 @@
 /**
  * ControllerTestCase file
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -2,8 +2,6 @@
 /**
  * A factory class to manage the life cycle of test fixtures
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeBaseReporter.php
@@ -2,8 +2,6 @@
 /**
  * CakeBaseReporter contains common functionality to all cake test suite reporters.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -2,8 +2,6 @@
 /**
  * CakeHtmlReporter
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/Reporter/CakeTextReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeTextReporter.php
@@ -2,8 +2,6 @@
 /**
  * CakeTextReporter contains reporting features used for plain text based output
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/templates/footer.php
+++ b/lib/Cake/TestSuite/templates/footer.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/templates/header.php
+++ b/lib/Cake/TestSuite/templates/header.php
@@ -2,8 +2,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/templates/menu.php
+++ b/lib/Cake/TestSuite/templates/menu.php
@@ -3,8 +3,6 @@
 /**
  * Short description for file.
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/templates/missing_connection.php
+++ b/lib/Cake/TestSuite/templates/missing_connection.php
@@ -2,8 +2,6 @@
 /**
  * Missing Connection error page
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/TestSuite/templates/phpunit.php
+++ b/lib/Cake/TestSuite/templates/phpunit.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Missing PHPUnit
- * error page.
- *
- * PHP 5
+ * Missing PHPUnit error page.
  *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/TestSuite/templates/xdebug.php
+++ b/lib/Cake/TestSuite/templates/xdebug.php
@@ -2,8 +2,6 @@
 /**
  * Xdebug error page
  *
- * PHP 5
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -4,8 +4,6 @@
  *
  * Methods to make numbers more readable.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -2,8 +2,6 @@
 /**
  * CakeTime utility class file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -4,8 +4,6 @@
  *
  * Provides enhanced logging, stack traces, and rendering debug views
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/File.php
+++ b/lib/Cake/Utility/File.php
@@ -2,8 +2,6 @@
 /**
  * Convenience class for reading, writing and appending to files.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -4,8 +4,6 @@
  *
  * Helpful methods to make unsafe strings usable.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/Security.php
+++ b/lib/Cake/Utility/Security.php
@@ -2,8 +2,6 @@
 /**
  * Core Security
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -2,8 +2,6 @@
 /**
  * Library of array functions for Cake.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -2,8 +2,6 @@
 /**
  * String handling methods.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -4,8 +4,6 @@
  *
  * The methods in these classes enable the datasources that use XML to work.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Elements/exception_stack_trace.ctp
+++ b/lib/Cake/View/Elements/exception_stack_trace.ctp
@@ -2,8 +2,6 @@
 /**
  * Prints a stack trace for an exception
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Elements/sql_dump.ctp
+++ b/lib/Cake/View/Elements/sql_dump.ctp
@@ -2,8 +2,6 @@
 /**
  * SQL Dump element. Dumps out SQL log information
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Errors/fatal_error.ctp
+++ b/lib/Cake/View/Errors/fatal_error.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_action.ctp
+++ b/lib/Cake/View/Errors/missing_action.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_behavior.ctp
+++ b/lib/Cake/View/Errors/missing_behavior.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_component.ctp
+++ b/lib/Cake/View/Errors/missing_component.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_connection.ctp
+++ b/lib/Cake/View/Errors/missing_connection.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_controller.ctp
+++ b/lib/Cake/View/Errors/missing_controller.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_database.ctp
+++ b/lib/Cake/View/Errors/missing_database.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_datasource.ctp
+++ b/lib/Cake/View/Errors/missing_datasource.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_datasource_config.ctp
+++ b/lib/Cake/View/Errors/missing_datasource_config.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_helper.ctp
+++ b/lib/Cake/View/Errors/missing_helper.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_plugin.ctp
+++ b/lib/Cake/View/Errors/missing_plugin.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_table.ctp
+++ b/lib/Cake/View/Errors/missing_table.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/pdo_error.ctp
+++ b/lib/Cake/View/Errors/pdo_error.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/private_action.ctp
+++ b/lib/Cake/View/Errors/private_action.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Errors/scaffold_error.ctp
+++ b/lib/Cake/View/Errors/scaffold_error.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -2,8 +2,6 @@
 /**
  * CacheHelper helps create full page view caching.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -8,8 +8,6 @@
  * support all options found in the JsHelper, as well as those in the jQuery
  * documentation.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -2,8 +2,6 @@
 /**
  * Javascript Generator class file.
  *
- * PHP 5
- *
  * CakePHP :  Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/NumberHelper.php
+++ b/lib/Cake/View/Helper/NumberHelper.php
@@ -4,8 +4,6 @@
  *
  * Methods to make numbers more readable.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -5,8 +5,6 @@
  * Provides Prototype specific JavaScript for JsHelper. Requires at least
  * Prototype 1.6
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/SessionHelper.php
+++ b/lib/Cake/View/Helper/SessionHelper.php
@@ -2,8 +2,6 @@
 /**
  * Session Helper provides access to the Session in the Views.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -4,8 +4,6 @@
  *
  * Text manipulations: Highlight, excerpt, truncate, strip of links, convert email addresses to mailto: links...
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -2,8 +2,6 @@
 /**
  * Time Helper class file.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/MediaView.php
+++ b/lib/Cake/View/MediaView.php
@@ -2,8 +2,6 @@
 /**
  * Methods to display or download any type of file
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/ScaffoldView.php
+++ b/lib/Cake/View/ScaffoldView.php
@@ -4,8 +4,6 @@
  *
  * Automatic forms and actions generation for rapid web application development.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/Scaffolds/form.ctp
+++ b/lib/Cake/View/Scaffolds/form.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Scaffolds/index.ctp
+++ b/lib/Cake/View/Scaffolds/index.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/Scaffolds/view.ctp
+++ b/lib/Cake/View/Scaffolds/view.ctp
@@ -1,7 +1,6 @@
 <?php
 /**
  *
- * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/View/ThemeView.php
+++ b/lib/Cake/View/ThemeView.php
@@ -2,8 +2,6 @@
 /**
  * A custom view class that is used for themeing
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -2,8 +2,6 @@
 /**
  * Methods for displaying presentation data in the view.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP 5
+ *
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -4,8 +4,6 @@
  *
  * Core functions for including other source files, loading models and so forth.
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/lib/Cake/bootstrap.php
+++ b/lib/Cake/bootstrap.php
@@ -4,8 +4,6 @@
  *
  * Handles loading of core files needed on every request
  *
- * PHP 5
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *


### PR DESCRIPTION
This statement does not serve a purpose anymore.
In a long forgotten world it indicated the main version number of PHP which the code in the file was compatible to.
http://pear.php.net/manual/en/standards.sample.php
But since PHP 5.1 and later this is only marginally true.
Thus I propose to remove it from CakePHP.
