### PR TITLE
Fixed some copyright and license statements in the file header DocBlocks

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright (c), Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * For full copyright and license information, please see the LICENSE.txt

--- a/lib/Cake/Log/Engine/SyslogLog.php
+++ b/lib/Cake/Log/Engine/SyslogLog.php
@@ -15,7 +15,7 @@
  * @link          http://www.cakefoundation.org/projects/info/cakephp CakePHP(tm) Project
  * @package       Cake.Log.Engine
  * @since         CakePHP(tm) v 2.4
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
 App::uses('BaseLog', 'Log/Engine');

--- a/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
+++ b/lib/Cake/Test/Case/Log/Engine/SyslogLogTest.php
@@ -14,7 +14,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @package       Cake.Test.Case.Log.Engine
  * @since         CakePHP(tm) v 2.4
- * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 App::uses('SyslogLog', 'Log/Engine');
 

--- a/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
+++ b/lib/Cake/Test/Case/Model/BehaviorCollectionTest.php
@@ -13,7 +13,7 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       Cake.Test.Case.Model
  * @since         1.2

--- a/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/PostgresTest.php
@@ -5,12 +5,12 @@
  * PHP 5
  *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @package       Cake.Test.Case.Model.Datasource.Database
  * @since         CakePHP(tm) v 1.2.0

--- a/lib/Cake/Test/Fixture/AdFixture.php
+++ b/lib/Cake/Test/Fixture/AdFixture.php
@@ -12,7 +12,7 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://www.cakephp.org
  * @package       Cake.Test.Fixture
  * @since         1.2

--- a/lib/Cake/Test/Fixture/AfterTreeFixture.php
+++ b/lib/Cake/Test/Fixture/AfterTreeFixture.php
@@ -12,7 +12,7 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://www.cakephp.org
  * @package       Cake.Test.Fixture
  * @since         1.2

--- a/lib/Cake/Test/Fixture/CampaignFixture.php
+++ b/lib/Cake/Test/Fixture/CampaignFixture.php
@@ -12,7 +12,7 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://www.cakephp.org
  * @package       Cake.Test.Fixture
  * @since         1.2


### PR DESCRIPTION
These lines were found by using some Regex:

Valid:
`* Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)`
Regex:
`\* Copyright (?!\(c\) Cake Software Foundation, Inc\. \(http://cakefoundation\.org\))`

Valid:
`* Licensed under The MIT License`
Regex:
`Licensed under (?!The MIT License)`

Valid:
`* @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)`
Regex:
`@copyright\s*\w(?!opyright \(c\) Cake Software Foundation, Inc\. \(http://cakefoundation\.org\))`

Valid:
`* @license       http://www.opensource.org/licenses/mit-license.php MIT License`
Regex:
`@license\s*\w(?!ttp://www.opensource.org/licenses/mit-license.php MIT License)`

Those regex could be incorporated into the Jenkins Server for example...
