### PR TITLE
add `unsigned` field parameter

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -348,6 +348,7 @@ class Mysql extends DboSource {
 				'null' => ($column->Null === 'YES' ? true : false),
 				'default' => $column->Default,
 				'length' => $this->length($column->Type),
+				'unsigned' => $this->unsigned($column->Type)
 			);
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];
@@ -780,6 +781,16 @@ class Mysql extends DboSource {
 			return "enum($vals)";
 		}
 		return 'text';
+	}
+
+/**
+ * Check if column type is unsigned
+ *
+ * @param string $real Real database-layer column type (i.e. "varchar(255)")
+ * @return bool True if column is unsigned, false otherwise
+ */
+	public function unsigned($real) {
+		return strpos(strtolower($real), 'unsigned') !== false;
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -86,7 +86,13 @@ class Mysql extends DboSource {
 	public $fieldParameters = array(
 		'charset' => array('value' => 'CHARACTER SET', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'beforeDefault'),
 		'collate' => array('value' => 'COLLATE', 'quote' => false, 'join' => ' ', 'column' => 'Collation', 'position' => 'beforeDefault'),
-		'comment' => array('value' => 'COMMENT', 'quote' => true, 'join' => ' ', 'column' => 'Comment', 'position' => 'afterDefault')
+		'comment' => array('value' => 'COMMENT', 'quote' => true, 'join' => ' ', 'column' => 'Comment', 'position' => 'afterDefault'),
+		'unsigned' => array(
+			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'afterDefault',
+			'noVal' => true,
+			'options' => array(true),
+			'types' => array('integer', 'float', 'biginteger')
+		)
 	);
 
 /**

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -350,7 +350,7 @@ class Mysql extends DboSource {
 				'length' => $this->length($column->Type)
 			);
 			if (in_array($fields[$column->Field]['type'], $this->fieldParameters['unsigned']['types'], true)) {
-				$fields[$column->Field]['unsigned'] = $this->unsigned($column->Type);
+				$fields[$column->Field]['unsigned'] = $this->_unsigned($column->Type);
 			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];
@@ -786,16 +786,6 @@ class Mysql extends DboSource {
 	}
 
 /**
- * Check if column type is unsigned
- *
- * @param string $real Real database-layer column type (i.e. "varchar(255)")
- * @return bool True if column is unsigned, false otherwise
- */
-	public function unsigned($real) {
-		return strpos(strtolower($real), 'unsigned') !== false;
-	}
-
-/**
  * Gets the schema name
  *
  * @return string The schema name
@@ -811,6 +801,16 @@ class Mysql extends DboSource {
  */
 	public function nestedTransactionSupported() {
 		return $this->useNestedTransactions && version_compare($this->getVersion(), '4.1', '>=');
+	}
+
+/**
+ * Check if column type is unsigned
+ *
+ * @param string $real Real database-layer column type (i.e. "varchar(255)")
+ * @return bool True if column is unsigned, false otherwise
+ */
+	protected function _unsigned($real) {
+		return strpos(strtolower($real), 'unsigned') !== false;
 	}
 
 }

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -91,7 +91,7 @@ class Mysql extends DboSource {
 			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'beforeDefault',
 			'noVal' => true,
 			'options' => array(true),
-			'types' => array('integer', 'float', 'biginteger', 'numeric')
+			'types' => array('integer', 'float', 'biginteger', 'numeric', 'decimal')
 		)
 	);
 

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -91,7 +91,7 @@ class Mysql extends DboSource {
 			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'beforeDefault',
 			'noVal' => true,
 			'options' => array(true),
-			'types' => array('integer', 'float', 'biginteger', 'numeric', 'decimal')
+			'types' => array('integer', 'float', 'decimal', 'biginteger')
 		)
 	);
 

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -88,7 +88,7 @@ class Mysql extends DboSource {
 		'collate' => array('value' => 'COLLATE', 'quote' => false, 'join' => ' ', 'column' => 'Collation', 'position' => 'beforeDefault'),
 		'comment' => array('value' => 'COMMENT', 'quote' => true, 'join' => ' ', 'column' => 'Comment', 'position' => 'afterDefault'),
 		'unsigned' => array(
-			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'afterDefault',
+			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'beforeDefault',
 			'noVal' => true,
 			'options' => array(true),
 			'types' => array('integer', 'float', 'biginteger', 'numeric')

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -91,7 +91,7 @@ class Mysql extends DboSource {
 			'value' => 'UNSIGNED', 'quote' => false, 'join' => ' ', 'column' => false, 'position' => 'afterDefault',
 			'noVal' => true,
 			'options' => array(true),
-			'types' => array('integer', 'float', 'biginteger')
+			'types' => array('integer', 'float', 'biginteger', 'numeric')
 		)
 	);
 

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -347,9 +347,11 @@ class Mysql extends DboSource {
 				'type' => $this->column($column->Type),
 				'null' => ($column->Null === 'YES' ? true : false),
 				'default' => $column->Default,
-				'length' => $this->length($column->Type),
-				'unsigned' => $this->unsigned($column->Type)
+				'length' => $this->length($column->Type)
 			);
+			if (in_array($fields[$column->Field]['type'], $this->fieldParameters['unsigned']['types'], true)) {
+				$fields[$column->Field]['unsigned'] = $this->unsigned($column->Type);
+			}
 			if (!empty($column->Key) && isset($this->index[$column->Key])) {
 				$fields[$column->Field]['key'] = $this->index[$column->Key];
 			}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3148,7 +3148,6 @@ class DboSource extends DataSource {
 				if (isset($value['types']) && !in_array($columnData['type'], $value['types'], true)) {
 					continue;
 				}
-				
 				$val = $columnData[$paramName];
 				if ($value['quote']) {
 					$val = $this->value($val);

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3142,14 +3142,18 @@ class DboSource extends DataSource {
 	protected function _buildFieldParameters($columnString, $columnData, $position) {
 		foreach ($this->fieldParameters as $paramName => $value) {
 			if (isset($columnData[$paramName]) && $value['position'] == $position) {
-				if (isset($value['options']) && !in_array($columnData[$paramName], $value['options'])) {
+				if (isset($value['options']) && !in_array($columnData[$paramName], $value['options'], true)) {
 					continue;
 				}
+				if (isset($value['types']) && !in_array($columnData['type'], $value['types'], true)) {
+					continue;
+				}
+				
 				$val = $columnData[$paramName];
 				if ($value['quote']) {
 					$val = $this->value($val);
 				}
-				$columnString .= ' ' . $value['value'] . $value['join'] . $val;
+				$columnString .= ' ' . $value['value'] . (empty($value['noVal']) ? $value['join'] . $val : '');
 			}
 		}
 		return $columnString;

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3278,8 +3278,8 @@ class MysqlTest extends CakeTestCase {
 		$types = $this->Dbo->fieldParameters['unsigned']['types'];
 		$schema = $Model->schema();
 		foreach ($types as $type) {
-			$this->assertArrayHasKey('unsigned', $schema['u'.$type]);
-			$this->assertTrue($schema['u'.$type]['unsigned']);
+			$this->assertArrayHasKey('unsigned', $schema['u' . $type]);
+			$this->assertTrue($schema['u' . $type]['unsigned']);
 			$this->assertArrayHasKey('unsigned', $schema[$type]);
 			$this->assertFalse($schema[$type]['unsigned']);
 		}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3157,16 +3157,16 @@ class MysqlTest extends CakeTestCase {
 	
 	
 /**
- * testBuildColumn3 method
+ * Test `unsigned` field parameter
  *
  * @param array $data Column data
  * @param string $expected Expected sql part
  * 
  * @return void
  * 
- * @dataProvider buildColumn3Provider
+ * @dataProvider buildColumnUnsignedProvider
  */
-	public function testBuildColumn3($data, $expected) {
+	public function testBuildColumnUnsigned($data, $expected) {
 		$restore = $this->Dbo->columns;
 		$this->Dbo->columns = array('string' => 1, 'integer' => 1, 'float' => 1, 'biginteger' => 1, 'any' => 1);
 
@@ -3177,11 +3177,11 @@ class MysqlTest extends CakeTestCase {
 	}
 	
 /**
- * Data provider testBuildColumn3 method
+ * Data provider testBuildColumnUnsigned method
  *
  * @return array
  */
-	public function buildColumn3Provider() {
+	public function buildColumnUnsignedProvider() {
 		return array(
 			//set #0
 			array(

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -47,7 +47,7 @@ class MysqlTest extends CakeTestCase {
 	public $fixtures = array(
 		'core.apple', 'core.article', 'core.articles_tag', 'core.attachment', 'core.comment',
 		'core.sample', 'core.tag', 'core.user', 'core.post', 'core.author', 'core.data_test',
-		'core.binary_test', 'core.inno'
+		'core.binary_test', 'core.inno', 'core.unsigned'
 	);
 
 /**
@@ -3165,7 +3165,7 @@ class MysqlTest extends CakeTestCase {
  * 
  * @dataProvider buildColumnUnsignedProvider
  */
-	public function testBuildColumnUnsigned($data, $expected) {//debug($this->Dbo->columns);
+	public function testBuildColumnUnsigned($data, $expected) {
 		$result = $this->Dbo->buildColumn($data);
 		$this->assertEquals($expected, $result);
 	}
@@ -3264,6 +3264,25 @@ class MysqlTest extends CakeTestCase {
 				'`testName` decimal UNSIGNED DEFAULT 1'
 			)
 		);
+	}
+
+/**
+ * Test getting `unsigned` field parameter from DB
+ * 
+ * @return void
+ */
+	public function testSchemaUnsigned() {
+		$this->loadFixtures('Unsigned');
+		$Model = ClassRegistry::init('Model');
+		$Model->setSource('unsigned');
+		$types = $this->Dbo->fieldParameters['unsigned']['types'];
+		$schema = $Model->schema();
+		foreach ($types as $type) {
+			$this->assertArrayHasKey('unsigned', $schema['u'.$type]);
+			$this->assertTrue($schema['u'.$type]['unsigned']);
+			$this->assertArrayHasKey('unsigned', $schema[$type]);
+			$this->assertFalse($schema[$type]['unsigned']);
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3154,7 +3154,7 @@ class MysqlTest extends CakeTestCase {
 		);
 		$this->Dbo->buildColumn($data);
 	}
-	
+
 /**
  * Test `unsigned` field parameter
  *
@@ -3169,7 +3169,7 @@ class MysqlTest extends CakeTestCase {
 		$result = $this->Dbo->buildColumn($data);
 		$this->assertEquals($expected, $result);
 	}
-	
+
 /**
  * Data provider testBuildColumnUnsigned method
  *

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3253,7 +3253,7 @@ class MysqlTest extends CakeTestCase {
 				),
 				'`testName` decimal UNSIGNED'
 			),
-			//set #7
+			//set #8
 			array(
 				array(
 					'name' => 'testName',

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3253,6 +3253,16 @@ class MysqlTest extends CakeTestCase {
 					'unsigned' => true
 				),
 				'`testName` decimal UNSIGNED'
+			),
+			//set #7
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'numeric',
+					'unsigned' => true,
+					'default' => 1
+				),
+				'`testName` decimal UNSIGNED DEFAULT 1'
 			)
 		);
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3248,7 +3248,7 @@ class MysqlTest extends CakeTestCase {
 			array(
 				array(
 					'name' => 'testName',
-					'type' => 'numeric',
+					'type' => 'decimal',
 					'unsigned' => true
 				),
 				'`testName` decimal UNSIGNED'
@@ -3257,20 +3257,11 @@ class MysqlTest extends CakeTestCase {
 			array(
 				array(
 					'name' => 'testName',
-					'type' => 'numeric',
+					'type' => 'decimal',
 					'unsigned' => true,
 					'default' => 1
 				),
 				'`testName` decimal UNSIGNED DEFAULT 1'
-			),
-			//set #8
-			array(
-				array(
-					'name' => 'testName',
-					'type' => 'decimal',
-					'unsigned' => true
-				),
-				'`testName` decimal UNSIGNED'
 			)
 		);
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3283,6 +3283,7 @@ class MysqlTest extends CakeTestCase {
 			$this->assertArrayHasKey('unsigned', $schema[$type]);
 			$this->assertFalse($schema[$type]['unsigned']);
 		}
+		$this->assertArrayNotHasKey('unsigned', $schema['string']);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3166,14 +3166,9 @@ class MysqlTest extends CakeTestCase {
  * 
  * @dataProvider buildColumnUnsignedProvider
  */
-	public function testBuildColumnUnsigned($data, $expected) {
-		$restore = $this->Dbo->columns;
-		$this->Dbo->columns = array('string' => 1, 'integer' => 1, 'float' => 1, 'biginteger' => 1, 'any' => 1);
-
+	public function testBuildColumnUnsigned($data, $expected) {//debug($this->Dbo->columns);
 		$result = $this->Dbo->buildColumn($data);
 		$this->assertEquals($expected, $result);
-		
-		$this->Dbo->columns = $restore;
 	}
 	
 /**
@@ -3188,18 +3183,20 @@ class MysqlTest extends CakeTestCase {
 				array(
 					'name' => 'testName',
 					'type' => 'integer',
+					'length' => 11,
 					'unsigned' => true
 				),
-				'`testName`  UNSIGNED'
+				'`testName` int(11) UNSIGNED'
 			),
 			//set #1
 			array(
 				array(
 					'name' => 'testName',
 					'type' => 'biginteger',
+					'length' => 20,
 					'unsigned' => true
 				),
-				'`testName`  UNSIGNED'
+				'`testName` bigint(20) UNSIGNED'
 			),
 			//set #2
 			array(
@@ -3208,43 +3205,54 @@ class MysqlTest extends CakeTestCase {
 					'type' => 'float',
 					'unsigned' => true
 				),
-				'`testName`  UNSIGNED'
+				'`testName` float UNSIGNED'
 			),
 			//set #3
 			array(
 				array(
 					'name' => 'testName',
 					'type' => 'string',
+					'length' => 255,
 					'unsigned' => true
 				),
-				'`testName` '
+				'`testName` varchar(255)'
 			),
 			//set #4
 			array(
 				array(
 					'name' => 'testName',
-					'type' => 'any',
+					'type' => 'date',
 					'unsigned' => true
 				),
-				'`testName` '
+				'`testName` date'
 			),
 			//set #5
 			array(
 				array(
 					'name' => 'testName',
-					'type' => 'any',
+					'type' => 'date',
 					'unsigned' => false
 				),
-				'`testName` '
+				'`testName` date'
 			),
 			//set #6
 			array(
 				array(
 					'name' => 'testName',
 					'type' => 'integer',
+					'length' => 11,
 					'unsigned' => false
 				),
-				'`testName` '
+				'`testName` int(11)'
+			),
+			//set #7
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'numeric',
+					'unsigned' => true
+				),
+				'`testName` decimal UNSIGNED'
 			)
 		);
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3262,6 +3262,15 @@ class MysqlTest extends CakeTestCase {
 					'default' => 1
 				),
 				'`testName` decimal UNSIGNED DEFAULT 1'
+			),
+			//set #8
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'decimal',
+					'unsigned' => true
+				),
+				'`testName` decimal UNSIGNED'
 			)
 		);
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3154,6 +3154,100 @@ class MysqlTest extends CakeTestCase {
 		);
 		$this->Dbo->buildColumn($data);
 	}
+	
+	
+/**
+ * testBuildColumn3 method
+ *
+ * @param array $data Column data
+ * @param string $expected Expected sql part
+ * 
+ * @return void
+ * 
+ * @dataProvider buildColumn3Provider
+ */
+	public function testBuildColumn3($data, $expected) {
+		$restore = $this->Dbo->columns;
+		$this->Dbo->columns = array('string' => 1, 'integer' => 1, 'float' => 1, 'biginteger' => 1, 'any' => 1);
+
+		$result = $this->Dbo->buildColumn($data);
+		$this->assertEquals($expected, $result);
+		
+		$this->Dbo->columns = $restore;
+	}
+	
+/**
+ * Data provider testBuildColumn3 method
+ *
+ * @return array
+ */
+	public function buildColumn3Provider() {
+		return array(
+			//set #0
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'integer',
+					'unsigned' => true
+				),
+				'`testName`  UNSIGNED'
+			),
+			//set #1
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'biginteger',
+					'unsigned' => true
+				),
+				'`testName`  UNSIGNED'
+			),
+			//set #2
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'float',
+					'unsigned' => true
+				),
+				'`testName`  UNSIGNED'
+			),
+			//set #3
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'string',
+					'unsigned' => true
+				),
+				'`testName` '
+			),
+			//set #4
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'any',
+					'unsigned' => true
+				),
+				'`testName` '
+			),
+			//set #5
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'any',
+					'unsigned' => false
+				),
+				'`testName` '
+			),
+			//set #6
+			array(
+				array(
+					'name' => 'testName',
+					'type' => 'integer',
+					'unsigned' => false
+				),
+				'`testName` '
+			)
+		);
+	}
 
 /**
  * test hasAny()

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -3155,7 +3155,6 @@ class MysqlTest extends CakeTestCase {
 		$this->Dbo->buildColumn($data);
 	}
 	
-	
 /**
  * Test `unsigned` field parameter
  *

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2216,7 +2216,8 @@ class ModelIntegrationTest extends BaseModelTest {
 				'null' => false,
 				'default' => null,
 				'length' => $intLength,
-				'key' => 'primary'
+				'key' => 'primary',
+				'unsigned' => false
 			),
 			'user' => array(
 				'type' => 'string',

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -2204,7 +2204,7 @@ class ModelIntegrationTest extends BaseModelTest {
 		} else {
 			$intLength = 11;
 		}
-		foreach (array('collate', 'charset', 'comment') as $type) {
+		foreach (array('collate', 'charset', 'comment', 'unsigned') as $type) {
 			foreach ($result as $i => $r) {
 				unset($result[$i][$type]);
 			}
@@ -2216,8 +2216,7 @@ class ModelIntegrationTest extends BaseModelTest {
 				'null' => false,
 				'default' => null,
 				'length' => $intLength,
-				'key' => 'primary',
-				'unsigned' => false
+				'key' => 'primary'
 			),
 			'user' => array(
 				'type' => 'string',

--- a/lib/Cake/Test/Fixture/UnsignedFixture.php
+++ b/lib/Cake/Test/Fixture/UnsignedFixture.php
@@ -14,7 +14,7 @@
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @package       Cake.Test.Fixture
- * @since         CakePHP(tm) v 1.2.0.4667
+ * @since         CakePHP(tm) v 2.5.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 

--- a/lib/Cake/Test/Fixture/UnsignedFixture.php
+++ b/lib/Cake/Test/Fixture/UnsignedFixture.php
@@ -46,6 +46,7 @@ class UnsignedFixture extends CakeTestFixture {
 		'ubiginteger' => array('type' => 'biginteger', 'length' => '20', 'default' => 3, 'unsigned' => true),
 		'float' => array('type' => 'float', 'length' => '4'),
 		'ufloat' => array('type' => 'float', 'length' => '4', 'unsigned' => true),
+		'string' => array('type' => 'string', 'length' => '4'),
 		'tableParameters' => array(
 			'engine' => 'MyISAM'
 		)

--- a/lib/Cake/Test/Fixture/UnsignedFixture.php
+++ b/lib/Cake/Test/Fixture/UnsignedFixture.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Short description for file.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @package       Cake.Test.Fixture
+ * @since         CakePHP(tm) v 1.2.0.4667
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Short description for class.
+ *
+ * @package       Cake.Test.Fixture
+ */
+class UnsignedFixture extends CakeTestFixture {
+
+/**
+ * table property
+ *
+ * @var array
+ */
+	public $table = 'unsigned';
+
+/**
+ * fields property
+ *
+ * @var array
+ */
+	public $fields = array(
+		'uinteger' => array('type' => 'integer', 'null' => '', 'default' => '1', 'length' => '8', 'key' => 'primary', 'unsigned' => true),
+		'integer' => array('type' => 'integer', 'length' => '8', 'unsigned' => false),
+		'udecimal' => array('type' => 'decimal', 'length' => '4', 'unsigned' => true),
+		'decimal' => array('type' => 'decimal', 'length' => '4'),
+		'biginteger' => array('type' => 'biginteger', 'length' => '20', 'default' => 3),
+		'ubiginteger' => array('type' => 'biginteger', 'length' => '20', 'default' => 3, 'unsigned' => true),
+		'float' => array('type' => 'float', 'length' => '4'),
+		'ufloat' => array('type' => 'float', 'length' => '4', 'unsigned' => true),
+		'tableParameters' => array(
+			'engine' => 'MyISAM'
+		)
+	);
+
+/**
+ * records property
+ *
+ * @var array
+ */
+	public $records = array();
+}


### PR DESCRIPTION
- change check to strict for `options` of `$fieldParameters`
- add `types` parameter and strict check if it present in `$fieldParameters` (if it present and not contain column type field parameter will be skipped)
- add `noVal` parameter to `$fieldParameters` if it present and not empty value of this parameter from column will be ignored
- add `unsigned` field parameter for integer, float and biginteger. If it set to `true` an 'UNSIGNED' will be add in sql column part, if not set or set not to `true` this parameter will be skipped
