### PR TITLE
3.0 Convert Cache + Behavior classes to use _config

### DIFF
--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -27,7 +27,7 @@ abstract class CacheEngine {
  *
  * @var array
  */
-	public $settings = [];
+	protected $_config = [];
 
 /**
  * Contains the compiled string with all groups
@@ -42,23 +42,23 @@ abstract class CacheEngine {
  *
  * Called automatically by the cache frontend
  *
- * @param array $settings Associative array of parameters for the engine
+ * @param array $config Associative array of parameters for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
  */
-	public function init($settings = []) {
-		$settings += $this->settings + [
+	public function init($config = []) {
+		$config += $this->_config + [
 			'prefix' => 'cake_',
 			'duration' => 3600,
 			'probability' => 100,
 			'groups' => []
 		];
-		$this->settings = $settings;
-		if (!empty($this->settings['groups'])) {
-			sort($this->settings['groups']);
-			$this->_groupPrefix = str_repeat('%s_', count($this->settings['groups']));
+		$this->_config = $config;
+		if (!empty($this->_config['groups'])) {
+			sort($this->_config['groups']);
+			$this->_groupPrefix = str_repeat('%s_', count($this->_config['groups']));
 		}
-		if (!is_numeric($this->settings['duration'])) {
-			$this->settings['duration'] = strtotime($this->settings['duration']) - time();
+		if (!is_numeric($this->_config['duration'])) {
+			$this->_config['duration'] = strtotime($this->_config['duration']) - time();
 		}
 		return true;
 	}
@@ -146,16 +146,16 @@ abstract class CacheEngine {
  * @return array
  */
 	public function groups() {
-		return $this->settings['groups'];
+		return $this->_config['groups'];
 	}
 
 /**
- * Cache Engine settings
+ * Cache Engine config
  *
- * @return array settings
+ * @return array config
  */
 	public function settings() {
-		return $this->settings;
+		return $this->_config;
 	}
 
 /**

--- a/Cake/Cache/CacheRegistry.php
+++ b/Cake/Cache/CacheRegistry.php
@@ -88,7 +88,8 @@ class CacheRegistry extends ObjectRegistry {
 			);
 		}
 
-		if ($instance->settings['probability'] && time() % $instance->settings['probability'] === 0) {
+		$settings = $instance->settings();
+		if ($settings['probability'] && time() % $settings['probability'] === 0) {
 			$instance->gc();
 		}
 		return $instance;

--- a/Cake/Cache/Engine/WincacheEngine.php
+++ b/Cake/Cache/Engine/WincacheEngine.php
@@ -39,7 +39,6 @@ class WincacheEngine extends CacheEngine {
  *
  * @param array $config array of setting for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
- * @see CacheEngine::__defaults
  */
 	public function init($config = []) {
 		if (!isset($config['prefix'])) {

--- a/Cake/Cache/Engine/WincacheEngine.php
+++ b/Cake/Cache/Engine/WincacheEngine.php
@@ -36,17 +36,16 @@ class WincacheEngine extends CacheEngine {
  * Initialize the Cache Engine
  *
  * Called automatically by the cache frontend
- * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = array());
  *
- * @param array $settings array of setting for the engine
+ * @param array $config array of setting for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
  * @see CacheEngine::__defaults
  */
-	public function init($settings = []) {
-		if (!isset($settings['prefix'])) {
-			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
+	public function init($config = []) {
+		if (!isset($config['prefix'])) {
+			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
-		parent::init($settings);
+		parent::init($config);
 		return function_exists('wincache_ucache_info');
 	}
 
@@ -79,7 +78,7 @@ class WincacheEngine extends CacheEngine {
 	public function read($key) {
 		$time = time();
 		$cachetime = intval(wincache_ucache_get($key . '_expires'));
-		if ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime) {
+		if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
 			return false;
 		}
 		return wincache_ucache_get($key);
@@ -133,7 +132,7 @@ class WincacheEngine extends CacheEngine {
 		$cacheKeys = $info['ucache_entries'];
 		unset($info);
 		foreach ($cacheKeys as $key) {
-			if (strpos($key['key_name'], $this->settings['prefix']) === 0) {
+			if (strpos($key['key_name'], $this->_config['prefix']) === 0) {
 				wincache_ucache_delete($key['key_name']);
 			}
 		}
@@ -149,13 +148,13 @@ class WincacheEngine extends CacheEngine {
  */
 	public function groups() {
 		if (empty($this->_compiledGroupNames)) {
-			foreach ($this->settings['groups'] as $group) {
-				$this->_compiledGroupNames[] = $this->settings['prefix'] . $group;
+			foreach ($this->_config['groups'] as $group) {
+				$this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
 			}
 		}
 
 		$groups = wincache_ucache_get($this->_compiledGroupNames);
-		if (count($groups) !== count($this->settings['groups'])) {
+		if (count($groups) !== count($this->_config['groups'])) {
 			foreach ($this->_compiledGroupNames as $group) {
 				if (!isset($groups[$group])) {
 					wincache_ucache_set($group, 1);
@@ -167,7 +166,7 @@ class WincacheEngine extends CacheEngine {
 
 		$result = [];
 		$groups = array_values($groups);
-		foreach ($this->settings['groups'] as $i => $group) {
+		foreach ($this->_config['groups'] as $i => $group) {
 			$result[] = $group . $groups[$i];
 		}
 		return $result;
@@ -181,7 +180,7 @@ class WincacheEngine extends CacheEngine {
  */
 	public function clearGroup($group) {
 		$success = null;
-		wincache_ucache_inc($this->settings['prefix'] . $group, 1, $success);
+		wincache_ucache_inc($this->_config['prefix'] . $group, 1, $success);
 		return $success;
 	}
 

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -35,24 +35,23 @@ class XcacheEngine extends CacheEngine {
  *
  * @var array
  */
-	public $settings = [];
+	protected $_config = [];
 
 /**
  * Initialize the Cache Engine
  *
  * Called automatically by the cache frontend
- * To reinitialize the settings call Cache::engine('EngineName', [optional] settings = []);
  *
- * @param array $settings array of setting for the engine
+ * @param array $config array of setting for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
  */
-	public function init($settings = []) {
+	public function init($config = []) {
 		if (php_sapi_name() !== 'cli') {
 			parent::init(array_merge([
 				'prefix' => Inflector::slug(APP_DIR) . '_',
 				'PHP_AUTH_USER' => 'user',
 				'PHP_AUTH_PW' => 'password'
-				], $settings)
+				], $config)
 			);
 			return function_exists('xcache_info');
 		}
@@ -83,7 +82,7 @@ class XcacheEngine extends CacheEngine {
 		if (xcache_isset($key)) {
 			$time = time();
 			$cachetime = intval(xcache_get($key . '_expires'));
-			if ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime) {
+			if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
 				return false;
 			}
 			return xcache_get($key);
@@ -150,11 +149,11 @@ class XcacheEngine extends CacheEngine {
  */
 	public function groups() {
 		$result = [];
-		foreach ($this->settings['groups'] as $group) {
-			$value = xcache_get($this->settings['prefix'] . $group);
+		foreach ($this->_config['groups'] as $group) {
+			$value = xcache_get($this->_config['prefix'] . $group);
 			if (!$value) {
 				$value = 1;
-				xcache_set($this->settings['prefix'] . $group, $value, 0);
+				xcache_set($this->_config['prefix'] . $group, $value, 0);
 			}
 			$result[] = $group . $value;
 		}
@@ -168,7 +167,7 @@ class XcacheEngine extends CacheEngine {
  * @return boolean success
  */
 	public function clearGroup($group) {
-		return (bool)xcache_inc($this->settings['prefix'] . $group, 1);
+		return (bool)xcache_inc($this->_config['prefix'] . $group, 1);
 	}
 
 /**
@@ -176,7 +175,7 @@ class XcacheEngine extends CacheEngine {
  * Makes necessary changes (and reverting them back) in $_SERVER
  *
  * This has to be done because xcache_clear_cache() needs to pass Basic Http Auth
- * (see xcache.admin configuration settings)
+ * (see xcache.admin configuration config)
  *
  * @param boolean $reverse Revert changes
  * @return void
@@ -197,10 +196,10 @@ class XcacheEngine extends CacheEngine {
 				if (!empty($value)) {
 					$backup[$key] = $value;
 				}
-				if (!empty($this->settings[$setting])) {
-					$_SERVER[$key] = $this->settings[$setting];
-				} elseif (!empty($this->settings[$key])) {
-					$_SERVER[$key] = $this->settings[$key];
+				if (!empty($this->_config[$setting])) {
+					$_SERVER[$key] = $this->_config[$setting];
+				} elseif (!empty($this->_config[$key])) {
+					$_SERVER[$key] = $this->_config[$key];
 				} else {
 					$_SERVER[$key] = $value;
 				}

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -103,61 +103,61 @@ class Behavior implements EventListener {
 	protected static $_reflectionCache = [];
 
 /**
- * Default settings
+ * Default configuration
  *
- * These are merged with user-provided settings when the behavior is used.
+ * These are merged with user-provided configuration when the behavior is used.
  *
  * @var array
  */
-	protected $_defaultSettings = [];
+	protected $_defaultConfig = [];
 
 /**
- * Contains configuration settings.
+ * Contains configuration.
  *
  * @var array
  */
-	protected $_settings = [];
+	protected $_config = [];
 
 /**
  * Constructor
  *
- * Merge settings with the default and store in the settings property
+ * Merge config with the default and store in the config property
  *
  * Does not retain a reference to the Table object. If you need this
  * you should override the constructor.
  *
  * @param Table $table The table this behavior is attached to.
- * @param array $settings The settings for this behavior.
+ * @param array $config The config for this behavior.
  */
-	public function __construct(Table $table, array $settings = []) {
-		$this->_settings = $settings + $this->_defaultSettings;
+	public function __construct(Table $table, array $config = []) {
+		$this->_config = $config + $this->_defaultConfig;
 	}
 
 /**
- * Read the settings being used.
+ * Read the configuration being used.
  *
  * @return array
  */
-	public function settings() {
-		return $this->_settings;
+	public function config() {
+		return $this->_config;
 	}
 
 /**
- * verifySettings
+ * verifyConfig
  *
  * Check that implemented* keys contain values pointing at callable
  *
  * @return void
- * @throws Cake\Error\Exception if settings are invalid
+ * @throws Cake\Error\Exception if config are invalid
  */
-	public function verifySettings() {
+	public function verifyConfig() {
 		$keys = ['implementedFinders', 'implementedMethods'];
 		foreach ($keys as $key) {
-			if (!isset($this->_settings[$key])) {
+			if (!isset($this->_config[$key])) {
 				continue;
 			}
 
-			foreach ($this->_settings[$key] as $method) {
+			foreach ($this->_config[$key] as $method) {
 				if (!is_callable([$this, $method])) {
 					throw new Exception(__d('cake_dev', 'The method %s is not callable on class %s', $method, get_class($this)));
 				}
@@ -184,8 +184,8 @@ class Behavior implements EventListener {
 			'Model.beforeDelete' => 'beforeDelete',
 			'Model.afterDelete' => 'afterDelete',
 		];
-		$settings = $this->settings();
-		$priority = isset($settings['priority']) ? $settings['priority'] : null;
+		$config = $this->config();
+		$priority = isset($config['priority']) ? $config['priority'] : null;
 		$events = [];
 
 		foreach ($eventMap as $event => $method) {
@@ -219,15 +219,15 @@ class Behavior implements EventListener {
  * With the above example, a call to `$Table->find('this')` will call `$Behavior->findThis()`
  * and a call to `$Table->find('alias')` will call `$Behavior->findMethodName()`
  *
- * It is recommended, though not required, to define implementedFinders in the settings property
+ * It is recommended, though not required, to define implementedFinders in the config property
  * of child classes such that it is not necessary to use reflections to derive the available
  * method list. See core behaviors for examples
  *
  * @return array
  */
 	public function implementedFinders() {
-		if (isset($this->_settings['implementedFinders'])) {
-			return $this->_settings['implementedFinders'];
+		if (isset($this->_config['implementedFinders'])) {
+			return $this->_config['implementedFinders'];
 		}
 
 		$reflectionMethods = $this->_reflectionCache();
@@ -249,15 +249,15 @@ class Behavior implements EventListener {
  * With the above example, a call to `$Table->method()` will call `$Behavior->method()`
  * and a call to `$Table->aliasedmethod()` will call `$Behavior->somethingElse()`
  *
- * It is recommended, though not required, to define implementedFinders in the settings property
+ * It is recommended, though not required, to define implementedFinders in the config property
  * of child classes such that it is not necessary to use reflections to derive the available
  * method list. See core behaviors for examples
  *
  * @return array
  */
 	public function implementedMethods() {
-		if (isset($this->_settings['implementedMethods'])) {
-			return $this->_settings['implementedMethods'];
+		if (isset($this->_config['implementedMethods'])) {
+			return $this->_config['implementedMethods'];
 		}
 
 		$reflectionMethods = $this->_reflectionCache();

--- a/Cake/ORM/BehaviorRegistry.php
+++ b/Cake/ORM/BehaviorRegistry.php
@@ -104,12 +104,12 @@ class BehaviorRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $alias The alias of the object.
- * @param array $settings An array of settings to use for the behavior.
+ * @param array $config An array of config to use for the behavior.
  * @return Behavior The constructed behavior class.
  */
-	protected function _create($class, $alias, $settings) {
-		$instance = new $class($this->_table, $settings);
-		$enable = isset($settings['enabled']) ? $settings['enabled'] : true;
+	protected function _create($class, $alias, $config) {
+		$instance = new $class($this->_table, $config);
+		$enable = isset($config['enabled']) ? $config['enabled'] : true;
 		if ($enable) {
 			$this->_eventManager->attach($instance);
 		}

--- a/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorRegistryTest.php
@@ -56,10 +56,10 @@ class BehaviorRegistryTest extends TestCase {
  */
 	public function testLoad() {
 		Plugin::load('TestPlugin');
-		$settings = ['alias' => 'Sluggable', 'replacement' => '-'];
-		$result = $this->Behaviors->load('Sluggable', $settings);
+		$config = ['alias' => 'Sluggable', 'replacement' => '-'];
+		$result = $this->Behaviors->load('Sluggable', $config);
 		$this->assertInstanceOf('TestApp\Model\Behavior\SluggableBehavior', $result);
-		$this->assertEquals($settings, $result->settings());
+		$this->assertEquals($config, $result->config());
 
 		$result = $this->Behaviors->load('TestPlugin.PersisterOne');
 		$this->assertInstanceOf('TestPlugin\Model\Behavior\PersisterOneBehavior', $result);
@@ -145,7 +145,7 @@ class BehaviorRegistryTest extends TestCase {
 		$this->assertTrue($this->Behaviors->hasMethod('PERSIST'));
 
 		$this->assertFalse($this->Behaviors->hasMethod('__construct'));
-		$this->assertFalse($this->Behaviors->hasMethod('settings'));
+		$this->assertFalse($this->Behaviors->hasMethod('config'));
 		$this->assertFalse($this->Behaviors->hasMethod('implementedEvents'));
 
 		$this->assertFalse($this->Behaviors->hasMethod('nope'));

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -79,13 +79,6 @@ class Test3Behavior extends Behavior {
 	}
 
 /**
- * verifySettings
- */
-	public function verifySettings() {
-		parent::verifySettings();
-	}
-
-/**
  * implementedEvents
  *
  * This class does pretend to implement beforeFind
@@ -133,9 +126,9 @@ class BehaviorTest extends TestCase {
  */
 	public function testConstructor() {
 		$table = $this->getMock('Cake\ORM\Table');
-		$settings = ['key' => 'value'];
-		$behavior = new TestBehavior($table, $settings);
-		$this->assertEquals($settings, $behavior->settings());
+		$config = ['key' => 'value'];
+		$behavior = new TestBehavior($table, $config);
+		$this->assertEquals($config, $behavior->config());
 	}
 
 	public function testReflectionCache() {
@@ -277,34 +270,34 @@ class BehaviorTest extends TestCase {
 	}
 
 /**
- * testVerifySettings
+ * testVerifyConfig
  *
  * Don't expect an exception to be thrown
  *
  * @return void
  */
-	public function testVerifySettings() {
+	public function testVerifyConfig() {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
-		$behavior->verifySettings();
+		$behavior->verifyConfig();
 		$this->assertTrue(true, 'No exception thrown');
 	}
 
 /**
- * testVerifySettingsImplementedFindersOverriden
+ * testVerifyConfigImplementedFindersOverriden
  *
  * Simply don't expect an exception to be thrown
  *
  * @return void
  */
-	public function testVerifySettingsImplementedFindersOverriden() {
+	public function testVerifyConfigImplementedFindersOverriden() {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table, [
 			'implementedFinders' => [
 				'aliased' => 'findFoo'
 			]
 		]);
-		$behavior->verifySettings();
+		$behavior->verifyConfig();
 		$this->assertTrue(true, 'No exception thrown');
 	}
 
@@ -323,17 +316,17 @@ class BehaviorTest extends TestCase {
 				'aliased' => 'findNotDefined'
 			]
 		]);
-		$behavior->verifySettings();
+		$behavior->verifyConfig();
 	}
 
 /**
- * testVerifySettingsImplementedMethodsOverriden
+ * testVerifyConfigImplementedMethodsOverriden
  *
  * Don't expect an exception to be thrown
  *
  * @return void
  */
-	public function testVerifySettingsImplementedMethodsOverriden() {
+	public function testVerifyConfigImplementedMethodsOverriden() {
 		$table = $this->getMock('Cake\ORM\Table');
 		$behavior = new Test2Behavior($table);
 		$behavior = new Test2Behavior($table, [
@@ -341,7 +334,7 @@ class BehaviorTest extends TestCase {
 				'aliased' => 'doSomething'
 			]
 		]);
-		$behavior->verifySettings();
+		$behavior->verifyConfig();
 		$this->assertTrue(true, 'No exception thrown');
 	}
 
@@ -360,7 +353,7 @@ class BehaviorTest extends TestCase {
 				'aliased' => 'iDoNotExist'
 			]
 		]);
-		$behavior->verifySettings();
+		$behavior->verifyConfig();
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/BehaviorTest.php
+++ b/Cake/Test/TestCase/ORM/BehaviorTest.php
@@ -79,6 +79,13 @@ class Test3Behavior extends Behavior {
 	}
 
 /**
+ * Test method to ensure it is ignored as a callable method.
+ */
+	public function verifyConfig() {
+		return parent::verifyConfig();
+	}
+
+/**
  * implementedEvents
  *
  * This class does pretend to implement beforeFind


### PR DESCRIPTION
As outlined in https://github.com/cakephp/cakephp/issues/2298, I've converted the behavior + cache classes to use `_config` instead of `settings`. I've left long standing public methods alone, as changing the public interface will cause further compatibility breaks.

I didn't touch the Component or Helper classes as I think additional public methods will be required, and for example making PaginatorComponent's settings protected will break Controller::paginate().
