### PR TITLE
3.0 ORM improvements

### DIFF
--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -585,6 +585,7 @@ class Query extends DatabaseQuery {
  * @param callable $reducer
  * @param boolean $overwrite
  * @return Cake\ORM\Query|array
+ * @see Cake\ORM\MapReduce for details on how to use emit data to the map reducer.
  */
 	public function mapReduce(callable $mapper = null, callable $reducer = null, $overwrite = false) {
 		if ($overwrite) {
@@ -601,9 +602,9 @@ class Query extends DatabaseQuery {
  * Returns the first result out of executing this query, if the query has not been
  * executed before, it will set the limit clause to 1 for performance reasons.
  *
- * ###Example:
+ * ### Example:
  *
- * ``$singleUser = $query->select(['id', 'username'])->first()``
+ * `$singleUser = $query->select(['id', 'username'])->first();`
  *
  * @return mixed the first result from the ResultSet
  */
@@ -620,14 +621,16 @@ class Query extends DatabaseQuery {
  * Return the COUNT(*) for for the query.
  *
  * This method will replace the selected fields with a COUNT(*)
- * and execute the queries returning the number of rows.
+ * erase any configured mapReduce functions and execute the query
+ * returning the number of rows.
  *
  * @return integer
  */
 	public function total() {
-		return $this->select(['count' => $this->count('*')], true)
-			->hydrate(false)
-			->first()['count'];
+		$query = $this->select(['count' => $this->count('*')], true)
+			->hydrate(false);
+		$query->mapReduce(null, null, true);
+		return $query->first()['count'];
 	}
 
 /**

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -539,7 +539,7 @@ class Query extends DatabaseQuery {
 		];
 
 		foreach ($options as $option => $values) {
-			if (isset($valid[$option])) {
+			if (isset($valid[$option]) && isset($values)) {
 				$this->{$valid[$option]}($values);
 			} else {
 				$this->_options[$option] = $values;

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -617,6 +617,20 @@ class Query extends DatabaseQuery {
 	}
 
 /**
+ * Return the COUNT(*) for for the query.
+ *
+ * This method will replace the selected fields with a COUNT(*)
+ * and execute the queries returning the number of rows.
+ *
+ * @return integer
+ */
+	public function total() {
+		return $this->select(['count' => $this->count('*')], true)
+			->hydrate(false)
+			->first()['count'];
+	}
+
+/**
  * Toggle hydrating entites.
  *
  * If set to false array results will be returned

--- a/Cake/ORM/ResultSetDecorator.php
+++ b/Cake/ORM/ResultSetDecorator.php
@@ -16,9 +16,11 @@
  */
 namespace Cake\ORM;
 
+use \ArrayIterator;
 use \IteratorAggregate;
 use \JsonSerializable;
 use \Serializable;
+use \Traversable;
 
 /**
  * Generic ResultSet decorator. This will make any traversable object appear to
@@ -37,7 +39,27 @@ class ResultSetDecorator implements IteratorAggregate, Serializable, JsonSeriali
  */
 	protected $_results;
 
-	public function __construct(\Traversable $results) {
+/**
+ * Internal index pointer.
+ *
+ * @var integer
+ */
+	protected $_index = 0;
+
+/**
+ * The array form of the results. Used to 
+ * facilitate one().
+ *
+ * @var array
+ */
+	protected $_arrayResults;
+
+/**
+ * Constructor
+ *
+ * @param Traversable $results
+ */
+	public function __construct(Traversable $results) {
 		$this->_results = $results;
 	}
 
@@ -48,9 +70,26 @@ class ResultSetDecorator implements IteratorAggregate, Serializable, JsonSeriali
  */
 	public function getIterator() {
 		if (is_array($this->_results)) {
-			$this->_results = new \ArrayIterator($this->_results);
+			$this->_results = new ArrayIterator($this->_results);
 		}
 		return $this->_results;
+	}
+
+/**
+ * Get a single result from the results.
+ *
+ * @return mixed
+ */
+	public function one() {
+		if (empty($this->_arrayResults) && !is_array($this->_results)) {
+			$this->_arrayResults = iterator_to_array($this->_results);
+		}
+		$index = $this->_index;
+		$this->_index++;
+		if (!isset($this->_arrayResults[$index])) {
+			return false;
+		}
+		return $this->_arrayResults[$index];
 	}
 
 }

--- a/Cake/ORM/ResultSetDecorator.php
+++ b/Cake/ORM/ResultSetDecorator.php
@@ -17,6 +17,7 @@
 namespace Cake\ORM;
 
 use \ArrayIterator;
+use \Countable;
 use \IteratorAggregate;
 use \JsonSerializable;
 use \Serializable;
@@ -28,7 +29,7 @@ use \Traversable;
  *
  * @return void
  */
-class ResultSetDecorator implements IteratorAggregate, Serializable, JsonSerializable {
+class ResultSetDecorator implements Countable, IteratorAggregate, Serializable, JsonSerializable {
 
 	use ResultCollectionTrait;
 
@@ -38,21 +39,6 @@ class ResultSetDecorator implements IteratorAggregate, Serializable, JsonSeriali
  * @var array
  */
 	protected $_results;
-
-/**
- * Internal index pointer.
- *
- * @var integer
- */
-	protected $_index = 0;
-
-/**
- * The array form of the results. Used to 
- * facilitate one().
- *
- * @var array
- */
-	protected $_arrayResults;
 
 /**
  * Constructor
@@ -78,18 +64,35 @@ class ResultSetDecorator implements IteratorAggregate, Serializable, JsonSeriali
 /**
  * Get a single result from the results.
  *
- * @return mixed
+ * Calling this method will convert the underlying data into
+ * an array and will return the first result in the data set.
+ *
+ * @return mixed The first value in the results will be returned.
  */
 	public function one() {
-		if (empty($this->_arrayResults) && !is_array($this->_results)) {
-			$this->_arrayResults = iterator_to_array($this->_results);
+		if (!is_array($this->_results)) {
+			$this->_results = iterator_to_array($this->_results);
 		}
-		$index = $this->_index;
-		$this->_index++;
-		if (!isset($this->_arrayResults[$index])) {
+		if (count($this->_results) < 1) {
 			return false;
 		}
-		return $this->_arrayResults[$index];
+		return current($this->_results);
+	}
+
+/**
+ * Make this object countable.
+ *
+ * Part of the Countable interface. Calling this method
+ * will convert the underlying traversable object into an array and
+ * get the count of the underlying data.
+ *
+ * @return integer.
+ */
+	public function count() {
+		if (!is_array($this->_results)) {
+			$this->_results = iterator_to_array($this->_results);
+		}
+		return count($this->_results);
 	}
 
 }

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -302,6 +302,20 @@ class Table {
 	}
 
 /**
+ * Test to see if a Table has a specific field/column.
+ *
+ * Delegates to the schema object and checks for column presence
+ * using the Schema\Table instance.
+ *
+ * @param string $field The field to check for.
+ * @return boolean True if the field exists, false if it does not.
+ */
+	public function hasField($field) {
+		$schema = $this->schema();
+		return $schema->column($field) !== null;
+	}
+
+/**
  * Returns the primary key field name or sets a new one
  *
  * @param string $key sets a new name to be used as primary key

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1117,6 +1117,29 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that first can be called against a query with a mapReduce
+ *
+ * @return void
+ */
+	public function testFirstMapReduce() {
+		$map = function($key, $row, $mapReduce) {
+			$mapReduce->emitIntermediate('id', $row['id']);
+		};
+		$reduce = function($key, $values, $mapReduce) {
+			$mapReduce->emit(array_sum($values));
+		};
+
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
+		$query = new Query($this->connection, $table);
+		$query->select(['id'])
+			->hydrate(false)
+			->mapReduce($map, $reduce);
+
+		$first = $query->first();
+		$this->assertEquals(1, $first);
+	}
+
+/**
  * Testing hydrating a result set into Entity objects
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1351,4 +1351,23 @@ class QueryTest extends TestCase {
 		$this->assertInstanceOf($authorEntity, $first->author);
 	}
 
+/**
+ * Test getting totals from queries.
+ *
+ * @return void
+ */
+	public function testTotal() {
+		$table = TableRegistry::get('articles');
+		$result = $table->find('all')->total();
+		$this->assertEquals(3, $result);
+
+		$query = $table->find('all')
+			->where(['id >' => 1]);
+		$result = $query->total();
+		$this->assertEquals(2, $result);
+
+		$result = $query->execute();
+		$this->assertEquals(['count' => 2], $result->one());
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -920,6 +920,20 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * ApplyOptions should ignore null values.
+ *
+ * @return void
+ */
+	public function testApplyOptionsIgnoreNull() {
+		$options = [
+			'fields' => null,
+		];
+		$query = new Query($this->connection, $this->table);
+		$query->applyOptions($options);
+		$this->assertEquals([], $query->clause('select'));
+	}
+
+/**
  * Tests getOptions() method
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/ResultSetDecoratorTest.php
+++ b/Cake/Test/TestCase/ORM/ResultSetDecoratorTest.php
@@ -69,4 +69,31 @@ class ResultSetDecoratorTest extends TestCase {
 		$serialized = serialize($decorator);
 		$this->assertEquals([1, 2, 3], unserialize($serialized)->toArray());
 	}
+
+/**
+ * Test the one() method which is part of the ResultSet duck type.
+ *
+ * @return void
+ */
+	public function testOne() {
+		$data = new \ArrayIterator([1, 2, 3]);
+		$decorator = new ResultSetDecorator($data);
+
+		$this->assertEquals(1, $decorator->one());
+		$this->assertEquals(1, $decorator->one());
+	}
+
+/**
+ * Test the count() method which is part of the ResultSet duck type.
+ *
+ * @return void
+ */
+	public function testCount() {
+		$data = new \ArrayIterator([1, 2, 3]);
+		$decorator = new ResultSetDecorator($data);
+
+		$this->assertEquals(3, $decorator->count());
+		$this->assertCount(3, $decorator);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -30,6 +30,11 @@ class ResultSetTest extends TestCase {
 
 	public $fixtures = ['core.article'];
 
+/**
+ * setup
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$this->connection = ConnectionManager::get('test');
@@ -126,6 +131,64 @@ class ResultSetTest extends TestCase {
 
 		$expected = json_encode($this->fixtureData);
 		$this->assertEquals($expected, json_encode($results));
+	}
+
+/**
+ * Test one() method with a statement backed result set.
+ *
+ * @return void
+ */
+	public function testOne() {
+		$query = $this->table->find('all');
+		$results = $query->hydrate(false)->execute();
+
+		$row = $results->one();
+		$this->assertEquals($this->fixtureData[0], $row);
+
+		$this->assertNull($results->one(), 'No more rows.');
+		$this->assertNull($results->one(), 'No more rows.');
+	}
+
+/**
+ * Test one() method with a result set that has been unserialized
+ *
+ * @return void
+ */
+	public function testOneAfterSerialize() {
+		$query = $this->table->find('all');
+		$results = $query->hydrate(false)->execute();
+		$results = unserialize(serialize($results));
+
+		$row = $results->one();
+		$this->assertEquals($this->fixtureData[0], $row);
+
+		$this->assertNull($results->one(), 'No more rows.');
+		$this->assertNull($results->one(), 'No more rows.');
+	}
+
+/**
+ * Test the countable interface.
+ *
+ * @return void
+ */
+	public function testCount() {
+		$query = $this->table->find('all');
+		$results = $query->execute();
+
+		$this->assertCount(3, $results, 'Should be countable and 3');
+	}
+
+/**
+ * Test the countable interface after unserialize
+ *
+ * @return void
+ */
+	public function testCountAfterSerialize() {
+		$query = $this->table->find('all');
+		$results = $query->execute();
+		$results = unserialize(serialize($results));
+
+		$this->assertCount(3, $results, 'Should be countable and 3');
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1774,4 +1774,16 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertFalse($result);
 	}
 
+/**
+ * test hasField()
+ *
+ * @return void
+ */
+	public function testHasField() {
+		$table = TableRegistry::get('articles');
+		$this->assertFalse($table->hasField('nope'), 'Should not be there.');
+		$this->assertTrue($table->hasField('title'), 'Should be there.');
+		$this->assertTrue($table->hasField('body'), 'Should be there.');
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -569,6 +569,17 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'connection' => $this->connection,
 		]);
 		$table->displayField('username');
+		$query = $table->find('list')
+			->hydrate(false)
+			->order('id');
+		$expected = [
+			1 => 'mariano',
+			2 => 'nate',
+			3 => 'larry',
+			4 => 'garrett'
+		];
+		$this->assertSame($expected, $query->toArray());
+
 		$query = $table->find('list', ['fields' => ['id', 'username']])
 			->hydrate(false)
 			->order('id');


### PR DESCRIPTION
I've started working on the required changes to get the PaginatorComponent working with the new ORM. I've run into enough complications that I had to do a separate set of changes to fix/add some of the missing features. A quick rundown of the things changed:
- I added `Query::total()` to get the total number of rows from a query. I would have called the method `count` but that creates a function expression instead. I'd love to have a better name, but this is what I could come up with. I feel this method is useful as it encapsulates doing a `COUNT(*)` with a given set of joins, conditions, group + having.
- `Query::applyOptions()` now ignores null values. This solves issues when building queries dynamically.
- `Table::hasField` was added. This is useful for providing a simple external interface to check if a table has a specific field without forcing the caller to know about the schema system.
- `ResultSet` is now countable. There were a few places where the results of find were expected to be countable, so it made sense to me that a database resultset could have its length know.
- `ResultSetDecorator` was missing a few methods which caused fatal errors when you combined mapReduce() with first().
