### PR TITLE
Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.

### DIFF
--- a/Cake/Test/TestCase/View/JsonViewTest.php
+++ b/Cake/Test/TestCase/View/JsonViewTest.php
@@ -46,6 +46,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('data' => array('user' => 'fake', 'list' => array('item1', 'item2'))),
 				'data',
+				null,
 				json_encode(array('user' => 'fake', 'list' => array('item1', 'item2')))
 			),
 
@@ -53,6 +54,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('data' => array('user' => 'fake', 'list' => array('item1', 'item2'))),
 				'no_key',
+				null,
 				json_encode(null)
 			),
 
@@ -60,6 +62,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				array('no', 'user'),
+				null,
 				json_encode(array('no' => 'nope', 'user' => 'fake'))
 			),
 
@@ -67,6 +70,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				array(),
+				null,
 				json_encode(null)
 			),
 
@@ -74,6 +78,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				array('no', 'user', 'no_key'),
+				null,
 				json_encode(array('no' => 'nope', 'user' => 'fake'))
 			),
 
@@ -81,12 +86,14 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				array('no_key'),
+				null,
 				json_encode(null)
 			),
 
 			// Test render with Null in _serialize (unset).
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
+				null,
 				null,
 				null
 			),
@@ -95,6 +102,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				false,
+				null,
 				json_encode(null)
 			),
 
@@ -102,6 +110,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				true,
+				null,
 				json_encode(null)
 			),
 
@@ -109,6 +118,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				'',
+				null,
 				json_encode(null)
 			),
 
@@ -116,6 +126,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('original_name' => 'my epic name', 'user' => 'fake', 'list' => array('item1', 'item2')),
 				array('new_name' => 'original_name', 'user'),
+				null,
 				json_encode(array('new_name' => 'my epic name', 'user' => 'fake'))
 			),
 
@@ -123,6 +134,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('null' => null),
 				array('null'),
+				null,
 				json_encode(array('null' => null))
 			),
 
@@ -130,6 +142,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('false' => false),
 				'false',
+				null,
 				json_encode(false)
 			),
 
@@ -137,6 +150,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('true' => true),
 				'true',
+				null,
 				json_encode(true)
 			),
 
@@ -144,6 +158,7 @@ class JsonViewTest extends TestCase {
 			array(
 				array('empty' => ''),
 				'empty',
+				null,
 				json_encode('')
 			),
 
@@ -151,7 +166,32 @@ class JsonViewTest extends TestCase {
 			array(
 				array('zero' => 0),
 				'zero',
+				null,
 				json_encode(0)
+			),
+
+			// Test render with encode <, >, ', &, and " for RFC4627-compliant to be serialized.
+			array(
+				array('rfc4627_escape' => '<tag> \'quote\' "double-quote" &'),
+				'rfc4627_escape',
+				null,
+				json_encode('<tag> \'quote\' "double-quote" &', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT)
+			),
+
+			// Test render with _jsonOptions null to be serialized.
+			array(
+				array('noescape' => '<tag> \'quote\' "double-quote" &'),
+				'noescape',
+				false,
+				json_encode('<tag> \'quote\' "double-quote" &')
+			),
+
+			// Test render with setting _jsonOptions to be serialized.
+			array(
+				array('rfc4627_escape' => '<tag> \'quote\' "double-quote" &'),
+				'rfc4627_escape',
+				JSON_HEX_TAG | JSON_HEX_APOS,
+				json_encode('<tag> \'quote\' "double-quote" &', JSON_HEX_TAG | JSON_HEX_APOS)
 			),
 		);
 	}
@@ -162,13 +202,14 @@ class JsonViewTest extends TestCase {
  * @dataProvider renderWithoutViewProvider
  * @return void
  */
-	public function testRenderWithoutView($data, $serialize, $expected) {
+	public function testRenderWithoutView($data, $serialize, $jsonOptions, $expected) {
 		$Request = new Request();
 		$Response = new Response();
 		$Controller = new Controller($Request, $Response);
 
 		$Controller->set($data);
 		$Controller->set('_serialize', $serialize);
+		$Controller->set('_jsonOptions', $jsonOptions);
 		$View = new JsonView($Controller);
 		$output = $View->render(false);
 

--- a/Cake/Test/TestCase/View/JsonViewTest.php
+++ b/Cake/Test/TestCase/View/JsonViewTest.php
@@ -178,7 +178,7 @@ class JsonViewTest extends TestCase {
 				json_encode('<tag> \'quote\' "double-quote" &', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT)
 			),
 
-			// Test render with _jsonOptions null to be serialized.
+			// Test render with _jsonOptions = false to be serialized.
 			array(
 				array('noescape' => '<tag> \'quote\' "double-quote" &'),
 				'noescape',

--- a/Cake/View/JsonView.php
+++ b/Cake/View/JsonView.php
@@ -146,11 +146,16 @@ class JsonView extends View {
 			$data = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
 		}
 
-		if (Configure::read('debug')) {
-			return json_encode($data, JSON_PRETTY_PRINT);
+		$jsonOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+		if (isset($this->viewVars['_jsonOptions'])) {
+			$jsonOptions = $this->viewVars['_jsonOptions'];
 		}
 
-		return json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
+		if (Configure::read('debug')) {
+			return json_encode($data, $jsonOptions | JSON_PRETTY_PRINT);
+		}
+
+		return json_encode($data, $jsonOptions);
 	}
 
 }

--- a/Cake/View/JsonView.php
+++ b/Cake/View/JsonView.php
@@ -150,7 +150,7 @@ class JsonView extends View {
 			return json_encode($data, JSON_PRETTY_PRINT);
 		}
 
-		return json_encode($data);
+		return json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 	}
 
 }

--- a/Cake/View/JsonView.php
+++ b/Cake/View/JsonView.php
@@ -148,7 +148,11 @@ class JsonView extends View {
 
 		$jsonOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
 		if (isset($this->viewVars['_jsonOptions'])) {
-			$jsonOptions = $this->viewVars['_jsonOptions'];
+			if ($this->viewVars['_jsonOptions'] === false) {
+				$jsonOptions = 0;
+			} else {
+				$jsonOptions = $this->viewVars['_jsonOptions'];
+			}
 		}
 
 		if (Configure::read('debug')) {


### PR DESCRIPTION
Those who RFC compliant or not than good?
As shown in the code this 
https://github.com/symfony/HttpFoundation/blob/master/JsonResponse.php#L92
