### PR TITLE
Extract cache engine defaults to a defaultConfig property

### DIFF
--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -364,22 +364,6 @@ class Cache {
 	}
 
 /**
- * Return the settings for the named cache engine.
- *
- * @param string $name Name of the configuration to get settings for. Defaults to 'default'
- * @return array list of settings for this engine
- * @see Cache::config()
- */
-	public static function settings($config = 'default') {
-		$engine = static::engine($config);
-		if (!$engine) {
-			return [];
-		}
-
-		return $engine->settings();
-	}
-
-/**
  * Retrieve group names to config mapping.
  *
  * {{{

--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -76,7 +76,7 @@ use Cake\Utility\Inflector;
  *
  * @see app/Config/core.php for configuration settings
  * @param string $name Name of the configuration
- * @param array $settings Optional associative array of settings passed to the engine
+ * @param array $config Optional associative array of settings passed to the engine
  * @return array [engine, settings] on success, false on failure
  * @throws Cake\Error\Exception
  */
@@ -208,17 +208,17 @@ class Cache {
  */
 	public static function write($key, $value, $config = 'default') {
 		$engine = static::engine($config);
-		$settings = static::settings($config);
-
 		if (!$engine) {
 			return false;
 		}
-		$key = $engine->key($key);
 
+		$key = $engine->key($key);
 		if (!$key || is_resource($value)) {
 			return false;
 		}
-		$success = $engine->write($settings['prefix'] . $key, $value, $settings['duration']);
+
+		$config = $engine->config();
+		$success = $engine->write($config['prefix'] . $key, $value, $config['duration']);
 		if ($success === false && $value !== '') {
 			trigger_error(
 				__d('cake_dev',
@@ -252,7 +252,6 @@ class Cache {
  */
 	public static function read($key, $config = 'default') {
 		$engine = static::engine($config);
-		$settings = static::settings($config);
 		if (!$engine) {
 			return false;
 		}
@@ -262,7 +261,8 @@ class Cache {
 			return false;
 		}
 
-		return $engine->read($settings['prefix'] . $key);
+		$config = $engine->config();
+		return $engine->read($config['prefix'] . $key);
 	}
 
 /**
@@ -276,17 +276,17 @@ class Cache {
  */
 	public static function increment($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		$settings = static::settings($config);
-
 		if (!$engine) {
 			return false;
 		}
-		$key = $engine->key($key);
 
+		$key = $engine->key($key);
 		if (!$key || !is_int($offset) || $offset < 0) {
 			return false;
 		}
-		return $engine->increment($settings['prefix'] . $key, $offset);
+
+		$config = $engine->config();
+		return $engine->increment($config['prefix'] . $key, $offset);
 	}
 
 /**
@@ -300,17 +300,17 @@ class Cache {
  */
 	public static function decrement($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		$settings = static::settings($config);
-
 		if (!$engine) {
 			return false;
 		}
-		$key = $engine->key($key);
 
+		$key = $engine->key($key);
 		if (!$key || !is_int($offset) || $offset < 0) {
 			return false;
 		}
-		return $engine->decrement($settings['prefix'] . $key, $offset);
+
+		$config = $engine->config();
+		return $engine->decrement($config['prefix'] . $key, $offset);
 	}
 
 /**
@@ -331,9 +331,7 @@ class Cache {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public static function delete($key, $config = 'default') {
-		$settings = static::settings($config);
 		$engine = static::engine($config);
-
 		if (!$engine) {
 			return false;
 		}
@@ -343,7 +341,8 @@ class Cache {
 			return false;
 		}
 
-		return $engine->delete($settings['prefix'] . $key);
+		$config = $engine->config();
+		return $engine->delete($config['prefix'] . $key);
 	}
 
 /**

--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -57,22 +57,7 @@ use Cake\Utility\Inflector;
  *   This engine is recommended to people deploying on windows with IIS.
  * - `RedisEngine` - Uses redis and php-redis extension to store cache data.
  *
- * The following keys are used in core cache engines:
- *
- * - `duration` Specify how long items in this cache configuration last.
- * - `groups` List of groups or 'tags' associated to every key stored in this config.
- *    handy for deleting a complete group from cache.
- * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
- *    with either another cache config or another application.
- * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
- *    cache::gc from ever being called automatically.
- * - `servers' Used by memcache. Give the address of the memcached servers to use.
- * - `compress` Used by memcache. Enables memcache's compressed format.
- * - `serialize` Used by FileCache. Should cache objects be serialized first.
- * - `path` Used by FileCache. Path to where cachefiles should be saved.
- * - `lock` Used by FileCache. Should files be locked before writing to them?
- * - `user` Used by Xcache. Username for XCache
- * - `password` Used by Xcache/Redis. Password for XCache/Redis
+ * See Cache engine documentation for expected configuration keys.
  *
  * @see app/Config/core.php for configuration settings
  * @param string $name Name of the configuration

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -33,7 +33,7 @@ abstract class CacheEngine {
  * Default configuration
  *
  * These settings apply to all cache engines, and can be overriden by a specific cache
- * engine or runtime settings
+ * engine or runtime config
  *
  * @var array
  */
@@ -165,7 +165,7 @@ abstract class CacheEngine {
  *
  * @return array config
  */
-	public function settings() {
+	public function config() {
 		return $this->_config;
 	}
 

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -30,6 +30,21 @@ abstract class CacheEngine {
 	protected $_config = [];
 
 /**
+ * Default configuration
+ *
+ * These settings apply to all cache engines, and can be overriden by a specific cache
+ * engine or runtime settings
+ *
+ * @var array
+ */
+	protected static $_defaultConfig = [
+		'prefix' => 'cake_',
+		'duration' => 3600,
+		'probability' => 100,
+		'groups' => []
+	];
+
+/**
  * Contains the compiled string with all groups
  * prefixes to be prepended to every key in this cache engine
  *
@@ -40,18 +55,14 @@ abstract class CacheEngine {
 /**
  * Initialize the cache engine
  *
- * Called automatically by the cache frontend
+ * Called automatically by the cache frontend. Merge the runtime config with the defaults
+ * for the specific cache engine, and the general defaults before use
  *
  * @param array $config Associative array of parameters for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($config = []) {
-		$config += $this->_config + [
-			'prefix' => 'cake_',
-			'duration' => 3600,
-			'probability' => 100,
-			'groups' => []
-		];
+		$config += $this->_config + static::$_defaultConfig + self::$_defaultConfig;
 		$this->_config = $config;
 		if (!empty($this->_config['groups'])) {
 			sort($this->_config['groups']);

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -45,7 +45,7 @@ abstract class CacheEngine {
  *
  * @var array
  */
-	protected static $_defaultConfig = [
+	protected $_defaultConfig = [
 		'duration' => 3600,
 		'groups' => [],
 		'prefix' => 'cake_',
@@ -70,7 +70,7 @@ abstract class CacheEngine {
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($config = []) {
-		$config += $this->_config + static::$_defaultConfig;
+		$config += $this->_config + $this->_defaultConfig;
 		$this->_config = $config;
 		if (!empty($this->_config['groups'])) {
 			sort($this->_config['groups']);

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -23,25 +23,33 @@ use Cake\Utility\Inflector;
 abstract class CacheEngine {
 
 /**
- * Settings of current engine instance
+ * Runtime config
+ *
+ * This is the config of a particular instance
  *
  * @var array
  */
 	protected $_config = [];
 
 /**
- * Default configuration
+ * The default cache configuration is overriden in most cache adapters. These are
+ * the keys that are common to all adapters. If overriden, this property is not used.
  *
- * These settings apply to all cache engines, and can be overriden by a specific cache
- * engine or runtime config
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
  *
  * @var array
  */
 	protected static $_defaultConfig = [
-		'prefix' => 'cake_',
 		'duration' => 3600,
-		'probability' => 100,
-		'groups' => []
+		'groups' => [],
+		'prefix' => 'cake_',
+		'probability' => 100
 	];
 
 /**
@@ -62,7 +70,7 @@ abstract class CacheEngine {
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($config = []) {
-		$config += $this->_config + static::$_defaultConfig + self::$_defaultConfig;
+		$config += $this->_config + static::$_defaultConfig;
 		$this->_config = $config;
 		if (!empty($this->_config['groups'])) {
 			sort($this->_config['groups']);

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -64,7 +64,7 @@ abstract class CacheEngine {
  * Initialize the cache engine
  *
  * Called automatically by the cache frontend. Merge the runtime config with the defaults
- * for the specific cache engine, and the general defaults before use
+ * before use.
  *
  * @param array $config Associative array of parameters for the engine
  * @return boolean True if the engine has been successfully initialized, false if not

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -70,8 +70,7 @@ abstract class CacheEngine {
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($config = []) {
-		$config += $this->_config + $this->_defaultConfig;
-		$this->_config = $config;
+		$this->_config = $config + $this->_defaultConfig;
 		if (!empty($this->_config['groups'])) {
 			sort($this->_config['groups']);
 			$this->_groupPrefix = str_repeat('%s_', count($this->_config['groups']));

--- a/Cake/Cache/CacheRegistry.php
+++ b/Cake/Cache/CacheRegistry.php
@@ -60,19 +60,19 @@ class CacheRegistry extends ObjectRegistry {
  * Part of the template method for Cake\Utility\ObjectRegistry::load()
  * @param string|CacheEngine $class The classname or object to make.
  * @param string $alias The alias of the object.
- * @param array $settings An array of settings to use for the cache engine.
+ * @param array $config An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
  * @throws Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
-	protected function _create($class, $alias, $settings) {
+	protected function _create($class, $alias, $config) {
 		if (is_object($class)) {
 			$instance = $class;
 		}
 
-		unset($settings['className']);
+		unset($config['className']);
 		if (!isset($instance)) {
-			$instance = new $class($settings);
+			$instance = new $class($config);
 		}
 
 		if (!($instance instanceof CacheEngine)) {
@@ -82,14 +82,14 @@ class CacheRegistry extends ObjectRegistry {
 			));
 		}
 
-		if (!$instance->init($settings)) {
+		if (!$instance->init($config)) {
 			throw new Error\Exception(
 				__d('cake_dev', 'Cache engine %s is not properly configured.', $class)
 			);
 		}
 
-		$settings = $instance->settings();
-		if ($settings['probability'] && time() % $settings['probability'] === 0) {
+		$config = $instance->config();
+		if ($config['probability'] && time() % $config['probability'] === 0) {
 			$instance->gc();
 		}
 		return $instance;

--- a/Cake/Cache/Engine/ApcEngine.php
+++ b/Cake/Cache/Engine/ApcEngine.php
@@ -36,14 +36,14 @@ class ApcEngine extends CacheEngine {
  *
  * Called automatically by the cache frontend
  *
- * @param array $settings array of setting for the engine
+ * @param array $config array of setting for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
  */
-	public function init($settings = []) {
-		if (!isset($settings['prefix'])) {
-			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
+	public function init($config = []) {
+		if (!isset($config['prefix'])) {
+			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
-		parent::init($settings);
+		parent::init($config);
 		return function_exists('apc_dec');
 	}
 
@@ -73,7 +73,7 @@ class ApcEngine extends CacheEngine {
 	public function read($key) {
 		$time = time();
 		$cachetime = intval(apc_fetch($key . '_expires'));
-		if ($cachetime !== 0 && ($cachetime < $time || ($time + $this->settings['duration']) < $cachetime)) {
+		if ($cachetime !== 0 && ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime)) {
 			return false;
 		}
 		return apc_fetch($key);
@@ -126,7 +126,7 @@ class ApcEngine extends CacheEngine {
 		$cacheKeys = $info['cache_list'];
 		unset($info);
 		foreach ($cacheKeys as $key) {
-			if (strpos($key['info'], $this->settings['prefix']) === 0) {
+			if (strpos($key['info'], $this->_config['prefix']) === 0) {
 				apc_delete($key['info']);
 			}
 		}
@@ -142,13 +142,13 @@ class ApcEngine extends CacheEngine {
  */
 	public function groups() {
 		if (empty($this->_compiledGroupNames)) {
-			foreach ($this->settings['groups'] as $group) {
-				$this->_compiledGroupNames[] = $this->settings['prefix'] . $group;
+			foreach ($this->_config['groups'] as $group) {
+				$this->_compiledGroupNames[] = $this->_config['prefix'] . $group;
 			}
 		}
 
 		$groups = apc_fetch($this->_compiledGroupNames);
-		if (count($groups) !== count($this->settings['groups'])) {
+		if (count($groups) !== count($this->_config['groups'])) {
 			foreach ($this->_compiledGroupNames as $group) {
 				if (!isset($groups[$group])) {
 					apc_store($group, 1);
@@ -160,7 +160,7 @@ class ApcEngine extends CacheEngine {
 
 		$result = [];
 		$groups = array_values($groups);
-		foreach ($this->settings['groups'] as $i => $group) {
+		foreach ($this->_config['groups'] as $i => $group) {
 			$result[] = $group . $groups[$i];
 		}
 		return $result;
@@ -173,7 +173,7 @@ class ApcEngine extends CacheEngine {
  * @return boolean success
  */
 	public function clearGroup($group) {
-		apc_inc($this->settings['prefix'] . $group, 1, $success);
+		apc_inc($this->_config['prefix'] . $group, 1, $success);
 		return $success;
 	}
 

--- a/Cake/Cache/Engine/FileEngine.php
+++ b/Cake/Cache/Engine/FileEngine.php
@@ -45,7 +45,7 @@ class FileEngine extends CacheEngine {
 	protected $_File = null;
 
 /**
- * The defaults used unless overriden by runtime configuration
+ * The default config used unless overriden by runtime configuration
  *
  * - `duration` Specify how long items in this cache configuration last.
  * - `groups` List of groups or 'tags' associated to every key stored in this config.

--- a/Cake/Cache/Engine/FileEngine.php
+++ b/Cake/Cache/Engine/FileEngine.php
@@ -45,29 +45,33 @@ class FileEngine extends CacheEngine {
 	protected $_File = null;
 
 /**
- * Settings
+ * The defaults used unless overriden by runtime configuration
  *
- * - path = absolute path to cache directory, default => CACHE
- * - prefix = string prefix for filename, default => cake_
- * - lock = enable file locking on write, default => true
- * - serialize = serialize the data, default => true
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `isWindows` Automatically populated with whether the host is windows or not
+ * - `lock` Used by FileCache. Should files be locked before writing to them?
+ * - `mask` The mask used for created files
+ * - `path` Path to where cachefiles should be saved.
+ * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
+ * - `serialize` Should cache objects be serialized first.
  *
  * @var array
  */
-	protected $_config = [];
-
-/**
- * _defaultConfig
- *
- * @var mixed
- */
 	protected static $_defaultConfig = [
+		'duration' => 3600,
+		'groups' => [],
+		'isWindows' => false,
+		'lock' => true,
+		'mask' => 0664,
 		'path' => CACHE,
 		'prefix' => 'cake_',
-		'lock' => true,
-		'serialize' => true,
-		'isWindows' => false,
-		'mask' => 0664
+		'probability' => 100,
+		'serialize' => true
 	];
 
 /**

--- a/Cake/Cache/Engine/FileEngine.php
+++ b/Cake/Cache/Engine/FileEngine.php
@@ -62,7 +62,7 @@ class FileEngine extends CacheEngine {
  *
  * @var array
  */
-	protected static $_defaultConfig = [
+	protected $_defaultConfig = [
 		'duration' => 3600,
 		'groups' => [],
 		'isWindows' => false,

--- a/Cake/Cache/Engine/FileEngine.php
+++ b/Cake/Cache/Engine/FileEngine.php
@@ -57,6 +57,20 @@ class FileEngine extends CacheEngine {
 	protected $_config = [];
 
 /**
+ * _defaultConfig
+ *
+ * @var mixed
+ */
+	protected static $_defaultConfig = [
+		'path' => CACHE,
+		'prefix' => 'cake_',
+		'lock' => true,
+		'serialize' => true,
+		'isWindows' => false,
+		'mask' => 0664
+	];
+
+/**
  * True unless FileEngine::__active(); fails
  *
  * @var boolean
@@ -72,14 +86,6 @@ class FileEngine extends CacheEngine {
  * @return boolean True if the engine has been successfully initialized, false if not
  */
 	public function init($config = []) {
-		$config += [
-			'path' => CACHE,
-			'prefix' => 'cake_',
-			'lock' => true,
-			'serialize' => true,
-			'isWindows' => false,
-			'mask' => 0664
-		];
 		parent::init($config);
 
 		if (DS === '\\') {

--- a/Cake/Cache/Engine/MemcachedEngine.php
+++ b/Cake/Cache/Engine/MemcachedEngine.php
@@ -40,7 +40,7 @@ class MemcachedEngine extends CacheEngine {
 	protected $_Memcached = null;
 
 /**
- * The defaults used unless overriden by runtime configuration
+ * The default config used unless overriden by runtime configuration
  *
  * - `compress` Whether to compress data
  * - `duration` Specify how long items in this cache configuration last.

--- a/Cake/Cache/Engine/MemcachedEngine.php
+++ b/Cake/Cache/Engine/MemcachedEngine.php
@@ -40,35 +40,39 @@ class MemcachedEngine extends CacheEngine {
 	protected $_Memcached = null;
 
 /**
- * Settings
- *
- *  - servers = string or array of memcached servers, default => 127.0.0.1. If an
- *    array MemcacheEngine will use them as a pool.
- *  - compress = boolean, default => false
- *  - persistent = string The name of the persistent connection. All configurations using
- *    the same persistent value will share a single underlying connection.
- *  - serialize = string, default => php. The serializer engine used to serialize data.
- *    Available engines are php, igbinary and json. Beside php, the memcached extension
- *    must be compiled with the appropriate serializer support.
- *
- * @var array
- */
-	protected $_config = [];
-
-/**
- * Default config
- *
  * The defaults used unless overriden by runtime configuration
+ *
+ * - `compress` Whether to compress data
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `login` Login to access the Memcache server
+ * - `password` Password to access the Memcache server
+ * - `persistent` The name of the persistent connection. All configurations using
+ *    the same persistent value will share a single underlying connection.
+ * - `prefix` Prepended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
+ * - `serialize` The serializer engine used to serialize data. Available engines are php,
+ *    igbinary and json. Beside php, the memcached extension must be compiled with the
+ *    appropriate serializer support.
+ * - `servers` String or array of memcached servers. If an array MemcacheEngine will use
+ *    them as a pool.
  *
  * @var array
  */
 	protected static $_defaultConfig = [
-		'servers' => ['127.0.0.1'],
 		'compress' => false,
-		'persistent' => false,
+		'duration' => 3600,
+		'groups' => [],
 		'login' => null,
 		'password' => null,
-		'serialize' => 'php'
+		'persistent' => false,
+		'prefix' => 'cake_',
+		'probability' => 100,
+		'serialize' => 'php',
+		'servers' => ['127.0.0.1'],
 	];
 
 /**

--- a/Cake/Cache/Engine/MemcachedEngine.php
+++ b/Cake/Cache/Engine/MemcachedEngine.php
@@ -62,7 +62,7 @@ class MemcachedEngine extends CacheEngine {
  *
  * @var array
  */
-	protected static $_defaultConfig = [
+	protected $_defaultConfig = [
 		'compress' => false,
 		'duration' => 3600,
 		'groups' => [],

--- a/Cake/Cache/Engine/MemcachedEngine.php
+++ b/Cake/Cache/Engine/MemcachedEngine.php
@@ -56,6 +56,22 @@ class MemcachedEngine extends CacheEngine {
 	protected $_config = [];
 
 /**
+ * Default config
+ *
+ * The defaults used unless overriden by runtime configuration
+ *
+ * @var array
+ */
+	protected static $_defaultConfig = [
+		'servers' => ['127.0.0.1'],
+		'compress' => false,
+		'persistent' => false,
+		'login' => null,
+		'password' => null,
+		'serialize' => 'php'
+	];
+
+/**
  * List of available serializer engines
  *
  * Memcached must be compiled with json and igbinary support to use these engines
@@ -84,14 +100,6 @@ class MemcachedEngine extends CacheEngine {
 		if (!isset($config['prefix'])) {
 			$config['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
-		$config += [
-			'servers' => ['127.0.0.1'],
-			'compress' => false,
-			'persistent' => false,
-			'login' => null,
-			'password' => null,
-			'serialize' => 'php'
-		];
 		parent::init($config);
 
 		if (!is_array($this->_config['servers'])) {

--- a/Cake/Cache/Engine/RedisEngine.php
+++ b/Cake/Cache/Engine/RedisEngine.php
@@ -31,7 +31,7 @@ class RedisEngine extends CacheEngine {
 	protected $_Redis = null;
 
 /**
- * The defaults used unless overriden by runtime configuration
+ * The default config used unless overriden by runtime configuration
  *
  * - `database` database number to use for connection.
  * - `duration` Specify how long items in this cache configuration last.

--- a/Cake/Cache/Engine/RedisEngine.php
+++ b/Cake/Cache/Engine/RedisEngine.php
@@ -44,6 +44,23 @@ class RedisEngine extends CacheEngine {
 	protected $_config = [];
 
 /**
+ * Default config
+ *
+ * The defaults used unless overriden by runtime configuration
+ *
+ * @var array
+ */
+	protected static $_defaultConfig = [
+		'prefix' => null,
+		'server' => '127.0.0.1',
+		'database' => 0,
+		'port' => 6379,
+		'password' => false,
+		'timeout' => 0,
+		'persistent' => true
+	];
+
+/**
  * Initialize the Cache Engine
  *
  * Called automatically by the cache frontend
@@ -55,16 +72,7 @@ class RedisEngine extends CacheEngine {
 		if (!class_exists('Redis')) {
 			return false;
 		}
-		parent::init(array_merge([
-			'prefix' => null,
-			'server' => '127.0.0.1',
-			'database' => 0,
-			'port' => 6379,
-			'password' => false,
-			'timeout' => 0,
-			'persistent' => true
-			], $config)
-		);
+		parent::init($config);
 
 		return $this->_connect();
 	}

--- a/Cake/Cache/Engine/RedisEngine.php
+++ b/Cake/Cache/Engine/RedisEngine.php
@@ -31,33 +31,35 @@ class RedisEngine extends CacheEngine {
 	protected $_Redis = null;
 
 /**
- * Settings
- *
- *  - server = string URL or ip to the Redis server host
- *  - database = integer database number to use for connection
- *  - port = integer port number to the Redis server (default: 6379)
- *  - timeout = float timeout in seconds (default: 0)
- *  - persistent = boolean Connects to the Redis server with a persistent connection (default: true)
- *
- * @var array
- */
-	protected $_config = [];
-
-/**
- * Default config
- *
  * The defaults used unless overriden by runtime configuration
+ *
+ * - `database` database number to use for connection.
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `password` Redis server password.
+ * - `persistent` Connect to the Redis server with a persistent connection
+ * - `port` port number to the Redis server.
+ * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
+ * - `server` URL or ip to the Redis server host.
+ * - `timeout` timeout in seconds (float).
  *
  * @var array
  */
 	protected static $_defaultConfig = [
-		'prefix' => null,
-		'server' => '127.0.0.1',
 		'database' => 0,
-		'port' => 6379,
+		'duration' => 3600,
+		'groups' => [],
 		'password' => false,
-		'timeout' => 0,
-		'persistent' => true
+		'persistent' => true,
+		'port' => 6379,
+		'prefix' => null,
+		'probability' => 100,
+		'server' => '127.0.0.1',
+		'timeout' => 0
 	];
 
 /**

--- a/Cake/Cache/Engine/RedisEngine.php
+++ b/Cake/Cache/Engine/RedisEngine.php
@@ -49,7 +49,7 @@ class RedisEngine extends CacheEngine {
  *
  * @var array
  */
-	protected static $_defaultConfig = [
+	protected $_defaultConfig = [
 		'database' => 0,
 		'duration' => 3600,
 		'groups' => [],

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -28,7 +28,7 @@ use Cake\Cache\CacheEngine;
 class XcacheEngine extends CacheEngine {
 
 /**
- * The defaults used unless overriden by runtime configuration
+ * The default config used unless overriden by runtime configuration
  *
  * - `duration` Specify how long items in this cache configuration last.
  * - `groups` List of groups or 'tags' associated to every key stored in this config.

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -28,22 +28,25 @@ use Cake\Cache\CacheEngine;
 class XcacheEngine extends CacheEngine {
 
 /**
- * Settings
+ * The defaults used unless overriden by runtime configuration
  *
- *  - PHP_AUTH_USER = xcache.admin.user, default cake
- *  - PHP_AUTH_PW = xcache.admin.password, default cake
- *
- * @var array
- */
-	protected $_config = [];
-
-/**
- * Default config
+ * - `duration` Specify how long items in this cache configuration last.
+ * - `groups` List of groups or 'tags' associated to every key stored in this config.
+ *    handy for deleting a complete group from cache.
+ * - `prefix` Prefix appended to all entries. Good for when you need to share a keyspace
+ *    with either another cache config or another application.
+ * - `probability` Probability of hitting a cache gc cleanup. Setting to 0 will disable
+ *    cache::gc from ever being called automatically.
+ * - `PHP_AUTH_USER` xcache.admin.user
+ * - `PHP_AUTH_PW` xcache.admin.password
  *
  * @var array
  */
 	protected static $_defaultConfig = [
+		'duration' => 3600,
+		'groups' => [],
 		'prefix' => null,
+		'probability' => 100,
 		'PHP_AUTH_USER' => 'user',
 		'PHP_AUTH_PW' => 'password'
 	];
@@ -192,7 +195,7 @@ class XcacheEngine extends CacheEngine {
 	protected function _auth($reverse = false) {
 		static $backup = [];
 		$keys = ['PHP_AUTH_USER' => 'user', 'PHP_AUTH_PW' => 'password'];
-		foreach ($keys as $key => $setting) {
+		foreach ($keys as $key => $value) {
 			if ($reverse) {
 				if (isset($backup[$key])) {
 					$_SERVER[$key] = $backup[$key];
@@ -205,8 +208,8 @@ class XcacheEngine extends CacheEngine {
 				if (!empty($value)) {
 					$backup[$key] = $value;
 				}
-				if (!empty($this->_config[$setting])) {
-					$_SERVER[$key] = $this->_config[$setting];
+				if (!empty($this->_config[$value])) {
+					$_SERVER[$key] = $this->_config[$value];
 				} elseif (!empty($this->_config[$key])) {
 					$_SERVER[$key] = $this->_config[$key];
 				} else {

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -38,6 +38,17 @@ class XcacheEngine extends CacheEngine {
 	protected $_config = [];
 
 /**
+ * Default config
+ *
+ * @var array
+ */
+	protected static $_defaultConfig = [
+		'prefix' => null,
+		'PHP_AUTH_USER' => 'user',
+		'PHP_AUTH_PW' => 'password'
+	];
+
+/**
  * Initialize the Cache Engine
  *
  * Called automatically by the cache frontend
@@ -47,12 +58,10 @@ class XcacheEngine extends CacheEngine {
  */
 	public function init($config = []) {
 		if (php_sapi_name() !== 'cli') {
-			parent::init(array_merge([
-				'prefix' => Inflector::slug(APP_DIR) . '_',
-				'PHP_AUTH_USER' => 'user',
-				'PHP_AUTH_PW' => 'password'
-				], $config)
-			);
+			if (!isset($config['prefix'])) {
+				$config['prefix'] = Inflector::slug(APP_DIR) . '_';
+			}
+			parent::init($config);
 			return function_exists('xcache_info');
 		}
 		return false;

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -42,7 +42,7 @@ class XcacheEngine extends CacheEngine {
  *
  * @var array
  */
-	protected static $_defaultConfig = [
+	protected $_defaultConfig = [
 		'duration' => 3600,
 		'groups' => [],
 		'prefix' => null,

--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -22,9 +22,9 @@ use Cake\ORM\Table;
 class TimestampBehavior extends Behavior {
 
 /**
- * Default settings
+ * Default config
  *
- * These are merged with user-provided settings when the behavior is used.
+ * These are merged with user-provided config when the behavior is used.
  *
  * events - an event-name keyed array of which fields to update, and when, for a given event
  * possible values for when a field will be updated are "always", "new" or "existing", to set
@@ -68,11 +68,11 @@ class TimestampBehavior extends Behavior {
  */
 	public function handleEvent(Event $event, Entity $entity) {
 		$eventName = $event->name();
-		$settings = $this->config();
+		$config = $this->config();
 
 		$new = $entity->isNew() !== false;
 
-		foreach ($settings['events'][$eventName] as $field => $when) {
+		foreach ($config['events'][$eventName] as $field => $when) {
 			if (!in_array($when, ['always', 'new', 'existing'])) {
 				throw new \UnexpectedValueException(
 					__d('cake_dev', 'When should be one of "always", "new" or "existing". The passed value "%s" is invalid', $when)
@@ -83,7 +83,7 @@ class TimestampBehavior extends Behavior {
 				($when === 'new' && $new) ||
 				($when === 'existing' && !$new)
 			) {
-				$this->_updateField($entity, $field, $settings['refreshTimestamp']);
+				$this->_updateField($entity, $field, $config['refreshTimestamp']);
 			}
 		}
 

--- a/Cake/Model/Behavior/TimestampBehavior.php
+++ b/Cake/Model/Behavior/TimestampBehavior.php
@@ -36,7 +36,7 @@ class TimestampBehavior extends Behavior {
  *
  * @var array
  */
-	protected $_defaultSettings = [
+	protected static $_defaultConfig = [
 		'implementedFinders' => [],
 		'implementedMethods' => ['timestamp' => 'timestamp'],
 		'events' => [
@@ -64,18 +64,18 @@ class TimestampBehavior extends Behavior {
  * @param Entity $entity
  * @throws \UnexpectedValueException if a field's when value is misdefined
  * @return true (irrespective of the behavior logic, the save will not be prevented)
- * @throws \UnexpectedValueException When the value for an event is not 'new', 'existing' or true.
+ * @throws \UnexpectedValueException When the value for an event is not 'always', 'new' or 'existing'
  */
 	public function handleEvent(Event $event, Entity $entity) {
 		$eventName = $event->name();
-		$settings = $this->settings();
+		$settings = $this->config();
 
 		$new = $entity->isNew() !== false;
 
 		foreach ($settings['events'][$eventName] as $field => $when) {
 			if (!in_array($when, ['always', 'new', 'existing'])) {
 				throw new \UnexpectedValueException(
-					__d('cake', 'When should be one of "always", "new" or "existing". The passed value "%s" is invalid', $when)
+					__d('cake_dev', 'When should be one of "always", "new" or "existing". The passed value "%s" is invalid', $when)
 				);
 			}
 			if (
@@ -98,7 +98,7 @@ class TimestampBehavior extends Behavior {
  * @return array
  */
 	public function implementedEvents() {
-		return array_fill_keys(array_keys($this->_settings['events']), 'handleEvent');
+		return array_fill_keys(array_keys($this->_config['events']), 'handleEvent');
 	}
 
 /**

--- a/Cake/ORM/Behavior.php
+++ b/Cake/ORM/Behavior.php
@@ -109,7 +109,7 @@ class Behavior implements EventListener {
  *
  * @var array
  */
-	protected $_defaultConfig = [];
+	protected static $_defaultConfig = [];
 
 /**
  * Contains configuration.
@@ -130,7 +130,7 @@ class Behavior implements EventListener {
  * @param array $config The config for this behavior.
  */
 	public function __construct(Table $table, array $config = []) {
-		$this->_config = $config + $this->_defaultConfig;
+		$this->_config = $config + static::$_defaultConfig;
 	}
 
 /**

--- a/Cake/Test/TestApp/View/Pages/home.ctp
+++ b/Cake/Test/TestApp/View/Pages/home.ctp
@@ -67,7 +67,8 @@ endif;
 </p>
 <p>
 	<?php
-		$settings = Cache::settings('_cake_model_');
+		$engine = Cache::engine('_cake_model_');
+		$settings = $engine ? $engine->config() : false;
 		if (!empty($settings)):
 			echo '<span class="notice success">';
 				echo __d('cake_dev', 'The %s is being used for core caching. To change the config edit APP/Config/cache.php', '<em>'. $settings['engine'] . 'Engine</em>');

--- a/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/Cake/Test/TestCase/Cache/CacheTest.php
@@ -78,13 +78,13 @@ class CacheTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 		Plugin::load('TestPlugin');
 
-		$settings = ['engine' => 'TestAppCache', 'path' => TMP, 'prefix' => 'cake_test_'];
-		Cache::config('libEngine', $settings);
+		$config = ['engine' => 'TestAppCache', 'path' => TMP, 'prefix' => 'cake_test_'];
+		Cache::config('libEngine', $config);
 		$engine = Cache::engine('libEngine');
 		$this->assertInstanceOf('\TestApp\Cache\Engine\TestAppCacheEngine', $engine);
 
-		$settings = ['engine' => 'TestPlugin.TestPluginCache', 'path' => TMP, 'prefix' => 'cake_test_'];
-		$result = Cache::config('pluginLibEngine', $settings);
+		$config = ['engine' => 'TestPlugin.TestPluginCache', 'path' => TMP, 'prefix' => 'cake_test_'];
+		$result = Cache::config('pluginLibEngine', $config);
 		$engine = Cache::engine('pluginLibEngine');
 		$this->assertInstanceOf('\TestPlugin\Cache\Engine\TestPluginCacheEngine', $engine);
 
@@ -151,9 +151,9 @@ class CacheTest extends TestCase {
  * @dataProvider configProvider
  * @return void
  */
-	public function testConfigVariants($settings) {
+	public function testConfigVariants($config) {
 		$this->assertNotContains('test', Cache::configured(), 'test config should not exist.');
-		Cache::config('tests', $settings);
+		Cache::config('tests', $config);
 
 		$engine = Cache::engine('tests');
 		$this->assertInstanceOf('Cake\Cache\Engine\FileEngine', $engine);
@@ -167,8 +167,8 @@ class CacheTest extends TestCase {
  * @return void
  */
 	public function testConfigInvalidEngine() {
-		$settings = array('engine' => 'Imaginary');
-		Cache::config('test', $settings);
+		$config = array('engine' => 'Imaginary');
+		Cache::config('test', $config);
 		Cache::engine('test');
 	}
 
@@ -203,14 +203,14 @@ class CacheTest extends TestCase {
  * @return void
  */
 	public function testConfigRead() {
-		$settings = [
+		$config = [
 			'engine' => 'File',
 			'path' => TMP,
 			'prefix' => 'cake_'
 		];
-		Cache::config('tests', $settings);
-		$expected = $settings;
-		$expected['className'] = $settings['engine'];
+		Cache::config('tests', $config);
+		$expected = $config;
+		$expected['className'] = $config['engine'];
 		unset($expected['engine']);
 		$this->assertEquals($expected, Cache::config('tests'));
 	}

--- a/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/ApcEngineTest.php
@@ -60,13 +60,13 @@ class ApcEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'Apc',
 			'prefix' => 'cake_',
 		];
 		Cache::drop('apc');
-		Cache::config('apc', array_merge($defaults, $settings));
+		Cache::config('apc', array_merge($defaults, $config));
 	}
 
 /**

--- a/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -66,13 +66,13 @@ class FileEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'File',
 			'path' => TMP . 'tests',
 		];
 		Cache::drop('file_test');
-		Cache::config('file_test', array_merge($defaults, $settings));
+		Cache::config('file_test', array_merge($defaults, $config));
 	}
 
 /**

--- a/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -71,14 +71,14 @@ class MemcachedEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'Memcached',
 			'prefix' => 'cake_',
 			'duration' => 3600
 		];
 		Cache::drop('memcached');
-		Cache::config('memcached', array_merge($defaults, $settings));
+		Cache::config('memcached', array_merge($defaults, $config));
 	}
 
 /**
@@ -98,13 +98,13 @@ class MemcachedEngineTest extends TestCase {
 	}
 
 /**
- * testSettings method
+ * testConfig method
  *
  * @return void
  */
-	public function testSettings() {
-		$settings = Cache::settings('memcached');
-		unset($settings['path']);
+	public function testConfig() {
+		$config = Cache::engine('memcached')->config();
+		unset($config['path']);
 		$expecting = array(
 			'prefix' => 'cake_',
 			'duration' => 3600,
@@ -117,7 +117,7 @@ class MemcachedEngineTest extends TestCase {
 			'groups' => array(),
 			'serialize' => 'php'
 		);
-		$this->assertEquals($expecting, $settings);
+		$this->assertEquals($expecting, $config);
 	}
 
 /**
@@ -152,7 +152,7 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testInvalidSerializerSetting() {
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'className' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
@@ -162,7 +162,7 @@ class MemcachedEngineTest extends TestCase {
 		$this->setExpectedException(
 			'Cake\Error\Exception', 'invalid_serializer is not a valid serializer engine for Memcached'
 		);
-		$Memcached->init($settings);
+		$Memcached->init($config);
 	}
 
 /**
@@ -172,14 +172,14 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testPhpSerializerSetting() {
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'className' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
 			'serialize' => 'php'
 		);
 
-		$Memcached->init($settings);
+		$Memcached->init($config);
 		$this->assertEquals(Memcached::SERIALIZER_PHP, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
 	}
 
@@ -195,14 +195,14 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
 			'serialize' => 'json'
 		);
 
-		$Memcached->init($settings);
+		$Memcached->init($config);
 		$this->assertEquals(Memcached::SERIALIZER_JSON, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
 	}
 
@@ -218,14 +218,14 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
 			'serialize' => 'igbinary'
 		);
 
-		$Memcached->init($settings);
+		$Memcached->init($config);
 		$this->assertEquals(Memcached::SERIALIZER_IGBINARY, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
 	}
 
@@ -241,7 +241,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'className' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
@@ -251,7 +251,7 @@ class MemcachedEngineTest extends TestCase {
 		$this->setExpectedException(
 			'Cake\Error\Exception', 'Memcached extension is not compiled with json support'
 		);
-		$Memcached->init($settings);
+		$Memcached->init($config);
 	}
 
 /**
@@ -266,7 +266,7 @@ class MemcachedEngineTest extends TestCase {
 		);
 
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
@@ -276,7 +276,7 @@ class MemcachedEngineTest extends TestCase {
 		$this->setExpectedException(
 			'Cake\Error\Exception', 'Memcached extension is not compiled with igbinary support'
 		);
-		$Memcached->init($settings);
+		$Memcached->init($config);
 	}
 
 /**
@@ -287,7 +287,7 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testSaslAuthException() {
 		$Memcached = new TestMemcachedEngine();
-		$settings = array(
+		$config = array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1:11211'),
 			'persistent' => false,
@@ -303,11 +303,11 @@ class MemcachedEngineTest extends TestCase {
 		$this->setExpectedException(
 			'Cake\Error\Exception', 'Memcached extension is not build with SASL support'
 		);
-		$Memcached->init($settings);
+		$Memcached->init($config);
 	}
 
 /**
- * testSettings method
+ * testConfig method
  *
  * @return void
  */
@@ -330,8 +330,8 @@ class MemcachedEngineTest extends TestCase {
 		$Memcached = new MemcachedEngine();
 		$Memcached->init(array('engine' => 'Memcached', 'servers' => $servers));
 
-		$settings = $Memcached->settings();
-		$this->assertEquals($settings['servers'], $servers);
+		$config = $Memcached->config();
+		$this->assertEquals($config['servers'], $servers);
 		Cache::drop('dual_server');
 	}
 
@@ -649,7 +649,7 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testLongDurationEqualToZero() {
 		$memcached = new TestMemcachedEngine();
-		$memcached->settings['compress'] = false;
+		$memcached->_config['compress'] = false;
 
 		$mock = $this->getMock('Memcached');
 		$memcached->setMemcached($mock);

--- a/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -649,7 +649,7 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testLongDurationEqualToZero() {
 		$memcached = new TestMemcachedEngine();
-		$memcached->_config['compress'] = false;
+		$memcached->init(['compress' => false]);
 
 		$mock = $this->getMock('Memcached');
 		$memcached->setMemcached($mock);

--- a/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/RedisEngineTest.php
@@ -55,23 +55,23 @@ class RedisEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'Redis',
 			'prefix' => 'cake_',
 			'duration' => 3600
 		];
 		Cache::drop('redis');
-		Cache::config('redis', array_merge($defaults, $settings));
+		Cache::config('redis', array_merge($defaults, $config));
 	}
 
 /**
- * testSettings method
+ * testConfig method
  *
  * @return void
  */
-	public function testSettings() {
-		$settings = Cache::settings('redis');
+	public function testConfig() {
+		$config = Cache::engine('redis')->config();
 		$expecting = array(
 			'prefix' => 'cake_',
 			'duration' => 3600,
@@ -84,7 +84,7 @@ class RedisEngineTest extends TestCase {
 			'password' => false,
 			'database' => 0,
 		);
-		$this->assertEquals($expecting, $settings);
+		$this->assertEquals($expecting, $config);
 	}
 
 /**
@@ -94,7 +94,7 @@ class RedisEngineTest extends TestCase {
  */
 	public function testConnect() {
 		$Redis = new RedisEngine();
-		$this->assertTrue($Redis->init(Cache::settings('redis')));
+		$this->assertTrue($Redis->init(Cache::engine('redis')->config()));
 	}
 
 /**

--- a/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -56,13 +56,13 @@ class WincacheEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'Wincache',
 			'prefix' => 'cake_'
 		];
 		Cache::drop('wincache');
-		Cache::config('wincache', array_merge($defaults, $settings));
+		Cache::config('wincache', array_merge($defaults, $config));
 	}
 
 /**

--- a/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -47,13 +47,13 @@ class XcacheEngineTest extends TestCase {
  *
  * @return void
  */
-	protected function _configCache($settings = []) {
+	protected function _configCache($config = []) {
 		$defaults = [
 			'className' => 'Xcache',
 			'prefix' => 'cake_',
 		];
 		Cache::drop('xcache');
-		Cache::config('xcache', array_merge($defaults, $settings));
+		Cache::config('xcache', array_merge($defaults, $config));
 	}
 
 /**
@@ -68,22 +68,22 @@ class XcacheEngineTest extends TestCase {
 	}
 
 /**
- * testSettings method
+ * testConfig method
  *
  * @return void
  */
-	public function testSettings() {
-		$settings = Cache::settings();
+	public function testConfig() {
+		$config = Cache::engine('xcache')->config();
 		$expecting = [
 			'prefix' => 'cake_',
 			'duration' => 3600,
 			'probability' => 100,
 		];
-		$this->assertTrue(isset($settings['PHP_AUTH_USER']));
-		$this->assertTrue(isset($settings['PHP_AUTH_PW']));
+		$this->assertTrue(isset($config['PHP_AUTH_USER']));
+		$this->assertTrue(isset($config['PHP_AUTH_PW']));
 
-		unset($settings['PHP_AUTH_USER'], $settings['PHP_AUTH_PW']);
-		$this->assertEquals($settings, $expecting);
+		unset($config['PHP_AUTH_USER'], $config['PHP_AUTH_PW']);
+		$this->assertEquals($config, $expecting);
 	}
 
 /**

--- a/Cake/Test/TestCase/Console/Command/Task/ExtractTaskTest.php
+++ b/Cake/Test/TestCase/Console/Command/Task/ExtractTaskTest.php
@@ -127,23 +127,23 @@ class ExtractTaskTest extends TestCase {
 		$this->assertRegExp($pattern, $result);
 
 		// extract.ctp
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:15;6\n';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:\d+;\d+\n';
 		$pattern .= 'msgid "You have %d new message."\nmsgid_plural "You have %d new messages."/';
 		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/msgid "You have %d new message."\nmsgstr ""/';
 		$this->assertNotRegExp($pattern, $result, 'No duplicate msgid');
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:7\n';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:\d+\n';
 		$pattern .= 'msgid "You deleted %d message."\nmsgid_plural "You deleted %d messages."/';
 		$this->assertRegExp($pattern, $result);
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:14\n';
-		$pattern .= '\#: (\\\\|\/)home\.ctp:126\n';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:\d+\n';
+		$pattern .= '\#: (\\\\|\/)home\.ctp:\d+\n';
 		$pattern .= 'msgid "Editing this Page"\nmsgstr ""/';
 		$this->assertRegExp($pattern, $result);
 
-		$pattern = '/\#: (\\\\|\/)extract\.ctp:22\nmsgid "';
+		$pattern = '/\#: (\\\\|\/)extract\.ctp:\d+\nmsgid "';
 		$pattern .= 'Hot features!';
 		$pattern .= '\\\n - No Configuration: Set-up the database and let the magic begin';
 		$pattern .= '\\\n - Extremely Simple: Just look at the name...It\'s Cake';
@@ -190,8 +190,7 @@ class ExtractTaskTest extends TestCase {
 
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
-		$pattern = '/\#: .*extract\.ctp:31\n/';
-		$this->assertNotRegExp($pattern, $result);
+		$this->assertNotContains('You have a new message (category: LC_TIME).', $result);
 	}
 
 /**
@@ -214,10 +213,10 @@ class ExtractTaskTest extends TestCase {
 		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
-		$pattern = '/\#: .*extract\.ctp:6\n/';
+		$pattern = '/\#: .*extract\.ctp:\d+\n/';
 		$this->assertNotRegExp($pattern, $result);
 
-		$pattern = '/\#: .*default\.ctp:26\n/';
+		$pattern = '/\#: .*default\.ctp:\d+\n/';
 		$this->assertNotRegExp($pattern, $result);
 	}
 
@@ -292,7 +291,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->execute();
 		$result = file_get_contents($this->path . DS . 'default.pot');
 		$this->assertNotRegExp('#Pages#', $result);
-		$this->assertContains('translate.ctp:1', $result);
+		$this->assertRegExp('/translate\.ctp:\d+/', $result);
 		$this->assertContains('This is a translatable string', $result);
 		$this->assertContains('I can haz plugin model validation message', $result);
 	}

--- a/Cake/Test/TestCase/Console/Command/Task/ExtractTaskTest.php
+++ b/Cake/Test/TestCase/Console/Command/Task/ExtractTaskTest.php
@@ -139,7 +139,7 @@ class ExtractTaskTest extends TestCase {
 		$this->assertRegExp($pattern, $result);
 
 		$pattern = '/\#: (\\\\|\/)extract\.ctp:14\n';
-		$pattern .= '\#: (\\\\|\/)home\.ctp:125\n';
+		$pattern .= '\#: (\\\\|\/)home\.ctp:126\n';
 		$pattern .= 'msgid "Editing this Page"\nmsgstr ""/';
 		$this->assertRegExp($pattern, $result);
 

--- a/Cake/Test/TestCase/Model/Behavior/TimestampBehaviorTest.php
+++ b/Cake/Test/TestCase/Model/Behavior/TimestampBehaviorTest.php
@@ -181,7 +181,7 @@ class TimestampBehaviorTest extends TestCase {
  * testInvalidEventConfig
  *
  * @expectedException UnexpectedValueException
- * @expectedExceptionMessage 'When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid'
+ * @expectedExceptionMessage When should be one of "always", "new" or "existing". The passed value "fat fingers" is invalid
  * @return void
  */
 	public function testInvalidEventConfig() {


### PR DESCRIPTION
Follow up to #2326, also made defaultConfifg static, and corrected the timestamp behavior's config.
