### PR TITLE
Specifying label text in input overrides label class in inputDefaults

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -9356,6 +9356,28 @@ class FormHelperTest extends CakeTestCase {
 			'label' => false,
 		);
 		$this->assertEquals($expected, $result);
+		
+		$this->Form->inputDefaults(array(
+			'div' => false,
+			'label' => array(
+				'class' => 'special'
+			)
+		));
+		$result = $this->Form->input('Contact.field1', array(
+			'label' => array(
+				'text' => 'Label'
+			)
+		));
+		$expected = array(
+			'label' => array('for' => 'ContactField1', 'class' => 'special'),
+			'Label',
+			'/label',
+			'input' => array(
+				'type' => 'text', 'name' => 'data[Contact][field1]',
+				'id' => 'ContactField1'
+			),
+		);
+		$this->assertTags($result, $expected);
 	}
 
 }


### PR DESCRIPTION
FormHelper needs to be updated so that specifying a single option key in input does not override the entire option array set in inputDefaults.

See test case diff for example.
