### PR TITLE
Fix duplicated webroot path on HtmlHelper::meta('icon').

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -1757,6 +1757,14 @@ class HtmlHelperTest extends CakeTestCase {
 			)
 		);
 		$this->assertTags($result, $expected);
+
+		$this->Html->request->webroot = '/testing/';
+		$result = $this->Html->meta('icon');
+		$expected = array(
+			'link' => array('href' => '/testing/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'icon'),
+			array('link' => array('href' => '/testing/favicon.ico', 'type' => 'image/x-icon', 'rel' => 'shortcut icon'))
+		);
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -253,7 +253,7 @@ class HtmlHelper extends AppHelper {
 			);
 
 			if ($type === 'icon' && $url === null) {
-				$types['icon']['link'] = $this->webroot('favicon.ico');
+				$types['icon']['link'] = 'favicon.ico';
 			}
 
 			if (isset($types[$type])) {


### PR DESCRIPTION
The call of HtmlHelper::meta('icon') without specify the second param (URL) returns the webroot path duplicated in generated tag, example:

When webroot path is "/cakephp/" returns:
...href="/cakephp/cakephp/favicon.ico" type="image/x-icon" rel="icon"...
