### PR TITLE
3.0 Entity::toArray() should recurse into associated entities

### DIFF
--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -273,12 +273,25 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * Returns an array with all the properties that have been set
  * to this entity
  *
+ * This method will recursively transform entities assigned to properties
+ * into arrays as well.
+ *
  * @return array
  */
 	public function toArray() {
 		$result = [];
 		foreach ($this->_properties as $property => $value) {
-			$result[$property] = $this->get($property);
+			$value = $this->get($property);
+			if (is_array($value) && isset($value[0]) && $value[0] instanceof self) {
+				$result[$property] = [];
+				foreach ($value as $k => $entity) {
+					$result[$property][$k] = $entity->toArray();
+				}
+			} elseif ($value instanceof self) {
+				$result[$property] = $value->toArray();
+			} else {
+				$result[$property] = $value;
+			}
 		}
 		return $result;
 	}

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -357,7 +357,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * @return array
  */
 	public function jsonSerialize() {
-		return $this->_properties;
+		return $this->toArray();
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -430,7 +430,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testExtract() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
@@ -454,7 +454,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testDirty() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
@@ -476,7 +476,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testDirtyChangingProperties() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'title' => 'Foo',
 		]);
 		$entity->dirty('title', false);
@@ -498,7 +498,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testExtractDirty() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
@@ -516,7 +516,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testClean() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
@@ -537,7 +537,7 @@ class EntityTest extends TestCase {
  * @return void
  */
 	public function testIsNew() {
-		$entity = new \Cake\ORM\Entity([
+		$entity = new Entity([
 			'id' => 1,
 			'title' => 'Foo',
 			'author_id' => 3
@@ -589,6 +589,45 @@ class EntityTest extends TestCase {
 			->getMock();
 		$entity->expects($this->once())->method('isNew');
 		$entity->__construct(['a' => 'b', 'c' => 'd'], ['markNew' => true]);
+	}
+
+/**
+ * Test toArray method.
+ *
+ * @return void
+ */
+	public function testToArray() {
+		$data = ['name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+		$entity = new Entity($data);
+
+		$this->assertEquals($data, $entity->toArray());
+	}
+
+/**
+ * Test toArray recursive.
+ */
+	public function testToArrayRecursive() {
+		$data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
+		$user = new Entity($data);
+		$comments = [
+			new Entity(['user_id' => 1, 'body' => 'Comment 1']),
+			new Entity(['user_id' => 1, 'body' => 'Comment 2']),
+		];
+		$user->comments = $comments;
+		$user->profile = new Entity(['email' => 'mark@example.com']);
+
+		$expected = [
+			'id' => 1,
+			'name' => 'James',
+			'age' => 20,
+			'phones' => ['123', '457'],
+			'profile' => ['email' => 'mark@example.com'],
+			'comments' => [
+				['user_id' => 1, 'body' => 'Comment 1'],
+				['user_id' => 1, 'body' => 'Comment 2'],
+			]
+		];
+		$this->assertEquals($expected, $user->toArray());
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -605,6 +605,8 @@ class EntityTest extends TestCase {
 
 /**
  * Test toArray recursive.
+ *
+ * @return void
  */
 	public function testToArrayRecursive() {
 		$data = ['id' => 1, 'name' => 'James', 'age' => 20, 'phones' => ['123', '457']];
@@ -628,6 +630,22 @@ class EntityTest extends TestCase {
 			]
 		];
 		$this->assertEquals($expected, $user->toArray());
+	}
+
+/**
+ * Test that get accessors are called when converting to arrays.
+ *
+ * @return void
+ */
+	public function testToArrayWithAccessor() {
+		$entity = $this->getMock('\Cake\ORM\Entity', ['getName']);
+		$entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
+		$entity->expects($this->any())
+			->method('getName')
+			->will($this->returnValue('Jose'));
+
+		$expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
+		$this->assertEquals($expected, $entity->toArray());
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1228,21 +1228,17 @@ class QueryTest extends TestCase {
 		}
 
 		$this->assertCount(2, $first->tags);
-		$articleTag = new \Cake\ORM\Entity(['article_id' => 1, 'tag_id' => 1]);
-		$articleTag->clean();
 		$expected = [
 			'id' => 1,
 			'name' => 'tag1',
-			'articles_tags' => $articleTag
+			'articles_tags' => ['article_id' => 1, 'tag_id' => 1]
 		];
 		$this->assertEquals($expected, $first->tags[0]->toArray());
 
-		$articleTag = new \Cake\ORM\Entity(['article_id' => 1, 'tag_id' => 2]);
-		$articleTag->clean();
 		$expected = [
 			'id' => 2,
 			'name' => 'tag2',
-			'articles_tags' => $articleTag
+			'articles_tags' => ['article_id' => 1, 'tag_id' => 2]
 		];
 		$this->assertEquals($expected, $first->tags[1]->toArray());
 	}


### PR DESCRIPTION
As per #2341, when converting an entity instance into an array or JSON, any nested/related entities should also be transformed. This makes the rest of the framework not have to know the internals of entities, and fixes any issues where accessors were not being used for generating JSON.
### Questions I had while working on this
- Do we also want to allow virtual/calculated properties to be exported?
- How do we want to allow developers to 'hide' properties from JSON/array formats. For example you wouldn't want to include password hashes or encrypted blobs in your JSON. Perhaps a `$_hidden = ['password'];` property on the entity?
