### PR TITLE
Added msgpack support for Memcached

### DIFF
--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -60,7 +60,6 @@ class MemcachedEngine extends CacheEngine {
 	protected $_serializers = array(
 		'igbinary' => Memcached::SERIALIZER_IGBINARY,
 		'json' => Memcached::SERIALIZER_JSON,
-		'msgpack' => Memcached::SERIALIZER_MSGPACK,
 		'php' => Memcached::SERIALIZER_PHP
 	);
 
@@ -81,6 +80,11 @@ class MemcachedEngine extends CacheEngine {
 		if (!isset($settings['prefix'])) {
 			$settings['prefix'] = Inflector::slug(APP_DIR) . '_';
 		}
+
+		if (defined('Memcached::HAVE_MSGPACK') && Memcached::HAVE_MSGPACK) {
+			$this->_serializers['msgpack'] = Memcached::SERIALIZER_MSGPACK;
+		}
+
 		$settings += array(
 			'engine' => 'Memcached',
 			'servers' => array('127.0.0.1'),

--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -60,6 +60,7 @@ class MemcachedEngine extends CacheEngine {
 	protected $_serializers = array(
 		'igbinary' => Memcached::SERIALIZER_IGBINARY,
 		'json' => Memcached::SERIALIZER_JSON,
+		'msgpack' => Memcached::SERIALIZER_MSGPACK,
 		'php' => Memcached::SERIALIZER_PHP
 	);
 

--- a/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
@@ -224,7 +224,7 @@ class MemcachedEngineTest extends CakeTestCase {
  */
 	public function testMsgpackSerializerSetting() {
 		$this->skipIf(
-			!Memcached::HAVE_MSGPACK,
+			!defined('Memcached::HAVE_MSGPACK') || !Memcached::HAVE_MSGPACK,
 			'Memcached extension is not compiled with msgpack support'
 		);
 
@@ -272,7 +272,7 @@ class MemcachedEngineTest extends CakeTestCase {
  */
 	public function testMsgpackSerializerThrowException() {
 		$this->skipIf(
-			Memcached::HAVE_MSGPACK,
+			defined('Memcached::HAVE_MSGPACK') && Memcached::HAVE_MSGPACK,
 			'Memcached extension is compiled with msgpack support'
 		);
 

--- a/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
@@ -218,6 +218,29 @@ class MemcachedEngineTest extends CakeTestCase {
 	}
 
 /**
+ * testMsgpackSerializerSetting method
+ *
+ * @return void
+ */
+	public function testMsgpackSerializerSetting() {
+		$this->skipIf(
+			!Memcached::HAVE_MSGPACK,
+			'Memcached extension is not compiled with msgpack support'
+		);
+
+		$Memcached = new TestMemcachedEngine();
+		$settings = array(
+			'engine' => 'Memcached',
+			'servers' => array('127.0.0.1:11211'),
+			'persistent' => false,
+			'serialize' => 'msgpack'
+		);
+
+		$Memcached->init($settings);
+		$this->assertEquals(Memcached::SERIALIZER_MSGPACK, $Memcached->getMemcached()->getOption(Memcached::OPT_SERIALIZER));
+	}
+
+/**
  * testJsonSerializerThrowException method
  *
  * @return void
@@ -238,6 +261,31 @@ class MemcachedEngineTest extends CakeTestCase {
 
 		$this->setExpectedException(
 			'CacheException', 'Memcached extension is not compiled with json support'
+		);
+		$Memcached->init($settings);
+	}
+
+/**
+ * testMsgpackSerializerThrowException method
+ *
+ * @return void
+ */
+	public function testMsgpackSerializerThrowException() {
+		$this->skipIf(
+			Memcached::HAVE_MSGPACK,
+			'Memcached extension is compiled with msgpack support'
+		);
+
+		$Memcached = new TestMemcachedEngine();
+		$settings = array(
+			'engine' => 'Memcached',
+			'servers' => array('127.0.0.1:11211'),
+			'persistent' => false,
+			'serialize' => 'msgpack'
+		);
+
+		$this->setExpectedException(
+			'CacheException', 'Memcached extension is not compiled with msgpack support'
 		);
 		$Memcached->init($settings);
 	}

--- a/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
@@ -285,7 +285,7 @@ class MemcachedEngineTest extends CakeTestCase {
 		);
 
 		$this->setExpectedException(
-			'CacheException', 'Memcached extension is not compiled with msgpack support'
+			'CacheException', 'msgpack is not a valid serializer engine for Memcached'
 		);
 		$Memcached->init($settings);
 	}


### PR DESCRIPTION
Added `msgpack` support for MemcachedEngine. `ext-memcached` has to be compiled with msgpack in order for this to work properly. Without, the engine will throw an exception that the serializer is invalid.

More information about msgpack:
http://msgpack.org/

Msgpack exists in memcached as of today:
https://github.com/php-memcached-dev/php-memcached/pull/103

Earlier pull request has been pending for some months, but now it's finally official.
