### PR TITLE
Leave db->cacheSources unaltered.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1125,10 +1125,13 @@ class Model extends Object implements CakeEventListener {
 	public function setSource($tableName) {
 		$this->setDataSource($this->useDbConfig);
 		$db = ConnectionManager::getDataSource($this->useDbConfig);
-		$db->cacheSources = ($this->cacheSources && $db->cacheSources);
 
 		if (method_exists($db, 'listSources')) {
+			$restore = $db->cacheSources;
+			$db->cacheSources = $this->cacheSources;
 			$sources = $db->listSources();
+			$db->cacheSources = $restore;
+
 			if (is_array($sources) && !in_array(strtolower($this->tablePrefix . $tableName), array_map('strtolower', $sources))) {
 				throw new MissingTableException(array(
 					'table' => $this->tablePrefix . $tableName,

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -843,6 +843,7 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
+
 		if (!$className) {
 			return false;
 		}
@@ -1128,7 +1129,7 @@ class Model extends Object implements CakeEventListener {
 
 		if (method_exists($db, 'listSources')) {
 			$restore = $db->cacheSources;
-			$db->cacheSources = $this->cacheSources;
+			$db->cacheSources = ($restore && $this->cacheSources);
 			$sources = $db->listSources();
 			$db->cacheSources = $restore;
 

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -843,7 +843,6 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
-
 		if (!$className) {
 			return false;
 		}

--- a/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
+++ b/lib/Cake/Test/Case/Model/ModelIntegrationTest.php
@@ -155,17 +155,17 @@ class ModelIntegrationTest extends BaseModelTest {
 	}
 
 /**
- * Tests that $cacheSources can only be disabled in the db using model settings, not enabled
+ * Tests that $cacheSources is restored despite the settings on the model.
  *
  * @return void
  */
-	public function testCacheSourcesDisabling() {
+	public function testCacheSourcesRestored() {
 		$this->loadFixtures('JoinA', 'JoinB', 'JoinAB', 'JoinC', 'JoinAC');
 		$this->db->cacheSources = true;
 		$TestModel = new JoinA();
 		$TestModel->cacheSources = false;
 		$TestModel->setSource('join_as');
-		$this->assertFalse($this->db->cacheSources);
+		$this->assertTrue($this->db->cacheSources);
 
 		$this->db->cacheSources = false;
 		$TestModel = new JoinA();


### PR DESCRIPTION
When a model uses cacheSources = false, it should not have side effects on the datasource.

Fixes #2364
