### PR TITLE
Decouple Cache and CacheEngine

### DIFF
--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -197,8 +197,7 @@ class Cache {
 			return false;
 		}
 
-		$key = $engine->key($key);
-		if (!$key || is_resource($value)) {
+		if (is_resource($value)) {
 			return false;
 		}
 
@@ -240,11 +239,6 @@ class Cache {
 			return false;
 		}
 
-		$key = $engine->key($key);
-		if (!$key) {
-			return false;
-		}
-
 		return $engine->read($key);
 	}
 
@@ -263,8 +257,7 @@ class Cache {
 			return false;
 		}
 
-		$key = $engine->key($key);
-		if (!$key || !is_int($offset) || $offset < 0) {
+		if (!is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -286,8 +279,7 @@ class Cache {
 			return false;
 		}
 
-		$key = $engine->key($key);
-		if (!$key || !is_int($offset) || $offset < 0) {
+		if (!is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -314,11 +306,6 @@ class Cache {
 	public static function delete($key, $config = 'default') {
 		$engine = static::engine($config);
 		if (!$engine) {
-			return false;
-		}
-
-		$key = $engine->key($key);
-		if (!$key) {
 			return false;
 		}
 

--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -193,11 +193,7 @@ class Cache {
  */
 	public static function write($key, $value, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
-		if (is_resource($value)) {
+		if (!$engine || is_resource($value)) {
 			return false;
 		}
 
@@ -253,11 +249,7 @@ class Cache {
  */
 	public static function increment($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
-		if (!is_int($offset) || $offset < 0) {
+		if (!$engine || !is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -275,11 +267,7 @@ class Cache {
  */
 	public static function decrement($key, $offset = 1, $config = 'default') {
 		$engine = static::engine($config);
-		if (!$engine) {
-			return false;
-		}
-
-		if (!is_int($offset) || $offset < 0) {
+		if (!$engine || !is_int($offset) || $offset < 0) {
 			return false;
 		}
 
@@ -341,8 +329,7 @@ class Cache {
 			return false;
 		}
 
-		$success = $engine->clearGroup($group);
-		return $success;
+		return $engine->clearGroup($group);
 	}
 
 /**

--- a/Cake/Cache/Cache.php
+++ b/Cake/Cache/Cache.php
@@ -202,8 +202,7 @@ class Cache {
 			return false;
 		}
 
-		$config = $engine->config();
-		$success = $engine->write($config['prefix'] . $key, $value, $config['duration']);
+		$success = $engine->write($key, $value);
 		if ($success === false && $value !== '') {
 			trigger_error(
 				__d('cake_dev',
@@ -246,8 +245,7 @@ class Cache {
 			return false;
 		}
 
-		$config = $engine->config();
-		return $engine->read($config['prefix'] . $key);
+		return $engine->read($key);
 	}
 
 /**
@@ -270,8 +268,7 @@ class Cache {
 			return false;
 		}
 
-		$config = $engine->config();
-		return $engine->increment($config['prefix'] . $key, $offset);
+		return $engine->increment($key, $offset);
 	}
 
 /**
@@ -294,8 +291,7 @@ class Cache {
 			return false;
 		}
 
-		$config = $engine->config();
-		return $engine->decrement($config['prefix'] . $key, $offset);
+		return $engine->decrement($key, $offset);
 	}
 
 /**
@@ -326,8 +322,7 @@ class Cache {
 			return false;
 		}
 
-		$config = $engine->config();
-		return $engine->delete($config['prefix'] . $key);
+		return $engine->delete($key);
 	}
 
 /**

--- a/Cake/Cache/CacheEngine.php
+++ b/Cake/Cache/CacheEngine.php
@@ -97,10 +97,9 @@ abstract class CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache for.
  * @return boolean True if the data was successfully cached, false on failure
  */
-	abstract public function write($key, $value, $duration);
+	abstract public function write($key, $value);
 
 /**
  * Read a key from the cache
@@ -194,6 +193,21 @@ abstract class CacheEngine {
 
 		$key = preg_replace('/[\s]+/', '_', strtolower(trim(str_replace([DS, '/', '.'], '_', strval($key)))));
 		return $prefix . $key;
+	}
+
+/**
+ * Generates a safe key, taking account of the configured key prefix
+ *
+ * @param string $key the key passed over
+ * @return mixed string $key or false
+ */
+	protected function _key($key) {
+		$key = $this->key($key);
+		if (!$key) {
+			throw new \InvalidArgumentException(__d('cake_dev', 'An empty value is not valid as a cache key'));
+		}
+
+		return $this->_config['prefix'] . $key;
 	}
 
 }

--- a/Cake/Cache/Engine/ApcEngine.php
+++ b/Cake/Cache/Engine/ApcEngine.php
@@ -54,11 +54,13 @@ class ApcEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
+		$key = $this->_key($key);
+
 		$expires = 0;
+		$duration = $this->_config['duration'];
 		if ($duration) {
 			$expires = time() + $duration;
 		}
@@ -73,6 +75,8 @@ class ApcEngine extends CacheEngine {
  * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		$time = time();
 		$cachetime = intval(apc_fetch($key . '_expires'));
 		if ($cachetime !== 0 && ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime)) {
@@ -89,6 +93,8 @@ class ApcEngine extends CacheEngine {
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return apc_inc($key, $offset);
 	}
 
@@ -100,6 +106,8 @@ class ApcEngine extends CacheEngine {
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return apc_dec($key, $offset);
 	}
 
@@ -110,6 +118,8 @@ class ApcEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		return apc_delete($key);
 	}
 

--- a/Cake/Cache/Engine/FileEngine.php
+++ b/Cake/Cache/Engine/FileEngine.php
@@ -117,13 +117,14 @@ class FileEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $data Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
-	public function write($key, $data, $duration) {
+	public function write($key, $data) {
 		if ($data === '' || !$this->_init) {
 			return false;
 		}
+
+		$key = $this->_key($key);
 
 		if ($this->_setKey($key, true) === false) {
 			return false;
@@ -143,6 +144,7 @@ class FileEngine extends CacheEngine {
 			}
 		}
 
+		$duration = $this->_config['duration'];
 		$expires = time() + $duration;
 		$contents = $expires . $lineBreak . $data . $lineBreak;
 
@@ -167,6 +169,8 @@ class FileEngine extends CacheEngine {
  * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		if (!$this->_init || $this->_setKey($key) === false) {
 			return false;
 		}
@@ -215,9 +219,12 @@ class FileEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		if ($this->_setKey($key) === false || !$this->_init) {
 			return false;
 		}
+
 		$path = $this->_File->getRealPath();
 		$this->_File = null;
 

--- a/Cake/Cache/Engine/MemcachedEngine.php
+++ b/Cake/Cache/Engine/MemcachedEngine.php
@@ -208,14 +208,16 @@ class MemcachedEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  * @see http://php.net/manual/en/memcache.set.php
  */
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
+		$duration = $this->_config['duration'];
 		if ($duration > 30 * DAY) {
 			$duration = 0;
 		}
+
+		$key = $this->_key($key);
 
 		return $this->_Memcached->set($key, $value, $duration);
 	}
@@ -227,6 +229,8 @@ class MemcachedEngine extends CacheEngine {
  * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		return $this->_Memcached->get($key);
 	}
 
@@ -239,6 +243,8 @@ class MemcachedEngine extends CacheEngine {
  * @throws Cake\Error\Exception when you try to increment with compress = true
  */
 	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return $this->_Memcached->increment($key, $offset);
 	}
 
@@ -251,6 +257,8 @@ class MemcachedEngine extends CacheEngine {
  * @throws Cake\Error\Exception when you try to decrement with compress = true
  */
 	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return $this->_Memcached->decrement($key, $offset);
 	}
 
@@ -261,6 +269,8 @@ class MemcachedEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		return $this->_Memcached->delete($key);
 	}
 

--- a/Cake/Cache/Engine/RedisEngine.php
+++ b/Cake/Cache/Engine/RedisEngine.php
@@ -113,13 +113,16 @@ class RedisEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
+		$key = $this->_key($key);
+
 		if (!is_int($value)) {
 			$value = serialize($value);
 		}
+
+		$duration = $this->_config['duration'];
 		if ($duration === 0) {
 			return $this->_Redis->set($key, $value);
 		}
@@ -134,6 +137,8 @@ class RedisEngine extends CacheEngine {
  * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		$value = $this->_Redis->get($key);
 		if (ctype_digit($value)) {
 			$value = (int)$value;
@@ -152,6 +157,8 @@ class RedisEngine extends CacheEngine {
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return (int)$this->_Redis->incrBy($key, $offset);
 	}
 
@@ -163,6 +170,8 @@ class RedisEngine extends CacheEngine {
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return (int)$this->_Redis->decrBy($key, $offset);
 	}
 
@@ -173,6 +182,8 @@ class RedisEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		return $this->_Redis->delete($key) > 0;
 	}
 

--- a/Cake/Cache/Engine/WincacheEngine.php
+++ b/Cake/Cache/Engine/WincacheEngine.php
@@ -57,10 +57,12 @@ class WincacheEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
+		$key = $this->_key($key);
+
+		$duration = $this->_config['duration'];
 		$expires = time() + $duration;
 
 		$data = array(
@@ -79,6 +81,8 @@ class WincacheEngine extends CacheEngine {
  *     there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		$time = time();
 		$cachetime = intval(wincache_ucache_get($key . '_expires'));
 		if ($cachetime < $time || ($time + $this->_config['duration']) < $cachetime) {
@@ -95,6 +99,8 @@ class WincacheEngine extends CacheEngine {
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return wincache_ucache_inc($key, $offset);
 	}
 
@@ -106,6 +112,8 @@ class WincacheEngine extends CacheEngine {
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return wincache_ucache_dec($key, $offset);
 	}
 
@@ -116,6 +124,8 @@ class WincacheEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		return wincache_ucache_delete($key);
 	}
 

--- a/Cake/Cache/Engine/XcacheEngine.php
+++ b/Cake/Cache/Engine/XcacheEngine.php
@@ -73,10 +73,12 @@ class XcacheEngine extends CacheEngine {
  *
  * @param string $key Identifier for the data
  * @param mixed $value Data to be cached
- * @param integer $duration How long to cache the data, in seconds
  * @return boolean True if the data was successfully cached, false on failure
  */
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
+		$key = $this->_key($key);
+
+		$duration = $this->_config['duration'];
 		$expires = time() + $duration;
 		xcache_set($key . '_expires', $expires, $duration);
 		return xcache_set($key, $value, $duration);
@@ -89,6 +91,8 @@ class XcacheEngine extends CacheEngine {
  * @return mixed The cached data, or false if the data doesn't exist, has expired, or if there was an error fetching it
  */
 	public function read($key) {
+		$key = $this->_key($key);
+
 		if (xcache_isset($key)) {
 			$time = time();
 			$cachetime = intval(xcache_get($key . '_expires'));
@@ -109,6 +113,8 @@ class XcacheEngine extends CacheEngine {
  * @return New incremented value, false otherwise
  */
 	public function increment($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return xcache_inc($key, $offset);
 	}
 
@@ -121,6 +127,8 @@ class XcacheEngine extends CacheEngine {
  * @return New decremented value, false otherwise
  */
 	public function decrement($key, $offset = 1) {
+		$key = $this->_key($key);
+
 		return xcache_dec($key, $offset);
 	}
 
@@ -131,6 +139,8 @@ class XcacheEngine extends CacheEngine {
  * @return boolean True if the value was successfully deleted, false if it didn't exist or couldn't be removed
  */
 	public function delete($key) {
+		$key = $this->_key($key);
+
 		return xcache_unset($key);
 	}
 

--- a/Cake/Test/TestApp/Cache/Engine/TestAppCacheEngine.php
+++ b/Cake/Test/TestApp/Cache/Engine/TestAppCacheEngine.php
@@ -25,7 +25,7 @@ use Cake\Cache\CacheEngine;
 
 class TestAppCacheEngine extends CacheEngine {
 
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
 		if ($key === 'fail') {
 			return false;
 		}

--- a/Cake/Test/TestApp/Plugin/TestPlugin/Cache/Engine/TestPluginCacheEngine.php
+++ b/Cake/Test/TestApp/Plugin/TestPlugin/Cache/Engine/TestPluginCacheEngine.php
@@ -25,7 +25,7 @@ use Cake\Cache\CacheEngine;
 
 class TestPluginCacheEngine extends CacheEngine {
 
-	public function write($key, $value, $duration) {
+	public function write($key, $value) {
 	}
 
 	public function read($key) {

--- a/Cake/Test/TestCase/Cache/CacheTest.php
+++ b/Cake/Test/TestCase/Cache/CacheTest.php
@@ -332,6 +332,18 @@ class CacheTest extends TestCase {
 	}
 
 /**
+ * testWriteEmptyValues method
+ *
+ * @expectedException InvalidArgumentException
+ * @expectedExceptionMessage An empty value is not valid as a cache key
+ * @return void
+ */
+	public function testWriteEmptyKey() {
+		$this->_configCache();
+		Cache::write(null, 'not null', 'tests');
+	}
+
+/**
  * Test that failed writes cause errors to be triggered.
  *
  * @return void

--- a/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/FileEngineTest.php
@@ -80,8 +80,6 @@ class FileEngineTest extends TestCase {
  */
 	public function testReadAndWriteCacheExpired() {
 		$this->_configCache(['duration' => 1]);
-		$result = Cache::write(null, 'here', 'file_test');
-		$this->assertFalse($result);
 
 		$result = Cache::read('test', 'file_test');
 		$expecting = '';

--- a/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/Cake/Test/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -649,16 +649,16 @@ class MemcachedEngineTest extends TestCase {
  */
 	public function testLongDurationEqualToZero() {
 		$memcached = new TestMemcachedEngine();
-		$memcached->init(['compress' => false]);
+		$memcached->init(['prefix' => 'Foo_', 'compress' => false, 'duration' => 50 * DAY]);
 
 		$mock = $this->getMock('Memcached');
 		$memcached->setMemcached($mock);
 		$mock->expects($this->once())
 			->method('set')
-			->with('key', 'value', 0);
+			->with('Foo_key', 'value', 0);
 
 		$value = 'value';
-		$memcached->write('key', $value, 50 * DAY);
+		$memcached->write('key', $value);
 	}
 
 /**


### PR DESCRIPTION
The cache class currently reads config out of the engine classes to feed them back in. It's also possible to effectively ignore a cache engine's config by accessing the engine object directly, which doesn't enforce anything regarding its own config.
