### PR TITLE
make assertTags error messages more meaningful

### DIFF
--- a/Cake/TestSuite/TestCase.php
+++ b/Cake/TestSuite/TestCase.php
@@ -470,14 +470,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			list($description, $expressions, $itemNum) = $assertation;
 			$matches = false;
 			foreach ((array)$expressions as $expression) {
-				if (preg_match(sprintf('/^%s/s', $expression), $string, $match)) {
+				$expression = sprintf('/^%s/s', $expression);
+				if (preg_match($expression, $string, $match)) {
 					$matches = true;
 					$string = substr($string, strlen($match[0]));
 					break;
 				}
 			}
 			if (!$matches) {
-				$this->assertTrue(false, sprintf('Item #%d / regex #%d failed: %s', $itemNum, $i, $description));
+				$this->assertRegExp($expression, $string, sprintf('Item #%d / regex #%d failed: %s', $itemNum, $i, $description));
 				if ($fullDebug) {
 					debug($string, true);
 					debug($regex, true);


### PR DESCRIPTION
By failing using assertRegExp when there is no match, the developer will
have a fighting chance of understanding what the error is. As is
developers are probably left dumping variables trying to understand what
the reported error message actually means in terms of what broke.
