### PR TITLE
Always remove verify_host from SSL context.

### DIFF
--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -689,8 +689,8 @@ class HttpSocket extends CakeSocket {
 		}
 		if (!empty($this->config['context']['ssl']['verify_host'])) {
 			$this->config['context']['ssl']['CN_match'] = $host;
-			unset($this->config['context']['ssl']['verify_host']);
 		}
+		unset($this->config['context']['ssl']['verify_host']);
 	}
 
 /**


### PR DESCRIPTION
It is only used to be able to set `CN_match`.
