### PR TITLE
3.0 - Allow properties to be hidden and computed properties to be exposed

### DIFF
--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -319,6 +319,21 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	}
 
 /**
+ * Get the list of visible properties.
+ *
+ * The list of visible properties is all standard properties
+ * plus virtual properties minus hidden properties.
+ *
+ * @return array A list of properties that are 'visible' in all
+ *     representations.
+ */
+	public function visibleProperties() {
+		$properties = array_keys($this->_properties);
+		$properties = array_merge($properties, $this->_virtual);
+		return array_diff($properties, $this->_hidden);
+	}
+
+/**
  * Returns an array with all the properties that have been set
  * to this entity
  *
@@ -329,7 +344,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  */
 	public function toArray() {
 		$result = [];
-		foreach ($this->_properties as $property => $value) {
+		foreach ($this->visibleProperties() as $property) {
 			$value = $this->get($property);
 			if (is_array($value) && isset($value[0]) && $value[0] instanceof self) {
 				$result[$property] = [];

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -34,6 +34,23 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	protected $_properties = [];
 
 /**
+ * List of property names that should **not** be included in JSON or Array
+ * representations of this Entity.
+ *
+ * @var array
+ */
+	protected $_hidden = [];
+
+/**
+ * List of computed or virtual fields that **should** be included in JSON or array
+ * representations of this Entity. If a field is present in both _hidden and _virtual
+ * the field will **not** be in the array/json versions of the entity.
+ *
+ * @var array
+ */
+	protected $_virtual = [];
+
+/**
  * Holds the name of the class for the instance object
  *
  * @var string
@@ -278,6 +295,30 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	}
 
 /**
+ * Add additional properties to the hidden list.
+ *
+ * If the second argument is true, the hidden field list will be reset with
+ * the properties provided. The counterpart to this method is makeVisible()
+ *
+ * @param array $properties The properties to hide.
+ * @param boolean $reset The reset flag.
+ * @return void
+ */
+	public function makeHidden($properties, $reset = false) {
+	}
+
+/**
+ * Remove properties from the hidden list.
+ *
+ * The counterpart to this method is makeHidden().
+ *
+ * @param array $properties The properties to hide.
+ * @return void
+ */
+	public function makeVisible($properties) {
+	}
+
+/**
  * Returns an array with all the properties that have been set
  * to this entity
  *
@@ -302,6 +343,15 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 			}
 		}
 		return $result;
+	}
+
+/**
+ * Returns the properties that will be serialized as json
+ *
+ * @return array
+ */
+	public function jsonSerialize() {
+		return $this->toArray();
 	}
 
 /**
@@ -357,15 +407,6 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 			static::$_accessors[$this->_className] = array_flip(get_class_methods($this));
 		}
 		return isset(static::$_accessors[$this->_className][$method]);
-	}
-
-/**
- * Returns the properties that will be serialized as json
- *
- * @return array
- */
-	public function jsonSerialize() {
-		return $this->toArray();
 	}
 
 /**

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -302,20 +302,20 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  *
  * @param array $properties The properties to hide.
  * @param boolean $reset The reset flag.
- * @return void
+ * @return Entity $this
  */
-	public function makeHidden($properties, $reset = false) {
+	public function hideProperties($properties) {
+		$this->_hidden = $properties;
+		return $this;
 	}
 
 /**
- * Remove properties from the hidden list.
+ * Get the list of hidden properties on this entity.
  *
- * The counterpart to this method is makeHidden().
- *
- * @param array $properties The properties to hide.
- * @return void
+ * @return array
  */
-	public function makeVisible($properties) {
+	public function hiddenProperties() {
+		return $this->_hidden;
 	}
 
 /**

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -371,7 +371,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	}
 
 /**
- * Returns the properties that will be serialized as json
+ * Returns the properties that will be serialized as JSON
  *
  * @return array
  */

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -295,27 +295,37 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	}
 
 /**
- * Add additional properties to the hidden list.
+ * Get/Set the hidden properties on this entity.
  *
- * If the second argument is true, the hidden field list will be reset with
- * the properties provided. The counterpart to this method is makeVisible()
+ * If the properties argument is null, the currently hidden properties
+ * will be returned. Otherwise the hidden properties will be set.
  *
- * @param array $properties The properties to hide.
- * @param boolean $reset The reset flag.
- * @return Entity $this
+ * @param null|array Either an array of properties to hide or null to get properties
+ * @return array|Entity
  */
-	public function hideProperties($properties) {
+	public function hiddenProperties($properties = null) {
+		if ($properties === null) {
+			return $this->_hidden;
+		}
 		$this->_hidden = $properties;
 		return $this;
 	}
 
 /**
- * Get the list of hidden properties on this entity.
+ * Get/Set the virtual properties on this entity.
  *
- * @return array
+ * If the properties argument is null, the currently virtual properties
+ * will be returned. Otherwise the virtual properties will be set.
+ *
+ * @param null|array Either an array of properties to treat as virtual or null to get properties
+ * @return array|Entity
  */
-	public function hiddenProperties() {
-		return $this->_hidden;
+	public function virtualProperties($properties = null) {
+		if ($properties === null) {
+			return $this->_virtual;
+		}
+		$this->_virtual = $properties;
+		return $this;
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -649,12 +649,40 @@ class EntityTest extends TestCase {
 		$this->assertEquals($expected, $entity->toArray());
 	}
 
+/**
+ * Test that toArray respects hidden properties.
+ *
+ * @return void
+ */
 	public function testToArrayHiddenProperties() {
-		$this->markTestIncomplete("not done");
+		$data = ['secret' => 'sauce', 'name' => 'mark', 'id' => 1];
+		$entity = new Entity($data);
+		$entity->hiddenProperties(['secret']);
+		$this->assertEquals(['name' => 'mark', 'id' => 1], $entity->toArray());
 	}
 
+/**
+ * Test toArray includes 'virtual' properties.
+ *
+ * @return void
+ */
 	public function testToArrayVirtualProperties() {
-		$this->markTestIncomplete("not done");
+		$entity = $this->getMock('\Cake\ORM\Entity', ['getName']);
+		$entity->expects($this->any())
+			->method('getName')
+			->will($this->returnValue('Jose'));
+		$entity->set(['email' => 'mark@example.com']);
+
+		$entity->virtualProperties(['name']);
+		$expected = ['name' => 'Jose', 'email' => 'mark@example.com'];
+		$this->assertEquals($expected, $entity->toArray());
+
+		$this->assertEquals(['name'], $entity->virtualProperties());
+
+		$entity->hiddenProperties(['name']);
+		$expected = ['email' => 'mark@example.com'];
+		$this->assertEquals($expected, $entity->toArray());
+		$this->assertEquals(['name'], $entity->hiddenProperties());
 	}
 
 /**
@@ -752,14 +780,6 @@ class EntityTest extends TestCase {
 		$entity->errors('a', 'is not good');
 		$entity->clean();
 		$this->assertEmpty($entity->errors());
-	}
-
-	public function testHideProperties() {
-		$this->markTestIncomplete("not done");
-	}
-
-	public function testVisibleProperties() {
-		$this->markTestIncomplete("not done");
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -649,6 +649,14 @@ class EntityTest extends TestCase {
 		$this->assertEquals($expected, $entity->toArray());
 	}
 
+	public function testToArrayHiddenProperties() {
+		$this->markTestIncomplete("not done");
+	}
+
+	public function testToArrayVirtualProperties() {
+		$this->markTestIncomplete("not done");
+	}
+
 /**
  * Tests that missing fields will not be passed as null to the validator
  *
@@ -745,4 +753,13 @@ class EntityTest extends TestCase {
 		$entity->clean();
 		$this->assertEmpty($entity->errors());
 	}
+
+	public function testHideProperties() {
+		$this->markTestIncomplete("not done");
+	}
+
+	public function testVisibleProperties() {
+		$this->markTestIncomplete("not done");
+	}
+
 }


### PR DESCRIPTION
As per #2369 I've added the ability to hide concrete properties and expose virtual/computed ones. I've changed the names a bit since #2369 because I felt the new ones worked better. I am totally open to changing the names of methods/properties again if we can come up with better ones.
