### PR TITLE
Fixed database layer classes to updrade cakedc/migraitons plugin for cakephp 3.0

### DIFF
--- a/Cake/Database/ConnectionManager.php
+++ b/Cake/Database/ConnectionManager.php
@@ -155,7 +155,14 @@ class ConnectionManager {
  * @deprecated Will be removed in 3.0 stable.
  */
 	public static function getDataSource($name) {
-		return static::get($name);
+		$db = static::get($name);
+		if ($datasource = get_class($db->config()['datasource'])) {
+			$token = explode('\\', $datasource);
+			$datasource = 'Migrations\\Model\\Datasource\\Database\\' . array_pop($token);
+			$datasource = new $datasource($db->config());
+		}
+
+		return $datasource;
 	}
 
 /**

--- a/Cake/Model/Datasource/DataSource.php
+++ b/Cake/Model/Datasource/DataSource.php
@@ -107,7 +107,7 @@ class DataSource extends Object {
 			return $this->_sources;
 		}
 
-		$key = ConnectionManager::getSourceName($this) . '_' . $this->config['database'] . '_list';
+		$key = $this->config['name'] . '_' . $this->config['database'] . '_list';
 		$key = preg_replace('/[^A-Za-z0-9_\-.+]/', '_', $key);
 		$sources = Cache::read($key, '_cake_model_');
 
@@ -308,7 +308,7 @@ class DataSource extends Object {
 			$this->_descriptions[$object] =& $data;
 		}
 
-		$key = ConnectionManager::getSourceName($this) . '_' . $object;
+		$key = $this->config['name'] . '_' . $object;
 		$cache = Cache::read($key, '_cake_model_');
 
 		if (empty($cache)) {

--- a/Cake/Model/Model.php
+++ b/Cake/Model/Model.php
@@ -1124,11 +1124,13 @@ class Model extends Object implements EventListener {
  */
 	public function setSource($tableName) {
 		$this->setDataSource($this->useDbConfig);
-		$db = ConnectionManager::getDataSource($this->useDbConfig);
-		$db->cacheSources = ($this->cacheSources && $db->cacheSources);
+		$db = ConnectionManager::get($this->useDbConfig);
+		$dataSource = ConnectionManager::getDataSource($this->useDbConfig);
 
-		if (method_exists($db, 'listSources')) {
-			$sources = $db->listSources();
+		$dataSource->cacheSources = ($this->cacheSources && $dataSource->cacheSources);
+
+		if (method_exists($db->schemaCollection(), 'listTables')) {
+			$sources = $db->schemaCollection()->listTables();
 			if (is_array($sources) && !in_array(strtolower($this->tablePrefix . $tableName), array_map('strtolower', $sources))) {
 				throw new Error\MissingTableException(array(
 					'table' => $this->tablePrefix . $tableName,
@@ -3464,18 +3466,18 @@ class Model extends Object implements EventListener {
 			$this->useDbConfig = $dataSource;
 		}
 
-		$db = ConnectionManager::getDataSource($this->useDbConfig);
-		if (!empty($oldConfig) && isset($db->config['prefix'])) {
-			$oldDb = ConnectionManager::getDataSource($oldConfig);
+		$db = ConnectionManager::get($this->useDbConfig);
+		if (!empty($oldConfig) && isset($db->config()['prefix'])) {
+			$oldDb = ConnectionManager::get($oldConfig);
 
-			if (!isset($this->tablePrefix) || (!isset($oldDb->config['prefix']) || $this->tablePrefix == $oldDb->config['prefix'])) {
-				$this->tablePrefix = $db->config['prefix'];
+			if (!isset($this->tablePrefix) || (!isset($oldDb->config()['prefix']) || $this->tablePrefix == $oldDb->config()['prefix'])) {
+				$this->tablePrefix = $db->config()['prefix'];
 			}
-		} elseif (isset($db->config['prefix'])) {
-			$this->tablePrefix = $db->config['prefix'];
+		} elseif (isset($db->config()['prefix'])) {
+			$this->tablePrefix = $db->config()['prefix'];
 		}
 
-		$this->schemaName = $db->getSchemaName();
+		$this->schemaName = $db->config()['database'];
 	}
 
 /**
@@ -3585,7 +3587,7 @@ class Model extends Object implements EventListener {
  *  $query to continue with new $query
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforefind
  */
-	public function beforeFind($query) {
+	public function beforeFind(Event $event, $query) {
 		return true;
 	}
 
@@ -3598,7 +3600,7 @@ class Model extends Object implements EventListener {
  * @return mixed Result of the find operation
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#afterfind
  */
-	public function afterFind($results, $primary = false) {
+	public function afterFind(Event $event, $results, $primary = false) {
 		return $results;
 	}
 
@@ -3611,7 +3613,7 @@ class Model extends Object implements EventListener {
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforesave
  * @see Model::save()
  */
-	public function beforeSave($options = array()) {
+	public function beforeSave(Event $event, $options = array()) {
 		return true;
 	}
 
@@ -3624,7 +3626,7 @@ class Model extends Object implements EventListener {
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#aftersave
  * @see Model::save()
  */
-	public function afterSave($created, $options = array()) {
+	public function afterSave(Event $event, $created, $options = array()) {
 	}
 
 /**
@@ -3634,7 +3636,7 @@ class Model extends Object implements EventListener {
  * @return boolean True if the operation should continue, false if it should abort
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforedelete
  */
-	public function beforeDelete($cascade = true) {
+	public function beforeDelete(Event $event, $cascade = true) {
 		return true;
 	}
 
@@ -3644,7 +3646,7 @@ class Model extends Object implements EventListener {
  * @return void
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#afterdelete
  */
-	public function afterDelete() {
+	public function afterDelete(Event $event) {
 	}
 
 /**
@@ -3656,7 +3658,7 @@ class Model extends Object implements EventListener {
  * @link http://book.cakephp.org/2.0/en/models/callback-methods.html#beforevalidate
  * @see Model::save()
  */
-	public function beforeValidate($options = array()) {
+	public function beforeValidate(Event $event, $options = array()) {
 		return true;
 	}
 
@@ -3665,7 +3667,7 @@ class Model extends Object implements EventListener {
  *
  * @return void
  */
-	public function afterValidate() {
+	public function afterValidate(Event $event) {
 	}
 
 /**

--- a/Cake/Utility/ObjectCollection.php
+++ b/Cake/Utility/ObjectCollection.php
@@ -108,7 +108,7 @@ abstract class ObjectCollection {
 				$subject = $event->subject();
 			}
 			foreach (array('break', 'breakOn', 'collectReturn', 'modParams') as $opt) {
-				if (isset($event->{$opt})) {
+				if (isset($event->{$opt}) && !is_scalar($event->{$opt})) {
 					$options[$opt] = $event->{$opt};
 				}
 			}
@@ -122,7 +122,7 @@ abstract class ObjectCollection {
 				'collectReturn' => false,
 				'modParams' => false
 			),
-			$options
+			is_array($options) ? $options : []
 		);
 		$collected = array();
 		$list = array_keys($this->_enabled);


### PR DESCRIPTION
Hi, I've upgraded cakedc/migrations plugin for cakephp 3.0 requirements.
https://github.com/topaz2/migrations/tree/feature/cakephp-3.0

Since cakephp 3.0 still heavily depends on DataSource instance which has been removed, there was some fix needed to core. However, fix given to ConnectionManager::getDataSource() fixes a lot of undefined method call called from cakephp 3.0 core,  but also adds dependency on migrations pluign. I'll give a try to remove deprecated ConnectionManager::getDataSource() call from migraitons plugin later, feel free to remove dependency whenever cakephp 3.0 core is ready to.
