### PR TITLE
Moved exception throwing to after paging info it set for request.

### DIFF
--- a/lib/Cake/Controller/Component/PaginatorComponent.php
+++ b/lib/Cake/Controller/Component/PaginatorComponent.php
@@ -212,9 +212,6 @@ class PaginatorComponent extends Component {
 		$pageCount = intval(ceil($count / $limit));
 		$requestedPage = $page;
 		$page = max(min($page, $pageCount), 1);
-		if ($requestedPage > $page) {
-			throw new NotFoundException();
-		}
 
 		$paging = array(
 			'page' => $page,
@@ -236,6 +233,10 @@ class PaginatorComponent extends Component {
 			(array)$this->Controller->request['paging'],
 			array($object->alias => $paging)
 		);
+
+		if ($requestedPage > $page) {
+			throw new NotFoundException();
+		}
 
 		if (
 			!in_array('Paginator', $this->Controller->helpers) &&

--- a/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/PaginatorComponentTest.php
@@ -919,7 +919,6 @@ class PaginatorComponentTest extends CakeTestCase {
 /**
  * testOutOfRangePageNumberAndPageCountZero
  *
- * @expectedException NotFoundException
  * @return void
  */
 	public function testOutOfRangePageNumberAndPageCountZero() {
@@ -933,7 +932,17 @@ class PaginatorComponentTest extends CakeTestCase {
 		$Controller->paginate = array(
 			'conditions' => array('PaginatorControllerPost.id >' => 100)
 		);
-		$Controller->Paginator->paginate('PaginatorControllerPost');
+
+		try {
+			$Controller->Paginator->paginate('PaginatorControllerPost');
+			$this->fail();
+		} catch (NotFoundException $e) {
+			$this->assertEquals(
+				1,
+				$Controller->request->params['paging']['PaginatorControllerPost']['page'],
+				'Page number should not be 0'
+			);
+		}
 	}
 
 /**


### PR DESCRIPTION
This fixes the regression caused in 2096d3f632. When catching exception
thrown by PaginatorComponent::paginate() in controller, developer again
has access to paging info in request object.

Closes #2402
