### PR TITLE
3.0 Add method to Table to introspect loaded behaviors.

### DIFF
--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -453,6 +453,28 @@ class Table implements EventListener {
 	}
 
 /**
+ * Get the list of Behaviors loaded.
+ *
+ * This method will return the *aliases* of the behaviors attached
+ * to this instance.
+ *
+ * @return array
+ */
+	public function behaviors() {
+		return $this->_behaviors->loaded();
+	}
+
+/**
+ * Check if a behavior with the given alias has been loaded.
+ *
+ * @param string $name The behavior alias to check.
+ * @return array
+ */
+	public function hasBehavior($name) {
+		return $this->_behaviors->loaded($name);
+	}
+
+/**
  * Returns a association objected configured for the specified alias if any
  *
  * @param string $name the alias used for the association

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2119,4 +2119,18 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertNull($result->clause('order'));
 	}
 
+/**
+ * Test the behavior method.
+ *
+ * @return void
+ */
+	public function testBehaviorIntrospection() {
+		$table = TableRegistry::get('users');
+		$this->assertEquals([], $table->behaviors(), 'no loaded behaviors');
+
+		$table->addBehavior('Timestamp');
+		$this->assertEquals(['Timestamp'], $table->behaviors(), 'Should have loaded behavior');
+		$this->assertTrue($table->hasBehavior('Timestamp'), 'should be true on loaded behavior');
+		$this->assertFalse($table->hasBehavior('Tree'), 'should be false on unloaded behavior');
+	}
 }


### PR DESCRIPTION
Add behaviors() and hasBehavior() to Table to allow introspecting the loaded behaviors.

Refs #2304
