### PR TITLE
3.0 table events

### DIFF
--- a/Cake/Event/EventManager.php
+++ b/Cake/Event/EventManager.php
@@ -118,7 +118,7 @@ class EventManager {
  * @return void
  */
 	protected function _attachSubscriber(EventListener $subscriber) {
-		foreach ($subscriber->implementedEvents() as $eventKey => $function) {
+		foreach ((array)$subscriber->implementedEvents() as $eventKey => $function) {
 			$options = array();
 			$method = $function;
 			if (is_array($function) && isset($function['callable'])) {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -20,6 +20,7 @@ use Cake\Core\App;
 use Cake\Database\Schema\Table as Schema;
 use Cake\Database\Type;
 use Cake\Event\Event;
+use Cake\Event\EventListener;
 use Cake\Event\EventManager;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
@@ -59,7 +60,7 @@ use Cake\Utility\Inflector;
  *
  * @see Cake\Event\EventManager for reference on the events system.
  */
-class Table {
+class Table implements EventListener {
 
 /**
  * Name of the table as it can be found in the database
@@ -186,6 +187,7 @@ class Table {
 		$this->_eventManager = $eventManager ?: new EventManager();
 		$this->_behaviors = $behaviors ?: new BehaviorRegistry($this);
 		$this->initialize($config);
+		$this->_eventManager->attach($this);
 	}
 
 /**
@@ -1233,6 +1235,36 @@ class Table {
 		throw new \BadMethodCallException(
 			__d('cake_dev', 'Unknown method "%s"', $method)
 		);
+	}
+
+/**
+ * Get the Model callbacks this table is interested in.
+ *
+ * By implementing the conventional methods a table class is assumed
+ * to be interested in the related event.
+ *
+ * Override this method if you need to add non-conventional event listeners.
+ * Or if you want you table to listen to non-standard events.
+ *
+ * @return array
+ */
+	public function implementedEvents() {
+		$eventMap = [
+			'Model.beforeFind' => 'beforeFind',
+			'Model.beforeSave' => 'beforeSave',
+			'Model.afterSave' => 'afterSave',
+			'Model.beforeDelete' => 'beforeDelete',
+			'Model.afterDelete' => 'afterDelete',
+		];
+		$events = [];
+
+		foreach ($eventMap as $event => $method) {
+			if (!method_exists($this, $method)) {
+				continue;
+			}
+			$events[$event] = $method;
+		}
+		return $events;
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -771,6 +771,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertSame($expected, $query->toArray());
 	}
 
+/**
+ * Test the default entityClass.
+ *
+ * @return void
+ */
 	public function testEntityClassDefault() {
 		$table = new Table();
 		$this->assertEquals('\Cake\ORM\Entity', $table->entityClass());
@@ -782,7 +787,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @return void
  */
-	public function testRepositoryClassInAPP() {
+	public function testRepositoryClassInApp() {
 		$class = $this->getMockClass('\Cake\ORM\Entity');
 
 		if (!class_exists('TestApp\Model\Entity\TestUser')) {
@@ -1033,6 +1038,27 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$query = $table->find('special');
 		$this->assertInstanceOf('Cake\ORM\Query', $query);
 		$this->assertNotEmpty($query->clause('where'));
+	}
+
+/**
+ * Test implementedEvents
+ *
+ * @return void
+ */
+	public function testImplementedEvents() {
+		$table = $this->getMock(
+			'Cake\ORM\Table',
+			['beforeFind', 'beforeSave', 'afterSave', 'beforeDelete', 'afterDelete']
+		);
+		$result = $table->implementedEvents();
+		$expected = [
+			'Model.beforeFind' => 'beforeFind',
+			'Model.beforeSave' => 'beforeSave',
+			'Model.afterSave' => 'afterSave',
+			'Model.beforeDelete' => 'beforeDelete',
+			'Model.afterDelete' => 'afterDelete',
+		];
+		$this->assertEquals($expected, $result, 'Events do not match.');
 	}
 
 /**
@@ -1669,7 +1695,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$options = new \ArrayObject(['atomic' => true]);
 
 		$mock = $this->getMock('Cake\Event\EventManager');
+
 		$mock->expects($this->at(0))
+			->method('attach');
+
+		$mock->expects($this->at(1))
 			->method('dispatch')
 			->with($this->logicalAnd(
 				$this->attributeEqualTo('_name', 'Model.beforeDelete'),
@@ -1679,7 +1709,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 				)
 			));
 
-		$mock->expects($this->at(1))
+		$mock->expects($this->at(2))
 			->method('dispatch')
 			->with($this->logicalAnd(
 				$this->attributeEqualTo('_name', 'Model.afterDelete'),


### PR DESCRIPTION
Use the same conventions as behaviors for mapping event names to  methods. Table objects bind their events **after** the initialize method. This allows them to have the same sequencing as controllers + historical behavior.
