### PR TITLE
3.0 save associated entities

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -437,4 +437,25 @@ abstract class Association {
  */
 	public abstract function cascadeDelete(Entity $entity, $options = []);
 
+
+/**
+ * Returns whether or not the 'source' table is the owning side for this
+ * association. This means that rows in the 'target' table would miss important
+ * or required information if the row in 'source' did not exist.
+ *
+ * @return boolean
+ */
+	public abstract function isOwningSide();
+
+/**
+ * Proxies the saving operation for an entity to the target table
+ *
+ * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param array|\ArrayObject $options
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
+ * @see Table::save()
+ */
+	public abstract function save(Entity $entity, $options = []);
+
 }

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -438,13 +438,13 @@ abstract class Association {
 	public abstract function cascadeDelete(Entity $entity, $options = []);
 
 /**
- * Returns whether or not the 'source' table is the owning side for this
+ * Returns whether or not the passed table is the owning side for this
  * association. This means that rows in the 'target' table would miss important
  * or required information if the row in 'source' did not exist.
  *
  * @return boolean
  */
-	public abstract function isOwningSide();
+	public abstract function isOwningSide(Table $side);
 
 /**
  * Proxies the saving operation for an entity to the target table

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -437,7 +437,6 @@ abstract class Association {
  */
 	public abstract function cascadeDelete(Entity $entity, $options = []);
 
-
 /**
  * Returns whether or not the 'source' table is the owning side for this
  * association. This means that rows in the 'target' table would miss important

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -97,6 +97,19 @@ class BelongsTo extends Association {
 	}
 
 /**
+ * Proxies the saving operation for an entity to the target table
+ *
+ * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param array|\ArrayObject $options
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
+ * @see Table::save()
+ */
+	public function save(Entity $entity, $options = []) {
+		return $entity;
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -98,7 +98,7 @@ class BelongsTo extends Association {
 
 /**
  * Takes an entity from the source table and looks if there is a field
- * matching the property name for this association. Found entity will be
+ * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
  * `$options`
  *

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -87,6 +87,16 @@ class BelongsTo extends Association {
 	}
 
 /**
+ * Returns boolean false, as rows in source table could not exist or would miss
+ * important information should corresponding row in target table not exist.
+ *
+ * @return boolean
+ */
+	public function isOwningSide() {
+		return false;
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -20,6 +20,7 @@ use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Association;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 
 /**
@@ -87,13 +88,14 @@ class BelongsTo extends Association {
 	}
 
 /**
- * Returns boolean false, as rows in source table could not exist or would miss
- * important information should corresponding row in target table not exist.
+ * Returns whether or not the passed table is the owning side for this
+ * association. This means that rows in the 'target' table would miss important
+ * or required information if the row in 'source' did not exist.
  *
  * @return boolean
  */
-	public function isOwningSide() {
-		return false;
+	public function isOwningSide(Table $side) {
+		return $side === $this->target();
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -97,10 +97,14 @@ class BelongsTo extends Association {
 	}
 
 /**
- * Proxies the saving operation for an entity to the target table
+ * Takes an entity from the source table and looks if there is a field
+ * matching the property name for this association. Found entity will be
+ * saved on the target table for this association by passing supplied
+ * `$options`
  *
- * @param \Cake\ORM\Entity $entity the data to be saved
- * @param array|\ArrayObject $options
+ * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param array|\ArrayObject $options options to be passed to the save method in
+ * the target table
  * @return boolean|Entity false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -110,7 +110,7 @@ class BelongsTo extends Association {
 		if (!$targetEntity) {
 			return $entity;
 		}
-		
+
 		$table = $this->target();
 		$targetEntity = $table->save($targetEntity, $options);
 		if (!$targetEntity) {

--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -106,6 +106,22 @@ class BelongsTo extends Association {
  * @see Table::save()
  */
 	public function save(Entity $entity, $options = []) {
+		$targetEntity = $entity->get($this->property());
+		if (!$targetEntity) {
+			return $entity;
+		}
+		
+		$table = $this->target();
+		$targetEntity = $table->save($targetEntity, $options);
+		if (!$targetEntity) {
+			return false;
+		}
+
+		$properties = array_combine(
+			(array)$this->foreignKey(),
+			$targetEntity->extract((array)$table->primaryKey())
+		);
+		$entity->set($properties);
 		return $entity;
 	}
 

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -346,20 +346,20 @@ class BelongsToMany extends Association {
  * @param \Cake\ORM\Entity $sourceEntity the entity from source table in this
  * association
  * @param array list of entities to link to link to the source entity using the
- * pivot table
+ * junction table
  * @return boolean success
  */
 	protected function _saveLinks(Entity $sourceEntity, $targetEntities, $options) {
 		$target = $this->target();
-		$pivot = $this->pivot();
+		$junction = $this->junction();
 		$source = $this->source();
-		$entityClass = $pivot->entityClass();
-		$belongsTo = $pivot->association($target->alias());
+		$entityClass = $junction->entityClass();
+		$belongsTo = $junction->association($target->alias());
 		$foreignKey = (array)$this->foreignKey();
 		$assocForeignKey = (array)$belongsTo->foreignKey();
 		$targetPrimaryKey = (array)$target->primaryKey();
 		$sourcePrimaryKey = (array)$source->primaryKey();
-		$jointProperty = $target->association($pivot->alias())->property();
+		$jointProperty = $target->association($junction->alias())->property();
 
 		foreach ($targetEntities as $k => $e) {
 			$joint = $e->get($jointProperty);
@@ -373,7 +373,7 @@ class BelongsToMany extends Association {
 				$sourceEntity->extract($sourcePrimaryKey)
 			));
 			$joint->set(array_combine($assocForeignKey, $e->extract($targetPrimaryKey)));
-			$saved = $pivot->save($joint, $options);
+			$saved = $junction->save($joint, $options);
 
 			if (!$saved && !empty($options['atomic'])) {
 				return false;

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -257,14 +257,22 @@ class BelongsToMany extends Association {
 	}
 
 /**
- * Proxies the saving operation for an entity to the target table
+ * Takes an entity from the source table and looks if there is a field
+ * matching the property name for this association. Found entity will be
+ * saved on the target table for this association by passing supplied
+ * `$options`
  *
- * @param \Cake\ORM\Entity $entity the data to be saved
- * @param array|\ArrayObject $options
- * @return boolean|Entity false if $entity could not be saved, otherwise it returns
- * the saved entity
+ * Using this save function will only create new links between each side
+ * of this association. It will no destroy existing ones even though they
+ * may not be present in the array of entities to be saved.
+ *
+ * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param array|\ArrayObject $options options to be passed to the save method in
+ * the target table
  * @throws \InvalidArgumentException if the property representing the association
  * in the parent entity cannot be traversed
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
  * @see Table::save()
  */
 	public function save(Entity $entity, $options = []) {

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -259,7 +259,7 @@ class BelongsToMany extends Association {
 
 /**
  * Takes an entity from the source table and looks if there is a field
- * matching the property name for this association. Found entity will be
+ * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
  * `$options`
  *

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -346,7 +346,6 @@ class BelongsToMany extends Association {
 		$source = $this->source();
 		$entityClass = $pivot->entityClass();
 		$belongsTo = $pivot->association($target->alias());
-		$property = $belongsTo->property();
 		$foreignKey = (array)$this->foreignKey();
 		$assocForeignKey = (array)$belongsTo->foreignKey();
 		$targetPrimaryKey = (array)$target->primaryKey();
@@ -354,7 +353,7 @@ class BelongsToMany extends Association {
 		$jointProperty = $target->association($pivot->alias())->property();
 
 		foreach ($targetEntities as $k => $e) {
-			$joint = $e->get($property);
+			$joint = $e->get($jointProperty);
 			if (!$joint) {
 				$joint = new $entityClass;
 				$joint->isNew(true);
@@ -372,6 +371,7 @@ class BelongsToMany extends Association {
 			}
 
 			$e->set($jointProperty, $joint);
+			$e->dirty($jointProperty, false);
 		}
 
 		return true;

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -264,7 +264,7 @@ class BelongsToMany extends Association {
  * `$options`
  *
  * Using this save function will only create new links between each side
- * of this association. It will no destroy existing ones even though they
+ * of this association. It will not destroy existing ones even though they
  * may not be present in the array of entities to be saved.
  *
  * @param \Cake\ORM\Entity $entity an entity from the source table

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -253,7 +253,7 @@ class BelongsToMany extends Association {
  *
  * @return boolean
  */
-	public function isOwningSide() {
+	public function isOwningSide(Table $side) {
 		return true;
 	}
 

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -245,6 +245,16 @@ class BelongsToMany extends Association {
 	}
 
 /**
+ * Returns boolean false, as none of the tables 'own' rows in the other side
+ * of the association
+ *
+ * @return boolean
+ */
+	public function isOwningSide() {
+		return false;
+	}
+
+/**
  * Appends any conditions required to load the relevant set of records in the
  * target table query given a filter key and some filtering values.
  *

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -263,6 +263,8 @@ class BelongsToMany extends Association {
  * @param array|\ArrayObject $options
  * @return boolean|Entity false if $entity could not be saved, otherwise it returns
  * the saved entity
+ * @throws \InvalidArgumentException if the property representing the association
+ * in the parent entity cannot be traversed
  * @see Table::save()
  */
 	public function save(Entity $entity, $options = []) {
@@ -277,7 +279,21 @@ class BelongsToMany extends Association {
 		return $success;
 	}
 
-	protected function _saveTarget($parentEntity, $entities, $options) {
+/**
+ * Persists each of the entities into the target table and creates links between
+ * the parent entity and each one of the saved target entities.
+ *
+ * @param \Cake\ORM\Entity $parentEntity the source entity containing the target
+ * entities to be saved.
+ * @param array|\Traversable list of entities to persist in target table and to
+ * link to the parent entity
+ * @param array $options list of options accepted by Table::save()
+ * @throws \InvalidArgumentException if the property representing the association
+ * in the parent entity cannot be traversed
+ * @return \Cake\ORM\Entity|boolean The parent entity after all links have been
+ * created if no errors happened, false otherwise
+ */
+	protected function _saveTarget(Entity $parentEntity, $entities, $options) {
 		if (!(is_array($entities) || $entities instanceof \Traversable)) {
 			$name = $this->property();
 			$message = __d('cake_dev', 'Could not save %s, it cannot be traversed', $name);
@@ -315,7 +331,16 @@ class BelongsToMany extends Association {
 		return $parentEntity;
 	}
 
-	protected function _saveLinks($sourceEntity, $targetEntities, $options) {
+/**
+ * Creates links between the source entity and each of the passed target entities
+ *
+ * @param \Cake\ORM\Entity $sourceEntity the entity from source table in this
+ * association
+ * @param array list of entities to link to link to the source entity using the
+ * pivot table
+ * @return boolean success
+ */
+	protected function _saveLinks(Entity $sourceEntity, $targetEntities, $options) {
 		$target = $this->target();
 		$pivot = $this->pivot();
 		$source = $this->source();

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -346,10 +346,7 @@ class BelongsToMany extends Association {
 				return false;
 			}
 
-			if ($saved) {
-				$e->set($jointProperty, $joint);
-				$savedEntities[$k] = $e;
-			}
+			$e->set($jointProperty, $joint);
 		}
 
 		return true;

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -245,13 +245,26 @@ class BelongsToMany extends Association {
 	}
 
 /**
- * Returns boolean false, as none of the tables 'own' rows in the other side
- * of the association
+ * Returns boolean true, as both of the tables 'own' rows in the other side
+ * of the association via the joint table.
  *
  * @return boolean
  */
 	public function isOwningSide() {
-		return false;
+		return true;
+	}
+
+/**
+ * Proxies the saving operation for an entity to the target table
+ *
+ * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param array|\ArrayObject $options
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
+ * @see Table::save()
+ */
+	public function save(Entity $entity, $options = []) {
+		return $entity;
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -226,12 +226,14 @@ class BelongsToMany extends Association {
  * @return boolean Success.
  */
 	public function cascadeDelete(Entity $entity, $options = []) {
-		$foreignKey = $this->foreignKey();
+		$foreignKey = (array)$this->foreignKey();
 		$primaryKey = $this->source()->primaryKey();
-		$conditions = [
-			$foreignKey => $entity->get($primaryKey)
-		];
-		// TODO fix multi-column primary keys.
+		$conditions = [];
+
+		if ($primaryKey) {
+			$conditions = array_combine($foreignKey, $entity->extract((array)$primaryKey));
+		}
+
 		$conditions = array_merge($conditions, $this->conditions());
 
 		$table = $this->pivot();

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -104,10 +104,14 @@ class HasMany extends Association {
 	}
 
 /**
- * Proxies the saving operation for an entity to the target table
+ * Takes an entity from the source table and looks if there is a field
+ * matching the property name for this association. Found entity will be
+ * saved on the target table for this association by passing supplied
+ * `$options`
  *
- * @param \Cake\ORM\Entity $entity the data to be saved
- * @param array|\ArrayObject $options
+ * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param array|\ArrayObject $options options to be passed to the save method in
+ * the target table
  * @return boolean|Entity false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -21,6 +21,7 @@ use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\ExternalAssociationTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 
 /**
  * Represents an N - 1 relationship where the target side of the relationship
@@ -94,13 +95,14 @@ class HasMany extends Association {
 	}
 
 /**
- * Returns boolean true, as target rows could not exist or would miss information
- * should corresponding rows in source association not exist.
+ * Returns whether or not the passed table is the owning side for this
+ * association. This means that rows in the 'target' table would miss important
+ * or required information if the row in 'source' did not exist.
  *
  * @return boolean
  */
-	public function isOwningSide() {
-		return true;
+	public function isOwningSide(Table $side) {
+		return $side === $this->source();
 	}
 
 /**

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -19,6 +19,7 @@ namespace Cake\ORM\Association;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\ExternalAssociationTrait;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 
 /**
@@ -100,6 +101,19 @@ class HasMany extends Association {
  */
 	public function isOwningSide() {
 		return true;
+	}
+
+/**
+ * Proxies the saving operation for an entity to the target table
+ *
+ * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param array|\ArrayObject $options
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
+ * @see Table::save()
+ */
+	public function save(Entity $entity, $options = []) {
+		return $entity;
 	}
 
 }

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -105,7 +105,7 @@ class HasMany extends Association {
 
 /**
  * Takes an entity from the source table and looks if there is a field
- * matching the property name for this association. Found entity will be
+ * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
  * `$options`
  *

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -92,4 +92,14 @@ class HasMany extends Association {
 		return $this->_resultInjector($fetchQuery, $resultMap);
 	}
 
+/**
+ * Returns boolean true, as target rows could not exist or would miss information
+ * should corresponding rows in source association not exist.
+ *
+ * @return boolean
+ */
+	public function isOwningSide() {
+		return true;
+	}
+
 }

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -103,6 +103,22 @@ class HasOne extends Association {
  * @see Table::save()
  */
 	public function save(Entity $entity, $options = []) {
+		$targetEntity = $entity->get($this->property());
+		if (!$targetEntity) {
+			return $entity;
+		}
+
+		$properties = array_combine(
+			(array)$this->foreignKey(),
+			$entity->extract((array)$this->source()->primaryKey())
+		);
+		$targetEntity->set($properties);
+
+		if (!$this->target()->save($targetEntity, $options)) {
+			$targetEntity->unsetProperty(array_keys($properties));
+			return false;
+		}
+
 		return $entity;
 	}
 

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -19,6 +19,7 @@ namespace Cake\ORM\Association;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 
@@ -90,6 +91,19 @@ class HasOne extends Association {
  */
 	public function isOwningSide() {
 		return true;
+	}
+
+/**
+ * Proxies the saving operation for an entity to the target table
+ *
+ * @param \Cake\ORM\Entity $entity the data to be saved
+ * @param array|\ArrayObject $options
+ * @return boolean|Entity false if $entity could not be saved, otherwise it returns
+ * the saved entity
+ * @see Table::save()
+ */
+	public function save(Entity $entity, $options = []) {
+		return $entity;
 	}
 
 /**

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -21,6 +21,7 @@ use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
+use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 
 /**
@@ -84,13 +85,14 @@ class HasOne extends Association {
 	}
 
 /**
- * Returns boolean true, as target rows could not exist or would miss information
- * should corresponding rows in source association not exist.
+ * Returns whether or not the passed table is the owning side for this
+ * association. This means that rows in the 'target' table would miss important
+ * or required information if the row in 'source' did not exist.
  *
  * @return boolean
  */
-	public function isOwningSide() {
-		return true;
+	public function isOwningSide(Table $side) {
+		return $side === $this->source();
 	}
 
 /**

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -94,10 +94,14 @@ class HasOne extends Association {
 	}
 
 /**
- * Proxies the saving operation for an entity to the target table
+ * Takes an entity from the source table and looks if there is a field
+ * matching the property name for this association. Found entity will be
+ * saved on the target table for this association by passing supplied
+ * `$options`
  *
- * @param \Cake\ORM\Entity $entity the data to be saved
- * @param array|\ArrayObject $options
+ * @param \Cake\ORM\Entity $entity an entity from the source table
+ * @param array|\ArrayObject $options options to be passed to the save method in
+ * the target table
  * @return boolean|Entity false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -83,6 +83,16 @@ class HasOne extends Association {
 	}
 
 /**
+ * Returns boolean true, as target rows could not exist or would miss information
+ * should corresponding rows in source association not exist.
+ *
+ * @return boolean
+ */
+	public function isOwningSide() {
+		return true;
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -95,7 +95,7 @@ class HasOne extends Association {
 
 /**
  * Takes an entity from the source table and looks if there is a field
- * matching the property name for this association. Found entity will be
+ * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
  * `$options`
  *

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -391,13 +391,20 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * argument, it will return whether the property was modified or not
  * after the object creation.
  *
+ * When called with no arguments it will return whether or not there is any
+ * dirty property in the entity
+ *
  * @param string $property the field to set or check status for
  * @param null|boolean true means the property was changed, false means
  * it was not changed and null will make the function return current state
  * for that property
  * @return boolean whether the property was changed or not
  */
-	public function dirty($property, $isDirty = null) {
+	public function dirty($property = null, $isDirty = null) {
+		if ($property === null) {
+			return !empty($this->_dirty);
+		}
+
 		if ($isDirty === null) {
 			return isset($this->_dirty[$property]);
 		}

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -457,7 +457,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * argument, it will return whether the property was modified or not
  * after the object creation.
  *
- * When called with no arguments it will return whether or not there is any
+ * When called with no arguments it will return whether or not there are any
  * dirty property in the entity
  *
  * @param string $property the field to set or check status for

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -981,12 +981,12 @@ class Table {
 		$parents = $children = [];
 		foreach ($assocs as $assoc) {
 			$association = $this->association($assoc);
-			if (!$assoc) {
+			if (!$association) {
 				$msg = __d('cake_dev', '%s is not associated to %s', $this->alias(), $assoc);
-				throw new \InvalidArgumentException();
+				throw new \InvalidArgumentException($msg);
 			}
 	
-			if ($assoc->isOwningSide()) {
+			if ($association->isOwningSide()) {
 				$children[] = $assoc;
 			} else {
 				$parents[] = $assoc;
@@ -1002,6 +1002,7 @@ class Table {
 
 		foreach ($assocs as $alias) {
 			$association = $this->association($alias);
+			unset($options['associated']);
 			if (!$association->save($entity, $options)) {
 				return false;
 			}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1012,7 +1012,11 @@ class Table {
 
 	protected function _sortAssociationTypes($assocs) {
 		$parents = $children = [];
-		foreach ($assocs as $assoc) {
+		foreach ($assocs as $key => $assoc) {
+			if (!is_string($assoc)) {
+				$assoc = $key;
+			}
+
 			$association = $this->association($assoc);
 			if (!$association) {
 				$msg = __d('cake_dev', '%s is not associated to %s', $this->alias(), $assoc);
@@ -1033,6 +1037,7 @@ class Table {
 			return $entity;
 		}
 
+		$associated = $options['associated'];
 		unset($options['associated']);
 
 		foreach ($assocs as $alias) {
@@ -1041,6 +1046,10 @@ class Table {
 
 			if (!$entity->dirty($property)) {
 				continue;
+			}
+
+			if (isset($associated[$alias])) {
+				$options = (array)$associated[$alias] + $options;
 			}
 
 			if (!$association->save($entity, $options)) {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1010,6 +1010,17 @@ class Table {
 		return $success;
 	}
 
+/**
+ * Auxiliary method used to sort out which associations are defined in this table
+ * as the owning side and which not based on a list of provided aliases.
+ *
+ * @param array $assocs list of association aliases
+ * @throws \InvalidArgumentException if one of the provided aliases is not an
+ * actual association defined for this table
+ * @return array with two values, first one contain associations which target
+ * is the owning side (or parent associations) and second value is an array of
+ * associations aliases for which this table is the owning side.
+ */
 	protected function _sortAssociationTypes($assocs) {
 		$parents = $children = [];
 		foreach ($assocs as $key => $assoc) {
@@ -1032,6 +1043,20 @@ class Table {
 		return [$parents, $children];
 	}
 
+/**
+ * Runs through a list of aliases and for each of them calls the `save()` method
+ * on the corresponding association objects passing $entity and $options as values.
+ * If the alias for one of the associations contains an array as values in $assocs,
+ * $options will me merge to this value before passed to the save operation.
+ *
+ *
+ * @param array $assocs list of association aliases.
+ * @param \Cake\ORM\Entity $entity the entity belonging to this table and maybe
+ * containing associated entities.
+ * @param array $options options to be passed to the save operation
+ * @return boolean|\Cake\ORM\Entity The saved source entity on success, false
+ * otherwise
+ */
 	protected function _saveAssociations($assocs, $entity, array $options) {
 		if (empty($assocs)) {
 			return $entity;

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -872,6 +872,8 @@ class Table {
  * returns the same entity after a successful save or false in case
  * of any error.
  *
+ * ### Options
+ *
  * The options array can receive the following keys:
  *
  * - atomic: Whether to execute the save and callbacks inside a database
@@ -880,7 +882,15 @@ class Table {
  * fails, it will abort the save operation. If this key is set to a string value,
  * the validator object registered in this table under the provided name will be
  * used instead of the default one. (default:true)
+ * - associated: If true it will save all associated entities as they are found
+ * in the passed `$entity` whenever the property defined for the association
+ * is marked as dirty. Associated records are saved recursively unless told
+ * otherwise. If an array, it will be interpreted as the list of associations
+ * to be saved. It is possible to different options for saving on associated
+ * table objects using this key by making the custom options the array value.
+ * If false no associated records will be saved. (default: true)
  *
+ * ### Events
  *
  * When saving, this method will trigger four events:
  *
@@ -912,6 +922,26 @@ class Table {
  * inserted or updated in the database. It does that by checking the `isNew`
  * method on the entity, if no information can be found there, it will go
  * directly to the database to check the entity's status.
+ *
+ * ### Saving on associated tables
+ *
+ * This method will by default persist entities belonging to associated tables,
+ * whenever a dirty property matching the name of the property name set for an
+ * association in this table. It is possible to control what associations will
+ * be saved and to pass additional option for saving them.
+ *
+ * {{{
+ * $articles->save($entity, ['associated' => ['Comment']); // Only save comment assoc
+ *
+ * // Save the company, the employees and related addresses for each of them.
+ * // For employees use the 'special' validation group
+ * $companies->save($entity, [
+ * 'associated' => ['Employee' => ['associated' => ['Address'], 'validate' => 'special']
+ * ]);
+ *
+ * // Save no associations
+ * $articles->save($entity, ['associated' => false]);
+ * }}}
  *
  * @param \Cake\ORM\Entity the entity to be saved
  * @param array $options

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -121,7 +121,7 @@ class Table implements EventListener {
 /**
  * The name of the field that represents the primary key in the table
  *
- * @var string
+ * @var array
  */
 	protected $_primaryKey;
 
@@ -937,7 +937,7 @@ class Table implements EventListener {
  * in the passed `$entity` whenever the property defined for the association
  * is marked as dirty. Associated records are saved recursively unless told
  * otherwise. If an array, it will be interpreted as the list of associations
- * to be saved. It is possible to different options for saving on associated
+ * to be saved. It is possible to provide different options for saving on associated
  * table objects using this key by making the custom options the array value.
  * If false no associated records will be saved. (default: true)
  *
@@ -1128,7 +1128,7 @@ class Table implements EventListener {
  * Runs through a list of aliases and for each of them calls the `save()` method
  * on the corresponding association objects passing $entity and $options as values.
  * If the alias for one of the associations contains an array as values in $assocs,
- * $options will me merge to this value before passed to the save operation.
+ * $options will be merged to this value before passed to the save operation.
  *
  *
  * @param array $assocs list of association aliases.

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -960,8 +960,9 @@ class Table {
 
 		$data = $entity->extract($this->schema()->columns(), true);
 		$keys = array_keys($data);
+		$isNew = $entity->isNew();
 
-		if ($entity->isNew()) {
+		if ($isNew) {
 			$success = $this->_insert($entity, $data);
 		} else {
 			$success = $this->_update($entity, $data);
@@ -972,6 +973,11 @@ class Table {
 			$this->getEventManager()->dispatch($event);
 			$entity->isNew(false);
 			$success = $this->_saveAssociations($children, $entity, $originalOptions);
+		}
+
+		if (!$success && $isNew) {
+			$entity->unsetProperty($this->primaryKey());
+			$entity->isNew(true);
 		}
 
 		return $success;

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -923,6 +923,11 @@ class Table {
 			'validate' => true,
 			'associated' => true
 		]);
+
+		if ($entity->isNew() === false && !$entity->dirty()) {
+			return $entity;
+		}
+
 		if ($options['atomic']) {
 			$connection = $this->connection();
 			$success = $connection->transactional(function() use ($entity, $options) {

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1149,16 +1149,17 @@ class Table implements EventListener {
 		foreach ($assocs as $alias) {
 			$association = $this->association($alias);
 			$property = $association->property();
+			$passOptions = $options;
 
 			if (!$entity->dirty($property)) {
 				continue;
 			}
 
 			if (isset($associated[$alias])) {
-				$options = (array)$associated[$alias] + $options;
+				$passOptions = (array)$associated[$alias] + $options;
 			}
 
-			if (!$association->save($entity, $options)) {
+			if (!$association->save($entity, $passOptions)) {
 				return false;
 			}
 		}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1115,7 +1115,7 @@ class Table implements EventListener {
 				throw new \InvalidArgumentException($msg);
 			}
 
-			if ($association->isOwningSide()) {
+			if ($association->isOwningSide($this)) {
 				$children[] = $assoc;
 			} else {
 				$parents[] = $assoc;

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -43,6 +43,9 @@ class BelongsToManyTest extends TestCase {
 		$this->tag->schema([
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
 		]);
 		$this->article = $this->getMock(
 			'Cake\ORM\Table', ['find', 'delete'], [['alias' => 'Articles', 'table' => 'articles']]
@@ -50,6 +53,9 @@ class BelongsToManyTest extends TestCase {
 		$this->article->schema([
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
 		]);
 		TableRegistry::set('Articles', $this->article);
 	}
@@ -171,7 +177,10 @@ class BelongsToManyTest extends TestCase {
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
-				'tag_id' => ['type' => 'integer']
+				'tag_id' => ['type' => 'integer'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]
+				]
 			]
 		]);
 		$association = new BelongsToMany('Tags', $config);

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -40,6 +40,9 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'company_name' => ['type' => 'string'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
 			]
 		]);
 		$this->client = TableRegistry::get('Clients', [
@@ -47,6 +50,9 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 				'id' => ['type' => 'integer'],
 				'client_name' => ['type' => 'string'],
 				'company_id' => ['type' => 'integer'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
 			]
 		]);
 	}

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -40,6 +40,9 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
 			]
 		]);
 		$this->article = $this->getMock(
@@ -51,6 +54,9 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'id' => ['type' => 'integer'],
 			'title' => ['type' => 'string'],
 			'author_id' => ['type' => 'integer'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
 		]);
 	}
 

--- a/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -39,6 +39,9 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'schema' => [
 				'id' => ['type' => 'integer'],
 				'username' => ['type' => 'string'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
 			]
 		]);
 		$this->profile = TableRegistry::get('Profiles', [
@@ -46,6 +49,9 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 				'id' => ['type' => 'integer'],
 				'first_name' => ['type' => 'string'],
 				'user_id' => ['type' => 'integer'],
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
 			]
 		]);
 	}

--- a/Cake/Test/TestCase/ORM/AssociationTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationTest.php
@@ -52,7 +52,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
 		];
 		$this->association = $this->getMock(
 			'\Cake\ORM\Association',
-			['_options', 'attachTo', '_joinCondition', 'cascadeDelete'],
+			['_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide', 'save'],
 			['Foo', $config]
 		);
 	}

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -475,7 +475,7 @@ class EntityTest extends TestCase {
 		$entity->dirty('author_id', false);
 		$this->assertFalse($entity->dirty());
 	}
-	
+
 /**
  * Tests dirty() when altering properties values and adding new ones
  *

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -464,11 +464,16 @@ class EntityTest extends TestCase {
 		$this->assertTrue($entity->dirty('title'));
 		$this->assertTrue($entity->dirty('author_id'));
 
+		$this->assertTrue($entity->dirty());
+
 		$entity->dirty('id', false);
 		$this->assertFalse($entity->dirty('id'));
 		$this->assertTrue($entity->dirty('title'));
 		$entity->dirty('title', false);
 		$this->assertFalse($entity->dirty('title'));
+		$this->assertTrue($entity->dirty());
+		$entity->dirty('author_id', false);
+		$this->assertFalse($entity->dirty());
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -475,7 +475,7 @@ class EntityTest extends TestCase {
 		$entity->dirty('author_id', false);
 		$this->assertFalse($entity->dirty());
 	}
-
+	
 /**
  * Tests dirty() when altering properties values and adding new ones
  *

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -49,16 +49,27 @@ class QueryTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->connection = ConnectionManager::get('test');
-		$schema = ['id' => ['type' => 'integer']];
+		$schema = [
+			'id' => ['type' => 'integer'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
+		];
 		$schema1 = [
 			'id' => ['type' => 'integer'],
 			'name' => ['type' => 'string'],
-			'phone' => ['type' => 'string']
+			'phone' => ['type' => 'string'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
 		];
 		$schema2 = [
 			'id' => ['type' => 'integer'],
 			'total' => ['type' => 'string'],
-			'placed' => ['type' => 'datetime']
+			'placed' => ['type' => 'datetime'],
+			'_constraints' => [
+				'primary' => ['type' => 'primary', 'columns' => ['id']]
+			]
 		];
 
 		$this->table = $table = TableRegistry::get('foo', ['schema' => $schema]);

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -128,7 +128,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testPrimaryKey() {
-		$table = new Table(['table' => 'users']);
+		$table = new Table([
+			'table' => 'users',
+			'schema' => [
+				'id' => ['type' => 'integer'],
+				'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+			]
+		]);
 		$this->assertEquals('id', $table->primaryKey());
 		$table->primaryKey('thingID');
 		$this->assertEquals('thingID', $table->primaryKey());
@@ -176,7 +182,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'table' => 'users',
 			'schema' => [
 				'id' => ['type' => 'string'],
-				'foo' => ['type' => 'string']
+				'foo' => ['type' => 'string'],
+				'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 			]
 		]);
 		$this->assertEquals('id', $table->displayField());
@@ -192,7 +199,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'table' => 'users',
 			'schema' => [
 				'id' => ['type' => 'string'],
-				'foo' => ['type' => 'string']
+				'foo' => ['type' => 'string'],
+				'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 			]
 		]);
 		$this->assertEquals('id', $table->displayField());

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2434,4 +2434,32 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertSame($entity, $table->save($entity));
 	}
 
+/**
+ * Integration test to show how to append a new tag to an article
+ *
+ * @group save
+ * @return void
+ */
+	public function testBelongsToManyIntegration() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$tags = $article->tags;
+		$this->assertNotEmpty($tags);
+		$tags[] = new \TestApp\Model\Entity\Tag([
+			'name' => 'Something New'
+		]);
+		$article->tags = $tags;
+		$this->assertSame($article, $table->save($article));
+		$tags = $article->tags;
+		$this->assertCount(3, $tags);
+		$this->assertFalse($tags[2]->isNew());
+		$this->assertEquals(4, $tags[2]->id);
+		$this->assertEquals(1, $tags[2]->extraInfo->article_id);
+		$this->assertEquals(4, $tags[2]->extraInfo->tag_id);
+
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertEquals($tags, $article->tags);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2418,4 +2418,20 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals(5, $entity->tags[1]->extraInfo->tag_id);
 	}
 
+/**
+ * Tests that saving a persisted and clean entity will is a no-op
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveCleanEntity() {
+		$table = $this->getMock('\Cake\ORM\Table', ['_processSave']);
+		$entity = new \Cake\ORM\Entity(
+			['id' => 'foo'],
+			['markNew' => false, 'markClean' => true]
+		);
+		$table->expects($this->never())->method('_processSave');
+		$this->assertSame($entity, $table->save($entity));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2557,7 +2557,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 		$table->association('tags')
-			->pivot()
+			->junction()
 			->validator()
 			->add('article_id', 'num', ['rule' => ['comparison', '>', 4]]);
 
@@ -2595,7 +2595,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 		$table->association('tags')
-			->pivot()
+			->junction()
 			->validator()
 			->add('tag_id', 'num', ['rule' => ['comparison', '>', 4]]);
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2201,7 +2201,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @group save
  * @return void
  */
-	public function testsSaveBelongsToWithValidationErrorNotAtomic() {
+	public function testSaveBelongsToWithValidationErrorNotAtomic() {
 		$entity = new \Cake\ORM\Entity([
 			'title' => 'A Title',
 			'body' => 'A body'

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1953,7 +1953,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'body' => 'A body'
 		]);
 		$entity->author = new \Cake\ORM\Entity([
-			'name' => 'Jose',
+			'name' => 'Jose'
 		]);
 
 		$table = TableRegistry::get('articles');
@@ -1963,6 +1963,35 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertFalse($entity->author->isNew());
 		$this->assertEquals(5, $entity->author->id);
 		$this->assertEquals(5, $entity->get('author_id'));
+	}
+
+/**
+ * Tests saving belongsTo association and get a validation error
+ *
+ * @group save
+ * @return void
+ */
+	public function testsSaveBelongsToWithValidationError() {
+		$entity = new \Cake\ORM\Entity([
+			'title' => 'A Title',
+			'body' => 'A body'
+		]);
+		$entity->author = new \Cake\ORM\Entity([
+			'name' => 'Jose'
+		]);
+
+		$table = TableRegistry::get('articles');
+		$table->belongsTo('authors');
+		$table->association('authors')
+			->target()
+			->validator()
+			->add('name', 'num', ['rule' => 'numeric']);
+
+		$this->assertFalse($table->save($entity));
+		$this->assertTrue($entity->isNew());
+		$this->assertTrue($entity->author->isNew());
+		$this->assertNull($entity->get('author_id'));
+		$this->assertNotEmpty($entity->author->errors('name'));
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1994,4 +1994,60 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertNotEmpty($entity->author->errors('name'));
 	}
 
+/**
+ * Tests saving hasOne association
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveHasOne() {
+		$entity = new \Cake\ORM\Entity([
+			'name' => 'Jose'
+		]);
+		$entity->article = new \Cake\ORM\Entity([
+			'title' => 'A Title',
+			'body' => 'A body'
+		]);
+
+		$table = TableRegistry::get('authors');
+		$table->hasOne('articles');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertFalse($entity->isNew());
+		$this->assertFalse($entity->article->isNew());
+		$this->assertEquals(4, $entity->article->id);
+		$this->assertEquals(5, $entity->article->get('author_id'));
+		$this->assertFalse($entity->article->dirty('author_id'));
+	}
+
+/**
+ * Tests saving hasOne association and returning a validation error will
+ * abort the saving process
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveHasOneWithValidationError() {
+		$entity = new \Cake\ORM\Entity([
+			'name' => 'Jose'
+		]);
+		$entity->article = new \Cake\ORM\Entity([
+			'title' => 'A Title',
+			'body' => 'A body'
+		]);
+
+		$table = TableRegistry::get('authors');
+		$table->hasOne('articles');
+		$table->association('articles')
+			->target()
+			->validator()
+			->add('title', 'num', ['rule' => 'numeric']);
+		$this->assertFalse($table->save($entity));
+		$this->assertFalse($entity->isNew());
+		$this->assertTrue($entity->article->isNew());
+		$this->assertNull($entity->article->id);
+		$this->assertNull($entity->article->get('author_id'));
+		$this->assertTrue($entity->article->dirty('author_id'));
+		$this->assertNotEMpty($entity->article->errors('title'));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2225,11 +2225,44 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->validator()
 			->add('name', 'num', ['rule' => 'numeric']);
 
-		$this->assertSame($entity, $table->save($entity));
+		$this->assertSame($entity, $table->save($entity, ['atomic' => false]));
 		$this->assertFalse($entity->isNew());
 		$this->assertTrue($entity->author->isNew());
 		$this->assertNull($entity->get('author_id'));
 		$this->assertNotEmpty($entity->author->errors('name'));
+	}
+
+/**
+ * Tests saving belongsToMany records
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveBelongsToMany() {
+		$entity = new \Cake\ORM\Entity([
+			'title' => 'A Title',
+			'body' => 'A body'
+		]);
+		$entity->tags = [
+			new \Cake\ORM\Entity([
+				'name' => 'Something New'
+			]),
+			new \Cake\ORM\Entity([
+				'name' => 'Another Something'
+			])
+		];
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertFalse($entity->isNew());
+		$this->assertFalse($entity->tags[0]->isNew());
+		$this->assertFalse($entity->tags[1]->isNew());
+		$this->assertEquals(4, $entity->tags[0]->id);
+		$this->assertEquals(5, $entity->tags[1]->id);
+		$this->assertEquals(4, $entity->tags[0]->extraInfo->article_id);
+		$this->assertEquals(4, $entity->tags[1]->extraInfo->article_id);
+		$this->assertEquals(4, $entity->tags[0]->extraInfo->tag_id);
+		$this->assertEquals(5, $entity->tags[1]->extraInfo->tag_id);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1941,4 +1941,28 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals(['Not good'], $entity->errors('username'));
 	}
 
+/**
+ * Tests saving belongsTo association
+ *
+ * @group save
+ * @return void
+ */
+	public function testsSaveBelongsTo() {
+		$entity = new \Cake\ORM\Entity([
+			'title' => 'A Title',
+			'body' => 'A body'
+		]);
+		$entity->author = new \Cake\ORM\Entity([
+			'name' => 'Jose',
+		]);
+
+		$table = TableRegistry::get('articles');
+		$table->belongsTo('authors');
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertFalse($entity->isNew());
+		$this->assertFalse($entity->author->isNew());
+		$this->assertEquals(5, $entity->author->id);
+		$this->assertEquals(5, $entity->get('author_id'));
+	}
+
 }


### PR DESCRIPTION
This PR includes all the logic for saving associated records. Some of the highlights:
- `Table::save()` will save associations by default
- It is possible to whitelist the associations that will be inspected
- Only entities stored in a dirty property of the source object will be saved
- Saving is delegated to association classes
- BelongsToMany will _NOT_ destroy existing links only update or create new ones

Things that will be addressed in future PRs:
- A "Set" saving strategy for HasMany: Delete all in target association before saving records
- Dedicated methods for handling BelongsToMany: `$belongsToMany->link($article, [$tag1, $tag2])` `$belongsToMany->unlink($article, [$tag1, $tag2])` and `$belongsToMany->replace($article, [$tag1, $tag2])`;
