### PR TITLE
Hide the command list and completion shell on the cli

### DIFF
--- a/Cake/Console/Command/Task/CommandTask.php
+++ b/Cake/Console/Command/Task/CommandTask.php
@@ -35,13 +35,14 @@ class CommandTask extends Shell {
  */
 	public function getShellList() {
 		$skipFiles = ['AppShell'];
+		$hiddenCommands = ['CommandListShell', 'CompletionShell'];
 
 		$plugins = Plugin::loaded();
 		$shellList = array_fill_keys($plugins, null) + ['CORE' => null, 'app' => null];
 
 		$corePath = App::core('Console/Command');
 		$shells = App::objects('file', $corePath[0]);
-		$shells = array_diff($shells, $skipFiles);
+		$shells = array_diff($shells, $skipFiles, $hiddenCommands);
 		$this->_appendShells('CORE', $shells, $shellList);
 
 		$appShells = App::objects('Console/Command', null, false);

--- a/Cake/Test/TestCase/Console/Command/CommandListShellTest.php
+++ b/Cake/Test/TestCase/Console/Command/CommandListShellTest.php
@@ -94,7 +94,7 @@ class CommandListShellTest extends TestCase {
 		$expected = "/\[.*TestPluginTwo.*\] example, welcome/";
 		$this->assertRegExp($expected, $output);
 
-		$expected = "/\[.*CORE.*\] acl, bake, command_list, completion, i18n, server, test, upgrade/";
+		$expected = "/\[.*CORE.*\] acl, bake, i18n, server, test, upgrade/";
 		$this->assertRegExp($expected, $output);
 
 		$expected = "/\[.*app.*\] sample/";

--- a/Cake/Test/TestCase/Console/Command/CompletionShellTest.php
+++ b/Cake/Test/TestCase/Console/Command/CompletionShellTest.php
@@ -112,7 +112,7 @@ class CompletionShellTest extends TestCase {
 		$this->Shell->runCommand('commands', array());
 		$output = $this->Shell->stdout->output;
 
-		$expected = "TestPlugin.example TestPluginTwo.example TestPluginTwo.welcome acl bake command_list completion i18n server test upgrade sample\n";
+		$expected = "TestPlugin.example TestPluginTwo.example TestPluginTwo.welcome acl bake i18n server test upgrade sample\n";
 		$this->assertEquals($expected, $output);
 	}
 


### PR DESCRIPTION
Neither of these commands are intended to be called by end-users, so they are just taken-up-space in the available shell list.

This changes the cli output from:

```
-> Console/cake

Welcome to CakePHP v3.0.0-dev Console
...
Available Shells:

[CORE] acl, bake, command_list, completion, i18n, server, test, upgrade
```

to:

```
-> Console/cake

Welcome to CakePHP v3.0.0-dev Console
...
Available Shells:

[CORE] acl, bake, i18n, server, test, upgrade
```
