### PR TITLE
Update Router.php

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -509,11 +509,11 @@ class Router {
 			$urlName = Inflector::underscore($name);
 			$plugin = Inflector::underscore($plugin);
 			if ($plugin && !$hasPrefix) {
-				$prefix = '/' . $plugin . '/';
+				$prefix = '/' . $plugin;
 			}
 
 			foreach (self::$_resourceMap as $params) {
-				$url = $prefix . $urlName . (($params['id']) ? '/:id' : '');
+				$url = $prefix . '/' . $urlName . (($params['id']) ? '/:id' : '');
 
 				Router::connect($url,
 					array(


### PR DESCRIPTION
~~If not edited like this, prefixes won't work with mappedResources because the prefix get's pasted to the url without a separator "/".~~

I made a mistake editing the file so I closed this pull request.
