### PR TITLE
Check if the item is an array.

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -130,7 +130,7 @@ class Hash {
 			if ($conditions) {
 				$filter = array();
 				foreach ($next as $item) {
-					if (self::_matches($item, $conditions)) {
+					if (is_array($item) && self::_matches($item, $conditions)) {
 						$filter[] = $item;
 					}
 				}


### PR DESCRIPTION
Using the Hash::extract function I found a small "bug". 
Step to reproduce: 
You have an array and you want to extract some data from this array. If you interrogate for an item/data witch exists and is asked like an array, but isn't array the Utility class expect a warning.

Solution:
Instead send any type of data as a first parameter to the "_matches" function, I check if the parameter if is an array.
