### PR TITLE
Expose a 'defaultOptions' argument in Shell::getOptionParser().

### DIFF
--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -356,12 +356,13 @@ class AclShell extends AppShell {
 	}
 
 /**
- * Get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
 
 		$type = array(
 			'choices' => array('aro', 'aco'),
@@ -369,9 +370,8 @@ class AclShell extends AppShell {
 			'help' => __d('cake_console', 'Type of node to create.')
 		);
 
-		$parser->description(
-			__d('cake_console', 'A console tool for managing the DbAcl')
-			)->addSubcommand('create', array(
+		$parser->description(__d('cake_console', 'A console tool for managing the DbAcl'))
+			->addSubcommand('create', array(
 				'help' => __d('cake_console', 'Create a new ACL node'),
 				'parser' => array(
 					'description' => __d('cake_console', 'Creates a new ACL object <node> under the parent'),
@@ -387,8 +387,8 @@ class AclShell extends AppShell {
 							'required' => true
 						)
 					)
-				)
-			))->addSubcommand('delete', array(
+				)))
+			->addSubcommand('delete', array(
 				'help' => __d('cake_console', 'Deletes the ACL object with the given <node> reference'),
 				'parser' => array(
 					'description' => __d('cake_console', 'Delete an ACL node.'),
@@ -399,8 +399,8 @@ class AclShell extends AppShell {
 							'required' => true,
 						)
 					)
-				)
-			))->addSubcommand('setparent', array(
+				)))
+			->addSubcommand('setparent', array(
 				'help' => __d('cake_console', 'Moves the ACL node under a new parent.'),
 				'parser' => array(
 					'description' => __d('cake_console', 'Moves the ACL object specified by <node> beneath <parent>'),
@@ -415,8 +415,8 @@ class AclShell extends AppShell {
 							'required' => true
 						)
 					)
-				)
-			))->addSubcommand('getpath', array(
+				)))
+			->addSubcommand('getpath', array(
 				'help' => __d('cake_console', 'Print out the path to an ACL node.'),
 				'parser' => array(
 					'description' => array(
@@ -430,8 +430,8 @@ class AclShell extends AppShell {
 							'required' => true,
 						)
 					)
-				)
-			))->addSubcommand('check', array(
+				)))
+			->addSubcommand('check', array(
 				'help' => __d('cake_console', 'Check the permissions between an ACO and ARO.'),
 				'parser' => array(
 					'description' => array(
@@ -442,8 +442,8 @@ class AclShell extends AppShell {
 						'aco' => array('help' => __d('cake_console', 'ACO to check.'), 'required' => true),
 						'action' => array('help' => __d('cake_console', 'Action to check'), 'default' => 'all')
 					)
-				)
-			))->addSubcommand('grant', array(
+				)))
+			->addSubcommand('grant', array(
 				'help' => __d('cake_console', 'Grant an ARO permissions to an ACO.'),
 				'parser' => array(
 					'description' => array(
@@ -454,8 +454,8 @@ class AclShell extends AppShell {
 						'aco' => array('help' => __d('cake_console', 'ACO to grant access to.'), 'required' => true),
 						'action' => array('help' => __d('cake_console', 'Action to grant'), 'default' => 'all')
 					)
-				)
-			))->addSubcommand('deny', array(
+				)))
+			->addSubcommand('deny', array(
 				'help' => __d('cake_console', 'Deny an ARO permissions to an ACO.'),
 				'parser' => array(
 					'description' => array(
@@ -466,8 +466,8 @@ class AclShell extends AppShell {
 						'aco' => array('help' => __d('cake_console', 'ACO to deny.'), 'required' => true),
 						'action' => array('help' => __d('cake_console', 'Action to deny'), 'default' => 'all')
 					)
-				)
-			))->addSubcommand('inherit', array(
+				)))
+			->addSubcommand('inherit', array(
 				'help' => __d('cake_console', 'Inherit an ARO\'s parent permissions.'),
 				'parser' => array(
 					'description' => array(
@@ -478,8 +478,8 @@ class AclShell extends AppShell {
 						'aco' => array('help' => __d('cake_console', 'ACO to inherit permissions on.'), 'required' => true),
 						'action' => array('help' => __d('cake_console', 'Action to inherit'), 'default' => 'all')
 					)
-				)
-			))->addSubcommand('view', array(
+				)))
+			->addSubcommand('view', array(
 				'help' => __d('cake_console', 'View a tree or a single node\'s subtree.'),
 				'parser' => array(
 					'description' => array(
@@ -491,10 +491,10 @@ class AclShell extends AppShell {
 						'type' => $type,
 						'node' => array('help' => __d('cake_console', 'The optional node to view the subtree of.'))
 					)
-				)
-			))->addSubcommand('initdb', array(
-				'help' => __d('cake_console', 'Initialize the DbAcl tables. Uses this command : cake schema create DbAcl')
-			))->epilog(
+				)))
+			->addSubcommand('initdb', array(
+				'help' => __d('cake_console', 'Initialize the DbAcl tables. Uses this command : cake schema create DbAcl')))
+			->epilog(
 				array(
 					'Node and parent arguments can be in one of the following formats:',
 					'',
@@ -505,8 +505,8 @@ class AclShell extends AppShell {
 					"   i.e. <group>/<subgroup>/<parent>.",
 					'',
 					"To add a node at the root level, enter 'root' or '/' as the <parent> parameter."
-				)
-			);
+				));
+
 		return $parser;
 	}
 

--- a/lib/Cake/Console/Command/ApiShell.php
+++ b/lib/Cake/Console/Command/ApiShell.php
@@ -137,20 +137,23 @@ class ApiShell extends AppShell {
 	}
 
 /**
- * Get and configure the optionparser.
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		$parser->addArgument('type', array(
-			'help' => __d('cake_console', 'Either a full path or type of class (model, behavior, controller, component, view, helper)')
-		))->addArgument('className', array(
-			'help' => __d('cake_console', 'A CakePHP core class name (e.g: Component, HtmlHelper).')
-		))->addOption('method', array(
-			'short' => 'm',
-			'help' => __d('cake_console', 'The specific method you want help on.')
-		))->description(__d('cake_console', 'Lookup doc block comments for classes in CakePHP.'));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Lookup doc block comments for classes in CakePHP.'))
+			->addArgument('type', array(
+				'help' => __d('cake_console', 'Either a full path or type of class (model, behavior, controller, component, view, helper)')))
+			->addArgument('className', array(
+				'help' => __d('cake_console', 'A CakePHP core class name (e.g: Component, HtmlHelper).')))
+			->addOption('method', array(
+				'short' => 'm',
+				'help' => __d('cake_console', 'The specific method you want help on.')));
+
 		return $parser;
 	}
 

--- a/lib/Cake/Console/Command/BakeShell.php
+++ b/lib/Cake/Console/Command/BakeShell.php
@@ -203,50 +203,53 @@ class BakeShell extends AppShell {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(__d('cake_console',
-			'The Bake script generates controllers, views and models for your application.' .
-			' If run with no command line arguments, Bake guides the user through the class creation process.' .
-			' You can customize the generation process by telling Bake where different parts of your application are using command line arguments.'
-		))->addSubcommand('all', array(
-			'help' => __d('cake_console', 'Bake a complete MVC. optional <name> of a Model'),
-		))->addSubcommand('project', array(
-			'help' => __d('cake_console', 'Bake a new app folder in the path supplied or in current directory if no path is specified'),
-			'parser' => $this->Project->getOptionParser()
-		))->addSubcommand('plugin', array(
-			'help' => __d('cake_console', 'Bake a new plugin folder in the path supplied or in current directory if no path is specified.'),
-			'parser' => $this->Plugin->getOptionParser()
-		))->addSubcommand('db_config', array(
-			'help' => __d('cake_console', 'Bake a database.php file in config directory.'),
-			'parser' => $this->DbConfig->getOptionParser()
-		))->addSubcommand('model', array(
-			'help' => __d('cake_console', 'Bake a model.'),
-			'parser' => $this->Model->getOptionParser()
-		))->addSubcommand('view', array(
-			'help' => __d('cake_console', 'Bake views for controllers.'),
-			'parser' => $this->View->getOptionParser()
-		))->addSubcommand('controller', array(
-			'help' => __d('cake_console', 'Bake a controller.'),
-			'parser' => $this->Controller->getOptionParser()
-		))->addSubcommand('fixture', array(
-			'help' => __d('cake_console', 'Bake a fixture.'),
-			'parser' => $this->Fixture->getOptionParser()
-		))->addSubcommand('test', array(
-			'help' => __d('cake_console', 'Bake a unit test.'),
-			'parser' => $this->Test->getOptionParser()
-		))->addOption('connection', array(
-			'help' => __d('cake_console', 'Database connection to use in conjunction with `bake all`.'),
-			'short' => 'c',
-			'default' => 'default'
-		))->addOption('theme', array(
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(
+				__d('cake_console',	'The Bake script generates controllers, views and models for your application.' .
+				' If run with no command line arguments, Bake guides the user through the class creation process.' .
+				' You can customize the generation process by telling Bake where different parts of your application are using command line arguments.'))
+			->addSubcommand('all', array(
+				'help' => __d('cake_console', 'Bake a complete MVC. optional <name> of a Model')))
+			->addSubcommand('project', array(
+				'help' => __d('cake_console', 'Bake a new app folder in the path supplied or in current directory if no path is specified'),
+				'parser' => $this->Project->getOptionParser()))
+			->addSubcommand('plugin', array(
+				'help' => __d('cake_console', 'Bake a new plugin folder in the path supplied or in current directory if no path is specified.'),
+				'parser' => $this->Plugin->getOptionParser()))
+			->addSubcommand('db_config', array(
+				'help' => __d('cake_console', 'Bake a database.php file in config directory.'),
+				'parser' => $this->DbConfig->getOptionParser()))
+			->addSubcommand('model', array(
+				'help' => __d('cake_console', 'Bake a model.'),
+				'parser' => $this->Model->getOptionParser()))
+			->addSubcommand('view', array(
+				'help' => __d('cake_console', 'Bake views for controllers.'),
+				'parser' => $this->View->getOptionParser()))
+			->addSubcommand('controller', array(
+				'help' => __d('cake_console', 'Bake a controller.'),
+				'parser' => $this->Controller->getOptionParser()))
+			->addSubcommand('fixture', array(
+				'help' => __d('cake_console', 'Bake a fixture.'),
+				'parser' => $this->Fixture->getOptionParser()))
+			->addSubcommand('test', array(
+				'help' => __d('cake_console', 'Bake a unit test.'),
+				'parser' => $this->Test->getOptionParser()))
+			->addOption('connection', array(
+				'help' => __d('cake_console', 'Database connection to use in conjunction with `bake all`.'),
+				'short' => 'c',
+				'default' => 'default'))
+			->addOption('theme', array(
+				'short' => 't',
+				'help' => __d('cake_console', 'Theme to use when baking code.')));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/CommandListShell.php
+++ b/lib/Cake/Console/Command/CommandListShell.php
@@ -120,13 +120,15 @@ class CommandListShell extends AppShell {
 	}
 
 /**
- * get the option parser
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(__d('cake_console', 'Get the list of available shells for this CakePHP application.'))
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Get the list of available shells for this CakePHP application.'))
 			->addOption('sort', array(
 				'help' => __d('cake_console', 'Does nothing (deprecated)'),
 				'boolean' => true
@@ -135,6 +137,8 @@ class CommandListShell extends AppShell {
 				'help' => __d('cake_console', 'Get the listing as XML.'),
 				'boolean' => true
 			));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/CompletionShell.php
+++ b/lib/Cake/Console/Command/CompletionShell.php
@@ -96,12 +96,13 @@ class CompletionShell extends AppShell {
 	}
 
 /**
- * getOptionParser for _this_ shell
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
 
 		$parser->description(__d('cake_console', 'Used by shells like bash to autocomplete command name, options and arguments'))
 			->addSubcommand('commands', array(
@@ -136,8 +137,8 @@ class CompletionShell extends AppShell {
 			))->epilog(
 				array(
 					__d('cake_console', 'This command is not intended to be called manually'),
-				)
-			);
+				));
+
 		return $parser;
 	}
 

--- a/lib/Cake/Console/Command/ConsoleShell.php
+++ b/lib/Cake/Console/Command/ConsoleShell.php
@@ -105,11 +105,14 @@ class ConsoleShell extends AppShell {
 	}
 
 /**
- * getOptionParser
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
 		$description = array(
 			'The interactive console is a tool for testing parts of your',
 			'app before you write code.',
@@ -177,7 +180,8 @@ class ConsoleShell extends AppShell {
 			'',
 			"\tRoutes show",
 		);
-		return parent::getOptionParser()
+
+		return $parser
 			->description($description)
 			->epilog($epilog);
 	}

--- a/lib/Cake/Console/Command/I18nShell.php
+++ b/lib/Cake/Console/Command/I18nShell.php
@@ -100,20 +100,23 @@ class I18nShell extends AppShell {
 	}
 
 /**
- * Get and configure the Option parser
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-			__d('cake_console', 'I18n Shell initializes i18n database table for your application and generates .pot files(s) with translations.')
-			)->addSubcommand('initdb', array(
-				'help' => __d('cake_console', 'Initialize the i18n table.')
-			))->addSubcommand('extract', array(
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(
+				__d('cake_console', 'I18n Shell initializes i18n database table for your application and generates .pot files(s) with translations.'))
+			->addSubcommand('initdb', array(
+				'help' => __d('cake_console', 'Initialize the i18n table.')))
+			->addSubcommand('extract', array(
 				'help' => __d('cake_console', 'Extract the po translations from your application'),
-				'parser' => $this->Extract->getOptionParser()
-			));
+				'parser' => $this->Extract->getOptionParser()));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/SchemaShell.php
+++ b/lib/Cake/Console/Command/SchemaShell.php
@@ -457,11 +457,14 @@ class SchemaShell extends AppShell {
 	}
 
 /**
- * get the option parser
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
 		$plugin = array(
 			'short' => 'p',
 			'help' => __d('cake_console', 'The plugin to use.'),
@@ -515,58 +518,55 @@ class SchemaShell extends AppShell {
 			'boolean' => true
 		);
 
-		$parser = parent::getOptionParser();
 		$parser->description(
-			__d('cake_console',
-				'The Schema Shell generates a schema object from the database and updates the database from the schema.'
-			)
-		)->addSubcommand('view', array(
-			'help' => __d('cake_console', 'Read and output the contents of a schema file'),
-			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection'),
-				'arguments' => compact('name')
-			)
-		))->addSubcommand('generate', array(
-			'help' => __d('cake_console', 'Reads from --connection and writes to --path. Generate snapshots with -s'),
-			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force', 'models', 'exclude'),
-				'arguments' => array(
-					'snapshot' => array('help' => __d('cake_console', 'Generate a snapshot.'))
-				)
-			)
-		))->addSubcommand('dump', array(
-			'help' => __d('cake_console', 'Dump database SQL based on a schema file to stdout.'),
-			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'write'),
-				'arguments' => compact('name')
-			)
-		))->addSubcommand('create', array(
-			'help' => __d('cake_console', 'Drop and create tables based on the schema file.'),
-			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'yes'),
-				'args' => array(
-					'name' => array(
-						'help' => __d('cake_console', 'Name of schema to use.')
-					),
-					'table' => array(
-						'help' => __d('cake_console', 'Only create the specified table.')
+				__d('cake_console', 'The Schema Shell generates a schema object from the database and updates the database from the schema.'))
+			->addSubcommand('view', array(
+				'help' => __d('cake_console', 'Read and output the contents of a schema file'),
+				'parser' => array(
+					'options' => compact('plugin', 'path', 'file', 'name', 'connection'),
+					'arguments' => compact('name')
+				)))
+			->addSubcommand('generate', array(
+				'help' => __d('cake_console', 'Reads from --connection and writes to --path. Generate snapshots with -s'),
+				'parser' => array(
+					'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'snapshot', 'force', 'models', 'exclude'),
+					'arguments' => array(
+						'snapshot' => array('help' => __d('cake_console', 'Generate a snapshot.'))
 					)
-				)
-			)
-		))->addSubcommand('update', array(
-			'help' => __d('cake_console', 'Alter the tables based on the schema file.'),
-			'parser' => array(
-				'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'force', 'yes'),
-				'args' => array(
-					'name' => array(
-						'help' => __d('cake_console', 'Name of schema to use.')
-					),
-					'table' => array(
-						'help' => __d('cake_console', 'Only create the specified table.')
+				)))
+			->addSubcommand('dump', array(
+				'help' => __d('cake_console', 'Dump database SQL based on a schema file to stdout.'),
+				'parser' => array(
+					'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'write'),
+					'arguments' => compact('name')
+				)))
+			->addSubcommand('create', array(
+				'help' => __d('cake_console', 'Drop and create tables based on the schema file.'),
+				'parser' => array(
+					'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'yes'),
+					'args' => array(
+						'name' => array(
+							'help' => __d('cake_console', 'Name of schema to use.')
+						),
+						'table' => array(
+							'help' => __d('cake_console', 'Only create the specified table.')
+						)
 					)
-				)
-			)
-		));
+				)))
+			->addSubcommand('update', array(
+				'help' => __d('cake_console', 'Alter the tables based on the schema file.'),
+				'parser' => array(
+					'options' => compact('plugin', 'path', 'file', 'name', 'connection', 'dry', 'snapshot', 'force', 'yes'),
+					'args' => array(
+						'name' => array(
+							'help' => __d('cake_console', 'Name of schema to use.')
+						),
+						'table' => array(
+							'help' => __d('cake_console', 'Only create the specified table.')
+						)
+					)
+				)));
+
 		return $parser;
 	}
 

--- a/lib/Cake/Console/Command/ServerShell.php
+++ b/lib/Cake/Console/Command/ServerShell.php
@@ -137,30 +137,26 @@ class ServerShell extends AppShell {
 	}
 
 /**
- * Get and configure the optionparser.
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-
-		$parser->addOption('host', array(
-			'short' => 'H',
-			'help' => __d('cake_console', 'ServerHost')
-		));
-		$parser->addOption('port', array(
-			'short' => 'p',
-			'help' => __d('cake_console', 'ListenPort')
-		));
-		$parser->addOption('document_root', array(
-			'short' => 'd',
-			'help' => __d('cake_console', 'DocumentRoot')
-		));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
 
 		$parser->description(array(
-			__d('cake_console', 'PHP Built-in Server for CakePHP'),
-			__d('cake_console', '<warning>[WARN] Don\'t use this at the production environment</warning>'),
-		));
+				__d('cake_console', 'PHP Built-in Server for CakePHP'),
+				__d('cake_console', '<warning>[WARN] Don\'t use this at the production environment</warning>')))
+			->addOption('host', array(
+				'short' => 'H',
+				'help' => __d('cake_console', 'ServerHost')))
+			->addOption('port', array(
+				'short' => 'p',
+				'help' => __d('cake_console', 'ListenPort')))
+			->addOption('document_root', array(
+				'short' => 'd',
+				'help' => __d('cake_console', 'DocumentRoot')));
 
 		return $parser;
 	}

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -456,37 +456,40 @@ class ControllerTask extends BakeTask {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-				__d('cake_console', 'Bake a controller for a model. Using options you can bake public, admin or both.')
-			)->addArgument('name', array(
-				'help' => __d('cake_console', 'Name of the controller to bake. Can use Plugin.name to bake controllers into plugins.')
-			))->addOption('public', array(
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Bake a controller for a model. Using options you can bake public, admin or both.'))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'Name of the controller to bake. Can use Plugin.name to bake controllers into plugins.')))
+			->addOption('public', array(
 				'help' => __d('cake_console', 'Bake a controller with basic crud actions (index, view, add, edit, delete).'),
-				'boolean' => true
-			))->addOption('admin', array(
+				'boolean' => true))
+			->addOption('admin', array(
 				'help' => __d('cake_console', 'Bake a controller with crud actions for one of the Routing.prefixes.'),
-				'boolean' => true
-			))->addOption('plugin', array(
+				'boolean' => true))
+			->addOption('plugin', array(
 				'short' => 'p',
-				'help' => __d('cake_console', 'Plugin to bake the controller into.')
-			))->addOption('connection', array(
+				'help' => __d('cake_console', 'Plugin to bake the controller into.')))
+			->addOption('connection', array(
 				'short' => 'c',
-				'help' => __d('cake_console', 'The connection the controller\'s model is on.')
-			))->addOption('theme', array(
+				'help' => __d('cake_console', 'The connection the controller\'s model is on.')))
+			->addOption('theme', array(
 				'short' => 't',
-				'help' => __d('cake_console', 'Theme to use when baking code.')
-			))->addOption('force', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('force', array(
 				'short' => 'f',
-				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
-			))->addSubcommand('all', array(
-				'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')
-			))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')))
+			->addSubcommand('all', array(
+				'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')))
+			->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -368,15 +368,18 @@ class DbConfigTask extends AppShell {
 	}
 
 /**
- * get the option parser
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-				__d('cake_console', 'Bake new database configuration settings.')
-			);
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(
+				__d('cake_console', 'Bake new database configuration settings.'));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -296,52 +296,50 @@ class ExtractTask extends AppShell {
 	}
 
 /**
- * Get & configure the option parser
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(__d('cake_console', 'CakePHP Language String Extraction:'))
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'CakePHP Language String Extraction:'))
 			->addOption('app', array('help' => __d('cake_console', 'Directory where your application is located.')))
 			->addOption('paths', array('help' => __d('cake_console', 'Comma separated list of paths.')))
 			->addOption('merge', array(
 				'help' => __d('cake_console', 'Merge all domain and category strings into the default.po file.'),
-				'choices' => array('yes', 'no')
-			))
+				'choices' => array('yes', 'no')))
 			->addOption('output', array('help' => __d('cake_console', 'Full path to output directory.')))
 			->addOption('files', array('help' => __d('cake_console', 'Comma separated list of files.')))
 			->addOption('exclude-plugins', array(
 				'boolean' => true,
 				'default' => true,
-				'help' => __d('cake_console', 'Ignores all files in plugins if this command is run inside from the same app directory.')
-			))
+				'help' => __d('cake_console', 'Ignores all files in plugins if this command is run inside from the same app directory.')))
 			->addOption('plugin', array(
-				'help' => __d('cake_console', 'Extracts tokens only from the plugin specified and puts the result in the plugin\'s Locale directory.')
-			))
+				'help' => __d('cake_console', 'Extracts tokens only from the plugin specified and puts the result in the plugin\'s Locale directory.')))
 			->addOption('ignore-model-validation', array(
 				'boolean' => true,
 				'default' => false,
 				'help' => __d('cake_console', 'Ignores validation messages in the $validate property.' .
 					' If this flag is not set and the command is run from the same app directory,' .
-					' all messages in model validation rules will be extracted as tokens.')
-			))
+					' all messages in model validation rules will be extracted as tokens.'
+				)))
 			->addOption('validation-domain', array(
-				'help' => __d('cake_console', 'If set to a value, the localization domain to be used for model validation messages.')
-			))
+				'help' => __d('cake_console', 'If set to a value, the localization domain to be used for model validation messages.')))
 			->addOption('exclude', array(
 				'help' => __d('cake_console', 'Comma separated list of directories to exclude.' .
-					' Any path containing a path segment with the provided values will be skipped. E.g. test,vendors')
-			))
+					' Any path containing a path segment with the provided values will be skipped. E.g. test,vendors'
+				)))
 			->addOption('overwrite', array(
 				'boolean' => true,
 				'default' => false,
-				'help' => __d('cake_console', 'Always overwrite existing .pot files.')
-			))
+				'help' => __d('cake_console', 'Always overwrite existing .pot files.')))
 			->addOption('extract-core', array(
 				'help' => __d('cake_console', 'Extract messages from the CakePHP core libs.'),
-				'choices' => array('yes', 'no')
-			));
+				'choices' => array('yes', 'no')));
+
+		return $parser;
 	}
 
 /**

--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -60,42 +60,47 @@ class FixtureTask extends BakeTask {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-			__d('cake_console', 'Generate fixtures for use with the test suite. You can use `bake fixture all` to bake all fixtures.')
-		)->addArgument('name', array(
-			'help' => __d('cake_console', 'Name of the fixture to bake. Can use Plugin.name to bake plugin fixtures.')
-		))->addOption('count', array(
-			'help' => __d('cake_console', 'When using generated data, the number of records to include in the fixture(s).'),
-			'short' => 'n',
-			'default' => 10
-		))->addOption('connection', array(
-			'help' => __d('cake_console', 'Which database configuration to use for baking.'),
-			'short' => 'c',
-			'default' => 'default'
-		))->addOption('plugin', array(
-			'help' => __d('cake_console', 'CamelCased name of the plugin to bake fixtures for.'),
-			'short' => 'p',
-		))->addOption('schema', array(
-			'help' => __d('cake_console', 'Importing schema for fixtures rather than hardcoding it.'),
-			'short' => 's',
-			'boolean' => true
-		))->addOption('theme', array(
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		))->addOption('force', array(
-			'short' => 'f',
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
-		))->addOption('records', array(
-			'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, where [n] is either --count or the default of 10.'),
-			'short' => 'r',
-			'boolean' => true
-		))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(
+				__d('cake_console', 'Generate fixtures for use with the test suite. You can use `bake fixture all` to bake all fixtures.'))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'Name of the fixture to bake. Can use Plugin.name to bake plugin fixtures.')))
+			->addOption('count', array(
+				'help' => __d('cake_console', 'When using generated data, the number of records to include in the fixture(s).'),
+				'short' => 'n',
+				'default' => 10))
+			->addOption('connection', array(
+				'help' => __d('cake_console', 'Which database configuration to use for baking.'),
+				'short' => 'c',
+				'default' => 'default'))
+			->addOption('plugin', array(
+				'help' => __d('cake_console', 'CamelCased name of the plugin to bake fixtures for.'),
+				'short' => 'p'))
+			->addOption('schema', array(
+				'help' => __d('cake_console', 'Importing schema for fixtures rather than hardcoding it.'),
+				'short' => 's',
+				'boolean' => true))
+			->addOption('theme', array(
+				'short' => 't',
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('force', array(
+				'short' => 'f',
+				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')))
+			->addOption('records', array(
+				'help' => __d('cake_console', 'Used with --count and <name>/all commands to pull [n] records from the live tables, ' .
+					'where [n] is either --count or the default of 10.'),
+				'short' => 'r',
+				'boolean' => true))
+			->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+
+		return $parser;
 	}
 
 /**

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -999,31 +999,34 @@ class ModelTask extends BakeTask {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-				__d('cake_console', 'Bake models.')
-			)->addArgument('name', array(
-				'help' => __d('cake_console', 'Name of the model to bake. Can use Plugin.name to bake plugin models.')
-			))->addSubcommand('all', array(
-				'help' => __d('cake_console', 'Bake all model files with associations and validation.')
-			))->addOption('plugin', array(
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Bake models.'))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'Name of the model to bake. Can use Plugin.name to bake plugin models.')))
+			->addSubcommand('all', array(
+				'help' => __d('cake_console', 'Bake all model files with associations and validation.')))
+			->addOption('plugin', array(
 				'short' => 'p',
-				'help' => __d('cake_console', 'Plugin to bake the model into.')
-			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Plugin to bake the model into.')))
+			->addOption('theme', array(
 				'short' => 't',
-				'help' => __d('cake_console', 'Theme to use when baking code.')
-			))->addOption('connection', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('connection', array(
 				'short' => 'c',
-				'help' => __d('cake_console', 'The connection the model table is on.')
-			))->addOption('force', array(
+				'help' => __d('cake_console', 'The connection the model table is on.')))
+			->addOption('force', array(
 				'short' => 'f',
-				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
-			))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')))
+			->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+
+		return $parser;
 	}
 
 /**

--- a/lib/Cake/Console/Command/Task/PluginTask.php
+++ b/lib/Cake/Console/Command/Task/PluginTask.php
@@ -209,18 +209,21 @@ class PluginTask extends AppShell {
 	}
 
 /**
- * get the option parser for the plugin task
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(__d('cake_console',
-			'Create the directory structure, AppModel and AppController classes for a new plugin. ' .
-			'Can create plugins in any of your bootstrapped plugin paths.'
-		))->addArgument('name', array(
-			'help' => __d('cake_console', 'CamelCased name of the plugin to create.')
-		));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(
+				__d('cake_console',	'Create the directory structure, AppModel and AppController classes for a new plugin. ' .
+				'Can create plugins in any of your bootstrapped plugin paths.'))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'CamelCased name of the plugin to create.')));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/Task/ProjectTask.php
+++ b/lib/Cake/Console/Command/Task/ProjectTask.php
@@ -419,26 +419,29 @@ class ProjectTask extends AppShell {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-				__d('cake_console', 'Generate a new CakePHP project skeleton.')
-			)->addArgument('name', array(
-				'help' => __d('cake_console', 'Application directory to make, if it starts with "/" the path is absolute.')
-			))->addOption('empty', array(
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Generate a new CakePHP project skeleton.'))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'Application directory to make, if it starts with "/" the path is absolute.')))
+			->addOption('empty', array(
 				'boolean' => true,
-				'help' => __d('cake_console', 'Create empty files in each of the directories. Good if you are using git')
-			))->addOption('theme', array(
+				'help' => __d('cake_console', 'Create empty files in each of the directories. Good if you are using git')))
+			->addOption('theme', array(
 				'short' => 't',
-				'help' => __d('cake_console', 'Theme to use when baking code.')
-			))->addOption('skel', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('skel', array(
 				'default' => current(App::core('Console')) . 'Templates' . DS . 'skel',
-				'help' => __d('cake_console', 'The directory layout to use for the new application skeleton. Defaults to cake/Console/Templates/skel of CakePHP used to create the project.')
-			));
+				'help' => __d('cake_console', 'The directory layout to use for the new application skeleton. ' .
+					'Defaults to cake/Console/Templates/skel of CakePHP used to create the project.')));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -543,13 +543,15 @@ class TestTask extends BakeTask {
 	}
 
 /**
- * get the option parser.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(__d('cake_console', 'Bake test case skeletons for classes.'))
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Bake test case skeletons for classes.'))
 			->addArgument('type', array(
 				'help' => __d('cake_console', 'Type of class to bake, can be any of the following: controller, model, helper, component or behavior.'),
 				'choices' => array(
@@ -558,19 +560,21 @@ class TestTask extends BakeTask {
 					'Helper', 'helper',
 					'Component', 'component',
 					'Behavior', 'behavior'
-				)
-			))->addArgument('name', array(
-				'help' => __d('cake_console', 'An existing class to bake tests for.')
-			))->addOption('theme', array(
+				)))
+			->addArgument('name', array(
+				'help' => __d('cake_console', 'An existing class to bake tests for.')))
+			->addOption('theme', array(
 				'short' => 't',
-				'help' => __d('cake_console', 'Theme to use when baking code.')
-			))->addOption('plugin', array(
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('plugin', array(
 				'short' => 'p',
-				'help' => __d('cake_console', 'CamelCased name of the plugin to bake tests for.')
-			))->addOption('force', array(
+				'help' => __d('cake_console', 'CamelCased name of the plugin to bake tests for.')))
+			->addOption('force', array(
 				'short' => 'f',
-				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
-			))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')))
+			->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -412,38 +412,41 @@ class ViewTask extends BakeTask {
 	}
 
 /**
- * get the option parser for this task
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
-		return $parser->description(
-			__d('cake_console', 'Bake views for a controller, using built-in or custom templates.')
-		)->addArgument('controller', array(
-			'help' => __d('cake_console', 'Name of the controller views to bake. Can be Plugin.name as a shortcut for plugin baking.')
-		))->addArgument('action', array(
-			'help' => __d('cake_console', "Will bake a single action's file. core templates are (index, add, edit, view)")
-		))->addArgument('alias', array(
-			'help' => __d('cake_console', 'Will bake the template in <action> but create the filename after <alias>.')
-		))->addOption('plugin', array(
-			'short' => 'p',
-			'help' => __d('cake_console', 'Plugin to bake the view into.')
-		))->addOption('admin', array(
-			'help' => __d('cake_console', 'Set to only bake views for a prefix in Routing.prefixes'),
-			'boolean' => true
-		))->addOption('theme', array(
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		))->addOption('connection', array(
-			'short' => 'c',
-			'help' => __d('cake_console', 'The connection the connected model is on.')
-		))->addOption('force', array(
-			'short' => 'f',
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
-		))->addSubcommand('all', array(
-			'help' => __d('cake_console', 'Bake all CRUD action views for all controllers. Requires models and controllers to exist.')
-		))->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
+		$parser->description(__d('cake_console', 'Bake views for a controller, using built-in or custom templates.'))
+			->addArgument('controller', array(
+				'help' => __d('cake_console', 'Name of the controller views to bake. Can be Plugin.name as a shortcut for plugin baking.')))
+			->addArgument('action', array(
+				'help' => __d('cake_console', "Will bake a single action's file. core templates are (index, add, edit, view)")))
+			->addArgument('alias', array(
+				'help' => __d('cake_console', 'Will bake the template in <action> but create the filename after <alias>.')))
+			->addOption('plugin', array(
+				'short' => 'p',
+				'help' => __d('cake_console', 'Plugin to bake the view into.')))
+			->addOption('admin', array(
+				'help' => __d('cake_console', 'Set to only bake views for a prefix in Routing.prefixes'),
+				'boolean' => true))
+			->addOption('theme', array(
+				'short' => 't',
+				'help' => __d('cake_console', 'Theme to use when baking code.')))
+			->addOption('connection', array(
+				'short' => 'c',
+				'help' => __d('cake_console', 'The connection the connected model is on.')))
+			->addOption('force', array(
+				'short' => 'f',
+				'help' => __d('cake_console', 'Force overwriting existing files without prompting.')))
+			->addSubcommand('all', array(
+				'help' => __d('cake_console', 'Bake all CRUD action views for all controllers. Requires models and controllers to exist.')))
+			->epilog(__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.'));
+
+		return $parser;
 	}
 
 /**

--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -38,125 +38,125 @@ class TestShell extends Shell {
 	protected $_dispatcher = null;
 
 /**
- * get the option parser for the test suite.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = new ConsoleOptionParser($this->name);
-		$parser->description(array(
-			__d('cake_console', 'The CakePHP Testsuite allows you to run test cases from the command line'),
-		))->addArgument('category', array(
-			'help' => __d('cake_console', 'The category for the test, or test file, to test.'),
-			'required' => false,
-		))->addArgument('file', array(
-			'help' => __d('cake_console', 'The path to the file, or test file, to test.'),
-			'required' => false,
-		))->addOption('log-junit', array(
-			'help' => __d('cake_console', '<file> Log test execution in JUnit XML format to file.'),
-			'default' => false
-		))->addOption('log-json', array(
-			'help' => __d('cake_console', '<file> Log test execution in JSON format to file.'),
-			'default' => false
-		))->addOption('log-tap', array(
-			'help' => __d('cake_console', '<file> Log test execution in TAP format to file.'),
-			'default' => false
-		))->addOption('log-dbus', array(
-			'help' => __d('cake_console', 'Log test execution to DBUS.'),
-			'default' => false
-		))->addOption('coverage-html', array(
-			'help' => __d('cake_console', '<dir> Generate code coverage report in HTML format.'),
-			'default' => false
-		))->addOption('coverage-clover', array(
-			'help' => __d('cake_console', '<file> Write code coverage data in Clover XML format.'),
-			'default' => false
-		))->addOption('testdox-html', array(
-			'help' => __d('cake_console', '<file> Write agile documentation in HTML format to file.'),
-			'default' => false
-		))->addOption('testdox-text', array(
-			'help' => __d('cake_console', '<file> Write agile documentation in Text format to file.'),
-			'default' => false
-		))->addOption('filter', array(
-			'help' => __d('cake_console', '<pattern> Filter which tests to run.'),
-			'default' => false
-		))->addOption('group', array(
-			'help' => __d('cake_console', '<name> Only runs tests from the specified group(s).'),
-			'default' => false
-		))->addOption('exclude-group', array(
-			'help' => __d('cake_console', '<name> Exclude tests from the specified group(s).'),
-			'default' => false
-		))->addOption('list-groups', array(
-			'help' => __d('cake_console', 'List available test groups.'),
-			'boolean' => true
-		))->addOption('loader', array(
-			'help' => __d('cake_console', 'TestSuiteLoader implementation to use.'),
-			'default' => false
-		))->addOption('repeat', array(
-			'help' => __d('cake_console', '<times> Runs the test(s) repeatedly.'),
-			'default' => false
-		))->addOption('tap', array(
-			'help' => __d('cake_console', 'Report test execution progress in TAP format.'),
-			'boolean' => true
-		))->addOption('testdox', array(
-			'help' => __d('cake_console', 'Report test execution progress in TestDox format.'),
-			'default' => false,
-			'boolean' => true
-		))->addOption('no-colors', array(
-			'help' => __d('cake_console', 'Do not use colors in output.'),
-			'boolean' => true
-		))->addOption('stderr', array(
-			'help' => __d('cake_console', 'Write to STDERR instead of STDOUT.'),
-			'boolean' => true
-		))->addOption('stop-on-error', array(
-			'help' => __d('cake_console', 'Stop execution upon first error or failure.'),
-			'boolean' => true
-		))->addOption('stop-on-failure', array(
-			'help' => __d('cake_console', 'Stop execution upon first failure.'),
-			'boolean' => true
-		))->addOption('stop-on-skipped', array(
-			'help' => __d('cake_console', 'Stop execution upon first skipped test.'),
-			'boolean' => true
-		))->addOption('stop-on-incomplete', array(
-			'help' => __d('cake_console', 'Stop execution upon first incomplete test.'),
-			'boolean' => true
-		))->addOption('strict', array(
-			'help' => __d('cake_console', 'Mark a test as incomplete if no assertions are made.'),
-			'boolean' => true
-		))->addOption('wait', array(
-			'help' => __d('cake_console', 'Waits for a keystroke after each test.'),
-			'boolean' => true
-		))->addOption('process-isolation', array(
-			'help' => __d('cake_console', 'Run each test in a separate PHP process.'),
-			'boolean' => true
-		))->addOption('no-globals-backup', array(
-			'help' => __d('cake_console', 'Do not backup and restore $GLOBALS for each test.'),
-			'boolean' => true
-		))->addOption('static-backup', array(
-			'help' => __d('cake_console', 'Backup and restore static attributes for each test.'),
-			'boolean' => true
-		))->addOption('syntax-check', array(
-			'help' => __d('cake_console', 'Try to check source files for syntax errors.'),
-			'boolean' => true
-		))->addOption('bootstrap', array(
-			'help' => __d('cake_console', '<file> A "bootstrap" PHP file that is run before the tests.'),
-			'default' => false
-		))->addOption('configuration', array(
-			'help' => __d('cake_console', '<file> Read configuration from XML file.'),
-			'default' => false
-		))->addOption('no-configuration', array(
-			'help' => __d('cake_console', 'Ignore default configuration file (phpunit.xml).'),
-			'boolean' => true
-		))->addOption('include-path', array(
-			'help' => __d('cake_console', '<path(s)> Prepend PHP include_path with given path(s).'),
-			'default' => false
-		))->addOption('directive', array(
-			'help' => __d('cake_console', 'key[=value] Sets a php.ini value.'),
-			'default' => false
-		))->addOption('fixture', array(
-			'help' => __d('cake_console', 'Choose a custom fixture manager.'),
-		))->addOption('debug', array(
-			'help' => __d('cake_console', 'More verbose output.'),
-		));
+	public function getOptionParser($defaultOptions = true) {
+		$parser = new ConsoleOptionParser($this->name, $defaultOptions);
+
+		$parser->description(array(__d('cake_console', 'The CakePHP Testsuite allows you to run test cases from the command line')))
+			->addArgument('category', array(
+				'help' => __d('cake_console', 'The category for the test, or test file, to test.'),
+				'required' => false))
+			->addArgument('file', array(
+				'help' => __d('cake_console', 'The path to the file, or test file, to test.'),
+				'required' => false))
+			->addOption('log-junit', array(
+				'help' => __d('cake_console', '<file> Log test execution in JUnit XML format to file.'),
+				'default' => false))
+			->addOption('log-json', array(
+				'help' => __d('cake_console', '<file> Log test execution in JSON format to file.'),
+				'default' => false))
+			->addOption('log-tap', array(
+				'help' => __d('cake_console', '<file> Log test execution in TAP format to file.'),
+				'default' => false))
+			->addOption('log-dbus', array(
+				'help' => __d('cake_console', 'Log test execution to DBUS.'),
+				'default' => false))
+			->addOption('coverage-html', array(
+				'help' => __d('cake_console', '<dir> Generate code coverage report in HTML format.'),
+				'default' => false))
+			->addOption('coverage-clover', array(
+				'help' => __d('cake_console', '<file> Write code coverage data in Clover XML format.'),
+				'default' => false))
+			->addOption('testdox-html', array(
+				'help' => __d('cake_console', '<file> Write agile documentation in HTML format to file.'),
+				'default' => false))
+			->addOption('testdox-text', array(
+				'help' => __d('cake_console', '<file> Write agile documentation in Text format to file.'),
+				'default' => false))
+			->addOption('filter', array(
+				'help' => __d('cake_console', '<pattern> Filter which tests to run.'),
+				'default' => false))
+			->addOption('group', array(
+				'help' => __d('cake_console', '<name> Only runs tests from the specified group(s).'),
+				'default' => false))
+			->addOption('exclude-group', array(
+				'help' => __d('cake_console', '<name> Exclude tests from the specified group(s).'),
+				'default' => false))
+			->addOption('list-groups', array(
+				'help' => __d('cake_console', 'List available test groups.'),
+				'boolean' => true))
+			->addOption('loader', array(
+				'help' => __d('cake_console', 'TestSuiteLoader implementation to use.'),
+				'default' => false))
+			->addOption('repeat', array(
+				'help' => __d('cake_console', '<times> Runs the test(s) repeatedly.'),
+				'default' => false))
+			->addOption('tap', array(
+				'help' => __d('cake_console', 'Report test execution progress in TAP format.'),
+				'boolean' => true))
+			->addOption('testdox', array(
+				'help' => __d('cake_console', 'Report test execution progress in TestDox format.'),
+				'default' => false,
+				'boolean' => true))
+			->addOption('no-colors', array(
+				'help' => __d('cake_console', 'Do not use colors in output.'),
+				'boolean' => true))
+			->addOption('stderr', array(
+				'help' => __d('cake_console', 'Write to STDERR instead of STDOUT.'),
+				'boolean' => true))
+			->addOption('stop-on-error', array(
+				'help' => __d('cake_console', 'Stop execution upon first error or failure.'),
+				'boolean' => true))
+			->addOption('stop-on-failure', array(
+				'help' => __d('cake_console', 'Stop execution upon first failure.'),
+				'boolean' => true))
+			->addOption('stop-on-skipped', array(
+				'help' => __d('cake_console', 'Stop execution upon first skipped test.'),
+				'boolean' => true))
+			->addOption('stop-on-incomplete', array(
+				'help' => __d('cake_console', 'Stop execution upon first incomplete test.'),
+				'boolean' => true))
+			->addOption('strict', array(
+				'help' => __d('cake_console', 'Mark a test as incomplete if no assertions are made.'),
+				'boolean' => true))
+			->addOption('wait', array(
+				'help' => __d('cake_console', 'Waits for a keystroke after each test.'),
+				'boolean' => true))
+			->addOption('process-isolation', array(
+				'help' => __d('cake_console', 'Run each test in a separate PHP process.'),
+				'boolean' => true))
+			->addOption('no-globals-backup', array(
+				'help' => __d('cake_console', 'Do not backup and restore $GLOBALS for each test.'),
+				'boolean' => true))
+			->addOption('static-backup', array(
+				'help' => __d('cake_console', 'Backup and restore static attributes for each test.'),
+				'boolean' => true))
+			->addOption('syntax-check', array(
+				'help' => __d('cake_console', 'Try to check source files for syntax errors.'),
+				'boolean' => true))
+			->addOption('bootstrap', array(
+				'help' => __d('cake_console', '<file> A "bootstrap" PHP file that is run before the tests.'),
+				'default' => false))
+			->addOption('configuration', array(
+				'help' => __d('cake_console', '<file> Read configuration from XML file.'),
+				'default' => false))
+			->addOption('no-configuration', array(
+				'help' => __d('cake_console', 'Ignore default configuration file (phpunit.xml).'),
+				'boolean' => true))
+			->addOption('include-path', array(
+				'help' => __d('cake_console', '<path(s)> Prepend PHP include_path with given path(s).'),
+				'default' => false))
+			->addOption('directive', array(
+				'help' => __d('cake_console', 'key[=value] Sets a php.ini value.'),
+				'default' => false))
+			->addOption('fixture', array(
+				'help' => __d('cake_console', 'Choose a custom fixture manager.')))
+			->addOption('debug', array(
+				'help' => __d('cake_console', 'More verbose output.')));
 
 		return $parser;
 	}

--- a/lib/Cake/Console/Command/TestsuiteShell.php
+++ b/lib/Cake/Console/Command/TestsuiteShell.php
@@ -32,16 +32,17 @@ App::uses('CakeTestLoader', 'TestSuite');
 class TestsuiteShell extends TestShell {
 
 /**
- * get the option parser for the test suite.
+ * Gets the option parser instance and configures it.
  *
- * @return void
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
+ * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
-		$parser = parent::getOptionParser();
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
 		$parser->description(array(
 			__d('cake_console', 'The CakePHP Testsuite allows you to run test cases from the command line'),
-			__d('cake_console', "<warning>This shell is for backwards-compatibility only</warning>\nuse the test shell instead"),
-		));
+			__d('cake_console', "<warning>This shell is for backwards-compatibility only</warning>\nuse the test shell instead")));
 
 		return $parser;
 	}

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -779,11 +779,14 @@ class UpgradeShell extends AppShell {
 	}
 
 /**
- * get the option parser
+ * Gets the option parser instance and configures it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  */
-	public function getOptionParser() {
+	public function getOptionParser($defaultOptions = true) {
+		$parser = parent::getOptionParser($defaultOptions);
+
 		$subcommandParser = array(
 			'options' => array(
 				'plugin' => array(
@@ -808,53 +811,44 @@ class UpgradeShell extends AppShell {
 			)
 		);
 
-		return parent::getOptionParser()
-			->description(__d('cake_console', "A shell to help automate upgrading from CakePHP 1.3 to 2.0. \n" .
+		$parser->description(
+				__d('cake_console', "A shell to help automate upgrading from CakePHP 1.3 to 2.0. \n" .
 				"Be sure to have a backup of your application before running these commands."))
 			->addSubcommand('all', array(
 				'help' => __d('cake_console', 'Run all upgrade commands.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('tests', array(
 				'help' => __d('cake_console', 'Update tests class names to FooTest rather than FooTestCase.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('locations', array(
 				'help' => __d('cake_console', 'Move files and folders to their new homes.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('i18n', array(
 				'help' => __d('cake_console', 'Update the i18n translation method calls.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('helpers', array(
 				'help' => __d('cake_console', 'Update calls to helpers.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('basics', array(
 				'help' => __d('cake_console', 'Update removed basics functions to PHP native functions.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('request', array(
 				'help' => __d('cake_console', 'Update removed request access, and replace with $this->request.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('configure', array(
 				'help' => __d('cake_console', "Update Configure::read() to Configure::read('debug')"),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('constants', array(
 				'help' => __d('cake_console', "Replace Obsolete constants"),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('components', array(
 				'help' => __d('cake_console', 'Update components to extend Component class.'),
-				'parser' => $subcommandParser
-			))
+				'parser' => $subcommandParser))
 			->addSubcommand('exceptions', array(
 				'help' => __d('cake_console', 'Replace use of cakeError with exceptions.'),
-				'parser' => $subcommandParser
-			));
+				'parser' => $subcommandParser));
+
+		return $parser;
 	}
 
 }

--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -458,12 +458,13 @@ class Shell extends Object {
  * Gets the option parser instance and configures it.
  * By overriding this method you can configure the ConsoleOptionParser before returning it.
  *
+ * @param boolean $defaultOptions Whether you want the verbose and quiet options set.
  * @return ConsoleOptionParser
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::getOptionParser
  */
-	public function getOptionParser() {
+	public function getOptionParser($defaultOptions = true) {
 		$name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
-		$parser = new ConsoleOptionParser($name);
+		$parser = new ConsoleOptionParser($name, $defaultOptions);
 		return $parser;
 	}
 


### PR DESCRIPTION
This way, you don't need to rewrite the whole getOptionParser() when you
just need to omit the default options.

The same happens with subcommands [built from arrays](https://github.com/cakephp/cakephp/blob/master/lib/Cake/Console/ConsoleOptionParser.php#L198).

What should be the best way to avoid setting defaults? Pass an option to `'parser'` so that `buildFromArray()` knows what to do?¿

Should the subcommands inherit the parents choices?¿
