### PR TITLE
Baked test methods are marked incomplete.

### DIFF
--- a/lib/Cake/Console/Templates/default/classes/test.ctp
+++ b/lib/Cake/Console/Templates/default/classes/test.ctp
@@ -75,6 +75,7 @@ class <?php echo $fullClassName; ?>Test extends CakeTestCase {
  * @return void
  */
 	public function test<?php echo Inflector::camelize($method); ?>() {
+		$this->markTestIncomplete('test<?php echo Inflector::camelize($method); ?> not implemented.');
 	}
 
 <?php endforeach; ?>

--- a/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/TestTaskTest.php
@@ -413,6 +413,8 @@ class TestTaskTest extends CakeTestCase {
 
 		$this->assertContains('function testDoSomething()', $result);
 		$this->assertContains('function testDoSomethingElse()', $result);
+		$this->assertContains('$this->markTestIncomplete(\'testDoSomething not implemented.\')', $result);
+		$this->assertContains('$this->markTestIncomplete(\'testDoSomethingElse not implemented.\')', $result);
 
 		$this->assertContains("'app.test_task_article'", $result);
 		$this->assertContains("'app.test_task_comment'", $result);


### PR DESCRIPTION
Previously empty (and "passing") test methods now include PHPunit's `markTestIncomplete()` to better reflect the truth of the resulting file: The test methods are stubbed out, but are not yet complete and passing.

It is much easier when _running_ tests to locate incomplete test methods.

Fixes issue #2437.
