### PR TITLE
Possible issue with password checks

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -118,12 +118,10 @@ abstract class BaseAuthenticate {
 		}
 
 		$user = $result[$model];
-		if ($password) {
-			if (!$this->passwordHasher()->check($password, $user[$fields['password']])) {
-				return false;
-			}
-			unset($user[$fields['password']]);
+		if (!$this->passwordHasher()->check($password, $user[$fields['password']])) {
+			return false;
 		}
+		unset($user[$fields['password']]);
 
 		unset($result[$model]);
 		return array_merge($user, $result);


### PR DESCRIPTION
It is possible to login with just a username and a blank / empty password, because you check for a password before hashing it.  If the password is equal to '', was skipping the password hash all together, and just returning the user it found by username conditions only. This was found on a live production site, that you could login with a username only.
