### PR TITLE
3.0 controller repository method.

### DIFF
--- a/Cake/Console/Shell.php
+++ b/Cake/Console/Shell.php
@@ -27,6 +27,7 @@ use Cake\Utility\ClassRegistry;
 use Cake\Utility\File;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
+use Cake\Utility\RepositoryAwareTrait;
 use Cake\Utility\String;
 
 /**
@@ -36,6 +37,8 @@ use Cake\Utility\String;
 class Shell extends Object {
 
 	use MergeVariablesTrait;
+	use RepositoryAwareTrait;
+
 /**
  * Output constant making verbose shells.
  */
@@ -117,21 +120,6 @@ class Shell extends Object {
 	public $taskNames = [];
 
 /**
- * Contains models to load and instantiate
- *
- * @var array
- * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::$uses
- */
-	public $uses = [];
-
-/**
- * This shell's primary model class name, the first model in the $uses property
- *
- * @var string
- */
-	public $modelClass = null;
-
-/**
  * Task Collection for the command, used to create Tasks.
  *
  * @var TaskRegistry
@@ -179,6 +167,7 @@ class Shell extends Object {
 			list(, $class) = namespaceSplit(get_class($this));
 			$this->name = str_replace(['Shell', 'Task'], '', $class);
 		}
+		$this->_setModelClass($this->name);
 		$this->Tasks = new TaskRegistry($this);
 
 		$this->stdout = $stdout ? $stdout : new ConsoleOutput('php://stdout');
@@ -187,7 +176,7 @@ class Shell extends Object {
 
 		$this->_useLogger();
 		$this->_mergeVars(
-			['tasks', 'uses'],
+			['tasks'],
 			['associative' => ['tasks']]
 		);
 	}
@@ -201,7 +190,6 @@ class Shell extends Object {
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::initialize
  */
 	public function initialize() {
-		$this->_loadModels();
 		$this->loadTasks();
 	}
 
@@ -234,73 +222,19 @@ class Shell extends Object {
 	}
 
 /**
- * If $uses is an array load each of the models in the array
- *
- * @return boolean
- */
-	protected function _loadModels() {
-		if (is_array($this->uses)) {
-			list(, $this->modelClass) = pluginSplit(current($this->uses));
-			foreach ($this->uses as $modelClass) {
-				$this->loadModel($modelClass);
-			}
-		}
-		return true;
-	}
-
-/**
- * Lazy loads models using the loadModel() method if declared in $uses
+ * Lazy loads models using the repository() method if it matches modelClass
  *
  * @param string $name
  * @return void
  */
 	public function __isset($name) {
-		if (is_array($this->uses)) {
-			foreach ($this->uses as $modelClass) {
-				list(, $class) = pluginSplit($modelClass);
-				if ($name === $class) {
-					return $this->loadModel($modelClass);
-				}
-				list(, $class) = namespaceSplit($modelClass);
-				if ($name === $class) {
-					return $this->loadModel($class);
-				}
+		if ($name === $this->modelClass) {
+			list($plugin, $class) = pluginSplit($name, true);
+			if (!$plugin) {
+				$plugin = $this->plugin ? $this->plugin . '.' : null;
 			}
+			return $this->repository($plugin . $this->modelClass);
 		}
-	}
-
-/**
- * Loads and instantiates models required by this shell.
- *
- * @param string $modelClass Name of model class to load
- * @param mixed $id Initial ID the instanced model class should have
- * @return mixed true when single model found and instance created, error returned if model not found.
- * @throws Cake\Error\MissingModelException if the model class cannot be found.
- */
-	public function loadModel($modelClass = null, $id = null) {
-		if ($modelClass === null) {
-			$modelClass = $this->modelClass;
-		}
-
-		$this->uses = ($this->uses) ? (array)$this->uses : [];
-		if (!in_array($modelClass, $this->uses)) {
-			$this->uses[] = $modelClass;
-		}
-
-		list($plugin, $modelClass) = pluginSplit($modelClass, true);
-		if (!isset($this->modelClass)) {
-			$this->modelClass = $modelClass;
-		}
-
-		$this->{$modelClass} = ClassRegistry::init([
-			'class' => $plugin . $modelClass,
-			'alias' => $modelClass,
-			'id' => $id
-		]);
-		if (!$this->{$modelClass}) {
-			throw new Error\MissingModelException($modelClass);
-		}
-		return true;
 	}
 
 /**

--- a/Cake/Console/Shell.php
+++ b/Cake/Console/Shell.php
@@ -168,6 +168,7 @@ class Shell extends Object {
 			$this->name = str_replace(['Shell', 'Task'], '', $class);
 		}
 		$this->_setModelClass($this->name);
+		$this->repositoryFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
 		$this->Tasks = new TaskRegistry($this);
 
 		$this->stdout = $stdout ? $stdout : new ConsoleOutput('php://stdout');

--- a/Cake/Controller/Controller.php
+++ b/Cake/Controller/Controller.php
@@ -30,6 +30,7 @@ use Cake\Routing\Router;
 use Cake\Utility\ClassRegistry;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
+use Cake\Utility\RepositoryAwareTrait;
 use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
 
@@ -80,6 +81,7 @@ class Controller extends Object implements EventListener {
 
 	use MergeVariablesTrait;
 	use RequestActionTrait;
+	use RepositoryAwareTrait;
 	use ViewVarsTrait;
 
 /**
@@ -284,25 +286,6 @@ class Controller extends Object implements EventListener {
 	public $methods = array();
 
 /**
- * This controller's primary model class name, the Inflector::singularize()'ed version of
- * the controller's $name property.
- *
- * Example: For a controller named 'Comments', the modelClass would be 'Comment'
- *
- * @var string
- */
-	public $modelClass = null;
-
-/**
- * This controller's model key name, an underscored version of the controller's $modelClass property.
- *
- * Example: For a controller named 'ArticleComments', the modelKey would be 'article_comment'
- *
- * @var string
- */
-	public $modelKey = null;
-
-/**
  * Holds any validation errors produced by the last call of the validateErrors() method/
  *
  * @var array Validation errors, or false if none
@@ -338,8 +321,7 @@ class Controller extends Object implements EventListener {
 			$this->viewPath = $viewPath;
 		}
 
-		$this->modelClass = Inflector::singularize($this->name);
-		$this->modelKey = Inflector::underscore($this->modelClass);
+		$this->_setModelClass($this->name);
 
 		$childMethods = get_class_methods($this);
 		$parentMethods = get_class_methods('Cake\Controller\Controller');
@@ -597,41 +579,6 @@ class Controller extends Object implements EventListener {
  */
 	public function shutdownProcess() {
 		$this->getEventManager()->dispatch(new Event('Controller.shutdown', $this));
-	}
-
-/**
- * Loads and constructs repository objects required by this controller.
- *
- * Typically used to load ORM Table objects as required. Can
- * also be used to load other types of repository objects your application uses.
- *
- * If a repository provider does not return an object a MissingModelException will
- * be thrown.
- *
- * @param string $modelClass Name of model class to load. Defaults to $this->modelClass
- * @param string $type The type of repository to load. Defaults to 'Table' which
- *   delegates to Cake\ORM\TableRegistry.
- * @return boolean True when single repository found and instance created.
- * @throws Cake\Error\MissingModelException if the model class cannot be found.
- */
-	public function repository($modelClass = null, $type = 'Table') {
-		if (isset($this->{$modelClass})) {
-			return $this->{$modelClass};
-		}
-
-		if ($modelClass === null) {
-			$modelClass = $this->modelClass;
-		}
-
-		list($plugin, $modelClass) = pluginSplit($modelClass, true);
-
-		if ($type === 'Table') {
-			$this->{$modelClass} = TableRegistry::get($plugin . $modelClass);
-		}
-		if (!$this->{$modelClass}) {
-			throw new Error\MissingModelException($modelClass);
-		}
-		return true;
 	}
 
 /**

--- a/Cake/Controller/Controller.php
+++ b/Cake/Controller/Controller.php
@@ -322,6 +322,7 @@ class Controller extends Object implements EventListener {
 		}
 
 		$this->_setModelClass($this->name);
+		$this->repositoryFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
 
 		$childMethods = get_class_methods($this);
 		$parentMethods = get_class_methods('Cake\Controller\Controller');

--- a/Cake/Controller/Controller.php
+++ b/Cake/Controller/Controller.php
@@ -80,8 +80,8 @@ use Cake\View\View;
 class Controller extends Object implements EventListener {
 
 	use MergeVariablesTrait;
-	use RequestActionTrait;
 	use RepositoryAwareTrait;
+	use RequestActionTrait;
 	use ViewVarsTrait;
 
 /**

--- a/Cake/Controller/Controller.php
+++ b/Cake/Controller/Controller.php
@@ -361,15 +361,15 @@ class Controller extends Object implements EventListener {
  * @param string $name
  * @return boolean
  */
-	public function __isset($name) {
+	public function __get($name) {
 		if ($name === $this->modelClass) {
 			list($plugin, $class) = pluginSplit($name, true);
 			if (!$plugin) {
 				$plugin = $this->plugin ? $this->plugin . '.' : null;
 			}
-			return $this->repository($plugin . $this->modelClass);
+			$this->repository($plugin . $this->modelClass);
+			return $this->{$this->modelClass};
 		}
-
 		return false;
 	}
 
@@ -615,6 +615,10 @@ class Controller extends Object implements EventListener {
  * @throws Cake\Error\MissingModelException if the model class cannot be found.
  */
 	public function repository($modelClass = null, $type = 'Table') {
+		if (isset($this->{$modelClass})) {
+			return $this->{$modelClass};
+		}
+
 		if ($modelClass === null) {
 			$modelClass = $this->modelClass;
 		}
@@ -623,8 +627,6 @@ class Controller extends Object implements EventListener {
 
 		if ($type === 'Table') {
 			$this->{$modelClass} = TableRegistry::get($plugin . $modelClass);
-		} else {
-			$this->{$modelClass} = $this->_loadRepository($plugin . $modelClass, $type);
 		}
 		if (!$this->{$modelClass}) {
 			throw new Error\MissingModelException($modelClass);

--- a/Cake/Controller/Scaffold.php
+++ b/Cake/Controller/Scaffold.php
@@ -119,7 +119,7 @@ class Scaffold {
 		$this->redirect = array('action' => 'index');
 
 		$this->modelClass = $controller->modelClass;
-		$this->modelKey = $controller->modelKey;
+		$this->modelKey = Inflector::underscore($this->modelClass);
 
 		if (!is_object($this->controller->{$this->modelClass})) {
 			throw new Error\MissingModelException($this->modelClass);

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -117,6 +117,7 @@ class HasMany extends Association {
  * @return boolean|Entity false if $entity could not be saved, otherwise it returns
  * the saved entity
  * @see Table::save()
+ * @throws \InvalidArgumentException when the association data cannot be traversed.
  */
 	public function save(Entity $entity, $options = []) {
 		$targetEntities = $entity->get($this->property());

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/Cake/Test/TestCase/Console/ShellTest.php
+++ b/Cake/Test/TestCase/Console/ShellTest.php
@@ -34,7 +34,7 @@ class MergeShell extends Shell {
 
 	public $tasks = array('DbConfig', 'Fixture');
 
-	public $uses = array('Comment');
+	public $modelClass = 'Articles';
 
 }
 
@@ -170,39 +170,39 @@ class ShellTest extends TestCase {
 
 		Plugin::load('TestPlugin');
 		$this->Shell->tasks = array('DbConfig' => array('one', 'two'));
-		$this->Shell->uses = array('TestPlugin.TestPluginPost');
+		$this->Shell->plugin = 'TestPlugin';
+		$this->Shell->modelClass = 'TestPluginComments';
 		$this->Shell->initialize();
 
-		$this->assertTrue(isset($this->Shell->TestPluginPost));
-		$this->assertInstanceOf('TestPlugin\Model\TestPluginPost', $this->Shell->TestPluginPost);
-		$this->assertEquals('TestPluginPost', $this->Shell->modelClass);
-		Plugin::unload('TestPlugin');
-
-		$this->Shell->uses = array('TestApp\Model\Comment');
-		$this->Shell->initialize();
-		$this->assertTrue(isset($this->Shell->Comment));
-		$this->assertInstanceOf('TestApp\Model\Comment', $this->Shell->Comment);
-		$this->assertEquals('TestApp\Model\Comment', $this->Shell->modelClass);
+		$this->assertTrue(isset($this->Shell->TestPluginComments));
+		$this->assertInstanceOf(
+			'TestPlugin\Model\Repository\TestPluginCommentsTable',
+			$this->Shell->TestPluginComments
+		);
 	}
 
 /**
- * testLoadModel method
+ * test repository method
  *
  * @return void
  */
-	public function testLoadModel() {
+	public function testRepository() {
 		Configure::write('App.namespace', 'TestApp');
 
 		$Shell = new MergeShell();
-		$this->assertEquals('Comment', $Shell->Comment->alias);
-		$this->assertInstanceOf('TestApp\Model\Comment', $Shell->Comment);
-		$this->assertEquals('Comment', $Shell->modelClass);
+		$this->assertInstanceOf(
+			'TestApp\Model\Repository\ArticlesTable',
+			$Shell->Articles
+		);
+		$this->assertEquals('Articles', $Shell->modelClass);
 
 		Plugin::load('TestPlugin');
-		$this->Shell->loadModel('TestPlugin.TestPluginPost');
-		$this->assertTrue(isset($this->Shell->TestPluginPost));
-		$this->assertInstanceOf('TestPlugin\Model\TestPluginPost', $this->Shell->TestPluginPost);
-		$this->assertEquals('TestPluginPost', $this->Shell->modelClass);
+		$this->Shell->repository('TestPlugin.TestPluginComments');
+		$this->assertTrue(isset($this->Shell->TestPluginComments));
+		$this->assertInstanceOf(
+			'TestPlugin\Model\Repository\TestPluginCommentsTable',
+			$this->Shell->TestPluginComments
+		);
 	}
 
 /**

--- a/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -534,7 +534,7 @@ class ControllerTest extends TestCase {
 		$TestController->constructClasses();
 
 		$this->assertEquals(
-			'Post',
+			'Posts',
 			$TestController->modelClass,
 			'modelClass should not be overwritten when defined.'
 		);

--- a/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -49,7 +49,7 @@ class ControllerTestAppController extends Controller {
  *
  * @var string
  */
-	public $modelClass = 'Post';
+	public $modelClass = 'Posts';
 
 /**
  * components property
@@ -83,7 +83,7 @@ class TestController extends ControllerTestAppController {
  *
  * @var string
  */
-	public $modelClass = 'Comment';
+	public $modelClass = 'Comments';
 
 /**
  * index method

--- a/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -230,7 +230,25 @@ class ControllerTest extends TestCase {
 	}
 
 /**
- * testLoadModel method
+ * test autoload modelClass
+ *
+ * @return void
+ */
+	public function testRepositoryAutoload() {
+		Configure::write('App.namespace', 'TestApp');
+		$request = new Request('controller_posts/index');
+		$response = $this->getMock('Cake\Network\Response');
+		$Controller = new Controller($request, $response);
+		$Controller->modelClass = 'Articles';
+
+		$this->assertInstanceOf(
+			'TestApp\Model\Repository\ArticlesTable',
+			$Controller->Articles
+		);
+	}
+
+/**
+ * testRepository method
  *
  * @return void
  */

--- a/Cake/Test/TestCase/Controller/ControllerTest.php
+++ b/Cake/Test/TestCase/Controller/ControllerTest.php
@@ -533,7 +533,11 @@ class ControllerTest extends TestCase {
 		$TestController = new AnotherTestController($request);
 		$TestController->constructClasses();
 
-		$this->assertEquals('AnotherTest', $TestController->modelClass);
+		$this->assertEquals(
+			'Post',
+			$TestController->modelClass,
+			'modelClass should not be overwritten when defined.'
+		);
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2571,7 +2571,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertNull($entity->tags[1]->extraInfo);
 	}
 
-
 /**
  * Tests saving belongsToMany records with a validation error in a joint entity
  * and atomic set to false

--- a/Cake/Test/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/Cake/Test/TestCase/Utility/MergeVariablesTraitTest.php
@@ -121,15 +121,4 @@ class MergeVariablesTraitTest extends TestCase {
 		$this->assertEquals(['test'], $object->hasBoolean);
 	}
 
-/**
- * Test that merging reversed works.
- *
- * @return void
- */
-	public function testMergeVariablesReversed() {
-		$object = new Grandchild();
-		$object->mergeVars(['listProperty'], ['reverse' => ['listProperty']]);
-		$expected = ['Four', 'Five', 'Two', 'Three', 'One'];
-		$this->assertSame($expected, $object->listProperty);
-	}
 }

--- a/Cake/Test/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/Cake/Test/TestCase/Utility/MergeVariablesTraitTest.php
@@ -1,12 +1,13 @@
 <?php
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/Cake/Test/TestCase/Utility/RepositoryAwareTraitTest.php
+++ b/Cake/Test/TestCase/Utility/RepositoryAwareTraitTest.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/Cake/Test/TestCase/Utility/RepositoryAwareTraitTest.php
+++ b/Cake/Test/TestCase/Utility/RepositoryAwareTraitTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Utility;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\RepositoryAwareTrait;
+
+/**
+ * Testing stub.
+ */
+class Stub {
+
+	use RepositoryAwareTrait;
+
+	public function setProps($name) {
+		$this->_setModelClass($name);
+	}
+
+}
+
+/**
+ * RepositoryAwareTrait test case
+ */
+class RepositoryAwareTraitTest extends TestCase {
+
+/**
+ * Test set modelClass
+ *
+ * @return void
+ */
+	public function testSetModelClass() {
+		$stub = new Stub();
+		$this->assertNull($stub->modelClass);
+
+		$stub->setProps('StubArticles');
+		$this->assertEquals('StubArticles', $stub->modelClass);
+	}
+
+/**
+ * test repository()
+ *
+ * @return void
+ */
+	public function testRepository() {
+		$stub = new Stub();
+		$stub->setProps('Articles');
+		$stub->repositoryFactory('Table', ['\Cake\ORM\TableRegistry', 'get']);
+
+		$this->assertTrue($stub->repository());
+		$this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
+
+		$this->assertTrue($stub->repository('Comments'));
+		$this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
+	}
+
+/**
+ * test alternate repository factories.
+ *
+ * @return void
+ */
+	public function testRepositoryFactory() {
+		$stub = new Stub();
+		$stub->setProps('Articles');
+
+		$stub->repositoryFactory('Test', function($name) {
+			$mock = new \StdClass();
+			$mock->name = $name;
+			return $mock;
+		});
+
+		$result = $stub->repository('Magic', 'Test');
+		$this->assertTrue($result);
+		$this->assertInstanceOf('\StdClass', $stub->Magic);
+		$this->assertEquals('Magic', $stub->Magic->name);
+	}
+
+}

--- a/Cake/Utility/MergeVariablesTrait.php
+++ b/Cake/Utility/MergeVariablesTrait.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
- * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
- * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)

--- a/Cake/Utility/MergeVariablesTrait.php
+++ b/Cake/Utility/MergeVariablesTrait.php
@@ -29,10 +29,6 @@ trait MergeVariablesTrait {
  *
  * - `associative` - A list of properties that should be treated as associative arrays.
  *   Properties in this list will be passed through Hash::normalize() before merging.
- * - `reverse` - A list of properties that should be merged in reverse.  Reverse merging
- *   allows the parent properties to follow the child classes.  Generally this option is only
- *   useful when merging list properties that need to maintain the child property values
- *   as the first elements in the merged list.
  *
  * @param array $properties An array of properties and the merge strategy for them.
  * @param array $options The options to use when merging properties.
@@ -71,18 +67,12 @@ trait MergeVariablesTrait {
  */
 	protected function _mergeProperty($property, $parentClasses, $options) {
 		$thisValue = $this->{$property};
-		$isAssoc = $isReversed = false;
+		$isAssoc =  false;
 		if (
 			isset($options['associative']) &&
 			in_array($property, (array)$options['associative'])
 		) {
 			$isAssoc = true;
-		}
-		if (
-			isset($options['reverse']) &&
-			in_array($property, (array)$options['reverse'])
-		) {
-			$isReversed = true;
 		}
 
 		if ($isAssoc) {
@@ -100,11 +90,7 @@ trait MergeVariablesTrait {
 			if ($isAssoc) {
 				$parentProperty = Hash::normalize($parentProperty);
 			}
-			if ($isReversed) {
-				$thisValue = Hash::merge($thisValue, $parentProperty);
-			} else {
-				$thisValue = Hash::merge($parentProperty, $thisValue);
-			}
+			$thisValue = Hash::merge($parentProperty, $thisValue);
 		}
 		$this->{$property} = $thisValue;
 	}

--- a/Cake/Utility/MergeVariablesTrait.php
+++ b/Cake/Utility/MergeVariablesTrait.php
@@ -67,7 +67,7 @@ trait MergeVariablesTrait {
  */
 	protected function _mergeProperty($property, $parentClasses, $options) {
 		$thisValue = $this->{$property};
-		$isAssoc =  false;
+		$isAssoc = false;
 		if (
 			isset($options['associative']) &&
 			in_array($property, (array)$options['associative'])

--- a/Cake/Utility/RepositoryAwareTrait.php
+++ b/Cake/Utility/RepositoryAwareTrait.php
@@ -27,10 +27,10 @@ use Cake\Utility\Inflector;
 trait RepositoryAwareTrait {
 
 /**
- * This object's primary model class name, the Inflector::singularize()'ed version of
+ * This object's primary model class name, the Inflector::pluralized()'ed version of
  * the object's $name property.
  *
- * Example: For a object named 'Comments', the modelClass would be 'Comment'
+ * Example: For a object named 'Comments', the modelClass would be 'Comments'
  *
  * @var string
  */
@@ -71,14 +71,15 @@ trait RepositoryAwareTrait {
  *   delegates to Cake\ORM\TableRegistry.
  * @return boolean True when single repository found and instance created.
  * @throws Cake\Error\MissingModelException if the model class cannot be found.
+ * @throws Cake\Error\Exception When using a type that has not been registered.
  */
 	public function repository($modelClass = null, $type = 'Table') {
-		if (isset($this->{$modelClass})) {
-			return $this->{$modelClass};
-		}
-
 		if ($modelClass === null) {
 			$modelClass = $this->modelClass;
+		}
+
+		if (isset($this->{$modelClass})) {
+			return true;
 		}
 
 		list($plugin, $modelClass) = pluginSplit($modelClass, true);

--- a/Cake/Utility/RepositoryAwareTrait.php
+++ b/Cake/Utility/RepositoryAwareTrait.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility;
+
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Provides functionality for loading table classes
+ * and other repositories onto properties of the host object.
+ *
+ * Example users of this trait are Cake\Controller\Controller and 
+ * Cake\Console\Shell.
+ */
+trait RepositoryAwareTrait {
+
+/**
+ * This object's primary model class name, the Inflector::singularize()'ed version of
+ * the object's $name property.
+ *
+ * Example: For a object named 'Comments', the modelClass would be 'Comment'
+ *
+ * @var string
+ */
+	public $modelClass;
+
+/**
+ * This objects's repository key name, an underscored version of the objects's $modelClass property.
+ *
+ * Example: For an object named 'ArticleComments', the modelKey would be 'article_comment'
+ *
+ * @var string
+ */
+	public $modelKey;
+
+/**
+ * Set the modelClass and modelKey properties based on conventions.
+ *
+ * If the properties are already set they w
+ */
+	protected function _setModelClass($name) {
+		$this->modelClass = Inflector::singularize($this->name);
+		$this->modelKey = Inflector::underscore($this->modelClass);
+	}
+/**
+ * Loads and constructs repository objects required by this object
+ *
+ * Typically used to load ORM Table objects as required. Can
+ * also be used to load other types of repository objects your application uses.
+ *
+ * If a repository provider does not return an object a MissingModelException will
+ * be thrown.
+ *
+ * @param string $modelClass Name of model class to load. Defaults to $this->modelClass
+ * @param string $type The type of repository to load. Defaults to 'Table' which
+ *   delegates to Cake\ORM\TableRegistry.
+ * @return boolean True when single repository found and instance created.
+ * @throws Cake\Error\MissingModelException if the model class cannot be found.
+ */
+	public function repository($modelClass = null, $type = 'Table') {
+		if (isset($this->{$modelClass})) {
+			return $this->{$modelClass};
+		}
+
+		if ($modelClass === null) {
+			$modelClass = $this->modelClass;
+		}
+
+		list($plugin, $modelClass) = pluginSplit($modelClass, true);
+
+		if ($type === 'Table') {
+			$this->{$modelClass} = TableRegistry::get($plugin . $modelClass);
+		}
+		// TODO add other providers
+		if (!$this->{$modelClass}) {
+			throw new Error\MissingModelException($modelClass);
+		}
+		return true;
+	}
+
+}

--- a/Cake/Utility/RepositoryAwareTrait.php
+++ b/Cake/Utility/RepositoryAwareTrait.php
@@ -48,11 +48,18 @@ trait RepositoryAwareTrait {
 /**
  * Set the modelClass and modelKey properties based on conventions.
  *
- * If the properties are already set they w
+ * If the properties are already set they will not be overwritten
+ *
+ * @param string $name
+ * @return void
  */
 	protected function _setModelClass($name) {
-		$this->modelClass = Inflector::singularize($this->name);
-		$this->modelKey = Inflector::underscore($this->modelClass);
+		if (empty($this->modelClass)) {
+			$this->modelClass = Inflector::singularize($this->name);
+		}
+		if (empty($this->modelKey)) {
+			$this->modelKey = Inflector::underscore($this->modelClass);
+		}
 	}
 /**
  * Loads and constructs repository objects required by this object

--- a/Cake/Utility/RepositoryAwareTrait.php
+++ b/Cake/Utility/RepositoryAwareTrait.php
@@ -56,6 +56,7 @@ trait RepositoryAwareTrait {
 			$this->modelClass = Inflector::pluralize($name);
 		}
 	}
+
 /**
  * Loads and constructs repository objects required by this object
  *


### PR DESCRIPTION
Add the repository method discussed in #2424. I've removed a few things along the way:
- Controller::$modelKey - only used by scaffold which is probably also going to get removed.
- Controller::$uses - Repositories should be loaded with the repository() method now. There is a __get() method to load the convention based repository.
- Shell::$uses - Met a similar fate as Controller::$uses.
- Controller::loadModel() & Shell::loadModel() have been removed and replaced with the repository() method.

I've included a way to add new repository types so the code isn't overly coupled. This hopefully will also make it simple to add new repository types for other datasources.
