### PR TITLE
Fixed edge case which allowed login with empty password.

### DIFF
--- a/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthenticate.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -118,7 +116,7 @@ abstract class BaseAuthenticate {
 		}
 
 		$user = $result[$model];
-		if ($password) {
+		if ($password !== null) {
 			if (!$this->passwordHasher()->check($password, $user[$fields['password']])) {
 				return false;
 			}

--- a/lib/Cake/Test/Case/Controller/Component/Auth/FormAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/FormAuthenticateTest.php
@@ -119,6 +119,40 @@ class FormAuthenticateTest extends CakeTestCase {
 	}
 
 /**
+ * Test for password as empty string with _checkFields() call skipped
+ * Refs https://github.com/cakephp/cakephp/pull/2441
+ *
+ * @return void
+ */
+	public function testAuthenticatePasswordIsEmptyString() {
+		$request = new CakeRequest('posts/index', false);
+		$request->data = array(
+			'User' => array(
+				'user' => 'mariano',
+				'password' => ''
+		));
+
+		$this->auth = $this->getMock(
+			'FormAuthenticate',
+			array('_checkFields'),
+			array(
+				$this->Collection,
+				array(
+					'fields' => array('username' => 'user', 'password' => 'password'),
+					'userModel' => 'User'
+				)
+			)
+		);
+
+		// Simulate that check for ensuring password is not empty is missing.
+		$this->auth->expects($this->once())
+			->method('_checkFields')
+			->will($this->returnValue(true));
+
+		$this->assertFalse($this->auth->authenticate($request, $this->response));
+	}
+
+/**
  * test authenticate field is not string
  *
  * @return void


### PR DESCRIPTION
Ensure skipping call to FormAuthenticate::_checkFields() does not allow
logging in with empty password. Closes #2441.
