### PR TITLE
CakeFixtureManager::load now calls CakeTestFixture::truncate

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/Fixture/CakeFixtureManagerTest.php
+++ b/lib/Cake/Test/Case/TestSuite/Fixture/CakeFixtureManagerTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * CakeFixtureManager file
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP Project
+ * @package       Cake.Test.Case.TestSuite.Fixture
+ * @since         CakePHP v 2.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+App::uses('DboSource', 'Model/Datasource');
+App::uses('CakeFixtureManager', 'TestSuite/Fixture');
+App::uses('UuidFixture', 'Test/Fixture');
+
+/**
+ * Test Case for CakeFixtureManager class
+ *
+ * @package       Cake.Test.Case.TestSuite
+ */
+class CakeFixtureManagerTest extends CakeTestCase {
+
+/**
+ * reset environment.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->fixtureManager = new CakeFixtureManager();
+	}
+
+/**
+ * tearDown
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->fixtureManager);
+	}
+
+/**
+ * testLoadTruncatesTable
+ *
+ * @return void
+ */
+	public function testLoadTruncatesTable() {
+		$MockFixture = $this->getMock('UuidFixture', array('truncate'));
+		$MockFixture
+			->expects($this->once())
+			->method('truncate')
+			->will($this->returnValue(true));
+
+		$fixtureManager = $this->fixtureManager;
+		$fixtureManagerReflection = new ReflectionClass($fixtureManager);
+
+		$_loadedProperty = $fixtureManagerReflection->getProperty('_loaded');
+		$_loadedProperty->setAccessible(true);
+		$_loadedProperty->setValue($fixtureManager, array('core.uuid' => $MockFixture));
+
+		$TestCase = $this->getMock('CakeTestCase');
+		$TestCase->fixtures = array('core.uuid');
+		$TestCase->autoFixtures = true;
+		$TestCase->dropTables = false;
+
+		$fixtureManager->load($TestCase);
+	}
+
+/**
+ * testLoadSingleTruncatesTable
+ *
+ * @return void
+ */
+	public function testLoadSingleTruncatesTable() {
+		$MockFixture = $this->getMock('UuidFixture', array('truncate'));
+		$MockFixture
+			->expects($this->once())
+			->method('truncate')
+			->will($this->returnValue(true));
+
+		$fixtureManager = $this->fixtureManager;
+		$fixtureManagerReflection = new ReflectionClass($fixtureManager);
+
+		$_fixtureMapProperty = $fixtureManagerReflection->getProperty('_fixtureMap');
+		$_fixtureMapProperty->setAccessible(true);
+		$_fixtureMapProperty->setValue($fixtureManager, array('UuidFixture' => $MockFixture));
+
+		$dboMethods = array_diff(get_class_methods('DboSource'), array('enabled'));
+		$dboMethods[] = 'connect';
+		$db = $this->getMock('DboSource', $dboMethods);
+		$db->config['prefix'] = '';
+
+		$fixtureManager->loadSingle('Uuid', $db, false);
+	}
+}

--- a/lib/Cake/Test/Case/TestSuite/Fixture/CakeFixtureManagerTest.php
+++ b/lib/Cake/Test/Case/TestSuite/Fixture/CakeFixtureManagerTest.php
@@ -62,9 +62,9 @@ class CakeFixtureManagerTest extends CakeTestCase {
 		$fixtureManager = $this->fixtureManager;
 		$fixtureManagerReflection = new ReflectionClass($fixtureManager);
 
-		$_loadedProperty = $fixtureManagerReflection->getProperty('_loaded');
-		$_loadedProperty->setAccessible(true);
-		$_loadedProperty->setValue($fixtureManager, array('core.uuid' => $MockFixture));
+		$loadedProperty = $fixtureManagerReflection->getProperty('_loaded');
+		$loadedProperty->setAccessible(true);
+		$loadedProperty->setValue($fixtureManager, array('core.uuid' => $MockFixture));
 
 		$TestCase = $this->getMock('CakeTestCase');
 		$TestCase->fixtures = array('core.uuid');
@@ -89,9 +89,9 @@ class CakeFixtureManagerTest extends CakeTestCase {
 		$fixtureManager = $this->fixtureManager;
 		$fixtureManagerReflection = new ReflectionClass($fixtureManager);
 
-		$_fixtureMapProperty = $fixtureManagerReflection->getProperty('_fixtureMap');
-		$_fixtureMapProperty->setAccessible(true);
-		$_fixtureMapProperty->setValue($fixtureManager, array('UuidFixture' => $MockFixture));
+		$fixtureMapProperty = $fixtureManagerReflection->getProperty('_fixtureMap');
+		$fixtureMapProperty->setAccessible(true);
+		$fixtureMapProperty->setValue($fixtureManager, array('UuidFixture' => $MockFixture));
 
 		$dboMethods = array_diff(get_class_methods('DboSource'), array('enabled'));
 		$dboMethods[] = 'connect';

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -209,6 +209,7 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 				$db->begin();
 				$this->_setupTable($fixture, $db, $test->dropTables);
+				$fixture->truncate($db);
 				$fixture->insert($db);
 				$db->commit();
 			}


### PR DESCRIPTION
The `CakeFixtureManager::loadSingle` method calls `$this->_setupTable`, followed by `$fixture->truncate` before inserting fixture data into the db.

On the other hand, the `CakeFixtureManager::load` method does not call `$fixture->truncate` after setting up the table.  This behavior can cause problems (e.g. InnoDB Foreign key constraint errors) if `CakeTestCase::$dropTables` is set to false.

This change simply updates `CakeFixtureManager::load` to conform with the same behavior as `CakeFixtureManager::loadSingle`
