### PR TITLE
We no longer clear the data, post-save.

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1863,7 +1863,6 @@ class Model extends Object implements CakeEventListener {
 				$success = $this->data;
 			}
 
-			$this->data = false;
 			$this->_clearCache();
 			$this->validationErrors = array();
 		}


### PR DESCRIPTION
It doesn't look like there's a functional reason that >data is cleared after a save. It also doesn't look like it'll break anything to fix it.

Fixing this means that applications can cleanly pass-around models rather than arrays that have to be re-loaded into models every time you want something to happen. Hence, encapsulation is encouraged and risk is reduced.
