### PR TITLE
Fixed error in CakeSession that would call start() in an infinite loop

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -629,12 +629,12 @@ class CakeResponse {
 /**
  * Queries & sets valid HTTP response codes & messages.
  *
- * @param integer|array $code If $code is an integer, then the corresponding code/message is 
- *        returned if it exists, null if it does not exist. If $code is an array, then the 
- *        keys are used as codes and the values as messages to add to the default HTTP 
- *        codes. The codes must be integers greater than 99 and less than 1000. Keep in 
- *        mind that the HTTP specification outlines that status codes begin with a digit 
- *        between 1 and 5, which defines the class of response the client is to expect. 
+ * @param integer|array $code If $code is an integer, then the corresponding code/message is
+ *        returned if it exists, null if it does not exist. If $code is an array, then the
+ *        keys are used as codes and the values as messages to add to the default HTTP
+ *        codes. The codes must be integers greater than 99 and less than 1000. Keep in
+ *        mind that the HTTP specification outlines that status codes begin with a digit
+ *        between 1 and 5, which defines the class of response the client is to expect.
  *        Example:
  *
  *        httpCodes(404); // returns array(404 => 'Not Found')

--- a/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SessionComponentTest.php
@@ -177,6 +177,7 @@ class SessionComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testSessionError() {
+		CakeSession::$lastError = null;
 		$Session = new SessionComponent($this->ComponentCollection);
 		$this->assertFalse($Session->error());
 	}

--- a/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/CakeSessionTest.php
@@ -548,8 +548,12 @@ class CakeSessionTest extends CakeTestCase {
 				'engine' => 'TestAppLibSession'
 			)
 		));
-		TestCakeSession::destroy();
+
+		TestCakeSession::start();
 		$this->assertTrue(TestCakeSession::started());
+
+		TestCakeSession::destroy();
+		$this->assertFalse(TestCakeSession::started());
 
 		App::build();
 	}
@@ -572,8 +576,11 @@ class CakeSessionTest extends CakeTestCase {
 			)
 		));
 
-		TestCakeSession::destroy();
+		TestCakeSession::start();
 		$this->assertTrue(TestCakeSession::started());
+
+		TestCakeSession::destroy();
+		$this->assertFalse(TestCakeSession::started());
 
 		App::build();
 	}
@@ -750,6 +757,33 @@ class CakeSessionTest extends CakeTestCase {
 		TestCakeSession::start();
 		$this->assertEquals(600, Configure::read('Session.cookieTimeout'));
 		$this->assertEquals(400, Configure::read('Session.timeout'));
+	}
+
+/**
+ * Proves that invalid sessions will be destroyed and re-created
+ * if invalid
+ *
+ * @return void
+ */
+	public function testInvalidSessionRenew() {
+		TestCakeSession::start();
+		$this->assertNotEmpty($_SESSION['Config']);
+		$data = $_SESSION;
+
+		session_write_close();
+		$_SESSION = null;
+
+		TestCakeSession::start();
+		$this->assertEquals($data, $_SESSION);
+		TestCakeSession::write('Foo', 'Bar');
+
+		session_write_close();
+		$_SESSION = null;
+
+		TestCakeSession::userAgent('bogus!');
+		TestCakeSession::start();
+		$this->assertNotEquals($data, $_SESSION);
+		$this->assertEquals('bogus!', $_SESSION['Config']['userAgent']);
 	}
 
 }


### PR DESCRIPTION
When the session is marked as invalid during `start`, `destroy` method was called, which would try again to validate the session and destroy, falling into an infinite loop.
