### PR TITLE
2.4 delete all regression

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2700,6 +2700,7 @@ class Model extends Object implements CakeEventListener {
 
 		$ids = $this->find('all', array_merge(array(
 			'fields' => "DISTINCT {$this->alias}.{$this->primaryKey}",
+			'order' => false,
 			'recursive' => 0), compact('conditions'))
 		);
 

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -492,6 +492,33 @@ class ModelDeleteTest extends BaseModelTest {
 	}
 
 /**
+ * testDeleteAllWithOrderProperty
+ *
+ * Ensure find done in deleteAll works with models that has $order property set
+ *
+ * @return void
+ */
+	public function testDeleteAllWithOrderProperty() {
+		$this->loadFixtures('Article', 'User');
+
+		$TestModel = new Article();
+		$TestModel->order = 'Article.published desc';
+		$TestModel->unbindModel(array(
+			'belongsTo' => array('User'),
+			'hasMany' => array('Comment'),
+			'hasAndBelongsToMany' => array('Tag')
+		), false);
+
+		$result = $TestModel->deleteAll(
+			array('Article.user_id' => array(1, 3)),
+			true,
+			true
+		);
+
+		$this->assertTrue($result);
+	}
+
+/**
  * testRecursiveDel method
  *
  * @return void


### PR DESCRIPTION
Fix deleteAll with postgres regression as discussed in #2421

> This seems to break croogo tests with postgres: https://travis-ci.org/rchavik/croogo/builds/15111575
> Tested with one commit prior to this: https://travis-ci.org/rchavik/croogo/builds/15111445 which seem fine
> The @markstory suggested to have an order clause for the find, even if to disable the default sort
