### PR TITLE
Adds key 'through' for chaining associations.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1644,15 +1644,21 @@ class DboSource extends DataSource {
 			return array();
 		}
 
+		// For hasOne and belongsTo associations (local, within same database)
+		$srcAlias = $model->alias;
+		if (!empty($assoc['through'])) {
+			$srcAlias = $assoc['through'];
+		}
+
 		switch (true) {
 			case ($assoc['external'] && $type === 'hasOne'):
 				return array("{$alias}.{$assoc['foreignKey']}" => '{$__cakeID__$}');
 			case ($assoc['external'] && $type === 'belongsTo'):
 				return array("{$alias}.{$linkModel->primaryKey}" => '{$__cakeForeignKey__$}');
 			case (!$assoc['external'] && $type === 'hasOne'):
-				return array("{$alias}.{$assoc['foreignKey']}" => $this->identifier("{$model->alias}.{$model->primaryKey}"));
+				return array("{$alias}.{$assoc['foreignKey']}" => $this->identifier("{$srcAlias}.{$model->primaryKey}"));
 			case (!$assoc['external'] && $type === 'belongsTo'):
-				return array("{$model->alias}.{$assoc['foreignKey']}" => $this->identifier("{$alias}.{$linkModel->primaryKey}"));
+				return array("{$srcAlias}.{$assoc['foreignKey']}" => $this->identifier("{$alias}.{$linkModel->primaryKey}"));
 			case ($type === 'hasMany'):
 				return array("{$alias}.{$assoc['foreignKey']}" => array('{$__cakeID__$}'));
 			case ($type === 'hasAndBelongsToMany'):

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -550,8 +550,8 @@ class Model extends Object implements CakeEventListener {
  * @var array
  */
 	protected $_associationKeys = array(
-		'belongsTo' => array('className', 'foreignKey', 'conditions', 'fields', 'order', 'counterCache'),
-		'hasOne' => array('className', 'foreignKey', 'conditions', 'fields', 'order', 'dependent'),
+		'belongsTo' => array('className', 'foreignKey', 'conditions', 'fields', 'order', 'counterCache', 'through'),
+		'hasOne' => array('className', 'foreignKey', 'conditions', 'fields', 'order', 'dependent', 'through'),
 		'hasMany' => array('className', 'foreignKey', 'conditions', 'fields', 'order', 'limit', 'offset', 'dependent', 'exclusive', 'finderQuery', 'counterQuery'),
 		'hasAndBelongsToMany' => array('className', 'joinTable', 'with', 'foreignKey', 'associationForeignKey', 'conditions', 'fields', 'order', 'limit', 'offset', 'unique', 'finderQuery')
 	);


### PR DESCRIPTION
Refs #2451.

Distant associations can be retrieved through the key `'through'`, without
having to resort to key `'conditions'` to do so. Thus, keeping key
'conditions' clean and reserved for truly out of the ordinary cases.

Existing key `'foreignKey'` is used in this case, rather than being
supplanted by key 'conditions'.
