### PR TITLE
Always use forward slash when refering to sub types

### DIFF
--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -431,7 +431,7 @@ class Table implements EventListener {
 		}
 
 		if ($name !== null) {
-			$class = App::classname($name, 'Model\Entity');
+			$class = App::classname($name, 'Model/Entity');
 			$this->_entityClass = $class;
 		}
 

--- a/Cake/ORM/TableRegistry.php
+++ b/Cake/ORM/TableRegistry.php
@@ -135,7 +135,7 @@ class TableRegistry {
 
 		if (empty($options['className'])) {
 			$class = Inflector::camelize($alias);
-			$className = App::classname($class, 'Model\Repository', 'Table');
+			$className = App::classname($class, 'Model/Repository', 'Table');
 			$options['className'] = $className ?: 'Cake\ORM\Table';
 		}
 

--- a/Cake/TestSuite/TestCase.php
+++ b/Cake/TestSuite/TestCase.php
@@ -595,7 +595,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	public function getMockForModel($alias, $methods = array(), $options = array()) {
 		if (empty($options['className'])) {
 			$class = Inflector::camelize($alias);
-			$className = App::classname($class, 'Model\Repository', 'Table');
+			$className = App::classname($class, 'Model/Repository', 'Table');
 			if (!$className) {
 				throw new \Cake\ORM\Error\MissingTableClassException(array($alias));
 			}


### PR DESCRIPTION
Using a backslash has the implicit suggestion that you can also use a
backslash in classname, but whereas these two calls are equilvalent:

```
App::classname('Name', 'Sub/Type');
App::classname('Name', 'Sub\Type');
```

These are not:

```
App::classname('Sub/Name', 'Type');
App::classname('Sub\Name', 'Type');
```

The last example is taken to be a fully qualified classname, and will
therefore fail. Rather than leave the suggestion that slashes are
treated equally for all parameters - ensure consistent usage.
