### PR TITLE
Add Model type hints, and ease testing for Model.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2870,26 +2870,32 @@ class DboSource extends DataSource {
 	}
 
 /**
- * Create a GROUP BY SQL clause
+ * Create a GROUP BY SQL clause.
  *
- * @param string $group Group By Condition
- * @param Model $model
- * @return string string condition or null
+ * @param string|array $fields Group By fields
+ * @param Model $Model
+ * @return string Group By clause or null.
  */
-	public function group($group, $model = null) {
-		if ($group) {
-			if (!is_array($group)) {
-				$group = array($group);
-			}
-			foreach ($group as $index => $key) {
-				if (is_object($model) && $model->isVirtualField($key)) {
-					$group[$index] = '(' . $model->getVirtualField($key) . ')';
+	public function group($fields, Model $Model = null) {
+		if (empty($fields)) {
+			return null;
+		}
+
+		if (!is_array($fields)) {
+			$fields = array($fields);
+		}
+
+		if (!empty($Model)) {
+			foreach ($fields as $index => $key) {
+				if ($Model->isVirtualField($key)) {
+					$fields[$index] = '(' . $Model->getVirtualField($key) . ')';
 				}
 			}
-			$group = implode(', ', $group);
-			return ' GROUP BY ' . $this->_quoteFields($group);
 		}
-		return null;
+
+		$fields = implode(', ', $fields);
+
+		return ' GROUP BY ' . $this->_quoteFields($fields);
 	}
 
 /**

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2119,7 +2119,7 @@ class DboSource extends DataSource {
 				if (!isset($params[1])) {
 					$params[1] = 'count';
 				}
-				if (is_object($Model) && $Model->isVirtualField($params[0])) {
+				if ($Model->isVirtualField($params[0])) {
 					$arg = $this->_quoteFields($Model->getVirtualField($params[0]));
 				} else {
 					$arg = $this->name($params[0]);
@@ -2130,7 +2130,7 @@ class DboSource extends DataSource {
 				if (!isset($params[1])) {
 					$params[1] = $params[0];
 				}
-				if (is_object($Model) && $Model->isVirtualField($params[0])) {
+				if ($Model->isVirtualField($params[0])) {
 					$arg = $this->_quoteFields($Model->getVirtualField($params[0]));
 				} else {
 					$arg = $this->name($params[0]);


### PR DESCRIPTION
`Model` objects should be in CamelCase.
Add Model type hints.
Replace `is_object()` calls in favor of `!== null` when the test subject is already type hinted as a `Model`.

Update `_parseKey()` signature so that `Model $Model = null` can be set as last argument, like `conditions()`, `conditionKeysToString()`, `order()` and `group()`.

Update `DboSource::group()`:
- Update documentation.
- Bail early when fields are empty.
