### PR TITLE
3.0 - Create entities from arrays

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -49,6 +49,12 @@ abstract class Association {
  */
 	const STRATEGY_SELECT = 'select';
 
+	const ONE_TO_ONE = 'oneToOne';
+
+	const ONE_TO_MANY = 'oneToMany';
+
+	const MANY_TO_MANY = 'manyToMany';
+
 /**
  * Name given to the association, it usually represents the alias
  * assigned to the target associated table
@@ -413,6 +419,15 @@ abstract class Association {
 			$row[$sourceAlias][$this->property()] = $row[$targetAlias];
 		}
 		return $row;
+	}
+
+/**
+ * Get the relationship type.
+ *
+ * @return string Constant of either ONE_TO_ONE, MANY_TO_ONE, or MANY_TO_MANY.
+ */
+	public function type() {
+		return self::ONE_TO_ONE;
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -164,7 +164,7 @@ class BelongsToMany extends Association {
 /**
  * Get the relationship type.
  *
- * @return string MANY_TO_ONE
+ * @return string
  */
 	public function type() {
 		return self::MANY_TO_MANY;

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -162,6 +162,15 @@ class BelongsToMany extends Association {
 	}
 
 /**
+ * Get the relationship type.
+ *
+ * @return string MANY_TO_ONE
+ */
+	public function type() {
+		return self::MANY_TO_MANY;
+	}
+
+/**
  * Return false as join conditions are defined in the junction table
  *
  * @param array $options list of options passed to attachTo method

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -163,7 +163,7 @@ class HasMany extends Association {
 /**
  * Get the relationship type.
  *
- * @return string MANY_TO_ONE
+ * @return string
  */
 	public function type() {
 		return self::ONE_TO_MANY;

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -160,4 +160,13 @@ class HasMany extends Association {
 		return $entity;
 	}
 
+/**
+ * Get the relationship type.
+ *
+ * @return string MANY_TO_ONE
+ */
+	public function type() {
+		return self::ONE_TO_MANY;
+	}
+
 }

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -62,9 +62,14 @@ class Marshaller {
 	public function one(array $data, $include = []) {
 		$include = Hash::normalize($include);
 
+		$tableName = $this->_table->alias();
 		$entityClass = $this->_table->entityClass();
-
 		$entity = new $entityClass();
+
+		if (isset($data[$tableName])) {
+			$data = $data[$tableName];
+		}
+
 		foreach ($data as $key => $value) {
 			$assoc = null;
 			if (array_key_exists($key, $include)) {

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -72,10 +72,9 @@ class Marshaller {
 			}
 			if ($assoc) {
 				$value = $this->_marshalAssociation($assoc, $value, $include[$key]);
-				$entity->set($assoc->property(), $value);
-			} else {
-				$entity->set($key, $value);
+				$key = $assoc->property();
 			}
+			$entity->set($key, $value);
 		}
 		return $entity;
 	}
@@ -90,9 +89,8 @@ class Marshaller {
 		$marshaller = $targetTable->marshaller();
 		if ($assoc->type() === Association::ONE_TO_ONE) {
 			return $marshaller->one($value, (array)$include);
-		} else {
-			return $marshaller->many($value, (array)$include);
 		}
+		return $marshaller->many($value, (array)$include);
 	}
 
 /**

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -66,8 +66,11 @@ class Marshaller {
 
 		$entity = new $entityClass();
 		foreach ($data as $key => $value) {
+			$assoc = null;
 			if (array_key_exists($key, $include)) {
 				$assoc = $this->_table->association($key);
+			}
+			if ($assoc) {
 				$value = $this->_marshalAssociation($assoc, $value, $include[$key]);
 				$entity->set($assoc->property(), $value);
 			} else {

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM;
+
+use Cake\ORM\Table;
+
+/**
+ * Contains logic to convert array data into entities.
+ *
+ * Useful when converting request data into entities.
+ *
+ * @see Cake\ORM\Table::newEntity()
+ * @see Cake\ORM\Table::newEntities()
+ */
+class Marshaller {
+
+/**
+ * Whether or not this marhshaller is in safe mode.
+ *
+ * @var boolean
+ */
+	protected $_safe;
+
+/**
+ * The table instance this marshaller is for.
+ *
+ * @var Cake\ORM\Table
+ */
+	protected $_table;
+
+/**
+ * Constructor.
+ *
+ * @param Cake\ORM\Table $table
+ */
+	public function __construct(Table $table, $safe = false) {
+		$this->_table = $table;
+		$this->_safe = $safe;
+	}
+
+/**
+ * Hydrate one entity and its associated data.
+ *
+ * @param array $data The data to hydrate.
+ * @param array $associations The associations to include.
+ * @return Cake\ORM\Entity
+ */
+	public function one(array $data, $associations = []) {
+	}
+
+/**
+ * Hydrate many entities and their associated data.
+ *
+ * @param array $data The data to hydrate.
+ * @param array $associations The associations to include.
+ * @return array An array of hydrated records.
+ */
+	public function many(array $data, $associations = []) {
+	}
+
+}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -27,6 +27,7 @@ use Cake\ORM\Association\HasOne;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Entity;
 use Cake\ORM\Error\MissingEntityException;
+use Cake\ORM\Marshaller;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 
@@ -1500,6 +1501,68 @@ class Table implements EventListener {
 		throw new \BadMethodCallException(
 			__d('cake_dev', 'Unknown method "%s"', $method)
 		);
+	}
+
+/**
+ * Get the object used to marshal/convert array data into objects.
+ *
+ * Override this method if you want a table object to use custom
+ * marshalling logic.
+ *
+ * @return Cake\ORM\Marhsaller;
+ */
+	public function marshaller() {
+		return new Marshaller($this);
+	}
+
+/**
+ * Create a new entity + associated entities from an array.
+ *
+ * This is most useful when hydrating request data back into entities.
+ * For example, in your controller code:
+ *
+ * {{{
+ * $article = $this->Articles->newEntity($this->request->data());
+ * }}}
+ *
+ * The hydrated entity will correctly do an insert/update based
+ * on the primary key data existing in the database when the entity
+ * is saved. Until the entity is saved, it will be a detached record.
+ *
+ * @param array $data The data to build an entity with.
+ * @param array $associations A whitelist of associations
+ *   to hydrate. Defaults to all associations
+ */
+	public function newEntity(array $data, $associations = null) {
+		if ($associations === null) {
+			$associations = array_keys($this->_associations);
+		}
+		$marshaller = $this->marshaller();
+		return $marshaller->one($data, $associations);
+	}
+
+/**
+ * Create a list of entities + associated entities from an array.
+ *
+ * This is most useful when hydrating request data back into entities.
+ * For example, in your controller code:
+ *
+ * {{{
+ * $articles = $this->Articles->newEntities($this->request->data());
+ * }}}
+ *
+ * The hydrated entities can the be iterated and saved.
+ *
+ * @param array $data The data to build an entity with.
+ * @param array $associations A whitelist of associations
+ *   to hydrate. Defaults to all associations
+ */
+	public function newEntities(array $data, $associations = null) {
+		if ($associations === null) {
+			$associations = array_keys($this->_associations);
+		}
+		$marshaller = $this->marshaller();
+		return $marshaller->many($data, $associations);
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1539,7 +1539,7 @@ class Table implements EventListener {
  * {{{
  * $articles = $this->Articles->newEntity(
  *   $this->request->data(),
- *   ['Tags', 'Comments' => ['User']]
+ *   ['Tags', 'Comments' => ['Users']]
  * );
  * }}}
  *
@@ -1573,7 +1573,7 @@ class Table implements EventListener {
  * {{{
  * $articles = $this->Articles->newEntities(
  *   $this->request->data(),
- *   ['Tags', 'Comments' => ['User']]
+ *   ['Tags', 'Comments' => ['Users']]
  * );
  * }}}
  *

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1509,10 +1509,13 @@ class Table implements EventListener {
  * Override this method if you want a table object to use custom
  * marshalling logic.
  *
+ * @param boolean $safe Whether or not this marshaller 
+ *   should be in safe mode.
  * @return Cake\ORM\Marhsaller;
+ * @see Cake\ORM\Marshaller
  */
-	public function marshaller() {
-		return new Marshaller($this);
+	public function marshaller($safe = false) {
+		return new Marshaller($this, $safe);
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1532,6 +1532,17 @@ class Table implements EventListener {
  * on the primary key data existing in the database when the entity
  * is saved. Until the entity is saved, it will be a detached record.
  *
+ * By default all the associations on this table will be hydrated. You can
+ * limit which associations are built, or include deeper associations
+ * using the associations parameter:
+ *
+ * {{{
+ * $articles = $this->Articles->newEntity(
+ *   $this->request->data(),
+ *   ['Tags', 'Comments' => ['User']]
+ * );
+ * }}}
+ *
  * @param array $data The data to build an entity with.
  * @param array $associations A whitelist of associations
  *   to hydrate. Defaults to all associations
@@ -1554,7 +1565,17 @@ class Table implements EventListener {
  * $articles = $this->Articles->newEntities($this->request->data());
  * }}}
  *
- * The hydrated entities can the be iterated and saved.
+ * The hydrated entities can then be iterated and saved. By default
+ * all the associations on this table will be hydrated. You can
+ * limit which associations are built, or include deeper associations
+ * using the associations parameter:
+ *
+ * {{{
+ * $articles = $this->Articles->newEntities(
+ *   $this->request->data(),
+ *   ['Tags', 'Comments' => ['User']]
+ * );
+ * }}}
  *
  * @param array $data The data to build an entity with.
  * @param array $associations A whitelist of associations

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -78,6 +78,33 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * test one() with a wrapping model name.
+ *
+ * @return void
+ */
+	public function testOneWithAdditionalName() {
+		$data = [
+			'Articles' => [
+				'title' => 'My title',
+				'body' => 'My content',
+				'author_id' => 1,
+				'not_in_schema' => true,
+				'Users' => [
+					'username' => 'mark',
+				]
+			]
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, ['Users']);
+
+		$this->assertInstanceOf('Cake\ORM\Entity', $result);
+		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
+		$this->assertNull($result->isNew(), 'Should be detached');
+		$this->assertEquals($data['Articles']['title'], $result->title);
+		$this->assertEquals($data['Articles']['Users']['username'], $result->user->username);
+	}
+
+/**
  * test one() with association data.
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -103,11 +103,11 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data['body'], $result->body);
 		$this->assertEquals($data['author_id'], $result->author_id);
 
+		$this->assertNull($result->comments);
 		$this->assertInternalType('array', $result->Comments);
-		$this->assertCount(2, $result->Comments);
-		$this->assertInternalType('array', $result->Comments[0]);
-		$this->assertInternalType('array', $result->Comments[1]);
+		$this->assertEquals($data['Comments'], $result->Comments);
 
+		$this->assertNull($result->Users);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->user);
 		$this->assertEquals($data['Users']['username'], $result->user->username);
 		$this->assertEquals($data['Users']['password'], $result->user->password);
@@ -119,7 +119,36 @@ class MarshallerTest extends TestCase {
  * @return void
  */
 	public function testOneAssociationsMany() {
-		$this->markTestIncomplete('not done');
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 1,
+			'Comments' => [
+				['comment' => 'First post', 'user_id' => 2],
+				['comment' => 'Second post', 'user_id' => 2],
+			],
+			'Users' => [
+				'username' => 'mark',
+				'password' => 'secret'
+			]
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, ['Comments']);
+
+		$this->assertEquals($data['title'], $result->title);
+		$this->assertEquals($data['body'], $result->body);
+		$this->assertEquals($data['author_id'], $result->author_id);
+
+		$this->assertNull($result->Comments);
+		$this->assertInternalType('array', $result->comments);
+		$this->assertCount(2, $result->comments);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->comments[0]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->comments[1]);
+		$this->assertEquals($data['Comments'][0]['comment'], $result->comments[0]->comment);
+
+		$this->assertNull($result->user);
+		$this->assertInternalType('array', $result->Users);
+		$this->assertEquals($data['Users'], $result->Users);
 	}
 
 	public function testOneDeepAssociations() {

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -89,7 +89,7 @@ class MarshallerTest extends TestCase {
 				'body' => 'My content',
 				'author_id' => 1,
 				'not_in_schema' => true,
-				'Users' => [
+				'user' => [
 					'username' => 'mark',
 				]
 			]
@@ -101,7 +101,7 @@ class MarshallerTest extends TestCase {
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
 		$this->assertNull($result->isNew(), 'Should be detached');
 		$this->assertEquals($data['Articles']['title'], $result->title);
-		$this->assertEquals($data['Articles']['Users']['username'], $result->user->username);
+		$this->assertEquals($data['Articles']['user']['username'], $result->user->username);
 	}
 
 /**
@@ -114,11 +114,11 @@ class MarshallerTest extends TestCase {
 			'title' => 'My title',
 			'body' => 'My content',
 			'author_id' => 1,
-			'Comments' => [
+			'comments' => [
 				['comment' => 'First post', 'user_id' => 2],
 				['comment' => 'Second post', 'user_id' => 2],
 			],
-			'Users' => [
+			'user' => [
 				'username' => 'mark',
 				'password' => 'secret'
 			]
@@ -130,14 +130,12 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data['body'], $result->body);
 		$this->assertEquals($data['author_id'], $result->author_id);
 
-		$this->assertNull($result->comments);
-		$this->assertInternalType('array', $result->Comments);
-		$this->assertEquals($data['Comments'], $result->Comments);
+		$this->assertInternalType('array', $result->comments);
+		$this->assertEquals($data['comments'], $result->comments);
 
-		$this->assertNull($result->Users);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->user);
-		$this->assertEquals($data['Users']['username'], $result->user->username);
-		$this->assertEquals($data['Users']['password'], $result->user->password);
+		$this->assertEquals($data['user']['username'], $result->user->username);
+		$this->assertEquals($data['user']['password'], $result->user->password);
 	}
 
 /**
@@ -150,11 +148,11 @@ class MarshallerTest extends TestCase {
 			'title' => 'My title',
 			'body' => 'My content',
 			'author_id' => 1,
-			'Comments' => [
+			'comments' => [
 				['comment' => 'First post', 'user_id' => 2],
 				['comment' => 'Second post', 'user_id' => 2],
 			],
-			'Users' => [
+			'user' => [
 				'username' => 'mark',
 				'password' => 'secret'
 			]
@@ -166,16 +164,14 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data['body'], $result->body);
 		$this->assertEquals($data['author_id'], $result->author_id);
 
-		$this->assertNull($result->Comments);
 		$this->assertInternalType('array', $result->comments);
 		$this->assertCount(2, $result->comments);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->comments[0]);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->comments[1]);
-		$this->assertEquals($data['Comments'][0]['comment'], $result->comments[0]->comment);
+		$this->assertEquals($data['comments'][0]['comment'], $result->comments[0]->comment);
 
-		$this->assertNull($result->user);
-		$this->assertInternalType('array', $result->Users);
-		$this->assertEquals($data['Users'], $result->Users);
+		$this->assertInternalType('array', $result->user);
+		$this->assertEquals($data['user'], $result->user);
 	}
 
 /**
@@ -187,10 +183,10 @@ class MarshallerTest extends TestCase {
 		$data = [
 			'comment' => 'First post',
 			'user_id' => 2,
-			'Articles' => [
+			'article' => [
 				'title' => 'Article title',
 				'body' => 'Article body',
-				'Users' => [
+				'user' => [
 					'username' => 'mark',
 					'password' => 'secret'
 				],
@@ -200,15 +196,13 @@ class MarshallerTest extends TestCase {
 		$result = $marshall->one($data, ['Articles' => ['Users']]);
 
 		$this->assertEquals(
-			$data['Articles']['title'],
+			$data['article']['title'],
 			$result->article->title
 		);
 		$this->assertEquals(
-			$data['Articles']['Users']['username'],
+			$data['article']['user']['username'],
 			$result->article->user->username
 		);
-		$this->assertNull($result->article->Users);
-		$this->assertNull($result->Articles);
 	}
 
 /**
@@ -241,14 +235,14 @@ class MarshallerTest extends TestCase {
 			[
 				'comment' => 'First post',
 				'user_id' => 2,
-				'Users' => [
+				'user' => [
 					'username' => 'mark',
 				],
 			],
 			[
 				'comment' => 'Second post',
 				'user_id' => 2,
-				'Users' => [
+				'user' => [
 					'username' => 'jose',
 				],
 			],
@@ -260,11 +254,11 @@ class MarshallerTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Entity', $result[0]);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result[1]);
 		$this->assertEquals(
-			$data[0]['Users']['username'],
+			$data[0]['user']['username'],
 			$result[0]->user->username
 		);
 		$this->assertEquals(
-			$data[1]['Users']['username'],
+			$data[1]['user']['username'],
 			$result[1]->user->username
 		);
 	}

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\Marshaller;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Marshaller test case
+ */
+class MarshallerTest extends TestCase {
+
+	public $fixtures = ['core.article', 'core.user', 'core.comment'];
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$articles = TableRegistry::get('Articles');
+		$articles->belongsTo('Users');
+		$articles->hasMany('Comments');
+
+		$comments = TableRegistry::get('Comments');
+		$comments->belongsTo('Articles');
+		$comments->belongsTo('Users');
+
+		$this->articles = $articles;
+		$this->comments = $comments;
+	}
+
+/**
+ * Teardown
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		TableRegistry::clear();
+		unset($this->articles, $this->comments);
+	}
+
+/**
+ * Test one() in a simple use.
+ *
+ * @return void
+ */
+	public function testOneSimple() {
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 1,
+			'not_in_schema' => true
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, []);
+
+		$this->assertInstanceOf('Cake\ORM\Entity', $result);
+		$this->assertEquals($data, $result->toArray());
+		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
+		$this->assertNull($result->isNew(), 'Should be detached');
+	}
+
+/**
+ * test one() with association data.
+ *
+ * @return void
+ */
+	public function testOneAssociationsSingle() {
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 1,
+			'Comments' => [
+				['comment' => 'First post', 'user_id' => 2],
+				['comment' => 'Second post', 'user_id' => 2],
+			],
+			'Users' => [
+				'username' => 'mark',
+				'password' => 'secret'
+			]
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, ['Users']);
+
+		$this->assertEquals($data['title'], $result->title);
+		$this->assertEquals($data['body'], $result->body);
+		$this->assertEquals($data['author_id'], $result->author_id);
+
+		$this->assertInternalType('array', $result->Comments);
+		$this->assertCount(2, $result->Comments);
+		$this->assertInternalType('array', $result->Comments[0]);
+		$this->assertInternalType('array', $result->Comments[1]);
+
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->user);
+		$this->assertEquals($data['Users']['username'], $result->user->username);
+		$this->assertEquals($data['Users']['password'], $result->user->password);
+	}
+
+/**
+ * test one() with association data.
+ *
+ * @return void
+ */
+	public function testOneAssociationsMany() {
+		$this->markTestIncomplete('not done');
+	}
+
+	public function testOneDeepAssociations() {
+		$this->markTestIncomplete('not done');
+	}
+
+	public function testManySimple() {
+		$this->markTestIncomplete('not done');
+	}
+
+	public function testManyAssociations() {
+		$this->markTestIncomplete('not done');
+	}
+
+	public function testManyDeepAssociations() {
+		$this->markTestIncomplete('not done');
+	}
+
+}

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -151,20 +151,95 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data['Users'], $result->Users);
 	}
 
+/**
+ * Test one() with deeper associations.
+ *
+ * @return void
+ */
 	public function testOneDeepAssociations() {
-		$this->markTestIncomplete('not done');
+		$data = [
+			'comment' => 'First post',
+			'user_id' => 2,
+			'Articles' => [
+				'title' => 'Article title',
+				'body' => 'Article body',
+				'Users' => [
+					'username' => 'mark',
+					'password' => 'secret'
+				],
+			]
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->one($data, ['Articles' => ['Users']]);
+
+		$this->assertEquals(
+			$data['Articles']['title'],
+			$result->article->title
+		);
+		$this->assertEquals(
+			$data['Articles']['Users']['username'],
+			$result->article->user->username
+		);
+		$this->assertNull($result->article->Users);
+		$this->assertNull($result->Articles);
 	}
 
+/**
+ * Test many() with a simple set of data.
+ *
+ * @return void
+ */
 	public function testManySimple() {
-		$this->markTestIncomplete('not done');
+		$data = [
+			['comment' => 'First post', 'user_id' => 2],
+			['comment' => 'Second post', 'user_id' => 2],
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->many($data);
+
+		$this->assertCount(2, $result);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result[0]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result[1]);
+		$this->assertEquals($data[0]['comment'], $result[0]->comment);
+		$this->assertEquals($data[1]['comment'], $result[1]->comment);
 	}
 
+/**
+ * test many() with nested associations.
+ *
+ * @return void
+ */
 	public function testManyAssociations() {
-		$this->markTestIncomplete('not done');
-	}
+		$data = [
+			[
+				'comment' => 'First post',
+				'user_id' => 2,
+				'Users' => [
+					'username' => 'mark',
+				],
+			],
+			[
+				'comment' => 'Second post',
+				'user_id' => 2,
+				'Users' => [
+					'username' => 'jose',
+				],
+			],
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->many($data, ['Users']);
 
-	public function testManyDeepAssociations() {
-		$this->markTestIncomplete('not done');
+		$this->assertCount(2, $result);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result[0]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result[1]);
+		$this->assertEquals(
+			$data[0]['Users']['username'],
+			$result[0]->user->username
+		);
+		$this->assertEquals(
+			$data[1]['Users']['username'],
+			$result[1]->user->username
+		);
 	}
 
 }


### PR DESCRIPTION
As described in #2425 I've tried to implement the code described in that issue. I've not attempted to integrate it into result set processing yet as I wanted to keep this set of changes smaller and easier to review. Somethings to note:
- Request/array data needs to use association aliases as the keys for the request data. I'm not sure this is ideal, but it is a simple approach. I'm happy to change it if there are alternative ideas.
- By default only one level of associations are hydrated. Infinite recursion is a worry I have so I'd rather not enable that by default.
- The `_safe` flag is currently unused, but when the mass assignment feature is complete, this value will be used to disable guarded/protected fields.
