### PR TITLE
Revert change done in 11f543f1f2.

### DIFF
--- a/lib/Cake/Controller/Component/CookieComponent.php
+++ b/lib/Cake/Controller/Component/CookieComponent.php
@@ -472,7 +472,7 @@ class CookieComponent extends Component {
 		if (is_array($value)) {
 			$value = $this->_implode($value);
 		}
-		if (!$this->_encrypted || !$value) {
+		if (!$this->_encrypted) {
 			return $value;
 		}
 		$prefix = "Q2FrZQ==.";

--- a/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/CookieComponentTest.php
@@ -202,11 +202,11 @@ class CookieComponentTest extends CakeTestCase {
 	}
 
 /**
- * test write() Encrypted data with null & empty string & boolean value 
+ * test write() encrypted data with falsey value
  *
  * @return void
  */
-	public function testWriteWithNullEmptyString() {
+	public function testWriteWithFalseyValue() {
 		$this->Cookie->type('aes');
 		$this->Cookie->key = 'qSI232qs*&sXOw!adre@34SAv!@*(XSL#$%)asGb$@11~_+!@#HKis~#^';
 
@@ -228,7 +228,11 @@ class CookieComponentTest extends CakeTestCase {
 
 		$this->Cookie->write('Testing', '0');
 		$result = $this->Cookie->read('Testing');
-		$this->assertEquals('0', $result);
+		$this->assertSame('0', $result);
+
+		$this->Cookie->write('Testing', 0);
+		$result = $this->Cookie->read('Testing');
+		$this->assertSame(0, $result);
 	}
 
 /**


### PR DESCRIPTION
The change is unneeded now as Security::encrypt() no longer throws exception
for falsey values.
