### PR TITLE
3.0 - habtm methods

### DIFF
--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -258,9 +258,11 @@ class SqliteSchema extends BaseSchema {
 		if (isset($data['null']) && $data['null'] === false) {
 			$out .= ' NOT NULL';
 		}
-		if ($data['type'] === 'integer' && $name == $table->primaryKey()[0]) {
+
+		if ($data['type'] === 'integer' && [$name] === (array)$table->primaryKey()) {
 			$out .= ' PRIMARY KEY AUTOINCREMENT';
 		}
+
 		if (isset($data['null']) && $data['null'] === true) {
 			$out .= ' DEFAULT NULL';
 			unset($data['default']);

--- a/Cake/Database/Type.php
+++ b/Cake/Database/Type.php
@@ -17,7 +17,6 @@
 namespace Cake\Database;
 
 use Cake\Database\Driver;
-use Exception;
 use PDO;
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -492,9 +492,10 @@ class BelongsToMany extends Association {
 		return $this->junction()->connection()->transactional(
 			function() use ($sourceEntity, $targetEntities, $primaryValue, $options) {
 				$foreignKey = (array)$this->foreignKey();
+				$belongsTo = $this->_junctionTable->association($this->target()->alias());
 				$existing = $this->_junctionTable->find('all')
 					->where(array_combine($foreignKey, $primaryValue))
-					->andWHere($this->conditions());
+					->andWHere($belongsTo->conditions());
 
 				$jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
 				$inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities);

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -393,7 +393,7 @@ class BelongsToMany extends Association {
  * as new or their status is unknown, an exception will be thrown.
  *
  * When using this method, all entities in `$targetEntities` will be appended to
- * the source entity'property corresponding to this association object.
+ * the source entity's property corresponding to this association object.
  *
  * This method does not check link uniqueness.
  *
@@ -442,7 +442,7 @@ class BelongsToMany extends Association {
  * {{{
  * $article->tags = [$tag1, $tag2, $tag3, $tag4];
  * $tags = [$tag1, $tag2, $tag3];
- * $articles->association('tags')->unlink($article, [$tag1, $tag2, $tag3]);
+ * $articles->association('tags')->unlink($article, $tags);
  * }}}
  *
  * `$article->get('tags')` will contain only `[$tag4]` after deleting in the database
@@ -502,7 +502,7 @@ class BelongsToMany extends Association {
  * only the link for cake will be kept in database, the link for 'framework' will be
  * deleted and the links for 'php' and 'awesome' will be created.
  *
- * Existing links are not delete and created again, they are either left untouched
+ * Existing links are not deleted and created again, they are either left untouched
  * or updated so that potential extra information stored in the joint row is not
  * lost. Updating the link row can be done by making sure the corresponding passed
  * target entity contains the joint property with its primary key and any extra
@@ -554,7 +554,7 @@ class BelongsToMany extends Association {
 				$belongsTo = $this->_junctionTable->association($this->target()->alias());
 				$existing = $this->_junctionTable->find('all')
 					->where(array_combine($foreignKey, $primaryValue))
-					->andWHere($belongsTo->conditions());
+					->andWhere($belongsTo->conditions());
 
 				$jointEntities = $this->_collectJointEntities($sourceEntity, $targetEntities);
 				$inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities);

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -493,8 +493,8 @@ class BelongsToMany extends Association {
 		$inserts = $this->_diffLinks($existing, $jointEntities, $targetEntities);
 
 		$property = $this->property();
-		$sourceEntity->set($property, []);
-		$this->link($sourceEntity, $inserts, $options);
+		$sourceEntity->set($property, $inserts);
+		$this->save($sourceEntity, $options + ['associated' => false]);
 		$sourceEntity->set($property, $targetEntities);
 		$sourceEntity->dirty($property, false);
 	}

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -699,7 +699,7 @@ class BelongsToMany extends Association {
 		$assocForeignKey = (array)$belongsTo->foreignKey();
 		$sourceKey = $sourceEntity->extract((array)$source->primaryKey());
 
-		foreach($missing as $key) {
+		foreach ($missing as $key) {
 			$unions[] = $junction->find('all')
 				->where(array_combine($foreignKey, $sourceKey))
 				->andWhere(array_combine($assocForeignKey, $key))

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -484,8 +484,9 @@ class BelongsToMany extends Association {
 		$primaryKey = (array)$this->source()->primaryKey();
 		$primaryValue = $sourceEntity->extract($primaryKey);
 
-		if (empty($primaryValue)) {
-			throw new \InvalidArgumentException;
+		if (count(array_filter($primaryValue, 'strlen')) !== count($primaryKey)) {
+			$message = __d('cake_dev', 'Could not find primary key value for source entity');
+			throw new \InvalidArgumentException($message);
 		}
 
 		return $this->junction()->connection()->transactional(

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -73,12 +73,12 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	protected static $_accessors = [];
 
 /**
- * Indicates whether or not this entity has already been persisted.
+ * Indicates whether or not this entity is yet to be persisted.
  * A null value indicates an unknown persistence status
  *
  * @var boolean
  */
-	protected $_persisted = null;
+	protected $_new = null;
 
 /**
  * List of errors per field as stored in this object
@@ -512,9 +512,9 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  */
 	public function isNew($new = null) {
 		if ($new === null) {
-			return $this->_persisted;
+			return $this->_new;
 		}
-		return $this->_persisted = (bool)$new;
+		return $this->_new = (bool)$new;
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1349,6 +1349,8 @@ class Table implements EventListener {
  *
  * @param Entity $entity The entity to delete.
  * @param ArrayObject $options The options for the delete.
+ * @throws \InvalidArgumentException if there are no primary key values of the
+ * passed entity
  * @return boolean success
  */
 	protected function _processDelete($entity, $options) {
@@ -1367,6 +1369,11 @@ class Table implements EventListener {
 		}
 		$primaryKey = (array)$this->primaryKey();
 		$conditions = (array)$entity->extract($primaryKey);
+
+		if (!array_filter($conditions, 'strlen')) {
+			$msg = __d('cake_dev', 'Deleting requires a primary key value');
+			throw new \InvalidArgumentException($msg);
+		}
 
 		$query = $this->_buildQuery();
 		$statement = $query->delete($this->table())

--- a/Cake/Test/Fixture/ArticlesTagFixture.php
+++ b/Cake/Test/Fixture/ArticlesTagFixture.php
@@ -32,7 +32,7 @@ class ArticlesTagFixture extends TestFixture {
 	public $fields = array(
 		'article_id' => ['type' => 'integer', 'null' => false],
 		'tag_id' => ['type' => 'integer', 'null' => false],
-		'_constraints' => ['UNIQUE_TAG2' => ['type' => 'unique', 'columns' => ['article_id', 'tag_id']]]
+		'_constraints' => ['UNIQUE_TAG2' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]]
 	);
 
 /**

--- a/Cake/Test/TestApp/Model/Repository/TagsTable.php
+++ b/Cake/Test/TestApp/Model/Repository/TagsTable.php
@@ -21,7 +21,7 @@ class TagsTable extends Table {
 
 	public function initialize(array $config) {
 		$this->belongsTo('authors');
-		$this->belongsToMany('tags');
+		$this->belongsToMany('articles');
 		$this->hasMany('articlesTags', ['propertyName' => 'extraInfo']);
 	}
 

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -907,7 +907,7 @@ class BelongsToManyTest extends TestCase {
  * @expectedExceptionMessage Could not find primary key value for source entity
  * @return void
  */
-	public function testRplaceWithMissingPrimaryKey() {
+	public function testReplaceWithMissingPrimaryKey() {
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -640,7 +640,7 @@ class BelongsToManyTest extends TestCase {
 	}
 
 /**
- * Test liking entities having a non persited source entity
+ * Test linking entities having a non persisted source entity
  *
  * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Source entity needs to be persisted before proceeding

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -683,7 +683,12 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testLinkSuccess() {
-		$joint = $this->getMock('\Cake\ORM\Table', ['save'], [['alias' => 'ArticlesTags']]);
+		$connection = \Cake\Database\ConnectionManager::get('test');
+		$joint = $this->getMock(
+			'\Cake\ORM\Table',
+			['save'],
+			[['alias' => 'ArticlesTags', 'connection' => $connection]]
+		);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -643,7 +643,7 @@ class BelongsToManyTest extends TestCase {
  * Test liking entities having a non persited source entity
  *
  * @expectedException \InvalidArgumentException
- * @expectedExceptionMessage Source entity needs to be persisted before linking
+ * @expectedExceptionMessage Source entity needs to be persisted before proceeding
  * @return void
  */
 	public function testLinkWithNotPersistedSource() {

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -714,6 +714,7 @@ class BelongsToManyTest extends TestCase {
 			->will($this->returnValue($entity));
 
 		$this->assertTrue($assoc->link($entity, $tags, $saveOptions));
+		$this->assertSame($entity->test, $tags);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -900,7 +900,8 @@ class BelongsToManyTest extends TestCase {
 	}
 
 /**
- * Test liking entities having a non persited source entity
+ * Tests that replaceLink requires the sourceEntity to have primaryKey values
+ * for the source entity
  *
  * @expectedException \InvalidArgumentException
  * @expectedExceptionMessage Could not find primary key value for source entity
@@ -916,6 +917,101 @@ class BelongsToManyTest extends TestCase {
 		$entity = new Entity(['foo' => 1], ['markNew' => false]);
 		$tags = [new Entity(['id' => 2]), new Entity(['id' => 3])];
 		$assoc->replaceLinks($entity, $tags);
+	}
+
+/**
+ * Tests that replaceLinks will delete entities not present in the passed
+ * array, maintain those are already persisted and were passed and also
+ * insert the rest.
+ *
+ * @return void
+ */
+	public function testReplaceLinkSuccess() {
+		$connection = \Cake\Database\ConnectionManager::get('test');
+		$joint = $this->getMock(
+			'\Cake\ORM\Table',
+			['delete', 'find'],
+			[['alias' => 'ArticlesTags', 'connection' => $connection]]
+		);
+		$config = [
+			'sourceTable' => $this->article,
+			'targetTable' => $this->tag,
+			'through' => $joint,
+			'joinTable' => 'tags_articles'
+		];
+		$assoc = $this->getMock(
+			'\Cake\ORM\Association\BelongsToMany',
+			['_collectJointEntities', 'save'],
+			['tags', $config]
+		);
+
+		$assoc
+			->junction()
+			->association('tags')
+			->conditions(['foo' => 1]);
+
+		$query1 = $this->getMock(
+			'\Cake\ORM\Query',
+			['where', 'andWhere', 'addDefaultTypes'],
+			[$connection, $joint]
+		);
+
+		$joint->expects($this->at(0))->method('find')
+			->with('all')
+			->will($this->returnValue($query1));
+
+		$query1->expects($this->once())
+			->method('where')
+			->with(['article_id' => 1])
+			->will($this->returnSelf());
+		$query1->expects($this->at(1))
+			->method('andWhere')
+			->with(['foo' => 1])
+			->will($this->returnSelf());
+
+		$existing = [
+			new Entity(['article_id' => 1, 'tag_id' => 2]),
+			new Entity(['article_id' => 1, 'tag_id' => 4]),
+			new Entity(['article_id' => 1, 'tag_id' => 5]),
+			new Entity(['article_id' => 1, 'tag_id' => 6])
+		];
+		$query1->setResult(new \ArrayIterator($existing));
+
+
+		$opts = ['markNew' => false];
+		$tags = [
+			new Entity(['id' => 2], $opts),
+			new Entity(['id' => 3], $opts),
+			new Entity(['id' => 6, 'articlesTag' => new Entity(['bar' => 'baz'])])
+		];
+		$entity = new Entity(['id' => 1, 'test' => $tags], $opts);
+
+		$jointEntities = [
+			new Entity(['article_id' => 1, 'tag_id' => 2]),
+		];
+		$assoc->expects($this->once())->method('_collectJointEntities')
+			->with($entity, $tags)
+			->will($this->returnValue($jointEntities));
+
+		$joint->expects($this->at(1))
+			->method('delete')
+			->with($existing[1]);
+		$joint->expects($this->at(2))
+			->method('delete')
+			->with($existing[2]);
+
+		$options = ['foo' => 'bar'];
+		$assoc->expects($this->once())
+			->method('save')
+			->with($entity, $options + ['associated' => false])
+			->will($this->returnCallback(function($entity) use ($tags) {
+				$this->assertSame([$tags[1], $tags[2]], $entity->get('tags'));
+				return true;
+			}));
+
+		$assoc->replaceLinks($entity, $tags, $options);
+		$this->assertSame($tags, $entity->tags);
+		$this->assertFalse($entity->dirty('tags'));
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -899,4 +899,23 @@ class BelongsToManyTest extends TestCase {
 		$this->assertEquals($tags, $entity->get('test'));
 	}
 
+/**
+ * Test liking entities having a non persited source entity
+ *
+ * @expectedException \InvalidArgumentException
+ * @expectedExceptionMessage Could not find primary key value for source entity
+ * @return void
+ */
+	public function testRplaceWithMissingPrimaryKey() {
+		$config = [
+			'sourceTable' => $this->article,
+			'targetTable' => $this->tag,
+			'joinTable' => 'tags_articles'
+		];
+		$assoc = new BelongsToMany('Test', $config);
+		$entity = new Entity(['foo' => 1], ['markNew' => false]);
+		$tags = [new Entity(['id' => 2]), new Entity(['id' => 3])];
+		$assoc->replaceLinks($entity, $tags);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -977,7 +977,6 @@ class BelongsToManyTest extends TestCase {
 		];
 		$query1->setResult(new \ArrayIterator($existing));
 
-
 		$opts = ['markNew' => false];
 		$tags = [
 			new Entity(['id' => 2], $opts),
@@ -987,7 +986,7 @@ class BelongsToManyTest extends TestCase {
 		$entity = new Entity(['id' => 1, 'test' => $tags], $opts);
 
 		$jointEntities = [
-			new Entity(['article_id' => 1, 'tag_id' => 2]),
+			new Entity(['article_id' => 1, 'tag_id' => 2])
 		];
 		$assoc->expects($this->once())->method('_collectJointEntities')
 			->with($entity, $tags)

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2571,7 +2571,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertNull($entity->tags[1]->extraInfo);
 	}
 
-
 /**
  * Tests saving belongsToMany records with a validation error in a joint entity
  * and atomic set to false
@@ -2830,7 +2829,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$article = new \Cake\ORM\Entity(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
 
@@ -2851,7 +2850,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$article = new \Cake\ORM\Entity(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
 
@@ -2876,7 +2875,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$article = new \Cake\ORM\Entity(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['name' => 'foo']);
@@ -2902,7 +2901,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$article = new \Cake\ORM\Entity(['id' => 1], $options);
 		$tags = [];
 
 		$table->association('tags')->replaceLinks($article, $tags);
@@ -2923,7 +2922,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$article = new \Cake\ORM\Entity(['id' => 1], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag([
 			'id' => 2,
 			'extraInfo' => new \Cake\ORM\Entity([

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2809,13 +2809,14 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tagsTable = TableRegistry::get('tags');
 		$options = ['markNew' => false];
 
-		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
-		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
+		$article = $table->find('all')
+			->where(['id' => 1])
+			->contain(['tags'])->first();
 
-		$table->association('tags')->unlink($article, $tags);
-		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
-		$this->assertCount(1, $left->tags);
-		$this->assertEquals(2, $left->tags[0]->get('id'));
+		$table->association('tags')->unlink($article, [$article->tags[0]]);
+		$this->assertCount(1, $article->tags);
+		$this->assertEquals(2, $article->tags[0]->get('id'));
+		$this->assertFalse($article->dirty('tags'));
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2870,7 +2870,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @return void
  */
-	public function testReplacelinksBelongsToManyMultiple() {
+	public function testReplacelinksBelongsToMany() {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 		$tagsTable = TableRegistry::get('tags');
@@ -2881,6 +2881,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
 
 		$table->association('tags')->replaceLinks($article, $tags);
+		$this->assertSame($tags, $article->tags);
 		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
 		$this->assertCount(2, $article->tags);
 		$this->assertEquals(2, $article->tags[0]->id);

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2762,4 +2762,40 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		]));
 	}
 
+/**
+ * Integration test for linking entities with belongsToMany
+ *
+ * @return void
+ */
+	public function testLinkBelongsToMany() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity([
+			'id' => 1,
+		], $options);
+
+		$newTag = new \TestApp\Model\Entity\Tag([
+			'name' => 'Foo'
+		]);
+		$tags[] = new \TestApp\Model\Entity\Tag([
+			'id' => 3
+		], $options);
+		$tags[] = $newTag;
+
+		$tagsTable->save($newTag);
+		$table->association('tags')->link($article, $tags);
+
+		$this->assertEquals($article->tags, $tags);
+		foreach ($tags as $tag) {
+			$this->assertFalse($tag->isNew());
+		}
+
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertEquals($article->tags[2]->id, $tags[0]->id);
+		$this->assertEquals($article->tags[3], $tags[1]);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2798,6 +2798,11 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals($article->tags[3], $tags[1]);
 	}
 
+/**
+ * Integration test to show how to unlink a single record from a belongsToMany
+ *
+ * @return void
+ */
 	public function testUnlinkBelongsToMany() {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
@@ -2811,6 +2816,52 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
 		$this->assertCount(1, $left->tags);
 		$this->assertEquals(2, $left->tags[0]->get('id'));
+	}
+
+/**
+ * Integration test to show how to unlink multiple records from a belongsToMany
+ *
+ * @return void
+ */
+	public function testUnlinkBelongsToManyMultiple() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
+
+		$table->association('tags')->unlink($article, $tags);
+		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertNull($left->tags);
+	}
+
+/**
+ * Integration test to show how to unlink multiple records from a belongsToMany
+ * providing some of the joint
+ *
+ * @return void
+ */
+	public function testUnlinkBelongsToManyPassingJoint() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
+
+		$tags[1]->extraInfo = new \Cake\ORM\Entity([
+			'article_id' => 1,
+			'tag_id' => 2
+		]);
+
+		$table->association('tags')->unlink($article, $tags);
+		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertNull($left->tags);
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2798,4 +2798,19 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals($article->tags[3], $tags[1]);
 	}
 
+	public function testUnlinkBelongsToMany() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 1], $options);
+
+		$table->association('tags')->unlink($article, $tags);
+		$left = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertCount(1, $left->tags);
+		$this->assertEquals(2, $left->tags[0]->get('id'));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2865,4 +2865,26 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertNull($left->tags);
 	}
 
+/**
+ * Integration test to show how to replace records from a belongsToMany
+ *
+ * @return void
+ */
+	public function testReplacelinksBelongsToManyMultiple() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
+
+		$table->association('tags')->replaceLinks($article, $tags);
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertCount(2, $article->tags);
+		$this->assertEquals(2, $article->tags[0]->id);
+		$this->assertEquals(3, $article->tags[1]->id);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2879,13 +2879,16 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 2], $options);
 		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['name' => 'foo']);
 
 		$table->association('tags')->replaceLinks($article, $tags);
 		$this->assertSame($tags, $article->tags);
 		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
-		$this->assertCount(2, $article->tags);
+		$this->assertCount(3, $article->tags);
 		$this->assertEquals(2, $article->tags[0]->id);
 		$this->assertEquals(3, $article->tags[1]->id);
+		$this->assertEquals(4, $article->tags[2]->id);
+		$this->assertEquals('foo', $article->tags[2]->name);
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2888,4 +2888,54 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals(3, $article->tags[1]->id);
 	}
 
+/**
+ * Integration test to show how remove all links from a belongsToMany
+ *
+ * @return void
+ */
+	public function testReplacelinksBelongsToManyWithEmpty() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags = [];
+
+		$table->association('tags')->replaceLinks($article, $tags);
+		$this->assertSame($tags, $article->tags);
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertNull($article->tags);
+	}
+
+/**
+ * Integration test to show how to replace records from a belongsToMany
+ * passing the joint property along in the target entity
+ *
+ * @return void
+ */
+	public function testReplacelinksBelongsToManyWithJoint() {
+		$table = TableRegistry::get('articles');
+		$table->belongsToMany('tags');
+		$tagsTable = TableRegistry::get('tags');
+		$options = ['markNew' => false];
+
+		$article = new \Cake\ORM\Entity(['id' => 1,], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag([
+			'id' => 2,
+			'extraInfo' => new \Cake\ORM\Entity([
+				'article_id' => 1,
+				'tag_id' => 2,
+			])
+		], $options);
+		$tags[] = new \TestApp\Model\Entity\Tag(['id' => 3], $options);
+
+		$table->association('tags')->replaceLinks($article, $tags);
+		$this->assertSame($tags, $article->tags);
+		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
+		$this->assertCount(2, $article->tags);
+		$this->assertEquals(2, $article->tags[0]->id);
+		$this->assertEquals(3, $article->tags[1]->id);
+	}
+
 }


### PR DESCRIPTION
Following the PR for saving associated entities, this adds new methods to `BelongsToMany`. These are responsible for linking, unlinking or replacing links between both tables. In a future PR these methods will be used to provide saving modes for BelongsToMany.
