### PR TITLE
Add Configure timezone to bootstrap

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -270,9 +270,9 @@
 	//date_default_timezone_set('UTC');
 
 /**
- * `Config.timezone` is available which you can set to user's timezone string.
+ * `Config.timezone` is available in which you can set users' timezone string.
  * If a method of CakeTime class is called with $timezone parameter as null and `Config.timezone` is set,
- * then the value of `Config.timezone` will be used. This feature allows you to set user's timezone just
+ * then the value of `Config.timezone` will be used. This feature allows you to set users' timezone just
  * once instead of passing it each time in function calls.
  */
 	//Configure::write('Config.timezone', 'Europe/Paris')

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -270,9 +270,9 @@
 	//date_default_timezone_set('UTC');
 
 /**
- * ‘Config.timezone’ is available which you can set to user’s timezone string.
- * If a method of CakeTime class is called with $timezone parameter as null and ‘Config.timezone’ is set,
- * then the value of ‘Config.timezone’ will be used. This feature allows you to set user’s timezone just
+ * `Config.timezone` is available which you can set to user's timezone string.
+ * If a method of CakeTime class is called with $timezone parameter as null and `Config.timezone` is set,
+ * then the value of `Config.timezone` will be used. This feature allows you to set user's timezone just
  * once instead of passing it each time in function calls.
  */
 	//Configure::write('Config.timezone', 'Europe/Paris')

--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -270,6 +270,14 @@
 	//date_default_timezone_set('UTC');
 
 /**
+ * ‘Config.timezone’ is available which you can set to user’s timezone string.
+ * If a method of CakeTime class is called with $timezone parameter as null and ‘Config.timezone’ is set,
+ * then the value of ‘Config.timezone’ will be used. This feature allows you to set user’s timezone just
+ * once instead of passing it each time in function calls.
+ */
+	//Configure::write('Config.timezone', 'Europe/Paris')
+
+/**
  *
  * Cache Engine Configuration
  * Default settings provided below

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -331,7 +331,7 @@ class Validation {
 			$separator . '((1[6-9]|[2-9]\\d)\\d{2})$%';
 
 		$regex['my'] = '%^(' . $month . $separator . $year . ')$%';
-		$regex['ym'] = '%^(' . $year . $separator . $month  . ')$%';
+		$regex['ym'] = '%^(' . $year . $separator . $month . ')$%';
 		$regex['y'] = '%^(' . $fourDigitYear . ')$%';
 
 		$format = (is_array($format)) ? array_values($format) : array($format);


### PR DESCRIPTION
While moseying over Time::fromString() in the 3.0 branch, I noticed this timezone fallback.  It's not anywhere within 2.x core (besides a test) and not mentioned in the 2.x documentation (besides the 2.2 migration guide).  So, to bring attention to this option, I figured this could be an uncomment-able option within bootstrap.
