### PR TITLE
3.0 habtm strategies

### DIFF
--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -319,7 +319,7 @@ class BelongsToMany extends Association {
 			$msg = __d('cake_dev', 'Invalid save strategy "%s"', $strategy);
 			throw new \InvalidArgumentException($msg);
 		}
-		return $this->_strategy = $strategy;
+		return $this->_saveStrategy = $strategy;
 	}
 
 /**

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -332,10 +332,10 @@ class BelongsToMany extends Association {
  * between each side of this association. It will not destroy existing ones even
  * though they may not be present in the array of entities to be saved.
  *
- * When using the 'replace' strategy, existing links will be removed and new ones
- * will be created in between both tables in the association. If there exists
- * links in the database to some of the entities intended to be saved by this method,
- * they will be updated, not deleted.
+ * When using the 'replace' strategy, existing links will be removed and new links
+ * will be created in the joint table. If there exists links in the database to some
+ * of the entities intended to be saved by this method, they will be updated,
+ * not deleted.
  *
  * @param \Cake\ORM\Entity $entity an entity from the source table
  * @param array|\ArrayObject $options options to be passed to the save method in

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -105,7 +105,7 @@ class BelongsToMany extends Association {
  *
  * @var string
  */
-	protected $_saveStrategy = self::SAVE_APPEND;
+	protected $_saveStrategy = self::SAVE_REPLACE;
 
 /**
  * Sets the table instance for the junction relation. If no arguments
@@ -644,7 +644,13 @@ class BelongsToMany extends Association {
 				}
 
 				$property = $this->property();
-				$sourceEntity->set($property, $targetEntities);
+				$inserted = array_combine(
+					array_keys($inserts),
+					(array)$sourceEntity->get($property)
+				);
+				$targetEntities = $inserted + $targetEntities;
+				ksort($targetEntities);
+				$sourceEntity->set($property, array_values($targetEntities));
 				$sourceEntity->dirty($property, false);
 				return true;
 			}
@@ -711,7 +717,7 @@ class BelongsToMany extends Association {
 			}
 		}
 
-		return array_values($targetEntities);
+		return $targetEntities;
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -640,6 +640,10 @@ class Table implements EventListener {
  *   or 'subquery'. If subquery is selected the query used to return results
  *   in the source table will be used as conditions for getting rows in the
  *   target table.
+ * - saveStrategy: Either 'append' or 'replace'. Indicates the mode to be used
+ *   for saving associated entities. The former will only create new links
+ *   between both side of the relation and the latter will do a wipe and
+ *   replace to create the links between the passed entities when saving.
  *
  * This method will return the association object that was built.
  *
@@ -1516,7 +1520,7 @@ class Table implements EventListener {
  * Override this method if you want a table object to use custom
  * marshalling logic.
  *
- * @param boolean $safe Whether or not this marshaller 
+ * @param boolean $safe Whether or not this marshaller
  *   should be in safe mode.
  * @return Cake\ORM\Marhsaller;
  * @see Cake\ORM\Marshaller

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -161,6 +161,41 @@ class BelongsToManyTest extends TestCase {
 	}
 
 /**
+ * Tests saveStrategy
+ *
+ * @return void
+ */
+	public function testSaveStrategy() {
+		$assoc = new BelongsToMany('Test');
+		$this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
+		$assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+		$this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+		$assoc->saveStrategy(BelongsToMany::SAVE_APPEND);
+		$this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
+	}
+
+/**
+ * Tests that it is possible to pass the save strategy in the constructor
+ *
+ * @return void
+ */
+	public function testSaveStrategyInOptions() {
+		$assoc = new BelongsToMany('Test', ['saveStrategy' => BelongsToMany::SAVE_REPLACE]);
+		$this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+	}
+
+/**
+ * Tests that passing an invalid strategy will throw an exception
+ *
+ * @expectedException \InvalidArgumentException
+ * @expectedExceptionMessage Invalid save strategy "depsert"
+ * @return void
+ */
+	public function testSaveStrategyInvalid() {
+		$assoc = new BelongsToMany('Test', ['saveStrategy' => 'depsert']);
+	}
+
+/**
  * Tests that the correct join and fields are attached to a query depending on
  * the association config
  *

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1057,4 +1057,56 @@ class BelongsToManyTest extends TestCase {
 		$this->assertFalse($entity->dirty('tags'));
 	}
 
+/**
+ * Tests saving with replace strategy returning true
+ *
+ * @return void
+ */
+	public function testSaveWithReplace() {
+		$assoc = $this->getMock(
+			'\Cake\ORM\Association\BelongsToMany',
+			['replaceLinks'],
+			['tags']
+		);
+		$entity = new Entity([
+			'id' =>1,
+			'tags' => [
+				new Entity(['name' => 'foo'])
+			]
+		]);
+
+		$options = ['foo' => 'bar'];
+		$assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+		$assoc->expects($this->once())->method('replaceLinks')
+			->with($entity, $entity->tags, $options)
+			->will($this->returnValue(true));
+		$this->assertSame($entity, $assoc->save($entity, $options));
+	}
+
+/**
+ * Tests saving with replace strategy returning true
+ *
+ * @return void
+ */
+	public function testSaveWithReplaceReturnFalse() {
+		$assoc = $this->getMock(
+			'\Cake\ORM\Association\BelongsToMany',
+			['replaceLinks'],
+			['tags']
+		);
+		$entity = new Entity([
+			'id' =>1,
+			'tags' => [
+				new Entity(['name' => 'foo'])
+			]
+		]);
+
+		$options = ['foo' => 'bar'];
+		$assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+		$assoc->expects($this->once())->method('replaceLinks')
+			->with($entity, $entity->tags, $options)
+			->will($this->returnValue(false));
+		$this->assertSame(false, $assoc->save($entity, $options));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -950,7 +950,7 @@ class BelongsToManyTest extends TestCase {
 		];
 		$assoc = $this->getMock(
 			'\Cake\ORM\Association\BelongsToMany',
-			['_collectJointEntities', 'save'],
+			['_collectJointEntities', '_saveTarget'],
 			['tags', $config]
 		);
 
@@ -1010,10 +1010,10 @@ class BelongsToManyTest extends TestCase {
 
 		$options = ['foo' => 'bar'];
 		$assoc->expects($this->once())
-			->method('save')
-			->with($entity, $options + ['associated' => false])
-			->will($this->returnCallback(function($entity) use ($tags) {
-				$this->assertSame([$tags[1], $tags[2]], $entity->get('tags'));
+			->method('_saveTarget')
+			->with($entity, [$tags[1], $tags[2]], $options + ['associated' => false])
+			->will($this->returnCallback(function($entity, $inserts) use ($tags) {
+				$this->assertSame([$tags[1], $tags[2]], $inserts);
 				return true;
 			}));
 

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1106,7 +1106,7 @@ class BelongsToManyTest extends TestCase {
 		$assoc->expects($this->once())->method('replaceLinks')
 			->with($entity, $entity->tags, $options)
 			->will($this->returnValue(false));
-		$this->assertSame(false, $assoc->save($entity, $options));
+		$this->assertFalse($assoc->save($entity, $options));
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -167,11 +167,11 @@ class BelongsToManyTest extends TestCase {
  */
 	public function testSaveStrategy() {
 		$assoc = new BelongsToMany('Test');
-		$this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
-		$assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
 		$this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
 		$assoc->saveStrategy(BelongsToMany::SAVE_APPEND);
 		$this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
+		$assoc->saveStrategy(BelongsToMany::SAVE_REPLACE);
+		$this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
 	}
 
 /**
@@ -180,8 +180,8 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testSaveStrategyInOptions() {
-		$assoc = new BelongsToMany('Test', ['saveStrategy' => BelongsToMany::SAVE_REPLACE]);
-		$this->assertEquals(BelongsToMany::SAVE_REPLACE, $assoc->saveStrategy());
+		$assoc = new BelongsToMany('Test', ['saveStrategy' => BelongsToMany::SAVE_APPEND]);
+		$this->assertEquals(BelongsToMany::SAVE_APPEND, $assoc->saveStrategy());
 	}
 
 /**
@@ -1046,9 +1046,10 @@ class BelongsToManyTest extends TestCase {
 		$options = ['foo' => 'bar'];
 		$assoc->expects($this->once())
 			->method('_saveTarget')
-			->with($entity, [$tags[1], $tags[2]], $options + ['associated' => false])
+			->with($entity, [1 => $tags[1], 2 => $tags[2]], $options + ['associated' => false])
 			->will($this->returnCallback(function($entity, $inserts) use ($tags) {
-				$this->assertSame([$tags[1], $tags[2]], $inserts);
+				$this->assertSame([1 => $tags[1], 2 => $tags[2]], $inserts);
+				$entity->tags = $inserts;
 				return true;
 			}));
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2881,7 +2881,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$tags[] = new \TestApp\Model\Entity\Tag(['name' => 'foo']);
 
 		$table->association('tags')->replaceLinks($article, $tags);
-		$this->assertSame($tags, $article->tags);
+		$this->assertEquals(2, $article->tags[0]->id);
+		$this->assertEquals(3, $article->tags[1]->id);
+		$this->assertEquals(4, $article->tags[2]->id);
+
 		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
 		$this->assertCount(3, $article->tags);
 		$this->assertEquals(2, $article->tags[0]->id);


### PR DESCRIPTION
This add the ability to select between 2 saving modes for belongsToMany: `append` and `replace`, it is basically just a switch between the already implemented modes with a configuration method and another options in the constructor.
