### PR TITLE
Correct doc block

### DIFF
--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -107,7 +107,7 @@ class String {
  * @param string $separator The token to split the data on.
  * @param string $leftBound The left boundary to ignore separators in.
  * @param string $rightBound The right boundary to ignore separators in.
- * @return array Array of tokens in $data.
+ * @return mixed Array of tokens in $data or original input if empty.
  */
 	public static function tokenize($data, $separator = ',', $leftBound = '(', $rightBound = ')') {
 		if (empty($data) || is_array($data)) {


### PR DESCRIPTION
When the input is an empty string the doc block is wrong and misleading.
It will return the string again - I would have expected an empty array, though.

I would prefer to drop the is_array() check (nonsense since we expect a string) and return empty array() if empty:

```
if (empty($data)) {
    return array();
}
```

But that will have to wait for 2.5 then.
