### PR TITLE
3.0 - Adding find to assocs

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -431,6 +431,22 @@ abstract class Association {
 	}
 
 /**
+ * Proxies the finding operation to the target table's find method
+ * and modifies the query accordingly based of this association
+ * configuration
+ *
+ * @param string $type
+ * @param array $options options for query
+ * @see \Cake\ORM\Table::find()
+ * @return \Cake\ORM\Query
+ */
+	public function find($type, $options = []) {
+		return $this->target()
+			->find($type, $options)
+			->where($this->conditions());
+	}
+
+/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table. If false is returned then
  * it will not attach any new conditions to the join clause

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -779,15 +779,15 @@ class BelongsToMany extends Association {
 		}
 
 		$belongsTo = $junction->association($target->alias());
+		$hasMany = $source->association($junction->alias());
 		$foreignKey = (array)$this->foreignKey();
 		$assocForeignKey = (array)$belongsTo->foreignKey();
 		$sourceKey = $sourceEntity->extract((array)$source->primaryKey());
 
 		foreach ($missing as $key) {
-			$unions[] = $junction->find('all')
+			$unions[] = $hasMany->find('all')
 				->where(array_combine($foreignKey, $sourceKey))
-				->andWhere(array_combine($assocForeignKey, $key))
-				->andWhere($belongsTo->conditions());
+				->andWhere(array_combine($assocForeignKey, $key));
 		}
 
 		$query = array_shift($unions);

--- a/Cake/ORM/Association/DependentDeleteTrait.php
+++ b/Cake/ORM/Association/DependentDeleteTrait.php
@@ -42,18 +42,19 @@ trait DependentDeleteTrait {
 		$foreignKey = $this->foreignKey();
 		$primaryKey = $this->source()->primaryKey();
 
+		// TODO fix multi-column primary keys.
 		$conditions = [
 			$foreignKey => $entity->get($primaryKey)
 		];
-		// TODO fix multi-column primary keys.
-		$conditions = array_merge($conditions, $this->conditions());
 
 		if ($this->_cascadeCallbacks) {
-			foreach ($table->find('all')->where($conditions) as $related) {
+			foreach ($this->find('all')->where($conditions) as $related) {
 				$table->delete($related, $options);
 			}
 			return true;
 		}
+
+		$conditions = array_merge($conditions, $this->conditions());
 		return $table->deleteAll($conditions);
 	}
 }

--- a/Cake/ORM/Association/ExternalAssociationTrait.php
+++ b/Cake/ORM/Association/ExternalAssociationTrait.php
@@ -174,7 +174,6 @@ trait ExternalAssociationTrait {
 	protected function _buildQuery($options) {
 		$target = $this->target();
 		$alias = $target->alias();
-		$options['conditions'] = array_merge($this->conditions(), $options['conditions']);
 		$key = $this->_linkField($options);
 
 		$filter = $options['keys'];
@@ -182,7 +181,7 @@ trait ExternalAssociationTrait {
 			$filter = $this->_buildSubquery($options['query'], $key);
 		}
 
-		$fetchQuery = $target
+		$fetchQuery = $this
 			->find('all')
 			->where($options['conditions'])
 			->hydrate($options['query']->hydrate());

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -826,10 +826,8 @@ class BelongsToManyTest extends TestCase {
 			'through' => $joint,
 			'joinTable' => 'tags_articles'
 		];
-		$assoc = new BelongsToMany('Test', $config);
-		$assoc
-			->junction()
-			->association('tags')
+		$assoc = $this->article->belongsToMany('Test', $config);
+		$this->article->association('ArticlesTags')
 			->conditions(['foo' => 1]);
 
 		$query1 = $this->getMock('\Cake\ORM\Query', [], [$connection, $joint]);
@@ -843,34 +841,34 @@ class BelongsToManyTest extends TestCase {
 			->with('all')
 			->will($this->returnValue($query2));
 
-		$query1->expects($this->once())
+		$query1->expects($this->at(0))
+			->method('where')
+			->with(['foo' => 1])
+			->will($this->returnSelf());
+		$query1->expects($this->at(1))
 			->method('where')
 			->with(['article_id' => 1])
 			->will($this->returnSelf());
-		$query1->expects($this->at(1))
-			->method('andWhere')
-			->with(['tag_id' => 2])
-			->will($this->returnSelf());
 		$query1->expects($this->at(2))
 			->method('andWhere')
-			->with(['foo' => 1])
+			->with(['tag_id' => 2])
 			->will($this->returnSelf());
 		$query1->expects($this->once())
 			->method('union')
 			->with($query2)
 			->will($this->returnSelf());
 
-		$query2->expects($this->once())
+		$query2->expects($this->at(0))
+			->method('where')
+			->with(['foo' => 1])
+			->will($this->returnSelf());
+		$query2->expects($this->at(1))
 			->method('where')
 			->with(['article_id' => 1])
 			->will($this->returnSelf());
-		$query2->expects($this->at(1))
-			->method('andWhere')
-			->with(['tag_id' => 3])
-			->will($this->returnSelf());
 		$query2->expects($this->at(2))
 			->method('andWhere')
-			->with(['foo' => 1])
+			->with(['tag_id' => 3])
 			->will($this->returnSelf());
 
 		$jointEntities = [

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -400,14 +400,14 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with(['Tags.name' => 'foo'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 		$query->expects($this->at(1))->method('where')
 			->with([])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('order')
 			->with(['id' => 'ASC'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->hydrate(false);
 
@@ -457,22 +457,22 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with(['Tags.name' => 'foo'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->at(1))->method('where')
 			->with(['Tags.id !=' => 3])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('order')
 			->with(['name' => 'DESC'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('select')
 			->with([
 				'Tags__name' => 'Tags.name',
 				'ArticlesTags__article_id' => 'ArticlesTags.article_id'
 			])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->hydrate(false);
 
@@ -574,11 +574,11 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with(['Tags.name' => 'foo'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->at(1))->method('where')
 			->with([])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('contain')
 			->with([

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -398,8 +398,11 @@ class BelongsToManyTest extends TestCase {
 			])
 			->will($this->returnSelf());
 
-		$query->expects($this->once())->method('where')
+		$query->expects($this->at(0))->method('where')
 			->with(['Tags.name' => 'foo'])
+			->will($this->returnValue($query));
+		$query->expects($this->at(1))->method('where')
+			->with([])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -452,11 +455,12 @@ class BelongsToManyTest extends TestCase {
 			])
 			->will($this->returnSelf());
 
-		$query->expects($this->once())->method('where')
-			->with([
-				'Tags.name' => 'foo',
-				'Tags.id !=' => 3
-			])
+		$query->expects($this->at(0))->method('where')
+			->with(['Tags.name' => 'foo'])
+			->will($this->returnValue($query));
+
+		$query->expects($this->at(1))->method('where')
+			->with(['Tags.id !=' => 3])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('order')
@@ -510,7 +514,7 @@ class BelongsToManyTest extends TestCase {
 			->will($this->returnValue($query));
 		$query->expects($this->any())->method('contain')->will($this->returnSelf());
 
-		$query->expects($this->once())->method('where')->will($this->returnSelf());
+		$query->expects($this->exactly(2))->method('where')->will($this->returnSelf());
 
 		$association->eagerLoader([
 			'keys' => $keys,
@@ -560,10 +564,6 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
-		$query->expects($this->once())->method('where')
-			->with(['Tags.name' => 'foo'])
-			->will($this->returnSelf());
-
 		$expected = clone $parent;
 		$joins = $expected->join();
 		unset($joins[1]);
@@ -572,8 +572,12 @@ class BelongsToManyTest extends TestCase {
 			->select('ArticlesTags.article_id', true)
 			->join($joins, [], true);
 
-		$query->expects($this->once())->method('where')
+		$query->expects($this->at(0))->method('where')
 			->with(['Tags.name' => 'foo'])
+			->will($this->returnValue($query));
+
+		$query->expects($this->at(1))->method('where')
+			->with([])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('contain')

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -177,19 +177,19 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with(['Articles.is_active' => true])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->at(1))->method('where')
 			->with([])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('andWhere')
 			->with(['Articles.author_id IN' => $keys])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('order')
 			->with(['id' => 'ASC'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$association->eagerLoader(compact('keys', 'query'));
 	}
@@ -226,32 +226,32 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with(['Articles.is_active' => true])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->at(1))->method('where')
 			->with(['Articles.id !=' => 3])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('andWhere')
 			->with(['Articles.author_id IN' => $keys])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('order')
 			->with(['title' => 'DESC'])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('select')
 			->with([
 				'Articles__title' => 'Articles.title',
 				'Articles__author_id' => 'Articles.author_id'
 			])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$query->expects($this->once())->method('contain')
 			->with([
 				'Categories' => ['fields' => ['a', 'b']],
 			])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$association->eagerLoader([
 			'conditions' => ['Articles.id !=' => 3],
@@ -326,10 +326,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$query->expects($this->at(0))->method('where')
 			->with([])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 		$query->expects($this->at(1))->method('where')
 			->with([])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$expected = clone $parent;
 		$joins = $expected->join();
@@ -340,7 +340,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->join($joins, [], true);
 		$query->expects($this->once())->method('andWhere')
 			->with(['Articles.author_id IN' => $expected])
-			->will($this->returnValue($query));
+			->will($this->returnSelf());
 
 		$callable = $association->eagerLoader([
 			'query' => $parent, 'strategy' => HasMany::STRATEGY_SUBQUERY, 'keys' => []

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -504,9 +504,13 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		]);
 
 		$query = $this->getMock('\Cake\ORM\Query', [], [], '', false);
-		$query->expects($this->once())
+		$query->expects($this->at(0))
 			->method('where')
-			->with(['Articles.is_active' => true, 'author_id' => 1])
+			->with(['Articles.is_active' => true])
+			->will($this->returnSelf());
+		$query->expects($this->at(1))
+			->method('where')
+			->with(['author_id' => 1])
 			->will($this->returnSelf());
 		$query->expects($this->any())
 			->method('getIterator')

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -175,8 +175,12 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
-		$query->expects($this->once())->method('where')
+		$query->expects($this->at(0))->method('where')
 			->with(['Articles.is_active' => true])
+			->will($this->returnValue($query));
+
+		$query->expects($this->at(1))->method('where')
+			->with([])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
@@ -220,8 +224,12 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
-		$query->expects($this->once())->method('where')
-			->with(['Articles.is_active' => true, 'Articles.id !=' => 3])
+		$query->expects($this->at(0))->method('where')
+			->with(['Articles.is_active' => true])
+			->will($this->returnValue($query));
+
+		$query->expects($this->at(1))->method('where')
+			->with(['Articles.id !=' => 3])
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('andWhere')
@@ -316,7 +324,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($results));
 
-		$query->expects($this->once())->method('where')
+		$query->expects($this->at(0))->method('where')
+			->with([])
+			->will($this->returnValue($query));
+		$query->expects($this->at(1))->method('where')
 			->with([])
 			->will($this->returnValue($query));
 


### PR DESCRIPTION
I was missing this feature in the Association class. An easy way to find in the target table in an association that will apply the correct conditions. This solves a longstanding problem cake had since its beginning, there was actually no association between one table and the other. In 2.x:

``` php
//Custom conditions for Article are not applied, for example published => true
$this->Author->Article->find('all');
```

Now:

``` php
$authors->association('Articles')->find('all'); //Custom conditions are applied.
```
