### PR TITLE
Correct tokenize for empty strings.

### DIFF
--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -303,6 +303,10 @@ class StringTest extends CakeTestCase {
 		$result = String::tokenize('tagA "single tag" tagB', ' ', '"', '"');
 		$expected = array('tagA', '"single tag"', 'tagB');
 		$this->assertEquals($expected, $result);
+
+		$result = String::tokenize('');
+		$expected = array();
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testReplaceWithQuestionMarkInString() {

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -99,17 +99,17 @@ class String {
 
 /**
  * Tokenizes a string using $separator, ignoring any instance of $separator that appears between
- * $leftBound and $rightBound
+ * $leftBound and $rightBound.
  *
- * @param string $data The data to tokenize
+ * @param string $data The data to tokenize.
  * @param string $separator The token to split the data on.
  * @param string $leftBound The left boundary to ignore separators in.
  * @param string $rightBound The right boundary to ignore separators in.
  * @return array Array of tokens in $data.
  */
 	public static function tokenize($data, $separator = ',', $leftBound = '(', $rightBound = ')') {
-		if (empty($data) || is_array($data)) {
-			return $data;
+		if (empty($data)) {
+			return array();
 		}
 
 		$depth = 0;


### PR DESCRIPTION
Follow-up on https://github.com/cakephp/cakephp/pull/2503
To correct the code of the method. Will need the master fix (doc block changes) to not be merged into 2.5 then.
