### PR TITLE
3.0 - Separate associations object

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -91,8 +91,7 @@ class Associations {
  * @param array $associations The list of associations to save parents from.
  *   associations not in this list will not be saved.
  * @param array $options The options for the save operation.
- * @return Entity modified entity
- * @throws new \InvalidArgumentExceptio when an unknown alias is used.
+ * @return Entity Modified entity
  */
 	public function saveParents(Table $table, Entity $entity, $associations, $options = []) {
 		if (empty($associations)) {
@@ -113,7 +112,7 @@ class Associations {
  * @param array $associations The list of associations to save children from.
  *   associations not in this list will not be saved.
  * @param array $options The options for the save operation.
- * @return boolean success
+ * @return Entity Modified entity
  */
 	public function saveChildren(Table $table, Entity $entity, $associations, $options) {
 		if (empty($associations)) {
@@ -131,7 +130,8 @@ class Associations {
  * @param array $options Original options
  * @param boolean $owningSide Compared with association classes'
  *   isOwningSide method.
- * @return void
+ * @return Entity modified entity.
+ * @throws new \InvalidArgumentException When an unknown alias is used.
  */
 	protected function _saveAssociations($table, $entity, $associations, $options, $owningSide) {
 		foreach ($associations as $alias => $nested) {

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -78,6 +78,18 @@ class Associations {
 	}
 
 /**
+ * Get an array of associations matching a specific type.
+ *
+ * @return array
+ */
+	public function type($class) {
+		$out = array_filter($this->_items, function ($assoc) use ($class) {
+			return strpos(get_class($assoc), $class) !== false;
+		});
+		return array_values($out);
+	}
+
+/**
  * Drop/remove an association.
  *
  * Once removed the association will not longer be reachable
@@ -85,7 +97,7 @@ class Associations {
  * @param string The alias name.
  * @return void
  */
-	public function drop($alias) {
+	public function remove($alias) {
 		unset($this->_items[strtolower($alias)]);
 	}
 

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM;
+
+/**
+ * A container/collection for association classes.
+ *
+ * Contains methods for managing associations, and
+ * ordering operations around saving and deleting.
+ */
+class Associations {
+
+	public function add($alias, Association $association) {
+	}
+
+	public function get($alias) {
+	}
+
+	public function has($alias) {
+	}
+
+	public function drop($alias) {
+	}
+
+	public function saveParents(Entity $entity, $associations, $options) {
+	}
+
+	protected function saveChildren(Entity $entity, $associations, $options) {
+	}
+
+	public function cascadeDelete(Entity $entity, $options) {
+	}
+
+}

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -16,6 +14,9 @@
  */
 namespace Cake\ORM;
 
+use Cake\ORM\Association;
+use Cake\ORM\Entity;
+
 /**
  * A container/collection for association classes.
  *
@@ -24,13 +25,41 @@ namespace Cake\ORM;
  */
 class Associations {
 
+	protected $_items = [];
+
+/**
+ * Add an association to the collection
+ *
+ * @param string $alias The association alias
+ * @param Association The association to add.
+ * @return void
+ */
 	public function add($alias, Association $association) {
+		$this->_items[strtolower($alias)] = $association;
 	}
 
+/**
+ * Fetch an attached association by name.
+ *
+ * @param string $alias The association alias to get.
+ * @return Association|null Either the association or null.
+ */
 	public function get($alias) {
+		$alias = strtolower($alias);
+		if (isset($this->_items[$alias])) {
+			return $this->_items[$alias];
+		}
+		return null;
 	}
 
+/**
+ * Check for an attached association by name.
+ *
+ * @param string $alias The association alias to get.
+ * @return boolean Whether or not the association exists.
+ */
 	public function has($alias) {
+		return isset($this->_items[strtolower($alias)]);
 	}
 
 	public function drop($alias) {

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -41,7 +41,7 @@ class Associations {
  * @return void
  */
 	public function add($alias, Association $association) {
-		$this->_items[strtolower($alias)] = $association;
+		return $this->_items[strtolower($alias)] = $association;
 	}
 
 /**
@@ -69,6 +69,15 @@ class Associations {
 	}
 
 /**
+ * Get the names of all the associations in the collection.
+ *
+ * @return array
+ */
+	public function keys() {
+		return array_keys($this->_items);
+	}
+
+/**
  * Drop/remove an association.
  *
  * Once removed the association will not longer be reachable
@@ -91,11 +100,11 @@ class Associations {
  * @param array $associations The list of associations to save parents from.
  *   associations not in this list will not be saved.
  * @param array $options The options for the save operation.
- * @return Entity Modified entity
+ * @return boolean Success
  */
 	public function saveParents(Table $table, Entity $entity, $associations, $options = []) {
 		if (empty($associations)) {
-			return $entity;
+			return true;
 		}
 		return $this->_saveAssociations($table, $entity, $associations, $options, false);
 	}
@@ -112,11 +121,11 @@ class Associations {
  * @param array $associations The list of associations to save children from.
  *   associations not in this list will not be saved.
  * @param array $options The options for the save operation.
- * @return Entity Modified entity
+ * @return boolean Success
  */
 	public function saveChildren(Table $table, Entity $entity, $associations, $options) {
 		if (empty($associations)) {
-			return $entity;
+			return true;
 		}
 		return $this->_saveAssociations($table, $entity, $associations, $options, true);
 	}
@@ -130,7 +139,7 @@ class Associations {
  * @param array $options Original options
  * @param boolean $owningSide Compared with association classes'
  *   isOwningSide method.
- * @return Entity modified entity.
+ * @return boolean Success
  * @throws new \InvalidArgumentException When an unknown alias is used.
  */
 	protected function _saveAssociations($table, $entity, $associations, $options, $owningSide) {
@@ -152,9 +161,11 @@ class Associations {
 			if ($relation->isOwningSide($table) !== $owningSide) {
 				continue;
 			}
-			$this->_save($relation, $entity, $nested, $options);
+			if (!$this->_save($relation, $entity, $nested, $options)) {
+				return false;
+			}
 		}
-		return $entity;
+		return true;
 	}
 
 /**
@@ -164,7 +175,7 @@ class Associations {
  * @param Entity $entity The entity to save
  * @param array $nested Options for deeper associations
  * @param array $options Original options
- * @return void
+ * @return boolean Success
  */
 	protected function _save($association, $entity, $nested, $options) {
 		if (!$entity->dirty($association->property())) {
@@ -173,7 +184,7 @@ class Associations {
 		if (!empty($nested)) {
 			$options = (array)$nested + $options;
 		}
-		$association->save($entity, $options);
+		return (bool)$association->save($entity, $options);
 	}
 
 /**

--- a/Cake/ORM/Associations.php
+++ b/Cake/ORM/Associations.php
@@ -143,6 +143,7 @@ class Associations {
  * @throws new \InvalidArgumentException When an unknown alias is used.
  */
 	protected function _saveAssociations($table, $entity, $associations, $options, $owningSide) {
+		unset($options['associated']);
 		foreach ($associations as $alias => $nested) {
 			if (is_int($alias)) {
 				$alias = $nested;
@@ -179,7 +180,7 @@ class Associations {
  */
 	protected function _save($association, $entity, $nested, $options) {
 		if (!$entity->dirty($association->property())) {
-			return;
+			return true;
 		}
 		if (!empty($nested)) {
 			$options = (array)$nested + $options;

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1094,7 +1094,7 @@ class Table implements EventListener {
 				$event = new Event('Model.afterSave', $this, compact('entity', 'options'));
 				$this->getEventManager()->dispatch($event);
 				$entity->isNew(false);
-				$success = $entity;
+				$success = true;
 			}
 		}
 
@@ -1102,8 +1102,10 @@ class Table implements EventListener {
 			$entity->unsetProperty($this->primaryKey());
 			$entity->isNew(true);
 		}
-
-		return $success;
+		if ($success) {
+			return $entity;
+		}
+		return false;
 	}
 
 /**

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -20,6 +20,7 @@ use Cake\Database\Type;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
+use Cake\ORM\Associations;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Association\HasMany;
@@ -132,12 +133,11 @@ class Table implements EventListener {
 	protected $_displayField;
 
 /**
- * The list of associations for this table. Indexed by association name,
- * values are Association object instances.
+ * The associations container for this Table.
  *
- * @var array
+ * @var Cake\ORM\Associations
  */
-	protected $_associations = [];
+	protected $_associated;
 
 /**
  * EventManager for this table.
@@ -210,8 +210,14 @@ class Table implements EventListener {
 		if (!empty($config['behaviors'])) {
 			$behaviors = $config['behaviors'];
 		}
+		$associations = null;
+		if (!empty($config['associations'])) {
+			$associations = $config['associations'];
+		}
 		$this->_eventManager = $eventManager ?: new EventManager();
+		$this->_associated = $associations ?: new Associations();
 		$this->_behaviors = $behaviors ?: new BehaviorRegistry($this);
+
 		$this->initialize($config);
 		$this->_eventManager->attach($this);
 	}
@@ -497,11 +503,7 @@ class Table implements EventListener {
  * @return Cake\ORM\Association
  */
 	public function association($name) {
-		$name = strtolower($name);
-		if (isset($this->_associations[$name])) {
-			return $this->_associations[$name];
-		}
-		return null;
+		return $this->_associated->get($name);
 	}
 
 /**
@@ -533,7 +535,7 @@ class Table implements EventListener {
 	public function belongsTo($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
 		$association = new BelongsTo($associated, $options);
-		return $this->_associations[strtolower($association->name())] = $association;
+		return $this->_associated->add($association->name(), $association);
 	}
 
 /**
@@ -570,7 +572,7 @@ class Table implements EventListener {
 	public function hasOne($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
 		$association = new HasOne($associated, $options);
-		return $this->_associations[strtolower($association->name())] = $association;
+		return $this->_associated->add($association->name(), $association);
 	}
 
 /**
@@ -611,7 +613,7 @@ class Table implements EventListener {
 	public function hasMany($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
 		$association = new HasMany($associated, $options);
-		return $this->_associations[strtolower($association->name())] = $association;
+		return $this->_associated->add($association->name(), $association);
 	}
 
 /**
@@ -651,7 +653,7 @@ class Table implements EventListener {
 	public function belongsToMany($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
 		$association = new BelongsToMany($associated, $options);
-		return $this->_associations[strtolower($association->name())] = $association;
+		return $this->_associated->add($association->name(), $association);
 	}
 
 /**
@@ -981,12 +983,18 @@ class Table implements EventListener {
  * be saved and to pass additional option for saving them.
  *
  * {{{
- * $articles->save($entity, ['associated' => ['Comment']); // Only save comment assoc
+ * // Only save the comments association
+ * $articles->save($entity, ['associated' => ['Comments']);
  *
  * // Save the company, the employees and related addresses for each of them.
  * // For employees use the 'special' validation group
  * $companies->save($entity, [
- * 'associated' => ['Employee' => ['associated' => ['Address'], 'validate' => 'special']
+ *   'associated' => [
+ *     'Employees' => [
+ *       'associated' => ['Addresses'],
+ *       'validate' => 'special'
+ *     ]
+ *   ]
  * ]);
  *
  * // Save no associations
@@ -1038,7 +1046,7 @@ class Table implements EventListener {
 		}
 
 		if ($options['associated'] === true) {
-			$options['associated'] = array_keys($this->_associations);
+			$options['associated'] = $this->_associated->keys();
 		}
 		$options['associated'] = array_filter((array)$options['associated']);
 
@@ -1053,9 +1061,12 @@ class Table implements EventListener {
 			return $event->result;
 		}
 
-		$originalOptions = $options->getArrayCopy();
-		list($parents, $children) = $this->_sortAssociationTypes($options['associated']);
-		$saved = $this->_saveAssociations($parents, $entity, $originalOptions);
+		$saved = $this->_associated->saveParents(
+			$this,
+			$entity,
+			$options['associated'],
+			$options->getArrayCopy()
+		);
 
 		if (!$saved && $options['atomic']) {
 			return false;
@@ -1072,7 +1083,12 @@ class Table implements EventListener {
 		}
 
 		if ($success) {
-			$success = $this->_saveAssociations($children, $entity, $originalOptions);
+			$success = $this->_associated->saveChildren(
+				$this,
+				$entity,
+				$options['associated'],
+				$options->getArrayCopy()
+			);
 			if ($success || !$options['atomic']) {
 				$entity->clean();
 				$event = new Event('Model.afterSave', $this, compact('entity', 'options'));
@@ -1088,82 +1104,6 @@ class Table implements EventListener {
 		}
 
 		return $success;
-	}
-
-/**
- * Auxiliary method used to sort out which associations are defined in this table
- * as the owning side and which not based on a list of provided aliases.
- *
- * @param array $assocs list of association aliases
- * @throws \InvalidArgumentException if one of the provided aliases is not an
- * actual association defined for this table
- * @return array with two values, first one contain associations which target
- * is the owning side (or parent associations) and second value is an array of
- * associations aliases for which this table is the owning side.
- */
-	protected function _sortAssociationTypes($assocs) {
-		$parents = $children = [];
-		foreach ($assocs as $key => $assoc) {
-			if (!is_string($assoc)) {
-				$assoc = $key;
-			}
-
-			$association = $this->association($assoc);
-			if (!$association) {
-				$msg = __d('cake_dev', '%s is not associated to %s', $this->alias(), $assoc);
-				throw new \InvalidArgumentException($msg);
-			}
-
-			if ($association->isOwningSide($this)) {
-				$children[] = $assoc;
-			} else {
-				$parents[] = $assoc;
-			}
-		}
-		return [$parents, $children];
-	}
-
-/**
- * Runs through a list of aliases and for each of them calls the `save()` method
- * on the corresponding association objects passing $entity and $options as values.
- * If the alias for one of the associations contains an array as values in $assocs,
- * $options will be merged to this value before passed to the save operation.
- *
- *
- * @param array $assocs list of association aliases.
- * @param \Cake\ORM\Entity $entity the entity belonging to this table and maybe
- * containing associated entities.
- * @param array $options options to be passed to the save operation
- * @return boolean|\Cake\ORM\Entity The saved source entity on success, false
- * otherwise
- */
-	protected function _saveAssociations($assocs, $entity, array $options) {
-		if (empty($assocs)) {
-			return $entity;
-		}
-
-		$associated = $options['associated'];
-		unset($options['associated']);
-
-		foreach ($assocs as $alias) {
-			$association = $this->association($alias);
-			$property = $association->property();
-			$passOptions = $options;
-
-			if (!$entity->dirty($property)) {
-				continue;
-			}
-
-			if (isset($associated[$alias])) {
-				$passOptions = (array)$associated[$alias] + $options;
-			}
-
-			if (!$association->save($entity, $passOptions)) {
-				return false;
-			}
-		}
-
-		return $entity;
 	}
 
 /**
@@ -1384,9 +1324,7 @@ class Table implements EventListener {
 			return $success;
 		}
 
-		foreach ($this->_associations as $assoc) {
-			$assoc->cascadeDelete($entity, $options->getArrayCopy());
-		}
+		$this->_associated->cascadeDelete($entity, $options->getArrayCopy());
 
 		$event = new Event('Model.afterDelete', $this, [
 			'entity' => $entity,
@@ -1556,7 +1494,7 @@ class Table implements EventListener {
  */
 	public function newEntity(array $data, $associations = null) {
 		if ($associations === null) {
-			$associations = array_keys($this->_associations);
+			$associations = $this->_associated->keys();
 		}
 		$marshaller = $this->marshaller();
 		return $marshaller->one($data, $associations);
@@ -1590,7 +1528,7 @@ class Table implements EventListener {
  */
 	public function newEntities(array $data, $associations = null) {
 		if ($associations === null) {
-			$associations = array_keys($this->_associations);
+			$associations = $this->_associated->keys();
 		}
 		$marshaller = $this->marshaller();
 		return $marshaller->many($data, $associations);

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -567,7 +567,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testCascadeDelete() {
-		$articleTag = $this->getMock('Cake\ORM\Table', ['deleteAll'], [], '', false);
+		$articleTag = $this->getMock('Cake\ORM\Table', ['deleteAll'], []);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -594,7 +594,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testCascadeDeleteWithCallbacks() {
-		$articleTag = $this->getMock('Cake\ORM\Table', ['find', 'delete'], [], '', false);
+		$articleTag = $this->getMock('Cake\ORM\Table', ['find', 'delete'], []);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,

--- a/Cake/Test/TestCase/ORM/AssociationsTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationsTest.php
@@ -39,7 +39,7 @@ class AssociationsTest extends TestCase {
  *
  * @return void
  */
-	public function testAddHasAndGet() {
+	public function testAddHasRemoveAndGet() {
 		$this->assertFalse($this->associations->has('users'));
 		$this->assertFalse($this->associations->has('Users'));
 
@@ -53,6 +53,39 @@ class AssociationsTest extends TestCase {
 
 		$this->assertSame($belongsTo, $this->associations->get('users'));
 		$this->assertSame($belongsTo, $this->associations->get('Users'));
+
+		$this->assertNull($this->associations->remove('Users'));
+
+		$this->assertFalse($this->associations->has('users'));
+		$this->assertFalse($this->associations->has('Users'));
+		$this->assertNull($this->associations->get('users'));
+		$this->assertNull($this->associations->get('Users'));
+	}
+
+/**
+ * Test keys()
+ *
+ * @return void
+ */
+	public function testKeys() {
+		$belongsTo = new BelongsTo([]);
+		$this->associations->add('Users', $belongsTo);
+		$this->associations->add('Categories', $belongsTo);
+		$this->assertEquals(['users', 'categories'], $this->associations->keys());
+
+		$this->associations->remove('Categories');
+		$this->assertEquals(['users'], $this->associations->keys());
+	}
+
+/**
+ * Test getting association names by type.
+ */
+	public function testType() {
+		$belongsTo = new BelongsTo([]);
+		$this->associations->add('Users', $belongsTo);
+
+		$this->assertSame([$belongsTo], $this->associations->type('BelongsTo'));
+		$this->assertSame([], $this->associations->type('HasMany'));
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/AssociationsTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationsTest.php
@@ -214,4 +214,28 @@ class AssociationsTest extends TestCase {
 		);
 		$this->assertSame($entity, $result);
 	}
+
+/**
+ * Test exceptional case.
+ *
+ * @expectedException \InvalidArgumentException
+ * @expectedExceptionMessage Cannot save Profiles, it is not associated to Users
+ */
+	public function testErrorOnUnknownAlias() {
+		$table = $this->getMock(
+			'Cake\ORM\Table',
+			['save'],
+			[['alias' => 'Users']]);
+
+		$entity = new Entity();
+		$entity->set('profile', ['key' => 'value']);
+
+		$this->associations->saveChildren(
+			$table,
+			$entity,
+			['Profiles'],
+			['atomic' => true]
+		);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/AssociationsTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationsTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\ORM\Association\BelongsTo;
+use Cake\ORM\Associations;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Associations test case.
+ */
+class AssociationsTest extends TestCase {
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->associations = new Associations();
+	}
+
+/**
+ * Test the simple add/has and get methods.
+ *
+ * @return void
+ */
+	public function testAddHasAndGet() {
+		$this->assertFalse($this->associations->has('users'));
+		$this->assertFalse($this->associations->has('Users'));
+
+		$this->assertNull($this->associations->get('users'));
+		$this->assertNull($this->associations->get('Users'));
+
+		$belongsTo = new BelongsTo([]);
+		$this->assertNull($this->associations->add('Users', $belongsTo));
+		$this->assertTrue($this->associations->has('users'));
+		$this->assertTrue($this->associations->has('Users'));
+
+		$this->assertSame($belongsTo, $this->associations->get('users'));
+		$this->assertSame($belongsTo, $this->associations->get('Users'));
+	}
+
+}

--- a/Cake/Test/TestCase/ORM/AssociationsTest.php
+++ b/Cake/Test/TestCase/ORM/AssociationsTest.php
@@ -47,7 +47,7 @@ class AssociationsTest extends TestCase {
 		$this->assertNull($this->associations->get('Users'));
 
 		$belongsTo = new BelongsTo([]);
-		$this->assertNull($this->associations->add('Users', $belongsTo));
+		$this->assertSame($belongsTo, $this->associations->add('Users', $belongsTo));
 		$this->assertTrue($this->associations->has('users'));
 		$this->assertTrue($this->associations->has('Users'));
 
@@ -77,7 +77,7 @@ class AssociationsTest extends TestCase {
 			->method('cascadeDelete')
 			->with($entity, $options);
 
-		$this->associations->cascadeDelete($entity, $options);
+		$this->assertNull($this->associations->cascadeDelete($entity, $options));
 	}
 
 /**
@@ -111,7 +111,8 @@ class AssociationsTest extends TestCase {
 
 		$mockOne->expects($this->once())
 			->method('save')
-			->with($entity, $options);
+			->with($entity, $options)
+			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
 			->method('save');
@@ -122,7 +123,7 @@ class AssociationsTest extends TestCase {
 			['Parent', 'Child'],
 			$options
 		);
-		$this->assertSame($entity, $result);
+		$this->assertTrue($result, 'Save should work.');
 	}
 
 /**
@@ -156,7 +157,8 @@ class AssociationsTest extends TestCase {
 
 		$mockOne->expects($this->once())
 			->method('save')
-			->with($entity, ['atomic' => true, 'associated' => ['Others']]);
+			->with($entity, ['atomic' => true, 'associated' => ['Others']])
+			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
 			->method('save');
@@ -167,7 +169,7 @@ class AssociationsTest extends TestCase {
 			['Parents' => ['associated' => ['Others']]],
 			$options
 		);
-		$this->assertSame($entity, $result);
+		$this->assertTrue($result, 'Save should work.');
 	}
 
 /**
@@ -201,7 +203,8 @@ class AssociationsTest extends TestCase {
 
 		$mockOne->expects($this->once())
 			->method('save')
-			->with($entity, $options + ['associated' => ['Other']]);
+			->with($entity, $options + ['associated' => ['Other']])
+			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
 			->method('save');
@@ -212,7 +215,7 @@ class AssociationsTest extends TestCase {
 			['Comments' => ['associated' => ['Other']]],
 			$options
 		);
-		$this->assertSame($entity, $result);
+		$this->assertTrue($result, 'Should succeed.');
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *


### PR DESCRIPTION
As per #2428 separate the associations object out. This object provides most of the features I think we'll need as we  rebuild FormHelper and bake. It provides a fairly spartan interface right now, but we can expand it as needed in the future.

I'm starting to question whether or not it is a good idea to keep `strtolower()`ing the association aliases, as I don't think most developers will expect the names to be case insensitive.
