### PR TITLE
Don't start a session on read if it's known to be empty

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -222,7 +222,7 @@ class CakeSession {
  * @return boolean True if variable is there
  */
 	public static function check($name = null) {
-		if (!self::start()) {
+		if (!isset($_COOKIE[session_name()]) || !self::start()) {
 			return false;
 		}
 		if (empty($name)) {
@@ -372,7 +372,7 @@ class CakeSession {
  * @return mixed The value of the session variable
  */
 	public static function read($name = null) {
-		if (!self::start()) {
+		if (!isset($_COOKIE[session_name()]) || !self::start()) {
 			return false;
 		}
 		if ($name === null) {


### PR DESCRIPTION
If an app only reads/checks the session there's no need to start a
session to know that the read/checked session value is empty.

Probably the most common use case this addresses is having

```
<?= $this->Session->flash() ?>
```

In a layout file. If it's the only thing referring to the session, it shouldn't
itself be starting a session.

Fixes #1981
