### PR TITLE
Remove bug if you bake all for view o controller

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -113,7 +113,14 @@ class ControllerTask extends BakeTask {
 		foreach ($this->__tables as $table) {
 			$model = $this->_modelName($table);
 			$controller = $this->_controllerName($model);
-			App::uses($model, 'Model');
+			/*
+			 * Where to search the model
+			 */
+			$plugin = null;
+			if ($this->plugin) {
+				$plugin = $this->plugin . '.';
+			}
+			App::uses($model, $plugin . 'Model');
 			if (class_exists($model)) {
 				$actions = $this->bakeActions($controller);
 				if ($admin) {

--- a/lib/Cake/Console/Command/Task/ViewTask.php
+++ b/lib/Cake/Console/Command/Task/ViewTask.php
@@ -175,7 +175,14 @@ class ViewTask extends BakeTask {
 		foreach ($tables as $table) {
 			$model = $this->_modelName($table);
 			$this->controllerName = $this->_controllerName($model);
-			App::uses($model, 'Model');
+			/*
+			 * Where to search the model
+			 */
+			$plugin = null;
+			if ($this->plugin) {
+				$plugin = $this->plugin . '.';
+			}
+			App::uses($model, $plugin . 'Model');
 			if (class_exists($model)) {
 				$vars = $this->_loadController();
 				if (!$actions) {


### PR DESCRIPTION
There was a bug in command "bake all" for a view or a controller if you wish to bake for a plugin.
This patch correctly load the model if -p <PluginName> option is used when baking.
