### PR TITLE
3.0 mass assignment

### DIFF
--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -115,19 +115,19 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * - useSetters: whether use internal setters for properties or not
  * - markClean: whether to mark all properties as clean after setting them
  * - markNew: whether this instance has not yet been persisted
- * - safe: whether to prevent inaccessible properties from being set (default: false)
+ * - guard: whether to prevent inaccessible properties from being set (default: false)
  */
 	public function __construct(array $properties = [], array $options = []) {
 		$options += [
 			'useSetters' => true,
 			'markClean' => false,
 			'markNew' => null,
-			'safe' => false
+			'guard' => false
 		];
 		$this->_className = get_class($this);
 		$this->set($properties, [
 			'setter' => $options['useSetters'],
-			'safe' => $options['safe']
+			'guard' => $options['guard']
 		]);
 
 		if ($options['markClean']) {
@@ -213,20 +213,20 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  *
  * Mass assignment should be treated carefully when accepting user input, for this
  * case you can tell this method to only set property that are marked as accessible
- * by setting the `safe` options in the `$options` parameter
+ * by setting the `guard` options in the `$options` parameter
  *
  * ### Example:
  *
- * ``$entity->set('name', 'Andrew', ['safe' => true]);``
+ * ``$entity->set('name', 'Andrew', ['guard' => true]);``
  *
- * ``$entity->set(['name' => 'Andrew', 'id' => 1], ['safe' => true]);``
+ * ``$entity->set(['name' => 'Andrew', 'id' => 1], ['guard' => true]);``
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
  * @param mixed|array $value the value to set to the property or an array if the
  * first argument is also an array, in which case will be treated as $options
  * @param array $options options to be used for setting the property. Allowed option
- * keys are `setter` and `safe`
+ * keys are `setter` and `guard`
  * @return \Cake\ORM\Entity
  */
 	public function set($property, $value = null, $options = []) {
@@ -236,10 +236,10 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 			$options = (array)$value;
 		}
 
-		$options += ['setter' => true, 'safe' => false];
+		$options += ['setter' => true, 'guard' => false];
 
 		foreach ($property as $p => $value) {
-			if ($options['safe'] === true && !$this->accessible($p)) {
+			if ($options['guard'] === true && !$this->accessible($p)) {
 				continue;
 			}
 

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -88,6 +88,14 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 	protected $_errors = [];
 
 /**
+ * List of properties in this entity that can be set safely
+ * an empty array means "all"
+ *
+ * @var array
+ */
+	protected $_accessible = [];
+
+/**
  * Initializes the internal properties of this entity out of the
  * keys in an array
  *
@@ -230,6 +238,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 			}
 			$this->_properties[$p] = $value;
 		}
+
 		return $this;
 	}
 
@@ -579,6 +588,27 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 
 		foreach ($field as $f => $error) {
 			$this->_errors[$f] = (array)$error;
+		}
+
+		return $this;
+	}
+
+	public function accessible($property, $set = null) {
+		if ($set === null && empty($this->_accessible)) {
+			return true;
+		}
+
+		if ($set === null) {
+			return !isset($this->_accessible[$property]) || $this->_accessible[$property];
+		}
+
+		if ($property === '*') {
+			$this->_accessible = [];
+			return $this;
+		}
+
+		foreach ((array)$property as $prop) {
+			$this->_accessible[$prop] = (bool)$set;
 		}
 
 		return $this;

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -239,7 +239,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 		$options += ['setter' => true, 'safe' => false];
 
 		foreach ($property as $p => $value) {
-			if ($options['safe'] === true && !$this->accessible($property)) {
+			if ($options['safe'] === true && !$this->accessible($p)) {
 				continue;
 			}
 

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -94,7 +94,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  *
  * The special property '*' can also be mapped, meaning that any other property
  * not defined in the map will take its value. For example, `'*' => true`
- * means that any property not defin
+ * means that any property not defined in the map will be accessible by default
  *
  * @var array
  */

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -618,16 +618,42 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 		return $this;
 	}
 
+/**
+ * Stores whether or not a property value can be changed or set in this entity.
+ * The special property '*' can also be marked as accessible or protected, meaning
+ * that any other property specified before will take its value. For example
+ * `$entity->accessible('*', true)`  means that any property not specified already
+ * will be accessible by default.
+ *
+ * You can also call this method with an array of properties, in which case they
+ * will each take the accessibility value specified in the second argument.
+ *
+ * ### Example:
+ *
+ * {{{
+ * $entity->accessible('id', true); // Mark id as not protected
+ * $entity->accessible('author_id', true); // Mark author_id as protected
+ * $entity->accessible(['id', 'user_id'], true); // Mark both properties as accessible
+ * $entity->accessible('*', false); // Mark all properties as protected
+ * }}}
+ *
+ * When called without the second param it will return whether or not the property
+ * can be set.
+ *
+ * ### Example:
+ *
+ * {{{
+ * $entity->accessible('id'); // Returns whether it can be set or not
+ * }}}
+ *
+ * @param string|array single or list of properties to change its accessibility
+ * @param boolean $set true marks the property as accessible, false will
+ * mark it as protected.
+ * @return Entity|boolean
+ */
 	public function accessible($property, $set = null) {
 		if ($set === null) {
 			return !empty($this->_accessible[$property]) || !empty($this->_accessible['*']);
-		}
-
-		if ($set === null) {
-			if (is_bool($this->_accessible)) {
-				return $this->_accessible;
-			}
-			return !isset($this->_accessible[$property]) || $this->_accessible[$property];
 		}
 
 		if ($property === '*') {

--- a/Cake/ORM/ResultSet.php
+++ b/Cake/ORM/ResultSet.php
@@ -309,7 +309,12 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			$results[$defaultAlias]
 		);
 
-		$options = ['useSetters' => false, 'markClean' => true, 'markNew' => false];
+		$options = [
+			'useSetters' => false,
+			'markClean' => true,
+			'markNew' => false,
+			'safe' => false
+		];
 		foreach (array_reverse($this->_associationMap) as $alias => $assoc) {
 			if (!isset($results[$alias])) {
 				continue;

--- a/Cake/ORM/ResultSet.php
+++ b/Cake/ORM/ResultSet.php
@@ -313,7 +313,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			'useSetters' => false,
 			'markClean' => true,
 			'markNew' => false,
-			'safe' => false
+			'guard' => false
 		];
 		foreach (array_reverse($this->_associationMap) as $alias => $assoc) {
 			if (!isset($results[$alias])) {

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1079,7 +1079,7 @@ class BelongsToManyTest extends TestCase {
 			['tags']
 		);
 		$entity = new Entity([
-			'id' =>1,
+			'id' => 1,
 			'tags' => [
 				new Entity(['name' => 'foo'])
 			]
@@ -1105,7 +1105,7 @@ class BelongsToManyTest extends TestCase {
 			['tags']
 		);
 		$entity = new Entity([
-			'id' =>1,
+			'id' => 1,
 			'tags' => [
 				new Entity(['name' => 'foo'])
 			]

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -879,4 +879,42 @@ class EntityTest extends TestCase {
 		$this->assertTrue($entity->accessible('newOne2'));
 	}
 
+/**
+ * Tests that only accessible properties can be set
+ *
+ * @return void
+ */
+	public function testSetWithAccessible() {
+		$entity = new Entity(['foo' => 1, 'bar' => 2]);
+		$options = ['safe' => true];
+		$entity->accessible('foo', true);
+		$entity->set('bar', 3, $options);
+		$entity->set('foo', 4, $options);
+		$this->assertEquals(2, $entity->get('bar'));
+		$this->assertEquals(4, $entity->get('foo'));
+
+		$entity->accessible('bar', true);
+		$entity->set('bar', 3, $options);
+		$this->assertEquals(3, $entity->get('bar'));
+	}
+
+/**
+ * Tests that only accessible properties can be set
+ *
+ * @return void
+ */
+	public function testSetWithAccessibleWithArray() {
+		$entity = new Entity(['foo' => 1, 'bar' => 2]);
+		$options = ['safe' => true];
+		$entity->accessible('foo', true);
+		$entity->set(['bar' => 3, 'foo' => 4], $options);
+		$this->assertEquals(2, $entity->get('bar'));
+		$this->assertEquals(4, $entity->get('foo'));
+
+		$entity->accessible('bar', true);
+		$entity->set(['bar' => 3, 'foo' => 5], $options);
+		$this->assertEquals(3, $entity->get('bar'));
+		$this->assertEquals(5, $entity->get('foo'));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -787,4 +787,54 @@ class EntityTest extends TestCase {
 		$this->assertEmpty($entity->errors());
 	}
 
+/**
+ * Tests accessible() method as a getter and setter
+ *
+ * @return void
+ */
+	public function testAccessible() {
+		$entity = new Entity;
+		$this->assertTrue($entity->accessible('foo'));
+		$this->assertTrue($entity->accessible('bar'));
+
+		$this->assertSame($entity, $entity->accessible('foo', false));
+		$this->assertFalse($entity->accessible('foo'));
+		$this->assertTrue($entity->accessible('bar'));
+
+		$this->assertSame($entity, $entity->accessible('bar', false));
+		$this->assertFalse($entity->accessible('foo'));
+		$this->assertFalse($entity->accessible('bar'));
+
+		$this->assertSame($entity, $entity->accessible('foo', true));
+		$this->assertTrue($entity->accessible('foo'));
+		$this->assertFalse($entity->accessible('bar'));
+
+		$this->assertSame($entity, $entity->accessible('bar', true));
+		$this->assertTrue($entity->accessible('foo'));
+		$this->assertTrue($entity->accessible('bar'));
+	}
+
+/**
+ * Tests that an array can be used to set
+ *
+ * @return void
+ */
+	public function testAccessibleAsArray() {
+		$entity = new Entity;
+		$entity->accessible(['foo', 'bar', 'baz'], false);
+		$this->assertFalse($entity->accessible('foo'));
+		$this->assertFalse($entity->accessible('bar'));
+		$this->assertFalse($entity->accessible('baz'));
+
+		$entity->accessible('foo', true);
+		$this->assertTrue($entity->accessible('foo'));
+		$this->assertFalse($entity->accessible('bar'));
+		$this->assertFalse($entity->accessible('baz'));
+
+		$entity->accessible(['foo', 'bar', 'baz'], true);
+		$this->assertTrue($entity->accessible('foo'));
+		$this->assertTrue($entity->accessible('bar'));
+		$this->assertTrue($entity->accessible('baz'));
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -132,31 +132,31 @@ class EntityTest extends TestCase {
 			->getMock();
 		$entity->expects($this->at(0))
 			->method('set')
-			->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'safe' => false]);
+			->with(['a' => 'b', 'c' => 'd'], ['setter' => true, 'guard' => false]);
 
 		$entity->expects($this->at(1))
 			->method('set')
-			->with(['foo' => 'bar'], ['setter' => false, 'safe' => false]);
+			->with(['foo' => 'bar'], ['setter' => false, 'guard' => false]);
 
 		$entity->__construct(['a' => 'b', 'c' => 'd']);
 		$entity->__construct(['foo' => 'bar'], ['useSetters' => false]);
 	}
 
 /**
- * Tests that the constructor will set initial properties and pass the safe
+ * Tests that the constructor will set initial properties and pass the guard
  * option along
  *
  * @return void
  */
-	public function testConstructorWithSafe() {
+	public function testConstructorWithGuard() {
 		$entity = $this->getMockBuilder('\Cake\ORM\Entity')
 			->setMethods(['set'])
 			->disableOriginalConstructor()
 			->getMock();
 		$entity->expects($this->once())
 			->method('set')
-			->with(['foo' => 'bar'], ['setter' => true, 'safe' => true]);
-		$entity->__construct(['foo' => 'bar'], ['safe' => true]);
+			->with(['foo' => 'bar'], ['setter' => true, 'guard' => true]);
+		$entity->__construct(['foo' => 'bar'], ['guard' => true]);
 	}
 
 /**
@@ -886,7 +886,7 @@ class EntityTest extends TestCase {
  */
 	public function testSetWithAccessible() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);
-		$options = ['safe' => true];
+		$options = ['guard' => true];
 		$entity->accessible('foo', true);
 		$entity->set('bar', 3, $options);
 		$entity->set('foo', 4, $options);
@@ -905,7 +905,7 @@ class EntityTest extends TestCase {
  */
 	public function testSetWithAccessibleWithArray() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);
-		$options = ['safe' => true];
+		$options = ['guard' => true];
 		$entity->accessible('foo', true);
 		$entity->set(['bar' => 3, 'foo' => 4], $options);
 		$this->assertEquals(2, $entity->get('bar'));


### PR DESCRIPTION
This implementes feature described in https://github.com/cakephp/cakephp/issues/2324

I went ahead and only implemented `accessible` (instead of both accessible and protect) as I think it does not follow the rest of the API having two method for doing the same thing. A difference from wat is described in the ticket is that $_accessible is a map and not just a list. You can specify which properties are accessible and which not, plus having the ability to set a default for any property not declared in the array.

Also tried to squeeze this into the Marshaller, but I had a couple questions:
- Should $_accessible be static? How do we plan having defaults the entity type?
- Should Marshaller take an array of properties instead of just '$safe'? this way we won't need to make `$_accessible` static as we can pass the options form the outside to any future instance.
