### PR TITLE
3.0 simplify find

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -438,7 +438,7 @@ abstract class Association {
  * @see \Cake\ORM\Table::find()
  * @return \Cake\ORM\Query
  */
-	public function find($type, $options = []) {
+	public function find($type = 'all', $options = []) {
 		return $this->target()
 			->find($type, $options)
 			->where($this->conditions());

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -433,8 +433,9 @@ abstract class Association {
  * and modifies the query accordingly based of this association
  * configuration
  *
- * @param string $type
- * @param array $options options for query
+ * @param string|array $type the type of query to perform, if an array is passed,
+ * it will be interpreted as the `$options` parameter
+ * @param array $options
  * @see \Cake\ORM\Table::find()
  * @return \Cake\ORM\Query
  */

--- a/Cake/ORM/Error/RecordNotFoundException.php
+++ b/Cake/ORM/Error/RecordNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM\Error;
+
+use Cake\Error\NotFoundException;
+
+/**
+ * Exception raised when a particular record was not found
+ *
+ */
+class RecordNotFoundException extends NotFoundException {
+
+}

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -670,17 +670,23 @@ class Table implements EventListener {
  * Each find() will trigger a `Model.beforeFind` event for all attached
  * listeners. Any listener can set a valid result set using $query
  *
- * @param string|array $type the type of query to perform, if an array is passed,
- * it will be interpreted as the `$options` parameter
- * @param array $options
+ * @param string $type the type of query to perform
+ * @param array $options An array that will be passed to Query::applyOptions
+ * By default it allows the following keys:
+ * - fields
+ * - conditions
+ * - order
+ * - limit
+ * - offset
+ * - page
+ * - order
+ * - group
+ * - having
+ * - contain
+ * - join
  * @return \Cake\ORM\Query
  */
 	public function find($type = 'all', $options = []) {
-		if (!is_string($type)) {
-			$options = $type;
-			$type = 'all';
-		}
-
 		$query = $this->_buildQuery();
 		$query->select()->applyOptions($options);
 		return $this->callFinder($type, $query, $options);

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -791,6 +791,28 @@ class Table implements EventListener {
 	}
 
 /**
+ * Returns a single record after finding it by its primary key, if no record is
+ * found this method throws an exception.
+ *
+ * @param mixed primary key value to find
+ * @param array $options options accepted by `Table::find()`
+ * @throws \Cake\ORM\RecordNotFoundException
+ * @return \Cake\ORM\Entity
+ * @see Table::find()
+ */
+	public function get($primaryKey, $options = []) {
+		$key = (array)$this->primaryKey();
+		$conditions = array_combine($key, (array)$primaryKey);
+		$entity = $this->find('all', $options)->where($conditions)->first();
+
+		if (!$entity) {
+			throw new Error\RecordNotFoundException;
+		}
+
+		return $entity;
+	}
+
+/**
  * Creates a new Query instance for this table
  *
  * @return \Cake\ORM\Query

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -28,6 +28,7 @@ use Cake\ORM\Association\HasOne;
 use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Entity;
 use Cake\ORM\Error\MissingEntityException;
+use Cake\ORM\Error\RecordNotFoundException;
 use Cake\ORM\Marshaller;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
@@ -816,7 +817,7 @@ class Table implements EventListener {
 		$entity = $this->find('all', $options)->where($conditions)->first();
 
 		if (!$entity) {
-			throw new Error\RecordNotFoundException(__d(
+			throw new RecordNotFoundException(__d(
 				'cake_dev', 'Record "%s" not found in table "%s"',
 				implode(',', (array)$primaryKey),
 				$this->alias()

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -794,9 +794,19 @@ class Table implements EventListener {
  * Returns a single record after finding it by its primary key, if no record is
  * found this method throws an exception.
  *
+ * ###Example:
+ *
+ * {{{
+ * $id = 10;
+ * $article = $articles->get($id);
+ *
+ * $article = $articles->get($id, ['contain' => ['Comments]]);
+ * }}}
+ *
  * @param mixed primary key value to find
  * @param array $options options accepted by `Table::find()`
- * @throws \Cake\ORM\RecordNotFoundException
+ * @throws \Cake\ORM\RecordNotFoundException if the record with such id could not
+ * be found
  * @return \Cake\ORM\Entity
  * @see Table::find()
  */
@@ -806,7 +816,11 @@ class Table implements EventListener {
 		$entity = $this->find('all', $options)->where($conditions)->first();
 
 		if (!$entity) {
-			throw new Error\RecordNotFoundException;
+			throw new Error\RecordNotFoundException(__d(
+				'cake_dev', 'Record "%s" not found in table "%s"',
+				implode(',', (array)$primaryKey),
+				$this->alias()
+			));
 		}
 
 		return $entity;

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -669,11 +669,17 @@ class Table implements EventListener {
  * Each find() will trigger a `Model.beforeFind` event for all attached
  * listeners. Any listener can set a valid result set using $query
  *
- * @param string $type the type of query to perform
+ * @param string|array $type the type of query to perform, if an array is passed,
+ * it will be interpreted as the `$options` parameter
  * @param array $options
  * @return \Cake\ORM\Query
  */
-	public function find($type, $options = []) {
+	public function find($type = 'all', $options = []) {
+		if (!is_string($type)) {
+			$options = $type;
+			$type = 'all';
+		}
+
 		$query = $this->_buildQuery();
 		$query->select()->applyOptions($options);
 		return $this->callFinder($type, $query, $options);

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -826,7 +826,7 @@ class Table implements EventListener {
 			throw new RecordNotFoundException(__d(
 				'cake_dev', 'Record "%s" not found in table "%s"',
 				implode(',', (array)$primaryKey),
-				$this->alias()
+				$this->table()
 			));
 		}
 

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -806,8 +806,8 @@ class Table implements EventListener {
  *
  * @param mixed primary key value to find
  * @param array $options options accepted by `Table::find()`
- * @throws \Cake\ORM\RecordNotFoundException if the record with such id could not
- * be found
+ * @throws \Cake\ORM\Error\RecordNotFoundException if the record with such id
+ * could not be found
  * @return \Cake\ORM\Entity
  * @see Table::find()
  */

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -3020,7 +3020,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['callFinder', '_buildQuery'],
 			[[
 				'connection' => $this->connection,
-				'alias' => 'articles',
+				'table' => 'articles',
 				'schema' => [
 					'id' => ['type' => 'integer'],
 					'bar' => ['type' => 'integer'],

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2963,27 +2963,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Tests that it is possible to pass the conditions as first argument in find
- *
- * @return void
- */
-	public function testFindFirstParamAsArray() {
-		$table = $this->getMock(
-			'\Cake\ORM\Table',
-			['callFinder'],
-			[[
-				'connection' => $this->connection,
-				'schema' => ['id' => ['type' => 'integer']]
-			]]
-		);
-
-		$query = (new \Cake\ORM\Query($this->connection, $table))->select(['id']);
-		$table->expects($this->once())->method('callFinder')
-			->with('all', $query, ['fields' => ['id']]);
-		$table->find(['fields' => ['id']]);
-	}
-
-/**
  * Test that get() will use the primary key for searching and return the first
  * entity found
  *

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2941,4 +2941,46 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals(3, $article->tags[1]->id);
 	}
 
+/**
+ * Tests that it is possible to call find with no arguments
+ *
+ * @return void
+ */
+	public function testSimplifiedFind() {
+		$table = $this->getMock(
+			'\Cake\ORM\Table',
+			['callFinder'],
+			[[
+				'connection' => $this->connection,
+				'schema' => ['id' => ['type' => 'integer']]
+			]]
+		);
+
+		$query = (new \Cake\ORM\Query($this->connection, $table))->select();
+		$table->expects($this->once())->method('callFinder')
+			->with('all', $query, []);
+		$table->find();
+	}
+
+/**
+ * Tests that it is possible to pass the conditions as first argument in find
+ *
+ * @return void
+ */
+	public function testFindFirstParamAsArray() {
+		$table = $this->getMock(
+			'\Cake\ORM\Table',
+			['callFinder'],
+			[[
+				'connection' => $this->connection,
+				'schema' => ['id' => ['type' => 'integer']]
+			]]
+		);
+
+		$query = (new \Cake\ORM\Query($this->connection, $table))->select(['id']);
+		$table->expects($this->once())->method('callFinder')
+			->with('all', $query, ['fields' => ['id']]);
+		$table->find(['fields' => ['id']]);
+	}
+
 }


### PR DESCRIPTION
This PR contains a small change to `Table::find()` and introduces `Table::get()`. Now `find()` can work with no arguments, it will just assume that you want a findAll.You can also provide an array as first argument, in which case it will also asume findAll and use the first argument as $options. I consider this reduces repetition when constantly using `find()` in your app, which is something I started to get tired of in 2.x

With the addition of `Table::get()` we have an alternative for `Model::read()` without all the evil. This is a shortcut method for quickly returning an entity matched by primary key. If the record cannot be found, it will throw an exception. This is particularly handy for repetitive tasks such as coding a `view`, `edit` or `delete` action where the record must be fetched before doing anything with it or throw a not found exception otherwise. It also relieves a bit the end user of having to type a rather verbose `$this->Articles->find('all')->where([id => $id])->first()`
