### PR TITLE
Unify marshalling with saving.

### DIFF
--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -64,6 +64,7 @@ class Marshaller {
 				$key = $nested;
 				$nested = [];
 			}
+			$nested = isset($nested['associated']) ? $nested['associated'] : [];
 			$assoc = $this->_table->association($key);
 			if ($assoc) {
 				$map[$assoc->property()] = [
@@ -81,6 +82,7 @@ class Marshaller {
  * @param array $data The data to hydrate.
  * @param array $include The associations to include.
  * @return Cake\ORM\Entity
+ * @see Cake\ORM\Table::newEntity()
  */
 	public function one(array $data, $include = []) {
 		$propertyMap = $this->_buildPropertyMap($include);
@@ -128,6 +130,7 @@ class Marshaller {
  * @param array $data The data to hydrate.
  * @param array $include The associations to include.
  * @return array An array of hydrated records.
+ * @see Cake\ORM\Table::newEntities()
  */
 	public function many(array $data, $include = []) {
 		$output = [];

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -1490,7 +1490,7 @@ class Table implements EventListener {
  * {{{
  * $articles = $this->Articles->newEntity(
  *   $this->request->data(),
- *   ['Tags', 'Comments' => ['Users']]
+ *   ['Tags', 'Comments' => ['associated' => ['Users']]]
  * );
  * }}}
  *
@@ -1524,7 +1524,7 @@ class Table implements EventListener {
  * {{{
  * $articles = $this->Articles->newEntities(
  *   $this->request->data(),
- *   ['Tags', 'Comments' => ['Users']]
+ *   ['Tags', 'Comments' => ['associated' => ['Users']]]
  * );
  * }}}
  *

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -193,7 +193,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->comments);
-		$result = $marshall->one($data, ['Articles' => ['Users']]);
+		$result = $marshall->one($data, ['Articles' => ['associated' => ['Users']]]);
 
 		$this->assertEquals(
 			$data['article']['title'],


### PR DESCRIPTION
Unify how nested associations are defined in marshalling and saving. Having two different formats makes it harder to remember and document the various features of the Table class.

I will update the documentation in my next bit of documentation work.
