### PR TITLE
3.0 safer mass assignment

### DIFF
--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -127,7 +127,7 @@ class BelongsTo extends Association {
 			(array)$this->foreignKey(),
 			$targetEntity->extract((array)$table->primaryKey())
 		);
-		$entity->set($properties);
+		$entity->set($properties, ['guard' => false]);
 		return $entity;
 	}
 

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -452,8 +452,8 @@ class BelongsToMany extends Association {
 			$joint->set(array_combine(
 				$foreignKey,
 				$sourceEntity->extract($sourcePrimaryKey)
-			));
-			$joint->set(array_combine($assocForeignKey, $e->extract($targetPrimaryKey)));
+			), ['guard' => false]);
+			$joint->set(array_combine($assocForeignKey, $e->extract($targetPrimaryKey)), ['guard' => false]);
 			$saved = $junction->save($joint, $options);
 
 			if (!$saved && !empty($options['atomic'])) {

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -143,7 +143,7 @@ class HasMany extends Association {
 				$targetEntity = clone $targetEntity;
 			}
 
-			$targetEntity->set($properties);
+			$targetEntity->set($properties, ['guard' => false]);
 			if ($target->save($targetEntity, $options)) {
 				$targetEntities[$k] = $targetEntity;
 				continue;

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -118,7 +118,7 @@ class HasOne extends Association {
 			(array)$this->foreignKey(),
 			$entity->extract((array)$this->source()->primaryKey())
 		);
-		$targetEntity->set($properties);
+		$targetEntity->set($properties, ['guard' => false]);
 
 		if (!$this->target()->save($targetEntity, $options)) {
 			$targetEntity->unsetProperty(array_keys($properties));

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -157,7 +157,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  * @return void
  */
 	public function __set($property, $value) {
-		$this->set([$property => $value]);
+		$this->set($property, $value);
 	}
 
 /**
@@ -447,7 +447,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  */
 
 	public function offsetSet($offset, $value) {
-		$this->set([$offset => $value]);
+		$this->set($offset, $value);
 	}
 
 /**

--- a/Cake/ORM/Entity.php
+++ b/Cake/ORM/Entity.php
@@ -195,31 +195,35 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  *
  * ## Example:
  *
- * {{
- *	$entity->set(['name' => 'andrew', 'id' => 1]);
- *	echo $entity->name // prints andrew
- *	echo $entity->id // prints 1
- * }}
+ * {{{
+ * $entity->set(['name' => 'andrew', 'id' => 1]);
+ * echo $entity->name // prints andrew
+ * echo $entity->id // prints 1
+ * }}}
  *
  * Some times it is handy to bypass setter functions in this entity when assigning
  * properties. You can achieve this by disabling the `setter` option using the
- * `$options` parameter
+ * `$options` parameter:
  *
- * ### Example:
+ * {{{
+ * $entity->set('name', 'Andrew', ['setter' => false]);
+ * $entity->set(['name' => 'Andrew', 'id' => 1], ['setter' => false]);
+ * }}}
  *
- * ``$entity->set('name', 'Andrew', ['setter' => false]);``
+ * Mass assignment should be treated carefully when accepting user input, by default
+ * entities will guard all fields when properties are assigned in bulk. You can disable
+ * the guarding for a single set call with the `guard` option:
  *
- * ``$entity->set(['name' => 'Andrew', 'id' => 1], ['setter' => false]);``
+ * {{{
+ * $entity->set(['name' => 'Andrew', 'id' => 1], ['guard' => true]);
+ * }}}
  *
- * Mass assignment should be treated carefully when accepting user input, for this
- * case you can tell this method to only set property that are marked as accessible
- * by setting the `guard` options in the `$options` parameter
+ * You do not need to use the guard option when assigning properties individually:
  *
- * ### Example:
- *
- * ``$entity->set('name', 'Andrew', ['guard' => true]);``
- *
- * ``$entity->set(['name' => 'Andrew', 'id' => 1], ['guard' => true]);``
+ * {{{
+ * // No need to use the guard option.
+ * $entity->set('name', 'Andrew');
+ * }}}
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
@@ -231,12 +235,14 @@ class Entity implements \ArrayAccess, \JsonSerializable {
  */
 	public function set($property, $value = null, $options = []) {
 		if (is_string($property)) {
+			$guard = false;
 			$property = [$property => $value];
 		} else {
+			$guard = true;
 			$options = (array)$value;
 		}
 
-		$options += ['setter' => true, 'guard' => false];
+		$options += ['setter' => true, 'guard' => $guard];
 
 		foreach ($property as $p => $value) {
 			if ($options['guard'] === true && !$this->accessible($p)) {
@@ -263,7 +269,6 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 			}
 			$this->_properties[$p] = $value;
 		}
-
 		return $this;
 	}
 

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -95,6 +95,7 @@ class Marshaller {
 			$data = $data[$tableName];
 		}
 
+		$properties = [];
 		foreach ($data as $key => $value) {
 			$assoc = null;
 			$nested = [];
@@ -105,8 +106,9 @@ class Marshaller {
 			if ($assoc) {
 				$value = $this->_marshalAssociation($assoc, $value, $nested);
 			}
-			$entity->set($key, $value);
+			$properties[$key] = $value;
 		}
+		$entity->set($properties);
 		return $entity;
 	}
 

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -812,7 +812,7 @@ class Table implements EventListener {
  *
  * @param mixed primary key value to find
  * @param array $options options accepted by `Table::find()`
- * @throws \Cake\ORM\Error\RecordNotFoundException if the record with such id
+ * @throws Cake\ORM\Error\RecordNotFoundException if the record with such id
  * could not be found
  * @return \Cake\ORM\Entity
  * @see Table::find()

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -927,4 +927,24 @@ class EntityTest extends TestCase {
 		$this->assertEquals(5, $entity->get('foo'));
 	}
 
+/**
+ * Test that accessible() and single property setting works.
+ *
+ * @return
+ */
+	public function testSetWithAccessibleSingleProperty() {
+		$entity = new Entity(['foo' => 1, 'bar' => 2]);
+		$entity->accessible('title', true);
+
+		$entity->set(['title' => 'test', 'body' => 'Nope']);
+		$this->assertEquals('test', $entity->title);
+		$this->assertNull($entity->body);
+
+		$entity->body = 'Yep';
+		$this->assertEquals('Yep', $entity->body, 'Single set should bypass guards.');
+
+		$entity->set('body', 'Yes');
+		$this->assertEquals('Yes', $entity->body, 'Single set should bypass guards.');
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/EntityTest.php
+++ b/Cake/Test/TestCase/ORM/EntityTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -49,6 +47,8 @@ class EntityTest extends TestCase {
  */
 	public function testSetMultiplePropertiesNoSetters() {
 		$entity = new Entity;
+		$entity->accessible('*', true);
+
 		$entity->set(['foo' => 'bar', 'id' => 1]);
 		$this->assertEquals('bar', $entity->foo);
 		$this->assertSame(1, $entity->id);
@@ -83,6 +83,7 @@ class EntityTest extends TestCase {
  */
 	public function testMultipleWithSetter() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['setName', 'setStuff']);
+		$entity->accessible('*', true);
 		$entity->expects($this->once())->method('setName')
 			->with('Jones')
 			->will($this->returnCallback(function($name) {
@@ -107,6 +108,8 @@ class EntityTest extends TestCase {
  */
 	public function testBypassSetters() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['setName', 'setStuff']);
+		$entity->accessible('*', true);
+
 		$entity->expects($this->never())->method('setName');
 		$entity->expects($this->never())->method('setStuff');
 
@@ -372,14 +375,16 @@ class EntityTest extends TestCase {
  */
 	public function testSetArrayAccess() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['set']);
+		$entity->accessible('*', true);
+
 		$entity->expects($this->at(0))
 			->method('set')
-			->with(['foo' => 1])
+			->with('foo', 1)
 			->will($this->returnSelf());
 
 		$entity->expects($this->at(1))
 			->method('set')
-			->with(['bar' => 2])
+			->with('bar', 2)
 			->will($this->returnSelf());
 
 		$entity['foo'] = 1;
@@ -662,6 +667,7 @@ class EntityTest extends TestCase {
  */
 	public function testToArrayWithAccessor() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['getName']);
+		$entity->accessible('*', true);
 		$entity->set(['name' => 'Mark', 'email' => 'mark@example.com']);
 		$entity->expects($this->any())
 			->method('getName')
@@ -690,6 +696,8 @@ class EntityTest extends TestCase {
  */
 	public function testToArrayVirtualProperties() {
 		$entity = $this->getMock('\Cake\ORM\Entity', ['getName']);
+		$entity->accessible('*', true);
+
 		$entity->expects($this->any())
 			->method('getName')
 			->will($this->returnValue('Jose'));
@@ -717,6 +725,8 @@ class EntityTest extends TestCase {
 			->setMethods(['getSomething'])
 			->disableOriginalConstructor()
 			->getMock();
+		$entity->accessible('*', true);
+
 		$validator = $this->getMock('\Cake\Validation\Validator');
 		$entity->set('a', 'b');
 

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2146,7 +2146,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @group save
  * @return void
  */
-	public function testsSaveBelongsTo() {
+	public function testSaveBelongsTo() {
 		$entity = new \Cake\ORM\Entity([
 			'title' => 'A Title',
 			'body' => 'A body'


### PR DESCRIPTION
When I was originally thinking about the mass-assignment protection I thought it should be enabled by default for bulk sets, but disabled when setting single properties. My thinking was:
- Setting a single property will rarely be done from request data, unless you are doing silly things.
- Setting bulk properties from request data should be protected by default. Having safe + secure defaults should be something a framework does for you. Having to opt into secure features using guard = true seems less than ideal to me.

While having bulk sets disabled by default may seem awkward I think it is a safer default given the issues mass-assignment has caused in the rails community.  I see bake as a place where we could build some smarts and help people set useful defaults up for accessible properties.
