### PR TITLE
3.0 schema cache

### DIFF
--- a/Cake/Test/TestCase/Database/Schema/CollectionTest.php
+++ b/Cake/Test/TestCase/Database/Schema/CollectionTest.php
@@ -16,7 +16,9 @@
  */
 namespace Cake\Test\TestCase\Database\Schema;
 
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Database\Connection;
 use Cake\Database\ConnectionManager;
 use Cake\Database\Schema\Collection;
 use Cake\Database\Schema\Table;
@@ -26,6 +28,10 @@ use Cake\TestSuite\TestCase;
  * Test case for Collection
  */
 class CollectionTest extends TestCase {
+
+	public $fixtures = [
+		'core.user'
+	];
 
 /**
  * Setup function
@@ -59,6 +65,28 @@ class CollectionTest extends TestCase {
 	public function testDescribeIncorrectTable() {
 		$schema = new Collection($this->connection);
 		$this->assertNull($schema->describe('derp'));
+	}
+
+/**
+ * Tests that schema metadata is cached
+ *
+ * @return void
+ */
+	public function testDescribeCache() {
+		$table = $this->connection->schemaCollection()->describe('users');
+
+		$config = $this->connection->config();
+		$config['cacheMetadata'] = true;
+
+		$connection = new Connection($config);
+		$schema = new Collection($connection);
+
+		Cache::delete('test_users', '_cake_model_');
+		$result = $schema->describe('users');
+		$this->assertEquals($table, $result);
+
+		$result = Cache::read('test_users', '_cake_model_');
+		$this->assertEquals($table, $result);
 	}
 
 }

--- a/Cake/Test/init.php
+++ b/Cake/Test/init.php
@@ -84,6 +84,11 @@ Cache::config([
 		'engine' => 'File',
 		'prefix' => 'cake_core_',
 		'serialize' => true
+	],
+	'_cake_model_' => [
+		'engine' => 'File',
+		'prefix' => 'cake_model_',
+		'serialize' => true
 	]
 ]);
 


### PR DESCRIPTION
Implements #2243.

Caching is done at Cake\ORM\Table. I couldn't use Cake\ORM\TableRegistry to cache and inject the schema into the table because table name resolution (used for generating cache keys) is only possible after the table is constructed.
