### PR TITLE
Avoid writing cache when the value is empty.

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -297,6 +297,9 @@ class Cache {
  * @return boolean True if the data was successfully cached, false on failure
  */
 	public static function write($key, $value, $config = 'default') {
+		if ($value !== null && !is_numeric($value) && empty($value)) {
+			return false;
+		}
 		$settings = self::settings($config);
 
 		if (empty($settings)) {


### PR DESCRIPTION
Create the cache when the value is empty, does not make it useless? Except that it is more processors?
