### PR TITLE
fix alias conflict when model is loading

### DIFF
--- a/lib/Cake/Controller/Controller.php
+++ b/lib/Cake/Controller/Controller.php
@@ -733,6 +733,7 @@ class Controller extends Object implements CakeEventListener {
 
 		list($plugin, $modelClass) = pluginSplit($modelClass, true);
 
+		$modelClass = Inflector::camelize($modelClass);
 		$this->{$modelClass} = ClassRegistry::init(array(
 			'class' => $plugin . $modelClass, 'alias' => $modelClass, 'id' => $id
 		));

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -131,7 +131,7 @@ class ClassRegistry {
 				if (empty($settings['alias'])) {
 					$settings['alias'] = $class;
 				}
-				$alias = $settings['alias'];
+				$alias = Inflector::camelize($settings['alias']);
 
 				$model = $_this->_duplicate($alias, $class);
 				if ($model) {


### PR DESCRIPTION
variable $alias in model has a bug when loading, It is hard for me to  explain,the following example is the best explanation of this bug :

```
<?php
class TestsController extends AppController {
    public $uses = array('Blog.Post');

    public function lastPosts() {
        $this->loadModel('Blog.post');
        echo $this->Post->name // Post
        echo $this->Post->alias // post
        echo $this->post->name // Post
        echo $this->post->alias // post

        $this->Post->isBug = 'no';
        $this->post->isBug = 'yes';

        echo $this->post->isBug // yes
        echo $this->Post->isBug // yes

        echo $this->Post->find('all'); // array( 'post' => array( 'id' ....))

        pr($this->uses)  //  array('Blog.Post','Blog.post')
    }
?>
```
