### PR TITLE
3.0 association save improvements

### DIFF
--- a/Cake/ORM/Association/BelongsTo.php
+++ b/Cake/ORM/Association/BelongsTo.php
@@ -113,7 +113,7 @@ class BelongsTo extends Association {
  */
 	public function save(Entity $entity, $options = []) {
 		$targetEntity = $entity->get($this->property());
-		if (!$targetEntity) {
+		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
 			return $entity;
 		}
 

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -394,6 +394,10 @@ class BelongsToMany extends Association {
 		$persisted = [];
 
 		foreach ($entities as $k => $entity) {
+			if (!($entity instanceof Entity)) {
+				continue;
+			}
+
 			if (!empty($options['atomic'])) {
 				$entity = clone $entity;
 			}

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -395,7 +395,7 @@ class BelongsToMany extends Association {
 
 		foreach ($entities as $k => $entity) {
 			if (!($entity instanceof Entity)) {
-				continue;
+				break;
 			}
 
 			if (!empty($options['atomic'])) {

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -140,7 +140,7 @@ class HasMany extends Association {
 
 		foreach ($targetEntities as $k => $targetEntity) {
 			if (!($targetEntity instanceof Entity)) {
-				continue;
+				break;
 			}
 
 			if (!empty($options['atomic'])) {

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -139,6 +139,10 @@ class HasMany extends Association {
 		$original = $targetEntities;
 
 		foreach ($targetEntities as $k => $targetEntity) {
+			if (!($targetEntity instanceof Entity)) {
+				continue;
+			}
+
 			if (!empty($options['atomic'])) {
 				$targetEntity = clone $targetEntity;
 			}

--- a/Cake/ORM/Association/HasOne.php
+++ b/Cake/ORM/Association/HasOne.php
@@ -110,7 +110,7 @@ class HasOne extends Association {
  */
 	public function save(Entity $entity, $options = []) {
 		$targetEntity = $entity->get($this->property());
-		if (!$targetEntity) {
+		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
 			return $entity;
 		}
 

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1148,9 +1148,8 @@ class BelongsToManyTest extends TestCase {
 			]
 		]);
 
-		$mock->expects($this->once())
-			->method('save')
-			->with($entity->tags[1]);
+		$mock->expects($this->never())
+			->method('save');
 
 		$association = new BelongsToMany('Tags', $config);
 		$association->save($entity);

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1119,4 +1119,41 @@ class BelongsToManyTest extends TestCase {
 		$this->assertFalse($assoc->save($entity, $options));
 	}
 
+/**
+ * Test that save() ignores non entity values.
+ *
+ * @return void
+ */
+	public function testSaveOnlyEntities() {
+		$connection = \Cake\Database\ConnectionManager::get('test');
+		$mock = $this->getMock(
+			'Cake\ORM\Table',
+			['save', 'schema'],
+			[['table' => 'tags', 'connection' => $connection]]
+		);
+		$mock->primaryKey('id');
+
+		$config = [
+			'sourceTable' => $this->article,
+			'targetTable' => $mock,
+			'saveStrategy' => BelongsToMany::SAVE_APPEND,
+		];
+
+		$entity = new Entity([
+			'id' => 1,
+			'title' => 'First Post',
+			'tags' => [
+				['tag' => 'nope'],
+				new Entity(['tag' => 'cakephp']),
+			]
+		]);
+
+		$mock->expects($this->once())
+			->method('save')
+			->with($entity->tags[1]);
+
+		$association = new BelongsToMany('Tags', $config);
+		$association->save($entity);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -193,4 +193,30 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$this->assertTrue($association->cascadeDelete($entity));
 	}
 
+/**
+ * Test that save() ignores non entity values.
+ *
+ * @return void
+ */
+	public function testSaveOnlyEntities() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->client,
+			'targetTable' => $mock,
+		];
+		$mock->expects($this->never())
+			->method('save');
+
+		$entity = new Entity([
+			'title' => 'A Title',
+			'body' => 'A body',
+			'author' => ['name' => 'Jose']
+		]);
+
+		$association = new BelongsTo('Authors', $config);
+		$result = $association->save($entity);
+		$this->assertSame($result, $entity);
+		$this->assertNull($entity->author_id);
+	}
+
 }

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -531,4 +531,32 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$this->assertTrue($association->cascadeDelete($entity));
 	}
 
+/**
+ * Test that save() ignores non entity values.
+ *
+ * @return void
+ */
+	public function testSaveOnlyEntities() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->author,
+			'targetTable' => $mock,
+		];
+
+		$entity = new Entity([
+			'username' => 'Mark',
+			'email' => 'mark@example.com',
+			'articles' => [
+				['title' => 'First Post'],
+				new Entity(['title' => 'Second Post']),
+			]
+		]);
+
+		$mock->expects($this->once())
+			->method('save')
+			->with($entity->articles[1]);
+
+		$association = new HasMany('Articles', $config);
+		$association->save($entity);
+	}
 }

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -552,9 +552,8 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			]
 		]);
 
-		$mock->expects($this->once())
-			->method('save')
-			->with($entity->articles[1]);
+		$mock->expects($this->never())
+			->method('save');
 
 		$association = new HasMany('Articles', $config);
 		$association->save($entity);

--- a/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -18,6 +18,7 @@ namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Association\HasOne;
+use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -173,4 +174,29 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association->attachTo($query, ['includeFields' => false]);
 	}
 
+/**
+ * Test that save() ignores non entity values.
+ *
+ * @return void
+ */
+	public function testSaveOnlyEntities() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->user,
+			'targetTable' => $mock,
+		];
+		$mock->expects($this->never())
+			->method('save');
+
+		$entity = new Entity([
+			'username' => 'Mark',
+			'email' => 'mark@example.com',
+			'profile' => ['twitter' => '@cakephp']
+		]);
+
+		$association = new HasOne('Profiles', $config);
+		$result = $association->save($entity);
+
+		$this->assertSame($result, $entity);
+	}
 }

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2219,6 +2219,33 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Tests saving associations only saves associations
+ * if they are entities.
+ *
+ * @group save
+ * @return void
+ */
+	public function testSaveOnlySaveAssociatedEntities() {
+		$entity = new \Cake\ORM\Entity([
+			'name' => 'Jose'
+		]);
+
+		// Not an entity.
+		$entity->article = [
+			'title' => 'A Title',
+			'body' => 'A body'
+		];
+
+		$table = TableRegistry::get('authors');
+		$table->hasOne('articles');
+
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertFalse($entity->isNew());
+		$this->assertEmpty($entity->article);
+	}
+
+
+/**
  * Tests saving hasOne association and returning a validation error will
  * abort the saving process
  *

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2241,7 +2241,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertSame($entity, $table->save($entity));
 		$this->assertFalse($entity->isNew());
-		$this->assertEmpty($entity->article);
+		$this->assertInternalType('array', $entity->article);
 	}
 
 


### PR DESCRIPTION
Association methods should only save _entity_ values, not any old data they happen to come across. Doing so prevents a few nasty problems:
- Fatal errors - calling methods on arrays makes PHP :cry:
- Unintended data being saved. The marhshalling code will convert any whitelisted associations into entities. Any non whitelisted properties will be left as arrays. Saving arrays == bad user data getting in.
