### PR TITLE
1.3 Allow condition keys with : or ? chars in sequence

### DIFF
--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -2158,16 +2158,7 @@ class DboSource extends DataSource {
 
 			if (is_array($value)) {
 				$valueCount = count($value);
-				$valueInsert = (
-					!empty($value) &&
-					(
-						substr_count($key, '?') == $valueCount ||
-						(
-							substr_count($key, ':') == $valueCount &&
-							preg_match("/(\:){" . $valueCount . "}/", $key) === 0
-						)
-					)
-				);
+				$valueInsert = (!empty($value) && (substr_count($key, '?') === $valueCount || (substr_count($key, ':') === $valueCount && preg_match("/(\:){" . $valueCount . "}/", $key) === 0)));
 			}
 
 			if (is_numeric($key) && empty($value)) {

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -2157,9 +2157,19 @@ class DboSource extends DataSource {
 			$not = null;
 
 			if (is_array($value)) {
+				$valueCount = count($value);
 				$valueInsert = (
 					!empty($value) &&
-					(substr_count($key, '?') == count($value) || substr_count($key, ':') == count($value))
+					(
+						(
+							substr_count($key, '?') == $valueCount &&
+							preg_match("/(\?){".$valueCount."}/", $key) == 0
+						) ||
+						(
+							substr_count($key, ':') == $valueCount &&
+							preg_match("/(\:){".$valueCount."}/", $key) == 0
+						)
+					)
 				);
 			}
 

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -2164,7 +2164,7 @@ class DboSource extends DataSource {
 						substr_count($key, '?') == $valueCount ||
 						(
 							substr_count($key, ':') == $valueCount &&
-							preg_match("/(\:){" . $valueCount . "}/", $key) == 0
+							preg_match("/(\:){" . $valueCount . "}/", $key) === 0
 						)
 					)
 				);

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -2161,13 +2161,10 @@ class DboSource extends DataSource {
 				$valueInsert = (
 					!empty($value) &&
 					(
-						(
-							substr_count($key, '?') == $valueCount &&
-							preg_match("/(\?){".$valueCount."}/", $key) == 0
-						) ||
+						substr_count($key, '?') == $valueCount ||
 						(
 							substr_count($key, ':') == $valueCount &&
-							preg_match("/(\:){".$valueCount."}/", $key) == 0
+							preg_match("/(\:){" . $valueCount . "}/", $key) == 0
 						)
 					)
 				);

--- a/cake/tests/cases/libs/model/datasources/dbo_source.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo_source.test.php
@@ -2764,6 +2764,18 @@ class DboSourceTest extends CakeTestCase {
 		)));
 		$expected = " WHERE '2009-03-04' BETWEEN Model.field1 AND Model.field2";
 		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('Model.field::integer' => array(5, 50, 500)));
+		$expected = " WHERE `Model`.`field`::integer IN ('5', '50', '500')";
+		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('Model.field::integer' => array(5, 50)));
+		$expected = " WHERE `Model`.`field`::integer IN ('5', '50')";
+		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('Model.field::integer BETWEEN ? AND ?' => array(5, 50)));
+		$expected = " WHERE `Model`.`field`::integer BETWEEN '5' AND '50'";
+		$this->assertEqual($result, $expected);
 	}
 
 /**

--- a/cake/tests/cases/libs/model/datasources/dbo_source.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo_source.test.php
@@ -2765,16 +2765,36 @@ class DboSourceTest extends CakeTestCase {
 		$expected = " WHERE '2009-03-04' BETWEEN Model.field1 AND Model.field2";
 		$this->assertEqual($result, $expected);
 		
+		$result = $this->testDb->conditions(array('Model.field::integer' => 5));
+		$expected = " WHERE `Model`.`field::integer` = '5'"; // known bug
+		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('"Model"."field"::integer' => 5));
+		$expected = " WHERE \"Model\".\"field\"::integer = '5'";
+		$this->assertEqual($result, $expected);
+		
 		$result = $this->testDb->conditions(array('Model.field::integer' => array(5, 50, 500)));
 		$expected = " WHERE `Model`.`field`::integer IN ('5', '50', '500')";
+		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('"Model"."field"::integer' => array(5, 50, 500)));
+		$expected = " WHERE \"Model\".\"field\"::integer IN ('5', '50', '500')";
 		$this->assertEqual($result, $expected);
 		
 		$result = $this->testDb->conditions(array('Model.field::integer' => array(5, 50)));
 		$expected = " WHERE `Model`.`field`::integer IN ('5', '50')";
 		$this->assertEqual($result, $expected);
 		
+		$result = $this->testDb->conditions(array('"Model"."field"::integer' => array(5, 50)));
+		$expected = " WHERE \"Model\".\"field\"::integer IN ('5', '50')";
+		$this->assertEqual($result, $expected);
+		
 		$result = $this->testDb->conditions(array('Model.field::integer BETWEEN ? AND ?' => array(5, 50)));
-		$expected = " WHERE `Model`.`field`::integer BETWEEN '5' AND '50'";
+		$expected = " WHERE `Model`.`field::integer` BETWEEN '5' AND '50'"; // known bug
+		$this->assertEqual($result, $expected);
+		
+		$result = $this->testDb->conditions(array('"Model"."field"::integer BETWEEN ? AND ?' => array(5, 50)));
+		$expected = " WHERE \"Model\".\"field\"::integer BETWEEN '5' AND '50'";
 		$this->assertEqual($result, $expected);
 	}
 

--- a/cake/tests/cases/libs/model/datasources/dbo_source.test.php
+++ b/cake/tests/cases/libs/model/datasources/dbo_source.test.php
@@ -2766,7 +2766,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertEqual($result, $expected);
 		
 		$result = $this->testDb->conditions(array('Model.field::integer' => 5));
-		$expected = " WHERE `Model`.`field::integer` = '5'"; // known bug
+		$expected = " WHERE `Model`.`field::integer` = '5'";
 		$this->assertEqual($result, $expected);
 		
 		$result = $this->testDb->conditions(array('"Model"."field"::integer' => 5));
@@ -2790,7 +2790,7 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertEqual($result, $expected);
 		
 		$result = $this->testDb->conditions(array('Model.field::integer BETWEEN ? AND ?' => array(5, 50)));
-		$expected = " WHERE `Model`.`field::integer` BETWEEN '5' AND '50'"; // known bug
+		$expected = " WHERE `Model`.`field::integer` BETWEEN '5' AND '50'";
 		$this->assertEqual($result, $expected);
 		
 		$result = $this->testDb->conditions(array('"Model"."field"::integer BETWEEN ? AND ?' => array(5, 50)));


### PR DESCRIPTION
This was failing when attempting to cast values inside a key; ie:

`'Model.field::integer' => array(1, 2)`

where the number of `:` or `?` characters is equal to the number of elements in the value array. 

That would cause it to attempt to run the `__parseKey()` function, ending up with a condition segment string such as `... Model.field::integer =` which was not the intended behavior.

This patch looks to see if the characters are all next to each other. If so, we can safely assume that the user is not trying to interpolate the values into the key string.

Since it checks for question marks first, this also allows casted condition keys to use BETWEEN syntax, ie: `'Model.field::integer BETWEEN ? and ?' => array(1, 100)`

would output the expected condition:
`Model.field::integer BETWEEN '1' and '100'`
