### PR TITLE
3.0 Make marshaller convert `_joinData` into entities.

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -47,10 +47,25 @@ abstract class Association {
  */
 	const STRATEGY_SELECT = 'select';
 
+/**
+ * Association type for one to one associations.
+ *
+ * @var string
+ */
 	const ONE_TO_ONE = 'oneToOne';
 
+/**
+ * Association type for one to many associations.
+ *
+ * @var string
+ */
 	const ONE_TO_MANY = 'oneToMany';
 
+/**
+ * Association type for many to many associations.
+ *
+ * @var string
+ */
 	const MANY_TO_MANY = 'manyToMany';
 
 /**

--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -153,16 +153,22 @@ class Marshaller {
  * @return array An array of built entities.
  */
 	protected function _belongsToMany(Association $assoc, array $data, $include = []) {
-		if (!in_array('_joinData', $include)) {
-			return $this->many($data, $include);
+		$records = $this->many($data, $include);
+		if (!in_array('_joinData', $include) && !isset($include['_joinData'])) {
+			return $records;
 		}
+
 		$joint = $assoc->junction();
 		$jointMarshaller = $joint->marshaller();
-		$records = $this->many($data, $include);
+
+		$nested = [];
+		if (isset($include['_joinData']['associated'])) {
+			$nested = (array)$include['_joinData']['associated'];
+		}
 
 		foreach ($records as $i => $record) {
 			if (isset($data[$i]['_joinData'])) {
-				$joinData = $jointMarshaller->one($data[$i]['_joinData'], $include);
+				$joinData = $jointMarshaller->one($data[$i]['_joinData'], $nested);
 				$record->set('_joinData', $joinData);
 			}
 		}

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -243,7 +243,11 @@ class MarshallerTest extends TestCase {
 			],
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->one($data, ['Tags']);
+		$result = $marshall->one($data, [
+			'Tags' => [
+				'associated' => ['_joinData']
+			]
+		]);
 
 		$this->assertEquals($data['title'], $result->title);
 		$this->assertEquals($data['body'], $result->body);
@@ -252,8 +256,16 @@ class MarshallerTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
 		$this->assertEquals($data['tags'][0]['tag'], $result->tags[0]->tag);
 
-		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]->_joinData);
-		$this->assertEquals($data['tags'][0]['_joinData']['active'], $result->tags[0]->_joinData->active);
+		$this->assertInstanceOf(
+			'Cake\ORM\Entity',
+			$result->tags[0]->_joinData,
+			'_joinData should be an entity.'
+		);
+		$this->assertEquals(
+			$data['tags'][0]['_joinData']['active'],
+			$result->tags[0]->_joinData->active,
+			'_joinData should be an entity.'
+		);
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -269,6 +269,59 @@ class MarshallerTest extends TestCase {
 	}
 
 /**
+ * Test marshalling nested associations on the _joinData structure.
+ *
+ * @return void
+ */
+	public function testOneBelongsToManyJoinDataAssociated() {
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 1,
+			'tags' => [
+				[
+					'tag' => 'news',
+					'_joinData' => [
+						'active' => 1,
+						'user' => ['username' => 'Bill'],
+					]
+				],
+				[
+					'tag' => 'cakephp',
+					'_joinData' => [
+						'active' => 0,
+						'user' => ['username' => 'Mark'],
+					]
+				],
+			],
+		];
+
+		$articlesTags = TableRegistry::get('ArticlesTags');
+		$articlesTags->belongsTo('Users');
+
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, [
+			'Tags' => [
+				'associated' => [
+					'_joinData' => ['associated' => ['Users']]
+				]
+			]
+		]);
+		$this->assertInstanceOf(
+			'Cake\ORM\Entity',
+			$result->tags[0]->_joinData->user,
+			'joinData should contain a user entity.'
+		);
+		$this->assertEquals('Bill', $result->tags[0]->_joinData->user->username);
+		$this->assertInstanceOf(
+			'Cake\ORM\Entity',
+			$result->tags[1]->_joinData->user,
+			'joinData should contain a user entity.'
+		);
+		$this->assertEquals('Mark', $result->tags[1]->_joinData->user->username);
+	}
+
+/**
  * Test one() with deeper associations.
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -20,24 +20,27 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
-
 /**
  * Test entity for mass assignment.
  */
 class OpenEntity extends Entity {
+
 	protected $_accessible = [
 		'*' => true,
 	];
+
 }
 
 /**
  * Test entity for mass assignment.
  */
 class ProtectedArticle extends Entity {
+
 	protected $_accessible = [
 		'title' => true,
 		'body' => true
 	];
+
 }
 
 /**

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -2247,7 +2247,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertInternalType('array', $entity->article);
 	}
 
-
 /**
  * Tests saving hasOne association and returning a validation error will
  * abort the saving process


### PR DESCRIPTION
As discussed in #2511 I've made the Marshaller able to convert _joinData into entities when the `_joinData` association is included. I use `_joinData` as the association name instead of the actual joint table alias as I thought it would be clearer and more consistent with the request data, and created entity.
