### PR TITLE
Fix issues in ORM\Query

### DIFF
--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -196,9 +196,21 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Resulting statement is traversable, so it can be used in any loop as you would
  * with an array.
  *
+ * This method can be overridden in query subclasses to decorate behavior
+ * around query execution.
+ *
  * @return Cake\Database\StatementInterface
  */
 	public function execute() {
+		return $this->_executeStatement();
+	}
+
+/**
+ * Internal implementation of statement execution.
+ *
+ * @return Cake\Database\StatementInterface
+ */
+	protected function _executeStatement() {
 		$query = $this->_transformQuery();
 		$statement = $this->_connection->prepare($query->sql());
 		$query->_bindStatement($statement);
@@ -546,7 +558,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * {{{
  *	$query->join([
  *		'a' => [
- *			'table' => 'authors', 'type' => 'LEFT', 'conditions' => 'a.id = b.author_id'
+ *			'table' => 'authors',
+ *			'type' => 'LEFT',
+ *			'conditions' => 'a.id = b.author_id'
  *		]
  *	]);
  *  // Produces LEFT JOIN authors a ON (a.id = b.author_id)
@@ -557,10 +571,14 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * {{{
  *	$query->join([
  *		'a' => [
- *			'table' => 'authors', 'type' => 'LEFT', 'conditions' => 'a.id = b.author_id'
+ *			'table' => 'authors',
+ *			'type' => 'LEFT',
+ *			'conditions' => 'a.id = b.author_id'
  *		],
  *		'p' => [
- *			'table' => 'products', 'type' => 'INNER', 'conditions' => 'a.owner_id = p.id
+ *			'table' => 'products',
+ *			'type' => 'INNER',
+ *			'conditions' => 'a.owner_id = p.id
  *		]
  *	]);
  *	// LEFT JOIN authors a ON (a.id = b.author_id)

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -867,7 +867,7 @@ class Table implements EventListener {
 		$query->update($this->table())
 			->set($fields)
 			->where($conditions);
-		$statement = $query->executeStatement();
+		$statement = $query->execute();
 		$success = $statement->rowCount() > 0;
 		$statement->closeCursor();
 		return $success;
@@ -959,7 +959,7 @@ class Table implements EventListener {
 		$query = $this->query();
 		$query->delete($this->table())
 			->where($conditions);
-		$statement = $query->executeStatement();
+		$statement = $query->execute();
 		$success = $statement->rowCount() > 0;
 		$statement->closeCursor();
 		return $success;
@@ -1190,7 +1190,7 @@ class Table implements EventListener {
 
 		$statement = $query->insert($this->table(), array_keys($data))
 			->values($data)
-			->executeStatement();
+			->execute();
 
 		$success = false;
 		if ($statement->rowCount() > 0) {
@@ -1251,7 +1251,7 @@ class Table implements EventListener {
 		$statement = $query->update($this->table())
 			->set($data)
 			->where($primaryKey)
-			->executeStatement();
+			->execute();
 
 		$success = false;
 		if ($statement->rowCount() > 0) {
@@ -1340,7 +1340,7 @@ class Table implements EventListener {
 		$query = $this->query();
 		$statement = $query->delete($this->table())
 			->where($conditions)
-			->executeStatement();
+			->execute();
 
 		$success = $statement->rowCount() > 0;
 		if (!$success) {

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -491,12 +491,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['query'],
 			[['table' => 'users']]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, null]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
 		$query->expects($this->once())
-			->method('executeStatement')
+			->method('_executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 		$table->updateAll(['username' => 'mark'], []);
 	}
@@ -530,12 +530,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['query'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['executeStatement'], [$this->connection, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, null]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
 		$query->expects($this->once())
-			->method('executeStatement')
+			->method('_executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 		$table->deleteAll(['id >' => 4]);
 	}
@@ -1230,7 +1230,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['executeStatement', 'addDefaultTypes'],
+			['_executeStatement', 'addDefaultTypes'],
 			[null, $table]
 		);
 		$statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
@@ -1245,7 +1245,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->expects($this->once())->method('query')
 			->will($this->returnValue($query));
 
-		$query->expects($this->once())->method('executeStatement')
+		$query->expects($this->once())->method('_executeStatement')
 			->will($this->returnValue($statement));
 
 		$statement->expects($this->once())->method('rowCount')
@@ -1311,7 +1311,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['executeStatement', 'addDefaultTypes'],
+			['_executeStatement', 'addDefaultTypes'],
 			[null, $table]
 		);
 
@@ -1326,7 +1326,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$connection->expects($this->once())->method('begin');
 		$connection->expects($this->once())->method('rollback');
-		$query->expects($this->once())->method('executeStatement')
+		$query->expects($this->once())->method('_executeStatement')
 			->will($this->throwException(new \PDOException));
 
 		$data = new \Cake\ORM\Entity([
@@ -1357,7 +1357,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['executeStatement', 'addDefaultTypes'],
+			['_executeStatement', 'addDefaultTypes'],
 			[null, $table]
 		);
 
@@ -1375,7 +1375,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue(0));
 		$connection->expects($this->once())->method('begin');
 		$connection->expects($this->once())->method('rollback');
-		$query->expects($this->once())->method('executeStatement')
+		$query->expects($this->once())->method('_executeStatement')
 			->will($this->returnValue($statement));
 
 		$data = new \Cake\ORM\Entity([
@@ -1538,7 +1538,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['executeStatement', 'addDefaultTypes', 'set'],
+			['_executeStatement', 'addDefaultTypes', 'set'],
 			[null, $table]
 		);
 
@@ -1549,7 +1549,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$statement->expects($this->once())->method('rowCount')
 			->will($this->returnValue(1));
 
-		$query->expects($this->once())->method('executeStatement')
+		$query->expects($this->once())->method('_executeStatement')
 			->will($this->returnValue($statement));
 
 		$query->expects($this->once())->method('set')


### PR DESCRIPTION
As I'm writing the docs for the query builder I ran into a few issues that I've attempted to solve:
- A ResultSet should not be returned for non-select type queries.
- The Model.beforeFind event should not be triggered when doing insert, delete, or update queries.
- The return type of ORM\Query::execute() can now return either a ResultSet or a StatementInterface. This accounts for the various kinds of queries that can be run. We might want to further separate results from executing queries. Perhaps having fetch()/get() get results and execute() get statements.
- Split resultset building from query execution. This will help make building cachable finders easier.
