### PR TITLE
3.0 - Split union into 2 methods.

### DIFF
--- a/Cake/Database/Dialect/SqliteDialectTrait.php
+++ b/Cake/Database/Dialect/SqliteDialectTrait.php
@@ -125,7 +125,7 @@ trait SqliteDialectTrait {
 			}
 
 			$q = $newQuery->connection()->newQuery();
-			$newQuery->union($q->select($select), true);
+			$newQuery->unionAll($q->select($select));
 		}
 
 		if ($newQuery->type()) {

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -1163,7 +1163,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * required by calling multiple times this method with different queries.
  *
  * By default, the UNION operator will remove duplicate rows, if you wish to include
- * every row for all queries, set the second argument to true.
+ * every row for all queries, use unionAll()
  *
  * ## Examples
  *
@@ -1176,9 +1176,33 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * ``SELECT id, name FROM things d UNION SELECT id, title FROM articles a``
  *
+ * @param string|Query $query full SQL query to be used in UNION operator
+ * @param boolean $overwrite whether to reset the list of queries to be operated or not
+ * @return Query
+ */
+	public function union($query, $overwrite = false) {
+		if ($overwrite) {
+			$this->_parts['union'] = [];
+		}
+		$this->_parts['union'][] = [
+			'all' => false,
+			'query' => $query
+		];
+		$this->_dirty();
+		return $this;
+	}
+
+/**
+ * Adds a complete query to be used in conjunction with the UNION ALL operator with
+ * this query. This is used to combine the result set of this query with the one
+ * that will be returned by the passed query. You can add as many queries as you
+ * required by calling multiple times this method with different queries.
+ *
+ * Unlike UNION, UNION ALL will not remove duplicate rows.
+ *
  * {{{
- *	$union = (new Query($conn))->select(['id', 'title'])->from(['a' => 'articles']);
- *	$query->select(['id', 'name'])->from(['d' => 'things'])->union($union, true);
+ * $union = (new Query($conn))->select(['id', 'title'])->from(['a' => 'articles']);
+ * $query->select(['id', 'name'])->from(['d' => 'things'])->unionAll($union);
  * }}}
  *
  * Will produce:
@@ -1186,15 +1210,17 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``SELECT id, name FROM things d UNION ALL SELECT id, title FROM articles a``
  *
  * @param string|Query $query full SQL query to be used in UNION operator
- * @param boolean $all whether to use UNION ALL or not
  * @param boolean $overwrite whether to reset the list of queries to be operated or not
  * @return Query
  */
-	public function union($query, $all = false, $overwrite = false) {
+	public function unionAll($query, $overwrite = false) {
 		if ($overwrite) {
 			$this->_parts['union'] = [];
 		}
-		$this->_parts['union'][] = compact('all', 'query');
+		$this->_parts['union'][] = [
+			'all' => true,
+			'query' => $query
+		];
 		$this->_dirty();
 		return $this;
 	}

--- a/Cake/Test/TestCase/Database/QueryTest.php
+++ b/Cake/Test/TestCase/Database/QueryTest.php
@@ -1449,7 +1449,7 @@ class QueryTest extends TestCase {
 		$union = (new Query($this->connection))
 			->select(['id', 'title'])
 			->from(['c' => 'articles']);
-		$query->select(['id', 'comment'], true)->union($union, false, true);
+		$query->select(['id', 'comment'], true)->union($union, true);
 		$result = $query->execute();
 		$this->assertCount(self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
 		$this->assertEquals($rows, $result->fetchAll());
@@ -1477,7 +1477,7 @@ class QueryTest extends TestCase {
 			->where(['id ' => 1])
 			->order(['id' => 'desc']);
 
-		$query->select(['foo' => 'id', 'bar' => 'comment'])->union($union, true);
+		$query->select(['foo' => 'id', 'bar' => 'comment'])->unionAll($union);
 		$result = $query->execute();
 		$this->assertCount(1 + self::COMMENT_COUNT + self::ARTICLE_COUNT, $result);
 		$this->assertNotEquals($rows, $result->fetchAll());


### PR DESCRIPTION
When writing the docs for unions() I thought it would be much easier to explain and used if we had  separate methods for union and unionAll. I find two methods makes reading code simpler as there are fewer boolean arguments floating around.
