### PR TITLE
3.0 - Add ability to handle a list of ids for belongs to many.

### DIFF
--- a/Cake/ORM/Marshaller.php
+++ b/Cake/ORM/Marshaller.php
@@ -153,6 +153,10 @@ class Marshaller {
  * @return array An array of built entities.
  */
 	protected function _belongsToMany(Association $assoc, array $data, $include = []) {
+		if (isset($data['_ids']) && is_array($data['_ids'])) {
+			return $this->_loadBelongsToMany($assoc, $data['_ids']);
+		}
+
 		$records = $this->many($data, $include);
 		if (!in_array('_joinData', $include) && !isset($include['_joinData'])) {
 			return $records;
@@ -173,6 +177,24 @@ class Marshaller {
 			}
 		}
 		return $records;
+	}
+
+/**
+ * Loads a list of belongs to many from ids.
+ *
+ * @param Association $assoc The association class for the belongsToMany association.
+ * @param array $ids The list of ids to load.
+ * @return array An array of entities.
+ */
+	protected function _loadBelongsToMany($assoc, $ids) {
+		$target = $assoc->target();
+		$primaryKey = (array)$target->primaryKey();
+		if (count($primaryKey) > 1) {
+			return [];
+		}
+		return $assoc->find('all')
+			->where([$primaryKey[0] . ' IN' => $ids])
+			->toArray();
 	}
 
 }

--- a/Cake/Test/TestCase/ORM/MarshallerTest.php
+++ b/Cake/Test/TestCase/ORM/MarshallerTest.php
@@ -48,7 +48,7 @@ class ProtectedArticle extends Entity {
  */
 class MarshallerTest extends TestCase {
 
-	public $fixtures = ['core.article', 'core.user', 'core.comment'];
+	public $fixtures = ['core.tag', 'core.article', 'core.user', 'core.comment'];
 
 /**
  * setup
@@ -411,6 +411,26 @@ class MarshallerTest extends TestCase {
 			$data[1]['user']['username'],
 			$result[1]->user->username
 		);
+	}
+
+/**
+ * Test generating a list of entities from a list of ids.
+ *
+ * @return void
+ */
+	public function testOneGenerateBelongsToManyEntitiesFromIds() {
+		$data = [
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
+			'tags' => ['_ids' => [1, 2, 3]]
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, ['Tags']);
+
+		$this->assertCount(3, $result->tags);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[1]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
 	}
 
 }


### PR DESCRIPTION
When building forms it is way easier to send a list of IDs instead of a list of entities. The marshaller should handle converting the list of ids into the related entities.

Refs #2510
