### PR TITLE
2.4 save tree invalid scope

### DIFF
--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -212,7 +212,7 @@ class TreeBehavior extends ModelBehavior {
 					'fields' => array($Model->primaryKey, $parent, $left, $right), 'recursive' => $recursive)
 				);
 
-				if ($values === false) {
+				if (empty($values)) {
 					return false;
 				}
 				list($node) = array_values($values);

--- a/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TreeBehaviorScopedTest.php
@@ -131,6 +131,29 @@ class TreeBehaviorScopedTest extends CakeTestCase {
 	}
 
 /**
+ * testSaveWithParentAndInvalidScope method
+ *
+ * Attempting to save an invalid data should not trigger an `Undefined offset`
+ * error
+ *
+ * @return void
+ */
+	public function testSaveWithParentAndInvalidScope() {
+		$this->Tree = new FlagTree();
+		$this->Tree->order = null;
+		$data = $this->Tree->create(array(
+			'name' => 'Flag',
+		));
+		$tree = $this->Tree->save($data);
+		$this->Tree->Behaviors->load('Tree', array(
+			'scope' => array('FlagTree.flag' => 100)
+		));
+		$tree['FlagTree']['parent_id'] = 1;
+		$result = $this->Tree->save($tree);
+		$this->assertFalse($result);
+	}
+
+/**
  * testMoveUpWithScope method
  *
  * @return void


### PR DESCRIPTION
Even though the data is invalid, cakephp should not barf with `undefined index` error
