### PR TITLE
3.0 - Make TableRegistry methods throw exceptions.

### DIFF
--- a/Cake/Network/Session/DatabaseSession.php
+++ b/Cake/Network/Session/DatabaseSession.php
@@ -51,9 +51,8 @@ class DatabaseSession implements SessionHandlerInterface {
 		$modelAlias = Configure::read('Session.handler.model');
 
 		if (empty($modelAlias)) {
-			$this->_table = TableRegistry::get('Sessions', [
-				'table' => 'cake_sessions',
-			]);
+			$config = TableRegistry::exists('Sessions') ? [] : ['table' => 'cake_sessions'];
+			$this->_table = TableRegistry::get('Sessions', $config);
 		} else {
 			$this->_table = TableRegistry::get($modelAlias);
 		}

--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -237,9 +237,11 @@ abstract class Association {
 		}
 
 		if ($table === null) {
-			$this->_targetTable = TableRegistry::get($this->_name, [
-				'className' => $this->_className,
-			]);
+			$config = [];
+			if (!TableRegistry::exists($this->_name)) {
+				$config = ['className' => $this->_className];
+			}
+			$this->_targetTable = TableRegistry::get($this->_name, $config);
 		}
 		return $this->_targetTable;
 	}

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -124,9 +124,12 @@ class BelongsToMany extends Association {
 			if (empty($this->_junctionTable)) {
 				$tableName = $this->_junctionTableName();
 				$tableAlias = Inflector::camelize($tableName);
-				$table = TableRegistry::get($tableAlias, [
-					'table' => $tableName
-				]);
+
+				$config = [];
+				if (!TableRegistry::exists($tableAlias)) {
+					$config = ['table' => $tableName];
+				}
+				$table = TableRegistry::get($tableAlias, $config);
 			} else {
 				return $this->_junctionTable;
 			}

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -211,7 +211,7 @@ class QueryTest extends TestCase {
 			]
 		];
 
-		$table = TableRegistry::get('foo', ['schema' => ['id' => ['type' => 'integer']]]);
+		$table = TableRegistry::get('foo');
 		$query = new Query($this->connection, $table);
 
 		$query->select('foo.id')->contain($contains)->sql();

--- a/Cake/Test/TestCase/ORM/TableRegistryTest.php
+++ b/Cake/Test/TestCase/ORM/TableRegistryTest.php
@@ -83,6 +83,33 @@ class TableRegistryTest extends TestCase {
 	}
 
 /**
+ * Test calling config() on existing instances throws an error.
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage You cannot configure "Users", it has already been constructed.
+ * @return void
+ */
+	public function testConfigOnDefinedInstance() {
+		$users = TableRegistry::get('Users');
+		TableRegistry::config('Users', ['table' => 'my_users']);
+	}
+
+/**
+ * Test the exists() method.
+ *
+ * @return void
+ */
+	public function testExists() {
+		$this->assertFalse(TableRegistry::exists('Articles'));
+
+		TableRegistry::config('Articles', ['table' => 'articles']);
+		$this->assertFalse(TableRegistry::exists('Articles'));
+
+		TableRegistry::get('Articles', ['table' => 'articles']);
+		$this->assertTrue(TableRegistry::exists('Articles'));
+	}
+
+/**
  * Test getting instances from the registry.
  *
  * @return void
@@ -94,9 +121,7 @@ class TableRegistryTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Table', $result);
 		$this->assertEquals('my_articles', $result->table());
 
-		$result2 = TableRegistry::get('Articles', [
-			'table' => 'herp_derp',
-		]);
+		$result2 = TableRegistry::get('Articles');
 		$this->assertSame($result, $result2);
 		$this->assertEquals('my_articles', $result->table());
 	}
@@ -112,6 +137,18 @@ class TableRegistryTest extends TestCase {
 		]);
 		$result = TableRegistry::get('Articles');
 		$this->assertEquals('my_articles', $result->table(), 'Should use config() data.');
+	}
+
+/**
+ * Test get with config throws an exception if the alias exists already.
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage You cannot configure "Users", it already exists in the registry.
+ * @return void
+ */
+	public function testGetExistingWithConfigData() {
+		$users = TableRegistry::get('Users');
+		TableRegistry::get('Users', ['table' => 'my_users']);
 	}
 
 /**


### PR DESCRIPTION
When you attempt to reconfigure an existing object in the registry either though config() or get() we should throw an exception. Prior to exceptions the updated configuration would not be applied.

Throwing exceptions will help developers find issues where they might not be getting the configuration data they think they should be getting.

Refs #2336
