### PR TITLE
Added composer.json for CakePHP 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "cakephp/cakephp",
+    "description": "The CakePHP framework",
+    "type": "library",
+    "keywords": ["framework"],
+    "homepage": "http://cakephp.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/cakephp/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/cakephp/cakephp/issues",
+        "forum": "http://stackoverflow.com/tags/cakephp",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/cakephp"
+    },
+    "require": {
+        "php": ">=5.2.8",
+        "ext-mcrypt": "*",
+        "ext-mbstring": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*",
+        "cakephp/debug_kit" : "2.2.*"
+    },
+    "bin": [
+        "lib/Cake/Console/cake"
+    ]
+}


### PR DESCRIPTION
Changes from the 3.x composer file:
- No autoloader configured
- Updated path to binary
- Added debug_kit as a dev requirement

We'll need to update packagist once this has gone through. I don't have access to that. @markstory or @lorenzo might.
