### PR TITLE
Adding Collection::compile as a way to optimize operations with a single collection

### DIFF
--- a/Cake/Collection/CollectionTrait.php
+++ b/Cake/Collection/CollectionTrait.php
@@ -668,9 +668,9 @@ trait CollectionTrait {
  * $allButJohn = $compiled->filter($johnMatcher);
  * }}}
  *
- * In the above example, had not the collection compiled before, the iterations
- * for `map`, `sortBy` and `extract` would've been executed twice: once for
- * getting `$isJohnHere` and once for `$allButJohn`
+ * In the above example, had the collection not been compiled before, the
+ * iterations for `map`, `sortBy` and `extract` would've been executed twice:
+ * once for getting `$isJohnHere` and once for `$allButJohn`
  *
  * You can think of this method as a way to create save points for complex
  * calculations in a collection.

--- a/Cake/Collection/CollectionTrait.php
+++ b/Cake/Collection/CollectionTrait.php
@@ -649,4 +649,40 @@ trait CollectionTrait {
 		return $this->toArray();
 	}
 
+/**
+ * Iterates once all elements in this collection and executes all stacked
+ * operations of them, finally it returns a new collection with the result.
+ * This is useful for converting non-rewindable internal iterators into
+ * a collection that can be rewound and used multiple times.
+ *
+ * A common use case is to re-use the same variable for calculating different
+ * data. In those cases it may be helpful and more performant to first compile
+ * a collection and then apply more operations to it.
+ *
+ * ### Example:
+ *
+ * {{{
+ * $collection->map($mapper)->sortBy('age')->extract('name');
+ * $compiled = $collection->compile();
+ * $isJohnHere = $compiled->some($johnMatcher);
+ * $allButJohn = $compiled->filter($johnMatcher);
+ * }}}
+ *
+ * In the above example, had not the collection compiled before, the iterations
+ * for `map`, `sortBy` and `extract` would've been executed twice: once for
+ * getting `$isJohnHere` and once for `$allButJohn`
+ *
+ * You can think of this method as a way to create save points for complex
+ * calculations in a collection.
+ *
+ * @param boolean $preserveKeys whether to use the keys returned by this
+ * collection as the array keys. Keep in mind that it is valid for iterators
+ * to return the same key for different elements, setting this value to false
+ * can help getting all items if keys are not important in the result.
+ * @return \Cake\Collection\Collection
+ */
+	public function compile($preserveKeys = true) {
+		return new Collection($this->toArray($preserveKeys));
+	}
+
 }

--- a/Cake/Test/TestCase/Collection/CollectionTest.php
+++ b/Cake/Test/TestCase/Collection/CollectionTest.php
@@ -604,4 +604,31 @@ class CollectionTest extends TestCase {
 		$this->assertEquals(['a' => 4, 'b' => 2, 'c' => 3], $combined->toArray());
 	}
 
+/**
+ * Tests that by calling compile internal iteration operations are not done
+ * more than once
+ *
+ * @return void
+ */
+	public function testCompile() {
+		$items = ['a' => 1, 'b' => 2, 'c' => 3];
+		$collection = new Collection($items);
+		$callable = $this->getMock('stdClass', ['__invoke']);
+		$callable->expects($this->at(0))
+			->method('__invoke')
+			->with(1, 'a')
+			->will($this->returnValue(4));
+		$callable->expects($this->at(1))
+			->method('__invoke')
+			->with(2, 'b')
+			->will($this->returnValue(5));
+		$callable->expects($this->at(2))
+			->method('__invoke')
+			->with(3, 'c')
+			->will($this->returnValue(6));
+		$compiled = $collection->map($callable)->compile();
+		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $compiled->toArray());
+		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $compiled->toArray());
+	}
+
 }


### PR DESCRIPTION
After the talk in IRC about streaming results I thought it would be nice to consolidate all results from an internal iterator into another collection. Also, I realized that by nesting iterators there would be a chance of wasting CPU by calculating stuff twice if the same variable is used.

This introduces `Collection::compile()`, a way of copying the results of toArray() from a collection into a new one in order to consolidate internal operations and to easily make iterators that would not rewind, rewindable
