### PR TITLE
3.0 Easier methods for ORM\Query

### DIFF
--- a/Cake/Database/Connection.php
+++ b/Cake/Database/Connection.php
@@ -269,7 +269,8 @@ class Connection {
  */
 	public function insert($table, array $data, array $types = []) {
 		$columns = array_keys($data);
-		return $this->newQuery()->insert($table, $columns, $types)
+		return $this->newQuery()->insert($columns, $types)
+			->into($table)
 			->values($data)
 			->execute();
 	}

--- a/Cake/Database/IdentifierQuoter.php
+++ b/Cake/Database/IdentifierQuoter.php
@@ -164,7 +164,7 @@ class IdentifierQuoter {
 				$column = $this->_driver->quoteIdentifier($column);
 			}
 		}
-		$query->insert($table, $columns);
+		$query->insert($columns)->into($table);
 	}
 
 /**

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -1292,20 +1292,32 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Note calling this method will reset any data previously set
  * with Query::values()
  *
- * @param string $table The table name to insert into.
  * @param array $columns The columns to insert into.
  * @param array $types A map between columns & their datatypes.
  * @return Query
  */
-	public function insert($table, $columns, $types = []) {
+	public function insert($columns, $types = []) {
 		$this->_dirty();
 		$this->_type = 'insert';
-		$this->_parts['insert'] = [$table, $columns];
+		$this->_parts['insert'][1] = $columns;
 
 		if (!$this->_parts['values']) {
 			$this->_parts['values'] = new ValuesExpression($columns, $types + $this->defaultTypes());
 		}
 
+		return $this;
+	}
+
+/**
+ * Set the table name for insert queries.
+ *
+ * @param string $table The table name to insert into.
+ * @return Query
+ */
+	public function into($table) {
+		$this->_dirty();
+		$this->_type = 'insert';
+		$this->_parts['insert'][0] = $table;
 		return $this;
 	}
 

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -1294,6 +1294,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string $table The table name to insert into.
  * @param array $columns The columns to insert into.
+ * @param array $types A map between columns & their datatypes.
  * @return Query
  */
 	public function insert($table, $columns, $types = []) {

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -986,12 +986,12 @@ class Query extends DatabaseQuery {
  *
  * @param array $columns The columns to insert into.
  * @param array $types A map between columns & their datatypes.
- * @param array $unused An unused parameter from the parent class' interface
  * @return Query
  */
-	public function insert($columns, $types = [], $unused = []) {
+	public function insert($columns, $types = []) {
 		$table = $this->repository()->table();
-		return parent::insert($table, $columns, $types);
+		$this->into($table);
+		return parent::insert($columns, $types);
 	}
 
 }

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -947,4 +947,51 @@ class Query extends DatabaseQuery {
 		parent::_dirty();
 	}
 
+/**
+ * Create an update query.
+ *
+ * This changes the query type to be 'update'.
+ * Can be combined with set() and where() methods to create update queries.
+ *
+ * @param string $table Unused parameter.
+ * @return Query
+ */
+	public function update($table = null) {
+		$table = $this->repository()->table();
+		return parent::update($table);
+	}
+
+/**
+ * Create a delete query.
+ *
+ * This changes the query type to be 'delete'.
+ * Can be combined with the where() method to create delete queries.
+ *
+ * @param string $table Unused parameter.
+ * @return Query
+ */
+	public function delete($table = null) {
+		$table = $this->repository()->table();
+		return parent::delete($table);
+	}
+
+/**
+ * Create an insert query.
+ *
+ * This changes the query type to be 'insert'.
+ * Note calling this method will reset any data previously set
+ * with Query::values()
+ *
+ * Can be combined with the where() method to create delete queries.
+ *
+ * @param array $columns The columns to insert into.
+ * @param array $types A map between columns & their datatypes.
+ * @param array $unused An unused parameter from the parent class' interface
+ * @return Query
+ */
+	public function insert($columns, $types = [], $unused = []) {
+		$table = $this->repository()->table();
+		return parent::insert($table, $columns, $types);
+	}
+
 }

--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -864,7 +864,7 @@ class Table implements EventListener {
  */
 	public function updateAll($fields, $conditions) {
 		$query = $this->query();
-		$query->update($this->table())
+		$query->update()
 			->set($fields)
 			->where($conditions);
 		$statement = $query->execute();
@@ -957,7 +957,7 @@ class Table implements EventListener {
  */
 	public function deleteAll($conditions) {
 		$query = $this->query();
-		$query->delete($this->table())
+		$query->delete()
 			->where($conditions);
 		$statement = $query->execute();
 		$success = $statement->rowCount() > 0;
@@ -1188,7 +1188,7 @@ class Table implements EventListener {
 			$data[$primary] = $id;
 		}
 
-		$statement = $query->insert($this->table(), array_keys($data))
+		$statement = $query->insert(array_keys($data))
 			->values($data)
 			->execute();
 
@@ -1248,7 +1248,7 @@ class Table implements EventListener {
 		}
 
 		$query = $this->query();
-		$statement = $query->update($this->table())
+		$statement = $query->update()
 			->set($data)
 			->where($primaryKey)
 			->execute();
@@ -1338,7 +1338,7 @@ class Table implements EventListener {
 		}
 
 		$query = $this->query();
-		$statement = $query->delete($this->table())
+		$statement = $query->delete()
 			->where($conditions)
 			->execute();
 

--- a/Cake/Test/TestCase/Database/Driver/PostgresTest.php
+++ b/Cake/Test/TestCase/Database/Driver/PostgresTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -150,13 +148,18 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 			[['log' => false]]
 		);
 		$query = new \Cake\Database\Query($connection);
-		$query->insert('articles', ['id', 'title'])->values([1, 'foo']);
+		$query->insert(['id', 'title'])
+			->into('articles')
+			->values([1, 'foo']);
 		$translator = $driver->queryTranslator('insert');
 		$query = $translator($query);
 		$this->assertEquals('RETURNING *', $query->clause('epilog'));
 
 		$query = new \Cake\Database\Query($connection);
-		$query->insert('articles', ['id', 'title'])->values([1, 'foo'])->epilog('FOO');
+		$query->insert(['id', 'title'])
+			->into('articles')
+			->values([1, 'foo'])
+			->epilog('FOO');
 		$query = $translator($query);
 		$this->assertEquals('FOO', $query->clause('epilog'));
 	}

--- a/Cake/Test/TestCase/Database/Log/QueryLoggerTest.php
+++ b/Cake/Test/TestCase/Database/Log/QueryLoggerTest.php
@@ -91,10 +91,13 @@ class QueryLoggerTest extends \Cake\TestSuite\TestCase {
 		$query = new LoggedQuery;
 		$query->query = 'SELECT a FROM b where a = ? AND b = ? AND c = ?';
 		$query->params = ['string', '3', null];
+
 		$engine = $this->getMock('\Cake\Log\Engine\BaseLog', ['write'], ['scopes' => ['queriesLog']]);
 		Log::engine('queryLoggerTest', $engine);
+
 		$engine2 = $this->getMock('\Cake\Log\Engine\BaseLog', ['write'], ['scopes' => ['foo']]);
-		Log::engine('queryLoggerTest2', $engine);
+		Log::engine('queryLoggerTest2', $engine2);
+
 		$engine2->expects($this->never())->method('write');
 		$logger->log($query);
 	}

--- a/Cake/Test/TestCase/Database/QueryTest.php
+++ b/Cake/Test/TestCase/Database/QueryTest.php
@@ -1702,7 +1702,8 @@ class QueryTest extends TestCase {
  */
 	public function testInsertSimple() {
 		$query = new Query($this->connection);
-		$query->insert('articles', ['title', 'body'])
+		$query->insert(['title', 'body'])
+			->into('articles')
 			->values([
 				'title' => 'mark',
 				'body' => 'test insert'
@@ -1738,7 +1739,8 @@ class QueryTest extends TestCase {
  */
 	public function testInsertSparseRow() {
 		$query = new Query($this->connection);
-		$query->insert('articles', ['title', 'body'])
+		$query->insert(['title', 'body'])
+			->into('articles')
 			->values([
 				'title' => 'mark',
 			]);
@@ -1772,7 +1774,8 @@ class QueryTest extends TestCase {
  */
 	public function testInsertMultipleRowsSparse() {
 		$query = new Query($this->connection);
-		$query->insert('articles', ['title', 'body'])
+		$query->insert(['title', 'body'])
+			->into('articles')
 			->values([
 				'body' => 'test insert'
 			])
@@ -1814,10 +1817,10 @@ class QueryTest extends TestCase {
 
 		$query = new Query($this->connection);
 		$query->insert(
-			'articles',
 			['title', 'body', 'author_id'],
 			['title' => 'string', 'body' => 'string', 'author_id' => 'integer']
 		)
+		->into('articles')
 		->values($select);
 
 		$result = $query->sql();
@@ -1853,7 +1856,8 @@ class QueryTest extends TestCase {
  */
 	public function testInsertFailureMixingTypesArrayFirst() {
 		$query = new Query($this->connection);
-		$query->insert('articles', ['name'])
+		$query->insert(['name'])
+			->into('articles')
 			->values(['name' => 'mark'])
 			->values(new Query($this->connection));
 	}
@@ -1865,7 +1869,8 @@ class QueryTest extends TestCase {
  */
 	public function testInsertFailureMixingTypesQueryFirst() {
 		$query = new Query($this->connection);
-		$query->insert('articles', ['name'])
+		$query->insert(['name'])
+			->into('articles')
 			->values(new Query($this->connection))
 			->values(['name' => 'mark']);
 	}
@@ -2015,7 +2020,8 @@ class QueryTest extends TestCase {
 	public function testAppendInsert() {
 		$query = new Query($this->connection);
 		$sql = $query
-			->insert('articles', ['id', 'title'])
+			->insert(['id', 'title'])
+			->into('articles')
 			->values([1, 'a title'])
 			->epilog('RETURNING id')
 			->sql();
@@ -2197,13 +2203,15 @@ class QueryTest extends TestCase {
 	public function testQuotingInsert() {
 		$this->connection->driver()->autoQuoting(true);
 		$query = new Query($this->connection);
-		$sql = $query->insert('foo', ['bar', 'baz'])
+		$sql = $query->insert(['bar', 'baz'])
+			->into('foo')
 			->where(['something' => 'value'])
 			->sql();
 		$this->assertQuotedQuery('INSERT INTO <foo> \(<bar>, <baz>\)', $sql);
 
 		$query = new Query($this->connection);
-		$sql = $query->insert('foo', [$query->newExpr()->add('bar')])
+		$sql = $query->insert([$query->newExpr()->add('bar')])
+			->into('foo')
 			->where(['something' => 'value'])
 			->sql();
 		$this->assertQuotedQuery('INSERT INTO <foo> \(\(bar\)\)', $sql);

--- a/Cake/Test/TestCase/Database/Schema/CollectionTest.php
+++ b/Cake/Test/TestCase/Database/Schema/CollectionTest.php
@@ -51,6 +51,7 @@ class CollectionTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		unset($this->connection);
+		Cache::clear(true, '_cake_model_');
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1413,40 +1413,53 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Test that there is no beforeFind event with update queries.
+ * Test update method.
  *
  * @return void
  */
-	public function testUpdateNoBeforeFind() {
+	public function testUpdate() {
 		$table = TableRegistry::get('articles');
-		$table->getEventManager()->attach(function() {
-			$this->fail('No callback should be fired');
-		}, 'Model.beforeFind');
 
-		$query = $table->query()
-			->update($table->table())
-			->set(['title' => 'First']);
+		$result = $table->query()
+			->update()
+			->set(['title' => 'First'])
+			->execute();
 
-		$result = $query->execute();
 		$this->assertInstanceOf('Cake\Database\StatementInterface', $result);
 		$this->assertTrue($result->rowCount() > 0);
 	}
 
 /**
- * Test that there is no beforeFind event with delete queries.
+ * Test insert method.
  *
  * @return void
  */
-	public function testDeleteNoBeforeFind() {
+	public function testInsert() {
 		$table = TableRegistry::get('articles');
-		$table->getEventManager()->attach(function() {
-			$this->fail('No callback should be fired');
-		}, 'Model.beforeFind');
 
-		$query = $table->query()
-			->delete($table->table());
+		$result = $table->query()
+			->insert(['title'])
+			->values(['title' => 'First'])
+			->values(['title' => 'Second'])
+			->execute();
 
-		$result = $query->execute();
+		$this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+		$this->assertEquals(2, $result->rowCount());
+	}
+
+/**
+ * Test delete method.
+ *
+ * @return void
+ */
+	public function testDelete() {
+		$table = TableRegistry::get('articles');
+
+		$result = $table->query()
+			->delete()
+			->where(['id >=' => 1])
+			->execute();
+
 		$this->assertInstanceOf('Cake\Database\StatementInterface', $result);
 		$this->assertTrue($result->rowCount() > 0);
 	}

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -489,15 +489,17 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = $this->getMock(
 			'Cake\ORM\Table',
 			['query'],
-			[['table' => 'users']]
+			[['table' => 'users', 'connection' => $this->connection]]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
+
 		$query->expects($this->once())
 			->method('_executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
+
 		$table->updateAll(['username' => 'mark'], []);
 	}
 
@@ -530,13 +532,15 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['query'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
+
 		$query->expects($this->once())
 			->method('_executeStatement')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
+
 		$table->deleteAll(['id >' => 4]);
 	}
 

--- a/Cake/Test/TestCase/ORM/TableUuidTest.php
+++ b/Cake/Test/TestCase/ORM/TableUuidTest.php
@@ -21,13 +21,14 @@ use Cake\Database\ConnectionManager;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
 use Cake\Utility\String;
 
 /**
  * Integration tests for Table class with uuid primary keys.
  *
  */
-class UuidTableTest extends \Cake\TestSuite\TestCase {
+class TableUuidTest extends TestCase {
 
 /**
  * Fixtures

--- a/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
+++ b/Cake/Test/TestCase/TestSuite/TestFixtureTest.php
@@ -234,22 +234,28 @@ class TestFixtureTest extends TestCase {
 
 		$query->expects($this->once())
 			->method('insert')
-			->with('articles', ['name', 'created'], ['string', 'datetime'])
+			->with(['name', 'created'], ['string', 'datetime'])
 			->will($this->returnSelf());
+
+		$query->expects($this->once())
+			->method('into')
+			->with('articles')
+			->will($this->returnSelf());
+
 		$expected = [
 			['name' => 'Gandalf', 'created' => '2009-04-28 19:20:00'],
 			['name' => 'Captain Picard', 'created' => '2009-04-28 19:20:00'],
 			['name' => 'Chewbacca', 'created' => '2009-04-28 19:20:00']
 		];
-		$query->expects($this->at(1))
+		$query->expects($this->at(2))
 			->method('values')
 			->with($expected[0])
 			->will($this->returnSelf());
-		$query->expects($this->at(2))
+		$query->expects($this->at(3))
 			->method('values')
 			->with($expected[1])
 			->will($this->returnSelf());
-		$query->expects($this->at(3))
+		$query->expects($this->at(4))
 			->method('values')
 			->with($expected[2])
 			->will($this->returnSelf());
@@ -279,7 +285,12 @@ class TestFixtureTest extends TestCase {
 
 		$query->expects($this->once())
 			->method('insert')
-			->with('strings', ['name', 'email', 'age'], ['string', 'string', 'integer'])
+			->with(['name', 'email', 'age'], ['string', 'string', 'integer'])
+			->will($this->returnSelf());
+
+		$query->expects($this->once())
+			->method('into')
+			->with('strings')
 			->will($this->returnSelf());
 
 		$expected = [
@@ -287,15 +298,15 @@ class TestFixtureTest extends TestCase {
 			['name' => 'John Doe', 'email' => 'john.doe@email.com', 'age' => 20],
 			['name' => 'Jane Doe', 'email' => 'jane.doe@email.com', 'age' => 30],
 		];
-		$query->expects($this->at(1))
+		$query->expects($this->at(2))
 			->method('values')
 			->with($expected[0])
 			->will($this->returnSelf());
-		$query->expects($this->at(2))
+		$query->expects($this->at(3))
 			->method('values')
 			->with($expected[1])
 			->will($this->returnSelf());
-		$query->expects($this->at(3))
+		$query->expects($this->at(4))
 			->method('values')
 			->with($expected[2])
 			->will($this->returnSelf());

--- a/Cake/TestSuite/Fixture/TestFixture.php
+++ b/Cake/TestSuite/Fixture/TestFixture.php
@@ -276,7 +276,8 @@ class TestFixture {
 		if (isset($this->records) && !empty($this->records)) {
 			list($fields, $values, $types) = $this->_getRecords();
 			$query = $db->newQuery()
-				->insert($this->table, $fields, $types);
+				->insert($fields, $types)
+				->into($this->table);
 
 			foreach ($values as $row) {
 				$query->values($row);

--- a/Cake/Validation/Validator.php
+++ b/Cake/Validation/Validator.php
@@ -386,7 +386,8 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  */
 	protected function _processRules(ValidationSet $rules, $value, $newRecord) {
 		$errors = [];
-		$this->provider('default'); // Loading default provider in case there is none
+		// Loading default provider in case there is none
+		$this->provider('default');
 		foreach ($rules as $name => $rule) {
 			$result = $rule->process($value, $this->_providers, $newRecord);
 			if ($result === true) {


### PR DESCRIPTION
Implement the changes described in #2550. I did not remove the column arguments for insert(). I figured keeping the method explicit was better than adding a bunch of implicit behavior. I also suspect these methods will be less frequently used as saving entities is generally simpler & better.
