### PR TITLE
Making it possible to call collection methods in the ResultSet directly from a Query object

### DIFF
--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -994,4 +994,26 @@ class Query extends DatabaseQuery {
 		return parent::insert($columns, $types);
 	}
 
+/**
+ * Enables calling methods from the ResultSet as if they were from this class
+ *
+ * @param string $method the method to call
+ * @param array $arguments list of arguments for the method to call
+ * @return mixed
+ * @throws \BadMethodCallException if no such method exists in ResultSet
+ */
+	public function __call($method, $arguments) {
+		if ($this->type() === 'select') {
+			$resultSetClass = __NAMESPACE__ . '\ResultSetDecorator';
+			if (in_array($method, get_class_methods($resultSetClass))) {
+				$object = $this->execute();
+				return call_user_func_array([$object, $method], $arguments);
+			}
+		}
+
+		throw new \BadMethodCallException(
+			__d('cake_dev', 'Unknown method "%s"', $method)
+		);
+	}
+
 }


### PR DESCRIPTION
This completes the "fantasy" of a Query as the result itself. This one is quite important to have as setting the results of a `$table->find()` directly to the view would not work correctly if collection methods are called on it from the template or a helper. With this change, users don't have to worry if the query has been executed at all before it is passed to another method.
