### PR TITLE
Add missing pkpass mimetype

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -299,6 +299,7 @@ class CakeResponse {
 		'vcf' => 'text/x-vcard',
 		'vtt' => 'text/vtt',
 		'mkv' => 'video/x-matroska',
+		'pkpass' => 'application/vnd.apple.pkpass'
 	);
 
 /**


### PR DESCRIPTION
This format is not yet available in the response class - and as Microsoft and other prop. formats are listed, we should add this missing one, as well.
Details see http://de.wikipedia.org/wiki/Passbook
