### PR TITLE
Must double quote the schema name in query

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Postgres.php
+++ b/lib/Cake/Model/Datasource/Database/Postgres.php
@@ -127,7 +127,7 @@ class Postgres extends DboSource {
 				$this->setEncoding($config['encoding']);
 			}
 			if (!empty($config['schema'])) {
-				$this->_execute('SET search_path TO ' . $config['schema']);
+				$this->_execute('SET search_path TO "' . $config['schema'] . '"');
 			}
 			if (!empty($config['settings'])) {
 				foreach ($config['settings'] as $key => $value) {


### PR DESCRIPTION
Schema names with reserved words such as "create" will fail this query without double quotes. 

Attempted prepared statement with ? placeholder. This failed with the following CakePHP error:

Error: A Database connection using "Postgres" was missing or unable to connect. 
The database server returned this error: SQLSTATE[42601]: Syntax error: 7 ERROR: syntax error at or near "$1" LINE 1: SET search_path TO $1 ^
