### PR TITLE
3.0 - Separate query->execute() & query->all()

### DIFF
--- a/Cake/Controller/Component/PaginatorComponent.php
+++ b/Cake/Controller/Component/PaginatorComponent.php
@@ -164,7 +164,7 @@ class PaginatorComponent extends Component {
 		$parameters = compact('conditions', 'fields', 'order', 'limit', 'page');
 		$query = $object->find($type, array_merge($parameters, $extra));
 
-		$results = $query->execute();
+		$results = $query->all();
 		$numResults = count($results);
 
 		$defaults = $this->getDefaults($alias, $settings);

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -47,7 +47,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @var string
  */
-	protected $_type;
+	protected $_type = 'select';
 
 /**
  * List of SQL parts that will be used to build this query

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -202,15 +202,6 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return Cake\Database\StatementInterface
  */
 	public function execute() {
-		return $this->_executeStatement();
-	}
-
-/**
- * Internal implementation of statement execution.
- *
- * @return Cake\Database\StatementInterface
- */
-	protected function _executeStatement() {
 		$query = $this->_transformQuery();
 		$statement = $this->_connection->prepare($query->sql());
 		$query->_bindStatement($statement);

--- a/Cake/Database/Query.php
+++ b/Cake/Database/Query.php
@@ -47,7 +47,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @var string
  */
-	protected $_type = 'select';
+	protected $_type;
 
 /**
  * List of SQL parts that will be used to build this query

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -254,7 +254,7 @@ class BelongsToMany extends Association {
 		$property = $this->target()->association($this->junction()->alias())->property();
 		$hydrated = $fetchQuery->hydrate();
 
-		foreach ($fetchQuery->execute() as $result) {
+		foreach ($fetchQuery->all() as $result) {
 			$result[$this->_junctionProperty] = $result[$property];
 			unset($result[$property]);
 

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -87,7 +87,7 @@ class HasMany extends Association {
 		$fetchQuery = $this->_buildQuery($options);
 		$resultMap = [];
 		$key = $options['foreignKey'];
-		foreach ($fetchQuery->execute() as $result) {
+		foreach ($fetchQuery->all() as $result) {
 			$resultMap[$result[$key]][] = $result;
 		}
 

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -417,7 +417,7 @@ class Query extends DatabaseQuery {
  *   queries a statement will be returned.
  */
 	public function execute() {
-		if ($this->_type === 'select' || $this->_type === null) {
+		if ($this->_type === 'select') {
 			$table = $this->repository();
 			$event = new Event('Model.beforeFind', $table, [$this, $this->_options]);
 			$table->getEventManager()->dispatch($event);

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -428,7 +428,7 @@ class Query extends DatabaseQuery {
  * @throws RuntimeException if this method is called on a non-select Query.
  */
 	public function all() {
-		if ($this->_type !== 'select') {
+		if ($this->_type !== 'select' && $this->_type !== null) {
 			throw new \RuntimeException(__d(
 				'cake_dev',
 				'You cannot call all() on a non-select query. Use execute() instead.'

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -651,13 +651,8 @@ class Query extends DatabaseQuery {
 			$this->limit(1);
 		}
 		$this->bufferResults();
-<<<<<<< HEAD
-		$this->_results = $this->execute();
-		return $this->_results->first();
-=======
 		$this->_results = $this->all();
-		return $this->_results->one();
->>>>>>> Separate execute() into 2 methods.
+		return $this->_results->first();
 	}
 
 /**
@@ -1025,8 +1020,8 @@ class Query extends DatabaseQuery {
 		if ($this->type() === 'select') {
 			$resultSetClass = __NAMESPACE__ . '\ResultSetDecorator';
 			if (in_array($method, get_class_methods($resultSetClass))) {
-				$object = $this->execute();
-				return call_user_func_array([$object, $method], $arguments);
+				$results = $this->all();
+				return call_user_func_array([$results, $method], $arguments);
 			}
 		}
 

--- a/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/Cake/Test/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -722,7 +722,7 @@ class PaginatorComponentTest extends TestCase {
  * @return Query
  */
 	protected function _getMockFindQuery() {
-		$query = $this->getMock('Cake\ORM\Query', ['total', 'execute'], [], '', false);
+		$query = $this->getMock('Cake\ORM\Query', ['total', 'all'], [], '', false);
 
 		$results = $this->getMock('Cake\ORM\ResultSet', [], [], '', false);
 		$results->expects($this->any())
@@ -730,7 +730,7 @@ class PaginatorComponentTest extends TestCase {
 			->will($this->returnValue(2));
 
 		$query->expects($this->any())
-			->method('execute')
+			->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->any())

--- a/Cake/Test/TestCase/Database/Schema/CollectionTest.php
+++ b/Cake/Test/TestCase/Database/Schema/CollectionTest.php
@@ -41,6 +41,8 @@ class CollectionTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->connection = ConnectionManager::get('test');
+		Cache::clear(false, '_cake_model_');
+		Cache::enable();
 	}
 
 /**
@@ -51,7 +53,6 @@ class CollectionTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		unset($this->connection);
-		Cache::clear(true, '_cake_model_');
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -319,15 +319,19 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['execute', 'contain'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all', 'contain'], [null, null]);
 
-		$this->tag->expects($this->once())->method('find')->with('all')
+		$this->tag->expects($this->once())
+			->method('find')
+			->with('all')
 			->will($this->returnValue($query));
+
 		$results = [
 			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
 			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())
+			->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('contain')
@@ -378,18 +382,22 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
-		$methods = ['execute', 'contain', 'where', 'order'];
+		$methods = ['all', 'contain', 'where', 'order'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
-		$this->tag->expects($this->once())->method('find')->with('all')
+		$this->tag->expects($this->once())
+			->method('find')
+			->with('all')
 			->will($this->returnValue($query));
 		$results = [
 			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
 			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())
+			->method('all')
 			->will($this->returnValue($results));
 
-		$query->expects($this->once())->method('contain')
+		$query->expects($this->once())
+			->method('contain')
 			->with([
 				'ArticlesTags' => [
 					'conditions' => ['ArticlesTags.article_id in' => $keys],
@@ -435,7 +443,7 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
-		$methods = ['execute', 'contain', 'where', 'order', 'select'];
+		$methods = ['all', 'contain', 'where', 'order', 'select'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -443,7 +451,7 @@ class BelongsToManyTest extends TestCase {
 			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
 			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->once())->method('contain')
@@ -508,9 +516,11 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
-		$methods = ['execute', 'contain', 'where', 'order', 'select'];
+		$methods = ['all', 'contain', 'where', 'order', 'select'];
 		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
-		$this->tag->expects($this->once())->method('find')->with('all')
+		$this->tag->expects($this->once())
+			->method('find')
+			->with('all')
 			->will($this->returnValue($query));
 		$query->expects($this->any())->method('contain')->will($this->returnSelf());
 
@@ -550,18 +560,21 @@ class BelongsToManyTest extends TestCase {
 
 		$query = $this->getMock(
 			'Cake\ORM\Query',
-			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
+			['all', 'where', 'andWhere', 'order', 'select', 'contain'],
 			[null, null]
 		);
 		$query->hydrate(false);
 
-		$this->tag->expects($this->once())->method('find')->with('all')
+		$this->tag->expects($this->once())
+			->method('find')
+			->with('all')
 			->will($this->returnValue($query));
 		$results = [
 			['id' => 1, 'name' => 'foo', 'articles_tags' => ['article_id' => 1]],
 			['id' => 2, 'name' => 'bar', 'articles_tags' => ['article_id' => 2]]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())
+			->method('all')
 			->will($this->returnValue($results));
 
 		$expected = clone $parent;

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -119,14 +119,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['execute'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all'], [null, null]);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2],
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())->method('all')
 			->will($this->returnValue($results));
 
 		$callable = $association->eagerLoader(compact('keys', 'query'));
@@ -162,7 +162,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
-			['execute', 'where', 'andWhere', 'order'],
+			['all', 'where', 'andWhere', 'order'],
 			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -172,7 +172,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
 
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->at(0))->method('where')
@@ -211,7 +211,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
-			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
+			['all', 'where', 'andWhere', 'order', 'select', 'contain'],
 			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -221,7 +221,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
 
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->at(0))->method('where')
@@ -281,7 +281,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$keys = [1, 2, 3, 4];
 		$query = $this->getMock(
 			'Cake\ORM\Query',
-			['execute'],
+			['all'],
 			[null, null]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -311,7 +311,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'Cake\ORM\Query',
-			['execute', 'where', 'andWhere', 'order', 'select', 'contain'],
+			['all', 'where', 'andWhere', 'order', 'select', 'contain'],
 			[null, null]
 		);
 
@@ -321,7 +321,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2],
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
-		$query->expects($this->once())->method('execute')
+		$query->expects($this->once())->method('all')
 			->will($this->returnValue($results));
 
 		$query->expects($this->at(0))->method('where')

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -864,7 +864,7 @@ class QueryTest extends TestCase {
 		$stmt = $this->getMock('Cake\Database\StatementInterface');
 		$results = new ResultSet($query, $stmt);
 		$query->setResult($results);
-		$this->assertSame($results, $query->execute());
+		$this->assertSame($results, $query->all());
 	}
 
 /**
@@ -1040,7 +1040,7 @@ class QueryTest extends TestCase {
  */
 	public function testResultsAreWrappedInMapReduce() {
 		$params = [$this->connection, $this->table];
-		$query = $this->getMock('\Cake\ORM\Query', ['_executeStatement'], $params);
+		$query = $this->getMock('\Cake\ORM\Query', ['execute'], $params);
 
 		$statement = $this->getMock('\Database\StatementInterface', ['fetch', 'closeCursor']);
 		$statement->expects($this->exactly(3))
@@ -1048,7 +1048,7 @@ class QueryTest extends TestCase {
 			->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2], false));
 
 		$query->expects($this->once())
-			->method('_executeStatement')
+			->method('execute')
 			->will($this->returnValue($statement));
 
 		$query->mapReduce(function($k, $v, $mr) {
@@ -1063,7 +1063,7 @@ class QueryTest extends TestCase {
 			}
 		);
 
-		$this->assertEquals([2, 3], iterator_to_array($query->execute()));
+		$this->assertEquals([2, 3], iterator_to_array($query->all()));
 	}
 
 /**
@@ -1107,9 +1107,9 @@ class QueryTest extends TestCase {
 		$query->select(['id'])->toArray();
 
 		$first = $query->hydrate(false)->first();
-		$resultSet = $query->execute();
+		$resultSet = $query->all();
 		$this->assertEquals(['id' => 1], $first);
-		$this->assertSame($resultSet, $query->execute());
+		$this->assertSame($resultSet, $query->all());
 	}
 
 /**
@@ -1143,7 +1143,7 @@ class QueryTest extends TestCase {
 	public function testHydrateSimple() {
 		$table = TableRegistry::get('articles', ['table' => 'articles']);
 		$query = new Query($this->connection, $table);
-		$results = $query->select()->execute()->toArray();
+		$results = $query->select()->toArray();
 
 		$this->assertCount(3, $results);
 		foreach ($results as $r) {
@@ -1301,7 +1301,7 @@ class QueryTest extends TestCase {
 			'entityClass' => '\\' . $class
 		]);
 		$query = new Query($this->connection, $table);
-		$results = $query->select()->execute()->toArray();
+		$results = $query->select()->toArray();
 
 		$this->assertCount(3, $results);
 		foreach ($results as $r) {
@@ -1395,7 +1395,7 @@ class QueryTest extends TestCase {
 		$result = $query->count();
 		$this->assertEquals(2, $result);
 
-		$result = $query->execute();
+		$result = $query->all();
 		$this->assertEquals(['count' => 2], $result->first());
 	}
 

--- a/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -75,7 +75,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testRewindStreaming() {
 		$query = $this->table->find('all')->bufferResults(false);
-		$results = $query->execute();
+		$results = $query->all();
 		$first = $second = [];
 		foreach ($results as $result) {
 			$first[] = $result;

--- a/Cake/Test/TestCase/ORM/ResultSetTest.php
+++ b/Cake/Test/TestCase/ORM/ResultSetTest.php
@@ -58,7 +58,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testRewind() {
 		$query = $this->table->find('all');
-		$results = $query->execute();
+		$results = $query->all();
 		$first = $second = [];
 		foreach ($results as $result) {
 			$first[] = $result;
@@ -96,11 +96,11 @@ class ResultSetTest extends TestCase {
  */
 	public function testSerialization() {
 		$query = $this->table->find('all');
-		$results = $query->execute();
+		$results = $query->all();
 		$expected = $results->toArray();
 
 		$query2 = $this->table->find('all');
-		$results2 = $query2->execute();
+		$results2 = $query2->all();
 		$serialized = serialize($results2);
 		$outcome = unserialize($serialized);
 		$this->assertEquals($expected, $outcome->toArray());
@@ -113,7 +113,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testIteratorAfterSerializationNoHydration() {
 		$query = $this->table->find('all')->hydrate(false);
-		$results = unserialize(serialize($query->execute()));
+		$results = unserialize(serialize($query->all()));
 
 		// Use a loop to test Iterator implementation
 		foreach ($results as $i => $row) {
@@ -128,7 +128,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testIteratorAfterSerializationHydrated() {
 		$query = $this->table->find('all');
-		$results = unserialize(serialize($query->execute()));
+		$results = unserialize(serialize($query->all()));
 
 		// Use a loop to test Iterator implementation
 		foreach ($results as $i => $row) {
@@ -145,7 +145,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testJsonSerialize() {
 		$query = $this->table->find('all');
-		$results = $query->execute();
+		$results = $query->all();
 
 		$expected = json_encode($this->fixtureData);
 		$this->assertEquals($expected, json_encode($results));
@@ -158,7 +158,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testFirst() {
 		$query = $this->table->find('all');
-		$results = $query->hydrate(false)->execute();
+		$results = $query->hydrate(false)->all();
 
 		$row = $results->first();
 		$this->assertEquals($this->fixtureData[0], $row);
@@ -174,7 +174,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testFirstAfterSerialize() {
 		$query = $this->table->find('all');
-		$results = $query->hydrate(false)->execute();
+		$results = $query->hydrate(false)->all();
 		$results = unserialize(serialize($results));
 
 		$row = $results->first();
@@ -191,7 +191,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testCount() {
 		$query = $this->table->find('all');
-		$results = $query->execute();
+		$results = $query->all();
 
 		$this->assertCount(3, $results, 'Should be countable and 3');
 	}
@@ -203,7 +203,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testCountAfterSerialize() {
 		$query = $this->table->find('all');
-		$results = $query->execute();
+		$results = $query->all();
 		$results = unserialize(serialize($results));
 
 		$this->assertCount(3, $results, 'Should be countable and 3');
@@ -216,7 +216,7 @@ class ResultSetTest extends TestCase {
  */
 	public function testGroupBy() {
 		$query = $this->table->find('all');
-		$results = $query->execute()->groupBy('author_id')->toArray();
+		$results = $query->all()->groupBy('author_id')->toArray();
 		$options = ['markNew' => false, 'markClean' => true];
 		$expected = [
 			1 => [

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -350,7 +350,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			$query->limit(1);
 		}, 'Model.beforeFind');
 
-		$result = $table->find('all')->execute();
+		$result = $table->find('all')->all();
 		$this->assertCount(1, $result, 'Should only have 1 record, limit 1 applied.');
 	}
 
@@ -373,7 +373,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $table->find('all');
 		$query->limit(1);
-		$this->assertEquals($expected, $query->execute());
+		$this->assertEquals($expected, $query->all());
 	}
 
 /**
@@ -491,13 +491,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['query'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, $table]);
+		$query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())
-			->method('_executeStatement')
+			->method('execute')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 
 		$table->updateAll(['username' => 'mark'], []);
@@ -532,13 +532,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			['query'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
-		$query = $this->getMock('Cake\ORM\Query', ['_executeStatement'], [$this->connection, $table]);
+		$query = $this->getMock('Cake\ORM\Query', ['execute'], [$this->connection, $table]);
 		$table->expects($this->once())
 			->method('query')
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())
-			->method('_executeStatement')
+			->method('execute')
 			->will($this->throwException(new \Cake\Database\Exception('Not good')));
 
 		$table->deleteAll(['id >' => 4]);
@@ -1234,7 +1234,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['_executeStatement', 'addDefaultTypes'],
+			['execute', 'addDefaultTypes'],
 			[null, $table]
 		);
 		$statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
@@ -1249,7 +1249,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table->expects($this->once())->method('query')
 			->will($this->returnValue($query));
 
-		$query->expects($this->once())->method('_executeStatement')
+		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($statement));
 
 		$statement->expects($this->once())->method('rowCount')
@@ -1315,7 +1315,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['_executeStatement', 'addDefaultTypes'],
+			['execute', 'addDefaultTypes'],
 			[null, $table]
 		);
 
@@ -1330,7 +1330,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$connection->expects($this->once())->method('begin');
 		$connection->expects($this->once())->method('rollback');
-		$query->expects($this->once())->method('_executeStatement')
+		$query->expects($this->once())->method('execute')
 			->will($this->throwException(new \PDOException));
 
 		$data = new \Cake\ORM\Entity([
@@ -1361,7 +1361,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		);
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['_executeStatement', 'addDefaultTypes'],
+			['execute', 'addDefaultTypes'],
 			[null, $table]
 		);
 
@@ -1375,11 +1375,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$statement = $this->getMock('\Cake\Database\Statement\StatementDecorator');
-		$statement->expects($this->once())->method('rowCount')
+		$statement->expects($this->once())
+			->method('rowCount')
 			->will($this->returnValue(0));
 		$connection->expects($this->once())->method('begin');
 		$connection->expects($this->once())->method('rollback');
-		$query->expects($this->once())->method('_executeStatement')
+		$query->expects($this->once())
+			->method('execute')
 			->will($this->returnValue($statement));
 
 		$data = new \Cake\ORM\Entity([
@@ -1542,7 +1544,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['_executeStatement', 'addDefaultTypes', 'set'],
+			['execute', 'addDefaultTypes', 'set'],
 			[null, $table]
 		);
 
@@ -1553,7 +1555,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$statement->expects($this->once())->method('rowCount')
 			->will($this->returnValue(1));
 
-		$query->expects($this->once())->method('_executeStatement')
+		$query->expects($this->once())->method('execute')
 			->will($this->returnValue($statement));
 
 		$query->expects($this->once())->method('set')
@@ -1652,7 +1654,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 				'author_id' => $entity->id
 			]
 		]);
-		$this->assertNull($query->execute()->first(), 'Should not find any rows.');
+		$this->assertNull($query->all()->first(), 'Should not find any rows.');
 	}
 
 /**
@@ -1693,7 +1695,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$junction = $table->association('tags')->junction();
 		$query = $junction->find('all')->where(['article_id' => 1]);
-		$this->assertNull($query->execute()->first(), 'Should not find any rows.');
+		$this->assertNull($query->all()->first(), 'Should not find any rows.');
 	}
 
 /**


### PR DESCRIPTION
Make the separation clear between `$query->execute()` which now _always_ returns a statement object, and add `$query->all()` which triggers `Model.beforeFind`, and fetches result sets.  Having separate methods allows ORM\Query to honor the contract of the parent class, and also gives a shorter method for general use.

The documentation has already been updated in cakephp/docs#969
