### PR TITLE
Form helper secure with html5 form attribtue

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -8872,7 +8872,7 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->end('', array('form' => 'MyTestFormWithSupportForSecurityComponent'));
 		$expected = array(
 			'div' => array('class' => 'submit'),
-			'input' => array('type' => 'submit', 'value' => ''),
+			'input' => array('type' => 'submit', 'value' => '', 'form' => 'MyTestFormWithSupportForSecurityComponent'),
 			'/div',
 			'/form'
 		);

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -686,9 +686,10 @@ class FormHelperTest extends CakeTestCase {
 	public function testFormSecurityFields() {
 		$key = 'testKey';
 		$fields = array('Model.password', 'Model.username', 'Model.valid' => '0');
-
+		$secureAttributes = array('form' => 'MyTestForm');
+		
 		$this->Form->request['_Token'] = array('key' => $key);
-		$result = $this->Form->secure($fields);
+		$result = $this->Form->secure($fields, $secureAttributes);
 
 		$hash = Security::hash(serialize($fields) . Configure::read('Security.salt'));
 		$hash .= ':' . 'Model.valid';
@@ -698,11 +699,13 @@ class FormHelperTest extends CakeTestCase {
 			'div' => array('style' => 'display:none;'),
 			array('input' => array(
 				'type' => 'hidden', 'name' => 'data[_Token][fields]',
-				'value' => $hash, 'id' => 'preg:/TokenFields\d+/'
+				'value' => $hash, 'id' => 'preg:/TokenFields\d+/',
+				'form' => 'MyTestForm',
 			)),
 			array('input' => array(
 				'type' => 'hidden', 'name' => 'data[_Token][unlocked]',
-				'value' => '', 'id' => 'preg:/TokenUnlocked\d+/'
+				'value' => '', 'id' => 'preg:/TokenUnlocked\d+/',
+				'form' => 'MyTestForm',
 			)),
 			'/div'
 		);
@@ -710,16 +713,18 @@ class FormHelperTest extends CakeTestCase {
 
 		$path = CAKE . 'Test' . DS . 'test_app' . DS . 'Config' . DS;
 		$this->Form->Html->loadConfig('htmlhelper_tags', $path);
-		$result = $this->Form->secure($fields);
+		$result = $this->Form->secure($fields, $secureAttributes);
 		$expected = array(
 			'div' => array('class' => 'hidden'),
 			array('input' => array(
 				'type' => 'hidden', 'name' => 'data[_Token][fields]',
-				'value' => $hash, 'id' => 'preg:/TokenFields\d+/'
+				'value' => $hash, 'id' => 'preg:/TokenFields\d+/',
+				'form' => 'MyTestForm',
 			)),
 			array('input' => array(
 				'type' => 'hidden', 'name' => 'data[_Token][unlocked]',
-				'value' => '', 'id' => 'preg:/TokenUnlocked\d+/'
+				'value' => '', 'id' => 'preg:/TokenUnlocked\d+/',
+				'form' => 'MyTestForm',
 			)),
 			'/div'
 		);

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -8869,6 +8869,15 @@ class FormHelperTest extends CakeTestCase {
 	public function testFormEnd() {
 		$this->assertEquals('</form>', $this->Form->end());
 
+		$result = $this->Form->end('', array('form' => 'MyTestFormWithSupportForSecurityComponent'));
+		$expected = array(
+			'div' => array('class' => 'submit'),
+			'input' => array('type' => 'submit', 'value' => ''),
+			'/div',
+			'/form'
+		);
+		$this->assertTags($result, $expected);
+
 		$result = $this->Form->end('');
 		$expected = array(
 			'div' => array('class' => 'submit'),

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -498,10 +498,12 @@ class FormHelper extends AppHelper {
  * array('label' => 'save', 'name' => 'Whatever', 'div' => array('class' => 'good')); <div class="good"> value="save" name="Whatever"
  * }}}
  *
- * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the Security Component. This is especially useful to set HTML5 attributes like 'form'
+ * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the
+ * Security Component. This is especially useful to set HTML5 attributes like 'form'
  *
  * @param string|array $options as a string will use $options as the value of button,
- * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the Security Component.
+ * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the
+ *   Security Component.
  * @return string a closing FORM tag optional submit button.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#closing-the-form
  */
@@ -541,10 +543,12 @@ class FormHelper extends AppHelper {
 /**
  * Generates a hidden field with a security hash based on the fields used in the form.
  *
- * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the Security Component. This is especially useful to set HTML5 attributes like 'form'.
+ * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the
+ * Security Component. This is especially useful to set HTML5 attributes like 'form'.
  *
  * @param array|null $fields If set specifies the list of fields to use when generating the hash, else $this->fields is being used.
- * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the Security Component.
+ * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the
+ *   Security Component.
  * @return string A hidden input field with a security hash
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::secure
  */

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -546,7 +546,8 @@ class FormHelper extends AppHelper {
  * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the
  * Security Component. This is especially useful to set HTML5 attributes like 'form'.
  *
- * @param array|null $fields If set specifies the list of fields to use when generating the hash, else $this->fields is being used.
+ * @param array|null $fields If set specifies the list of fields to use when generating the hash, else $this->fields
+ *   is being used.
  * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the
  *   Security Component.
  * @return string A hidden input field with a security hash

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -575,12 +575,12 @@ class FormHelper extends AppHelper {
 		$unlocked = implode($unlockedFields, '|');
 		$fields = Security::hash(serialize($fields) . $unlocked . Configure::read('Security.salt'), 'sha1');
 
-		$tokenFields = array_merge((array)$secureAttributes, array(
+		$tokenFields = array_merge($secureAttributes, array(
 			'value' => urlencode($fields . ':' . $locked),
 			'id' => 'TokenFields' . mt_rand(),
 		));
 		$out = $this->hidden('_Token.fields', $tokenFields);
-		$tokenUnlocked = array_merge((array)$secureAttributes, array(
+		$tokenUnlocked = array_merge($secureAttributes, array(
 			'value' => urlencode($unlocked),
 			'id' => 'TokenUnlocked' . mt_rand(),
 		));

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -498,11 +498,14 @@ class FormHelper extends AppHelper {
  * array('label' => 'save', 'name' => 'Whatever', 'div' => array('class' => 'good')); <div class="good"> value="save" name="Whatever"
  * }}}
  *
+ * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the Security Component. This is especially useful to set HTML5 attributes like 'form'
+ *
  * @param string|array $options as a string will use $options as the value of button,
+ * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the Security Component.
  * @return string a closing FORM tag optional submit button.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#closing-the-form
  */
-	public function end($options = null) {
+	public function end($options = null, $secureAttributes = array()) {
 		$out = null;
 		$submit = null;
 
@@ -524,7 +527,7 @@ class FormHelper extends AppHelper {
 			isset($this->request['_Token']) &&
 			!empty($this->request['_Token'])
 		) {
-			$out .= $this->secure($this->fields);
+			$out .= $this->secure($this->fields, $secureAttributes);
 			$this->fields = array();
 		}
 		$this->setEntity(null);
@@ -538,17 +541,24 @@ class FormHelper extends AppHelper {
 /**
  * Generates a hidden field with a security hash based on the fields used in the form.
  *
- * @param array $fields The list of fields to use when generating the hash
+ * If $secureAttributes is set, these html attributes will be merged into the hidden input tags generated for the Security Component. This is especially useful to set HTML5 attributes like 'form'.
+ *
+ * @param array|null $fields If set specifies the list of fields to use when generating the hash, else $this->fields is being used.
+ * @param array $secureAttributes will be passed as html attributes into the hidden input elements generated for the Security Component.
  * @return string A hidden input field with a security hash
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::secure
  */
-	public function secure($fields = array()) {
+	public function secure($fields = array(), $secureAttributes = array()) {
+		
 		if (!isset($this->request['_Token']) || empty($this->request['_Token'])) {
 			return;
 		}
 		$locked = array();
 		$unlockedFields = $this->_unlockedFields;
 
+		if (empty($fields) && !empty($this->fields)) {
+			$fields = $this->fields;
+		}
 		foreach ($fields as $key => $value) {
 			if (!is_int($key)) {
 				$locked[$key] = $value;
@@ -565,14 +575,16 @@ class FormHelper extends AppHelper {
 		$unlocked = implode($unlockedFields, '|');
 		$fields = Security::hash(serialize($fields) . $unlocked . Configure::read('Security.salt'), 'sha1');
 
-		$out = $this->hidden('_Token.fields', array(
+		$tokenFields = array_merge((array)$secureAttributes, array(
 			'value' => urlencode($fields . ':' . $locked),
-			'id' => 'TokenFields' . mt_rand()
+			'id' => 'TokenFields' . mt_rand(),
 		));
-		$out .= $this->hidden('_Token.unlocked', array(
+		$out = $this->hidden('_Token.fields', $tokenFields);
+		$tokenUnlocked = array_merge((array)$secureAttributes, array(
 			'value' => urlencode($unlocked),
-			'id' => 'TokenUnlocked' . mt_rand()
+			'id' => 'TokenUnlocked' . mt_rand(),
 		));
+		$out .= $this->hidden('_Token.unlocked', $tokenUnlocked);
 		return $this->Html->useTag('hiddenblock', $out);
 	}
 


### PR DESCRIPTION
Adds secureAttributes that are passed into the hidden input fields to enable support for html5 attribute "form" and similar.

This, for instance, allows, the seperation of HTML form controls/instantiation and html input fields into tables while not breaking Cake's SecurityComponent.

Target: 2.5
