### PR TITLE
Custom finder methods will receive the full array of extra options

### DIFF
--- a/Cake/ORM/Table.php
+++ b/Cake/ORM/Table.php
@@ -697,7 +697,7 @@ class Table implements EventListener {
  */
 	public function find($type = 'all', $options = []) {
 		$query = $this->query();
-		$query->select()->applyOptions($options);
+		$query->select();
 		return $this->callFinder($type, $query, $options);
 	}
 
@@ -1369,6 +1369,8 @@ class Table implements EventListener {
  * @throws \BadMethodCallException
  */
 	public function callFinder($type, Query $query, $options = []) {
+		$query->applyOptions($options);
+		$options = $query->getOptions();
 		$finder = 'find' . ucfirst($type);
 		if (method_exists($this, $finder)) {
 			return $this->{$finder}($query, $options);

--- a/Cake/Test/TestCase/ORM/TableTest.php
+++ b/Cake/Test/TestCase/ORM/TableTest.php
@@ -552,7 +552,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testFindApplyOptions() {
 		$table = $this->getMock(
 			'Cake\ORM\Table',
-			['query'],
+			['query', 'findAll'],
 			[['table' => 'users', 'connection' => $this->connection]]
 		);
 		$query = $this->getMock('Cake\ORM\Query', [], [$this->connection, $table]);
@@ -564,9 +564,15 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$query->expects($this->any())
 			->method('select')
 			->will($this->returnSelf());
+
+		$query->expects($this->once())->method('getOptions')
+			->will($this->returnValue(['connections' => ['a >' => 1]]));
 		$query->expects($this->once())
 			->method('applyOptions')
 			->with($options);
+
+		$table->expects($this->once())->method('findAll')
+			->with($query, ['connections' => ['a >' => 1]]);
 		$table->find('all', $options);
 	}
 
@@ -3012,7 +3018,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'applyOptions', 'where'],
+			['addDefaultTypes', 'first', 'where'],
 			[$this->connection, $table]
 		);
 
@@ -3023,9 +3029,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->with('all', $query, ['fields' => ['id']])
 			->will($this->returnValue($query));
 
-		$query->expects($this->once())->method('applyOptions')
-			->with(['fields' => ['id']])
-			->will($this->returnSelf());
 		$query->expects($this->once())->method('where')
 			->with(['bar' => 10])
 			->will($this->returnSelf());
@@ -3059,7 +3062,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$query = $this->getMock(
 			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'applyOptions', 'where'],
+			['addDefaultTypes', 'first', 'where'],
 			[$this->connection, $table]
 		);
 
@@ -3069,9 +3072,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->with('all', $query, ['contain' => ['foo']])
 			->will($this->returnValue($query));
 
-		$query->expects($this->once())->method('applyOptions')
-			->with(['contain' => ['foo']])
-			->will($this->returnSelf());
 		$query->expects($this->once())->method('where')
 			->with(['bar' => 10])
 			->will($this->returnSelf());


### PR DESCRIPTION
With this change, finder methods will receive the result of calling `$query->getOptions()` as the second argument. This mean that they will not only get options for the current find operation, but also from previously stacked finders. It is important to remember that `getOptions` will only return the extra keys that were not handler automatically by `applyOptions`.
