### PR TITLE
Handle percent symbol in translation functions

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -398,6 +398,41 @@ class BasicsTest extends CakeTestCase {
 	}
 
 /**
+ * testTranslatePercent
+ *
+ * @return void
+ */
+	public function testTranslatePercent() {
+		$result = __('%s are 100% real fruit', 'Apples');
+		$expected = 'Apples are 100% real fruit';
+		$this->assertEquals($expected, $result, 'Percent sign at end of word should be considered literal');
+
+		$result = __('%s are %d% real fruit', 'Apples', 100);
+		$expected = 'Apples are 100% real fruit';
+		$this->assertEquals($expected, $result, 'A digit marker should not be misinterpreted');
+
+		$result = __('%s are %s% real fruit', 'Apples', 100);
+		$expected = 'Apples are 100% real fruit';
+		$this->assertEquals($expected, $result, 'A string marker should not be misinterpreted');
+
+		$result = __('%nonsense %s', 'Apples');
+		$expected = '%nonsense Apples';
+		$this->assertEquals($expected, $result, 'A percent sign at the start of the string should be considered literal');
+
+		$result = __('%s are awesome%', 'Apples');
+		$expected = 'Apples are awesome%';
+		$this->assertEquals($expected, $result, 'A percent sign at the end of the string should be considered literal');
+
+		$result = __('%2$d %1$s entered the bowl', 'Apples', 2);
+		$expected = '2 Apples entered the bowl';
+		$this->assertEquals($expected, $result, 'Positional replacement markers should not be misinterpreted');
+
+		$result = __('%.2f% of all %s agree', 99.44444, 'Cats');
+		$expected = '99.44% of all Cats agree';
+		$this->assertEquals($expected, $result, 'significant-digit placeholder should not be misinterpreted');
+	}
+
+/**
  * test __n()
  *
  * @return void

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -559,6 +559,8 @@ if (!function_exists('__')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 1);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -589,6 +591,8 @@ if (!function_exists('__n')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 3);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -616,6 +620,8 @@ if (!function_exists('__d')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 2);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -647,6 +653,8 @@ if (!function_exists('__dn')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 4);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -689,6 +697,8 @@ if (!function_exists('__dc')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 3);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -735,6 +745,8 @@ if (!function_exists('__dcn')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 5);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 
@@ -773,6 +785,8 @@ if (!function_exists('__c')) {
 		} elseif (!is_array($args)) {
 			$args = array_slice(func_get_args(), 2);
 		}
+
+		$translated = preg_replace('/(?<!%)%(?![%bcdeEfFgGosuxX\d\.])/', '%%', $translated);
 		return vsprintf($translated, $args);
 	}
 


### PR DESCRIPTION
I don't know if this could open a can of worms but it's annoying that you can do this:

```
<?= __('100% Funsies!')
```

You can't do:

```
<?= __('100% %s!', 'Funsies'')
```

As it generates no output and [only a warning from the vsprintf call](https://gist.github.com/AD7six/18c9353afac1e1464166), and therefore have to do:

```
<?= __('100%% %s!', 'Funsies'')
```

Which most translators would read as a typo, and convert back to `100% %s!' resulting in no output.

So I've added automatic `%` -> `%%` conversion for any detected loose percent sign.
