### PR TITLE
3.0 composite key generation

### DIFF
--- a/Cake/Database/Schema/MysqlSchema.php
+++ b/Cake/Database/Schema/MysqlSchema.php
@@ -119,7 +119,6 @@ class MysqlSchema extends BaseSchema {
 
 /**
  * {@inheritdoc}
- *
  */
 	public function convertFieldDescription(Table $table, $row) {
 		$field = $this->_convertColumn($row['Type']);
@@ -129,12 +128,14 @@ class MysqlSchema extends BaseSchema {
 			'collate' => $row['Collation'],
 			'comment' => $row['Comment'],
 		];
+		if (isset($row['Extra']) && $row['Extra'] === 'auto_increment') {
+			$field['autoIncrement'] = true;
+		}
 		$table->addColumn($row['Field'], $field);
 	}
 
 /**
  * {@inheritdoc}
- *
  */
 	public function convertIndexDescription(Table $table, $row) {
 		$type = null;
@@ -306,7 +307,10 @@ class MysqlSchema extends BaseSchema {
 		if (isset($data['null']) && $data['null'] === false) {
 			$out .= ' NOT NULL';
 		}
-		if (in_array($data['type'], ['integer', 'biginteger']) && in_array($name, (array)$table->primaryKey())) {
+		if (
+			in_array($data['type'], ['integer', 'biginteger']) &&
+			([$name] == (array)$table->primaryKey() || $data['autoIncrement'] === true)
+		) {
 			$out .= ' AUTO_INCREMENT';
 		}
 		if (isset($data['null']) && $data['null'] === true) {

--- a/Cake/Database/Schema/SqliteSchema.php
+++ b/Cake/Database/Schema/SqliteSchema.php
@@ -125,6 +125,7 @@ class SqliteSchema extends BaseSchema {
 		];
 		if ($row['pk'] == true) {
 			$field['null'] = false;
+			$field['autoIncrement'] = true;
 		}
 		$table->addColumn($row['name'], $field);
 		if ($row['pk'] == true) {

--- a/Cake/Database/Schema/Table.php
+++ b/Cake/Database/Schema/Table.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -27,7 +25,8 @@ use Cake\Database\Exception;
  * methods.
  *
  * Once created Table instances can be added to
- * Schema\Collection objects.
+ * Schema\Collection objects. They can also be converted into SQL using the
+ * createSql(), dropSql() and truncateSql() methods.
  */
 class Table {
 
@@ -92,9 +91,11 @@ class Table {
 		],
 		'integer' => [
 			'unsigned' => null,
+			'autoIncrement' => null,
 		],
 		'biginteger' => [
 			'unsigned' => null,
+			'autoIncrement' => null,
 		],
 		'decimal' => [
 			'unsigned' => null,

--- a/Cake/Test/Fixture/ArticlesTagFixture.php
+++ b/Cake/Test/Fixture/ArticlesTagFixture.php
@@ -32,7 +32,9 @@ class ArticlesTagFixture extends TestFixture {
 	public $fields = array(
 		'article_id' => ['type' => 'integer', 'null' => false],
 		'tag_id' => ['type' => 'integer', 'null' => false],
-		'_constraints' => ['UNIQUE_TAG2' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]]
+		'_constraints' => [
+			'UNIQUE_TAG2' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]
+		]
 	);
 
 /**

--- a/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -427,6 +427,16 @@ SQL;
 				['type' => 'biginteger', 'length' => 20, 'unsigned' => true],
 				'`post_id` BIGINT UNSIGNED'
 			],
+			[
+				'post_id',
+				['type' => 'integer', 'length' => 20, 'autoIncrement' => true],
+				'`post_id` INTEGER(20) AUTO_INCREMENT'
+			],
+			[
+				'post_id',
+				['type' => 'biginteger', 'length' => 20, 'autoIncrement' => true],
+				'`post_id` BIGINT AUTO_INCREMENT'
+			],
 			// Decimal
 			[
 				'value',

--- a/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/Cake/Test/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -249,6 +249,7 @@ SQL;
 				'length' => 20,
 				'precision' => null,
 				'comment' => null,
+				'autoIncrement' => true,
 			],
 			'title' => [
 				'type' => 'string',
@@ -275,6 +276,7 @@ SQL;
 				'length' => 11,
 				'precision' => null,
 				'comment' => null,
+				'autoIncrement' => null,
 			],
 			'published' => [
 				'type' => 'boolean',
@@ -704,6 +706,69 @@ CREATE TABLE `posts` (
 `created` DATETIME,
 PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci
+SQL;
+		$result = $table->createSql($connection);
+		$this->assertCount(1, $result);
+		$this->assertEquals($expected, $result[0]);
+	}
+
+/**
+ * Test primary key generation & auto-increment.
+ *
+ * @return void
+ */
+	public function testCreateSqlCompositeIntegerKey() {
+		$driver = $this->_getMockedDriver();
+		$connection = $this->getMock('Cake\Database\Connection', [], [], '', false);
+		$connection->expects($this->any())->method('driver')
+			->will($this->returnValue($driver));
+
+		$table = (new Table('articles_tags'))
+			->addColumn('article_id', [
+				'type' => 'integer',
+				'null' => false
+			])
+			->addColumn('tag_id', [
+				'type' => 'integer',
+				'null' => false,
+			])
+			->addConstraint('primary', [
+				'type' => 'primary',
+				'columns' => ['article_id', 'tag_id']
+			]);
+
+		$expected = <<<SQL
+CREATE TABLE `articles_tags` (
+`article_id` INTEGER NOT NULL,
+`tag_id` INTEGER NOT NULL,
+PRIMARY KEY (`article_id`, `tag_id`)
+)
+SQL;
+		$result = $table->createSql($connection);
+		$this->assertCount(1, $result);
+		$this->assertEquals($expected, $result[0]);
+
+		$table = (new Table('composite_key'))
+			->addColumn('id', [
+				'type' => 'integer',
+				'null' => false,
+				'autoIncrement' => true
+			])
+			->addColumn('account_id', [
+				'type' => 'integer',
+				'null' => false,
+			])
+			->addConstraint('primary', [
+				'type' => 'primary',
+				'columns' => ['id', 'account_id']
+			]);
+
+		$expected = <<<SQL
+CREATE TABLE `composite_key` (
+`id` INTEGER NOT NULL AUTO_INCREMENT,
+`account_id` INTEGER NOT NULL,
+PRIMARY KEY (`id`, `account_id`)
+)
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);

--- a/Cake/Test/TestCase/Database/Schema/TableTest.php
+++ b/Cake/Test/TestCase/Database/Schema/TableTest.php
@@ -114,6 +114,7 @@ class TableTest extends TestCase {
 			'null' => null,
 			'unsigned' => null,
 			'comment' => null,
+			'autoIncrement' => null,
 		];
 		$this->assertEquals($expected, $result);
 


### PR DESCRIPTION
Improve composite key generation and reflection. When doing some testing against Percona 5.5 I found issues with multi-column primary keys that spanned two integer columns. The columns would both be incorrectly labeled as auto_increment which would be rejected by XtraDB.

This set of changes adds an 'autoIncrement' option for integer & biginteger columns. This flag lets developer mark which columns should be treated as autoIncrement/serial. This feature does nothing in SQLite as it doesn't support multicolumn primary keys with auto-increments.
