### PR TITLE
3.0 - Dot notation for contain and query builder callable

### DIFF
--- a/Cake/ORM/Association.php
+++ b/Cake/ORM/Association.php
@@ -393,6 +393,7 @@ abstract class Association {
 			'includeFields' => true,
 			'foreignKey' => $this->foreignKey(),
 			'conditions' => [],
+			'fields' => [],
 			'type' => $this->joinType(),
 			'table' => $target->table()
 		];
@@ -403,6 +404,14 @@ abstract class Association {
 			if ($joinCondition) {
 				$options['conditions'][] = $joinCondition;
 			}
+		}
+
+		$options['conditions'] = $query->newExpr()->add($options['conditions']);
+
+		if (!empty($options['queryBuilder'])) {
+			$newQuery = $options['queryBuilder']($target->query());
+			$options['fields'] = $newQuery->clause('select') ?: $options['fields'];
+			$options['conditions']->add($newQuery->clause('where'));
 		}
 
 		$joinOptions = ['table' => 1, 'conditions' => 1, 'type' => 1];

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -249,6 +249,11 @@ class BelongsToMany extends Association {
 			'strategy' => $this->strategy()
 		];
 		$fetchQuery = $this->_buildQuery($options);
+
+		if (!empty($options['queryBuilder'])) {
+			$fetchQuery = $options['queryBuilder']($fetchQuery);
+		}
+
 		$resultMap = [];
 		$key = $options['foreignKey'];
 		$property = $this->target()->association($this->junction()->alias())->property();

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -247,7 +247,7 @@ class BelongsToMany extends Association {
 			'foreignKey' => $this->foreignKey(),
 			'conditions' => [],
 			'sort' => $this->sort(),
-			'strategy' => $this->strategy(),
+			'strategy' => $this->strategy()
 		];
 
 		$queryBuilder = false;

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -247,12 +247,18 @@ class BelongsToMany extends Association {
 			'foreignKey' => $this->foreignKey(),
 			'conditions' => [],
 			'sort' => $this->sort(),
-			'strategy' => $this->strategy()
+			'strategy' => $this->strategy(),
 		];
-		$fetchQuery = $this->_buildQuery($options);
 
+		$queryBuilder = false;
 		if (!empty($options['queryBuilder'])) {
-			$fetchQuery = $options['queryBuilder']($fetchQuery);
+			$queryBuilder = $options['queryBuilder'];
+			unset($options['queryBuilder']);
+		}
+
+		$fetchQuery = $this->_buildQuery($options);
+		if ($queryBuilder) {
+			$fetchQuery = $queryBuilder($fetchQuery);
 		}
 
 		$resultMap = [];

--- a/Cake/ORM/Association/BelongsToMany.php
+++ b/Cake/ORM/Association/BelongsToMany.php
@@ -187,6 +187,7 @@ class BelongsToMany extends Association {
 			$includeFields = $options['includeFields'];
 		}
 
+		unset($options['queryBuilder']);
 		$options = ['conditions' => [$cond]] + compact('includeFields');
 		$this->target()
 			->association($junction->alias())

--- a/Cake/ORM/Association/ExternalAssociationTrait.php
+++ b/Cake/ORM/Association/ExternalAssociationTrait.php
@@ -205,6 +205,10 @@ trait ExternalAssociationTrait {
 			$fetchQuery->contain($options['contain']);
 		}
 
+		if (!empty($options['queryBuilder'])) {
+			$options['queryBuilder']($fetchQuery);
+		}
+
 		return $fetchQuery;
 	}
 

--- a/Cake/ORM/Association/HasMany.php
+++ b/Cake/ORM/Association/HasMany.php
@@ -85,6 +85,11 @@ class HasMany extends Association {
 			'strategy' => $this->strategy()
 		];
 		$fetchQuery = $this->_buildQuery($options);
+
+		if (!empty($options['queryBuilder'])) {
+			$fetchQuery = $options['queryBuilder']($fetchQuery);
+		}
+
 		$resultMap = [];
 		$key = $options['foreignKey'];
 		foreach ($fetchQuery->all() as $result) {

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -308,7 +308,7 @@ class Query extends DatabaseQuery {
 
 /**
  * Formats the containments array so that associations are always set as keys
- * in the array. This funciton merges the original associations array with
+ * in the array. This function merges the original associations array with
  * the new associations provided
  *
  * @param array $associations user provided containments array

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -348,8 +348,18 @@ class Query extends DatabaseQuery {
  * @return Query
  */
 	public function matching($assoc, callable $builder = null) {
-		$options = ['queryBuilder' => $builder, 'matching' => true];
-		return $this->contain([$assoc => array_filter($options)]);
+		$assocs = explode('.', $assoc);
+		$last = array_pop($assocs);
+		$containments = [];
+		$pointer =& $containments;
+
+		foreach ($assocs as $name) {
+			$pointer[$name] = ['matching' => true];
+			$pointer =& $pointer[$name];
+		}
+
+		$pointer[$last] = ['queryBuilder' => $builder, 'matching' => true];
+		return $this->contain($containments);
 	}
 
 /**

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -202,8 +202,26 @@ class Query extends DatabaseQuery {
  *	// Eager load the product info, and for each product load other 2 associations
  *	$query->contain(['Product' => ['Manufacturer', 'Distributor']);
  *
+ *	// Which is equivalent to calling
+ *	$query->contain(['Products.Manufactures', 'Products.Distributors']);
+ *
  *	// For an author query, load his region, state and country
  *	$query->contain('Regions.States.Countries');
+ * }}}
+ *
+ * It is possible to control the conditions and fields selected for each of the
+ * contained associations:
+ *
+ * ### Example:
+ *
+ * {{{
+ *	$query->contain(['Tags' => function($q) {
+ *		return $q->where(['Tags.is_popular' => true]);
+ *	}]);
+ *
+ *	$query->contain(['Products.Manufactures' => function($q) {
+ *		return $q->select(['name'])->where(['Manufactures.active' => true]);
+ *	}]);
  * }}}
  *
  * Each association might define special options when eager loaded, the allowed
@@ -211,31 +229,26 @@ class Query extends DatabaseQuery {
  *
  * - foreignKey: Used to set a different field to match both tables, if set to false
  *   no join conditions will be generated automatically
- * - conditions: An array of conditions that will be passed to either a query or
- *   join conditions. See `where` method for the valid format.
  * - fields: An array with the fields that should be fetched from the association
- * - sort: for associations that are not joined directly, the order they should
- *   appear in the resulting set
- * - matching: A boolean indicating if the parent association records should be
- *   filtered by those matching the conditions in the target association.
+ * - queryBuilder: Equivalent to passing a callable instead of an options array
  *
  * ### Example:
  *
  * {{{
  *  // Set options for the articles that will be eagerly loaded for an author
  *	$query->contain([
- *		'Article' => [
- *			'field' => ['title'],
- *			'conditions' => ['read_count >' => 100],
- *			'sort' => ['published' => 'DESC']
+ *		'Articles' => [
+ *			'fields' => ['title']
  *		]
  *	]);
  *
  *	// Use special join conditions for getting an article author's 'likes'
  *	$query->contain([
- *		'Like' => [
+ *		'Likes' => [
  *			'foreignKey' => false,
- *			'conditions' => ['Article.author_id = Like.user_id']
+ *			'queryBuilder' => function($q) {
+ *				return $q->where(...); // Add full filtering conditions
+ *			}
  *		]
  *	]);
  *

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -81,7 +81,8 @@ class Query extends DatabaseQuery {
 		'conditions' => 1,
 		'fields' => 1,
 		'sort' => 1,
-		'matching' => 1
+		'matching' => 1,
+		'queryBuilder' => 1
 	];
 
 /**
@@ -341,6 +342,10 @@ class Query extends DatabaseQuery {
 
 			if (is_array($options)) {
 				$options = $this->_reformatContain($options, []);
+			}
+
+			if ($options instanceof \Closure) {
+				$options = ['queryBuilder' => $options];
 			}
 
 			$pointer += [$table => []];

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -192,9 +192,9 @@ class Query extends DatabaseQuery {
  *	$query->contain(['Category', 'Tag']);
  * }}}
  *
- * Associations can be arbitrarily nested using arrays, this allows this object to
- * calculate joins or any additional queries that must be executed to bring the
- * required associated data.
+ * Associations can be arbitrarily nested using dot notation or nested arrays,
+ * this allows this object to calculate joins or any additional queries that
+ * must be executed to bring the required associated data.
  *
  * ### Example:
  *
@@ -203,7 +203,7 @@ class Query extends DatabaseQuery {
  *	$query->contain(['Product' => ['Manufacturer', 'Distributor']);
  *
  *	// For an author query, load his region, state and country
- *	$query->contain(['Region' => ['State' => 'Country']);
+ *	$query->contain('Regions.States.Countries');
  * }}}
  *
  * Each association might define special options when eager loaded, the allowed
@@ -247,19 +247,6 @@ class Query extends DatabaseQuery {
  * The resulting ArrayObject will always have association aliases as keys, and
  * options as values, if no options are passed, the values will be set to an empty
  * array
- *
- * ### Example:
- *
- * {{{
- *	// Set some associations
- *	$query->contain(['Article', 'Author' => ['fields' => ['Author.name']);
- *
- *  // Let's now add another field to Author
- *	$query->contain()['Author']['fields'][] = 'Author.email';
- *
- *	// Let's also add Article's tags
- *	$query->contain()['Article']['Tag'] = [];
- * }}}
  *
  * Please note that when modifying directly the containments array, you are
  * required to maintain the structure. That is, association names as keys

--- a/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToManyTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -221,9 +222,9 @@ class BelongsToManyTest extends TestCase {
 		$association = new BelongsToMany('Tags', $config);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -234,10 +235,10 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->at(2))->method('join')->with([
 			'ArticlesTags' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -275,9 +276,9 @@ class BelongsToManyTest extends TestCase {
 		$association = new BelongsToMany('Tags', $config);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -288,10 +289,10 @@ class BelongsToManyTest extends TestCase {
 
 		$query->expects($this->at(1))->method('join')->with([
 			'ArticlesTags' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]

--- a/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
+++ b/Cake/Test/TestCase/ORM/Association/BelongsToTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -95,10 +96,10 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$field = new IdentifierExpression('Clients.company_id');
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				],
+				]),
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]
@@ -125,9 +126,9 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsTo('Companies', $config);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Companies.is_active' => false
-				],
+				]),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -160,10 +161,10 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$field = new IdentifierExpression('Clients.company_id');
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				],
+				]),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -378,10 +379,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -409,9 +410,9 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Articles.is_active' => false
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -444,10 +445,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$association = new HasMany('Articles', $config);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]

--- a/Cake/Test/TestCase/ORM/Association/HasManyTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasManyTest.php
@@ -411,7 +411,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			return $query->select(['a', 'b'])->join('foo')->where(['a' => 1]);
 		};
 
-		$callable = $association->eagerLoader(compact('keys', 'query', 'queryBuilder'));
+		$association->eagerLoader(compact('keys', 'query', 'queryBuilder'));
 	}
 
 /**

--- a/Cake/Test/TestCase/ORM/Association/HasOneTest.php
+++ b/Cake/Test/TestCase/ORM/Association/HasOneTest.php
@@ -17,6 +17,7 @@
 namespace Cake\Test\TestCase\ORM\Association;
 
 use Cake\Database\Expression\IdentifierExpression;
+use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -95,10 +96,10 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$field = new IdentifierExpression('Profiles.user_id');
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -127,9 +128,9 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association = new HasOne('Profiles', $config);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Profiles.is_active' => false
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -162,10 +163,10 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$field = new IdentifierExpression('Profiles.user_id');
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				],
+				]),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -837,10 +837,9 @@ class QueryTest extends TestCase {
 		$results = $query->repository($table)
 			->select()
 			->hydrate(false)
-			->contain(['articles' => [
-				'matching' => true,
-				'conditions' => ['articles.id' => 2]
-			]])
+			->matching('articles', function($q) {
+				return $q->where(['articles.id' => 2]);
+			})
 			->toArray();
 		$expected = [
 			[
@@ -875,10 +874,9 @@ class QueryTest extends TestCase {
 		$table->belongsToMany('Tags');
 
 		$results = $query->repository($table)->select()
-			->contain(['Tags' => [
-				'matching' => true,
-				'conditions' => ['Tags.id' => 3]
-			]])
+			->matching('Tags', function($q) {
+				return $q->where(['Tags.id' => 3]);
+			})
 			->hydrate(false)
 			->toArray();
 		$expected = [
@@ -898,10 +896,9 @@ class QueryTest extends TestCase {
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->contain(['Tags' => [
-				'matching' => true,
-				'conditions' => ['Tags.name' => 'tag2']]
-			])
+			->matching('Tags', function($q) {
+				return $q->where(['Tags.name' => 'tag2']);
+			})
 			->hydrate(false)
 			->toArray();
 		$expected = [

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -125,9 +125,9 @@ class QueryTest extends TestCase {
 			->with(['clients' => [
 				'table' => 'clients',
 				'type' => 'LEFT',
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['clients.id' => new IdentifierExpression('foo.client_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -135,9 +135,9 @@ class QueryTest extends TestCase {
 			->with(['orders' => [
 				'table' => 'orders',
 				'type' => 'INNER',
-				'conditions' => [
+				'conditions' =>  new QueryExpression([
 					['clients.id' => new IdentifierExpression('orders.client_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -145,9 +145,9 @@ class QueryTest extends TestCase {
 			->with(['orderTypes' => [
 				'table' => 'order_types',
 				'type' => 'LEFT',
-				'conditions' => [
+				'conditions' =>  new QueryExpression([
 					['orderTypes.id' => new IdentifierExpression('orders.order_type_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -155,9 +155,9 @@ class QueryTest extends TestCase {
 			->with(['stuff' => [
 				'table' => 'things',
 				'type' => 'INNER',
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['orders.id' => new IdentifierExpression('stuff.order_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -165,9 +165,9 @@ class QueryTest extends TestCase {
 			->with(['stuffTypes' => [
 				'table' => 'stuff_types',
 				'type' => 'LEFT',
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['stuffTypes.id' => new IdentifierExpression('stuff.stuff_type_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -175,9 +175,9 @@ class QueryTest extends TestCase {
 			->with(['companies' => [
 				'table' => 'organizations',
 				'type' => 'LEFT',
-				'conditions' => [
+				'conditions' =>  new QueryExpression([
 					['companies.id' => new IdentifierExpression('clients.organization_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 
@@ -185,9 +185,9 @@ class QueryTest extends TestCase {
 			->with(['categories' => [
 				'table' => 'categories',
 				'type' => 'LEFT',
-				'conditions' => [
+				'conditions' => new QueryExpression([
 					['categories.id' => new IdentifierExpression('companies.category_id')]
-				]
+				])
 			]])
 			->will($this->returnValue($query));
 

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -198,23 +198,11 @@ class QueryTest extends TestCase {
 
 /**
  * Tests setting containments using dot notation, additionaly proves that options
- * are not overwritten whn combining dot notation and array notation
+ * are not overwritten when combining dot notation and array notation
  *
  * @return void
  */
 	public function testContainDotNotation() {
-		$contains = [
-			'clients' => [
-				'orders' => [
-					'orderTypes',
-					'stuff' => ['stuffTypes']
-				],
-				'companies' => [
-					'foreignKey' => 'organization_id',
-					'categories'
-				]
-			]
-		];
 		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
 		$query->contain([
 			'clients.orders.stuff',
@@ -240,6 +228,38 @@ class QueryTest extends TestCase {
 
 		$expected['clients']['orders'] += ['fields' => ['a', 'b']];
 		$expected['clients'] += ['sort' => ['a' => 'desc']];
+		$this->assertEquals($expected, $query->contain());
+	}
+
+/**
+ * Tests that it is possible to pass a function as the array value for contain
+ *
+ * @return void
+ */
+	public function testContainClosure() {
+		$builder = function($query) {
+		};
+		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
+		$query->contain([
+			'clients.orders.stuff' => ['fields' => ['a']],
+			'clients' => $builder
+		]);
+
+		$expected = new \ArrayObject([
+			'clients' => [
+				'orders' => [
+					'stuff' => ['fields' => ['a']]
+				],
+				'queryBuilder' => $builder
+			]
+		]);
+		$this->assertEquals($expected, $query->contain());
+
+		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
+		$query->contain([
+			'clients.orders.stuff' => ['fields' => ['a']],
+			'clients' => ['queryBuilder' => $builder]
+		]);
 		$this->assertEquals($expected, $query->contain());
 	}
 

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -197,6 +197,53 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests setting containments using dot notation, additionaly proves that options
+ * are not overwritten whn combining dot notation and array notation
+ *
+ * @return void
+ */
+	public function testContainDotNotation() {
+		$contains = [
+			'clients' => [
+				'orders' => [
+					'orderTypes',
+					'stuff' => ['stuffTypes']
+				],
+				'companies' => [
+					'foreignKey' => 'organization_id',
+					'categories'
+				]
+			]
+		];
+		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
+		$query->contain([
+			'clients.orders.stuff',
+			'clients.companies.categories' => ['conditions' => ['a >' => 1]]
+		]);
+		$expected = new \ArrayObject([
+			'clients' => [
+				'orders' => [
+					'stuff' => []
+				],
+				'companies' => [
+					'categories' => [
+						'conditions' => ['a >' => 1]
+					]
+				]
+			]
+		]);
+		$this->assertEquals($expected, $query->contain());
+		$query->contain([
+			'clients.orders' => ['fields' => ['a', 'b']],
+			'clients' => ['sort' => ['a' => 'desc']],
+		]);
+
+		$expected['clients']['orders'] += ['fields' => ['a', 'b']];
+		$expected['clients'] += ['sort' => ['a' => 'desc']];
+		$this->assertEquals($expected, $query->contain());
+	}
+
+/**
  * Test that fields for contained models are aliased and added to the select clause
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -918,6 +918,45 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to filter by deep associations
+ *
+ * @return void
+ */
+	public function testMatchingDotNotation() {
+		$query = new Query($this->connection, $this->table);
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles');
+		TableRegistry::get('articles')->belongsToMany('tags');
+
+		$results = $query->repository($table)
+			->select()
+			->hydrate(false)
+			->matching('articles.tags', function($q) {
+				return $q->where(['tags.id' => 2]);
+			})
+			->toArray();
+		$expected = [
+			[
+				'id' => 1,
+				'name' => 'mariano',
+				'articles' => [
+					'id' => 1,
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'author_id' => 1,
+					'published' => 'Y',
+					'tags' => [
+						'id' => 2,
+						'name' => 'tag2'
+					]
+				]
+			]
+		];
+		$this->assertEquals($expected, $results);
+	}
+
+/**
  * Test setResult()
  *
  * @return void

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -197,7 +197,7 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests setting containments using dot notation, additionaly proves that options
+ * Tests setting containments using dot notation, additionally proves that options
  * are not overwritten when combining dot notation and array notation
  *
  * @return void


### PR DESCRIPTION
I felt that creating contains for deeply nested association was a pain due to the verbosity of nested contains. Originally I avoided adding the dot notation for contain as in 2.x it is not flawless. This address those flaws from 2.x and brings back dot notation fro expressing containments

Additionally, I added the ability to express query conditions for a related table. I was missing this feature as it was not possible before to use custom finders and contain:

``` php
$articles->contain(['comments' => function($q) {
  return $q->find('approved')->find('latest');
}])
```

Without this change, you will need to re-express those custom finders using array conditions, which is kind of tedious and sad.
