### PR TITLE
2.5 error handling

### DIFF
--- a/app/View/Errors/error400.ctp
+++ b/app/View/Errors/error400.ctp
@@ -16,7 +16,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 ?>
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php printf(

--- a/app/View/Errors/error500.ctp
+++ b/app/View/Errors/error500.ctp
@@ -16,7 +16,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 ?>
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php echo __d('cake', 'An Internal Error Has Occurred.'); ?>

--- a/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error400.ctp
@@ -7,7 +7,7 @@
  * @since         CakePHP(tm) v 0.10.0.1076
  */
 ?>
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php printf(

--- a/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Errors/error500.ctp
@@ -7,7 +7,7 @@
  * @since         CakePHP(tm) v 0.10.0.1076
  */
 ?>
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php echo __d('cake', 'An Internal Error Has Occurred.'); ?>

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -188,10 +188,11 @@ class ExceptionRenderer {
 		$this->controller->response->statusCode($code);
 		$this->controller->set(array(
 			'code' => $code,
-			'url' => h($url),
+			'mame' => h($error->getMessage()),
 			'message' => h($error->getMessage()),
+			'url' => h($url),
 			'error' => $error,
-			'_serialize' => array('code', 'url', 'message')
+			'_serialize' => array('code', 'name', 'message', 'url')
 		));
 		$this->controller->set($error->getAttributes());
 		$this->_outputMessage($this->template);
@@ -211,10 +212,11 @@ class ExceptionRenderer {
 		$url = $this->controller->request->here();
 		$this->controller->response->statusCode($error->getCode());
 		$this->controller->set(array(
-			'url' => h($url),
+			'name' => h($message),
 			'message' => h($message),
+			'url' => h($url),
 			'error' => $error,
-			'_serialize' => array('url', 'message')
+			'_serialize' => array('name', 'message', 'url')
 		));
 		$this->_outputMessage('error400');
 	}
@@ -234,10 +236,11 @@ class ExceptionRenderer {
 		$code = ($error->getCode() > 500 && $error->getCode() < 506) ? $error->getCode() : 500;
 		$this->controller->response->statusCode($code);
 		$this->controller->set(array(
-			'url' => h($url),
+			'name' => h($message),
 			'message' => h($message),
+			'url' => h($url),
 			'error' => $error,
-			'_serialize' => array('url', 'message')
+			'_serialize' => array('name', 'message', 'url')
 		));
 		$this->_outputMessage('error500');
 	}
@@ -254,10 +257,11 @@ class ExceptionRenderer {
 		$this->controller->response->statusCode($code);
 		$this->controller->set(array(
 			'code' => $code,
-			'url' => h($url),
+			'name' => h($error->getMessage()),
 			'message' => h($error->getMessage()),
+			'url' => h($url),
 			'error' => $error,
-			'_serialize' => array('code', 'url', 'message', 'error')
+			'_serialize' => array('code', 'name', 'message', 'url', 'error')
 		));
 		$this->_outputMessage($this->template);
 	}

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -189,9 +189,9 @@ class ExceptionRenderer {
 		$this->controller->set(array(
 			'code' => $code,
 			'url' => h($url),
-			'name' => h($error->getMessage()),
+			'message' => h($error->getMessage()),
 			'error' => $error,
-			'_serialize' => array('code', 'url', 'name')
+			'_serialize' => array('code', 'url', 'message')
 		));
 		$this->controller->set($error->getAttributes());
 		$this->_outputMessage($this->template);
@@ -211,10 +211,10 @@ class ExceptionRenderer {
 		$url = $this->controller->request->here();
 		$this->controller->response->statusCode($error->getCode());
 		$this->controller->set(array(
-			'name' => h($message),
 			'url' => h($url),
+			'message' => h($message),
 			'error' => $error,
-			'_serialize' => array('name', 'url')
+			'_serialize' => array('url', 'message')
 		));
 		$this->_outputMessage('error400');
 	}
@@ -234,10 +234,10 @@ class ExceptionRenderer {
 		$code = ($error->getCode() > 500 && $error->getCode() < 506) ? $error->getCode() : 500;
 		$this->controller->response->statusCode($code);
 		$this->controller->set(array(
-			'name' => h($message),
-			'message' => h($url),
+			'url' => h($url),
+			'message' => h($message),
 			'error' => $error,
-			'_serialize' => array('name', 'message')
+			'_serialize' => array('url', 'message')
 		));
 		$this->_outputMessage('error500');
 	}
@@ -255,9 +255,9 @@ class ExceptionRenderer {
 		$this->controller->set(array(
 			'code' => $code,
 			'url' => h($url),
-			'name' => h($error->getMessage()),
+			'message' => h($error->getMessage()),
 			'error' => $error,
-			'_serialize' => array('code', 'url', 'name', 'error')
+			'_serialize' => array('code', 'url', 'message', 'error')
 		));
 		$this->_outputMessage($this->template);
 	}

--- a/lib/Cake/Test/test_app/View/Errors/error400.ctp
+++ b/lib/Cake/Test/test_app/View/Errors/error400.ctp
@@ -1,4 +1,4 @@
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php printf(

--- a/lib/Cake/Test/test_app/View/Errors/error500.ctp
+++ b/lib/Cake/Test/test_app/View/Errors/error500.ctp
@@ -1,4 +1,4 @@
-<h2><?php echo $name; ?></h2>
+<h2><?php echo $message; ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php echo __d('cake', 'An Internal Error Has Occurred.'); ?>

--- a/lib/Cake/View/Errors/pdo_error.ctp
+++ b/lib/Cake/View/Errors/pdo_error.ctp
@@ -19,7 +19,7 @@
 <h2><?php echo __d('cake_dev', 'Database Error'); ?></h2>
 <p class="error">
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
-	<?php echo $name; ?>
+	<?php echo $message; ?>
 </p>
 <?php if (!empty($error->queryString)) : ?>
 	<p class="notice">


### PR DESCRIPTION
Url, Name, Message are currently wildly mixed between the different errors.

Unify exception handling and error templates to be consistent.
This makes working with custom ones easier.
And it is also quite relevant for more consistent API responses.

I will update the migration guide regarding this then.
