### PR TITLE
3.0 make query caching simpler

### DIFF
--- a/Cake/Cache/CacheRegistry.php
+++ b/Cake/Cache/CacheRegistry.php
@@ -83,7 +83,7 @@ class CacheRegistry extends ObjectRegistry {
 
 		if (!$instance->init($config)) {
 			throw new Error\Exception(
-				sprintf('Cache engine %s is not properly configured.', $class)
+				sprintf('Cache engine %s is not properly configured.', get_class($instance))
 			);
 		}
 

--- a/Cake/Model/Behavior/CounterCacheBehavior.php
+++ b/Cake/Model/Behavior/CounterCacheBehavior.php
@@ -76,6 +76,7 @@ use Cake\Utility\Inflector;
  *     ]
  * ]
  * }}}
+ *
  */
 class CounterCacheBehavior extends Behavior {
 

--- a/Cake/ORM/Query.php
+++ b/Cake/ORM/Query.php
@@ -517,6 +517,9 @@ class Query extends DatabaseQuery {
 			$results = $this->_decorateResults(
 				new ResultSet($this, $this->execute())
 			);
+			if ($this->_cache) {
+				$this->_cache->store($this, $results);
+			}
 		}
 		$this->_results = $results;
 		return $this->_results;

--- a/Cake/ORM/QueryCacher.php
+++ b/Cake/ORM/QueryCacher.php
@@ -19,6 +19,7 @@ namespace Cake\ORM;
 use Cake\Cache\Cache;
 use Cake\Cache\CacheEngine;
 use Cake\ORM\Query;
+use Cake\ORM\ResultSet;
 use RuntimeException;
 
 /**
@@ -62,6 +63,19 @@ class QueryCacher {
 			return null;
 		}
 		return $result;
+	}
+
+/**
+ * Store the result set into the cache.
+ *
+ * @param Query $query The query the cache read is for.
+ * @param ResultSet The result set to store.
+ * @return void
+ */
+	public function store(Query $query, ResultSet $results) {
+		$key = $this->_resolveKey($query);
+		$storage = $this->_resolveCacher();
+		return $storage->write($key, $results);
 	}
 
 /**

--- a/Cake/ORM/QueryCacher.php
+++ b/Cake/ORM/QueryCacher.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM;
+
+use Cake\ORM\Query;
+
+/**
+ * Handles caching queries and loading results from the cache.
+ *
+ * Used by Cake\ORM\Query internally.
+ *
+ * @see Cake\ORM\Query::cache() for the public interface.
+ */
+class QueryCacher {
+
+/**
+ * Constructor.
+ *
+ * @param string|Closure $key
+ * @param string|CacheEngine $config
+ */
+	public function __construct($key, $config) {
+		$this->_key = $key;
+		$this->_config = $config;
+	}
+
+/**
+ * Load the cached results from the cache or run the query.
+ *
+ * @param Query $query The query the cache read is for.
+ * @return ResultSet|null Either the cached results or null.
+ */
+	public function fetch(Query $query) {
+	}
+
+}

--- a/Cake/Test/TestCase/ORM/QueryCacherTest.php
+++ b/Cake/Test/TestCase/ORM/QueryCacherTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\ORM;
+
+use Cake\TestSuite\TestCase;
+
+/**
+ * Query cacher test
+ */
+class QueryCacherTest extends TestCase {
+
+/**
+ * Setup method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->engine = $this->getMock('Cake\Cache\CacheEngine');
+		Cache::config('queryCache', $this->engine);
+	}
+
+/**
+ * Teardown method
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		Cache::drop('queryCache');
+	}
+
+/**
+ * Test fetching with a function to generate the key.
+ *
+ * @return void
+ */
+	public function testFetchFunctionKey() {
+	}
+
+/**
+ * Test fetching with a function to generate the key but the function is poop.
+ *
+ * @return void
+ */
+	public function testFetchFunctionKeyNoString() {
+	}
+
+/**
+ * Test fetching with a cache instance.
+ *
+ * @return void
+ */
+	public function testFetchCacheInstance() {
+	}
+
+/**
+ * Test fetching with a cache hit.
+ *
+ * @return void
+ */
+	public function testFetchCacheHit() {
+	}
+
+/**
+ * Test fetching with a cache miss.
+ *
+ * @return void
+ */
+	public function testFetchCacheMiss() {
+	}
+
+}

--- a/Cake/Test/TestCase/ORM/QueryTest.php
+++ b/Cake/Test/TestCase/ORM/QueryTest.php
@@ -1534,4 +1534,17 @@ class QueryTest extends TestCase {
 		TableRegistry::get('articles')->find('all')->derpFilter();
 	}
 
+/**
+ * cache() should fail on non select queries.
+ *
+ * @expectedException RuntimeException
+ * @return void
+ */
+	public function testCacheErrorOnNonSelect() {
+		$table = TableRegistry::get('articles', ['table' => 'articles']);
+		$query = new Query($this->connection, $table);
+		$query->insert(['test']);
+		$query->cache('my_key');
+	}
+
 }


### PR DESCRIPTION
Add `Query::cache()` as discussed in #2562. I decided to make the caching a separate object as it was complex enough that it could standalone.

After this change caching results of find() operations is super easy and only takes one method call. While this introduces some coupling between the ORM and Cache packages, I've intentionally left off any type hints to hopefully free up the dependencies allowing people to substitute any object that implements read/write into the query cacher.
