### PR TITLE
Added HTTP Status 422 (Unprocessable Entity) to CakeResponse

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -68,6 +68,7 @@ class CakeResponse {
 		415 => 'Unsupported Media Type',
 		416 => 'Requested range not satisfiable',
 		417 => 'Expectation Failed',
+		422 => 'Unprocessable Entity',
 		500 => 'Internal Server Error',
 		501 => 'Not Implemented',
 		502 => 'Bad Gateway',


### PR DESCRIPTION
Quick fix to add HTTP Status Code 422 (inspired by Inspired by https://github.com/cakephp/cakephp/pull/1247). I wanted to use this code in my personal project but it resulted in a CakeException because it was not list in $_statusCodes.

```
Error: [CakeException] Unknown status code
Request URL: <hidden>
Stack Trace:
   #0 <hidden>\vendor\pear-pear.cakephp.org\CakePHP\Cake\Network\CakeResponse.php(390): CakeResponse->statusCode(422)
```
