### PR TITLE
Add 3 abstract methods to Cake\Database\Driver

### DIFF
--- a/Cake/Database/Connection.php
+++ b/Cake/Database/Connection.php
@@ -504,7 +504,7 @@ class Connection {
 
 /**
  * Quotes a database identifier (a column name, table name, etc..) to
- * be used safely in queries without the risk of using reserver words
+ * be used safely in queries without the risk of using reserved words
  *
  * @param string $identifier
  * @return string

--- a/Cake/Database/Dialect/MysqlDialectTrait.php
+++ b/Cake/Database/Dialect/MysqlDialectTrait.php
@@ -50,7 +50,7 @@ trait MysqlDialectTrait {
 /**
  * Get the schema dialect.
  *
- * Used by Cake\Schema package to reflect schema and
+ * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
  * @return Cake\Database\Schema\MysqlSchema

--- a/Cake/Database/Dialect/PostgresDialectTrait.php
+++ b/Cake/Database/Dialect/PostgresDialectTrait.php
@@ -125,7 +125,7 @@ trait PostgresDialectTrait {
 /**
  * Get the schema dialect.
  *
- * Used by Cake\Schema package to reflect schema and
+ * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
  * @return Cake\Database\Schema\PostgresSchema

--- a/Cake/Database/Dialect/SqliteDialectTrait.php
+++ b/Cake/Database/Dialect/SqliteDialectTrait.php
@@ -138,7 +138,7 @@ trait SqliteDialectTrait {
 /**
  * Get the schema dialect.
  *
- * Used by Cake\Schema package to reflect schema and
+ * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
  * @return Cake\Database\Schema\SqliteSchema

--- a/Cake/Database/Driver.php
+++ b/Cake/Database/Driver.php
@@ -157,7 +157,7 @@ abstract class Driver {
 /**
  * Get the schema dialect.
  *
- * Used by Cake\Schema package to reflect schema and
+ * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
  * If all the tables that use this Driver specify their
@@ -169,7 +169,7 @@ abstract class Driver {
 
 /**
  * Quotes a database identifier (a column name, table name, etc..) to
- * be used safely in queries without the risk of using reserver words
+ * be used safely in queries without the risk of using reserved words
  *
  * @param string $identifier
  * @return string

--- a/Cake/Database/Driver.php
+++ b/Cake/Database/Driver.php
@@ -144,6 +144,39 @@ abstract class Driver {
 	}
 
 /**
+ * Returns a callable function that will be used to transform a passed Query object.
+ * This function, in turn, will return an instance of a Query object that has been
+ * transformed to accommodate any specificities of the SQL dialect in use.
+ *
+ * @param string $type the type of query to be transformed
+ * (select, insert, update, delete)
+ * @return callable
+ */
+	public abstract function queryTranslator($type);
+
+/**
+ * Get the schema dialect.
+ *
+ * Used by Cake\Schema package to reflect schema and
+ * generate schema.
+ *
+ * If all the tables that use this Driver specify their
+ * own schemas, then this may return null.
+ *
+ * @return Cake\Database\Schema\BaseSchema
+ */
+	public abstract function schemaDialect();
+
+/**
+ * Quotes a database identifier (a column name, table name, etc..) to
+ * be used safely in queries without the risk of using reserver words
+ *
+ * @param string $identifier
+ * @return string
+ */
+	public abstract function quoteIdentifier($identifier);
+
+/**
  * Escapes values for use in schema definitions.
  *
  * @param mixed $value The value to escape.

--- a/Cake/Database/SqlDialectTrait.php
+++ b/Cake/Database/SqlDialectTrait.php
@@ -20,7 +20,7 @@ trait SqlDialectTrait {
 
 /**
  * Quotes a database identifier (a column name, table name, etc..) to
- * be used safely in queries without the risk of using reserver words
+ * be used safely in queries without the risk of using reserved words
  *
  * @param string $identifier
  * @return string

--- a/Cake/Test/TestApp/Plugin/TestPlugin/Database/Driver/TestSource.php
+++ b/Cake/Test/TestApp/Plugin/TestPlugin/Database/Driver/TestSource.php
@@ -80,4 +80,37 @@ class TestSource extends Driver {
 	public function quote($value, $type) {
 	}
 
+/**
+ * Returns a callable function that will be used to transform a passed Query object.
+ * This function, in turn, will return an instance of a Query object that has been
+ * transformed to accommodate any specificities of the SQL dialect in use.
+ *
+ * @param string $type the type of query to be transformed
+ * (select, insert, update, delete)
+ * @return callable
+ */
+	public function queryTranslator($type);
+
+/**
+ * Get the schema dialect.
+ *
+ * Used by Cake\Database\Schema package to reflect schema and
+ * generate schema.
+ *
+ * If all the tables that use this Driver specify their
+ * own schemas, then this may return null.
+ *
+ * @return Cake\Database\Schema\BaseSchema
+ */
+	public function schemaDialect();
+
+/**
+ * Quotes a database identifier (a column name, table name, etc..) to
+ * be used safely in queries without the risk of using reserved words
+ *
+ * @param string $identifier
+ * @return string
+ */
+	public function quoteIdentifier($identifier);
+
 }


### PR DESCRIPTION
This is for https://github.com/cakephp/cakephp/issues/2602.  This just defines three new abstract methods inside of Cake/Database/Driver that are already being used by the code base (read the issue to see where these three are currently being used).

I copied the docblock of the three functions from where they are currently defined.  I modified docblock for schemaDialect to indicate a more generic return value and to note that it can return null in a specific case.
