### PR TITLE
Clearer error message

### DIFF
--- a/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
+++ b/lib/Cake/Test/Case/TestSuite/CakeTestFixtureTest.php
@@ -65,7 +65,7 @@ class CakeTestFixtureTestFixture extends CakeTestFixture {
 }
 
 /**
- * StringFieldsTestFixture class
+ * StringTestFixture class
  *
  * @package       Cake.Test.Case.TestSuite
  */
@@ -94,6 +94,50 @@ class StringsTestFixture extends CakeTestFixture {
 		'id' => array('type' => 'integer', 'key' => 'primary'),
 		'name' => array('type' => 'string', 'length' => '255'),
 		'email' => array('type' => 'string', 'length' => '255'),
+		'age' => array('type' => 'integer', 'default' => 10)
+	);
+
+/**
+ * Records property
+ *
+ * @var array
+ */
+	public $records = array(
+		array('name' => 'Mark Doe', 'email' => 'mark.doe@email.com'),
+		array('name' => 'John Doe', 'email' => 'john.doe@email.com', 'age' => 20),
+		array('email' => 'jane.doe@email.com', 'name' => 'Jane Doe', 'age' => 30)
+	);
+}
+
+/**
+ * InvalidTestFixture class
+ *
+ * @package       Cake.Test.Case.TestSuite
+ */
+class InvalidTestFixture extends CakeTestFixture {
+
+/**
+ * Name property
+ *
+ * @var string
+ */
+	public $name = 'Invalid';
+
+/**
+ * Table property
+ *
+ * @var string
+ */
+	public $table = 'invalid';
+
+/**
+ * Fields array - missing "email" row
+ *
+ * @var array
+ */
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'length' => '255'),
 		'age' => array('type' => 'integer', 'default' => 10)
 	);
 
@@ -480,6 +524,17 @@ class CakeTestFixtureTest extends CakeTestCase {
 			),
 		);
 		$this->assertEquals($expected, $this->insertMulti['fields_values']);
+	}
+
+/**
+ * test the insert method with invalid fixture
+ *
+ * @expectedException CakeException
+ * @return void
+ */
+	public function testInsertInvalid() {
+		$Fixture = new InvalidTestFixture();
+		$return = $Fixture->insert($this->criticDb);
 	}
 
 /**

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -280,7 +280,7 @@ class CakeTestFixture {
 				foreach ($this->records as $record) {
 					$merge = array_values(array_merge($default, $record));
 					if (count($fields) !== count($merge)) {
-						throw new CakeException('Fixure invalid: Count of fields does not match count of values');
+						throw new CakeException('Fixture invalid: Count of fields does not match count of values');
 					}
 					$values[] = $merge;
 				}

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -265,6 +265,7 @@ class CakeTestFixture {
  *
  * @param DboSource $db An instance of the database into which the records will be inserted
  * @return boolean on success or if there are no records to insert, or false on failure
+ * @throws CakeException if count of values and fields does not match.
  */
 	public function insert($db) {
 		if (!isset($this->_insert)) {
@@ -277,10 +278,15 @@ class CakeTestFixture {
 				$fields = array_unique($fields);
 				$default = array_fill_keys($fields, null);
 				foreach ($this->records as $record) {
-					$values[] = array_values(array_merge($default, $record));
+					$merge = array_values(array_merge($default, $record));
+					if (count($fields) !== count($merge)) {
+						throw new CakeException('Fixure invalid: Count of fields does not match count of values');
+					}
+					$values[] = $merge;
 				}
 				$nested = $db->useNestedTransactions;
 				$db->useNestedTransactions = false;
+
 				$result = $db->insertMulti($this->table, $fields, $values);
 				if (
 					$this->primaryKey &&

--- a/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
+++ b/lib/Cake/TestSuite/Fixture/CakeTestFixture.php
@@ -265,7 +265,7 @@ class CakeTestFixture {
  *
  * @param DboSource $db An instance of the database into which the records will be inserted
  * @return boolean on success or if there are no records to insert, or false on failure
- * @throws CakeException if count of values and fields does not match.
+ * @throws CakeException if counts of values and fields do not match.
  */
 	public function insert($db) {
 		if (!isset($this->_insert)) {
@@ -286,7 +286,6 @@ class CakeTestFixture {
 				}
 				$nested = $db->useNestedTransactions;
 				$db->useNestedTransactions = false;
-
 				$result = $db->insertMulti($this->table, $fields, $values);
 				if (
 					$this->primaryKey &&


### PR DESCRIPTION
Currently, with a fixture that has an incorrect count of values, your test simply errors out with
"SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens"

Some digging reveeled the issue in the insert() method.
With this PR the exception responds with "Count of fields does not match count of values"

We could make it say: "Fixure invalid: Count of fields does not match count of values" to be even more clear on the subject.
