### PR TITLE
Follow the deprecation note in the doc block of View class

### DIFF
--- a/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/Emails/html/default.ctp
@@ -10,7 +10,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html>
 <head>
-	<title><?php echo $title_for_layout; ?></title>
+	<title><?php echo $this->fetch('title'); ?></title>
 </head>
 <body>
 	<?php echo $this->fetch('content'); ?>

--- a/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/default.ctp
@@ -15,7 +15,7 @@ $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework
 	<?php echo $this->Html->charset(); ?>
 	<title>
 		<?php echo $cakeDescription ?>:
-		<?php echo $title_for_layout; ?>
+		<?php echo $this->fetch('title'); ?>
 	</title>
 	<?php
 		echo $this->Html->meta('icon');

--- a/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/error.ctp
@@ -15,7 +15,7 @@ $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework
 	<?php echo $this->Html->charset(); ?>
 	<title>
 		<?php echo $cakeDescription ?>:
-		<?php echo $title_for_layout; ?>
+		<?php echo $this->fetch('title'); ?>
 	</title>
 	<?php
 		echo $this->Html->meta('icon');

--- a/lib/Cake/Console/Templates/skel/View/Layouts/rss/default.ctp
+++ b/lib/Cake/Console/Templates/skel/View/Layouts/rss/default.ctp
@@ -3,7 +3,7 @@ if (!isset($channel)):
 	$channel = array();
 endif;
 if (!isset($channel['title'])):
-	$channel['title'] = $title_for_layout;
+	$channel['title'] = $this->fetch('title');
 endif;
 
 echo $this->Rss->document(

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -191,14 +191,14 @@ This is the body of the message
 MSGBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'text';
-		$expect = str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $message);
+		$expects = str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals(DebugCompTransport::$lastEmail, $expect);
+		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expect = str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $message);
+		$expects = str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals(DebugCompTransport::$lastEmail, $expect);
+		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
 	}
 
 /**
@@ -262,18 +262,18 @@ TEXTBLOC;
 HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'text';
-		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $header) . $text . "\n" . '</pre>';
+		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $header) . $text . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals(DebugCompTransport::$lastEmail, $expect);
+		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . "\n" . '</pre>';
+		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals(DebugCompTransport::$lastEmail, $expect);
+		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'both';
-		$expect = str_replace('{CONTENTTYPE}', 'multipart/mixed; boundary="{boundary}"', $header);
-		$expect .= "--{boundary}\n" .
+		$expects = str_replace('{CONTENTTYPE}', 'multipart/mixed; boundary="{boundary}"', $header);
+		$expects .= "--{boundary}\n" .
 			'Content-Type: multipart/alternative; boundary="alt-{boundary}"' . "\n\n" .
 			'--alt-{boundary}' . "\n" .
 			'Content-Type: text/plain; charset=UTF-8' . "\n" .
@@ -288,11 +288,11 @@ HTMLBLOC;
 			'--alt-{boundary}--' . "\n\n\n" .
 			'--{boundary}--' . "\n";
 
-		$expect = '<pre>' . $expect . '</pre>';
+		$expects = '<pre>' . $expects . '</pre>';
 
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$this->assertTextEquals(
-			$expect,
+			$expects,
 			preg_replace('/[a-z0-9]{32}/i', '{boundary}', DebugCompTransport::$lastEmail)
 		);
 
@@ -313,9 +313,9 @@ HTMLBLOC;
 HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expect = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . '</pre>';
+		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message', 'default', 'thin'));
-		$this->assertTextEquals(DebugCompTransport::$lastEmail, $expect);
+		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/EmailComponentTest.php
@@ -191,14 +191,14 @@ This is the body of the message
 MSGBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'text';
-		$expects = str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $message);
+		$expected = str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
+		$this->assertTextEquals($expected, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expects = str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $message);
+		$expected = str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $message);
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
+		$this->assertTextEquals($expected, DebugCompTransport::$lastEmail);
 	}
 
 /**
@@ -262,18 +262,18 @@ TEXTBLOC;
 HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'text';
-		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $header) . $text . "\n" . '</pre>';
+		$expected = '<pre>' . str_replace('{CONTENTTYPE}', 'text/plain; charset=UTF-8', $header) . $text . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
+		$this->assertTextEquals($expected, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . "\n" . '</pre>';
+		$expected = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . "\n" . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
-		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
+		$this->assertTextEquals($expected, DebugCompTransport::$lastEmail);
 
 		$this->Controller->EmailTest->sendAs = 'both';
-		$expects = str_replace('{CONTENTTYPE}', 'multipart/mixed; boundary="{boundary}"', $header);
-		$expects .= "--{boundary}\n" .
+		$expected = str_replace('{CONTENTTYPE}', 'multipart/mixed; boundary="{boundary}"', $header);
+		$expected .= "--{boundary}\n" .
 			'Content-Type: multipart/alternative; boundary="alt-{boundary}"' . "\n\n" .
 			'--alt-{boundary}' . "\n" .
 			'Content-Type: text/plain; charset=UTF-8' . "\n" .
@@ -288,11 +288,11 @@ HTMLBLOC;
 			'--alt-{boundary}--' . "\n\n\n" .
 			'--{boundary}--' . "\n";
 
-		$expects = '<pre>' . $expects . '</pre>';
+		$expected = '<pre>' . $expected . '</pre>';
 
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message'));
 		$this->assertTextEquals(
-			$expects,
+			$expected,
 			preg_replace('/[a-z0-9]{32}/i', '{boundary}', DebugCompTransport::$lastEmail)
 		);
 
@@ -313,9 +313,9 @@ HTMLBLOC;
 HTMLBLOC;
 
 		$this->Controller->EmailTest->sendAs = 'html';
-		$expects = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . '</pre>';
+		$expected = '<pre>' . str_replace('{CONTENTTYPE}', 'text/html; charset=UTF-8', $header) . $html . '</pre>';
 		$this->assertTrue($this->Controller->EmailTest->send('This is the body of the message', 'default', 'thin'));
-		$this->assertTextEquals($expects, DebugCompTransport::$lastEmail);
+		$this->assertTextEquals($expected, DebugCompTransport::$lastEmail);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/View/Layouts/Emails/html/default.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/Emails/html/default.ctp
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-	<title><?php echo $title_for_layout; ?></title>
+	<title><?php echo $this->fetch('title'); ?></title>
 </head>
 
 <body>

--- a/lib/Cake/Test/test_app/View/Layouts/Emails/html/japanese.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/Emails/html/japanese.ctp
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-	<title><?php echo $title_for_layout; ?></title>
+	<title><?php echo $this->fetch('title'); ?></title>
 </head>
 
 <body>

--- a/lib/Cake/Test/test_app/View/Layouts/Emails/html/thin.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/Emails/html/thin.ctp
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-	<title><?php echo $title_for_layout; ?></title>
+	<title><?php echo $this->fetch('title'); ?></title>
 </head>
 
 <body>

--- a/lib/Cake/Test/test_app/View/Layouts/cache_empty_sections.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/cache_empty_sections.ctp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title><?php echo $title_for_layout; ?></title>
+	<title><?php echo $this->fetch('title'); ?></title>
 	<!--nocache--><?php $x = 1; ?><!--/nocache-->
 </head>
 <body>

--- a/lib/Cake/Test/test_app/View/Layouts/default.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/default.ctp
@@ -10,7 +10,7 @@ $cakeDescription = __d('cake_dev', 'CakePHP: the rapid development php framework
 	<?php echo $this->Html->charset(); ?>
 	<title>
 		<?php echo $cakeDescription ?>:
-		<?php echo $title_for_layout; ?>
+		<?php echo $this->fetch('title'); ?>
 	</title>
 	<?php
 		echo $this->Html->meta('icon');

--- a/lib/Cake/Test/test_app/View/Layouts/rss/default.ctp
+++ b/lib/Cake/Test/test_app/View/Layouts/rss/default.ctp
@@ -5,7 +5,7 @@ if (!isset($channel)) {
 	$channel = array();
 }
 if (!isset($channel['title'])) {
-	$channel['title'] = $title_for_layout;
+	$channel['title'] = $this->fetch('title');
 }
 
 echo $this->Rss->document(

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -452,7 +452,6 @@ class View extends Object {
 		if ($this->hasRendered) {
 			return true;
 		}
-		$this->Blocks->set('content', '');
 
 		if ($view !== false && $viewFileName = $this->_getViewFileName($view)) {
 			$this->_currentType = self::TYPE_VIEW;
@@ -485,7 +484,8 @@ class View extends Object {
  * - `$scripts_for_layout` is deprecated and will be removed in CakePHP 3.0.
  *   Use the block features instead. `meta`, `css` and `script` will be populated
  *   by the matching methods on HtmlHelper.
- * - `$title_for_layout` is deprecated and will be removed in CakePHP 3.0
+ * - `$title_for_layout` is deprecated and will be removed in CakePHP 3.0.
+ *   Use the `title` block instead.
  * - `$content_for_layout` is deprecated and will be removed in CakePHP 3.0.
  *   Use the `content` block instead.
  *
@@ -515,9 +515,16 @@ class View extends Object {
 			'scripts_for_layout' => $scripts,
 		));
 
-		if (!isset($this->viewVars['title_for_layout'])) {
-			$this->viewVars['title_for_layout'] = Inflector::humanize($this->viewPath);
+		$title = $this->Blocks->get('title');
+		if ($title === '') {
+			if (isset($this->viewVars['title_for_layout'])) {
+				$title = $this->viewVars['title_for_layout'];
+			} else {
+				$title = Inflector::humanize($this->viewPath);
+			}
 		}
+		$this->viewVars['title_for_layout'] = $title;
+		$this->Blocks->set('title', $title);
 
 		$this->_currentType = self::TYPE_LAYOUT;
 		$this->Blocks->set('content', $this->_render($layoutFileName));


### PR DESCRIPTION
"`$title_for_layout` is deprecated and will be removed in CakePHP 3.0"

Switch to fetch('title')

This would be the quick way. And then drop the old "title_for_layout" in 3.0 alltogether.
We could also make it a complete rewrite now.
