### PR TITLE
3.0 checkbox widget

### DIFF
--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -53,9 +53,11 @@ class Checkbox {
 		if ($this->_isChecked($data)) {
 			$data['checked'] = true;
 		}
+		unset($data['selected']);
+
 		$attrs = $this->_templates->formatAttributes(
 			$data,
-			['name', 'value', 'selected']
+			['name', 'value']
 		);
 
 		return $this->_templates->format('checkbox', [

--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+use Cake\View\StringTemplate;
+
+/**
+ * Input widget for creating checkbox widgets.
+ */
+class Checkbox {
+
+/**
+ * Template instance.
+ *
+ * @var Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Constructor
+ *
+ * @param Cake\View\StringTemplate $templates
+ */
+	public function __construct($templates) {
+		$this->_templates = $templates;
+	}
+
+/**
+ * Render a checkbox element.
+ *
+ * @param array $data The data to create a checkbox with.
+ */
+	public function render($data) {
+		$data += [
+			'name' => '',
+			'value' => 1,
+			'checked' => false,
+			'disabled' => false,
+		];
+		$attrs = $this->_templates->formatAttributes(
+			$data,
+			['name', 'value']
+		);
+
+		return $this->_templates->format('checkbox', [
+			'name' => $data['name'],
+			'value' => $data['value'],
+			'attrs' => $attrs
+		]);
+	}
+
+}

--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -46,12 +46,16 @@ class Checkbox {
 		$data += [
 			'name' => '',
 			'value' => 1,
+			'selected' => null,
 			'checked' => false,
 			'disabled' => false,
 		];
+		if ($this->_isChecked($data)) {
+			$data['checked'] = true;
+		}
 		$attrs = $this->_templates->formatAttributes(
 			$data,
-			['name', 'value']
+			['name', 'value', 'selected']
 		);
 
 		return $this->_templates->format('checkbox', [
@@ -59,6 +63,22 @@ class Checkbox {
 			'value' => $data['value'],
 			'attrs' => $attrs
 		]);
+	}
+
+/**
+ * Check whether or not the checkbox should be checked.
+ *
+ * @param array $data Data to look at and determine checked state.
+ * @return boolean
+ */
+	protected function _isChecked($data) {
+		if (!empty($data['checked'])) {
+			return true;
+		}
+		if ((string)$data['selected'] === (string)$data['value']) {
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -14,8 +14,6 @@
  */
 namespace Cake\View\Input;
 
-use Cake\View\StringTemplate;
-
 /**
  * Input widget for creating checkbox widgets.
  */
@@ -40,7 +38,17 @@ class Checkbox {
 /**
  * Render a checkbox element.
  *
+ * Data supports the following keys:
+ *
+ * - `name` - The name of the input.
+ * - `value` - The value attribute. Defaults to '1'.
+ * - `checked` - Whether or not the checkbox should be checked.
+ * - `disabled` - Whether or not the checkbox should be disabled.
+ *
+ * Any other attributes passed in will be treated as HTML attributes.
+ *
  * @param array $data The data to create a checkbox with.
+ * @return string Generated HTML string.
  */
 	public function render($data) {
 		$data += [

--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -42,7 +42,8 @@ class Checkbox {
  *
  * - `name` - The name of the input.
  * - `value` - The value attribute. Defaults to '1'.
- * - `checked` - Whether or not the checkbox should be checked.
+ * - `val` - The current value. If it matches `value` the checkbox will be checked.
+ *   You can also use the 'checked' attribute to make the checkbox checked.
  * - `disabled` - Whether or not the checkbox should be disabled.
  *
  * Any other attributes passed in will be treated as HTML attributes.
@@ -54,14 +55,14 @@ class Checkbox {
 		$data += [
 			'name' => '',
 			'value' => 1,
-			'selected' => null,
+			'val' => null,
 			'checked' => false,
 			'disabled' => false,
 		];
 		if ($this->_isChecked($data)) {
 			$data['checked'] = true;
 		}
-		unset($data['selected']);
+		unset($data['val']);
 
 		$attrs = $this->_templates->formatAttributes(
 			$data,
@@ -85,7 +86,7 @@ class Checkbox {
 		if (!empty($data['checked'])) {
 			return true;
 		}
-		if ((string)$data['selected'] === (string)$data['value']) {
+		if ((string)$data['val'] === (string)$data['value']) {
 			return true;
 		}
 		return false;

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -61,7 +61,7 @@ class Radio {
  * - `options` - An array of options. See below for more information.
  * - `disabled` - Either true or an array of inputs to disable.
  *    When true, the select element will be disabled.
- * - `value` - A string of the option to mark as selected.
+ * - `selected` - A string of the option to mark as selected.
  * - `label` - Either false to disable label generation, or
  *   an array of attributes for all labels.
  *
@@ -73,7 +73,7 @@ class Radio {
 			'name' => '',
 			'options' => [],
 			'disabled' => null,
-			'value' => null,
+			'selected' => null,
 			'escape' => true,
 			'label' => true,
 			'empty' => false,
@@ -137,7 +137,7 @@ class Radio {
 			$radio['id'] = Inflector::slug($radio['name'] . '_' . $radio['value']);
 		}
 
-		if (isset($data['value']) && strval($data['value']) === strval($radio['value'])) {
+		if (isset($data['selected']) && strval($data['selected']) === strval($radio['value'])) {
 			$radio['checked'] = true;
 		}
 

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -61,7 +61,7 @@ class Radio {
  * - `options` - An array of options. See below for more information.
  * - `disabled` - Either true or an array of inputs to disable.
  *    When true, the select element will be disabled.
- * - `selected` - A string of the option to mark as selected.
+ * - `val` - A string of the option to mark as selected.
  * - `label` - Either false to disable label generation, or
  *   an array of attributes for all labels.
  *
@@ -73,7 +73,7 @@ class Radio {
 			'name' => '',
 			'options' => [],
 			'disabled' => null,
-			'selected' => null,
+			'val' => null,
 			'escape' => true,
 			'label' => true,
 			'empty' => false,
@@ -137,7 +137,7 @@ class Radio {
 			$radio['id'] = Inflector::slug($radio['name'] . '_' . $radio['value']);
 		}
 
-		if (isset($data['selected']) && strval($data['selected']) === strval($radio['value'])) {
+		if (isset($data['val']) && strval($data['val']) === strval($radio['value'])) {
 			$radio['checked'] = true;
 		}
 

--- a/src/View/Input/SelectBox.php
+++ b/src/View/Input/SelectBox.php
@@ -51,7 +51,7 @@ class SelectBox {
  * - `options` - An array of options.
  * - `disabled` - Either true or an array of options to disable.
  *    When true, the select element will be disabled.
- * - `value` - Either a string or an array of options to mark as selected.
+ * - `selected` - Either a string or an array of options to mark as selected.
  * - `empty` - Set to true to add an empty option at the top of the
  *   option elements. Set to a string to define the display value of the
  *   empty option.
@@ -121,7 +121,7 @@ class SelectBox {
 			'escape' => true,
 			'options' => [],
 			'disabled' => null,
-			'value' => null,
+			'selected' => null,
 		];
 
 		if (empty($data['name'])) {
@@ -129,7 +129,7 @@ class SelectBox {
 		}
 		$options = $this->_renderContent($data);
 		$name = $data['name'];
-		unset($data['name'], $data['options'], $data['empty'], $data['value'], $data['escape']);
+		unset($data['name'], $data['options'], $data['empty'], $data['selected'], $data['escape']);
 		if (isset($data['disabled']) && is_array($data['disabled'])) {
 			unset($data['disabled']);
 		}
@@ -168,7 +168,7 @@ class SelectBox {
 			return [];
 		}
 
-		$selected = isset($data['value']) ? $data['value'] : null;
+		$selected = isset($data['selected']) ? $data['selected'] : null;
 		$disabled = null;
 		if (isset($data['disabled']) && is_array($data['disabled'])) {
 			$disabled = $data['disabled'];

--- a/src/View/Input/SelectBox.php
+++ b/src/View/Input/SelectBox.php
@@ -51,7 +51,7 @@ class SelectBox {
  * - `options` - An array of options.
  * - `disabled` - Either true or an array of options to disable.
  *    When true, the select element will be disabled.
- * - `selected` - Either a string or an array of options to mark as selected.
+ * - `val` - Either a string or an array of options to mark as selected.
  * - `empty` - Set to true to add an empty option at the top of the
  *   option elements. Set to a string to define the display value of the
  *   empty option.
@@ -121,7 +121,7 @@ class SelectBox {
 			'escape' => true,
 			'options' => [],
 			'disabled' => null,
-			'selected' => null,
+			'val' => null,
 		];
 
 		if (empty($data['name'])) {
@@ -129,7 +129,7 @@ class SelectBox {
 		}
 		$options = $this->_renderContent($data);
 		$name = $data['name'];
-		unset($data['name'], $data['options'], $data['empty'], $data['selected'], $data['escape']);
+		unset($data['name'], $data['options'], $data['empty'], $data['val'], $data['escape']);
 		if (isset($data['disabled']) && is_array($data['disabled'])) {
 			unset($data['disabled']);
 		}
@@ -168,7 +168,7 @@ class SelectBox {
 			return [];
 		}
 
-		$selected = isset($data['selected']) ? $data['selected'] : null;
+		$selected = isset($data['val']) ? $data['val'] : null;
 		$disabled = null;
 		if (isset($data['disabled']) && is_array($data['disabled'])) {
 			$disabled = $data['disabled'];

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -54,7 +54,7 @@ class CheckboxTest extends TestCase {
 
 		$data = [
 			'name' => 'Comment[spam]',
-			'value' => 99
+			'value' => 99,
 		];
 		$result = $checkbox->render($data);
 		$expected = [
@@ -112,6 +112,58 @@ class CheckboxTest extends TestCase {
 			]
 		];
 		$this->assertTags($result, $expected);
+
+		$data = [
+			'name' => 'Comment[spam]',
+			'value' => 1,
+			'selected' => 1,
+		];
+		$result = $checkbox->render($data);
+		$this->assertTags($result, $expected);
+
+		$data['selected'] = '1';
+		$result = $checkbox->render($data);
+		$this->assertTags($result, $expected);
+
+		$data = [
+			'name' => 'Comment[spam]',
+			'value' => 1,
+			'selected' => '1x',
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 1,
+			]
+		];
+		$this->assertTags($result, $expected);
 	}
+
+/**
+ * Test rendering checked checkboxes with value.
+ *
+ * @return void
+ */
+	public function testRenderCheckedValue() {
+		$checkbox = new Checkbox($this->templates);
+		$data = [
+			'name' => 'Comment[spam]',
+			'value' => 1,
+			'checked' => 1,
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 1,
+				'checked' => 'checked',
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
 
 }

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -116,19 +116,19 @@ class CheckboxTest extends TestCase {
 		$data = [
 			'name' => 'Comment[spam]',
 			'value' => 1,
-			'selected' => 1,
+			'val' => 1,
 		];
 		$result = $checkbox->render($data);
 		$this->assertTags($result, $expected);
 
-		$data['selected'] = '1';
+		$data['val'] = '1';
 		$result = $checkbox->render($data);
 		$this->assertTags($result, $expected);
 
 		$data = [
 			'name' => 'Comment[spam]',
 			'value' => 1,
-			'selected' => '1x',
+			'val' => '1x',
 		];
 		$result = $checkbox->render($data);
 		$expected = [

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\Checkbox;
+use Cake\View\StringTemplate;
+
+/**
+ * Checkbox test case
+ */
+class CheckboxTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$templates = [
+			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
+		];
+		$this->templates = new StringTemplate();
+		$this->templates->add($templates);
+	}
+
+/**
+ * Test rendering simple checkboxes.
+ *
+ * @return void
+ */
+	public function testRenderSimple() {
+		$checkbox = new Checkbox($this->templates);
+		$data = [
+			'name' => 'Comment[spam]',
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 1,
+			]
+		];
+		$this->assertTags($result, $expected);
+
+		$data = [
+			'name' => 'Comment[spam]',
+			'value' => 99
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 99,
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test rendering disabled checkboxes.
+ *
+ * @return void
+ */
+	public function testRenderDisabled() {
+		$checkbox = new Checkbox($this->templates);
+		$data = [
+			'name' => 'Comment[spam]',
+			'disabled' => true,
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 1,
+				'disabled' => 'disabled',
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test rendering checked checkboxes.
+ *
+ * @return void
+ */
+	public function testRenderChecked() {
+		$checkbox = new Checkbox($this->templates);
+		$data = [
+			'name' => 'Comment[spam]',
+			'value' => 1,
+			'checked' => 1,
+		];
+		$result = $checkbox->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'checkbox',
+				'name' => 'Comment[spam]',
+				'value' => 1,
+				'checked' => 'checked',
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
+}

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -165,5 +165,4 @@ class CheckboxTest extends TestCase {
 		$this->assertTags($result, $expected);
 	}
 
-
 }

--- a/tests/TestCase/View/Input/RadioTest.php
+++ b/tests/TestCase/View/Input/RadioTest.php
@@ -215,7 +215,7 @@ class RadioTest extends TestCase {
 		$radio = new Radio($this->templates);
 		$data = [
 			'name' => 'Versions[ver]',
-			'selected' => '1',
+			'val' => '1',
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',

--- a/tests/TestCase/View/Input/RadioTest.php
+++ b/tests/TestCase/View/Input/RadioTest.php
@@ -215,7 +215,7 @@ class RadioTest extends TestCase {
 		$radio = new Radio($this->templates);
 		$data = [
 			'name' => 'Versions[ver]',
-			'value' => '1',
+			'selected' => '1',
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',

--- a/tests/TestCase/View/Input/SelectBoxTest.php
+++ b/tests/TestCase/View/Input/SelectBoxTest.php
@@ -141,7 +141,7 @@ class SelectBoxTest extends TestCase {
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
-			'value' => '1',
+			'selected' => '1',
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',
@@ -160,7 +160,7 @@ class SelectBoxTest extends TestCase {
 		];
 		$this->assertTags($result, $expected);
 
-		$data['value'] = 2;
+		$data['selected'] = 2;
 		$result = $select->render($data);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
@@ -211,7 +211,7 @@ class SelectBoxTest extends TestCase {
 			'multiple' => true,
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
-			'value' => ['1', '2', 'burp'],
+			'selected' => ['1', '2', 'burp'],
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',
@@ -373,7 +373,7 @@ class SelectBoxTest extends TestCase {
 		$select = new SelectBox($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
-			'value' => ['1', '2', 'burp'],
+			'selected' => ['1', '2', 'burp'],
 			'disabled' => ['1x', '2x', 'nope'],
 			'options' => [
 				'ones' => [
@@ -416,7 +416,7 @@ class SelectBoxTest extends TestCase {
 			'disabled' => true,
 			'name' => 'Birds[name]',
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie'],
-			'value' => 'a',
+			'selected' => 'a',
 		];
 		$result = $select->render($data);
 		$expected = [
@@ -440,7 +440,7 @@ class SelectBoxTest extends TestCase {
 		$select = new SelectBox($this->templates);
 		$data = [
 			'disabled' => ['a', 'c'],
-			'value' => 'a',
+			'selected' => 'a',
 			'name' => 'Birds[name]',
 			'options' => [
 				'a' => 'Albatross',
@@ -502,7 +502,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['empty'] = 'empty';
-		$data['value'] = '';
+		$data['selected'] = '';
 		$result = $select->render($data);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
@@ -513,7 +513,7 @@ class SelectBoxTest extends TestCase {
 		];
 		$this->assertTags($result, $expected);
 
-		$data['value'] = false;
+		$data['selected'] = false;
 		$result = $select->render($data);
 		$this->assertTags($result, $expected);
 	}

--- a/tests/TestCase/View/Input/SelectBoxTest.php
+++ b/tests/TestCase/View/Input/SelectBoxTest.php
@@ -141,7 +141,7 @@ class SelectBoxTest extends TestCase {
 		$data = [
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
-			'selected' => '1',
+			'val' => '1',
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',
@@ -160,7 +160,7 @@ class SelectBoxTest extends TestCase {
 		];
 		$this->assertTags($result, $expected);
 
-		$data['selected'] = 2;
+		$data['val'] = 2;
 		$result = $select->render($data);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
@@ -211,7 +211,7 @@ class SelectBoxTest extends TestCase {
 			'multiple' => true,
 			'id' => 'BirdName',
 			'name' => 'Birds[name]',
-			'selected' => ['1', '2', 'burp'],
+			'val' => ['1', '2', 'burp'],
 			'options' => [
 				1 => 'one',
 				'1x' => 'one x',
@@ -373,7 +373,7 @@ class SelectBoxTest extends TestCase {
 		$select = new SelectBox($this->templates);
 		$data = [
 			'name' => 'Birds[name]',
-			'selected' => ['1', '2', 'burp'],
+			'val' => ['1', '2', 'burp'],
 			'disabled' => ['1x', '2x', 'nope'],
 			'options' => [
 				'ones' => [
@@ -416,7 +416,7 @@ class SelectBoxTest extends TestCase {
 			'disabled' => true,
 			'name' => 'Birds[name]',
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie'],
-			'selected' => 'a',
+			'val' => 'a',
 		];
 		$result = $select->render($data);
 		$expected = [
@@ -440,7 +440,7 @@ class SelectBoxTest extends TestCase {
 		$select = new SelectBox($this->templates);
 		$data = [
 			'disabled' => ['a', 'c'],
-			'selected' => 'a',
+			'val' => 'a',
 			'name' => 'Birds[name]',
 			'options' => [
 				'a' => 'Albatross',
@@ -502,7 +502,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['empty'] = 'empty';
-		$data['selected'] = '';
+		$data['val'] = '';
 		$result = $select->render($data);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
@@ -513,7 +513,7 @@ class SelectBoxTest extends TestCase {
 		];
 		$this->assertTags($result, $expected);
 
-		$data['selected'] = false;
+		$data['val'] = false;
 		$result = $select->render($data);
 		$this->assertTags($result, $expected);
 	}


### PR DESCRIPTION
As part of #2267 this set of changes adds the checkbox widget. I've also done some refactoring in the radio and select widgets to rename 'value' into 'selected'. The widgets data keys should try and map to HTML wherever possible. I'd also like to keep consistency between as many widgets as possible. Since checkboxes use value for the HTML attribute, we will need to use 'selected' instead. I've updated the other widgets to use 'selected' as well for consistency's sake.
