### PR TITLE
3.0 - fix plugin associations

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -330,7 +330,8 @@ abstract class Association {
 			$this->_propertyName = $name;
 		}
 		if ($name === null && !$this->_propertyName) {
-			$this->_propertyName = Inflector::underscore($this->_name);
+			list($plugin, $name) = pluginSplit($this->_name);
+			$this->_propertyName = Inflector::underscore($name);
 		}
 		return $this->_propertyName;
 	}

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -82,7 +82,8 @@ class BelongsTo extends Association {
 			return parent::property($name);
 		}
 		if ($name === null && !$this->_propertyName) {
-			$this->_propertyName = Inflector::underscore(Inflector::singularize($this->_name));
+			list($plugin, $name) = pluginSplit($this->_name);
+			$this->_propertyName = Inflector::underscore(Inflector::singularize($name));
 		}
 		return $this->_propertyName;
 	}

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -79,7 +79,8 @@ class HasOne extends Association {
 			return parent::property($name);
 		}
 		if ($name === null && !$this->_propertyName) {
-			$this->_propertyName = Inflector::underscore(Inflector::singularize($this->_name));
+			list($plugin, $name) = pluginSplit($this->_name);
+			$this->_propertyName = Inflector::underscore(Inflector::singularize($name));
 		}
 		return $this->_propertyName;
 	}

--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -36,11 +36,15 @@ class Associations {
 /**
  * Add an association to the collection
  *
+ * If the alias added contains a `.` the part preceding the `.` will be dropped.
+ * This makes using plugins simpler as the Plugin.Class syntax is frequently used.
+ *
  * @param string $alias The association alias
  * @param Association The association to add.
- * @return void
+ * @return Association The association object being added.
  */
 	public function add($alias, Association $association) {
+		list($plugin, $alias) = pluginSplit($alias);
 		return $this->_items[strtolower($alias)] = $association;
 	}
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1294,4 +1294,19 @@ class BelongsToManyTest extends TestCase {
 		$association->save($entity);
 	}
 
+/**
+ * Test that plugin names are omitted from property()
+ *
+ * @return void
+ */
+	public function testPropertyNoPlugin() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->article,
+			'targetTable' => $mock,
+		];
+		$association = new BelongsToMany('Contacts.Tags', $config);
+		$this->assertEquals('tags', $association->property());
+	}
+
 }

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -257,4 +257,19 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$this->assertNull($entity->author_id);
 	}
 
+/**
+ * Test that plugin names are omitted from property()
+ *
+ * @return void
+ */
+	public function testPropertyNoPlugin() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->client,
+			'targetTable' => $mock,
+		];
+		$association = new BelongsTo('Contacts.Companies', $config);
+		$this->assertEquals('company', $association->property());
+	}
+
 }

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -649,4 +649,20 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$association = new HasMany('Articles', $config);
 		$association->save($entity);
 	}
+
+/**
+ * Test that plugin names are omitted from property()
+ *
+ * @return void
+ */
+	public function testPropertyNoPlugin() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->author,
+			'targetTable' => $mock,
+		];
+		$association = new HasMany('Contacts.Addresses', $config);
+		$this->assertEquals('addresses', $association->property());
+	}
+
 }

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -237,4 +237,20 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 
 		$this->assertSame($result, $entity);
 	}
+
+/**
+ * Test that plugin names are omitted from property()
+ *
+ * @return void
+ */
+	public function testPropertyNoPlugin() {
+		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
+		$config = [
+			'sourceTable' => $this->user,
+			'targetTable' => $mock,
+		];
+		$association = new HasOne('Contacts.Profiles', $config);
+		$this->assertEquals('profile', $association->property());
+	}
+
 }

--- a/tests/TestCase/ORM/AssociationsTest.php
+++ b/tests/TestCase/ORM/AssociationsTest.php
@@ -63,6 +63,21 @@ class AssociationsTest extends TestCase {
 	}
 
 /**
+ * Test associations with plugin names.
+ *
+ * @return void
+ */
+	public function testAddHasRemoveGetWithPlugin() {
+		$this->assertFalse($this->associations->has('Photos.Photos'));
+		$this->assertFalse($this->associations->has('Photos'));
+
+		$belongsTo = new BelongsTo([]);
+		$this->assertSame($belongsTo, $this->associations->add('Photos.Photos', $belongsTo));
+		$this->assertTrue($this->associations->has('Photos'));
+		$this->assertFalse($this->associations->has('Photos.Photos'));
+	}
+
+/**
  * Test keys()
  *
  * @return void


### PR DESCRIPTION
While investigating cakephp/app#17 and updating the documentation, I found a few thorny points in the ORM regarding plugins. The first problem was that using `Photos.Photos` as an association name, resulted in a similarly named association. This association became impossible to `contain()` as `.` has specific meaning in contain().  The second issue was even once those relations were loaded the hydrated property also contained a `.`. This was totally un-expected for me, so I corrected the behavior to better match how the ORM worked in 2.x
