### PR TITLE
allow additional status codes through constructor

### DIFF
--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -379,6 +379,7 @@ class CakeResponse {
  *
  * @param array $options list of parameters to setup the response. Possible values are:
  *	- body: the response text that should be sent to the client
+ *	- codes: additional allowable response codes
  *	- status: the HTTP status code to respond with
  *	- type: a complete mime-type string or an extension mapped in this class
  *	- charset: the charset for the response body
@@ -386,6 +387,9 @@ class CakeResponse {
 	public function __construct(array $options = array()) {
 		if (isset($options['body'])) {
 			$this->body($options['body']);
+		}
+		if (isset($options['codes'])) {
+			$this->httpCodes($options['codes']);
 		}
 		if (isset($options['status'])) {
 			$this->statusCode($options['status']);

--- a/lib/Cake/Test/Case/Network/CakeResponseTest.php
+++ b/lib/Cake/Test/Case/Network/CakeResponseTest.php
@@ -66,6 +66,21 @@ class CakeResponseTest extends CakeTestCase {
 		$this->assertEquals('my-custom-charset', $response->charset());
 		$this->assertEquals('audio/mpeg', $response->type());
 		$this->assertEquals(203, $response->statusCode());
+
+		$options = array(
+			'body' => 'This is the body',
+			'charset' => 'my-custom-charset',
+			'type' => 'mp3',
+			'status' => '422',
+			'codes' => array(
+				422 => 'Unprocessable Entity'
+			)
+		);
+		$response = new CakeResponse($options);
+		$this->assertEquals($options['body'], $response->body());
+		$this->assertEquals($options['charset'], $response->charset());
+		$this->assertEquals($response->getMimeType($options['type']), $response->type());
+		$this->assertEquals($options['status'], $response->statusCode());
 	}
 
 /**


### PR DESCRIPTION
It is currently possible to possible to trigger a CakeException by passing in an unsupported status code into the constructor.  This allows for additional status codes to be set (through $options['codes']).  While this is largely syntactic sugar, it can potentially prevent an exception.

Assuming we are inside of a class declaration, $object is an class instance, and $extraCodes is an object attribute, 

```
public function __construct($object) {
    $this->httpCodes($this->extraCodes);
    parent::__construct(
        'status' => $object->getStatusCode(),
        // etc ...
    );
}
```

would turn into ...

```
public function __construct($object) {
    parent::__construct(
        'status' => $object->getStatusCode(),
        'codes' => $this->extraCodes,
        // etc ...
    );
}
```

My current usage is that I am trying to build a CakeResponse from a different object (Adapter pattern) that can have a status code not in CakeResponse::$_statusCodes.  It's not ground-breaking and I could totally do without it.  But I think the second form follows a more functional style and thus is a little more concise than the first.
