### PR TITLE
3.0 text widget

### DIFF
--- a/src/View/Input/Text.php
+++ b/src/View/Input/Text.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+/**
+ * Text input class.
+ */
+class Text {
+
+/**
+ * StringTemplate instance.
+ *
+ * @var Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Constructor.
+ *
+ * @param StringTemplate $templates
+ */
+	public function __construct($templates) {
+		$this->_templates = $templates;
+	}
+
+/**
+ * Render a text widget or other simple widget like email/tel/number.
+ *
+ * @param array $data The data to build an input with.
+ * @return string
+ */
+	public function render($data) {
+		$data += [
+			'name' => '',
+			'value' => null,
+			'type' => 'text',
+			'escape' => true,
+		];
+		return $this->_templates->format('input', [
+			'name' => $data['name'],
+			'type' => $data['type'],
+			'attrs' => $this->_templates->formatAttributes(
+				$data,
+				['name', 'type']
+			),
+		]);
+	}
+
+}

--- a/src/View/Input/Text.php
+++ b/src/View/Input/Text.php
@@ -15,7 +15,11 @@
 namespace Cake\View\Input;
 
 /**
- * Text input class.
+ * Basic input class.
+ *
+ * This input class can be used to render basic simple
+ * input elements like hidden, text, email, tel and other
+ * types.
  */
 class Text {
 
@@ -38,16 +42,27 @@ class Text {
 /**
  * Render a text widget or other simple widget like email/tel/number.
  *
+ * This method accepts a number of keys:
+ *
+ * - `name` The name attribute.
+ * - `val` The value attribute.
+ * - `escape` Set to false to disable escaping on all attributes.
+ *
+ * Any other keys provided in $data will be converted into HTML attributes.
+ *
  * @param array $data The data to build an input with.
  * @return string
  */
 	public function render($data) {
 		$data += [
 			'name' => '',
-			'value' => null,
+			'val' => null,
 			'type' => 'text',
 			'escape' => true,
 		];
+		$data['value'] = $data['val'];
+		unset($data['val']);
+
 		return $this->_templates->format('input', [
 			'name' => $data['name'],
 			'type' => $data['type'],

--- a/tests/TestCase/View/Input/TextTest.php
+++ b/tests/TestCase/View/Input/TextTest.php
@@ -74,7 +74,7 @@ class TextTest extends TestCase {
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',
-			'value' => 'Some <value>'
+			'val' => 'Some <value>'
 		];
 		$result = $text->render($data);
 		$expected = [

--- a/tests/TestCase/View/Input/TextTest.php
+++ b/tests/TestCase/View/Input/TextTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\Text;
+use Cake\View\StringTemplate;
+
+/**
+ * Text input test.
+ */
+class TextTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$templates = [
+			'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
+		];
+		$this->templates = new StringTemplate();
+		$this->templates->add($templates);
+	}
+
+/**
+ * Test render in a simple case.
+ *
+ * @return void
+ */
+	public function testRenderSimple() {
+		$text = new Text($this->templates);
+		$result = $text->render(['name' => 'my_input']);
+		$expected = [
+			'input' => ['type' => 'text', 'name' => 'my_input']
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with custom type
+ *
+ * @return void
+ */
+	public function testRenderType() {
+		$text = new Text($this->templates);
+		$data = [
+			'name' => 'my_input',
+			'type' => 'email',
+		];
+		$result = $text->render($data);
+		$expected = [
+			'input' => ['type' => 'email', 'name' => 'my_input']
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with a value
+ *
+ * @return void
+ */
+	public function testRenderWithValue() {
+		$text = new Text($this->templates);
+		$data = [
+			'name' => 'my_input',
+			'type' => 'email',
+			'value' => 'Some <value>'
+		];
+		$result = $text->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'email',
+				'name' => 'my_input',
+				'value' => 'Some &lt;value&gt;'
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with additional attributes.
+ *
+ * @return void
+ */
+	public function testRenderAttributes() {
+		$text = new Text($this->templates);
+		$data = [
+			'name' => 'my_input',
+			'type' => 'email',
+			'class' => 'form-control',
+			'required' => true
+		];
+		$result = $text->render($data);
+		$expected = [
+			'input' => [
+				'type' => 'email',
+				'name' => 'my_input',
+				'class' => 'form-control',
+				'required' => 'required',
+			]
+		];
+		$this->assertTags($result, $expected);
+	}
+
+}


### PR DESCRIPTION
As part of cakephp/cakephp#2267 this set of changes implements the 'basic text' type. Which can also be used for simple HTML5 inputs like email, tel, number, hidden etc.
