### PR TITLE
3.0 multi checkbox

### DIFF
--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -37,8 +37,7 @@ trait StringTemplateTrait {
  * @return void
  */
 	public function initStringTemplates($templates = [], $templateClass = '\Cake\View\StringTemplate') {
-		$this->_templater = new $templateClass();
-		$this->_templater->add($templates);
+		$this->_templater = new $templateClass($templates);
 		if (isset($this->settings['templates'])) {
 			$this->_templater->load($this->settings['templates']);
 		}

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -86,7 +86,7 @@ class MultiCheckbox {
 			'disabled' => null,
 			'val' => null,
 		];
-		$out= [];
+		$out = [];
 		foreach ($data['options'] as $key => $val) {
 			$checkbox = [
 				'value' => $key,

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -41,6 +41,7 @@ class MultiCheckbox {
  *   checked.
  * - `disabled` Either a boolean or an array of checkboxes to disable.
  * - `escape` Set to false to disable HTML escaping.
+ * - `options` An associative array of value=>labels to generate options for.
  *
  * @param array $data
  * @return string

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -128,8 +128,11 @@ class MultiCheckbox {
  * @return boolean
  */
 	protected function _isDisabled($key, $disabled) {
-		if ($disabled === null) {
+		if ($disabled === null || $disabled === false) {
 			return false;
+		}
+		if ($disabled === true) {
+			return true;
 		}
 		$strict = !is_numeric($key);
 		return in_array((string)$key, $disabled, $strict);

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -56,7 +56,7 @@ class MultiCheckbox {
 			$checkbox['escape'] = $data['escape'];
 
 			if ($this->_isSelected($key, $data['val'])) {
-				$checkbox['selected'] = true;
+				$checkbox['checked'] = true;
 			}
 			if ($this->_isDisabled($key, $data['disabled'])) {
 				$checkbox['disabled'] = true;

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -16,8 +16,17 @@ namespace Cake\View\Input;
 
 use Cake\Utility\Inflector;
 
+/**
+ * Input widget class for generating multiple checkboxes.
+ *
+ */
 class MultiCheckbox {
 
+/**
+ * Template instance to use.
+ *
+ * @var Cake\View\StringTemplate
+ */
 	protected $_templates;
 
 /**
@@ -38,10 +47,33 @@ class MultiCheckbox {
  *   `[]` will be appended to the name.
  * - `options` An array of options to create checkboxes out of.
  * - `val` Either a string/integer or array of values that should be
- *   checked.
+ *   checked. Can also be a complex options set.
  * - `disabled` Either a boolean or an array of checkboxes to disable.
  * - `escape` Set to false to disable HTML escaping.
  * - `options` An associative array of value=>labels to generate options for.
+ *
+ * ### Options format
+ *
+ * The options option can take a variety of data format depending on
+ * the complexity of HTML you want generated.
+ *
+ * You can generate simple options using a basic associative array:
+ *
+ * {{{
+ * 'options' => ['elk' => 'Elk', 'beaver' => 'Beaver']
+ * }}}
+ *
+ * If you need to define additional attributes on your option elements
+ * you can use the complex form for options:
+ *
+ * {{{
+ * 'options' => [
+ *   ['value' => 'elk', 'text' => 'Elk', 'data-foo' => 'bar'],
+ * ]
+ * }}}
+ *
+ * This form **requires** that both the `value` and `text` keys be defined.
+ * If either is not set options will not be generated correctly.
  *
  * @param array $data
  * @return string

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -32,6 +32,16 @@ class MultiCheckbox {
 /**
  * Render multi-checkbox widget.
  *
+ * Data supports the following options.
+ *
+ * - `name` The name attribute of the inputs to create.
+ *   `[]` will be appended to the name.
+ * - `options` An array of options to create checkboxes out of.
+ * - `val` Either a string/integer or array of values that should be
+ *   checked.
+ * - `disabled` Either a boolean or an array of checkboxes to disable.
+ * - `escape` Set to false to disable HTML escaping.
+ *
  * @param array $data
  * @return string
  */
@@ -78,7 +88,7 @@ class MultiCheckbox {
 	protected function _renderInput($checkbox) {
 		$input = $this->_templates->format('checkbox', [
 			'name' => $checkbox['name'] . '[]',
-			'value' => $checkbox['value'],
+			'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
 			'attrs' => $this->_templates->formatAttributes(
 				$checkbox,
 				['name', 'value', 'text']

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+use Cake\Utility\Inflector;
+
+class MultiCheckbox {
+
+	protected $_templates;
+
+/**
+ * Render multi-checkbox widget.
+ *
+ * @param Cake\View\StringTemplate $templates
+ */
+	public function __construct($templates) {
+		$this->_templates = $templates;
+	}
+
+/**
+ * Render multi-checkbox widget.
+ *
+ * @param array $data
+ * @return string
+ */
+	public function render($data) {
+		$data += [
+			'name' => '',
+			'escape' => true,
+			'options' => [],
+			'disabled' => null,
+			'val' => null,
+		];
+		$out= [];
+		foreach ($data['options'] as $key => $val) {
+			$checkbox = [
+				'value' => $key,
+				'text' => $val,
+			];
+			if (is_array($val) && isset($val['text'], $val['value'])) {
+				$checkbox = $val;
+			}
+			$checkbox['name'] = $data['name'];
+			$checkbox['escape'] = $data['escape'];
+
+			if ($this->_isSelected($key, $data['val'])) {
+				$checkbox['selected'] = true;
+			}
+			if ($this->_isDisabled($key, $data['disabled'])) {
+				$checkbox['disabled'] = true;
+			}
+			if (empty($checkbox['id'])) {
+				$checkbox['id'] = mb_strtolower(Inflector::slug($checkbox['name'] . $checkbox['value'], '-'));
+			}
+
+			$out[] = $this->_renderInput($checkbox);
+		}
+		return implode('', $out);
+	}
+
+/**
+ * Render a single checkbox & wrapper.
+ *
+ * @return string
+ */
+	protected function _renderInput($checkbox) {
+		$input = $this->_templates->format('checkbox', [
+			'name' => $checkbox['name'] . '[]',
+			'value' => $checkbox['value'],
+			'attrs' => $this->_templates->formatAttributes(
+				$checkbox,
+				['name', 'value', 'text']
+			)
+		]);
+
+		$labelAttrs = [
+			'for' => $checkbox['id'],
+			'escape' => $checkbox['escape']
+		];
+		$label = $this->_templates->format('label', [
+			'text' => $checkbox['escape'] ? h($checkbox['text']) : $checkbox['text'],
+			'input' => $input,
+			'attrs' => $this->_templates->formatAttributes($labelAttrs)
+		]);
+
+		return $this->_templates->format('checkboxContainer', [
+			'label' => $label,
+			'input' => $input
+		]);
+	}
+
+/**
+ * Helper method for deciding what options are selected.
+ *
+ * @param string $key The key to test.
+ * @param array|string|null The selected values.
+ * @return boolean
+ */
+	protected function _isSelected($key, $selected) {
+		if ($selected === null) {
+			return false;
+		}
+		$isArray = is_array($selected);
+		if (!$isArray) {
+			return (string)$key === (string)$selected;
+		}
+		$strict = !is_numeric($key);
+		return in_array((string)$key, $selected, $strict);
+	}
+
+/**
+ * Helper method for deciding what options are disabled.
+ *
+ * @param string $key The key to test.
+ * @param array|null The disabled values.
+ * @return boolean
+ */
+	protected function _isDisabled($key, $disabled) {
+		if ($disabled === null) {
+			return false;
+		}
+		$strict = !is_numeric($key);
+		return in_array((string)$key, $disabled, $strict);
+	}
+
+}

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -134,7 +134,7 @@ class Radio {
 		$radio['name'] = $data['name'];
 
 		if (empty($radio['id'])) {
-			$radio['id'] = Inflector::slug($radio['name'] . '_' . $radio['value']);
+			$radio['id'] = mb_strtolower(Inflector::slug($radio['name'] . '_' . $radio['value'], '-'));
 		}
 
 		if (isset($data['val']) && strval($data['val']) === strval($radio['value'])) {

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -15,7 +15,6 @@
 namespace Cake\View\Input;
 
 use Cake\Utility\Inflector;
-use Cake\View\StringTemplate;
 use Traversable;
 
 /**

--- a/src/View/Input/SelectBox.php
+++ b/src/View/Input/SelectBox.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\View\Input;
 
-use Cake\View\StringTemplate;
 use Traversable;
 
 /**

--- a/src/View/StringTemplate.php
+++ b/src/View/StringTemplate.php
@@ -49,6 +49,17 @@ class StringTemplate {
 	];
 
 /**
+ * Constructor.
+ *
+ * @param array $templates A set of templates to add.
+ */
+	public function __construct(array $templates = null) {
+		if ($templates) {
+			$this->add($templates);
+		}
+	}
+
+/**
  * Load a config file containing templates.
  *
  * Template files should define a `$config` variable containing

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -33,8 +33,7 @@ class CheckboxTest extends TestCase {
 		$templates = [
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
+		$this->templates = new StringTemplate($templates);
 	}
 
 /**

--- a/tests/TestCase/View/Input/CheckboxTest.php
+++ b/tests/TestCase/View/Input/CheckboxTest.php
@@ -23,6 +23,11 @@ use Cake\View\StringTemplate;
  */
 class CheckboxTest extends TestCase {
 
+/**
+ * setup method.
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$templates = [

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -23,6 +23,11 @@ use Cake\View\StringTemplate;
  */
 class MultiCheckboxTest extends TestCase {
 
+/**
+ * setup method.
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$templates = [
@@ -201,6 +206,9 @@ class MultiCheckboxTest extends TestCase {
 			'/label',
 			'/div',
 		];
+		$this->assertTags($result, $expected);
+
+		$data['disabled'] = ['1', '1x'];
 		$this->assertTags($result, $expected);
 
 		$data = [

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -82,6 +82,50 @@ class MultiCheckboxTest extends TestCase {
 	}
 
 /**
+ * Test render complex and additional attributes.
+ *
+ * @return void
+ */
+	public function testRenderComplex() {
+		$input = new MultiCheckbox($this->templates);
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				['value' => '1', 'text' => 'CakePHP', 'data-test' => 'val'],
+				['value' => '2', 'text' => 'Development', 'class' => 'custom'],
+			]
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 1,
+				'id' => 'tags-id-1',
+				'data-test' => 'val',
+			]],
+			['label' => ['for' => 'tags-id-1']],
+			'CakePHP',
+			'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 2,
+				'id' => 'tags-id-2',
+				'class' => 'custom',
+			]],
+			['label' => ['for' => 'tags-id-2']],
+			'Development',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * Test render escpaing options.
  *
  * @return void

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -100,7 +100,50 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderSelected() {
-		$this->markTestIncomplete();
+		$input = new MultiCheckbox($this->templates);
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				1 => 'CakePHP',
+				'1x' => 'Development',
+			],
+			'val' => [1]
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 1,
+				'id' => 'tags-id-1',
+				'checked' => 'checked'
+			]],
+			['label' => ['for' => 'tags-id-1']],
+			'CakePHP',
+			'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => '1x',
+				'id' => 'tags-id-1x',
+			]],
+			['label' => ['for' => 'tags-id-1x']],
+			'Development',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
+
+		$data['val'] = 1;
+		$result = $input->render($data);
+		$this->assertTags($result, $expected);
+
+		$data['val'] = '1';
+		$result = $input->render($data);
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -35,8 +35,7 @@ class MultiCheckboxTest extends TestCase {
 			'label' => '<label{{attrs}}>{{text}}</label>',
 			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
+		$this->templates = new StringTemplate($templates);
 	}
 
 /**

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\MultiCheckbox;
+use Cake\View\StringTemplate;
+
+/**
+ * MultiCheckbox test case.
+ */
+class MultiCheckboxTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$templates = [
+			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
+			'label' => '<label{{attrs}}>{{text}}</label>',
+			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
+		];
+		$this->templates = new StringTemplate();
+		$this->templates->add($templates);
+	}
+
+/**
+ * Test render simple option sets.
+ *
+ * @return void
+ */
+	public function testRenderSimple() {
+		$input = new MultiCheckbox($this->templates);
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				1 => 'CakePHP',
+				2 => 'Development',
+			]
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 1,
+				'id' => 'tags-id-1',
+			]],
+			['label' => ['for' => 'tags-id-1']],
+			'CakePHP',
+			'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 2,
+				'id' => 'tags-id-2',
+			]],
+			['label' => ['for' => 'tags-id-2']],
+			'Development',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render escpaing options.
+ *
+ * @return void
+ */
+	public function testRenderEscaping() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test render complex options.
+ *
+ * @return void
+ */
+	public function testRenderComplex() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test render selected checkboxes.
+ *
+ * @return void
+ */
+	public function testRenderSelected() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test render disabled checkboxes.
+ *
+ * @return void
+ */
+	public function testRenderDisabled() {
+		$this->markTestIncomplete();
+	}
+
+}

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -82,7 +82,28 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderEscaping() {
-		$this->markTestIncomplete();
+		$input = new MultiCheckbox($this->templates);
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				'>' => '>>',
+			]
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => '&gt;',
+				'id' => 'tags-id',
+			]],
+			['label' => ['for' => 'tags-id']],
+			'&gt;&gt;',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -107,15 +107,6 @@ class MultiCheckboxTest extends TestCase {
 	}
 
 /**
- * Test render complex options.
- *
- * @return void
- */
-	public function testRenderComplex() {
-		$this->markTestIncomplete();
-	}
-
-/**
  * Test render selected checkboxes.
  *
  * @return void

--- a/tests/TestCase/View/Input/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Input/MultiCheckboxTest.php
@@ -107,7 +107,8 @@ class MultiCheckboxTest extends TestCase {
 				1 => 'CakePHP',
 				'1x' => 'Development',
 			],
-			'val' => [1]
+			'val' => [1],
+			'disabled' => false
 		];
 		$result = $input->render($data);
 		$expected = [
@@ -152,7 +153,79 @@ class MultiCheckboxTest extends TestCase {
  * @return void
  */
 	public function testRenderDisabled() {
-		$this->markTestIncomplete();
+		$input = new MultiCheckbox($this->templates);
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				1 => 'CakePHP',
+				'1x' => 'Development',
+			],
+			'disabled' => true,
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 1,
+				'id' => 'tags-id-1',
+				'disabled' => 'disabled'
+			]],
+			['label' => ['for' => 'tags-id-1']],
+			'CakePHP',
+			'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => '1x',
+				'id' => 'tags-id-1x',
+				'disabled' => 'disabled'
+			]],
+			['label' => ['for' => 'tags-id-1x']],
+			'Development',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
+
+		$data = [
+			'name' => 'Tags[id]',
+			'options' => [
+				1 => 'CakePHP',
+				'1x' => 'Development',
+			],
+			'disabled' => [1]
+		];
+		$result = $input->render($data);
+		$expected = [
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => 1,
+				'id' => 'tags-id-1',
+				'disabled' => 'disabled'
+			]],
+			['label' => ['for' => 'tags-id-1']],
+			'CakePHP',
+			'/label',
+			'/div',
+			['div' => ['class' => 'checkbox']],
+			['input' => [
+				'type' => 'checkbox',
+				'name' => 'Tags[id][]',
+				'value' => '1x',
+				'id' => 'tags-id-1x',
+			]],
+			['label' => ['for' => 'tags-id-1x']],
+			'Development',
+			'/label',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 }

--- a/tests/TestCase/View/Input/RadioTest.php
+++ b/tests/TestCase/View/Input/RadioTest.php
@@ -36,8 +36,7 @@ class RadioTest extends TestCase {
 			'label' => '<label{{attrs}}>{{text}}</label>',
 			'radioContainer' => '{{input}}{{label}}',
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
+		$this->templates = new StringTemplate($templates);
 	}
 
 /**

--- a/tests/TestCase/View/Input/RadioTest.php
+++ b/tests/TestCase/View/Input/RadioTest.php
@@ -24,6 +24,11 @@ use Cake\View\StringTemplate;
  */
 class RadioTest extends TestCase {
 
+/**
+ * setup method.
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$templates = [

--- a/tests/TestCase/View/Input/RadioTest.php
+++ b/tests/TestCase/View/Input/RadioTest.php
@@ -52,18 +52,18 @@ class RadioTest extends TestCase {
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => 'r',
-				'id' => 'Crayons_color_r'
+				'id' => 'crayons-color-r'
 			]],
-			['label' => ['for' => 'Crayons_color_r']],
+			['label' => ['for' => 'crayons-color-r']],
 			'Red',
 			'/label',
 			['input' => [
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => 'b',
-				'id' => 'Crayons_color_b'
+				'id' => 'crayons-color-b'
 			]],
-			['label' => ['for' => 'Crayons_color_b']],
+			['label' => ['for' => 'crayons-color-b']],
 			'Black',
 			'/label',
 		];
@@ -134,18 +134,18 @@ class RadioTest extends TestCase {
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => '',
-				'id' => 'Crayons_color'
+				'id' => 'crayons-color'
 			]],
-			['label' => ['for' => 'Crayons_color']],
+			['label' => ['for' => 'crayons-color']],
 			'empty',
 			'/label',
 			['input' => [
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => 'r',
-				'id' => 'Crayons_color_r'
+				'id' => 'crayons-color-r'
 			]],
-			['label' => ['for' => 'Crayons_color_r']],
+			['label' => ['for' => 'crayons-color-r']],
 			'Red',
 			'/label',
 		];
@@ -158,18 +158,18 @@ class RadioTest extends TestCase {
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => '',
-				'id' => 'Crayons_color'
+				'id' => 'crayons-color'
 			]],
-			['label' => ['for' => 'Crayons_color']],
+			['label' => ['for' => 'crayons-color']],
 			'Choose one',
 			'/label',
 			['input' => [
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => 'r',
-				'id' => 'Crayons_color_r'
+				'id' => 'crayons-color-r'
 			]],
-			['label' => ['for' => 'Crayons_color_r']],
+			['label' => ['for' => 'crayons-color-r']],
 			'Red',
 			'/label',
 		];
@@ -193,12 +193,12 @@ class RadioTest extends TestCase {
 		];
 		$result = $radio->render($data);
 		$expected = [
-			['label' => ['for' => 'Crayons_color_r']],
+			['label' => ['for' => 'crayons-color-r']],
 			['input' => [
 				'type' => 'radio',
 				'name' => 'Crayons[color]',
 				'value' => 'r',
-				'id' => 'Crayons_color_r'
+				'id' => 'crayons-color-r'
 			]],
 			'Red',
 			'/label',
@@ -225,31 +225,31 @@ class RadioTest extends TestCase {
 		$result = $radio->render($data);
 		$expected = [
 			['input' => [
-				'id' => 'Versions_ver_1',
+				'id' => 'versions-ver-1',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1',
 				'checked' => 'checked'
 			]],
-			['label' => ['for' => 'Versions_ver_1']],
+			['label' => ['for' => 'versions-ver-1']],
 			'one',
 			'/label',
 			['input' => [
-				'id' => 'Versions_ver_1x',
+				'id' => 'versions-ver-1x',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1x'
 			]],
-			['label' => ['for' => 'Versions_ver_1x']],
+			['label' => ['for' => 'versions-ver-1x']],
 			'one x',
 			'/label',
 			['input' => [
-				'id' => 'Versions_ver_2',
+				'id' => 'versions-ver-2',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '2'
 			]],
-			['label' => ['for' => 'Versions_ver_2']],
+			['label' => ['for' => 'versions-ver-2']],
 			'two',
 			'/label',
 		];
@@ -275,23 +275,23 @@ class RadioTest extends TestCase {
 		$result = $radio->render($data);
 		$expected = [
 			['input' => [
-				'id' => 'Versions_ver_1',
+				'id' => 'versions-ver-1',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1',
 				'disabled' => 'disabled'
 			]],
-			['label' => ['for' => 'Versions_ver_1']],
+			['label' => ['for' => 'versions-ver-1']],
 			'one',
 			'/label',
 			['input' => [
-				'id' => 'Versions_ver_1x',
+				'id' => 'versions-ver-1x',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1x',
 				'disabled' => 'disabled'
 			]],
-			['label' => ['for' => 'Versions_ver_1x']],
+			['label' => ['for' => 'versions-ver-1x']],
 			'one x',
 			'/label',
 		];
@@ -301,22 +301,22 @@ class RadioTest extends TestCase {
 		$result = $radio->render($data);
 		$expected = [
 			['input' => [
-				'id' => 'Versions_ver_1',
+				'id' => 'versions-ver-1',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1',
 				'disabled' => 'disabled'
 			]],
-			['label' => ['for' => 'Versions_ver_1']],
+			['label' => ['for' => 'versions-ver-1']],
 			'one',
 			'/label',
 			['input' => [
-				'id' => 'Versions_ver_1x',
+				'id' => 'versions-ver-1x',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1x',
 			]],
-			['label' => ['for' => 'Versions_ver_1x']],
+			['label' => ['for' => 'versions-ver-1x']],
 			'one x',
 			'/label',
 		];
@@ -342,13 +342,13 @@ class RadioTest extends TestCase {
 		$result = $radio->render($data);
 		$expected = [
 			['input' => [
-				'id' => 'Versions_ver_1',
+				'id' => 'versions-ver-1',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1',
 			]],
 			['input' => [
-				'id' => 'Versions_ver_1x',
+				'id' => 'versions-ver-1x',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1x',
@@ -370,21 +370,21 @@ class RadioTest extends TestCase {
 		$result = $radio->render($data);
 		$expected = [
 			['input' => [
-				'id' => 'Versions_ver_1',
+				'id' => 'versions-ver-1',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1',
 			]],
-			['label' => ['class' => 'my-class', 'for' => 'Versions_ver_1']],
+			['label' => ['class' => 'my-class', 'for' => 'versions-ver-1']],
 			'one',
 			'/label',
 			['input' => [
-				'id' => 'Versions_ver_1x',
+				'id' => 'versions-ver-1x',
 				'name' => 'Versions[ver]',
 				'type' => 'radio',
 				'value' => '1x',
 			]],
-			['label' => ['class' => 'my-class', 'for' => 'Versions_ver_1x']],
+			['label' => ['class' => 'my-class', 'for' => 'versions-ver-1x']],
 			'one x',
 			'/label',
 		];

--- a/tests/TestCase/View/Input/SelectBoxTest.php
+++ b/tests/TestCase/View/Input/SelectBoxTest.php
@@ -36,8 +36,7 @@ class SelectBoxTest extends TestCase {
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
+		$this->templates = new StringTemplate($templates);
 	}
 
 /**

--- a/tests/TestCase/View/Input/SelectBoxTest.php
+++ b/tests/TestCase/View/Input/SelectBoxTest.php
@@ -23,6 +23,11 @@ use Cake\View\StringTemplate;
  */
 class SelectBoxTest extends TestCase {
 
+/**
+ * setup method.
+ *
+ * @return void
+ */
 	public function setUp() {
 		parent::setUp();
 		$templates = [

--- a/tests/TestCase/View/Input/TextTest.php
+++ b/tests/TestCase/View/Input/TextTest.php
@@ -28,8 +28,7 @@ class TextTest extends TestCase {
 		$templates = [
 			'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
+		$this->templates = new StringTemplate($templates);
 	}
 
 /**

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -31,6 +31,19 @@ class StringTemplateTest extends TestCase {
 	}
 
 /**
+ * Test adding templates through the constructor.
+ *
+ * @return void
+ */
+	public function testConstructorAdd() {
+		$templates = [
+			'link' => '<a href="{{url}}">{{text}}</a>'
+		];
+		$template = new StringTemplate($templates);
+		$this->assertEquals($templates['link'], $template->get('link'));
+	}
+
+/**
  * test adding templates.
  *
  * @return void


### PR DESCRIPTION
As part of cakephp/cakephp#2267 this set of changes creates a standalone widget for multiple checkboxes. This widget used to be embedded inside the selectbox which made me very sad. Splitting this out results in simpler code everywhere and will allow developers to swap out each widget independently.

I've done some other changes around ID attribute generation. I've never really liked that we have 2 conventions for ID and classnames. In light of modern CSS frameworks I think it makes sense to standardize on dash separated ID attributes over PascalCase ones. ID generation is also in need of some work as it currently has the same issues @dereuromark recently fixed in 2.x around duplicate IDs.
### Next steps

Next I'm going to add a WidgetRegistry and split out a label widget. The duplication between radio, checkbox, and MultiCheckbox is becoming annoying. I think having a registry will also help @burzum's work on the datetime widget.

I'm thinking that the registry will contain construction logic for the various input widgets and be used by FormHelper to load widgets lazily as they are required and also ensure that only one of each widget object is created.
