### PR TITLE
Rename Repository to Model.

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -27,7 +27,7 @@ use Cake\Utility\ClassRegistry;
 use Cake\Utility\File;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
-use Cake\Utility\RepositoryAwareTrait;
+use Cake\Utility\ModelAwareTrait;
 use Cake\Utility\String;
 
 /**
@@ -37,7 +37,7 @@ use Cake\Utility\String;
 class Shell extends Object {
 
 	use MergeVariablesTrait;
-	use RepositoryAwareTrait;
+	use ModelAwareTrait;
 
 /**
  * Output constant making verbose shells.
@@ -168,7 +168,7 @@ class Shell extends Object {
 			$this->name = str_replace(['Shell', 'Task'], '', $class);
 		}
 		$this->_setModelClass($this->name);
-		$this->repositoryFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
+		$this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
 		$this->Tasks = new TaskRegistry($this);
 
 		$this->stdout = $stdout ? $stdout : new ConsoleOutput('php://stdout');
@@ -223,7 +223,7 @@ class Shell extends Object {
 	}
 
 /**
- * Lazy loads models using the repository() method if it matches modelClass
+ * Lazy loads models using the loadModel() method if it matches modelClass
  *
  * @param string $name
  * @return void
@@ -234,7 +234,7 @@ class Shell extends Object {
 			if (!$plugin) {
 				$plugin = $this->plugin ? $this->plugin . '.' : null;
 			}
-			return $this->repository($plugin . $this->modelClass);
+			return $this->loadModel($plugin . $this->modelClass);
 		}
 	}
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -29,7 +29,7 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
-use Cake\Utility\RepositoryAwareTrait;
+use Cake\Utility\ModelAwareTrait;
 use Cake\Utility\ViewVarsTrait;
 use Cake\View\View;
 
@@ -79,7 +79,7 @@ use Cake\View\View;
 class Controller extends Object implements EventListener {
 
 	use MergeVariablesTrait;
-	use RepositoryAwareTrait;
+	use ModelAwareTrait;
 	use RequestActionTrait;
 	use ViewVarsTrait;
 
@@ -313,7 +313,7 @@ class Controller extends Object implements EventListener {
 		}
 
 		$this->_setModelClass($this->name);
-		$this->repositoryFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
+		$this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
 
 		$childMethods = get_class_methods($this);
 		$parentMethods = get_class_methods('Cake\Controller\Controller');
@@ -341,7 +341,7 @@ class Controller extends Object implements EventListener {
 			if (!$plugin) {
 				$plugin = $this->plugin ? $this->plugin . '.' : null;
 			}
-			$this->repository($plugin . $this->modelClass);
+			$this->loadModel($plugin . $this->modelClass);
 			return $this->{$this->modelClass};
 		}
 		return false;

--- a/src/Utility/ModelAwareTrait.php
+++ b/src/Utility/ModelAwareTrait.php
@@ -21,10 +21,10 @@ use Cake\Utility\Inflector;
  * Provides functionality for loading table classes
  * and other repositories onto properties of the host object.
  *
- * Example users of this trait are Cake\Controller\Controller and 
+ * Example users of this trait are Cake\Controller\Controller and
  * Cake\Console\Shell.
  */
-trait RepositoryAwareTrait {
+trait ModelAwareTrait {
 
 /**
  * This object's primary model class name, the Inflector::pluralized()'ed version of
@@ -37,11 +37,11 @@ trait RepositoryAwareTrait {
 	public $modelClass;
 
 /**
- * A list of repository factory functions.
+ * A list of model factory functions.
  *
  * @var array
  */
-	protected $_repositoryFactories = [];
+	protected $_modelFactories = [];
 
 /**
  * Set the modelClass and modelKey properties based on conventions.
@@ -73,7 +73,7 @@ trait RepositoryAwareTrait {
  * @throws Cake\Error\MissingModelException if the model class cannot be found.
  * @throws Cake\Error\Exception When using a type that has not been registered.
  */
-	public function repository($modelClass = null, $type = 'Table') {
+	public function loadModel($modelClass = null, $type = 'Table') {
 		if ($modelClass === null) {
 			$modelClass = $this->modelClass;
 		}
@@ -84,13 +84,13 @@ trait RepositoryAwareTrait {
 
 		list($plugin, $modelClass) = pluginSplit($modelClass, true);
 
-		if (!isset($this->_repositoryFactories[$type])) {
+		if (!isset($this->_modelFactories[$type])) {
 			throw new Error\Exception(sprintf(
 				'Unknown repository type "%s". Make sure you register a type before trying to use it.',
 				$type
 			));
 		}
-		$factory = $this->_repositoryFactories[$type];
+		$factory = $this->_modelFactories[$type];
 		$this->{$modelClass} = $factory($plugin . $modelClass);
 		if (!$this->{$modelClass}) {
 			throw new Error\MissingModelException($modelClass);
@@ -105,8 +105,8 @@ trait RepositoryAwareTrait {
  * @param callable $factory The factory function used to create instances.
  * @return void
  */
-	public function repositoryFactory($type, callable $factory) {
-		$this->_repositoryFactories[$type] = $factory;
+	public function modelFactory($type, callable $factory) {
+		$this->_modelFactories[$type] = $factory;
 	}
 
 }

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -182,11 +182,11 @@ class ShellTest extends TestCase {
 	}
 
 /**
- * test repository method
+ * test LoadModel method
  *
  * @return void
  */
-	public function testRepository() {
+	public function testLoadModel() {
 		Configure::write('App.namespace', 'TestApp');
 
 		$Shell = new MergeShell();
@@ -197,7 +197,7 @@ class ShellTest extends TestCase {
 		$this->assertEquals('Articles', $Shell->modelClass);
 
 		Plugin::load('TestPlugin');
-		$this->Shell->repository('TestPlugin.TestPluginComments');
+		$this->Shell->loadModel('TestPlugin.TestPluginComments');
 		$this->assertTrue(isset($this->Shell->TestPluginComments));
 		$this->assertInstanceOf(
 			'TestPlugin\Model\Repository\TestPluginCommentsTable',

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -248,11 +248,11 @@ class ControllerTest extends TestCase {
 	}
 
 /**
- * testRepository method
+ * testLoadModel method
  *
  * @return void
  */
-	public function testRepository() {
+	public function testLoadModel() {
 		Configure::write('App.namespace', 'TestApp');
 		$request = new Request('controller_posts/index');
 		$response = $this->getMock('Cake\Network\Response');
@@ -260,7 +260,7 @@ class ControllerTest extends TestCase {
 
 		$this->assertFalse(isset($Controller->Articles));
 
-		$result = $Controller->repository('Articles');
+		$result = $Controller->loadModel('Articles');
 		$this->assertTrue($result);
 		$this->assertInstanceOf(
 			'TestApp\Model\Repository\ArticlesTable',
@@ -282,7 +282,7 @@ class ControllerTest extends TestCase {
 
 		$this->assertFalse(isset($Controller->TestPluginComments));
 
-		$result = $Controller->repository('TestPlugin.TestPluginComments');
+		$result = $Controller->loadModel('TestPlugin.TestPluginComments');
 		$this->assertTrue($result);
 		$this->assertInstanceOf(
 			'TestPlugin\Model\Repository\TestPluginCommentsTable',

--- a/tests/TestCase/Utility/ModelAwareTraitTest.php
+++ b/tests/TestCase/Utility/ModelAwareTraitTest.php
@@ -14,14 +14,14 @@
 namespace Cake\Test\TestCase\Utility;
 
 use Cake\TestSuite\TestCase;
-use Cake\Utility\RepositoryAwareTrait;
+use Cake\Utility\ModelAwareTrait;
 
 /**
  * Testing stub.
  */
 class Stub {
 
-	use RepositoryAwareTrait;
+	use ModelAwareTrait;
 
 	public function setProps($name) {
 		$this->_setModelClass($name);
@@ -30,9 +30,9 @@ class Stub {
 }
 
 /**
- * RepositoryAwareTrait test case
+ * ModelAwareTrait test case
  */
-class RepositoryAwareTraitTest extends TestCase {
+class ModelAwareTraitTest extends TestCase {
 
 /**
  * Test set modelClass
@@ -48,38 +48,38 @@ class RepositoryAwareTraitTest extends TestCase {
 	}
 
 /**
- * test repository()
+ * test loadModel()
  *
  * @return void
  */
-	public function testRepository() {
+	public function testLoadModel() {
 		$stub = new Stub();
 		$stub->setProps('Articles');
-		$stub->repositoryFactory('Table', ['\Cake\ORM\TableRegistry', 'get']);
+		$stub->modelFactory('Table', ['\Cake\ORM\TableRegistry', 'get']);
 
-		$this->assertTrue($stub->repository());
+		$this->assertTrue($stub->loadModel());
 		$this->assertInstanceOf('Cake\ORM\Table', $stub->Articles);
 
-		$this->assertTrue($stub->repository('Comments'));
+		$this->assertTrue($stub->loadModel('Comments'));
 		$this->assertInstanceOf('Cake\ORM\Table', $stub->Comments);
 	}
 
 /**
- * test alternate repository factories.
+ * test alternate model factories.
  *
  * @return void
  */
-	public function testRepositoryFactory() {
+	public function testModelFactory() {
 		$stub = new Stub();
 		$stub->setProps('Articles');
 
-		$stub->repositoryFactory('Test', function($name) {
+		$stub->modelFactory('Test', function($name) {
 			$mock = new \StdClass();
 			$mock->name = $name;
 			return $mock;
 		});
 
-		$result = $stub->repository('Magic', 'Test');
+		$result = $stub->loadModel('Magic', 'Test');
 		$this->assertTrue($result);
 		$this->assertInstanceOf('\StdClass', $stub->Magic);
 		$this->assertEquals('Magic', $stub->Magic->name);


### PR DESCRIPTION
Based on the discussion in #2660.

Update the RepositoryAwareTrait and repository related methods to use 'model' instead. Repositories are an implementation of the model in an application. Our users will want access to their models. Repositories
are an implementation detail in providing a conceptual model.

I can update the docs separately once this has been figured out.
