### PR TITLE
3.0 widget registry

### DIFF
--- a/src/View/Input/Checkbox.php
+++ b/src/View/Input/Checkbox.php
@@ -14,10 +14,12 @@
  */
 namespace Cake\View\Input;
 
+use Cake\View\Input\InputInterface;
+
 /**
  * Input widget for creating checkbox widgets.
  */
-class Checkbox {
+class Checkbox implements InputInterface {
 
 /**
  * Template instance.
@@ -51,7 +53,7 @@ class Checkbox {
  * @param array $data The data to create a checkbox with.
  * @return string Generated HTML string.
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'name' => '',
 			'value' => 1,

--- a/src/View/Input/InputInterface.php
+++ b/src/View/Input/InputInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+/**
+ * Interface for input widgets.
+ */
+interface InputInterface {
+
+/**
+ * Converts the $data into one or many HTML elements.
+ *
+ * @param array $data The data to render.
+ * @return string
+ */
+	public function render(array $data);
+
+}

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -61,7 +61,7 @@ class InputRegistry {
  * @param StringTemplate $templates Templates instance to use.
  * @param array $widgets See add() method for more information.
  */
-	public function __construct(StringTemplate $templates, array $widgets = null) {
+	public function __construct(StringTemplate $templates, array $widgets = []) {
 		$this->_templates = $templates;
 		if (!empty($widgets)) {
 			$this->add($widgets);

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -88,7 +88,7 @@ class InputRegistry {
  * @return void
  */
 	public function add(array $widgets) {
-		$this->_widgets = array_merge($this->_widgets, $widgets);
+		$this->_widgets = $widgets + $this->_widgets;
 	}
 
 /**
@@ -140,12 +140,16 @@ class InputRegistry {
 		if ($className === false || !class_exists($className)) {
 			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
 		}
-		$reflection = new ReflectionClass($className);
-		$arguments = [$this->_templates];
-		foreach ($widget as $requirement) {
-			$arguments[] = $this->get($requirement);
+		if (count($widget)) {
+			$reflection = new ReflectionClass($className);
+			$arguments = [$this->_templates];
+			foreach ($widget as $requirement) {
+				$arguments[] = $this->get($requirement);
+			}
+			$instance = $reflection->newInstanceArgs($arguments);
+		} else {
+			$instance = new $className($this->_templates);
 		}
-		$instance = $reflection->newInstanceArgs($arguments);
 		if (!($instance instanceof InputInterface)) {
 			throw new \RuntimeException(sprintf('"%s" does not implement the InputInterface', $className));
 		}

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -39,7 +39,14 @@ class InputRegistry {
  *
  * @var array
  */
-	protected $_widgets = [];
+	protected $_widgets = [
+		'checkbox' => ['Cake\View\Input\Checkbox'],
+		'label' => ['Cake\View\Input\Label'],
+		'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label'],
+		'radio' => ['Cake\View\Input\Radio', 'label'],
+		'select' => ['Cake\View\Input\SelectBox'],
+		'_default' => ['Cake\View\Input\Text'],
+	];
 
 /**
  * Templates to use.
@@ -105,6 +112,15 @@ class InputRegistry {
 		}
 		$this->_widgets[$name] = $this->_resolveWidget($this->_widgets[$name]);
 		return $this->_widgets[$name];
+	}
+
+/**
+ * Clear the registry and reset the widgets.
+ *
+ * @return void
+ */
+	public function clear() {
+		$this->_widgets = [];
 	}
 
 /**

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+use Cake\Core\App;
+use Cake\View\Input\InputInterface;
+use Cake\View\StringTemplate;
+use \ReflectionClass;
+
+/**
+ * A registry/factory for input widgets.
+ *
+ * Can be used by helpers/view logic to build form widgets
+ * and other HTML widgets.
+ *
+ * This class handles the mapping between names and concrete classes.
+ * It also has a basic name based dependency resolver that allows
+ * widgets to depend on each other.
+ *
+ * Each widget should expect a StringTemplate instance as their first
+ * argument. All other dependencies will be included after.
+ */
+class InputRegistry {
+
+/**
+ * Array of widgets + widget configuration.
+ *
+ * @var array
+ */
+	protected $_widgets = [];
+
+/**
+ * Templates to use.
+ *
+ * @var Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Constructor
+ *
+ * @param StringTemplate $templates Templates instance to use.
+ * @param array $widgets See add() method for more information.
+ */
+	public function __construct(StringTemplate $templates, array $widgets = null) {
+		$this->_templates = $templates;
+		$this->add($widgets);
+	}
+
+/**
+ * Adds or replaces existing widget instances/configuration with new ones.
+ *
+ * Widget arrays can either be descriptions or instances. For example:
+ *
+ * {{{
+ * $registry->add([
+ *   'label' => new MyLabel($templates),
+ *   'checkbox' => ['Fancy.MyCheckbox', 'label']
+ * ]);
+ * }}}
+ *
+ * The above shows how to define widgets as instances or as
+ * descriptions including dependencies. Classes can be defined
+ * with plugin notation, or fully namespaced class names.
+ *
+ * @param array $widgets Array of widgets to use.
+ * @return void
+ */
+	public function add(array $widgets) {
+		$this->_widgets = array_merge($this->_widgets, $widgets);
+	}
+
+/**
+ * Get a widget.
+ *
+ * Will either fetch an already created widget, or create a new instance
+ * if the widget has been defined. If the widget is undefined an instance of
+ * the `_default` widget will be returned. An exception will be thrown if
+ * the `_default` widget is undefined.
+ *
+ * @param string $name The widget name to get.
+ * @return mixed InputInterface widget interface class.
+ * @throws \RuntimeException when widget is undefined.
+ */
+	public function get($name) {
+		if (!isset($this->_widgets[$name]) && empty($this->_widgets['_default'])) {
+			throw new \RuntimeException(sprintf('Unknown widget "%s"', $name));
+		}
+		if (!isset($this->_widgets[$name])) {
+			$name = '_default';
+		}
+		$this->_widgets[$name] = $this->_resolveWidget($this->_widgets[$name]);
+		return $this->_widgets[$name];
+	}
+
+/**
+ * Resolves a widget spec into an instance.
+ *
+ * @param mixed $widget The widget to get
+ * @return InputInterface
+ * @throws \RuntimeException when class cannot be loaded or does not
+ *   implement InputInterface.
+ */
+	protected function _resolveWidget($widget) {
+		if (!is_array($widget)) {
+			return $widget;
+		}
+		$class = array_shift($widget);
+		$className = App::classname($class, 'View/Input');
+		if ($className === false) {
+			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
+		}
+		$reflection = new ReflectionClass($className);
+		$arguments = [$this->_templates];
+		foreach ($widget as $requirement) {
+			$arguments[] = $this->get($requirement);
+		}
+		$instance = $reflection->newInstanceArgs($arguments);
+		if (!($instance instanceof InputInterface)) {
+			throw new \RuntimeException(sprintf('"%s" does not implement the InputInterface', $className));
+		}
+		return $instance;
+	}
+
+}

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -56,7 +56,9 @@ class InputRegistry {
  */
 	public function __construct(StringTemplate $templates, array $widgets = null) {
 		$this->_templates = $templates;
-		$this->add($widgets);
+		if (!empty($widgets)) {
+			$this->add($widgets);
+		}
 	}
 
 /**
@@ -114,12 +116,12 @@ class InputRegistry {
  *   implement InputInterface.
  */
 	protected function _resolveWidget($widget) {
-		if (!is_array($widget)) {
+		if (is_object($widget)) {
 			return $widget;
 		}
 		$class = array_shift($widget);
 		$className = App::classname($class, 'View/Input');
-		if ($className === false) {
+		if ($className === false || !class_exists($className)) {
 			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
 		}
 		$reflection = new ReflectionClass($className);

--- a/src/View/Input/Label.php
+++ b/src/View/Input/Label.php
@@ -14,13 +14,15 @@
  */
 namespace Cake\View\Input;
 
+use Cake\View\Input\InputInterface;
+
 /**
  * Form 'widget' for creating labels.
  *
  * Generally this element is used by other widgets,
  * and FormHelper itself.
  */
-class Label {
+class Label implements InputInterface {
 
 /**
  * Templates
@@ -57,7 +59,7 @@ class Label {
  * @param array $data
  * @return string
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'text' => '',
 			'input' => '',

--- a/src/View/Input/MultiCheckbox.php
+++ b/src/View/Input/MultiCheckbox.php
@@ -15,12 +15,13 @@
 namespace Cake\View\Input;
 
 use Cake\Utility\Inflector;
+use Cake\View\Input\InputInterface;
 
 /**
  * Input widget class for generating multiple checkboxes.
  *
  */
-class MultiCheckbox {
+class MultiCheckbox implements InputInterface {
 
 /**
  * Template instance to use.
@@ -95,7 +96,7 @@ class MultiCheckbox {
  * @param array $data
  * @return string
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'name' => '',
 			'escape' => true,

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -15,7 +15,7 @@
 namespace Cake\View\Input;
 
 use Cake\Utility\Inflector;
-use Cake\View\InputInterface;
+use Cake\View\Input\InputInterface;
 use Traversable;
 
 /**

--- a/src/View/Input/Radio.php
+++ b/src/View/Input/Radio.php
@@ -15,6 +15,7 @@
 namespace Cake\View\Input;
 
 use Cake\Utility\Inflector;
+use Cake\View\InputInterface;
 use Traversable;
 
 /**
@@ -23,7 +24,7 @@ use Traversable;
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class Radio {
+class Radio implements InputInterface {
 
 /**
  * Template instance.
@@ -72,7 +73,7 @@ class Radio {
  * @param array $data The data to build radio buttons with.
  * @return string
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'name' => '',
 			'options' => [],

--- a/src/View/Input/SelectBox.php
+++ b/src/View/Input/SelectBox.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Input;
 
+use Cake\View\Input\InputInterface;
 use Traversable;
 
 /**
@@ -22,7 +23,7 @@ use Traversable;
  * This class is intended as an internal implementation detail
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
-class SelectBox {
+class SelectBox implements InputInterface {
 
 /**
  * Template instance.
@@ -113,7 +114,7 @@ class SelectBox {
  * @return string A generated select box.
  * @throws \RuntimeException when the name attribute is empty.
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'name' => '',
 			'empty' => false,

--- a/src/View/Input/Text.php
+++ b/src/View/Input/Text.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\View\Input;
 
+use Cake\View\Input\InputInterface;
+
 /**
  * Basic input class.
  *
@@ -21,7 +23,7 @@ namespace Cake\View\Input;
  * input elements like hidden, text, email, tel and other
  * types.
  */
-class Text {
+class Text implements InputInterface {
 
 /**
  * StringTemplate instance.
@@ -53,7 +55,7 @@ class Text {
  * @param array $data The data to build an input with.
  * @return string
  */
-	public function render($data) {
+	public function render(array $data) {
 		$data += [
 			'name' => '',
 			'val' => null,

--- a/tests/TestCase/View/Input/InputRegistryTest.php
+++ b/tests/TestCase/View/Input/InputRegistryTest.php
@@ -38,8 +38,26 @@ class InputRegistryTestCase extends TestCase {
  *
  * @return void
  */
+	public function testAddInConstructor() {
+		$widgets = [
+			'text' => ['Cake\View\Input\Text'],
+		];
+		$inputs = new InputRegistry($this->templates, $widgets);
+		$result = $inputs->get('text');
+		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+	}
+
+/**
+ * Test adding new widgets.
+ *
+ * @return void
+ */
 	public function testAdd() {
-		$this->markTestIncomplete();
+		$inputs = new InputRegistry($this->templates);
+		$result = $inputs->add([
+			'text' => ['Cake\View\Input\Text'],
+		]);
+		$this->assertNull($result);
 	}
 
 /**
@@ -48,7 +66,13 @@ class InputRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGet() {
-		$this->markTestIncomplete();
+		$inputs = new InputRegistry($this->templates);
+		$inputs->add([
+			'text' => ['Cake\View\Input\Text'],
+		]);
+		$result = $inputs->get('text');
+		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+		$this->assertSame($result, $inputs->get('text'));
 	}
 
 /**
@@ -57,7 +81,15 @@ class InputRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetFallback() {
-		$this->markTestIncomplete();
+		$inputs = new InputRegistry($this->templates);
+		$inputs->add([
+			'_default' => ['Cake\View\Input\Text'],
+		]);
+		$result = $inputs->get('text');
+		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+
+		$result2 = $inputs->get('hidden');
+		$this->assertSame($result, $result2);
 	}
 
 /**
@@ -84,7 +116,7 @@ class InputRegistryTestCase extends TestCase {
 			'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label']
 		]);
 		$result = $inputs->get('multicheckbox');
-		$this->assertInstanceOf('CakeView\Input\MultiCheckbox', $result);
+		$this->assertInstanceOf('Cake\View\Input\MultiCheckbox', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Input/InputRegistryTest.php
+++ b/tests/TestCase/View/Input/InputRegistryTest.php
@@ -101,6 +101,7 @@ class InputRegistryTestCase extends TestCase {
  */
 	public function testGetNoFallbackError() {
 		$inputs = new InputRegistry($this->templates);
+		$inputs->clear();
 		$inputs->get('foo');
 	}
 
@@ -111,6 +112,7 @@ class InputRegistryTestCase extends TestCase {
  */
 	public function testGetResolveDependency() {
 		$inputs = new InputRegistry($this->templates);
+		$inputs->clear();
 		$inputs->add([
 			'label' => ['Cake\View\Input\Label'],
 			'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label']
@@ -141,6 +143,7 @@ class InputRegistryTestCase extends TestCase {
  */
 	public function testGetResolveDependencyMissingDependency() {
 		$inputs = new InputRegistry($this->templates);
+		$inputs->clear();
 		$inputs->add(['multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label']]);
 		$inputs->get('multicheckbox');
 	}

--- a/tests/TestCase/View/Input/InputRegistryTest.php
+++ b/tests/TestCase/View/Input/InputRegistryTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\InputRegistry;
+use Cake\View\StringTemplate;
+
+/**
+ * InputRegistry test case
+ */
+class InputRegistryTestCase extends TestCase {
+
+/**
+ * setup method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->templates = new StringTemplate();
+	}
+
+/**
+ * Test adding new widgets.
+ *
+ * @return void
+ */
+	public function testAdd() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test getting registered widgets.
+ *
+ * @return void
+ */
+	public function testGet() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test getting fallback widgets.
+ *
+ * @return void
+ */
+	public function testGetFallback() {
+		$this->markTestIncomplete();
+	}
+
+/**
+ * Test getting errors
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Unknown widget "foo"
+ * @return void
+ */
+	public function testGetNoFallbackError() {
+		$inputs = new InputRegistry($this->templates);
+		$inputs->get('foo');
+	}
+
+/**
+ * Test getting resolve dependency
+ *
+ * @return void
+ */
+	public function testGetResolveDependency() {
+		$inputs = new InputRegistry($this->templates);
+		$inputs->add([
+			'label' => ['Cake\View\Input\Label'],
+			'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label']
+		]);
+		$result = $inputs->get('multicheckbox');
+		$this->assertInstanceOf('CakeView\Input\MultiCheckbox', $result);
+	}
+
+/**
+ * Test getting resolve dependency missing class
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Unable to locate widget class "TestApp\View\Derp"
+ * @return void
+ */
+	public function testGetResolveDependencyMissingClass() {
+		$inputs = new InputRegistry($this->templates);
+		$inputs->add(['test' => ['TestApp\View\Derp']]);
+		$inputs->get('test');
+	}
+
+/**
+ * Test getting resolve dependency missing dependency
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Unknown widget "label"
+ * @return void
+ */
+	public function testGetResolveDependencyMissingDependency() {
+		$inputs = new InputRegistry($this->templates);
+		$inputs->add(['multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label']]);
+		$inputs->get('multicheckbox');
+	}
+
+}


### PR DESCRIPTION
As part of #2267, this set of changes adds a registry for creating widgets. It helps address issues around deferring object creation and resolving dependencies. I've tried to keep the code as simple as possible.

I have also decided to try an interface instead of a base class. With only some of the classes sharing a constructor, there just wasn't enough shared behavior to make a base class useful.

My next step after this is to continue building out the remaining widgets.
