### PR TITLE
3.0 result formatters

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -716,7 +716,7 @@ trait CollectionTrait {
 		$parents = [];
 		$idPath = $this->_propertyExtractor($idPath);
 		$parentPath = $this->_propertyExtractor($parentPath);
-		$isObject = !is_array($this->first());
+		$isObject = !is_array((new Collection($this))->first());
 
 		$mapper = function($row, $key, $mapReduce) use (&$parents, $idPath, $parentPath) {
 			$row['children'] = [];

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -628,6 +628,80 @@ trait CollectionTrait {
 	}
 
 /**
+ * Returrns a new collection where the values extracted based on a value path
+ * and then indexed by a key path. Optionally this method can produce parent
+ * groups absed on a group property path.
+ *
+ * ### Examples:
+ *
+ * {{{
+ * $items = [
+ *	['id' => 1, 'name' => 'foo', 'parent' => 'a'],
+ *	['id' => 2, 'name' => 'bar', 'parent' => 'b'],
+ *	['id' => 3, 'name' => 'baz', 'parent' => 'a'],
+ * ];
+ *
+ * $combined = (new Collection($items))->combine('id', 'name');
+ *
+ * //Result will look like this when converted to array
+ * [
+ *	1 => 'foo',
+ *	2 => 'bar',
+ *	3 => 'baz,
+ * ];
+ *
+ * $combined = (new Collection($items))->combine('id', 'name', 'parent');
+ *
+ * //Result will look like this when converted to array
+ * [
+ *	'a' => [1 => 'foo', 3 => 'baz'],
+ *	'b' => [2 => 'bar']
+ * ];
+ * }}}
+ *
+ * @param callable|string $keyPath the column name path to use for indexing
+ * or a function returning the indexing key out of the provided element
+ * @param callable|string $valuePath the column name path to use as the array value
+ * or a function returning the value out of the provided element
+ * @param callable|string $valuePath the column name path to use as the parent
+ * grouping key or a function returning the key out of the provided element
+ * @return \Cake\Collection\Collection
+ */
+	public function combine($keyPath, $valuePath, $groupPath = null) {
+		$options = [
+			'keyPath' => $this->_propertyExtractor($keyPath),
+			'valuePath' => $this->_propertyExtractor($valuePath),
+			'groupPath' => $groupPath ? $this->_propertyExtractor($groupPath) : null
+		];
+
+		$mapper = function($value, $key, $mapReduce) use ($options) {
+			$rowKey = $options['keyPath'];
+			$rowVal = $options['valuePath'];
+
+			if (!($options['groupPath'])) {
+				$mapReduce->emit($rowVal($value, $key), $rowKey($value, $key));
+				return;
+			}
+
+			$key = $options['groupPath']($value, $key);
+			$mapReduce->emitIntermediate(
+				[$rowKey($value, $key) => $rowVal($value, $key)],
+				$key
+			);
+		};
+
+		$reducer = function($values, $key, $mapReduce) {
+			$result = [];
+			foreach ($values as $value) {
+				$result += $value;
+			}
+			$mapReduce->emit($result, $key);
+		};
+
+		return new Collection(new MapReduce($this, $mapper, $reducer));
+	}
+
+/**
  * Returns an array representation of the results
  *
  * @param boolean $preserveKeys whether to use the keys returned by this

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -629,9 +629,9 @@ trait CollectionTrait {
 	}
 
 /**
- * Returrns a new collection where the values extracted based on a value path
+ * Returns a new collection where the values extracted based on a value path
  * and then indexed by a key path. Optionally this method can produce parent
- * groups absed on a group property path.
+ * groups based on a group property path.
  *
  * ### Examples:
  *

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -707,9 +707,9 @@ trait CollectionTrait {
  * based on an id property path and a parent id property path.
  *
  * @param callable|string $idPath the column name path to use for determining
- * whther an element is parent of another
+ * whether an element is parent of another
  * @param callable|string $parentPath the column name path to use for determining
- * whther an element is child of another
+ * whether an element is child of another
  * @return \Cake\Collection\Collection
  */
 	public function nest($idPath, $parentPath) {

--- a/src/Model/Behavior/CounterCacheBehavior.php
+++ b/src/Model/Behavior/CounterCacheBehavior.php
@@ -84,7 +84,7 @@ class CounterCacheBehavior extends Behavior {
  * Keeping a reference to the table in order to,
  * be able to retrieve associations and fetch records for counting.
  *
- * @var array
+ * @var \Cake\ORM\Table
  */
 	protected $_table;
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -795,6 +795,45 @@ class Query extends DatabaseQuery {
 		return $this;
 	}
 
+/**
+ * Registers a new formatter callback function that is to be executed when the results
+ * are tried to be fetched from the database.
+ *
+ * Formatting callbacks will get as first parameter a `ResultSetDecorator` that
+ * can be traversed and modified at will. AS second parameter, the formatting
+ * callback will receive this query instance.
+ *
+ * Callbacks are required to return an iterator object, which will be used as
+ * the return value for this query's result. Formatter functions are applied
+ * after all the `MapReduce` routines for this query have been executed.
+ *
+ * If the first argument is set to null, it will return the list of previously
+ * registered map reduce routines.
+ *
+ * If the second argument is set to true, it will erase previous map reducers
+ * and replace it with the arguments passed.
+ *
+ * ### Example:
+ *
+ * {{{
+ * //Return all results from the table indexed by id
+ * $query->select(['id', 'name'])->formatResults(function($results, $query) {
+ *	return $results->indexBy('id');
+ * });
+ *
+ * //Add a new column to the ResultSet
+ * $query->select(['id', 'name'])->formatResults(function($results, $query) {
+ *	return $results->map(function($row) {
+ *		$row['age'] = $row['birth_date']->diff(new DateTime)->y;
+ *		return $row;
+ *	});
+ * });
+ * }}}
+ *
+ * @param callable $formatter
+ * @param boolean $overwrite
+ * @return Cake\ORM\Query|array
+ */
 	public function formatResults(callable $formatter = null, $overwrite = false) {
 		if ($overwrite) {
 			$this->_formatters = [];

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -876,7 +876,8 @@ class Query extends DatabaseQuery {
  * @return integer
  */
 	public function count() {
-		if ($this->clause('group') === [] && $this->mapReduce() === []) {
+		$noFormatters = $this->mapReduce() === [] && empty($this->_formatters);
+		if ($this->clause('group') === [] && $noFormatters) {
 			$this->select(['count' => $this->func()->count('*')], true)
 				->hydrate(false);
 			return (int)$this->first()['count'];

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -822,7 +822,7 @@ class Query extends DatabaseQuery {
  * });
  *
  * //Add a new column to the ResultSet
- * $query->select(['name', 'bith_date'])->formatResults(function($results, $query) {
+ * $query->select(['name', 'birth_date'])->formatResults(function($results, $query) {
  *	return $results->map(function($row) {
  *		$row['age'] = $row['birth_date']->diff(new DateTime)->y;
  *		return $row;

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -800,7 +800,7 @@ class Query extends DatabaseQuery {
  * are tried to be fetched from the database.
  *
  * Formatting callbacks will get as first parameter a `ResultSetDecorator` that
- * can be traversed and modified at will. AS second parameter, the formatting
+ * can be traversed and modified at will. As the second parameter, the formatting
  * callback will receive this query instance.
  *
  * Callbacks are required to return an iterator object, which will be used as
@@ -810,8 +810,8 @@ class Query extends DatabaseQuery {
  * If the first argument is set to null, it will return the list of previously
  * registered map reduce routines.
  *
- * If the second argument is set to true, it will erase previous map reducers
- * and replace it with the arguments passed.
+ * If the second argument is set to true, it will erase previous formatters
+ * and replace them with the passed first argument.
  *
  * ### Example:
  *
@@ -822,7 +822,7 @@ class Query extends DatabaseQuery {
  * });
  *
  * //Add a new column to the ResultSet
- * $query->select(['id', 'name'])->formatResults(function($results, $query) {
+ * $query->select(['name', 'bith_date'])->formatResults(function($results, $query) {
  *	return $results->map(function($row) {
  *		$row['age'] = $row['birth_date']->diff(new DateTime)->y;
  *		return $row;

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -881,7 +881,7 @@ class Query extends DatabaseQuery {
 		}
 
 		foreach ($this->_formatters as $formatter) {
-			$result = $formatter($this, $result);
+			$result = $formatter($result, $this);
 		}
 
 		if (!empty($this->_formatters) && !($result instanceof ResultSetDecorator)) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -727,11 +727,47 @@ class Table implements EventListener {
  *
  * The results of this finder will be in the following form:
  *
- *	[
+ * {{{
+ * [
+ *	1 => 'value for id 1',
+ *	2 => 'value for id 2',
+ *	4 => 'value for id 4'
+ * ]
+ * }}}
+ *
+ * You can specify which property will be used as the key and which as value
+ * by using the `$options` array, when not specified, it will use the results
+ * of calling `primaryKey` and `displayField` respectively in this table:
+ *
+ * {{{
+ * $table->find('list', [
+ *	'idField' => 'name',
+ *	'valueField' => 'age'
+ * ]);
+ * }}}
+ *
+ * Results can be put together in bigger groups when they share a property, you
+ * can customize the property to use for grouping by setting `groupField`:
+ *
+ * {{{
+ * $table->find('list', [
+ *	'groupField' => 'category_id',
+ * ]);
+ * }}}
+ *
+ * When using a `groupField` results will be returned in this format:
+ *
+ * {{{
+ * [
+ *	'group_1' => [
  *		1 => 'value for id 1',
  *		2 => 'value for id 2',
+ *	]
+ *	'group_2' => [
  *		4 => 'value for id 4'
  *	]
+ * ]
+ * }}}
  *
  * @param \Cake\ORM\Query $query
  * @param array $options

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -796,6 +796,18 @@ class Table implements EventListener {
  * Values belonging to a parent row based on their parent_id value will be
  * recursively nested inside the parent row values using the `children` property
  *
+ * You can customize what fields are used for nesting results, by default the
+ * primary key and the `parent_id` fields are used. If you you wish to change
+ * these defaults you need to provide the keys `idField` or `parentField` in
+ * `$options`:
+ *
+ * {{{
+ * $table->find('threaded', [
+ *	'idField' => 'id',
+ *	'parentField' => 'ancestor_id'
+ * ]);
+ * }}}
+ *
  * @param \Cake\ORM\Query $query
  * @param array $options
  * @return \Cake\ORM\Query

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -631,4 +631,49 @@ class CollectionTest extends TestCase {
 		$this->assertEquals(['a' => 4, 'b' => 5, 'c' => 6], $compiled->toArray());
 	}
 
+/**
+ * Tests the combine method
+ *
+ * @return void
+ */
+	public function testCombine() {
+		$items = [
+			['id' => 1, 'name' => 'foo', 'parent' => 'a'],
+			['id' => 2, 'name' => 'bar', 'parent' => 'b'],
+			['id' => 3, 'name' => 'baz', 'parent' => 'a']
+		];
+		$collection = (new Collection($items))->combine('id', 'name');
+		$expected = [1 => 'foo', 2 => 'bar', 3 => 'baz'];
+		$this->assertEquals($expected, $collection->toArray());
+
+		$expected = ['foo' => 1, 'bar' => 2, 'baz' => 3];
+		$collection = (new Collection($items))->combine('name', 'id');
+		$this->assertEquals($expected, $collection->toArray());
+
+		$collection = (new Collection($items))->combine('id', 'name', 'parent');
+		$expected = ['a' => [1 => 'foo', 3 => 'baz'], 'b' => [2 => 'bar']];
+		$this->assertEquals($expected, $collection->toArray());
+
+		$expected = [
+			'0-1' => ['foo-0-1' => '0-1-foo'],
+			'1-2' => ['bar-1-2' => '1-2-bar'],
+			'2-3' => ['baz-2-3' => '2-3-baz']
+		];
+		$collection = (new Collection($items))->combine(
+			function($value, $key) {
+				return $value['name'] . '-' . $key;
+			},
+			function($value, $key) {
+				return $key . '-' . $value['name'];
+			},
+			function($value, $key) {
+				return $key . '-' . $value['id'];
+			}
+		);
+		$this->assertEquals($expected, $collection->toArray());
+
+		$collection = (new Collection($items))->combine('id', 'crazy');
+		$this->assertEquals([1 => null, 2 => null, 3 => null], $collection->toArray());
+	}
+
 }

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\Collection;
 
+use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\TestSuite\TestCase;
 
@@ -775,6 +776,65 @@ class CollectionTest extends TestCase {
 					['id' => 10, 'parent_id' => 6, 'children' => []]
 				]
 			]
+		];
+		$this->assertEquals($expected, $collection->toArray());
+	}
+
+/**
+ * Tests the nest method with more than one level
+ *
+ * @return void
+ */
+	public function testNestObjects() {
+		$items = [
+			new ArrayObject(['id' => 1, 'parent_id' => null]),
+			new ArrayObject(['id' => 2, 'parent_id' => 1]),
+			new ArrayObject(['id' => 3, 'parent_id' => 2]),
+			new ArrayObject(['id' => 4, 'parent_id' => 2]),
+			new ArrayObject(['id' => 5, 'parent_id' => 3]),
+			new ArrayObject(['id' => 6, 'parent_id' => null]),
+			new ArrayObject(['id' => 7, 'parent_id' => 3]),
+			new ArrayObject(['id' => 8, 'parent_id' => 4]),
+			new ArrayObject(['id' => 9, 'parent_id' => 6]),
+			new ArrayObject(['id' => 10, 'parent_id' => 6])
+		];
+		$collection = (new Collection($items))->nest('id', 'parent_id');
+		$expected = [
+			new ArrayObject([
+				'id' => 1,
+				'parent_id' => null,
+				'children' => [
+					new ArrayObject([
+						'id' => 2,
+						'parent_id' => 1,
+						'children' => [
+							new ArrayObject([
+								'id' => 3,
+								'parent_id' => 2,
+								'children' => [
+									new ArrayObject(['id' => 5, 'parent_id' => 3, 'children' => []]),
+									new ArrayObject(['id' => 7, 'parent_id' => 3, 'children' => []])
+								]
+							]),
+							new ArrayObject([
+								'id' => 4,
+								'parent_id' => 2,
+								'children' => [
+									new ArrayObject(['id' => 8, 'parent_id' => 4, 'children' => []])
+								]
+							])
+						]
+					])
+				]
+			]),
+			new ArrayObject([
+				'id' => 6,
+				'parent_id' => null,
+				'children' => [
+					new ArrayObject(['id' => 9, 'parent_id' => 6, 'children' => []]),
+					new ArrayObject(['id' => 10, 'parent_id' => 6, 'children' => []])
+				]
+			])
 		];
 		$this->assertEquals($expected, $collection->toArray());
 	}

--- a/tests/TestCase/Collection/CollectionTest.php
+++ b/tests/TestCase/Collection/CollectionTest.php
@@ -676,4 +676,107 @@ class CollectionTest extends TestCase {
 		$this->assertEquals([1 => null, 2 => null, 3 => null], $collection->toArray());
 	}
 
+/**
+ * Tests the nest method with only one level
+ *
+ * @return void
+ */
+	public function testNest() {
+		$items = [
+			['id' => 1, 'parent_id' => null],
+			['id' => 2, 'parent_id' => 1],
+			['id' => 3, 'parent_id' => 1],
+			['id' => 4, 'parent_id' => 1],
+			['id' => 5, 'parent_id' => 6],
+			['id' => 6, 'parent_id' => null],
+			['id' => 7, 'parent_id' => 1],
+			['id' => 8, 'parent_id' => 6],
+			['id' => 9, 'parent_id' => 6],
+			['id' => 10, 'parent_id' => 6]
+		];
+		$collection = (new Collection($items))->nest('id', 'parent_id');
+		$expected = [
+			[
+				'id' => 1,
+				'parent_id' => null,
+				'children' => [
+					['id' => 2, 'parent_id' => 1, 'children' => []],
+					['id' => 3, 'parent_id' => 1, 'children' => []],
+					['id' => 4, 'parent_id' => 1, 'children' => []],
+					['id' => 7, 'parent_id' => 1, 'children' => []]
+				]
+			],
+			[
+				'id' => 6,
+				'parent_id' => null,
+				'children' => [
+					['id' => 5, 'parent_id' => 6, 'children' => []],
+					['id' => 8, 'parent_id' => 6, 'children' => []],
+					['id' => 9, 'parent_id' => 6, 'children' => []],
+					['id' => 10, 'parent_id' => 6, 'children' => []]
+				]
+			]
+		];
+		$this->assertEquals($expected, $collection->toArray());
+	}
+
+/**
+ * Tests the nest method with more than one level
+ *
+ * @return void
+ */
+	public function testNestMultiLevel() {
+		$items = [
+			['id' => 1, 'parent_id' => null],
+			['id' => 2, 'parent_id' => 1],
+			['id' => 3, 'parent_id' => 2],
+			['id' => 4, 'parent_id' => 2],
+			['id' => 5, 'parent_id' => 3],
+			['id' => 6, 'parent_id' => null],
+			['id' => 7, 'parent_id' => 3],
+			['id' => 8, 'parent_id' => 4],
+			['id' => 9, 'parent_id' => 6],
+			['id' => 10, 'parent_id' => 6]
+		];
+		$collection = (new Collection($items))->nest('id', 'parent_id');
+		$expected = [
+			[
+				'id' => 1,
+				'parent_id' => null,
+				'children' => [
+					[
+						'id' => 2,
+						'parent_id' => 1,
+						'children' => [
+							[
+								'id' => 3,
+								'parent_id' => 2,
+								'children' => [
+									['id' => 5, 'parent_id' => 3, 'children' => []],
+									['id' => 7, 'parent_id' => 3, 'children' => []]
+								]
+							],
+							[
+								'id' => 4,
+								'parent_id' => 2,
+								'children' => [
+									['id' => 8, 'parent_id' => 4, 'children' => []]
+								]
+							]
+						]
+					]
+				]
+			],
+			[
+				'id' => 6,
+				'parent_id' => null,
+				'children' => [
+					['id' => 9, 'parent_id' => 6, 'children' => []],
+					['id' => 10, 'parent_id' => 6, 'children' => []]
+				]
+			]
+		];
+		$this->assertEquals($expected, $collection->toArray());
+	}
+
 }

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -350,4 +350,54 @@ class CompositeKeyTest extends TestCase {
 		$this->assertEmpty($result->tags);
 	}
 
+/**
+ * Tests find('list') with composite keys
+ *
+ * @return void
+ */
+	public function testFindCompositeKeys() {
+		$table = new Table([
+			'table' => 'site_authors',
+			'connection' => $this->connection,
+		]);
+		$table->displayField('name');
+		$query = $table->find('list')
+			->hydrate(false)
+			->order('id');
+		$expected = [
+			'1;1' => 'mark',
+			'2;2' => 'juan',
+			'3;2' => 'jose',
+			'4;1' => 'andy'
+		];
+		$this->assertEquals($expected, $query->toArray());
+
+		$table->displayField(['name', 'site_id']);
+		$query = $table->find('list')
+			->hydrate(false)
+			->order('id');
+		$expected = [
+			'1;1' => 'mark;1',
+			'2;2' => 'juan;2',
+			'3;2' => 'jose;2',
+			'4;1' => 'andy;1'
+		];
+		$this->assertEquals($expected, $query->toArray());
+
+		$query = $table->find('list', ['groupField' => ['site_id', 'site_id']])
+			->hydrate(false)
+			->order('id');
+		$expected = [
+			'1;1' => [
+				'1;1' => 'mark;1',
+				'4;1' => 'andy;1'
+			],
+			'2;2' => [
+				'2;2' => 'juan;2',
+				'3;2' => 'jose;2'
+			]
+		];
+		$this->assertEquals($expected, $query->toArray());
+	}
+
 }


### PR DESCRIPTION
This implements query result formatters as a way to simplify some `afterFind` tasks. The benefit of using `Query::formatResults` over just calling the formatting functions directly is that you can stack formatter before the query is executed and that you have full control over the full results and what you want to return.

Also added `Collection::combine()` and `Collection::nest()` containing the same logic that was implemented in the table class. I feel this helped keeping the Table class leaner and more focused on what it actually does.

Implementing this allowed me to finish the composite primary keys ticket as now `find('list')` and `find('threaded')` work correctly with composite keys.

This also paves the way for implementing `TranslateBehavior` as it required some architecture for running simpler afterFind than with using mapReduce.

closes https://github.com/cakephp/cakephp/issues/2412
