### PR TITLE
3.0 - Sending Query object to drivers

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -196,10 +196,13 @@ class Connection {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string $sql
+ * @param string|Cake\Database\Query $sql
  * @return \Cake\Database\Statement
  */
 	public function prepare($sql) {
+		if ($sql instanceof Query) {
+			$sql = $sql->sql();
+		}
 		$statement = $this->_driver->prepare($sql);
 
 		if ($this->_logQueries) {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -200,9 +200,6 @@ class Connection {
  * @return \Cake\Database\Statement
  */
 	public function prepare($sql) {
-		if ($sql instanceof Query) {
-			$sql = $sql->sql();
-		}
 		$statement = $this->_driver->prepare($sql);
 
 		if ($this->_logQueries) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -92,10 +92,10 @@ abstract class Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string $sql
+ * @param string|Cake\Database\Query $query
  * @return Cake\Database\Statement
  */
-	public abstract function prepare($sql);
+	public abstract function prepare($query);
 
 /**
  * Starts a transaction

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Database\Driver;
 
+use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use PDO;
 
@@ -71,11 +72,12 @@ trait PDODriverTrait {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string $sql
+ * @param string|Cake\Database\Query $query
  * @return Cake\Database\Statement
  */
-	public function prepare($sql) {
+	public function prepare($query) {
 		$this->connect();
+		$sql = $query instanceof Query ? $query->sql() : $query;
 		$statement = $this->_connection->prepare($sql);
 		return new PDOStatement($statement, $this);
 	}

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -17,6 +17,7 @@
 namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\SqliteDialectTrait;
+use Cake\Database\Query;
 use Cake\Database\Statement\PDOStatement;
 use Cake\Database\Statement\SqliteStatement;
 use PDO;
@@ -84,11 +85,12 @@ class Sqlite extends \Cake\Database\Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string $sql
+ * @param string|Cake\Database\Query $query
  * @return Cake\Database\Statement
  */
-	public function prepare($sql) {
+	public function prepare($query) {
 		$this->connect();
+		$sql = $query instanceof Query ? $query->sql() : $query;
 		$statement = $this->_connection->prepare($sql);
 		return new SqliteStatement(new PDOStatement($statement, $this), $this);
 	}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -201,7 +201,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  */
 	public function execute() {
 		$query = $this->_transformQuery();
-		$statement = $this->_connection->prepare($query->sql());
+		$statement = $this->_connection->prepare($query);
 		$query->_bindStatement($statement);
 		$statement->execute();
 

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -120,6 +120,11 @@ class ConnectionTest extends TestCase {
 		$result = $this->connection->prepare($sql);
 		$this->assertInstanceOf('Cake\Database\StatementInterface', $result);
 		$this->assertEquals($sql, $result->queryString);
+
+		$query = $this->connection->newQuery()->select('1 + 1');
+		$result = $this->connection->prepare($query);
+		$this->assertInstanceOf('Cake\Database\StatementInterface', $result);
+		$this->assertEquals($sql, $result->queryString);
 	}
 
 /**


### PR DESCRIPTION
This change allows the Query object to be passed to the driver. In some situations the driver needs to execute queries before/after the query and it will give more flexibility to do it.

For instance, in SQL Server the driver need to change the `IDENTITY_INSERT` before execute an insert when the query contains the primary key value. With the query object it can easily be done. A custom Statement class can trigger the query to revert the `IDENTITY_INSERT` configuration.
