### PR TITLE
3.0 Add button widget

### DIFF
--- a/src/View/Input/Basic.php
+++ b/src/View/Input/Basic.php
@@ -23,7 +23,7 @@ use Cake\View\Input\InputInterface;
  * input elements like hidden, text, email, tel and other
  * types.
  */
-class Text implements InputInterface {
+class Basic implements InputInterface {
 
 /**
  * StringTemplate instance.

--- a/src/View/Input/Button.php
+++ b/src/View/Input/Button.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+use Cake\View\Input\InputInterface;
+
+/**
+ * Button input class
+ *
+ * This input class can be used to render button elements.
+ * If you need to make basic submit inputs with type=submit,
+ * use the Basic input widget.
+ */
+class Button implements InputInterface {
+
+/**
+ * StringTemplate instance.
+ *
+ * @var Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Constructor.
+ *
+ * @param StringTemplate $templates
+ */
+	public function __construct($templates) {
+		$this->_templates = $templates;
+	}
+
+/**
+ * Render a button.
+ *
+ * This method accepts a number of keys:
+ *
+ * - `text` The text of the button. Unlike all other form controls, buttons
+ *   do not escape their contents by default.
+ * - `escape` Set to true to enable escaping on all attributes.
+ * - `type` The button type defaults to 'submit'.
+ *
+ * Any other keys provided in $data will be converted into HTML attributes.
+ *
+ * @param array $data The data to build an input with.
+ * @return string
+ */
+	public function render(array $data) {
+		$data += [
+			'text' => '',
+			'type' => 'submit',
+			'escape' => false,
+		];
+		return $this->_templates->format('button', [
+			'text' => $data['escape'] ? h($data['text']) : $data['text'],
+			'type' => $data['type'],
+			'attrs' => $this->_templates->formatAttributes($data, ['type', 'text']),
+		]);
+	}
+
+}

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -40,11 +40,14 @@ class InputRegistry {
  * @var array
  */
 	protected $_widgets = [
+		'button' => ['Cake\View\Input\Button'],
 		'checkbox' => ['Cake\View\Input\Checkbox'],
+		'file' => ['Cake\View\Input\File'],
 		'label' => ['Cake\View\Input\Label'],
 		'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label'],
 		'radio' => ['Cake\View\Input\Radio', 'label'],
 		'select' => ['Cake\View\Input\SelectBox'],
+		'textarea' => ['Cake\View\Input\Textarea'],
 		'_default' => ['Cake\View\Input\Basic'],
 	];
 

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -45,7 +45,7 @@ class InputRegistry {
 		'multicheckbox' => ['Cake\View\Input\MultiCheckbox', 'label'],
 		'radio' => ['Cake\View\Input\Radio', 'label'],
 		'select' => ['Cake\View\Input\SelectBox'],
-		'_default' => ['Cake\View\Input\Text'],
+		'_default' => ['Cake\View\Input\Basic'],
 	];
 
 /**

--- a/tests/TestCase/View/Input/BasicTest.php
+++ b/tests/TestCase/View/Input/BasicTest.php
@@ -15,13 +15,13 @@
 namespace Cake\Test\TestCase\View\Input;
 
 use Cake\TestSuite\TestCase;
-use Cake\View\Input\Text;
+use Cake\View\Input\Basic;
 use Cake\View\StringTemplate;
 
 /**
- * Text input test.
+ * Basic input test.
  */
-class TextTest extends TestCase {
+class BasicTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -37,7 +37,7 @@ class TextTest extends TestCase {
  * @return void
  */
 	public function testRenderSimple() {
-		$text = new Text($this->templates);
+		$text = new Basic($this->templates);
 		$result = $text->render(['name' => 'my_input']);
 		$expected = [
 			'input' => ['type' => 'text', 'name' => 'my_input']
@@ -51,7 +51,7 @@ class TextTest extends TestCase {
  * @return void
  */
 	public function testRenderType() {
-		$text = new Text($this->templates);
+		$text = new Basic($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',
@@ -69,7 +69,7 @@ class TextTest extends TestCase {
  * @return void
  */
 	public function testRenderWithValue() {
-		$text = new Text($this->templates);
+		$text = new Basic($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',
@@ -92,7 +92,7 @@ class TextTest extends TestCase {
  * @return void
  */
 	public function testRenderAttributes() {
-		$text = new Text($this->templates);
+		$text = new Basic($this->templates);
 		$data = [
 			'name' => 'my_input',
 			'type' => 'email',

--- a/tests/TestCase/View/Input/ButtonTest.php
+++ b/tests/TestCase/View/Input/ButtonTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\Button;
+use Cake\View\StringTemplate;
+
+/**
+ * Basic input test.
+ */
+class ButtonTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$templates = [
+			'button' => '<button type="{{type}}"{{attrs}}>{{text}}</button>',
+		];
+		$this->templates = new StringTemplate($templates);
+	}
+
+/**
+ * Test render in a simple case.
+ *
+ * @return void
+ */
+	public function testRenderSimple() {
+		$button = new Button($this->templates);
+		$result = $button->render(['name' => 'my_input']);
+		$expected = [
+			'button' => ['type' => 'submit', 'name' => 'my_input'],
+			'/button'
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with custom type
+ *
+ * @return void
+ */
+	public function testRenderType() {
+		$button = new Button($this->templates);
+		$data = [
+			'name' => 'my_input',
+			'type' => 'button',
+			'text' => 'Some button'
+		];
+		$result = $button->render($data);
+		$expected = [
+			'button' => ['type' => 'button', 'name' => 'my_input'],
+			'Some button',
+			'/button'
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with a text
+ *
+ * @return void
+ */
+	public function testRenderWithText() {
+		$button = new Button($this->templates);
+		$data = [
+			'text' => 'Some <value>'
+		];
+		$result = $button->render($data);
+		$expected = [
+			'button' => ['type' => 'submit'],
+			'Some <value>',
+			'/button'
+		];
+		$this->assertTags($result, $expected);
+
+		$data['escape'] = true;
+		$result = $button->render($data);
+		$expected = [
+			'button' => ['type' => 'submit'],
+			'Some &lt;value&gt;',
+			'/button'
+		];
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test render with additional attributes.
+ *
+ * @return void
+ */
+	public function testRenderAttributes() {
+		$button = new Button($this->templates);
+		$data = [
+			'name' => 'my_input',
+			'text' => 'Go',
+			'class' => 'btn',
+			'required' => true
+		];
+		$result = $button->render($data);
+		$expected = [
+			'button' => [
+				'type' => 'submit',
+				'name' => 'my_input',
+				'class' => 'btn',
+				'required' => 'required'
+			],
+			'Go',
+			'/button'
+		];
+		$this->assertTags($result, $expected);
+	}
+
+}

--- a/tests/TestCase/View/Input/InputRegistryTest.php
+++ b/tests/TestCase/View/Input/InputRegistryTest.php
@@ -40,11 +40,11 @@ class InputRegistryTestCase extends TestCase {
  */
 	public function testAddInConstructor() {
 		$widgets = [
-			'text' => ['Cake\View\Input\Text'],
+			'text' => ['Cake\View\Input\Basic'],
 		];
 		$inputs = new InputRegistry($this->templates, $widgets);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+		$this->assertInstanceOf('Cake\View\Input\Basic', $result);
 	}
 
 /**
@@ -55,7 +55,7 @@ class InputRegistryTestCase extends TestCase {
 	public function testAdd() {
 		$inputs = new InputRegistry($this->templates);
 		$result = $inputs->add([
-			'text' => ['Cake\View\Input\Text'],
+			'text' => ['Cake\View\Input\Basic'],
 		]);
 		$this->assertNull($result);
 	}
@@ -68,10 +68,10 @@ class InputRegistryTestCase extends TestCase {
 	public function testGet() {
 		$inputs = new InputRegistry($this->templates);
 		$inputs->add([
-			'text' => ['Cake\View\Input\Text'],
+			'text' => ['Cake\View\Input\Basic'],
 		]);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+		$this->assertInstanceOf('Cake\View\Input\Basic', $result);
 		$this->assertSame($result, $inputs->get('text'));
 	}
 
@@ -83,10 +83,10 @@ class InputRegistryTestCase extends TestCase {
 	public function testGetFallback() {
 		$inputs = new InputRegistry($this->templates);
 		$inputs->add([
-			'_default' => ['Cake\View\Input\Text'],
+			'_default' => ['Cake\View\Input\Basic'],
 		]);
 		$result = $inputs->get('text');
-		$this->assertInstanceOf('Cake\View\Input\Text', $result);
+		$this->assertInstanceOf('Cake\View\Input\Basic', $result);
 
 		$result2 = $inputs->get('hidden');
 		$this->assertSame($result, $result2);


### PR DESCRIPTION
As part of #2267 this set of changes implements a button element, and renames text to basic, as that more accurately describes what it does. I think other than the datetime widget this is the last required widget. My hope is that @burzum has the datetime widget completed soon.

My next step is to start creating a few form context objects. Theese objects will provide an interface that formhelper will use to access entity values, introspect schema data and determine if a value is required. I was planning on building an adapter for the built in orm and simple arrays. I think having this separation is a big step in reducing and containing the coupling between formhelper and the orm.
