### PR TITLE
3.0 better count

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -173,8 +173,6 @@ class PaginatorComponent extends Component {
 		if (!$numResults) {
 			$count = 0;
 		} else {
-			$parameters = compact('conditions');
-			$query = $object->find($type, array_merge($parameters, $extra));
 			$count = $query->count();
 		}
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -872,20 +872,14 @@ class Query extends DatabaseQuery {
  * this method will replace the selected fields with a COUNT(*), and the resulting
  * count will be returned.
  *
- * If the query does contain GROUP BY or map reduce functions, then it
- * will be executed, and the number of rows in the ResultSet will be returned.
- *
  * @return integer
  */
 	public function count() {
-		$noFormatters = $this->mapReduce() === [] && empty($this->_formatters);
-		if ($this->clause('group') === [] && $noFormatters) {
-			$this->select(['count' => $this->func()->count('*')], true)
-				->hydrate(false);
-			return (int)$this->first()['count'];
-		}
-		$results = $this->execute();
-		return count($results);
+		$query = clone $this;
+		$query->select(['count' => $this->func()->count('*')])->hydrate(false);
+		$query->mapReduce(null, null, true);
+		$query->formatResults(null, true);
+		return (int)$query->first()['count'];
 	}
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -910,7 +910,7 @@ class Query extends DatabaseQuery {
  * count, for example removing unnecessary joins, removing group by or just return
  * an estimated number of rows.
  *
- * The callback will receive as first argument a  clone of this query and not this
+ * The callback will receive as first argument a clone of this query and not this
  * query itself.
  *
  * @param callable $counter

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -116,7 +116,7 @@ class PaginatorComponentTest extends TestCase {
 		);
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery();
-		$table->expects($this->at(0))
+		$table->expects($this->once())
 			->method('find')
 			->with('all', [
 				'conditions' => [],
@@ -126,15 +126,6 @@ class PaginatorComponentTest extends TestCase {
 				'limit' => 10,
 				'order' => ['PaginatorPosts.id' => 'ASC'],
 				'page' => 1,
-			])
-			->will($this->returnValue($query));
-
-		$table->expects($this->at(1))
-			->method('find')
-			->with('all', [
-				'conditions' => [],
-				'contain' => ['PaginatorAuthor'],
-				'group' => 'PaginatorPosts.published',
 			])
 			->will($this->returnValue($query));
 
@@ -180,7 +171,7 @@ class PaginatorComponentTest extends TestCase {
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery();
 
-		$table->expects($this->at(0))
+		$table->expects($this->once())
 			->method('find')
 			->with('all', [
 				'conditions' => [],
@@ -189,10 +180,6 @@ class PaginatorComponentTest extends TestCase {
 				'page' => 1,
 				'order' => ['PaginatorPosts.id' => 'DESC']
 			])
-			->will($this->returnValue($query));
-
-		$table->expects($this->at(1))
-			->method('find')
 			->will($this->returnValue($query));
 
 		$this->Paginator->paginate($table, $settings);
@@ -351,7 +338,7 @@ class PaginatorComponentTest extends TestCase {
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery();
 
-		$table->expects($this->at(0))
+		$table->expects($this->once())
 			->method('find')
 			->with('all', [
 				'fields' => null,
@@ -360,10 +347,6 @@ class PaginatorComponentTest extends TestCase {
 				'page' => 1,
 				'order' => ['PaginatorPosts.id' => 'asc'],
 			])
-			->will($this->returnValue($query));
-
-		$table->expects($this->at(1))
-			->method('find')
 			->will($this->returnValue($query));
 
 		$this->request->query = [
@@ -682,7 +665,7 @@ class PaginatorComponentTest extends TestCase {
 		);
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery();
-		$table->expects($this->at(0))
+		$table->expects($this->once())
 			->method('find')
 			->with('published', [
 				'conditions' => [],
@@ -690,13 +673,6 @@ class PaginatorComponentTest extends TestCase {
 				'limit' => 2,
 				'fields' => null,
 				'page' => 1,
-			])
-			->will($this->returnValue($query));
-
-		$table->expects($this->at(1))
-			->method('find')
-			->with('published', [
-				'conditions' => [],
 			])
 			->will($this->returnValue($query));
 
@@ -722,10 +698,13 @@ class PaginatorComponentTest extends TestCase {
  * @return Query
  */
 	protected function _getMockFindQuery() {
-		$query = $this->getMock('Cake\ORM\Query', ['total', 'all'], [], '', false);
+		$query = $this->getMockBuilder('Cake\ORM\Query')
+			->setMethods(['total', 'all', 'count'])
+			->disableOriginalConstructor()
+			->getMock();
 
 		$results = $this->getMock('Cake\ORM\ResultSet', [], [], '', false);
-		$results->expects($this->any())
+		$query->expects($this->any())
 			->method('count')
 			->will($this->returnValue(2));
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1516,6 +1516,27 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to provide
+ *
+ * @return void
+ */
+	public function testCountWuthCustomCounter() {
+		$table = TableRegistry::get('articles');
+		$query = $table->find('all');
+		$query
+			->select(['author_id', 's' => $query->func()->sum('id')])
+			->where(['id >' => 2])
+			->group(['author_id'])
+			->counter(function($q) use ($query) {
+				$this->assertNotSame($q, $query);
+				return $q->select([], true)->group([], true)->count();
+			});
+
+		$result = $query->count();
+		$this->assertEquals(1, $result);
+	}
+
+/**
  * Test update method.
  *
  * @return void

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1491,12 +1491,14 @@ class QueryTest extends TestCase {
 		$this->assertSame(3, $result);
 
 		$query = $table->find('all')
-			->where(['id >' => 1]);
+			->where(['id >' => 1])
+			->limit(1);
 		$result = $query->count();
 		$this->assertSame(2, $result);
 
 		$result = $query->all();
-		$this->assertEquals(['count' => 2], $result->first());
+		$this->assertCount(1, $result);
+		$this->assertEquals(2, $result->first()->id);
 	}
 
 /**
@@ -1506,10 +1508,11 @@ class QueryTest extends TestCase {
  */
 	public function testCountWithGroup() {
 		$table = TableRegistry::get('articles');
-		$query = $table->find('all')
-			->group(['published']);
+		$query = $table->find('all');
+		$query->select(['author_id', 's' => $query->func()->sum('id')])
+			->group(['author_id']);
 		$result = $query->count();
-		$this->assertEquals(1, $result);
+		$this->assertEquals(2, $result);
 	}
 
 /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1516,11 +1516,12 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that it is possible to provide
+ * Tests that it is possible to provide a callback for calculating the count
+ * of a query
  *
  * @return void
  */
-	public function testCountWuthCustomCounter() {
+	public function testCountWithCustomCounter() {
 		$table = TableRegistry::get('articles');
 		$query = $table->find('all');
 		$query


### PR DESCRIPTION
Improved the `Query::count()` method. Now it will work consistently when having `group by` or any formatting function. Also added a way to register a callback that will be used instead of Query::count() when present, this allows to have full control over the count query or to just return an estimated number of rows. 
