### PR TITLE
Fix double url decoding bug

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -235,7 +235,7 @@ class CakeRoute {
 
 		foreach ($this->keys as $key) {
 			if (isset($route[$key])) {
-				$route[$key] = rawurldecode($route[$key]);
+				$route[$key] = $route[$key];
 			}
 		}
 
@@ -247,7 +247,7 @@ class CakeRoute {
 		}
 
 		if (isset($route['_trailing_'])) {
-			$route['pass'][] = rawurldecode($route['_trailing_']);
+			$route['pass'][] = $route['_trailing_'];
 			unset($route['_trailing_']);
 		}
 

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -297,12 +297,12 @@ class CakeRoute {
 			$separatorIsPresent = strpos($param, $namedConfig['separator']) !== false;
 			if ((!isset($this->options['named']) || !empty($this->options['named'])) && $separatorIsPresent) {
 				list($key, $val) = explode($namedConfig['separator'], $param, 2);
-				$key = rawurldecode($key);
-				$val = rawurldecode($val);
+				$key = key;
+				$val = $val;
 				$hasRule = isset($rules[$key]);
 				$passIt = (!$hasRule && !$greedy) || ($hasRule && !$this->_matchNamed($val, $rules[$key], $context));
 				if ($passIt) {
-					$pass[] = rawurldecode($param);
+					$pass[] = $param;
 				} else {
 					if (preg_match_all('/\[([A-Za-z0-9_-]+)?\]/', $key, $matches, PREG_SET_ORDER)) {
 						$matches = array_reverse($matches);
@@ -323,7 +323,7 @@ class CakeRoute {
 					$named = array_merge_recursive($named, array($key => $val));
 				}
 			} else {
-				$pass[] = rawurldecode($param);
+				$pass[] = $param;
 			}
 		}
 		return array($pass, $named);

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -297,7 +297,7 @@ class CakeRoute {
 			$separatorIsPresent = strpos($param, $namedConfig['separator']) !== false;
 			if ((!isset($this->options['named']) || !empty($this->options['named'])) && $separatorIsPresent) {
 				list($key, $val) = explode($namedConfig['separator'], $param, 2);
-				$key = key;
+				$key = $key;
 				$val = $val;
 				$hasRule = isset($rules[$key]);
 				$passIt = (!$hasRule && !$greedy) || ($hasRule && !$this->_matchNamed($val, $rules[$key], $context));


### PR DESCRIPTION
Today I encountered an interesting bug where certain URLS of a production site were not working and reporting that the requested address couldn't be found. Upon further investigation  I learned that this was because the URL was being double urldecoded. The result was that anything inside of a url that was  "%[0-9]+'  AFTER urldecoding got decoded again and turned into a random character, or discarded. This resulted in the CakeRequest object having incorrect values in at least  the "here" property  and inside of the params array, which lead to the error being thrown. 

Concrete example taken from live code:
URL: http://local/outboundMessages/index/page:5/filters:%7B%22conditions%22%3A%5B%22billing_account_num%20LIKE%20%27%2555%25%27%22%5D%7D

Before change:
                'named' => array(
                    'page' => '5',
                    'filters' => '{"conditions":["billing_account_num LIKE 'U%'"]}'
                ),
After change:
'named' => array(
                    'page' => '5',
                    'filters' => '{"conditions":["billing_account_num LIKE '%55%'"]}'
                ),
As you can see, the URL is correctly decoded to: 
http://local/outboundMessages/index/page:5/filters:{"conditions":["billing_account_num LIKE '%55%'"]}
then decoded again, resulting in the 'U'.

This double decoding is not needed nor correct, and looks like it was largely put in  because the original author forgot that they had already decoded it. 
