### PR TITLE
Improves next() and prev() documentation

### DIFF
--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -264,6 +264,7 @@ class PaginatorHelper extends AppHelper {
  *
  * ### Options:
  *
+ * - `url` Allows sending routing parameters such as controllers, actions or passed arguments.
  * - `tag` The tag wrapping tag you want to use, defaults to 'span'. Set this to false to disable this option
  * - `escape` Whether you want the contents html entity encoded, defaults to true
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()
@@ -289,6 +290,7 @@ class PaginatorHelper extends AppHelper {
  *
  * ### Options:
  *
+ * - `url` Allows sending routing parameters such as controllers, actions or passed arguments.
  * - `tag` The tag wrapping tag you want to use, defaults to 'span'. Set this to false to disable this option
  * - `escape` Whether you want the contents html entity encoded, defaults to true
  * - `model` The model to use, defaults to PaginatorHelper::defaultModel()


### PR DESCRIPTION
Adds the explanation for the URL available option, which is really useful when dealing with non-default CakePHP routes, now lacking from the official documentation.
