### PR TITLE
3.0 Add datetime widget

### DIFF
--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\View\Input;
 
+use Cake\Utility\Time;
 use Cake\View\Input\InputInterface;
 use Cake\View\StringTemplate;
-use Cake\Utility\Time;
 
 /**
  * Input widget class for generating a date time input widget.

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Input;
+
+use Cake\View\StringTemplate;
+use Cake\Utility\Time;
+
+/**
+ * Input widget class for generating a date time input widget.
+ *
+ * This class is intended as an internal implementation detail
+ * of Cake\View\Helper\FormHelper and is not intended for direct use.
+ */
+class DateTime {
+
+/**
+ * List of inputs that can be rendered
+ *
+ * @var array
+ */
+	public $selects = [
+		'year',
+		'month',
+		'day',
+		'hour',
+		'minute',
+		'second',
+	];
+
+/**
+ * Template instance.
+ *
+ * @var \Cake\View\StringTemplate
+ */
+	protected $_templates;
+
+/**
+ * Deconstructed date
+ *
+ * @var array
+ */
+	protected $_date = [
+		'year' => null,
+		'month' => null,
+		'day' => null,
+		'hour' => null,
+		'minute' => null,
+		'second' => null,
+	];
+
+/**
+ * Constructor
+ *
+ * @param \Cake\View\StringTemplate $templates
+ * @param \Cake\View\Input\SelectBox $SelectBox
+ * @return \Cake\View\Input\DateTime
+ */
+	public function __construct(StringTemplate $templates, SelectBox $SelectBox) {
+		$this->SelectBox = $SelectBox;
+		$this->_templates = $templates;
+	}
+
+/**
+ * Renders a date time widget
+ *
+ * - `name` - Set the input name.
+ * - `disabled` - Either true or an array of options to disable.
+ * - `value` - A date time string, integer or DateTime object
+ * - `empty` - Set to true to add an empty option at the top of the
+ *   option elements. Set to a string to define the display value of the
+ *   empty option.
+ * - `year` - Array of options for the year select box.
+ * - `month` - Array of options for the month select box.
+ * - `day` - Array of options for the day select box.
+ * - `hour` - Array of options for the hour select box.
+ * - `minute` - Array of options for the minute select box.
+ * - `second` - Array of options for the second select box.
+ * - `timeZone` - Timezone string or DateTimeZone object.
+ *
+ * @param array $data Data to render with.
+ * @return string A generated select box.
+ * @throws \RuntimeException when the name attribute is empty.
+ */
+	public function render($data = []) {
+		$data += [
+			'name' => 'data',
+			'empty' => false,
+			'disabled' => null,
+			'value' => new \DateTime(),
+			'year' => [],
+			'month' => [
+				'names' => false,
+			],
+			'day' => [
+				'names' => false,
+			],
+			'hour' => [],
+			'minute' => [],
+			'second' => [],
+			'timeZone' => null
+		];
+
+		if (!empty($data['value'])) {
+			$this->_deconstuctDate($data['value'], $data['timeZone']);
+		}
+
+		$templateOptions = [];
+		foreach ($this->selects as $select) {
+			if ($data[$select] !== false) {
+				$method = $select . 'Select';
+				$data[$select]['name'] = $data['name'] . "['" . $select . "']";
+				$data[$select]['value'] = $this->_date[$select];
+				$data[$select]['empty'] = $data['empty'];
+				$data[$select]['disabled'] = $data['disabled'];
+				$data[$select] += $data[$select];
+				$templateOptions[$select] = $this->{$method}($data[$select]);
+			}
+			unset($data[$select]);
+		}
+		unset($data['name'], $data['empty'], $data['disabled'], $data['value'], $data['timeZone']);
+		$templateOptions['attrs'] = $this->_templates->formatAttributes($data);
+		return $this->_templates->format('dateWidget', $templateOptions);
+	}
+
+/**
+ * Deconstructs the passed date value into all time units
+ *
+ * @param string|integer|DateTime $date
+ * @param string|DateTimeZone
+ * @return array
+ */
+	protected function _deconstuctDate($date, $timeZone = null) {
+		$this->_date = [
+			'year' => Time::format($date, '%Y', null, $timeZone),
+			'month' => Time::format($date, '%m', null, $timeZone),
+			'day' => Time::format($date, '%d', null, $timeZone),
+			'hour' => Time::format($date, '%H', null, $timeZone),
+			'minute' => Time::format($date, '%M', null, $timeZone),
+			'second' => Time::format($date, '%S', null, $timeZone),
+		];
+	}
+
+/**
+ * Generates a year select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function yearSelect($options = []) {
+		$options += [
+			'name' => 'data[year]',
+			'value' => null,
+			'start' => date('Y', strtotime('-5 years')),
+			'end' => date('Y', strtotime('+5 years')),
+			'options' => []
+		];
+
+		if (empty($options['options'])) {
+			$options['options'] = $this->_generateNumbers($options['start'], $options['end']);
+		}
+
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Generates a month select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function monthSelect($options = []) {
+		$options += [
+			'name' => 'data[month]',
+			'names' => false,
+			'value' => null,
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true
+		];
+
+		if (empty($options['options'])) {
+			if ($options['names'] === true) {
+				$options['options'] = $this->_getMonthNames($options['leadingZeroKey']);
+			} else {
+				$options['options'] = $this->_generateNumbers(1, 12, $options);
+			}
+		}
+
+		unset($options['leadingZeroKey'], $options['leadingZeroValue'], $options['names']);
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Generates a day select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function daySelect($options = []) {
+		$options += [
+			'name' => 'data[day]',
+			'names' => false,
+			'value' => null,
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true,
+		];
+
+		if ($options['names'] === true) {
+			$options['options'] = $this->_getDayNames($options['leadingZeroKey']);
+		} else {
+			$options['options'] = $this->_generateNumbers(1, 7, $options);
+		}
+
+		$options['value'] = Time::format($options['value'], '%d');
+		unset($options['names'], $options['leadingZeroKey'], $options['leadingZeroValue']);
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Generates a hour select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function hourSelect($options = []) {
+		$options += [
+			'name' => 'data[hour]',
+			'value' => null,
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true,
+			'options' => $this->_generateNumbers(1, 24)
+		];
+
+		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Generates a minute select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function minuteSelect($options = []) {
+		$options += [
+			'name' => 'data[minute]',
+			'value' => null,
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true,
+			'options' => $this->_generateNumbers(1, 60)
+		];
+
+		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Generates a second select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function secondSelect($options = []) {
+		$options += [
+			'name' => 'data[second]',
+			'value' => null,
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true,
+			'options' => $this->_generateNumbers(1, 60)
+		];
+
+		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+		return $this->SelectBox->render($options);
+	}
+
+/**
+ * Returns a translated list of month names
+ *
+ * @param boolean $leadingZero
+ * @return array
+ */
+	protected function _getMonthNames($leadingZero = false) {
+		$months = [
+			'01' => __d('cake', 'January'),
+			'02' => __d('cake', 'February'),
+			'03' => __d('cake', 'March'),
+			'04' => __d('cake', 'April'),
+			'05' => __d('cake', 'May'),
+			'06' => __d('cake', 'June'),
+			'07' => __d('cake', 'July'),
+			'08' => __d('cake', 'August'),
+			'09' => __d('cake', 'September'),
+			'10' => __d('cake', 'October'),
+			'11' => __d('cake', 'November'),
+			'12' => __d('cake', 'December'),
+		];
+
+		if ($leadingZero === false) {
+			$i = 1;
+			foreach ($months as $key => $name) {
+				$months[$i++] = $name;
+				unset($months[$key]);
+			}
+		}
+
+		return $months;
+	}
+
+/**
+ * Returns a translated list of day names
+ *
+ * @todo find a way to define the first day of week
+ * @param boolean $leadingZero
+ * @return array
+ */
+	protected function _getDayNames($leadingZero = true) {
+		$days = [
+			'01' => __d('cake', 'Monday'),
+			'02' => __d('cake', 'Tuesday'),
+			'03' => __d('cake', 'Wednesday'),
+			'04' => __d('cake', 'Thursday'),
+			'05' => __d('cake', 'Friday'),
+			'06' => __d('cake', 'Saturday'),
+			'07' => __d('cake', 'Sunday'),
+		];
+
+		if ($leadingZero === false) {
+			$i = 1;
+			foreach ($days as $key => $name) {
+				$days[$i++] = $name;
+				unset($days[$key]);
+			}
+		}
+
+		return $days;
+	}
+
+/**
+ * Generates a range of numbers
+ *
+ * @param integer $start Start of the range of numbers to generate
+ * @param integer $end End of the range of numbers to generate
+ * @param array $options
+ * @return array
+ */
+	protected function _generateNumbers($start = 1, $end = 31, $options = []) {
+		$options += [
+			'leadingZeroKey' => true,
+			'leadingZeroValue' => true,
+		];
+
+		$numbers = [];
+		for ($i = $start; $i <= $end; $i++) {
+			$key = $i;
+			$value = $i;
+			if ($i < 10) {
+				if ($options['leadingZeroKey'] === true) {
+					$key = '0' . $key;
+				}
+				if ($options['leadingZeroValue'] === true) {
+					$value = '0' . $value;
+				}
+			}
+			$numbers[(string)$key] = (string)$value;
+		}
+		return $numbers;
+	}
+
+}

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -90,7 +90,7 @@ class DateTime implements InputInterface {
 			'name' => 'data',
 			'empty' => false,
 			'disabled' => null,
-			'val' => new \DateTime(),
+			'val' => null,
 			'year' => [],
 			'month' => [
 				'names' => false,
@@ -111,7 +111,13 @@ class DateTime implements InputInterface {
 				$method = $select . 'Select';
 				$data[$select]['name'] = $data['name'] . "[" . $select . "]";
 				$data[$select]['val'] = $selected[$select];
-				$data[$select]['empty'] = $data['empty'];
+
+				if (is_bool($data['empty'])) {
+					$data[$select]['empty'] = $data['empty'];
+				}
+				if (isset($data['empty'][$select])) {
+					$data[$select]['empty'] = $data['empty'][$select];
+				}
 				$data[$select]['disabled'] = $data['disabled'];
 				$data[$select] += $data[$select];
 				$templateOptions[$select] = $this->{$method}($data[$select]);
@@ -130,6 +136,12 @@ class DateTime implements InputInterface {
  * @return array
  */
 	protected function _deconstuctDate($value) {
+		if (empty($value)) {
+			return [
+				'year' => '', 'month' => '', 'day' => '',
+				'hour' => '', 'minute' => '', 'second' => ''
+			];
+		}
 		if (is_string($value)) {
 			$date = new \DateTime($value);
 		} elseif (is_int($value)) {

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -96,8 +96,15 @@ class DateTime implements InputInterface {
  * The `month` option accepts the `name` option which allows you to get month
  * names instead of month numbers.
  *
- * The `hour` option allows you to set the `format` option which accepts
- * 12 or 24, allowing you to indicate which hour format you want.
+ * The `hour` option allows you to set the following options:
+ *
+ * - `format` option which accepts 12 or 24, allowing 
+ *   you to indicate which hour format you want.
+ * - `start` The hour to start the options at.
+ * - `end` The hour to stop the options at.
+ *
+ * The start and end options are dependent on the format used. If the
+ * value is out of the start/end range it will not be included.
  *
  * The `minute` option allows you to define the following options:
  *

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -131,7 +131,7 @@ class DateTime implements InputInterface {
 			'meridian' => null,
 		];
 
-		$selected = $this->_deconstuctDate($data['val'], $data);
+		$selected = $this->_deconstructDate($data['val'], $data);
 
 		if (!isset($data['meridian']) &&
 			isset($data['hour']['format']) &&
@@ -178,7 +178,7 @@ class DateTime implements InputInterface {
  * @param array $options Options for conversion.
  * @return array
  */
-	protected function _deconstuctDate($value, $options) {
+	protected function _deconstructDate($value, $options) {
 		if (empty($value)) {
 			return [
 				'year' => '', 'month' => '', 'day' => '',

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -79,7 +79,7 @@ class DateTime implements InputInterface {
  * - `day` - Array of options for the day select box.
  * - `hour` - Array of options for the hour select box.
  * - `minute` - Array of options for the minute select box.
- * - `second` - Array of options for the second select box.
+ * - `second` - Set to true to enable the seconds input. Defaults to false.
  *
  * @param array $data Data to render with.
  * @return string A generated select box.
@@ -87,17 +87,13 @@ class DateTime implements InputInterface {
  */
 	public function render(array $data) {
 		$data += [
-			'name' => 'data',
+			'name' => '',
 			'empty' => false,
 			'disabled' => null,
 			'val' => null,
 			'year' => [],
-			'month' => [
-				'names' => false,
-			],
-			'day' => [
-				'names' => false,
-			],
+			'month' => [],
+			'day' => [],
 			'hour' => [],
 			'minute' => [],
 			'second' => [],
@@ -112,14 +108,13 @@ class DateTime implements InputInterface {
 				$data[$select]['name'] = $data['name'] . "[" . $select . "]";
 				$data[$select]['val'] = $selected[$select];
 
-				if (is_bool($data['empty'])) {
+				if (!isset($data[$select]['empty'])) {
 					$data[$select]['empty'] = $data['empty'];
 				}
-				if (isset($data['empty'][$select])) {
-					$data[$select]['empty'] = $data['empty'][$select];
+				if (!isset($data[$select]['disabled'])) {
+					$data[$select]['disabled'] = $data['disabled'];
 				}
-				$data[$select]['disabled'] = $data['disabled'];
-				$data[$select] += $data[$select];
+
 				$templateOptions[$select] = $this->{$method}($data[$select]);
 			}
 			unset($data[$select]);
@@ -176,17 +171,21 @@ class DateTime implements InputInterface {
  */
 	public function yearSelect($options = []) {
 		$options += [
-			'name' => 'data[year]',
+			'name' => '',
 			'val' => null,
 			'start' => date('Y', strtotime('-5 years')),
 			'end' => date('Y', strtotime('+5 years')),
+			'order' => 'desc',
 			'options' => []
 		];
 
 		if (empty($options['options'])) {
 			$options['options'] = $this->_generateNumbers($options['start'], $options['end']);
 		}
-
+		if ($options['order'] === 'asc') {
+			$options['options'] = array_reverse($options['options'], true);
+		}
+		unset($options['start'], $options['end'], $options['order']);
 		return $this->_select->render($options);
 	}
 
@@ -198,7 +197,7 @@ class DateTime implements InputInterface {
  */
 	public function monthSelect($options = []) {
 		$options += [
-			'name' => 'data[month]',
+			'name' => '',
 			'names' => false,
 			'val' => null,
 			'leadingZeroKey' => true,
@@ -225,7 +224,7 @@ class DateTime implements InputInterface {
  */
 	public function daySelect($options = []) {
 		$options += [
-			'name' => 'data[day]',
+			'name' => '',
 			'val' => null,
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => true,
@@ -244,7 +243,7 @@ class DateTime implements InputInterface {
  */
 	public function hourSelect($options = []) {
 		$options += [
-			'name' => 'data[hour]',
+			'name' => '',
 			'val' => null,
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => true,
@@ -263,7 +262,7 @@ class DateTime implements InputInterface {
  */
 	public function minuteSelect($options = []) {
 		$options += [
-			'name' => 'data[minute]',
+			'name' => '',
 			'val' => null,
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => true,
@@ -282,7 +281,7 @@ class DateTime implements InputInterface {
  */
 	public function secondSelect($options = []) {
 		$options += [
-			'name' => 'data[second]',
+			'name' => '',
 			'val' => null,
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => true,

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -186,20 +186,24 @@ class DateTime implements InputInterface {
 				'meridian' => '',
 			];
 		}
-		if (is_string($value)) {
-			$date = new \DateTime($value);
-		} elseif (is_int($value)) {
-			$date = new \DateTime('@' . $value);
-		} elseif (is_array($value)) {
+		try {
+			if (is_string($value)) {
+				$date = new \DateTime($value);
+			} elseif (is_int($value)) {
+				$date = new \DateTime('@' . $value);
+			} elseif (is_array($value)) {
+				$date = new \DateTime();
+				if (isset($value['year'], $value['month'], $value['day'])) {
+					$date->setDate($value['year'], $value['month'], $value['day']);
+				}
+				if (isset($value['hour'], $value['minute'], $value['second'])) {
+					$date->setTime($value['hour'], $value['minute'], $value['second']);
+				}
+			} else {
+				$date = clone $value;
+			}
+		} catch (\Exception $e) {
 			$date = new \DateTime();
-			if (isset($value['year'], $value['month'], $value['day'])) {
-				$date->setDate($value['year'], $value['month'], $value['day']);
-			}
-			if (isset($value['hour'], $value['minute'], $value['second'])) {
-				$date->setTime($value['hour'], $value['minute'], $value['second']);
-			}
-		} else {
-			$date = clone $value;
 		}
 
 		if (isset($options['minute']['interval'])) {

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -179,6 +179,9 @@ class DateTime implements InputInterface {
 			'options' => []
 		];
 
+		$options['start'] = min($options['val'], $options['start']);
+		$options['end'] = max($options['val'], $options['end']);
+
 		if (empty($options['options'])) {
 			$options['options'] = $this->_generateNumbers($options['start'], $options['end']);
 		}

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -206,7 +206,7 @@ class DateTime implements InputInterface {
 			'names' => false,
 			'val' => null,
 			'leadingZeroKey' => true,
-			'leadingZeroValue' => true
+			'leadingZeroValue' => false
 		];
 
 		if (empty($options['options'])) {
@@ -232,7 +232,7 @@ class DateTime implements InputInterface {
 			'name' => '',
 			'val' => null,
 			'leadingZeroKey' => true,
-			'leadingZeroValue' => true,
+			'leadingZeroValue' => false,
 		];
 		$options['options'] = $this->_generateNumbers(1, 31, $options);
 
@@ -250,12 +250,22 @@ class DateTime implements InputInterface {
 		$options += [
 			'name' => '',
 			'val' => null,
+			'format' => 24,
 			'leadingZeroKey' => true,
-			'leadingZeroValue' => true,
-			'options' => $this->_generateNumbers(1, 24)
+			'leadingZeroValue' => false,
 		];
+		$is24 = $options['format'] == 24;
 
-		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+		if (!$is24 && $options['val'] > 12) {
+			$options['val'] = sprintf('%02d', $options['val'] - 12);
+		}
+
+		if (empty($options['options'])) {
+			$end = $is24 ? 24 : 12;
+			$options['options'] = $this->_generateNumbers(1, $end, $options);
+		}
+
+		unset($options['format'], $options['leadingZeroKey'], $options['leadingZeroValue']);
 		return $this->_select->render($options);
 	}
 

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -81,6 +81,8 @@ class DateTime implements InputInterface {
  * - `hour` - Array of options for the hour select box.
  * - `minute` - Array of options for the minute select box.
  * - `second` - Set to true to enable the seconds input. Defaults to false.
+ * - `meridian` - Set to true to enable the meridian input. Defaults to false.
+ *   The meridian will be enabled automatically if you chose a 12 hour format.
  *
  * @param array $data Data to render with.
  * @return string A generated select box.

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -175,7 +175,8 @@ class DateTime implements InputInterface {
 		if (empty($value)) {
 			return [
 				'year' => '', 'month' => '', 'day' => '',
-				'hour' => '', 'minute' => '', 'second' => ''
+				'hour' => '', 'minute' => '', 'second' => '',
+				'meridian' => '',
 			];
 		}
 		if (is_string($value)) {

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -146,7 +146,7 @@ class DateTime implements InputInterface {
 					$select
 				));
 			}
-			$method = $select . 'Select';
+			$method = "_{$select}Select";
 			$data[$select]['name'] = $data['name'] . "[" . $select . "]";
 			$data[$select]['val'] = $selected[$select];
 
@@ -239,7 +239,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function yearSelect($options = []) {
+	protected function _yearSelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -268,7 +268,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function monthSelect($options = []) {
+	protected function _monthSelect($options = []) {
 		$options += [
 			'name' => '',
 			'names' => false,
@@ -295,7 +295,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function daySelect($options = []) {
+	protected function _daySelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -314,7 +314,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function hourSelect($options = []) {
+	protected function _hourSelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -343,7 +343,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function minuteSelect($options = []) {
+	protected function _minuteSelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -371,7 +371,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function secondSelect($options = []) {
+	protected function _secondSelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -390,7 +390,7 @@ class DateTime implements InputInterface {
  * @param array $options
  * @return string
  */
-	public function meridianSelect($options = []) {
+	protected function _meridianSelect($options = []) {
 		$options += [
 			'name' => '',
 			'val' => null,

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -45,6 +45,7 @@ class DateTime implements InputInterface {
 		'hour',
 		'minute',
 		'second',
+		'meridian',
 	];
 
 /**
@@ -83,7 +84,7 @@ class DateTime implements InputInterface {
  *
  * @param array $data Data to render with.
  * @return string A generated select box.
- * @throws \RuntimeException when the name attribute is empty.
+ * @throws \RuntimeException When option data is invalid.
  */
 	public function render(array $data) {
 		$data += [
@@ -97,9 +98,17 @@ class DateTime implements InputInterface {
 			'hour' => [],
 			'minute' => [],
 			'second' => [],
+			'meridian' => null,
 		];
 
 		$selected = $this->_deconstuctDate($data['val'], $data);
+
+		if (!isset($data['meridian']) &&
+			isset($data['hour']['format']) &&
+			$data['hour']['format'] == 12
+		) {
+			$data['meridian'] = [];
+		}
 
 		$templateOptions = [];
 		foreach ($this->_selects as $select) {
@@ -107,6 +116,12 @@ class DateTime implements InputInterface {
 				$templateOptions[$select] = '';
 				unset($data[$select]);
 				continue;
+			}
+			if (!is_array($data[$select])) {
+				throw \RuntimeException(sprintf(
+					'Options for "%s" must be an array|false|null',
+					$select
+				));
 			}
 			$method = $select . 'Select';
 			$data[$select]['name'] = $data['name'] . "[" . $select . "]";
@@ -167,7 +182,8 @@ class DateTime implements InputInterface {
 			'day' => $date->format('d'),
 			'hour' => $date->format('H'),
 			'minute' => $date->format('i'),
-			'second' => $date->format('s')
+			'second' => $date->format('s'),
+			'meridian' => $date->format('a'),
 		];
 	}
 
@@ -342,6 +358,21 @@ class DateTime implements InputInterface {
 		];
 
 		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
+		return $this->_select->render($options);
+	}
+
+/**
+ * Generates a meridian select
+ *
+ * @param array $options
+ * @return string
+ */
+	public function meridianSelect($options = []) {
+		$options += [
+			'name' => '',
+			'val' => null,
+			'options' => ['am' => 'am', 'pm' => 'pm']
+		];
 		return $this->_select->render($options);
 	}
 

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -103,20 +103,22 @@ class DateTime implements InputInterface {
 
 		$templateOptions = [];
 		foreach ($this->_selects as $select) {
-			if ($data[$select] !== false) {
-				$method = $select . 'Select';
-				$data[$select]['name'] = $data['name'] . "[" . $select . "]";
-				$data[$select]['val'] = $selected[$select];
-
-				if (!isset($data[$select]['empty'])) {
-					$data[$select]['empty'] = $data['empty'];
-				}
-				if (!isset($data[$select]['disabled'])) {
-					$data[$select]['disabled'] = $data['disabled'];
-				}
-
-				$templateOptions[$select] = $this->{$method}($data[$select]);
+			if ($data[$select] === false || $data[$select] === null) {
+				$templateOptions[$select] = '';
+				unset($data[$select]);
+				continue;
 			}
+			$method = $select . 'Select';
+			$data[$select]['name'] = $data['name'] . "[" . $select . "]";
+			$data[$select]['val'] = $selected[$select];
+
+			if (!isset($data[$select]['empty'])) {
+				$data[$select]['empty'] = $data['empty'];
+			}
+			if (!isset($data[$select]['disabled'])) {
+				$data[$select]['disabled'] = $data['disabled'];
+			}
+			$templateOptions[$select] = $this->{$method}($data[$select]);
 			unset($data[$select]);
 		}
 		unset($data['name'], $data['empty'], $data['disabled'], $data['val']);

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -320,21 +320,39 @@ class DateTime implements InputInterface {
 			'name' => '',
 			'val' => null,
 			'format' => 24,
+			'start' => null,
+			'end' => null,
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => false,
 		];
 		$is24 = $options['format'] == 24;
+
+		$defaultEnd = $is24 ? 24 : 12;
+
+		$options['start'] = max(1, $options['start']);
+
+		$options['end'] = min($defaultEnd, $options['end']);
+		if ($options['end'] === null) {
+			$options['end'] = $defaultEnd;
+		}
 
 		if (!$is24 && $options['val'] > 12) {
 			$options['val'] = sprintf('%02d', $options['val'] - 12);
 		}
 
 		if (empty($options['options'])) {
-			$end = $is24 ? 24 : 12;
-			$options['options'] = $this->_generateNumbers(1, $end, $options);
+			$options['options'] = $this->_generateNumbers(
+				$options['start'],
+				$options['end'],
+				$options
+			);
 		}
 
-		unset($options['format'], $options['leadingZeroKey'], $options['leadingZeroValue']);
+		unset(
+			$options['end'], $options['start'],
+			$options['format'], $options['leadingZeroKey'],
+			$options['leadingZeroValue']
+		);
 		return $this->_select->render($options);
 	}
 

--- a/src/View/Input/DateTime.php
+++ b/src/View/Input/DateTime.php
@@ -75,6 +75,12 @@ class DateTime implements InputInterface {
  * - `empty` - Set to true to add an empty option at the top of the
  *   option elements. Set to a string to define the display value of the
  *   empty option.
+ *
+ * In addtion to the above options, the following options allow you to control
+ * which input elements are generated. By setting any option to false you can disable
+ * that input picker. In addition each picker allows you to set additional options
+ * that are set as HTML properties on the picker.
+ *
  * - `year` - Array of options for the year select box.
  * - `month` - Array of options for the month select box.
  * - `day` - Array of options for the day select box.
@@ -83,6 +89,21 @@ class DateTime implements InputInterface {
  * - `second` - Set to true to enable the seconds input. Defaults to false.
  * - `meridian` - Set to true to enable the meridian input. Defaults to false.
  *   The meridian will be enabled automatically if you chose a 12 hour format.
+ *
+ * The `year` option accepts the `start` and `end` options. These let you control
+ * the year range that is generated. It defaults to +-5 years from today.
+ *
+ * The `month` option accepts the `name` option which allows you to get month
+ * names instead of month numbers.
+ *
+ * The `hour` option allows you to set the `format` option which accepts
+ * 12 or 24, allowing you to indicate which hour format you want.
+ *
+ * The `minute` option allows you to define the following options:
+ *
+ * - `interval` The interval to round options to.
+ * - `round` Accepts `up` or `down`. Defines which direction the current value
+ *   should be rounded to match the select options.
  *
  * @param array $data Data to render with.
  * @return string A generated select box.

--- a/src/View/Input/InputRegistry.php
+++ b/src/View/Input/InputRegistry.php
@@ -48,6 +48,7 @@ class InputRegistry {
 		'radio' => ['Cake\View\Input\Radio', 'label'],
 		'select' => ['Cake\View\Input\SelectBox'],
 		'textarea' => ['Cake\View\Input\Textarea'],
+		'datetime' => ['Cake\View\Input\DateTime', 'select'],
 		'_default' => ['Cake\View\Input\Basic'],
 	];
 

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -43,7 +43,7 @@ class DateTimeTest extends TestCase {
 			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
-			'dateWidget' => '{{year}}-{{month}}-{{day}} {{hour}}:{{minute}}:{{second}}'
+			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}'
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->selectBox = new SelectBox($this->templates);
@@ -251,12 +251,75 @@ class DateTimeTest extends TestCase {
 		$this->assertTags($result, $expected);
 	}
 
+/**
+ * Test rendering the month widget
+ *
+ * @return void
+ */
 	public function testRenderMonthWidget() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-01 12:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[month]'],
+			['option' => ['value' => '01']], '01', '/option',
+			['option' => ['value' => '02']], '02', '/option',
+			['option' => ['value' => '03']], '03', '/option',
+			['option' => ['value' => '04']], '04', '/option',
+			['option' => ['value' => '05']], '05', '/option',
+			['option' => ['value' => '06']], '06', '/option',
+			['option' => ['value' => '07']], '07', '/option',
+			['option' => ['value' => '08']], '08', '/option',
+			['option' => ['value' => '09', 'selected' => 'selected']], '09', '/option',
+			['option' => ['value' => '10']], '10', '/option',
+			['option' => ['value' => '11']], '11', '/option',
+			['option' => ['value' => '12']], '12', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
+/**
+ * Test rendering month widget with names.
+ *
+ * @return void
+ */
 	public function testRenderMonthWidgetWithNames() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-01 12:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'month' => ['data-foo' => 'test', 'names' => true],
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[month]', 'data-foo' => 'test'],
+			['option' => ['value' => '01']], 'January', '/option',
+			['option' => ['value' => '02']], 'February', '/option',
+			['option' => ['value' => '03']], 'March', '/option',
+			['option' => ['value' => '04']], 'April', '/option',
+			['option' => ['value' => '05']], 'May', '/option',
+			['option' => ['value' => '06']], 'June', '/option',
+			['option' => ['value' => '07']], 'July', '/option',
+			['option' => ['value' => '08']], 'August', '/option',
+			['option' => ['value' => '09', 'selected' => 'selected']], 'September', '/option',
+			['option' => ['value' => '10']], 'October', '/option',
+			['option' => ['value' => '11']], 'November', '/option',
+			['option' => ['value' => '12']], 'December', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 	public function testRenderDayWidget() {

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -33,7 +33,6 @@ class DateTimeTest extends TestCase {
 		parent::setUp();
 		$templates = [
 			'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>',
-			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
 			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}'

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -43,7 +43,7 @@ class DateTimeTest extends TestCase {
 			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
-			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}'
+			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}'
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->selectBox = new SelectBox($this->templates);
@@ -423,6 +423,8 @@ class DateTimeTest extends TestCase {
 		$this->assertNotContains('date[day]', $result, 'No day select.');
 		$this->assertNotContains('value="0"', $result, 'No zero hour');
 		$this->assertNotContains('value="25"', $result, 'No 25th hour');
+		$this->assertNotContains('<select name="date[meridian]">', $result);
+		$this->assertNotContains('<option value="pm" selected="selected">pm</option>', $result);
 	}
 
 /**
@@ -468,6 +470,9 @@ class DateTimeTest extends TestCase {
 		);
 		$this->assertNotContains('date[day]', $result, 'No day select.');
 		$this->assertNotContains('value="0"', $result, 'No zero hour');
+
+		$this->assertContains('<select name="date[meridian]">', $result);
+		$this->assertContains('<option value="pm" selected="selected">pm</option>', $result);
 	}
 
 /**
@@ -679,7 +684,45 @@ class DateTimeTest extends TestCase {
  * @return void
  */
 	public function testRenderMeridianWidget() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:00:25');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'meridian' => [],
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[meridian]'],
+			['option' => ['value' => 'am']], 'am', '/option',
+			['option' => ['value' => 'pm', 'selected' => 'selected']], 'pm', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
+
+		$now = new \DateTime('2010-09-09 09:00:25');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'meridian' => [],
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[meridian]'],
+			['option' => ['value' => 'am', 'selected' => 'selected']], 'am', '/option',
+			['option' => ['value' => 'pm']], 'pm', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 /**

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -84,8 +84,29 @@ class DateTimeTest extends TestCase {
 		$this->assertContains('<option value="45" selected="selected">45</option>', $result);
 	}
 
+/**
+ * Test rendering widgets with empty values.
+ *
+ * @retun void
+ */
 	public function testRenderEmptyValues() {
-		$this->markTestIncomplete();
+		$result = $this->DateTime->render([
+			'empty' => [
+				'year' => 'YEAR',
+				'month' => 'MONTH',
+				'day' => 'DAY',
+				'hour' => 'HOUR',
+				'minute' => 'MINUTE',
+				'second' => 'SECOND',
+				'meridian' => 'MERIDIAN',
+			]
+		]);
+		$this->assertContains('<option value="" selected="selected">YEAR</option>', $result);
+		$this->assertContains('<option value="" selected="selected">MONTH</option>', $result);
+		$this->assertContains('<option value="" selected="selected">DAY</option>', $result);
+		$this->assertContains('<option value="" selected="selected">HOUR</option>', $result);
+		$this->assertContains('<option value="" selected="selected">MINUTE</option>', $result);
+		$this->assertContains('<option value="" selected="selected">SECOND</option>', $result);
 	}
 
 	public function testRenderYearWidget() {
@@ -143,7 +164,6 @@ class DateTimeTest extends TestCase {
 	public function testRenderMeridianWidget() {
 		$this->markTestIncomplete();
 	}
-
 
 /**
  * testGenerateNumbers

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -491,7 +491,7 @@ class DateTimeTest extends TestCase {
 		]);
 		$this->assertContains('<select name="date[minute]" data-foo="test">', $result);
 		$this->assertContains(
-			'<option value="01">01</option>',
+			'<option value="00">00</option>',
 			$result,
 			'contains 1'
 		);
@@ -506,22 +506,134 @@ class DateTimeTest extends TestCase {
 			'selected value present'
 		);
 		$this->assertContains(
-			'<option value="60">60</option>',
+			'<option value="59">59</option>',
 			$result,
-			'contains 60'
+			'contains 59'
 		);
-		$this->assertNotContains('value="0"', $result, 'No zero value');
-		$this->assertNotContains('value="61"', $result, 'No 61 value');
+		$this->assertNotContains('value="60"', $result, 'No 60 value');
 	}
 
+/**
+ * Test minutes with interval values.
+ *
+ * @return void
+ */
 	public function testRenderMinuteWidgetInterval() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:23:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => [
+				'interval' => 5
+			],
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[minute]">', $result);
+		$this->assertContains(
+			'<option value="00">00</option>',
+			$result,
+			'contains 0'
+		);
+		$this->assertContains(
+			'<option value="05">05</option>',
+			$result,
+			'contains 05'
+		);
+		$this->assertContains(
+			'<option value="25" selected="selected">25</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertContains(
+			'<option value="55">55</option>',
+			$result,
+			'contains 59'
+		);
+		$this->assertNotContains('value="2"', $result, 'No 2 value');
+		$this->assertNotContains('value="23"', $result, 'No 23 value');
+		$this->assertNotContains('value="58"', $result, 'No 58 value');
+		$this->assertNotContains('value="59"', $result, 'No 59 value');
+		$this->assertNotContains('value="60"', $result, 'No 60 value');
 	}
 
+/**
+ * Test rounding up and down.
+ *
+ * @return void
+ */
 	public function testRenderMinuteWidgetIntervalRounding() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:22:00');
+		$data = [
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => [
+				'interval' => 5,
+				'round' => 'up',
+			],
+			'second' => false,
+			'val' => $now,
+		];
+		$result = $this->DateTime->render($data);
+		$this->assertContains(
+			'<option value="25" selected="selected">25</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertNotContains('value="23"', $result, 'No 23 value');
+
+		$data['minute']['round'] = 'down';
+		$result = $this->DateTime->render($data);
+		$this->assertContains(
+			'<option value="20" selected="selected">20</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertNotContains('value="23"', $result, 'No 23 value');
 	}
 
+/**
+ * Test that minute interval rounding can effect hours and days.
+ *
+ * @return void
+ */
+	public function testMinuteIntervalHourRollover() {
+		$now = new \DateTime('2010-09-09 23:58:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'minute' => [
+				'interval' => 5,
+				'round' => 'up',
+			],
+			'second' => false,
+			'val' => $now,
+		]);
+
+		$this->assertContains(
+			'<option value="00" selected="selected">00</option>',
+			$result,
+			'selected minute present'
+		);
+		$this->assertContains(
+			'<option value="10" selected="selected">10</option>',
+			$result,
+			'selected day present'
+		);
+	}
+
+/**
+ * Test render seconds basic.
+ *
+ * @return void
+ */
 	public function testRenderSecondsWidget() {
 		$now = new \DateTime('2010-09-09 13:00:25');
 		$result = $this->DateTime->render([
@@ -561,6 +673,11 @@ class DateTimeTest extends TestCase {
 		$this->assertNotContains('value="61"', $result, 'No 61 value');
 	}
 
+/**
+ * Test the merdian select.
+ *
+ * @return void
+ */
 	public function testRenderMeridianWidget() {
 		$this->markTestIncomplete();
 	}

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -84,6 +84,67 @@ class DateTimeTest extends TestCase {
 		$this->assertContains('<option value="45" selected="selected">45</option>', $result);
 	}
 
+	public function testRenderEmptyValues() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderYearWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderYearWidgetOrdering() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderYearWidgetMinAndMax() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderYearWidgetValueOutOfBounds() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMonthWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMonthWidgetWithNames() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderDayWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderHourWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderHourWidget24() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMinuteWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMinuteWidgetInterval() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMinuteWidgetIntervalRounding() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderSecondsWidget() {
+		$this->markTestIncomplete();
+	}
+
+	public function testRenderMeridianWidget() {
+		$this->markTestIncomplete();
+	}
+
+
 /**
  * testGenerateNumbers
  *
@@ -130,73 +191,6 @@ class DateTimeTest extends TestCase {
 			3 => '3'
 		);
 		$this->assertEquals($result, $expected);
-	}
-
-/**
- * testYearSelect
- *
- * @return void
- */
-	public function testYearSelect() {
-		$result = $this->DateTime->yearSelect();
-		$this->markTestIncomplete();
-	}
-
-/**
- * testMonthSelect
- *
- * @return void
- */
-	public function testMonthSelect() {
-		$result = $this->DateTime->monthSelect();
-		$expected = '<select name="data[month]"><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option></select>';
-		$this->assertEquals($result, $expected);
-
-		$result = $this->DateTime->monthSelect([
-			'names' => true,
-		]);
-		$this->markTestIncomplete();
-	}
-
-/**
- * testDaySelect
- *
- * @return void
- */
-	public function testDaySelect() {
-		$result = $this->DateTime->daySelect();
-		$expected = '<select name="data[day]"><option value="01" selected="selected">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option></select>';
-		$this->markTestIncomplete();
-	}
-
-/**
- * testHourSelect
- *
- * @return void
- */
-	public function testHourSelect() {
-		$result = $this->DateTime->hourSelect();
-		$this->markTestIncomplete();
-	}
-
-/**
- * testHourSelect
- *
- * @return void
- */
-	public function testMinuteSelect() {
-		$result = $this->DateTime->minuteSelect();
-		$this->markTestIncomplete();
-	}
-
-/**
- * testHourSelect
- *
- * @return void
- */
-	public function testSecondSelect() {
-		$result = $this->DateTime->secondSelect();
-		$this->markTestIncomplete();
 	}
 
 }

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Input;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\Input\SelectBox;
+use Cake\View\StringTemplate;
+
+class DateTime extends \Cake\View\Input\DateTime {
+	public function generateNumbers($start = 1, $end = 31, $options = []) {
+		return parent::_generateNumbers($start, $end, $options);
+	}
+	public function getDayNames($leadingZero = true) {
+		return parent::_getDayNames($leadingZero);
+	}
+}
+
+/**
+ * SelectBox test case
+ */
+class DateTimeTest extends TestCase {
+
+/**
+ * @setUp
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$templates = [
+			'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>',
+			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
+			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
+			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
+			'dateWidget' => '<div{{attrs}}>{{year}}-{{month}}-{{day}} {{hour}}:{{minute}}:{{second}}{{timeZone}}</div>'
+		];
+		$this->templates = new StringTemplate();
+		$this->templates->add($templates);
+		$this->SelectBox = new SelectBox($this->templates);
+		$this->DateTime = new DateTime($this->templates, $this->SelectBox);
+	}
+
+/**
+ * testRenderNoOptions
+ *
+ * @return void
+ */
+	public function testRenderNoOptions() {
+		$result = $this->DateTime->render();
+	}
+
+/**
+ * testGetDayNames
+ *
+ * @return void
+ */
+	public function testGetDayNames() {
+		$result = $this->DateTime->getDayNames();
+		$result = $this->DateTime->getDayNames(false);
+	}
+
+/**
+ * testGenerateNumbers
+ *
+ * @return void
+ */
+	public function testGenerateNumbers() {
+		$result = $this->DateTime->generateNumbers(1, 3);
+		$expected = array(
+			'01' => '01',
+			'02' => '02',
+			'03' => '03'
+		);
+		$this->assertEquals($result, $expected);
+
+		$result = $this->DateTime->generateNumbers(1, 3, [
+			'leadingZeroKey' => false
+		]);
+		$expected = array(
+			1 => '01',
+			2 => '02',
+			3 => '03'
+		);
+		$this->assertEquals($result, $expected);
+
+		$result = $this->DateTime->generateNumbers(1, 5, [
+			'leadingZeroValue' => false
+		]);
+		$expected = array(
+			'01' => '1',
+			'02' => '2',
+			'03' => '3',
+			'04' => '4',
+			'05' => '5'
+		);
+		$this->assertEquals($result, $expected);
+
+		$result = $this->DateTime->generateNumbers(1, 3, [
+			'leadingZeroValue' => false,
+			'leadingZeroKey' => false
+		]);
+		$expected = array(
+			1 => '1',
+			2 => '2',
+			3 => '3'
+		);
+		$this->assertEquals($result, $expected);
+	}
+
+/**
+ * testYearSelect
+ *
+ * @return void
+ */
+	public function testYearSelect() {
+		$result = $this->DateTime->yearSelect();
+	}
+
+/**
+ * testMonthSelect
+ *
+ * @return void
+ */
+	public function testMonthSelect() {
+		$result = $this->DateTime->monthSelect();
+		$expected = '<select name="data[month]"><option value="01">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option><option value="08">08</option><option value="09">09</option><option value="10">10</option><option value="11">11</option><option value="12">12</option></select>';
+		$this->assertEquals($result, $expected);
+
+		$result = $this->DateTime->monthSelect([
+			'names' => true,
+		]);
+	}
+
+/**
+ * testDaySelect
+ *
+ * @return void
+ */
+	public function testDaySelect() {
+		$result = $this->DateTime->daySelect();
+		$expected = '<select name="data[day]"><option value="01" selected="selected">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option></select>';
+		$this->assertEquals($result, $expected);
+	}
+
+/**
+ * testHourSelect
+ *
+ * @return void
+ */
+	public function testHourSelect() {
+		$result = $this->DateTime->hourSelect();
+	}
+
+/**
+ * testHourSelect
+ *
+ * @return void
+ */
+	public function testMinuteSelect() {
+		$result = $this->DateTime->minuteSelect();
+	}
+
+/**
+ * testHourSelect
+ *
+ * @return void
+ */
+	public function testSecondSelect() {
+		$result = $this->DateTime->secondSelect();
+	}
+
+}

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -19,16 +19,15 @@ use Cake\View\Input\SelectBox;
 use Cake\View\StringTemplate;
 
 class DateTime extends \Cake\View\Input\DateTime {
+
 	public function generateNumbers($start = 1, $end = 31, $options = []) {
 		return parent::_generateNumbers($start, $end, $options);
 	}
-	public function getDayNames($leadingZero = true) {
-		return parent::_getDayNames($leadingZero);
-	}
+
 }
 
 /**
- * SelectBox test case
+ * DateTime input test case
  */
 class DateTimeTest extends TestCase {
 
@@ -44,31 +43,45 @@ class DateTimeTest extends TestCase {
 			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
-			'dateWidget' => '<div{{attrs}}>{{year}}-{{month}}-{{day}} {{hour}}:{{minute}}:{{second}}{{timeZone}}</div>'
+			'dateWidget' => '<div{{attrs}}>{{year}}-{{month}}-{{day}} {{hour}}:{{minute}}:{{second}}</div>'
 		];
-		$this->templates = new StringTemplate();
-		$this->templates->add($templates);
-		$this->SelectBox = new SelectBox($this->templates);
-		$this->DateTime = new DateTime($this->templates, $this->SelectBox);
+		$this->templates = new StringTemplate($templates);
+		$this->selectBox = new SelectBox($this->templates);
+		$this->DateTime = new DateTime($this->templates, $this->selectBox);
 	}
 
 /**
- * testRenderNoOptions
+ * Data provider for testing various acceptable selected values.
  *
- * @return void
+ * @return array
  */
-	public function testRenderNoOptions() {
-		$result = $this->DateTime->render();
+	public static function selectedValuesProvider() {
+		$date = new \DateTime('2014-01-20 12:30:45');
+		return [
+			'DateTime' => [$date],
+			'string' => [$date->format('Y-m-d H:i:s')],
+			'int' => [$date->getTimestamp()],
+			'array' => [[
+				'year' => '2014', 'month' => '01', 'day' => '20',
+				'hour' => '12', 'minute' => '30', 'second' => '45',
+			]]
+		];
 	}
 
 /**
- * testGetDayNames
+ * test rendering selected values.
  *
+ * @dataProvider selectedValuesProvider
  * @return void
  */
-	public function testGetDayNames() {
-		$result = $this->DateTime->getDayNames();
-		$result = $this->DateTime->getDayNames(false);
+	public function testRenderSelected($selected) {
+		$result = $this->DateTime->render(['val' => $selected]);
+		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+		$this->assertContains('<option value="01" selected="selected">01</option>', $result);
+		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
+		$this->assertContains('<option value="12" selected="selected">12</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertContains('<option value="45" selected="selected">45</option>', $result);
 	}
 
 /**
@@ -126,6 +139,7 @@ class DateTimeTest extends TestCase {
  */
 	public function testYearSelect() {
 		$result = $this->DateTime->yearSelect();
+		$this->markTestIncomplete();
 	}
 
 /**
@@ -141,6 +155,7 @@ class DateTimeTest extends TestCase {
 		$result = $this->DateTime->monthSelect([
 			'names' => true,
 		]);
+		$this->markTestIncomplete();
 	}
 
 /**
@@ -151,7 +166,7 @@ class DateTimeTest extends TestCase {
 	public function testDaySelect() {
 		$result = $this->DateTime->daySelect();
 		$expected = '<select name="data[day]"><option value="01" selected="selected">01</option><option value="02">02</option><option value="03">03</option><option value="04">04</option><option value="05">05</option><option value="06">06</option><option value="07">07</option></select>';
-		$this->assertEquals($result, $expected);
+		$this->markTestIncomplete();
 	}
 
 /**
@@ -161,6 +176,7 @@ class DateTimeTest extends TestCase {
  */
 	public function testHourSelect() {
 		$result = $this->DateTime->hourSelect();
+		$this->markTestIncomplete();
 	}
 
 /**
@@ -170,6 +186,7 @@ class DateTimeTest extends TestCase {
  */
 	public function testMinuteSelect() {
 		$result = $this->DateTime->minuteSelect();
+		$this->markTestIncomplete();
 	}
 
 /**
@@ -179,6 +196,7 @@ class DateTimeTest extends TestCase {
  */
 	public function testSecondSelect() {
 		$result = $this->DateTime->secondSelect();
+		$this->markTestIncomplete();
 	}
 
 }

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -193,8 +193,62 @@ class DateTimeTest extends TestCase {
 		$this->assertTags($result, $expected);
 	}
 
+/**
+ * Test that a selected value outside of the chosen
+ * year boundary is also included as an option.
+ *
+ * @return void
+ */
 	public function testRenderYearWidgetValueOutOfBounds() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-01-01 12:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => [
+				'start' => 2013,
+				'end' => 2015,
+			],
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[year]'],
+			['option' => ['value' => '2010', 'selected' => 'selected']], '2010', '/option',
+			['option' => ['value' => '2011']], '2011', '/option',
+			['option' => ['value' => '2012']], '2012', '/option',
+			['option' => ['value' => '2013']], '2013', '/option',
+			['option' => ['value' => '2014']], '2014', '/option',
+			['option' => ['value' => '2015']], '2015', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
+
+		$now = new \DateTime('2013-01-01 12:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => [
+				'start' => 2010,
+				'end' => 2011,
+			],
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[year]'],
+			['option' => ['value' => '2010']], '2010', '/option',
+			['option' => ['value' => '2011']], '2011', '/option',
+			['option' => ['value' => '2012']], '2012', '/option',
+			['option' => ['value' => '2013', 'selected' => 'selected']], '2013', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 	public function testRenderMonthWidget() {

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -15,16 +15,9 @@
 namespace Cake\Test\TestCase\View\Input;
 
 use Cake\TestSuite\TestCase;
+use Cake\View\Input\DateTime;
 use Cake\View\Input\SelectBox;
 use Cake\View\StringTemplate;
-
-class DateTime extends \Cake\View\Input\DateTime {
-
-	public function generateNumbers($start = 1, $end = 31, $options = []) {
-		return parent::_generateNumbers($start, $end, $options);
-	}
-
-}
 
 /**
  * DateTime input test case
@@ -723,54 +716,6 @@ class DateTimeTest extends TestCase {
 			'/select',
 		];
 		$this->assertTags($result, $expected);
-	}
-
-/**
- * testGenerateNumbers
- *
- * @return void
- */
-	public function testGenerateNumbers() {
-		$result = $this->DateTime->generateNumbers(1, 3);
-		$expected = array(
-			'01' => '01',
-			'02' => '02',
-			'03' => '03'
-		);
-		$this->assertEquals($result, $expected);
-
-		$result = $this->DateTime->generateNumbers(1, 3, [
-			'leadingZeroKey' => false
-		]);
-		$expected = array(
-			1 => '01',
-			2 => '02',
-			3 => '03'
-		);
-		$this->assertEquals($result, $expected);
-
-		$result = $this->DateTime->generateNumbers(1, 5, [
-			'leadingZeroValue' => false
-		]);
-		$expected = array(
-			'01' => '1',
-			'02' => '2',
-			'03' => '3',
-			'04' => '4',
-			'05' => '5'
-		);
-		$this->assertEquals($result, $expected);
-
-		$result = $this->DateTime->generateNumbers(1, 3, [
-			'leadingZeroValue' => false,
-			'leadingZeroKey' => false
-		]);
-		$expected = array(
-			1 => '1',
-			2 => '2',
-			3 => '3'
-		);
-		$this->assertEquals($result, $expected);
 	}
 
 }

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -150,6 +150,7 @@ class DateTimeTest extends TestCase {
 			'year' => [
 				'start' => 2013,
 				'end' => 2015,
+				'order' => 'desc',
 			],
 			'month' => false,
 			'day' => false,
@@ -167,10 +168,29 @@ class DateTimeTest extends TestCase {
 			'/select',
 		];
 		$this->assertTags($result, $expected);
-	}
 
-	public function testRenderYearWidgetMinAndMax() {
-		$this->markTestIncomplete();
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => [
+				'start' => 2013,
+				'end' => 2015,
+				'order' => 'asc'
+			],
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[year]'],
+			['option' => ['value' => '2015']], '2015', '/option',
+			['option' => ['value' => '2014', 'selected' => 'selected']], '2014', '/option',
+			['option' => ['value' => '2013']], '2013', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 	public function testRenderYearWidgetValueOutOfBounds() {

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -470,8 +470,48 @@ class DateTimeTest extends TestCase {
 		$this->assertNotContains('value="0"', $result, 'No zero hour');
 	}
 
+/**
+ * Test rendering the minute widget with no options.
+ *
+ * @return void
+ */
 	public function testRenderMinuteWidget() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:25:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => [
+				'data-foo' => 'test',
+			],
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[minute]" data-foo="test">', $result);
+		$this->assertContains(
+			'<option value="01">01</option>',
+			$result,
+			'contains 1'
+		);
+		$this->assertContains(
+			'<option value="05">05</option>',
+			$result,
+			'contains 05'
+		);
+		$this->assertContains(
+			'<option value="25" selected="selected">25</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertContains(
+			'<option value="60">60</option>',
+			$result,
+			'contains 60'
+		);
+		$this->assertNotContains('value="0"', $result, 'No zero value');
+		$this->assertNotContains('value="61"', $result, 'No 61 value');
 	}
 
 	public function testRenderMinuteWidgetInterval() {
@@ -483,7 +523,42 @@ class DateTimeTest extends TestCase {
 	}
 
 	public function testRenderSecondsWidget() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:00:25');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => false,
+			'minute' => false,
+			'second' => [
+				'data-foo' => 'test',
+			],
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[second]" data-foo="test">', $result);
+		$this->assertContains(
+			'<option value="01">01</option>',
+			$result,
+			'contains 1'
+		);
+		$this->assertContains(
+			'<option value="05">05</option>',
+			$result,
+			'contains 05'
+		);
+		$this->assertContains(
+			'<option value="25" selected="selected">25</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertContains(
+			'<option value="60">60</option>',
+			$result,
+			'contains 60'
+		);
+		$this->assertNotContains('value="0"', $result, 'No zero value');
+		$this->assertNotContains('value="61"', $result, 'No 61 value');
 	}
 
 	public function testRenderMeridianWidget() {

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -379,6 +379,49 @@ class DateTimeTest extends TestCase {
  *
  * @return void
  */
+	public function testRenderHourWidget24StartAndEnd() {
+		$now = new \DateTime('2010-09-09 13:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => [
+				'start' => 8,
+				'end' => 16
+			],
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[hour]">', $result);
+		$this->assertNotContains(
+			'<option value="01">1</option>',
+			$result,
+			'no 1 am'
+		);
+		$this->assertNotContains(
+			'<option value="07">7</option>',
+			$result,
+			'contain 7'
+		);
+		$this->assertContains(
+			'<option value="13" selected="selected">13</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertNotContains(
+			'<option value="17">17</option>',
+			$result,
+			'contains 17 hours'
+		);
+	}
+
+/**
+ * Test rendering the hour picker in 24 hour mode.
+ *
+ * @return void
+ */
 	public function testRenderHourWidget24() {
 		$now = new \DateTime('2010-09-09 13:00:00');
 		$result = $this->DateTime->render([
@@ -467,6 +510,54 @@ class DateTimeTest extends TestCase {
 
 		$this->assertContains('<select name="date[meridian]">', $result);
 		$this->assertContains('<option value="pm" selected="selected">pm</option>', $result);
+	}
+
+/**
+ * Test rendering the hour picker in 12 hour mode.
+ *
+ * @return void
+ */
+	public function testRenderHourWidget12StartAndEnd() {
+		$now = new \DateTime('2010-09-09 13:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => [
+				'start' => 8,
+				'end' => 12
+			],
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[hour]">', $result);
+		$this->assertContains(
+			'<option value="08">8</option>',
+			$result,
+			'contains 8am'
+		);
+		$this->assertContains(
+			'<option value="12">12</option>',
+			$result,
+			'contains 8am'
+		);
+		$this->assertNotContains(
+			'<option value="01">1</option>',
+			$result,
+			'no 1 am'
+		);
+		$this->assertNotContains(
+			'<option value="07">7</option>',
+			$result,
+			'contain 7'
+		);
+		$this->assertNotContains(
+			'<option value="13" selected="selected">13</option>',
+			$result,
+			'selected value present'
+		);
 	}
 
 /**

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -43,6 +43,38 @@ class DateTimeTest extends TestCase {
 	}
 
 /**
+ * Data provider for testing various types of invalid selected values.
+ *
+ * @return array
+ */
+	public static function invalidSelectedValuesProvider() {
+		$date = new \DateTime('2014-01-20 12:30:45');
+		return [
+			'string' => ['Bag of poop'],
+			'int' => [-1],
+			'array' => [[
+				'derp' => 'hurt'
+			]]
+		];
+	}
+
+/**
+ * test rendering selected values.
+ *
+ * @dataProvider selectedValuesProvider
+ * @return void
+ */
+	public function testRenderSelectedInvalid($selected) {
+		$result = $this->DateTime->render(['val' => $selected]);
+		$now = new \DateTime();
+		$format = '<option value="%s" selected="selected">%s</option>';
+		$this->assertContains(
+			sprintf($format, $now->format('Y'), $now->format('Y')), 
+			$result
+		);
+	}
+
+/**
  * Data provider for testing various acceptable selected values.
  *
  * @return array

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -77,7 +77,7 @@ class DateTimeTest extends TestCase {
 	public function testRenderSelected($selected) {
 		$result = $this->DateTime->render(['val' => $selected]);
 		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
-		$this->assertContains('<option value="01" selected="selected">01</option>', $result);
+		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
 		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
 		$this->assertContains('<option value="12" selected="selected">12</option>', $result);
 		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
@@ -150,6 +150,7 @@ class DateTimeTest extends TestCase {
 			'year' => [
 				'start' => 2013,
 				'end' => 2015,
+				'data-foo' => 'test',
 				'order' => 'desc',
 			],
 			'month' => false,
@@ -161,7 +162,7 @@ class DateTimeTest extends TestCase {
 			'orderYear' => 'asc',
 		]);
 		$expected = [
-			'select' => ['name' => 'date[year]'],
+			'select' => ['name' => 'date[year]', 'data-foo' => 'test'],
 			['option' => ['value' => '2013']], '2013', '/option',
 			['option' => ['value' => '2014', 'selected' => 'selected']], '2014', '/option',
 			['option' => ['value' => '2015']], '2015', '/option',
@@ -269,15 +270,15 @@ class DateTimeTest extends TestCase {
 		]);
 		$expected = [
 			'select' => ['name' => 'date[month]'],
-			['option' => ['value' => '01']], '01', '/option',
-			['option' => ['value' => '02']], '02', '/option',
-			['option' => ['value' => '03']], '03', '/option',
-			['option' => ['value' => '04']], '04', '/option',
-			['option' => ['value' => '05']], '05', '/option',
-			['option' => ['value' => '06']], '06', '/option',
-			['option' => ['value' => '07']], '07', '/option',
-			['option' => ['value' => '08']], '08', '/option',
-			['option' => ['value' => '09', 'selected' => 'selected']], '09', '/option',
+			['option' => ['value' => '01']], '1', '/option',
+			['option' => ['value' => '02']], '2', '/option',
+			['option' => ['value' => '03']], '3', '/option',
+			['option' => ['value' => '04']], '4', '/option',
+			['option' => ['value' => '05']], '5', '/option',
+			['option' => ['value' => '06']], '6', '/option',
+			['option' => ['value' => '07']], '7', '/option',
+			['option' => ['value' => '08']], '8', '/option',
+			['option' => ['value' => '09', 'selected' => 'selected']], '9', '/option',
 			['option' => ['value' => '10']], '10', '/option',
 			['option' => ['value' => '11']], '11', '/option',
 			['option' => ['value' => '12']], '12', '/option',
@@ -322,16 +323,151 @@ class DateTimeTest extends TestCase {
 		$this->assertTags($result, $expected);
 	}
 
+/**
+ * Test rendering the day widget.
+ *
+ * @return void
+ */
 	public function testRenderDayWidget() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 12:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => [
+				'data-foo' => 'test',
+			],
+			'hour' => false,
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$expected = [
+			'select' => ['name' => 'date[day]', 'data-foo' => 'test'],
+			['option' => ['value' => '01']], '1', '/option',
+			['option' => ['value' => '02']], '2', '/option',
+			['option' => ['value' => '03']], '3', '/option',
+			['option' => ['value' => '04']], '4', '/option',
+			['option' => ['value' => '05']], '5', '/option',
+			['option' => ['value' => '06']], '6', '/option',
+			['option' => ['value' => '07']], '7', '/option',
+			['option' => ['value' => '08']], '8', '/option',
+			['option' => ['value' => '09', 'selected' => 'selected']], '9', '/option',
+			['option' => ['value' => '10']], '10', '/option',
+			['option' => ['value' => '11']], '11', '/option',
+			['option' => ['value' => '12']], '12', '/option',
+			['option' => ['value' => '13']], '13', '/option',
+			['option' => ['value' => '14']], '14', '/option',
+			['option' => ['value' => '15']], '15', '/option',
+			['option' => ['value' => '16']], '16', '/option',
+			['option' => ['value' => '17']], '17', '/option',
+			['option' => ['value' => '18']], '18', '/option',
+			['option' => ['value' => '19']], '19', '/option',
+			['option' => ['value' => '20']], '20', '/option',
+			['option' => ['value' => '21']], '21', '/option',
+			['option' => ['value' => '22']], '22', '/option',
+			['option' => ['value' => '23']], '23', '/option',
+			['option' => ['value' => '24']], '24', '/option',
+			['option' => ['value' => '25']], '25', '/option',
+			['option' => ['value' => '26']], '26', '/option',
+			['option' => ['value' => '27']], '27', '/option',
+			['option' => ['value' => '28']], '28', '/option',
+			['option' => ['value' => '29']], '29', '/option',
+			['option' => ['value' => '30']], '30', '/option',
+			['option' => ['value' => '31']], '31', '/option',
+			'/select',
+		];
+		$this->assertTags($result, $expected);
 	}
 
-	public function testRenderHourWidget() {
-		$this->markTestIncomplete();
-	}
-
+/**
+ * Test rendering the hour picker in 24 hour mode.
+ *
+ * @return void
+ */
 	public function testRenderHourWidget24() {
-		$this->markTestIncomplete();
+		$now = new \DateTime('2010-09-09 13:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => [
+				'data-foo' => 'test'
+			],
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[hour]" data-foo="test">', $result);
+		$this->assertContains(
+			'<option value="01">1</option>',
+			$result,
+			'contain 1 am'
+		);
+		$this->assertContains(
+			'<option value="05">5</option>',
+			$result,
+			'contain 5 am'
+		);
+		$this->assertContains(
+			'<option value="13" selected="selected">13</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertContains(
+			'<option value="24">24</option>',
+			$result,
+			'contains 24 hours'
+		);
+		$this->assertNotContains('date[day]', $result, 'No day select.');
+		$this->assertNotContains('value="0"', $result, 'No zero hour');
+		$this->assertNotContains('value="25"', $result, 'No 25th hour');
+	}
+
+/**
+ * Test rendering the hour widget in 12 hour mode.
+ *
+ * @return void
+ */
+	public function testRenderHourWidget12() {
+		$now = new \DateTime('2010-09-09 13:00:00');
+		$result = $this->DateTime->render([
+			'name' => 'date',
+			'year' => false,
+			'month' => false,
+			'day' => false,
+			'hour' => [
+				'format' => 12,
+				'data-foo' => 'test'
+			],
+			'minute' => false,
+			'second' => false,
+			'val' => $now,
+		]);
+		$this->assertContains('<select name="date[hour]" data-foo="test">', $result);
+		$this->assertContains(
+			'<option value="01" selected="selected">1</option>',
+			$result,
+			'contain 1pm selected'
+		);
+		$this->assertContains(
+			'<option value="05">5</option>',
+			$result,
+			'contain 5'
+		);
+		$this->assertContains(
+			'<option value="12">12</option>',
+			$result,
+			'contain 12'
+		);
+		$this->assertNotContains(
+			'<option value="13">13</option>',
+			$result,
+			'selected value present'
+		);
+		$this->assertNotContains('date[day]', $result, 'No day select.');
+		$this->assertNotContains('value="0"', $result, 'No zero hour');
 	}
 
 	public function testRenderMinuteWidget() {

--- a/tests/TestCase/View/Input/DateTimeTest.php
+++ b/tests/TestCase/View/Input/DateTimeTest.php
@@ -89,6 +89,7 @@ class DateTimeTest extends TestCase {
 			'hour' => ['empty' => 'HOUR'],
 			'minute' => ['empty' => 'MINUTE'],
 			'second' => ['empty' => 'SECOND'],
+			'meridian' => ['empty' => 'MERIDIAN'],
 		]);
 		$this->assertContains('<option value="" selected="selected">YEAR</option>', $result);
 		$this->assertContains('<option value="" selected="selected">MONTH</option>', $result);
@@ -96,6 +97,7 @@ class DateTimeTest extends TestCase {
 		$this->assertContains('<option value="" selected="selected">HOUR</option>', $result);
 		$this->assertContains('<option value="" selected="selected">MINUTE</option>', $result);
 		$this->assertContains('<option value="" selected="selected">SECOND</option>', $result);
+		$this->assertContains('<option value="" selected="selected">MERIDIAN</option>', $result);
 	}
 
 /**


### PR DESCRIPTION
As part of #2267 this set of changes add a datetime input widget. This widget is probably the most complex of all the widgets. @burzum started the work off in a slightly different direction than the existing code has taken which is a good thing. Each sub-input has a set of options that are localized to just that input element. This is useful because it allows each input to be customized by the user.

My current thinking is that FormHelper will provide features like `dateFormat`, `timeFormat` and other higher level options that are then parsed/split into the options Datetime supports.
### Next steps

With all the widgets done, I'm going to start on the context objects that will provide FormHelper access to request/current data and abstracted access to schema and required fields. This will allow the helper to be insulated from the ORM and make it easier to test, and integrate with other ORMs if that's what people want to do.
