### PR TITLE
3.0 translate behavior - First round

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -552,7 +552,6 @@ class Query implements ExpressionInterface, IteratorAggregate {
 	protected function _buildFromPart($parts, $generator) {
 		$select = ' FROM %s';
 		$normalized = [];
-		$driver = $this->connection()->driver();
 		$parts = $this->_stringifyExpressions($parts, $generator);
 		foreach ($parts as $k => $p) {
 			if (!is_numeric($k)) {

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Model\Behavior;
+
+use Cake\Collection\Collection;
+use Cake\Event\Event;
+use Cake\ORM\Behavior;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+
+class TranslateBehavior extends Behavior {
+
+/**
+ * Table instance
+ *
+ * @var \Cake\ORM\Table
+ */
+	protected $_table;
+
+	protected $_locale;
+
+/**
+ * Default config
+ *
+ * These are merged with user-provided config when the behavior is used.
+ *
+ * @var array
+ */
+	protected static $_defaultConfig = [
+		'implementedFinders' => [],
+		'implementedMethods' => ['locale' => 'locale']
+	];
+
+/**
+ * Constructor
+ *
+ * @param Table $table The table this behavior is attached to.
+ * @param array $config The config for this behavior.
+ */
+	public function __construct(Table $table, array $config = []) {
+		parent::__construct($table, $config);
+		$this->_table = $table;
+
+		$table->hasMany('I18n', [
+			'strategy' => 'subquery',
+			'foreignKey' => 'foreign_key',
+			'conditions' => ['I18n.model' => $table->alias()],
+			'propertyName' => '_i18n'
+		]);
+	}
+
+	public function beforeFind(Event $event, $query) {
+		$locale = (array)$this->locale();
+		$query->contain(['I18n' => function($q) use ($locale) {
+			if ($locale) {
+				$q->where(['I18n.locale IN' => $locale]);
+			}
+
+			return $q;
+		}]);
+
+		if (count($locale) === 1) {
+			$locale = current($locale);
+			$query->formatResults(function($results) use ($locale) {
+				return $this->_rowMapper($results, $locale);
+			});
+		}
+	}
+
+	public function locale($locale = null) {
+		if ($locale === null) {
+			return $this->_locale;
+		}
+		return $this->_locale = $locale;
+	}
+
+	protected function _rowMapper($results, $locale) {
+		return $results->map(function($row) use ($locale) {
+			$translations = (array)$row->get('_i18n');
+			$options = ['setter' => false, 'guard' => false];
+
+			foreach ($translations as $field) {
+				$row->set([
+					$field->get('field') => $field->get('content'),
+					'_locale' => $locale
+				], $options);
+			}
+			$row->clean();
+
+			return $row;
+		});
+	}
+
+}

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -256,6 +256,7 @@ class TranslateBehavior extends Behavior {
 			$options = ['setter' => false, 'guard' => false];
 			$row->set('_translations', $result, $options);
 			unset($row['_i18n']);
+			$row->clean();
 			return $row;
 		});
 	}

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -97,8 +97,9 @@ class TranslateBehavior extends Behavior {
 					'_locale' => $locale
 				], $options);
 			}
-			$row->clean();
 
+			$row->clean();
+			unset($row['_i18n']);
 			return $row;
 		});
 	}

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -89,7 +89,7 @@ class TranslateBehavior extends Behavior {
 	public function setupFieldAssociations($fields) {
 		$alias = $this->_table->alias();
 		foreach ($fields as $field) {
-			$name = $field . '_translation';
+			$name = $this->_table->alias() . '_' . $field . '_translation';
 			$target = TableRegistry::get($name);
 			$target->table('i18n');
 
@@ -137,8 +137,9 @@ class TranslateBehavior extends Behavior {
 
 		$contain = [];
 		$fields = $this->config()['fields'];
+		$alias = $this->_table->alias();
 		foreach ($fields as $field) {
-			$contain[$field . '_translation'] = $conditions;
+			$contain[$alias . '_' . $field . '_translation'] = $conditions;
 		}
 
 		$query->contain($contain);

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -128,7 +128,7 @@ class TranslateBehavior extends Behavior {
 			}])
 			->formatResults(function($results) {
 				return $this->_groupTranslations($results);
-			});
+			}, $query::PREPEND);
 	}
 
 	protected function _rowMapper($results, $locale) {

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -219,7 +219,11 @@ class TranslateBehavior extends Behavior {
 					continue;
 				}
 
-				$row->set($field, $translation->get('content'), $options);
+				$content = $translation->get('content');
+				if ($content !== null) {
+					$row->set($field, $content, $options);
+				}
+
 				unset($row[$name]);
 			}
 

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -164,7 +164,7 @@ class TranslateBehavior extends Behavior {
 	}
 
 /**
- * Custom finder method used to retrieve all translations for he found records.
+ * Custom finder method used to retrieve all translations for the found records.
  * Fetched translations can be filtered by locale by passing the `locales` key
  * in the options array.
  *
@@ -219,13 +219,11 @@ class TranslateBehavior extends Behavior {
 					continue;
 				}
 
-				$row->set([
-					$field => $translation->get('content'),
-					'_locale' => $locale
-				], $options);
+				$row->set($field, $translation->get('content'), $options);
 				unset($row[$name]);
 			}
 
+			$row->set('_locale', $locale, $options);
 			$row->clean();
 			return $row;
 		});

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -412,7 +412,7 @@ abstract class Association {
 		if (!empty($options['queryBuilder'])) {
 			$newQuery = $options['queryBuilder']($target->query());
 			$options['fields'] = $newQuery->clause('select') ?: $options['fields'];
-			$options['conditions']->add($newQuery->clause('where'));
+			$options['conditions']->add($newQuery->clause('where') ?: []);
 		}
 
 		$joinOptions = ['table' => 1, 'conditions' => 1, 'type' => 1];

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -320,7 +320,8 @@ trait ExternalAssociationTrait {
 			}
 		}
 		$filterQuery->join($joins, [], true);
-		return $filterQuery->select($foreignKey, true);
+		$fields = $query->aliasFields((array)$query->repository()->primaryKey());
+		return $filterQuery->select($fields, true);
 	}
 
 /**

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -83,10 +83,15 @@ class HasMany extends Association {
 			'sort' => $this->sort(),
 			'strategy' => $this->strategy()
 		];
-		$fetchQuery = $this->_buildQuery($options);
 
 		if (!empty($options['queryBuilder'])) {
-			$fetchQuery = $options['queryBuilder']($fetchQuery);
+			$queryBuilder = $options['queryBuilder'];
+			unset($options['queryBuilder']);
+		}
+
+		$fetchQuery = $this->_buildQuery($options);
+		if ($queryBuilder) {
+			$fetchQuery = $queryBuilder($fetchQuery);
 		}
 
 		$resultMap = [];

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -84,6 +84,7 @@ class HasMany extends Association {
 			'strategy' => $this->strategy()
 		];
 
+		$queryBuilder = false;
 		if (!empty($options['queryBuilder'])) {
 			$queryBuilder = $options['queryBuilder'];
 			unset($options['queryBuilder']);

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1041,7 +1041,6 @@ class Query extends DatabaseQuery {
 
 		foreach ($this->_resolveJoins($this->_table, $contain) as $options) {
 			$table = $options['instance']->target();
-			$alias = $table->alias();
 			$this->_addJoin($options['instance'], $options['config']);
 			foreach ($options['associations'] as $relation => $meta) {
 				if ($meta['instance'] && !$meta['canBeJoined']) {
@@ -1127,7 +1126,7 @@ class Query extends DatabaseQuery {
  */
 	protected function _eagerLoad($statement) {
 		$keys = $this->_collectKeys($statement);
-		foreach ($this->_loadEagerly as $association => $meta) {
+		foreach ($this->_loadEagerly as $meta) {
 			$contain = $meta['associations'];
 			$alias = $meta['instance']->source()->alias();
 			$keys = isset($keys[$alias]) ? $keys[$alias] : null;
@@ -1150,7 +1149,7 @@ class Query extends DatabaseQuery {
  */
 	protected function _collectKeys($statement) {
 		$collectKeys = [];
-		foreach ($this->_loadEagerly as $association => $meta) {
+		foreach ($this->_loadEagerly as $meta) {
 			$source = $meta['instance']->source();
 			if ($meta['instance']->requiresKeys($meta['config'])) {
 				$alias = $source->alias();

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -914,20 +914,19 @@ class Query extends DatabaseQuery {
 
 		$count = ['count' => $query->func()->count('*')];
 		if (!count($query->clause('group')) && !$query->clause('distinct')) {
-			return (int)$query
+			$statement = $query
 				->select($count, true)
-				->hydrate(false)
-				->first()['count'];
+				->execute();
+		} else {
+			// Forcing at least one field to be selected
+			$query->select($query->newExpr()->add('1'));
+			$statement = $this->connection()->newQuery()
+				->select($count)
+				->from(['count_source' => $query])
+				->execute();
 		}
 
-		// Forcing at least one field to be selected
-		$query->select($query->newExpr()->add('1'));
-		$statement = $this->connection()->newQuery()
-			->select($count)
-			->from(['count_source' => $query])
-			->execute();
 		$result = $statement->fetch('assoc')['count'];
-
 		$statement->closeCursor();
 		return (int)$result;
 	}

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -35,16 +35,22 @@ class Query extends DatabaseQuery {
 
 /**
  * Indicates that the operation should append to the list
+ *
+ * @var integer
  */
 	const APPEND = 0;
 
 /**
  * Indicates that the operation should prepend to the list
+ *
+ * @var integer
  */
 	const PREPEND = 1;
 
 /**
  * Indicates that the operation should overwrite the list
+ *
+ * @var boolean
  */
 	const OVERWRITE = true;
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -611,9 +611,6 @@ class Query extends DatabaseQuery {
 				'You cannot call all() on a non-select query. Use execute() instead.'
 			);
 		}
-		$table = $this->repository();
-		$event = new Event('Model.beforeFind', $table, [$this, $this->_options]);
-		$table->getEventManager()->dispatch($event);
 		return $this->getResults();
 	}
 
@@ -629,6 +626,15 @@ class Query extends DatabaseQuery {
 		if (isset($this->_results)) {
 			return $this->_results;
 		}
+
+		$table = $this->repository();
+		$event = new Event('Model.beforeFind', $table, [$this, $this->_options]);
+		$table->getEventManager()->dispatch($event);
+
+		if (isset($this->_results)) {
+			return $this->_results;
+		}
+
 		if ($this->_cache) {
 			$results = $this->_cache->fetch($this);
 		}

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -34,6 +34,21 @@ use Cake\ORM\Table;
 class Query extends DatabaseQuery {
 
 /**
+ * Indicates that the operation should append to the list
+ */
+	const APPEND = 0;
+
+/**
+ * Indicates that the operation should prepend to the list
+ */
+	const PREPEND = 1;
+
+/**
+ * Indicates that the operation should overwrite the list
+ */
+	const OVERWRITE = true;
+
+/**
  * Instance of a table object this query is bound to
  *
  * @var \Cake\ORM\Table
@@ -841,16 +856,22 @@ class Query extends DatabaseQuery {
  * }}}
  *
  * @param callable $formatter
- * @param boolean $overwrite
+ * @param boolean|integer $mode
  * @return Cake\ORM\Query|array
  */
-	public function formatResults(callable $formatter = null, $overwrite = false) {
-		if ($overwrite) {
+	public function formatResults(callable $formatter = null, $mode = self::APPEND) {
+		if ($mode === self::OVERWRITE) {
 			$this->_formatters = [];
 		}
 		if ($formatter === null) {
 			return $this->_formatters;
 		}
+
+		if ($mode === self::PREPEND) {
+			array_unshift($this->_formatters, $formatter);
+			return $this;
+		}
+
 		$this->_formatters[] = $formatter;
 		return $this;
 	}

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -1151,11 +1151,11 @@ class Query extends DatabaseQuery {
  * @return CallbackStatement $statement modified statement with extra loaders
  */
 	protected function _eagerLoad($statement) {
-		$keys = $this->_collectKeys($statement);
+		$collected = $this->_collectKeys($statement);
 		foreach ($this->_loadEagerly as $meta) {
 			$contain = $meta['associations'];
 			$alias = $meta['instance']->source()->alias();
-			$keys = isset($keys[$alias]) ? $keys[$alias] : null;
+			$keys = isset($collected[$alias]) ? $collected[$alias] : null;
 			$f = $meta['instance']->eagerLoader(
 				$meta['config'] + ['query' => $this, 'contain' => $contain, 'keys' => $keys]
 			);
@@ -1183,7 +1183,7 @@ class Query extends DatabaseQuery {
 				foreach ((array)$source->primaryKey() as $key) {
 					$pkFields[] = key($this->aliasField($key, $alias));
 				}
-				$collectKeys[] = [$alias, $pkFields, count($pkFields) === 1];
+				$collectKeys[$alias] = [$alias, $pkFields, count($pkFields) === 1];
 			}
 		}
 

--- a/tests/Fixture/TranslateFixture.php
+++ b/tests/Fixture/TranslateFixture.php
@@ -52,23 +52,23 @@ class TranslateFixture extends TestFixture {
  * @var array
  */
 	public $records = array(
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Title #1'),
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Content #1'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Titel #1'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Inhalt #1'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Titulek #1'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 1, 'field' => 'content', 'content' => 'Obsah #1'),
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Title #2'),
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'content', 'content' => 'Content #2'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Titel #2'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'content', 'content' => 'Inhalt #2'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Titulek #2'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 2, 'field' => 'content', 'content' => 'Obsah #2'),
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Title #3'),
-		array('locale' => 'eng', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'content', 'content' => 'Content #3'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titel #3'),
-		array('locale' => 'deu', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'content', 'content' => 'Inhalt #3'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titulek #3'),
-		array('locale' => 'cze', 'model' => 'TranslatedItem', 'foreign_key' => 3, 'field' => 'content', 'content' => 'Obsah #3')
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Title #1'),
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'Content #1'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Titel #1'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'Inhalt #1'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'title', 'content' => 'Titulek #1'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 1, 'field' => 'body', 'content' => 'Obsah #1'),
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Title #2'),
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'body', 'content' => 'Content #2'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Titel #2'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'body', 'content' => 'Inhalt #2'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'title', 'content' => 'Titulek #2'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 2, 'field' => 'body', 'content' => 'Obsah #2'),
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Title #3'),
+		array('locale' => 'eng', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Content #3'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titel #3'),
+		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Inhalt #3'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titulek #3'),
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Obsah #3')
 	);
 }

--- a/tests/Fixture/TranslateFixture.php
+++ b/tests/Fixture/TranslateFixture.php
@@ -74,5 +74,6 @@ class TranslateFixture extends TestFixture {
 		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 2, 'field' => 'comment', 'content' => 'Comment #2'),
 		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 3, 'field' => 'comment', 'content' => 'Comment #3'),
 		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 4, 'field' => 'comment', 'content' => 'Comment #4'),
+		array('locale' => 'spa', 'model' => 'Comments', 'foreign_key' => 4, 'field' => 'comment', 'content' => 'Comentario #4'),
 	);
 }

--- a/tests/Fixture/TranslateFixture.php
+++ b/tests/Fixture/TranslateFixture.php
@@ -69,6 +69,10 @@ class TranslateFixture extends TestFixture {
 		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titel #3'),
 		array('locale' => 'deu', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Inhalt #3'),
 		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'title', 'content' => 'Titulek #3'),
-		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Obsah #3')
+		array('locale' => 'cze', 'model' => 'Articles', 'foreign_key' => 3, 'field' => 'body', 'content' => 'Obsah #3'),
+		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 1, 'field' => 'comment', 'content' => 'Comment #1'),
+		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 2, 'field' => 'comment', 'content' => 'Comment #2'),
+		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 3, 'field' => 'comment', 'content' => 'Comment #3'),
+		array('locale' => 'eng', 'model' => 'Comments', 'foreign_key' => 4, 'field' => 'comment', 'content' => 'Comment #4'),
 	);
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -34,7 +34,8 @@ class TranslateBehaviorTest extends TestCase {
 	public $fixtures = [
 		'core.translate',
 		'core.article',
-		'core.comment'
+		'core.comment',
+		'core.author'
 	];
 
 	public function tearDown() {
@@ -391,6 +392,22 @@ class TranslateBehaviorTest extends TestCase {
 
 		$this->assertEquals('Titulek #1', $results->first()->title);
 		$this->assertEquals('Obsah #1', $results->first()->body);
+	}
+
+	public function testFindSingleLocaleBelongsto() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$authors = $table->belongsTo('Authors')->target();
+		$authors->addBehavior('Translate', ['fields' => ['name']]);
+
+		$table->locale('eng');
+		$authors->locale('eng');
+
+		$results = $table->find()->contain(['Authors' => function($q) {
+			return $q->select(['id', 'name']);
+		}]);
+
+		debug(json_encode($results->first()->author));
 	}
 
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -43,7 +43,6 @@ class TranslateBehaviorTest extends TestCase {
 		TableRegistry::clear();
 	}
 
-
 /**
  * Returns an array with all the translations found for a set of records
  *

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -315,9 +315,12 @@ class TranslateBehaviorTest extends TestCase {
 		$comments = $table->hasMany('Comments')->target();
 		$comments->addBehavior('Translate', ['fields' => ['comment']]);
 
-		$results = $table->find('translations')->contain(['Comments' => function($q) {
-			return $q->find('translations')->select(['id', 'comment', 'article_id']);
-		}]);
+		$results = $table->find('translations')->contain([
+			'Comments' => function($q) {
+				debug(\Cake\Utility\Debugger::trace());
+				return $q->find('translations')->select(['id', 'comment', 'article_id']);
+			}
+		]);
 
 
 		$article = $results->first();

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -53,5 +53,33 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertSame($expected, $results);
 	}
 
+/**
+ * Tests that overriding fields with the translate behavior works when
+ * using conditions and that all other columns are preserved
+ *
+ * @return void
+ */
+	public function testFindSingleLocaleWithConditions() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate');
+		$table->locale('eng');
+		$results = $table->find()
+			->where(['id' => 2])
+			->all();
+
+		$this->assertCount(1, $results);
+		$row = $results->first();
+
+		$expected = [
+			'id' => 2,
+			'title' => 'Title #2',
+			'body' => 'Content #2',
+			'author_id' => 3,
+			'published' => 'Y',
+			'_locale' => 'eng'
+		];
+		$this->assertEquals($expected, $row->toArray());
+	}
+
 }
 

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -35,6 +35,11 @@ class TranslateBehaviorTest extends TestCase {
 		'core.article'
 	];
 
+	public function tearDown() {
+		parent::tearDown();
+		TableRegistry::clear();
+	}
+
 /**
  * Tests that fields from a translated model are overriden
  *
@@ -61,7 +66,6 @@ class TranslateBehaviorTest extends TestCase {
  */
 	public function testFindSingleLocaleWithConditions() {
 		$table = TableRegistry::get('Articles');
-		$table->addBehavior('Translate');
 		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 		$table->locale('eng');
 		$results = $table->find()
@@ -89,7 +93,6 @@ class TranslateBehaviorTest extends TestCase {
  */
 	public function testFindList() {
 		$table = TableRegistry::get('Articles');
-		$table->addBehavior('Translate');
 		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 		$table->locale('eng');
 
@@ -105,11 +108,45 @@ class TranslateBehaviorTest extends TestCase {
  */
 	public function testFindCount() {
 		$table = TableRegistry::get('Articles');
-		$table->addBehavior('Translate');
 		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 		$table->locale('eng');
 
 		$this->assertEquals(3, $table->find()->count());
 	}
+
+	public function testFindTranslations() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$results = $table->find('translations');
+		$expected = [
+			[
+				'eng' => ['title' => 'Title #1', 'body' => 'Content #1', 'locale' => 'eng'],
+				'deu' => ['title' => 'Titel #1', 'body' => 'Inhalt #1', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #1', 'body' => 'Obsah #1', 'locale' => 'cze']
+			],
+			[
+				'eng' => ['title' => 'Title #2', 'body' => 'Content #2', 'locale' => 'eng'],
+				'deu' => ['title' => 'Titel #2', 'body' => 'Inhalt #2', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #2', 'body' => 'Obsah #2', 'locale' => 'cze']
+			],
+			[
+				'eng' => ['title' => 'Title #3', 'body' => 'Content #3', 'locale' => 'eng'],
+				'deu' => ['title' => 'Titel #3', 'body' => 'Inhalt #3', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #3', 'body' => 'Obsah #3', 'locale' => 'cze']
+			]
+		];
+
+		$translations = $results->map(function($row) {
+			$translations = $row->get('_translations');
+			if (!$translations) {
+				return [];
+			}
+			return array_map(function($t) {
+				return $t->toArray();
+			}, $translations);
+		});
+		$this->assertEquals($expected, $translations->toArray());
+	}
+
 }
 

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Model\Behavior;
+
+use Cake\Event\Event;
+use Cake\Model\Behavior\TranslateBehavior;
+use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Translate behavior test case
+ */
+class TranslateBehaviorTest extends TestCase {
+
+/**
+ * fixtures
+ *
+ * @var array
+ */
+	public $fixtures = [
+		'core.translate',
+		'core.article'
+	];
+
+/**
+ * Tests that fields from a translated model are overriden
+ *
+ * @return void
+ */
+	public function testFindSingleLocale() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate');
+		$table->locale('eng');
+		$results = $table->find()->combine('title', 'body', 'id')->toArray();
+		$expected = [
+			1 => ['Title #1' => 'Content #1'],
+			2 => ['Title #2' => 'Content #2'],
+			3 => ['Title #3' => 'Content #3'],
+		];
+		$this->assertSame($expected, $results);
+	}
+
+}
+

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -79,6 +79,23 @@ class TranslateBehaviorTest extends TestCase {
 	}
 
 /**
+ * Tests that fields from a translated model are not overriden if translation
+ * is null
+ *
+ * @return void
+ */
+	public function testFindSingleLocaleWithNullTranslation() {
+		$table = TableRegistry::get('Comments');
+		$table->addBehavior('Translate', ['fields' => ['comment']]);
+		$table->locale('spa');
+		$results = $table->find()
+			->where(['Comments.id' => 6])
+			->combine('id', 'comment')->toArray();
+		$expected = [6 => 'Second Comment for Second Article'];
+		$this->assertSame($expected, $results);
+	}
+
+/**
  * Tests that overriding fields with the translate behavior works when
  * using conditions and that all other columns are preserved
  *

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -308,4 +308,20 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $list->combine('id', 'comment')->toArray());
 	}
 
+	public function testTranslationsHasMany() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->hasMany('Comments');
+		$comments = $table->hasMany('Comments')->target();
+		$comments->addBehavior('Translate', ['fields' => ['comment']]);
+
+		$results = $table->find('translations')->contain(['Comments' => function($q) {
+			return $q->find('translations')->select(['id', 'comment', 'article_id']);
+		}]);
+
+
+		$article = $results->first();
+		debug(json_encode($article, JSON_PRETTY_PRINT));
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -42,7 +42,7 @@ class TranslateBehaviorTest extends TestCase {
  */
 	public function testFindSingleLocale() {
 		$table = TableRegistry::get('Articles');
-		$table->addBehavior('Translate');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 		$table->locale('eng');
 		$results = $table->find()->combine('title', 'body', 'id')->toArray();
 		$expected = [
@@ -62,9 +62,10 @@ class TranslateBehaviorTest extends TestCase {
 	public function testFindSingleLocaleWithConditions() {
 		$table = TableRegistry::get('Articles');
 		$table->addBehavior('Translate');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
 		$table->locale('eng');
 		$results = $table->find()
-			->where(['id' => 2])
+			->where(['Articles.id' => 2])
 			->all();
 
 		$this->assertCount(1, $results);

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -231,5 +231,50 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $results->toArray());
 	}
 
-}
+/**
+ * Tests that you can both override fields and find all translations
+ *
+ * @return void
+ */
+	public function testFindTranslationsWithFieldOverriding() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('cze');
+		$results = $table->find('translations', ['locales' => ['deu', 'cze']]);
+		$expected = [
+			[
+				'deu' => ['title' => 'Titel #1', 'body' => 'Inhalt #1', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #1', 'body' => 'Obsah #1', 'locale' => 'cze']
+			],
+			[
+				'deu' => ['title' => 'Titel #2', 'body' => 'Inhalt #2', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #2', 'body' => 'Obsah #2', 'locale' => 'cze']
+			],
+			[
+				'deu' => ['title' => 'Titel #3', 'body' => 'Inhalt #3', 'locale' => 'deu'],
+				'cze' => ['title' => 'Titulek #3', 'body' => 'Obsah #3', 'locale' => 'cze']
+			]
+		];
 
+		$translations = $results->map(function($row) {
+			$translations = $row->get('_translations');
+			if (!$translations) {
+				return [];
+			}
+			return array_map(function($t) {
+				return $t->toArray();
+			}, $translations);
+		});
+		$this->assertEquals($expected, $translations->toArray());
+
+		$expected = [
+			1 => ['Titulek #1' => 'Obsah #1'],
+			2 => ['Titulek #2' => 'Obsah #2'],
+			3 => ['Titulek #3' => 'Obsah #3']
+		];
+
+		$grouped = $results->combine('title', 'body', 'id');
+		$this->assertEquals($expected, $grouped->toArray());
+	}
+
+}

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -82,5 +82,34 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $row->toArray());
 	}
 
+/**
+ * Tests that translating fields work when other formatters are used
+ *
+ * @return void
+ */
+	public function testFindList() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('eng');
+
+		$results = $table->find('list')->toArray();
+		$expected = [1 => 'Title #1', 2 => 'Title #2', 3 => 'Title #3'];
+		$this->assertSame($expected, $results);
+	}
+
+/**
+ * Tests that the query count return the correct results
+ *
+ * @return void
+ */
+	public function testFindCount() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('eng');
+
+		$this->assertEquals(3, $table->find()->count());
+	}
 }
 

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -394,20 +394,4 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('Obsah #1', $results->first()->body);
 	}
 
-	public function testFindSingleLocaleBelongsto() {
-		$table = TableRegistry::get('Articles');
-		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
-		$authors = $table->belongsTo('Authors')->target();
-		$authors->addBehavior('Translate', ['fields' => ['name']]);
-
-		$table->locale('eng');
-		$authors->locale('eng');
-
-		$results = $table->find()->contain(['Authors' => function($q) {
-			return $q->select(['id', 'name']);
-		}]);
-
-		debug(json_encode($results->first()->author));
-	}
-
 }

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -669,11 +669,14 @@ class BelongsToManyTest extends TestCase {
 			'table' => 'articles_tags',
 			'schema' => [
 				'article_id' => ['type' => 'integer'],
-				'tag_id' => ['type' => 'integer']
+				'tag_id' => ['type' => 'integer'],
+				'_constraints' => [
+					'PK' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]
+				]
 			]
 		]);
 		$association = new BelongsToMany('Tags', $config);
-		$parent = (new Query(null, null))
+		$parent = (new Query(null, $this->article))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
 		$parent->hydrate(false);
@@ -681,8 +684,9 @@ class BelongsToManyTest extends TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'where', 'andWhere', 'order', 'select', 'matching'],
-			[null, null]
+			[null, $this->article]
 		);
+
 		$query->hydrate(false);
 
 		$this->tag->expects($this->once())
@@ -702,7 +706,7 @@ class BelongsToManyTest extends TestCase {
 		unset($joins[1]);
 		$expected
 			->contain([], true)
-			->select('ArticlesTags.article_id', true)
+			->select(['Articles__id' => 'Articles.id'], true)
 			->join($joins, [], true);
 
 		$query->expects($this->at(0))->method('where')

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -307,7 +307,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->article,
 		];
 		$association = new HasMany('Articles', $config);
-		$parent = (new Query(null, null))
+		$parent = (new Query(null, $this->author))
 			->join(['foo' => ['table' => 'foo', 'type' => 'inner', 'conditions' => []]])
 			->join(['bar' => ['table' => 'bar', 'type' => 'left', 'conditions' => []]]);
 
@@ -338,7 +338,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		unset($joins[1]);
 		$expected
 			->contain([], true)
-			->select('Articles.author_id', true)
+			->select(['Authors__id' => 'Authors.id'], true)
 			->join($joins, [], true);
 		$query->expects($this->once())->method('andWhere')
 			->with(['Articles.author_id IN' => $expected])

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -396,9 +396,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			->with(['a', 'b'])
 			->will($this->returnSelf());
 
-		$query->expects($this->any())->method('join')
-			->will($this->returnSelf());
-		$query->expects($this->at(6))->method('join')
+		$query->expects($this->at(3))->method('join')
 			->with('foo')
 			->will($this->returnSelf());
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1769,6 +1769,10 @@ class QueryTest extends TestCase {
 		$this->assertSame([$callback2], $query->formatResults());
 		$query->formatResults(null, true);
 		$this->assertSame([], $query->formatResults());
+
+		$query->formatResults($callback1);
+		$query->formatResults($callback2, $query::PREPEND);
+		$this->assertSame([$callback2, $callback1], $query->formatResults());
 	}
 
 /**


### PR DESCRIPTION
This PR addresses the basic functionality for the Translate behavior. So far it only handles the find operation under two different modes:
- Merge fields: From a single translation merge the fields into the main entity. Calling `$table->locale($language)` is required for it to work
- Put all translations into a property for each entity. This is done by using the `find('translations')` method and replaces the `bindTranslations` method from 2.x which was difficult to use, imo.
### Next steps:
- Make saving work
- Make fetching translations for belongsTo and hasOne work
