### PR TITLE
Log errors instead of calling trigger_error()

### DIFF
--- a/lib/Cake/Model/Permission.php
+++ b/lib/Cake/Model/Permission.php
@@ -83,7 +83,7 @@ class Permission extends AppModel {
 		$acoPath = $this->Aco->node($aco);
 
 		if (!$aroPath || !$acoPath) {
-			trigger_error(__d('cake_dev',
+			$this->log(__d('cake_dev',
 					"%s - Failed ARO/ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
 					'DbAcl::check()',
 					print_r($aro, true),
@@ -94,7 +94,7 @@ class Permission extends AppModel {
 		}
 
 		if (!$acoPath) {
-			trigger_error(__d('cake_dev',
+			$this->log(__d('cake_dev',
 					"%s - Failed ACO node lookup in permissions check. Node references:\nAro: %s\nAco: %s",
 					'DbAcl::check()',
 					print_r($aro, true),
@@ -105,7 +105,7 @@ class Permission extends AppModel {
 		}
 
 		if ($action !== '*' && !in_array('_' . $action, $permKeys)) {
-			trigger_error(__d('cake_dev', "ACO permissions key %s does not exist in %s", $action, 'DbAcl::check()'), E_USER_NOTICE);
+			$this->log(__d('cake_dev', "ACO permissions key %s does not exist in %s", $action, 'DbAcl::check()'), E_USER_NOTICE);
 			return false;
 		}
 
@@ -176,7 +176,7 @@ class Permission extends AppModel {
 		$save = array();
 
 		if (!$perms) {
-			trigger_error(__d('cake_dev', '%s - Invalid node', 'DbAcl::allow()'), E_USER_WARNING);
+			$this->log(__d('cake_dev', '%s - Invalid node', 'DbAcl::allow()'), E_USER_WARNING);
 			return false;
 		}
 		if (isset($perms[0])) {

--- a/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Acl/DbAclTest.php
@@ -256,7 +256,6 @@ class DbAclTest extends CakeTestCase {
 /**
  * testDbAclAllow method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testAllow() {
@@ -297,17 +296,16 @@ class DbAclTest extends CakeTestCase {
  * @return void
  */
 	public function testAllowInvalidPermission() {
-		$this->Acl->allow('Micheal', 'tpsReports', 'derp');
+		$this->assertFalse($this->Acl->allow('Micheal', 'tpsReports', 'derp'));
 	}
 
 /**
  * testAllowInvalidNode method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testAllowInvalidNode() {
-		$this->Acl->allow('Homer', 'tpsReports', 'create');
+		$this->assertFalse($this->Acl->allow('Homer', 'tpsReports', 'create'));
 	}
 
 /**
@@ -333,7 +331,6 @@ class DbAclTest extends CakeTestCase {
 /**
  * testCheckInvalidNode method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testCheckInvalidNode() {
@@ -343,21 +340,19 @@ class DbAclTest extends CakeTestCase {
 /**
  * testCheckInvalidPermission method
  *
- * @expectedException PHPUnit_Framework_Error_Notice
  * @return void
  */
 	public function testCheckInvalidPermission() {
-		$this->Acl->check('Lumbergh', 'smash', 'foobar');
+		$this->assertFalse($this->Acl->check('Lumbergh', 'smash', 'foobar'));
 	}
 
 /**
  * testCheckMissingPermission method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testCheckMissingPermission() {
-		$this->Acl->check('users', 'NonExistent', 'read');
+		$this->assertFalse($this->Acl->check('users', 'NonExistent', 'read'));
 	}
 
 /**
@@ -380,7 +375,6 @@ class DbAclTest extends CakeTestCase {
 /**
  * testDbAclDeny method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testDeny() {
@@ -450,7 +444,6 @@ class DbAclTest extends CakeTestCase {
 /**
  * testDbGrant method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testGrant() {
@@ -471,7 +464,6 @@ class DbAclTest extends CakeTestCase {
 /**
  * testDbRevoke method
  *
- * @expectedException PHPUnit_Framework_Error_Warning
  * @return void
  */
 	public function testRevoke() {


### PR DESCRIPTION
I truly hate these `trigger_error`s. I think they serve no purpose other than confusing newbies and myself.

Either we use Exception, or just return boolean (which we already do) so that caller know the result.
