### PR TITLE
Fix #2721 in TranslateBehavior::beforeFind()

### DIFF
--- a/lib/Cake/Model/Behavior/TranslateBehavior.php
+++ b/lib/Cake/Model/Behavior/TranslateBehavior.php
@@ -139,6 +139,8 @@ class TranslateBehavior extends ModelBehavior {
 			}
 			unset($this->_joinTable, $this->_runtimeModel);
 			return $query;
+		} elseif (is_string($query['fields'])) {
+			$query['fields'] = String::tokenize($query['fields']);
 		}
 
 		$fields = array_merge(

--- a/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
+++ b/lib/Cake/Test/Case/Model/Behavior/TranslateBehaviorTest.php
@@ -232,6 +232,32 @@ class TranslateBehaviorTest extends CakeTestCase {
 			)
 		);
 		$this->assertEquals($expected, $result);
+
+		$result = $TestModel->field('title', array('TranslatedItem.id' => 1));
+		$expected = 'Title #1';
+		$this->assertEquals($expected, $result);
+
+		$result = $TestModel->read('title', 1);
+		$expected = array(
+			'TranslatedItem' => array(
+				'id' => 1,
+				'slug' => 'first_translated',
+				'locale' => 'eng',
+				'title' => 'Title #1',
+				'translated_article_id' => 1,
+			)
+		);
+		$this->assertEquals($expected, $result);
+
+		$result = $TestModel->read('id, title', 1);
+		$expected = array(
+			'TranslatedItem' => array(
+				'id' => 1,
+				'locale' => 'eng',
+				'title' => 'Title #1',
+			)
+		);
+		$this->assertEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
Fix will correctly handle:
- Model::field('fieldname')
- Model::read('fieldname') and
- (legacy?) Model::read('field1, field2')
