### PR TITLE
Console Extract task doesn't handle validation messages with qoutes correctly

### DIFF
--- a/lib/Cake/Console/Command/Task/ExtractTask.php
+++ b/lib/Cake/Console/Command/Task/ExtractTask.php
@@ -525,6 +525,7 @@ class ExtractTask extends AppShell {
 				$msgid = $rule;
 			}
 			if ($msgid) {
+				$msgid = $this->_formatString(sprintf("'%s'", $msgid));
 				$details = array(
 					'file' => $file,
 					'line' => 'validation for field ' . $field

--- a/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
+++ b/lib/Cake/Test/Case/Console/Command/Task/ExtractTaskTest.php
@@ -351,6 +351,9 @@ class ExtractTaskTest extends CakeTestCase {
 
 		$pattern = '#msgid "Post body is super required"#';
 		$this->assertRegExp($pattern, $result);
+
+		$this->assertContains('msgid "double \\"quoted\\" validation"', $result, 'Strings with quotes not handled correctly');
+		$this->assertContains("msgid \"single 'quoted' validation\"", $result, 'Strings with quotes not handled correctly');
 	}
 
 /**

--- a/lib/Cake/Test/test_app/Model/Extract.php
+++ b/lib/Cake/Test/test_app/Model/Extract.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Test App Extract Model
+ *
+ * CakePHP : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP Project
+ * @package       Cake.Test.TestApp.Model
+ * @since         CakePHP v 2.4
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+/**
+ * Class Extract
+ *
+ * For testing Console i18n validation message extraction with quotes
+ *
+ * @package       Cake.Test.TestApp.Model
+ */
+class Extract extends AppModel {
+
+	public $useTable = false;
+
+	public $validate = array(
+		'title' => array(
+			'custom' => array(
+				'rule' => array('custom', '.*'),
+				'allowEmpty' => true,
+				'required' => false,
+				'message' => 'double "quoted" validation'
+			),
+			'between' => array(
+				'rule' => array('between', 5, 15),
+				'message' => "single 'quoted' validation"
+			)
+		),
+	);
+
+}


### PR DESCRIPTION
Hi,

When a validation message is `a string with "double" quotes` currently the output is

```
msgid "a string with "double" quotes"
```

when it should be

```
msgid "a string with \"double\" quotes"
```

I've created a testcase for it and a fix.
