### PR TITLE
Add Table alias before primarykeys for Table::get()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -887,6 +887,11 @@ class Table implements EventListener {
  */
 	public function get($primaryKey, $options = []) {
 		$key = (array)$this->primaryKey();
+		if (!empty($this->_alias)) {
+			foreach($key as $index => $keyname){
+				$key[$index] = $this->_alias . '.' . $keyname;
+			}
+		}
 		$conditions = array_combine($key, (array)$primaryKey);
 		$entity = $this->find('all', $options)->where($conditions)->first();
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -887,10 +887,9 @@ class Table implements EventListener {
  */
 	public function get($primaryKey, $options = []) {
 		$key = (array)$this->primaryKey();
-		if (!empty($this->_alias)) {
-			foreach($key as $index => $keyname){
-				$key[$index] = $this->_alias . '.' . $keyname;
-			}
+		$alias = $this->alias();
+		foreach ($key as $index => $keyname) {
+			$key[$index] = $alias . '.' . $keyname;
 		}
 		$conditions = array_combine($key, (array)$primaryKey);
 		$entity = $this->find('all', $options)->where($conditions)->first();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3045,7 +3045,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('where')
-			->with(['bar' => 10])
+			->with([$table->alias() . '.bar' => 10])
 			->will($this->returnSelf());
 		$query->expects($this->once())->method('first')
 			->will($this->returnValue($entity));
@@ -3088,7 +3088,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->will($this->returnValue($query));
 
 		$query->expects($this->once())->method('where')
-			->with(['bar' => 10])
+			->with([$table->alias() . '.bar' => 10])
 			->will($this->returnSelf());
 		$query->expects($this->once())->method('first')
 			->will($this->returnValue(false));


### PR DESCRIPTION
If get() method is used with contain there is a risk of having a integrity constraint violation :
## Case

```
$posts->get(1, ['contain' => ['Categories']]); 
// Was generating  
where(['id' => 1]) // ... 1052 Column 'id' in where clause is ambiguous
// Generates now
where(['Posts.id' => 1])
```

Not sure if it is the best way. Maybe we could use the Query to check this kind of problem.
## Solution

Prefixing primaryKeys with table alias for the get method
