### PR TITLE
Paginator can now use string or simple arrays for "order

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -293,7 +293,7 @@ class PaginatorComponent extends Component {
 			$options['order'] = [];
 		}
 		if (!is_array($options['order'])) {
-			$options['order'] = (array)$options['order'];
+			return $options;
 		}
 
 		if (!empty($options['sortWhitelist'])) {
@@ -312,13 +312,17 @@ class PaginatorComponent extends Component {
 			foreach ($options['order'] as $key => $value) {
 				$field = $key;
 				$alias = $tableAlias;
-				if (strpos($key, '.') !== false) {
-					list($alias, $field) = explode('.', $key);
-				}
-				$correctAlias = ($tableAlias == $alias);
+				if (is_numeric($key)){
+					$order[] = $value;
+				}else{
+					if (strpos($key, '.') !== false) {
+						list($alias, $field) = explode('.', $key);
+					}
+					$correctAlias = ($tableAlias == $alias);
 
-				if ($correctAlias && $object->hasField($field)) {
-					$order[$tableAlias . '.' . $field] = $value;
+					if ($correctAlias && $object->hasField($field)) {
+						$order[$tableAlias . '.' . $field] = $value;
+					}
 				}
 			}
 			$options['order'] = $order;

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -311,7 +311,7 @@ class PaginatorComponent extends Component {
 		foreach ($options['order'] as $key => $value) {
 			$field = $key;
 			$alias = $tableAlias;
-			if (is_numeric($key)){
+			if (is_numeric($key)) {
 				$order[] = $value;
 			} else {
 				if (strpos($key, '.') !== false) {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -305,28 +305,26 @@ class PaginatorComponent extends Component {
 			return $options;
 		}
 
-		if (is_array($options['order'])) {
-			$tableAlias = $object->alias();
-			$order = [];
+		$tableAlias = $object->alias();
+		$order = [];
 
-			foreach ($options['order'] as $key => $value) {
-				$field = $key;
-				$alias = $tableAlias;
-				if (is_numeric($key)){
-					$order[] = $value;
-				}else{
-					if (strpos($key, '.') !== false) {
-						list($alias, $field) = explode('.', $key);
-					}
-					$correctAlias = ($tableAlias == $alias);
+		foreach ($options['order'] as $key => $value) {
+			$field = $key;
+			$alias = $tableAlias;
+			if (is_numeric($key)){
+				$order[] = $value;
+			}else{
+				if (strpos($key, '.') !== false) {
+					list($alias, $field) = explode('.', $key);
+				}
+				$correctAlias = ($tableAlias == $alias);
 
-					if ($correctAlias && $object->hasField($field)) {
-						$order[$tableAlias . '.' . $field] = $value;
-					}
+				if ($correctAlias && $object->hasField($field)) {
+					$order[$tableAlias . '.' . $field] = $value;
 				}
 			}
-			$options['order'] = $order;
 		}
+		$options['order'] = $order;
 
 		return $options;
 	}

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -313,7 +313,7 @@ class PaginatorComponent extends Component {
 			$alias = $tableAlias;
 			if (is_numeric($key)){
 				$order[] = $value;
-			}else{
+			} else {
 				if (strpos($key, '.') !== false) {
 					list($alias, $field) = explode('.', $key);
 				}

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -509,27 +509,6 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
- * test that numeric array order are used by paginator
- *
- * @return void
- */
-	public function testValidateSortWithNumericArray() {
-		$model = $this->getMock('Cake\ORM\Table');
-		$model->expects($this->any())
-			->method('alias')
-			->will($this->returnValue('model'));
-		$model->expects($this->any())->method('hasField')->will($this->returnValue(true));
-
-		$options = array(
-			'order' => array('model.author_id DESC')
-		);
-		$result = $this->Paginator->validateSort($model, $options);
-		$expected = array('model.author_id DESC');
-
-		$this->assertEquals($expected, $result['order']);
-	}
-
-/**
  * Test that no sort doesn't trigger an error.
  *
  * @return void

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -488,7 +488,7 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
- * test that string order are used by paginator
+ * Tests that order strings can used by Paginator
  *
  * @return void
  */

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -488,6 +488,48 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
+ * test that string order are used by paginator
+ *
+ * @return void
+ */
+	public function testValidateSortWithString() {
+		$model = $this->getMock('Cake\ORM\Table');
+		$model->expects($this->any())
+			->method('alias')
+			->will($this->returnValue('model'));
+		$model->expects($this->any())->method('hasField')->will($this->returnValue(true));
+
+		$options = array(
+			'order' => 'model.author_id DESC'
+		);
+		$result = $this->Paginator->validateSort($model, $options);
+		$expected = 'model.author_id DESC';
+
+		$this->assertEquals($expected, $result['order']);
+	}
+
+/**
+ * test that numeric array order are used by paginator
+ *
+ * @return void
+ */
+	public function testValidateSortWithNumericArray() {
+		$model = $this->getMock('Cake\ORM\Table');
+		$model->expects($this->any())
+			->method('alias')
+			->will($this->returnValue('model'));
+		$model->expects($this->any())->method('hasField')->will($this->returnValue(true));
+
+		$options = array(
+			'order' => array('model.author_id DESC')
+		);
+		$result = $this->Paginator->validateSort($model, $options);
+		$expected = array('model.author_id DESC');
+
+		$this->assertEquals($expected, $result['order']);
+	}
+
+/**
  * Test that no sort doesn't trigger an error.
  *
  * @return void


### PR DESCRIPTION
## Problem

The paginator was expecting order with a defined structure :  

```
"order" => ["Key" => "DESC", "Key2" => "ASC"]
```

but ignore order if 

```
"order" => "Model.key DESC"
"order" => ["Model.key DESC", "Model.key ASC"]
```
## Solution

Edit the validateSort() from paginator component 
OR 
Consider that the user have to follow the first convention (and ignore this pull request)
