### PR TITLE
RFC Fix: CakeEventManager regression

### DIFF
--- a/lib/Cake/Event/CakeEventManager.php
+++ b/lib/Cake/Event/CakeEventManager.php
@@ -259,16 +259,18 @@ class CakeEventManager {
  * @return array
  */
 	public function listeners($eventKey) {
-		$globalListeners = array();
 		if (!$this->_isGlobal) {
 			$globalListeners = self::instance()->prioritisedListeners($eventKey);
+		} else {
+			$globalListeners = $this->prioritisedListeners($eventKey);
 		}
+		$listeners = array_merge($this->_listeners, self::instance()->_listeners);
 
-		if (empty($this->_listeners[$eventKey]) && empty($globalListeners)) {
+		if (empty($listeners[$eventKey]) && empty($globalListeners)) {
 			return array();
 		}
 
-		$listeners = $this->_listeners[$eventKey];
+		$listeners = $listeners[$eventKey];
 		foreach ($globalListeners as $priority => $priorityQ) {
 			if (!empty($listeners[$priority])) {
 				$listeners[$priority] = array_merge($priorityQ, $listeners[$priority]);

--- a/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
+++ b/lib/Cake/Test/Case/Event/CakeEventManagerTest.php
@@ -484,4 +484,24 @@ class CakeEventManagerTest extends CakeTestCase {
 		CakeEventManager::instance(new CakeEventManager());
 	}
 
+/**
+ * test callback
+ */
+	public function onMyEvent($event) {
+		$event->data['callback'] = 'ok';
+	}
+
+/**
+ * Tests events dispatched by a local manager can be handled by
+ * handler registered in the global event manager
+ */
+	public function testDispatchLocalHandledByGlobal() {
+		$callback = array($this, 'onMyEvent');
+		CakeEventManager::instance()->attach($callback, 'my_event');
+		$manager = new CakeEventManager();
+		$event = new CakeEvent('my_event', $manager);
+		$manager->dispatch($event);
+		$this->assertEquals('ok', $event->data['callback']);
+	}
+
 }


### PR DESCRIPTION
This seem to fix the issue on Croogo test suite.

Anybody care to explain why this works? :ghost: in the :computer: ?  :confused: ?

I don't have test yet, because I still don't know the root cause.
