### PR TITLE
Added regex support to Validation::mimeType().

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2362,8 +2362,8 @@ class ValidationTest extends CakeTestCase {
 		$this->assertTrue(Validation::mimeType($image, array('image/gif')));
 		$this->assertTrue(Validation::mimeType(array('tmp_name' => $image), array('image/gif')));
 		$this->assertTrue(Validation::mimeType(array('tmp_name' => $image), '#image/.+#'));
+		$this->assertTrue(Validation::mimeType($image, array('image/GIF')));
 
-		$this->assertFalse(Validation::mimeType($image, array('image/GIF')));
 		$this->assertFalse(Validation::mimeType($image, array('image/png')));
 		$this->assertFalse(Validation::mimeType(array('tmp_name' => $image), array('image/png')));
 	}

--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2356,9 +2356,12 @@ class ValidationTest extends CakeTestCase {
 	public function testMimeType() {
 		$image = CORE_PATH . 'Cake' . DS . 'Test' . DS . 'test_app' . DS . 'webroot' . DS . 'img' . DS . 'cake.power.gif';
 		$File = new File($image, false);
+
 		$this->skipIf(!$File->mime(), 'Cannot determine mimeType');
+
 		$this->assertTrue(Validation::mimeType($image, array('image/gif')));
 		$this->assertTrue(Validation::mimeType(array('tmp_name' => $image), array('image/gif')));
+		$this->assertTrue(Validation::mimeType(array('tmp_name' => $image), '#image/.+#'));
 
 		$this->assertFalse(Validation::mimeType($image, array('image/GIF')));
 		$this->assertFalse(Validation::mimeType($image, array('image/png')));

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -925,10 +925,10 @@ class Validation {
 	}
 
 /**
- * Checks the mime type of a file. Comparison is case sensitive.
+ * Checks the mime type of a file.
  *
  * @param string|array $check
- * @param array $mimeTypes to check for
+ * @param array|string $mimeTypes Array of mime types or regex pattern to check.
  * @return boolean Success
  * @throws CakeException when mime type can not be determined.
  */
@@ -943,6 +943,11 @@ class Validation {
 		if ($mime === false) {
 			throw new CakeException(__d('cake_dev', 'Can not determine the mimetype.'));
 		}
+
+		if (is_string($mimeTypes)) {
+			return self::_check($mime, $mimeTypes);
+		}
+
 		return in_array($mime, $mimeTypes);
 	}
 

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -948,6 +948,9 @@ class Validation {
 			return self::_check($mime, $mimeTypes);
 		}
 
+		foreach ($mimeTypes as $key => $val) {
+			$mimeTypes[$key] = strtolower($val);
+		}
 		return in_array($mime, $mimeTypes);
 	}
 


### PR DESCRIPTION
Doing 
`'image' => ['rule' => ['mimeType', '#image/.+#']]`
is way more convenient than 
`'image' => ['rule' => ['mimeType', ['image/gif', 'image/png', ...]]]`
