### PR TITLE
Rendering a proper value for html5 attribute 'step'

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -353,6 +353,8 @@ class ValidateUser extends CakeTestModel {
 		'email' => array('type' => 'string', 'null' => '', 'default' => '', 'length' => '255'),
 		'balance' => array('type' => 'float', 'null' => false, 'length' => '5,2'),
 		'cost_decimal' => array('type' => 'decimal', 'null' => false, 'length' => '6,3'),
+		'ratio' => array('type' => 'decimal', 'null' => false, 'length' => '10,6'),
+		'population' => array('type' => 'decimal', 'null' => false, 'length' => '15,0'),
 		'created' => array('type' => 'date', 'null' => '1', 'default' => '', 'length' => ''),
 		'updated' => array('type' => 'datetime', 'null' => '1', 'default' => '', 'length' => null)
 	);
@@ -1912,6 +1914,28 @@ class FormHelperTest extends CakeTestCase {
 			'Cost Decimal',
 			'/label',
 			'input' => array('name', 'type' => 'number', 'step' => '0.001', 'id'),
+			'/div',
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('ValidateUser.ratio');
+		$expected = array(
+			'div' => array('class'),
+			'label' => array('for'),
+			'Ratio',
+			'/label',
+			'input' => array('name', 'type' => 'number', 'step' => '0.000001', 'id'),
+			'/div',
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('ValidateUser.population');
+		$expected = array(
+			'div' => array('class'),
+			'label' => array('for'),
+			'Population',
+			'/label',
+			'input' => array('name', 'type' => 'number', 'step' => '1', 'id'),
 			'/div',
 		);
 		$this->assertTags($result, $expected);

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1173,7 +1173,11 @@ class FormHelper extends AppHelper {
 				!isset($options['step'])
 			) {
 				if ($type === 'decimal') {
-					$options['step'] = pow(10, -1 * substr($fieldDef['length'], strpos($fieldDef['length'], ',') + 1));
+					if (preg_match('/[0-9]+,([0-9]+)/', $fieldDef['length'], $fieldLenght) && intval($fieldLenght[1]) > 0) {
+						$options['step'] = '0.' . str_repeat('0', $fieldLenght[1] - 1) . '1';
+					} else {
+						$options['step'] = 1;
+					}
 				} elseif ($type === 'float') {
 					$options['step'] = 'any';
 				}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1173,11 +1173,8 @@ class FormHelper extends AppHelper {
 				!isset($options['step'])
 			) {
 				if ($type === 'decimal') {
-					if (preg_match('/[0-9]+,([0-9]+)/', $fieldDef['length'], $fieldLenght) && intval($fieldLenght[1]) > 0) {
-						$options['step'] = '0.' . str_repeat('0', $fieldLenght[1] - 1) . '1';
-					} else {
-						$options['step'] = 1;
-					}
+					$decimalPlaces = substr($fieldDef['length'], strpos($fieldDef['length'], ',') + 1);
+					$options['step'] = sprintf('%.' . $decimalPlaces . 'F', pow(10, -1 * $decimalPlaces));
 				} elseif ($type === 'float') {
 					$options['step'] = 'any';
 				}


### PR DESCRIPTION
This solve an issue when we have a decimal field, where decimal places are greater than 4. 
For example: a field 'ratio' defined as DECIMAL(10,6)

``` php
echo $this->Form->input('Unit.ratio');
```

now this render:

``` html
<input name="data[Unit][ratio]" step="1,0E-6" type="number"  id="Unit.ratio">
```
