### PR TITLE
3.0 Cleaner URL for paginatorHelper

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -185,6 +185,12 @@ class PaginatorComponent extends Component {
 			$order = (array)$order;
 		}
 		reset($order);
+		$sortDefault = $directionDefault = false;
+		if (isset($defaults['order']) && count($defaults['order']) && count($defaults['order']) == 1){
+			$sortDefault = key($defaults['order']);
+			$directionDefault = current($defaults['order']);
+		}
+
 		$paging = array(
 			'findType' => $type,
 			'page' => $page,
@@ -196,6 +202,8 @@ class PaginatorComponent extends Component {
 			'sort' => key($order),
 			'direction' => current($order),
 			'limit' => $defaults['limit'] != $options['limit'] ? $options['limit'] : null,
+			'sortDefault' => $sortDefault,
+			'directionDefault' => $directionDefault
 		);
 
 		if (!isset($request['paging'])) {

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -440,7 +440,7 @@ class PaginatorHelper extends Helper {
 		if (!empty($url['page']) && $url['page'] == 1) {
 			$url['page'] = null;
 		}
-		if (isset($paging['sortDefault']) && isset($paging['directionDefault']) && $url['sort'] == $paging['sortDefault'] && $url['direction'] == $paging['directionDefault'] ) {
+		if (isset($paging['sortDefault']) && isset($paging['directionDefault']) && $url['sort'] === $paging['sortDefault'] && $url['direction'] === $paging['directionDefault'] ) {
 			$url['sort'] = $url['direction'] = null;
 		}
 		return parent::url($url);

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -440,6 +440,9 @@ class PaginatorHelper extends Helper {
 		if (!empty($url['page']) && $url['page'] == 1) {
 			$url['page'] = null;
 		}
+		if (isset($paging['sortDefault']) && isset($paging['directionDefault']) && $url['sort'] == $paging['sortDefault'] && $url['direction'] == $paging['directionDefault'] ) {
+			$url['sort'] = $url['direction'] = null;
+		}
 		return parent::url($url);
 	}
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -186,7 +186,7 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
- * test that default sort and default direction are injectect into request
+ * test that default sort and default direction are injected into request
  *
  * @return void
  */

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -186,6 +186,36 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
+ * test that default sort and default direction are injectect into request
+ *
+ * @return void
+ */
+	public function testDefaultPaginateParamsIntoRequest() {
+		$settings = array(
+			'order' => ['PaginatorPosts.id' => 'DESC'],
+			'maxLimit' => 10,
+		);
+
+		$table = $this->_getMockPosts(['find']);
+		$query = $this->_getMockFindQuery();
+
+		$table->expects($this->once())
+			->method('find')
+			->with('all', [
+				'conditions' => [],
+				'fields' => null,
+				'limit' => 10,
+				'page' => 1,
+				'order' => ['PaginatorPosts.id' => 'DESC']
+			])
+			->will($this->returnValue($query));
+
+		$this->Paginator->paginate($table, $settings);
+		$this->assertEquals('PaginatorPosts.id', $this->request->params['paging']['PaginatorPosts']['sortDefault']);
+		$this->assertEquals('DESC', $this->request->params['paging']['PaginatorPosts']['directionDefault']);
+	}
+
+/**
  * test that option merging prefers specific models
  *
  * @return void

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -735,7 +735,7 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
- * Test that url generated doesn't include default sort & direction
+ * Test that generated URLs don't include sort and direction parameters
  *
  * @return void
  */

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -735,6 +735,35 @@ class PaginatorHelperTest extends TestCase {
 	}
 
 /**
+ * Test that url generated doesn't include default sort & direction
+ *
+ * @return void
+ */
+	public function testDefaultSortRemovedFromUrl() {
+		Router::setRequestInfo(array(
+			array('plugin' => null, 'controller' => 'articles', 'action' => 'index'),
+			array('base' => '/', 'here' => '/articles/', 'webroot' => '/')
+		));
+		$this->Paginator->request->params['paging'] = array(
+			'Article' => array(
+				'page' => 1, 'current' => 3, 'count' => 13,
+				'prevPage' => false, 'nextPage' => true, 'pageCount' => 8,
+				'sort' => 'Article.title', 'direction' => 'ASC',
+				'sortDefault' => 'Article.title', 'directionDefault' => 'ASC'
+			)
+		);
+		$result = $this->Paginator->next('Next');
+		$expected = array(
+			'li' => array('class' => 'next'),
+			'a'  => array('rel' => 'next', 'href' => '/articles/index?page=2'),
+			'Next',
+			'/a',
+			'/li'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * Test the prev() method.
  *
  * @return void


### PR DESCRIPTION
Avoid appending &sort and &direction if the sort parameters are the one from options
## Problem

PaginatorHelper is appending **sort** and **direction** parameter even if it's not needed
## Solution

Pass the default **sort** and **direction** into $this->request->params['paging']. (sortDefault and directionDefault) 
Within the PaginatorHelper::url() method check if the params are the same and unset $url['sort'] and $url['direction']
## Use Case

``` php
    // Controller
    public $paginate =  ['order' => ['Posts.created' => 'asc'], 'limit' => 10]; 

    // View 
    $this->Paginator->numbers()
    // Was generating 
    url?page=2&sort=Posts.created&direction=asc
    // Now generates
    url?page=2
```

If more than one order is defined my behavior is not used and the sort parameter is injected again 

``` php
    // Controller
    public $paginate =  ['order' => ['Posts.created' => 'asc', 'Posts.name' => 'asc'], 'limit' => 10]; 

    // View 
    $this->Paginator->numbers()
    // Was generating and will keep generating this
    url?page=2&sort=Pots.created&direction=asc
```

That's still a problem but (since the default order will be lost) but in my opinion it's a specific use case.
I don't know if paginator is supposed to support multiple orders so I didn't edited this use case.
