### PR TITLE
3.0 form context

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Form;
+
+use Cake\Network\Request;
+use Cake\Utility\Hash;
+
+/**
+ * Provides a basic array based context provider for FormHelper
+ * this adapter is useful in testing or when you have forms backed by
+ * by simple array data structures.
+ *
+ * Important keys:
+ *
+ * - `defaults` The default values for fields. These values
+ *   will be used when there is no request data set.
+ * - `required` A nested array of fields, relationships and boolean
+ *   flags to indicate a field is required.
+ * - `schema` An array of data that emulate the structures that
+ *   Cake\Database\Schema\Table uses. This array allows you to control
+ *   the inferred type for fields and allows auto generation of attributes
+ *   like maxlength, step and other HTML attributes.
+ */
+class ArrayContext {
+
+	protected $_request;
+	protected $_context;
+
+	public function __construct(Request $request, array $context) {
+		$this->_request = $request;
+		$this->_context = $context;
+	}
+
+/**
+ * Get the current value for a given field.
+ *
+ * This method will coalesce the current request data and the 'defaults'
+ * array.
+ *
+ * @param string $field A dot separated path to the field a value
+ *   is needed for.
+ * @return mixed
+ */
+	public function val($field) {
+	}
+
+/**
+ * Check if a given field is 'required'.
+ *
+ * In this context class, this is simply defined by the 'required' array.
+ *
+ * @param string $field A dot separated path to check required-ness for.
+ * @return boolean
+ */
+	public function isRequired($field) {
+	}
+
+/**
+ * Get the abstract field type for a given field name.
+ *
+ * @param string $field A dot separated path to get a schema type for.
+ * @return string An abstract data type.
+ * @see Cake\Database\Type
+ */
+	public function type($field) {
+
+	}
+
+/**
+ * Get an associative array of other attributes for a field name.
+ *
+ * @param string $field A dot separated path to get a additional data on.
+ * @return array An array of data describing the additional attributes on a field.
+ */
+	public function attributes($field) {
+
+	}
+
+}

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -95,6 +95,11 @@ class ArrayContext {
  * @return boolean
  */
 	public function isRequired($field) {
+		if (!is_array($this->_context['required'])) {
+			return false;
+		}
+		$required = Hash::get($this->_context['required'], $field);
+		return (bool)$required;
 	}
 
 /**
@@ -105,7 +110,11 @@ class ArrayContext {
  * @see Cake\Database\Type
  */
 	public function type($field) {
-
+		if (!is_array($this->_context['schema'])) {
+			return false;
+		}
+		$schema = Hash::get($this->_context['schema'], $field);
+		return isset($schema['type']) ? $schema['type'] : null;
 	}
 
 /**
@@ -115,7 +124,12 @@ class ArrayContext {
  * @return array An array of data describing the additional attributes on a field.
  */
 	public function attributes($field) {
-
+		if (!is_array($this->_context['schema'])) {
+			return [];
+		}
+		$schema = Hash::get($this->_context['schema'], $field);
+		$whitelist = ['length' => null, 'precision' => null];
+		return array_intersect_key($schema, $whitelist);
 	}
 
 }

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -18,9 +18,10 @@ use Cake\Network\Request;
 use Cake\Utility\Hash;
 
 /**
- * Provides a basic array based context provider for FormHelper
- * this adapter is useful in testing or when you have forms backed by
- * by simple array data structures.
+ * Provides a basic array based context provider for FormHelper.
+ *
+ * This adapter is useful in testing or when you have forms backed by
+ * simple array data structures.
  *
  * Important keys:
  *
@@ -110,12 +111,12 @@ class ArrayContext {
  * Get the abstract field type for a given field name.
  *
  * @param string $field A dot separated path to get a schema type for.
- * @return string An abstract data type.
+ * @return null|string An abstract data type or null.
  * @see Cake\Database\Type
  */
 	public function type($field) {
 		if (!is_array($this->_context['schema'])) {
-			return false;
+			return null;
 		}
 		$schema = Hash::get($this->_context['schema'], $field);
 		return isset($schema['type']) ? $schema['type'] : null;
@@ -124,7 +125,7 @@ class ArrayContext {
 /**
  * Get an associative array of other attributes for a field name.
  *
- * @param string $field A dot separated path to get a additional data on.
+ * @param string $field A dot separated path to get additional data on.
  * @return array An array of data describing the additional attributes on a field.
  */
 	public function attributes($field) {
@@ -154,7 +155,7 @@ class ArrayContext {
  *
  * @param string $field A dot separated path to check errors on.
  * @return mixed Either a string or an array of errors. Null
- *  will be returned when the field path is undefined.
+ *   will be returned when the field path is undefined.
  */
 	public function error($field) {
 		if (empty($this->_context['errors'])) {

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -25,13 +25,16 @@ use Cake\Utility\Hash;
  * Important keys:
  *
  * - `defaults` The default values for fields. These values
- *   will be used when there is no request data set.
+ *   will be used when there is no request data set. Data should be nested following
+ *   the dot separated paths you access your fields with.
  * - `required` A nested array of fields, relationships and boolean
  *   flags to indicate a field is required.
- * - `schema` An array of data that emulate the structures that
+ * - `schema` An array of data that emulate the column structures that
  *   Cake\Database\Schema\Table uses. This array allows you to control
  *   the inferred type for fields and allows auto generation of attributes
  *   like maxlength, step and other HTML attributes.
+ * - `errors` An array of validation errors. Errors should be nested following
+ *   the dot separated paths you access your fields with.
  */
 class ArrayContext {
 
@@ -61,6 +64,7 @@ class ArrayContext {
 			'schema' => [],
 			'required' => [],
 			'defaults' => [],
+			'errors' => [],
 		];
 		$this->_context = $context;
 	}
@@ -130,6 +134,33 @@ class ArrayContext {
 		$schema = Hash::get($this->_context['schema'], $field);
 		$whitelist = ['length' => null, 'precision' => null];
 		return array_intersect_key($schema, $whitelist);
+	}
+
+/**
+ * Check whether or not a field has an error attached to it
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return boolean Returns true if the errors for the field are not empty.
+ */
+	public function hasError($field) {
+		if (empty($this->_context['errors'])) {
+			return false;
+		}
+		return (bool)Hash::check($this->_context['errors'], $field);
+	}
+
+/**
+ * Get the errors for a given field
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return mixed Either a string or an array of errors. Null
+ *  will be returned when the field path is undefined.
+ */
+	public function error($field) {
+		if (empty($this->_context['errors'])) {
+			return null;
+		}
+		return Hash::get($this->_context['errors'], $field);
 	}
 
 }

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://cakephp.org CakePHP(tm) Project
- * @since         CakePHP(tm) v 2.0
+ * @since         CakePHP(tm) v 3.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\View\Form;
@@ -35,11 +35,33 @@ use Cake\Utility\Hash;
  */
 class ArrayContext {
 
+/**
+ * The request object.
+ *
+ * @var Cake\Network\Request
+ */
 	protected $_request;
+
+/**
+ * Context data for this object.
+ *
+ * @var array
+ */
 	protected $_context;
 
+/**
+ * Constructor.
+ *
+ * @param Cake\Network\Request
+ * @param array
+ */
 	public function __construct(Request $request, array $context) {
 		$this->_request = $request;
+		$context += [
+			'schema' => [],
+			'required' => [],
+			'defaults' => [],
+		];
 		$this->_context = $context;
 	}
 
@@ -54,6 +76,14 @@ class ArrayContext {
  * @return mixed
  */
 	public function val($field) {
+		$val = $this->_request->data($field);
+		if ($val !== null) {
+			return $val;
+		}
+		if (empty($this->_context['defaults']) || !is_array($this->_context['defaults'])) {
+			return null;
+		}
+		return Hash::get($this->_context['defaults'], $field);
 	}
 
 /**

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Form;
+
+use Cake\Network\Request;
+use Cake\TestSuite\TestCase;
+use Cake\View\Form\ArrayContext;
+
+/**
+ * Array context test case.
+ */
+class ArrayContextTest extends TestCase {
+
+/**
+ * setup method.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->request = new Request();
+	}
+
+/**
+ * Test reading values from the request & defaults.
+ */
+	public function testValPresent() {
+		$this->request->data = [
+			'Articles' => [
+				'title' => 'New title',
+				'body' => 'My copy',
+			]
+		];
+		$context = new ArrayContext($this->request, [
+			'defaults' => [
+				'Articles' => [
+					'title' => 'Default value',
+					'published' => 0
+				]
+			]
+		]);
+		$this->assertEquals('New title', $context->val('Articles.title'));
+		$this->assertEquals('My copy', $context->val('Articles.body'));
+		$this->assertEquals(0, $context->val('Articles.published'));
+		$this->assertNull($context->val('Articles.nope'));
+	}
+
+/**
+ * Test getting values when the request and defaults are missing.
+ *
+ * @return void
+ */
+	public function testValMissing() {
+		$context = new ArrayContext($this->request, []);
+		$this->assertNull($context->val('Comments.field'));
+	}
+
+	public function testIsRequired() {
+		$this->markTestIncomplete();
+	}
+
+	public function testIsRequiredUndefined() {
+		$this->markTestIncomplete();
+	}
+
+	public function testIsType() {
+		$this->markTestIncomplete();
+	}
+
+	public function testIsTypeUndefined() {
+		$this->markTestIncomplete();
+	}
+
+	public function testAttributes() {
+		$this->markTestIncomplete();
+	}
+
+}

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -147,4 +147,46 @@ class ArrayContextTest extends TestCase {
 		$this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.floaty'));
 	}
 
+/**
+ * Test fetching errors.
+ *
+ * @return void
+ */
+	public function testError() {
+		$context = new ArrayContext($this->request, [
+			'errors' => [
+				'Comments' => [
+					'comment' => ['Comment is required'],
+					'empty' => [],
+					'user_id' => 'A valid userid is required',
+				]
+			]
+		]);
+		$this->assertEquals(['Comment is required'], $context->error('Comments.comment'));
+		$this->assertEquals('A valid userid is required', $context->error('Comments.user_id'));
+		$this->assertEquals([], $context->error('Comments.empty'));
+		$this->assertNull($context->error('Comments.not_there'));
+	}
+
+/**
+ * Test checking errors.
+ *
+ * @return void
+ */
+	public function testHasError() {
+		$context = new ArrayContext($this->request, [
+			'errors' => [
+				'Comments' => [
+					'comment' => ['Comment is required'],
+					'empty' => [],
+					'user_id' => 'A valid userid is required',
+				]
+			]
+		]);
+		$this->assertFalse($context->hasError('Comments.not_there'));
+		$this->assertFalse($context->hasError('Comments.empty'));
+		$this->assertTrue($context->hasError('Comments.user_id'));
+		$this->assertTrue($context->hasError('Comments.comment'));
+	}
+
 }

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -67,24 +67,84 @@ class ArrayContextTest extends TestCase {
 		$this->assertNull($context->val('Comments.field'));
 	}
 
+/**
+ * Test isRequired
+ *
+ * @return void
+ */
 	public function testIsRequired() {
-		$this->markTestIncomplete();
+		$context = new ArrayContext($this->request, [
+			'required' => [
+				'Comments' => [
+					'required' => true,
+					'nope' => false
+				]
+			]
+		]);
+		$this->assertTrue($context->isRequired('Comments.required'));
+		$this->assertFalse($context->isRequired('Comments.nope'));
+		$this->assertFalse($context->isRequired('Articles.id'));
 	}
 
+/**
+ * Test isRequired when the required key is omitted
+ *
+ * @return void
+ */
 	public function testIsRequiredUndefined() {
-		$this->markTestIncomplete();
+		$context = new ArrayContext($this->request, []);
+		$this->assertFalse($context->isRequired('Comments.field'));
 	}
 
-	public function testIsType() {
-		$this->markTestIncomplete();
+/**
+ * Test the type method.
+ *
+ * @return void
+ */
+	public function testType() {
+		$context = new ArrayContext($this->request, [
+			'schema' => [
+				'Comments' => [
+					'id' => ['type' => 'integer'],
+					'comment' => ['length' => 255]
+				]
+			]
+		]);
+		$this->assertNull($context->type('Comments.undefined'));
+		$this->assertEquals('integer', $context->type('Comments.id'));
+		$this->assertNull($context->type('Comments.comment'));
 	}
 
+/**
+ * Test the type method when the data is missing.
+ *
+ * @return void
+ */
 	public function testIsTypeUndefined() {
-		$this->markTestIncomplete();
+		$context = new ArrayContext($this->request, []);
+		$this->assertNull($context->type('Comments.undefined'));
 	}
 
+/**
+ * Test fetching attributes.
+ *
+ * @return void
+ */
 	public function testAttributes() {
-		$this->markTestIncomplete();
+		$context = new ArrayContext($this->request, [
+			'schema' => [
+				'Comments' => [
+					'id' => ['type' => 'integer'],
+					'comment' => ['type' => 'string', 'length' => 255],
+					'decimal' => ['type' => 'decimal', 'precision' => 2, 'length' => 5],
+					'floaty' => ['type' => 'float', 'precision' => 2, 'length' => 5],
+				]
+			]
+		]);
+		$this->assertEquals([], $context->attributes('Comments.id'));
+		$this->assertEquals(['length' => 255], $context->attributes('Comments.comment'));
+		$this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.decimal'));
+		$this->assertEquals(['precision' => 2, 'length' => 5], $context->attributes('Comments.floaty'));
 	}
 
 }


### PR DESCRIPTION
Part of #2267. Start the first FormHelper context object. This one just handles basic arrays. While this doesn't seem super useful it will be helpful for building forms that are not attached to ORM object and for testing FormHelper as we can have fewer dependencies and not require a database connection to test HTML output which will be handy.

The next thing I'll be working on are the context classes for a single entity and a collection of entities. I think these will end up being separate as the data traversal will create too many `if` conditions should the collection + single context be combined.
