### PR TITLE
3.0 Start the ORM context

### DIFF
--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -63,6 +63,21 @@ class Associations {
 	}
 
 /**
+ * Fetch an association by property name.
+ *
+ * @param string $prop The property to find an association by.
+ * @return Association|null Either the association or null.
+ */
+	public function getByProperty($prop) {
+		foreach ($this->_items as $assoc) {
+			if ($assoc->property() === $prop) {
+				return $assoc;
+			}
+		}
+		return null;
+	}
+
+/**
  * Check for an attached association by name.
  *
  * @param string $alias The association alias to get.

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -113,6 +113,16 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 	}
 
 /**
+ * Check whether or not a validator contains any rules for the given field.
+ *
+ * @param string $name The field name to check.
+ * @return boolean
+ */
+	public function hasField($name) {
+		return isset($this->_fields[$name]);
+	}
+
+/**
  * Associates an object to a name so it can be used as a provider. Providers are
  * objects or class names that can contain methods used during validation of for
  * deciding whether a validation rule can be applied. All validation methods,

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -154,12 +154,12 @@ class ArrayContext {
  * Get the errors for a given field
  *
  * @param string $field A dot separated path to check errors on.
- * @return mixed Either a string or an array of errors. Null
- *   will be returned when the field path is undefined.
+ * @return array An array of errors, an empty array will be returned when the
+ *    context has no errors.
  */
 	public function error($field) {
 		if (empty($this->_context['errors'])) {
-			return null;
+			return [];
 		}
 		return Hash::get($this->_context['errors'], $field);
 	}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -135,11 +135,6 @@ class EntityContext {
 			return [$entity, $this->_rootName];
 		}
 
-		// Remove the Table name if present.
-		if (count($path) > 1 && $path[0] === $this->_rootName) {
-			array_shift($path);
-		}
-
 		$lastProp = $this->_rootName;
 		foreach ($path as $prop) {
 			$next = $this->_getProp($entity, $prop);

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -287,13 +287,7 @@ class EntityContext {
  * @return boolean Returns true if the errors for the field are not empty.
  */
 	public function hasError($field) {
-		$parts = explode('.', $field);
-		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return false;
-		}
-		$errors = $entity->errors(array_pop($parts));
-		return !empty($errors);
+		return $this->error($field) !== [];
 	}
 
 /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -16,6 +16,7 @@ namespace Cake\View\Form;
 
 use Cake\Network\Request;
 use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use Traversable;
 
@@ -70,6 +71,13 @@ class EntityContext {
 	protected $_validators = [];
 
 /**
+ * A dictionary of tables
+ *
+ * @var array
+ */
+	protected $_tables = [];
+
+/**
  * Constructor.
  *
  * @param Cake\Network\Request
@@ -98,11 +106,16 @@ class EntityContext {
 		if (is_string($this->_context['table'])) {
 			$plural = $this->_context['table'];
 		}
-		$this->_pluralName = $plural;
+		$table = TableRegistry::get($plural);
 
 		if (is_object($this->_context['validator'])) {
 			$this->_validators['_default'] = $this->_context['validator'];
+		} elseif (is_string($this->_context['validator'])) {
+			$this->_validators['_default'] = $table->validator($this->_context['validator']);
 		}
+
+		$this->_pluralName = $plural;
+		$this->_tables[$plural] = $table;
 	}
 
 /**

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -301,19 +301,17 @@ class EntityContext {
 		return !empty($errors);
 	}
 
-
 /**
  * Get the errors for a given field
  *
  * @param string $field A dot separated path to check errors on.
- * @return array|null Either an array of errors. Null will be returned when the
- *   field path is undefined or there is no error.
+ * @return array An array of errors.
  */
 	public function error($field) {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
 		if (!$entity) {
-			return false;
+			return [];
 		}
 		return $entity->errors(array_pop($parts));
 	}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -30,7 +30,7 @@ use Traversable;
  *
  * - `entity` The entity this context is operating on.
  * - `table` Either the ORM\Table instance to fetch schema/validators
- *   from, an array of table instances in the case of an form spanning
+ *   from, an array of table instances in the case of a form spanning
  *   multiple entities, or the name(s) of the table.
  *   If this is null the table name(s) will be determined using conventions.
  * - `validator` Either the Validation\Validator to use, or the name of the
@@ -163,7 +163,7 @@ class EntityContext {
  *
  * @param mixed $target The entity/array/collection to fetch $field from.
  * @param string $field The next field to fetch.
- * @return mixed.
+ * @return mixed
  */
 	protected function _getProp($target, $field) {
 		if (is_array($target) || $target instanceof Traversable) {
@@ -277,7 +277,7 @@ class EntityContext {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
 		if (!$entity) {
-			return null;
+			return [];
 		}
 		$table = $this->_getTable($prop);
 		$column = $table->schema()->column(array_pop($parts));

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Form;
+
+use Cake\Network\Request;
+use Cake\ORM\Entity;
+use Cake\Validation\Validator;
+use Traversable;
+
+/**
+ * Provides a form context around a single entity and its relations.
+ *
+ * This class lets FormHelper interface with entities or collections
+ * of entities.
+ *
+ * Important Keys:
+ *
+ * - `entity` The entity this context is operating on.
+ * - `table` Either the ORM\Table instance to fetch schema/validators
+ *   from, an array of table instances in the case of an form spanning
+ *   multiple entities, or the name(s) of the table.
+ *   If this is null the table name(s) will be determined using conventions.
+ *   This table object will be used to fetch the schema and
+ *   validation information.
+ * - `validator` Either the Validation\Validator to use, or the name of the
+ *   validation method to call on the table object. For example 'default'.
+ *   Defaults to 'default'.
+ */
+class EntityContext {
+
+/**
+ * The request object.
+ *
+ * @var Cake\Network\Request
+ */
+	protected $_request;
+
+/**
+ * Context data for this object.
+ *
+ * @var array
+ */
+	protected $_context;
+
+	protected $_pluralName;
+
+/**
+ * Constructor.
+ *
+ * @param Cake\Network\Request
+ * @param array
+ */
+	public function __construct(Request $request, array $context) {
+		$this->_request = $request;
+		$context += [
+			'entity' => null,
+			'schema' => null,
+			'table' => null,
+			'validator' => null
+		];
+		$this->_context = $context;
+		$this->_prepare();
+	}
+
+/**
+ * Prepare some additional data from the context.
+ *
+ * @return void
+ */
+	protected function _prepare() {
+		// TODO handle the other cases (string, array, instance)
+		if (is_string($this->_context['table'])) {
+			$plural = $this->_context['table'];
+		}
+		$this->_pluralName = $plural;
+	}
+
+/**
+ * Get the value for a given path.
+ *
+ * Traverses the entity data and finds the value for $path.
+ *
+ * @param string $field The dot separated path to the value.
+ * @return mixed The value of the field or null on a miss.
+ */
+	public function val($field) {
+		if (empty($this->_context['entity'])) {
+			return null;
+		}
+		$parts = explode('.', $field);
+
+		// Remove the model name if present.
+		if (count($parts) > 1 && $parts[0] === $this->_pluralName) {
+			array_shift($parts);
+		}
+
+		$val = $this->_context['entity'];
+		foreach ($parts as $prop) {
+			$val = $this->_getProp($val, $prop);
+			if (
+				!is_array($val) &&
+				!($val instanceof Traversable) &&
+				!($val instanceof Entity)
+			) {
+				return $val;
+			}
+		}
+		return $val;
+	}
+
+/**
+ * Read property values or traverse arrays/iterators.
+ *
+ * @param mixed $target The entity/array/collection to fetch $field from.
+ * @param string $field The next field to fetch.
+ * @return mixed.
+ */
+	protected function _getProp($target, $field) {
+		if (is_array($target) || $target instanceof Traversable) {
+			foreach ($target as $i => $val) {
+				if ($i == $field) {
+					return $val;
+				}
+			}
+		}
+		return $target->get($field);
+	}
+
+	public function isRequired($field) {
+	}
+
+	public function type($field) {
+	}
+
+	public function attributes($field) {
+	}
+
+	public function hasError($field) {
+	}
+
+	public function error($field) {
+	}
+
+}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -250,7 +250,22 @@ class EntityContext {
 		return $target;
 	}
 
+/**
+ * Get the abstract field type for a given field name.
+ *
+ * @param string $field A dot separated path to get a schema type for.
+ * @return null|string An abstract data type or null.
+ * @see Cake\Database\Type
+ */
 	public function type($field) {
+		$parts = explode('.', $field);
+		list($entity, $prop) = $this->_getEntity($parts);
+		if (!$entity) {
+			return null;
+		}
+		$table = $this->_getTable($prop);
+		$column = array_pop($parts);
+		return $table->schema()->columnType($column);
 	}
 
 	public function attributes($field) {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -267,7 +267,22 @@ class EntityContext {
 		return $table->schema()->columnType($column);
 	}
 
+/**
+ * Get an associative array of other attributes for a field name.
+ *
+ * @param string $field A dot separated path to get additional data on.
+ * @return array An array of data describing the additional attributes on a field.
+ */
 	public function attributes($field) {
+		$parts = explode('.', $field);
+		list($entity, $prop) = $this->_getEntity($parts);
+		if (!$entity) {
+			return null;
+		}
+		$table = $this->_getTable($prop);
+		$column = $table->schema()->column(array_pop($parts));
+		$whitelist = ['length' => null, 'precision' => null];
+		return array_intersect_key($column, $whitelist);
 	}
 
 	public function hasError($field) {

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -219,7 +219,7 @@ class EntityContext {
 		$method = 'default';
 		if (is_string($this->_context['validator'])) {
 			$method = $this->_context['validator'];
-		} elseif (isset($this->_context['validator'][$alias])){
+		} elseif (isset($this->_context['validator'][$alias])) {
 			$method = $this->_context['validator'][$alias];
 		}
 		return $table->validator($method);

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -285,10 +285,37 @@ class EntityContext {
 		return array_intersect_key($column, $whitelist);
 	}
 
+/**
+ * Check whether or not a field has an error attached to it
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return boolean Returns true if the errors for the field are not empty.
+ */
 	public function hasError($field) {
+		$parts = explode('.', $field);
+		list($entity, $prop) = $this->_getEntity($parts);
+		if (!$entity) {
+			return false;
+		}
+		$errors = $entity->errors(array_pop($parts));
+		return !empty($errors);
 	}
 
+
+/**
+ * Get the errors for a given field
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return array|null Either an array of errors. Null will be returned when the
+ *   field path is undefined or there is no error.
+ */
 	public function error($field) {
+		$parts = explode('.', $field);
+		list($entity, $prop) = $this->_getEntity($parts);
+		if (!$entity) {
+			return false;
+		}
+		return $entity->errors(array_pop($parts));
 	}
 
 }

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -17,7 +17,6 @@ namespace Cake\View\Form;
 use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 use Traversable;
 

--- a/tests/TestCase/ORM/AssociationsTest.php
+++ b/tests/TestCase/ORM/AssociationsTest.php
@@ -63,6 +63,20 @@ class AssociationsTest extends TestCase {
 	}
 
 /**
+ * Test getting associations by property.
+ *
+ * @return void
+ */
+	public function testGetByProperty() {
+		$belongsTo = new BelongsTo('Users', []);
+		$this->assertEquals('user', $belongsTo->property());
+		$this->associations->add('Users', $belongsTo);
+		$this->assertNull($this->associations->get('user'));
+
+		$this->assertSame($belongsTo, $this->associations->getByProperty('user'));
+	}
+
+/**
  * Test associations with plugin names.
  *
  * @return void

--- a/tests/TestCase/Validation/ValidatorTest.php
+++ b/tests/TestCase/Validation/ValidatorTest.php
@@ -50,9 +50,12 @@ class ValidatorTest extends \Cake\TestSuite\TestCase {
  */
 	public function testFieldDefault() {
 		$validator = new Validator;
+		$this->assertFalse($validator->hasField('foo'));
+
 		$field = $validator->field('foo');
 		$this->assertInstanceOf('\Cake\Validation\ValidationSet', $field);
 		$this->assertCount(0, $field);
+		$this->assertTrue($validator->hasField('foo'));
 	}
 
 /**

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -153,6 +153,9 @@ class ArrayContextTest extends TestCase {
  * @return void
  */
 	public function testError() {
+		$context = new ArrayContext($this->request, []);
+		$this->assertEquals([], $context->error('Comments.empty'));
+
 		$context = new ArrayContext($this->request, [
 			'errors' => [
 				'Comments' => [

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -14,10 +14,10 @@
  */
 namespace Cake\Test\TestCase\View\Form;
 
+use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -58,20 +58,11 @@ class EntityContextTest extends TestCase {
 			'entity' => $row,
 			'table' => 'Articles',
 		]);
-		$result = $context->val('Articles.title');
-		$this->assertEquals($row->title, $result);
-
 		$result = $context->val('title');
 		$this->assertEquals($row->title, $result);
 
-		$result = $context->val('Articles.body');
-		$this->assertEquals($row->body, $result);
-
 		$result = $context->val('body');
 		$this->assertEquals($row->body, $result);
-
-		$result = $context->val('Articles.nope');
-		$this->assertNull($result);
 
 		$result = $context->val('nope');
 		$this->assertNull($result);
@@ -99,28 +90,19 @@ class EntityContextTest extends TestCase {
 			'table' => 'Articles',
 		]);
 
-		$result = $context->val('Articles.user.fname');
-		$this->assertEquals($row->user->fname, $result);
-
 		$result = $context->val('user.fname');
 		$this->assertEquals($row->user->fname, $result);
-
-		$result = $context->val('Articles.comments.0.comment');
-		$this->assertEquals($row->comments[0]->comment, $result);
 
 		$result = $context->val('comments.0.comment');
 		$this->assertEquals($row->comments[0]->comment, $result);
 
-		$result = $context->val('Articles.comments.1.comment');
-		$this->assertEquals($row->comments[1]->comment, $result);
-
 		$result = $context->val('comments.1.comment');
 		$this->assertEquals($row->comments[1]->comment, $result);
 
-		$result = $context->val('Articles.comments.0.nope');
+		$result = $context->val('comments.0.nope');
 		$this->assertNull($result);
 
-		$result = $context->val('Articles.comments.0.nope.no_way');
+		$result = $context->val('comments.0.nope.no_way');
 		$this->assertNull($result);
 	}
 
@@ -138,9 +120,7 @@ class EntityContextTest extends TestCase {
 			'validator' => 'create',
 		]);
 
-		$this->assertTrue($context->isRequired('Articles.title'));
 		$this->assertTrue($context->isRequired('title'));
-		$this->assertFalse($context->isRequired('Articles.body'));
 		$this->assertFalse($context->isRequired('body'));
 
 		$this->assertFalse($context->isRequired('Herp.derp.derp'));
@@ -175,10 +155,7 @@ class EntityContextTest extends TestCase {
 		]);
 
 		$this->assertTrue($context->isRequired('comments.0.user_id'));
-		$this->assertTrue($context->isRequired('Articles.comments.0.user_id'));
-
 		$this->assertFalse($context->isRequired('comments.0.other'));
-		$this->assertFalse($context->isRequired('Articles.comments.0.other'));
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -297,6 +297,21 @@ class EntityContextTest extends TestCase {
 			'entity' => $row,
 			'table' => 'Articles',
 		]);
+
+		$expected = [
+			'length' => 255, 'precision' => null
+		];
+		$this->assertEquals($expected, $context->attributes('title'));
+
+		$expected = [
+			'length' => null, 'precision' => null
+		];
+		$this->assertEquals($expected, $context->attributes('body'));
+
+		$expected = [
+			'length' => 10, 'precision' => 3
+		];
+		$this->assertEquals($expected, $context->attributes('user.rating'));
 	}
 
 /**
@@ -321,7 +336,8 @@ class EntityContextTest extends TestCase {
 		$users->schema([
 			'id' => ['type' => 'integer', 'length' => 11],
 			'username' => ['type' => 'string', 'length' => 255],
-			'bio' => ['type' => 'text']
+			'bio' => ['type' => 'text'],
+			'rating' => ['type' => 'decimal', 'length' => 10, 'precision' => 3],
 		]);
 
 		$validator = new Validator();

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -315,6 +315,89 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test hasError
+ *
+ * @return void
+ */
+	public function testHasError() {
+		$this->_setupTables();
+
+		$row = new Entity([
+			'title' => 'My title',
+			'user' => new Entity(['username' => 'Mark']),
+		]);
+		$row->errors('title', []);
+		$row->errors('body', 'Gotta have one');
+		$row->errors('user_id', ['Required field']);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$this->assertFalse($context->hasError('title'));
+		$this->assertFalse($context->hasError('nope'));
+		$this->assertTrue($context->hasError('body'));
+		$this->assertTrue($context->hasError('user_id'));
+	}
+
+/**
+ * Test hasError on associated records
+ *
+ * @return void
+ */
+	public function testHasErrorAssociated() {
+		$this->_setupTables();
+
+		$row = new Entity([
+			'title' => 'My title',
+			'user' => new Entity(['username' => 'Mark']),
+		]);
+		$row->errors('title', []);
+		$row->errors('body', 'Gotta have one');
+		$row->user->errors('username', ['Required']);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$this->assertTrue($context->hasError('user.username'));
+		$this->assertFalse($context->hasError('user.nope'));
+		$this->assertFalse($context->hasError('no.nope'));
+	}
+
+/**
+ * Test error
+ *
+ * @return void
+ */
+	public function testError() {
+		$this->_setupTables();
+
+		$row = new Entity([
+			'title' => 'My title',
+			'user' => new Entity(['username' => 'Mark']),
+		]);
+		$row->errors('title', []);
+		$row->errors('body', 'Gotta have one');
+		$row->errors('user_id', ['Required field']);
+
+		$row->user->errors('username', ['Required']);
+
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$this->assertEquals([], $context->error('title'));
+
+		$expected = ['Gotta have one'];
+		$this->assertEquals($expected, $context->error('body'));
+
+		$expected = ['Required'];
+		$this->assertEquals($expected, $context->error('user.username'));
+	}
+
+/**
  * Setup tables for tests.
  *
  * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Form;
+
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\Network\Request;
+use Cake\TestSuite\TestCase;
+use Cake\View\Form\EntityContext;
+
+/**
+ * Entity context test case.
+ */
+class EntityContextTest extends TestCase {
+
+/**
+ * Fixtures to use.
+ *
+ * @var array
+ */
+	public $fixtures = ['core.article', 'core.comment'];
+
+/**
+ * setup method.
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->request = new Request();
+	}
+
+/**
+ * Test reading data.
+ *
+ * @return void
+ */
+	public function testValBasic() {
+		$row = new Entity([
+			'title' => 'Test entity',
+			'body' => 'Something new'
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+		$result = $context->val('Articles.title');
+		$this->assertEquals($row->title, $result);
+
+		$result = $context->val('title');
+		$this->assertEquals($row->title, $result);
+
+		$result = $context->val('Articles.body');
+		$this->assertEquals($row->body, $result);
+
+		$result = $context->val('body');
+		$this->assertEquals($row->body, $result);
+
+		$result = $context->val('Articles.nope');
+		$this->assertNull($result);
+
+		$result = $context->val('nope');
+		$this->assertNull($result);
+	}
+
+/**
+ * Test reading values from associated entities.
+ *
+ * @return void
+ */
+	public function testValAssociated() {
+		$row = new Entity([
+			'title' => 'Test entity',
+			'user' => new Entity([
+				'username' => 'mark',
+				'fname' => 'Mark'
+			]),
+			'comments' => [
+				new Entity(['comment' => 'Test comment']),
+				new Entity(['comment' => 'Second comment']),
+			]
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$result = $context->val('Articles.user.fname');
+		$this->assertEquals($row->user->fname, $result);
+
+		$result = $context->val('user.fname');
+		$this->assertEquals($row->user->fname, $result);
+
+		$result = $context->val('Articles.comments.0.comment');
+		$this->assertEquals($row->comments[0]->comment, $result);
+
+		$result = $context->val('comments.0.comment');
+		$this->assertEquals($row->comments[0]->comment, $result);
+
+		$result = $context->val('Articles.comments.1.comment');
+		$this->assertEquals($row->comments[1]->comment, $result);
+
+		$result = $context->val('comments.1.comment');
+		$this->assertEquals($row->comments[1]->comment, $result);
+
+		$result = $context->val('Articles.comments.0.nope');
+		$this->assertNull($result);
+
+		$result = $context->val('Articles.comments.0.nope.no_way');
+		$this->assertNull($result);
+	}
+
+}

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -281,4 +281,65 @@ class EntityContextTest extends TestCase {
 		$this->assertFalse($context->isRequired('user.first_name'));
 	}
 
+/**
+ * Test type() basic
+ *
+ * @return void
+ */
+	public function testType() {
+		$articles = TableRegistry::get('Articles');
+		$articles->schema([
+			'title' => ['type' => 'string'],
+			'body' => ['type' => 'text'],
+			'user_id' => ['type' => 'integer']
+		]);
+
+		$row = new Entity([
+			'title' => 'My title',
+			'body' => 'Some content',
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$this->assertEquals('string', $context->type('title'));
+		$this->assertEquals('text', $context->type('body'));
+		$this->assertEquals('integer', $context->type('user_id'));
+		$this->assertNull($context->type('nope'));
+	}
+
+/**
+ * Test getting types for associated records.
+ *
+ * @return void
+ */
+	public function testTypeAssociated() {
+		$articles = TableRegistry::get('Articles');
+		$articles->belongsTo('Users');
+		$users = TableRegistry::get('Users');
+
+		$articles->schema([
+			'title' => ['type' => 'string'],
+			'body' => ['type' => 'text']
+		]);
+		$users->schema([
+			'username' => ['type' => 'string'],
+			'bio' => ['type' => 'text']
+		]);
+
+		$row = new Entity([
+			'title' => 'My title',
+			'user' => new Entity(['username' => 'Mark']),
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$this->assertEquals('string', $context->type('user.username'));
+		$this->assertEquals('text', $context->type('user.bio'));
+		$this->assertNull($context->type('user.nope'));
+	}
+
 }

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -154,8 +154,32 @@ class EntityContextTest extends TestCase {
 		$this->assertFalse($context->isRequired('nope'));
 	}
 
-	public function testIsRequiredCustomValidationMethod() {
-		$this->markTestIncomplete();
+/**
+ * Test validator as a string.
+ *
+ * @return void
+ */
+	public function testIsRequiredStringValidator() {
+		$articles = TableRegistry::get('Articles');
+
+		$validator = $articles->validator();
+		$validator->add('title', 'minlength', [
+			'rule' => ['minlength', 10]
+		])
+		->add('body', 'maxlength', [
+			'rule' => ['maxlength', 1000]
+		])->allowEmpty('body');
+
+		$context = new EntityContext($this->request, [
+			'entity' => new Entity(),
+			'table' => 'Articles',
+			'validator' => 'default',
+		]);
+
+		$this->assertTrue($context->isRequired('Articles.title'));
+		$this->assertTrue($context->isRequired('title'));
+		$this->assertFalse($context->isRequired('Articles.body'));
+		$this->assertFalse($context->isRequired('body'));
 	}
 
 	public function testIsRequiredAssociated() {

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\View\Form;
 
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use Cake\View\Form\EntityContext;
@@ -120,6 +121,49 @@ class EntityContextTest extends TestCase {
 
 		$result = $context->val('Articles.comments.0.nope.no_way');
 		$this->assertNull($result);
+	}
+
+/**
+ * Test isRequired in basic scenarios.
+ *
+ * @return void
+ */
+	public function testIsRequired() {
+		$articles = TableRegistry::get('Articles');
+
+		$validator = $articles->validator();
+		$validator->add('title', 'minlength', [
+			'rule' => ['minlength', 10]
+		])
+		->add('body', 'maxlength', [
+			'rule' => ['maxlength', 1000]
+		])->allowEmpty('body');
+
+		$context = new EntityContext($this->request, [
+			'entity' => new Entity(),
+			'table' => 'Articles',
+			'validator' => $validator
+		]);
+
+		$this->assertTrue($context->isRequired('Articles.title'));
+		$this->assertTrue($context->isRequired('title'));
+		$this->assertFalse($context->isRequired('Articles.body'));
+		$this->assertFalse($context->isRequired('body'));
+
+		$this->assertFalse($context->isRequired('Herp.derp.derp'));
+		$this->assertFalse($context->isRequired('nope'));
+	}
+
+	public function testIsRequiredCustomValidationMethod() {
+		$this->markTestIncomplete();
+	}
+
+	public function testIsRequiredAssociated() {
+		$this->markTestIncomplete();
+	}
+
+	public function testIsRequiredAssociatedValidator() {
+		$this->markTestIncomplete();
 	}
 
 }


### PR DESCRIPTION
This set of changes is part of #2267 and adds a context class for single entities. I decided to start with single entities first as they are easier and I felt that managing a collection/single entity in one class might be too complicated. I'll refactor accordingly when I build out the collection support.

I've left in the ability to do `Articles.title` style inputs. After the conversation in #2754 I'm happy to remove this if people think it doesn't make sense to have it.
