### PR TITLE
BC fix for checkbox ids

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -3287,8 +3287,8 @@ class FormHelperTest extends CakeTestCase {
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'data[Model][multi_field]', 'value' => '', 'id' => 'ModelMultiField'),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'data[Model][multi_field][]', 'value' => '1/2', 'id' => 'ModelMultiField1/2')),
-			array('label' => array('for' => 'ModelMultiField1/2')),
+			array('input' => array('type' => 'checkbox', 'name' => 'data[Model][multi_field][]', 'value' => '1/2', 'id' => 'ModelMultiField12')),
+			array('label' => array('for' => 'ModelMultiField12')),
 			'half',
 			'/label',
 			'/div',
@@ -3568,8 +3568,8 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->radio('Model.field', array('1/2' => 'half'));
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'data[Model][field]', 'value' => '', 'id' => 'ModelField_'),
-			array('input' => array('type' => 'radio', 'name' => 'data[Model][field]', 'value' => '1/2', 'id' => 'ModelField1/2')),
-			'label' => array('for' => 'ModelField1/2'),
+			array('input' => array('type' => 'radio', 'name' => 'data[Model][field]', 'value' => '1/2', 'id' => 'ModelField12')),
+			'label' => array('for' => 'ModelField12'),
 			'half',
 			'/label'
 		);
@@ -4254,16 +4254,16 @@ class FormHelperTest extends CakeTestCase {
  */
 	public function testDomIdSuffix() {
 		$result = $this->Form->domIdSuffix('1 string with 1$-dollar signs');
-		$this->assertEquals('1StringWith1$-dollarSigns', $result);
+		$this->assertEquals('1StringWith1DollarSigns', $result);
 
 		$result = $this->Form->domIdSuffix('<abc x="foo" y=\'bar\'>');
-		$this->assertEquals('AbcX=FooY=Bar', $result);
-
-		$result = $this->Form->domIdSuffix('1 string with 1$-dollar signs', 'xhtml');
-		$this->assertEquals('1StringWith1-dollarSigns', $result);
-
-		$result = $this->Form->domIdSuffix('<abc x="foo" y=\'bar\'>', 'xhtml');
 		$this->assertEquals('AbcXFooYBar', $result);
+
+		$result = $this->Form->domIdSuffix('1 string with 1$-dollar signs', 'html5');
+		$this->assertEquals('1StringWith1$-dollarSigns', $result);
+
+		$result = $this->Form->domIdSuffix('<abc x="foo" y=\'bar\'>', 'html5');
+		$this->assertEquals('AbcX=FooY=Bar', $result);
 	}
 
 /**
@@ -4281,14 +4281,14 @@ class FormHelperTest extends CakeTestCase {
 		$result = $this->Form->domIdSuffix('a\'b');
 		$this->assertEquals('AB2', $result);
 
-		$result = $this->Form->domIdSuffix('1 string with 1$-dollar', 'xhtml');
-		$this->assertEquals('1StringWith1-dollar', $result);
+		$result = $this->Form->domIdSuffix('1 string with 1$-dollar');
+		$this->assertEquals('1StringWith1Dollar', $result);
 
-		$result = $this->Form->domIdSuffix('1 string with 1€-dollar', 'xhtml');
-		$this->assertEquals('1StringWith1-dollar1', $result);
+		$result = $this->Form->domIdSuffix('1 string with 1$-dollar');
+		$this->assertEquals('1StringWith1Dollar1', $result);
 
-		$result = $this->Form->domIdSuffix('1 string with 1$-dollar', 'xhtml');
-		$this->assertEquals('1StringWith1-dollar2', $result);
+		$result = $this->Form->domIdSuffix('1 string with 1$-dollar');
+		$this->assertEquals('1StringWith1Dollar2', $result);
 	}
 
 /**
@@ -5180,31 +5180,32 @@ class FormHelperTest extends CakeTestCase {
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a+', 'id' => 'ModelMultiFieldA+'
+				'value' => 'a+', 'id' => 'ModelMultiFieldA2'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA+')),
+			array('label' => array('for' => 'ModelMultiFieldA2')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a++', 'id' => 'ModelMultiFieldA++'
+				'value' => 'a++', 'id' => 'ModelMultiFieldA1'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA++')),
+			array('label' => array('for' => 'ModelMultiFieldA1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a+++', 'id' => 'ModelMultiFieldA+++'
+				'value' => 'a+++', 'id' => 'ModelMultiFieldA'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA+++')),
+			array('label' => array('for' => 'ModelMultiFieldA')),
 			'third',
 			'/label',
 			'/div'
 		);
+
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->select(

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2078,14 +2078,14 @@ class FormHelper extends AppHelper {
  * limitation, but to avoid layout issues it still filters out some sensitive chars.
  *
  * @param string $value The value that should be transferred into a DOM ID suffix.
- * @param string $type Doctype to use. Defaults to html5. Anything else will use limited chars.
+ * @param string $type Doctype to use. Defaults to html4.
  * @return string DOM ID
  */
-	public function domIdSuffix($value, $type = 'html5') {
+	public function domIdSuffix($value, $type = 'html4') {
 		if ($type === 'html5') {
 			$value = str_replace(array('@', '<', '>', ' ', '"', '\''), '_', $value);
 		} else {
-			$value = preg_replace('~[^\\pL\d-_]+~u', '_', $value);
+			$value = Inflector::camelize(Inflector::slug($value));
 		}
 		$value = Inflector::camelize($value);
 		$count = 1;


### PR DESCRIPTION
Revert to previous behavior for id generation of checkboxes, This can be reverted for 2.5+ if desired

Fixes #2733
