### PR TITLE
Added missing 'Session'-Component in bake

### DIFF
--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -186,7 +186,7 @@ class ControllerTask extends BakeTask {
 				);
 				
 	 	                if (strtolower($wannaUseSession) === 'y') {
-               				array_push($components, 'Session');
+					array_push($components, 'Session');
             			}
 			}
 		} else {

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -184,10 +184,10 @@ class ControllerTask extends BakeTask {
 				$wannaUseSession = $this->in(
 					__d('cake_console', "Would you like to use Session flash messages?"), array('y', 'n'), 'y'
 				);
-				
-	 	                if (strtolower($wannaUseSession) === 'y') {
+
+				if (strtolower($wannaUseSession) === 'y') {
 					array_push($components, 'Session');
-            			}
+				}
 			}
 		} else {
 			list($wannaBakeCrud, $wannaBakeAdminCrud) = $this->_askAboutMethods();

--- a/lib/Cake/Console/Command/Task/ControllerTask.php
+++ b/lib/Cake/Console/Command/Task/ControllerTask.php
@@ -184,6 +184,10 @@ class ControllerTask extends BakeTask {
 				$wannaUseSession = $this->in(
 					__d('cake_console', "Would you like to use Session flash messages?"), array('y', 'n'), 'y'
 				);
+				
+	 	                if (strtolower($wannaUseSession) === 'y') {
+               				array_push($components, 'Session');
+            			}
 			}
 		} else {
 			list($wannaBakeCrud, $wannaBakeAdminCrud) = $this->_askAboutMethods();


### PR DESCRIPTION
If a Controller was baked interactively and one want to use Session flash messages, the required 'Session'-Component wasn't added to the $components-Array
