### PR TITLE
fix unsupported operrand error

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1761,6 +1761,8 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postLink
  */
 	public function postLink($title, $url = null, $options = array(), $confirmMessage = false) {
+		if (!is_array($options))
+			$options = array($options);
 		$options += array('inline' => true, 'block' => null);
 		if (!$options['inline'] && empty($options['block'])) {
 			$options['block'] = __FUNCTION__;


### PR DESCRIPTION
Getting unsupported operand error when bake  view creates PostLink calls with null instead array() for an unused param value. Trying to += an null to an array.  I suppose you could fix the bake template for the correct call but, this cures it for it too.
