### PR TITLE
3.0 collection context

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -150,9 +150,6 @@ class EntityContext {
 		}
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return null;
-		}
 		return $entity->get(array_pop($parts));
 	}
 
@@ -187,7 +184,10 @@ class EntityContext {
 			}
 			$entity = $next;
 		}
-		return [false, false];
+		throw \RuntimeException(sprintf(
+			'Unable to fetch property "%s"',
+			implode(".", $path)
+		));
 	}
 
 /**
@@ -220,15 +220,8 @@ class EntityContext {
 		}
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return false;
-		}
 
 		$validator = $this->_getValidator($prop);
-		if (!$validator) {
-			return false;
-		}
-
 		$field = array_pop($parts);
 		if (!$validator->hasField($field)) {
 			return false;
@@ -242,7 +235,7 @@ class EntityContext {
  * conventions.
  *
  * @param string $entity The entity name to get a validator for.
- * @return Validator|false
+ * @return Validator
  */
 	protected function _getValidator($entity) {
 		$table = $this->_getTable($entity);
@@ -291,9 +284,6 @@ class EntityContext {
 	public function type($field) {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return null;
-		}
 		$table = $this->_getTable($prop);
 		$column = array_pop($parts);
 		return $table->schema()->columnType($column);
@@ -308,9 +298,6 @@ class EntityContext {
 	public function attributes($field) {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return [];
-		}
 		$table = $this->_getTable($prop);
 		$column = $table->schema()->column(array_pop($parts));
 		$whitelist = ['length' => null, 'precision' => null];
@@ -336,9 +323,6 @@ class EntityContext {
 	public function error($field) {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
-		if (!$entity) {
-			return [];
-		}
 		return $entity->errors(array_pop($parts));
 	}
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -25,6 +25,7 @@ use Traversable;
 
 /**
  * Provides a form context around a single entity and its relations.
+ * It also can be used as context around an array or iterator of entities.
  *
  * This class lets FormHelper interface with entities or collections
  * of entities.
@@ -35,7 +36,8 @@ use Traversable;
  * - `table` Either the ORM\Table instance to fetch schema/validators
  *   from, an array of table instances in the case of a form spanning
  *   multiple entities, or the name(s) of the table.
- *   If this is null the table name(s) will be determined using conventions.
+ *   If this is null the table name(s) will be determined using naming
+ *   conventions.
  * - `validator` Either the Validation\Validator to use, or the name of the
  *   validation method to call on the table object. For example 'default'.
  *   Defaults to 'default'. Can be an array of table alias=>validators when

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -155,6 +155,7 @@ class EntityContext {
  *
  * @param array $path The path to traverse to find the leaf entity.
  * @return array
+ * @throws \RuntimeException When properties cannot be read.
  */
 	protected function _getEntity($path) {
 		$entity = $this->_context['entity'];

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -323,6 +323,9 @@ class EntityContext {
 	public function error($field) {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
+		if (!$entity) {
+			return [];
+		}
 		return $entity->errors(array_pop($parts));
 	}
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -17,6 +17,7 @@ namespace Cake\View\Form;
 use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 use Traversable;
 
@@ -92,8 +93,20 @@ class EntityContext {
  */
 	protected function _prepare() {
 		$table = $this->_context['table'];
+		if (empty($table)) {
+			$entity = $this->_context['entity'];
+			if ($entity instanceof Entity) {
+				list($ns, $entityClass) = namespaceSplit(get_class($entity));
+				$table = Inflector::pluralize($entityClass);
+			}
+		}
 		if (is_string($table)) {
 			$table = TableRegistry::get($table);
+		}
+		if (!is_object($table)) {
+			throw new \RuntimeException(
+				'Unable to find table class for current entity'
+			);
 		}
 		$alias = $this->_rootName = $table->alias();
 		$this->_tables[$alias] = $table;

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -14,13 +14,12 @@
  */
 namespace Cake\View\Form;
 
+use Cake\Collection\Collection;
 use Cake\Network\Request;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
-use IteratorAggregate;
-use IteratorIterator;
 use Traversable;
 
 /**
@@ -109,14 +108,8 @@ class EntityContext {
 		$table = $this->_context['table'];
 		if (empty($table)) {
 			$entity = $this->_context['entity'];
-			if ($entity instanceof IteratorAggregate) {
-				$entity = $entity->getIterator()->current();
-			} elseif ($entity instanceof IteratorIterator) {
-				$entity = $entity->getInnerIterator()->current();
-			} elseif ($entity instanceof Traversable) {
-				$entity = $entity->current();
-			} elseif (is_array($entity)) {
-				$entity = current($entity);
+			if (is_array($entity) || $entity instanceof Traversable) {
+				$entity = (new Collection($entity))->first();
 			}
 			if ($entity instanceof Entity) {
 				list($ns, $entityClass) = namespaceSplit(get_class($entity));

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -107,6 +107,7 @@ class EntityContextTest extends TestCase {
 
 		$result = $context->error('title');
 		$this->assertEquals($row->errors('title'), $result);
+		$this->assertTrue($context->hasError('title'));
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -312,6 +312,35 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test reading values from associated entities.
+ *
+ * @return void
+ */
+	public function testValAssociatedHasMany() {
+		$row = new Entity([
+			'title' => 'First post',
+			'user' => new Entity([
+				'username' => 'mark',
+				'fname' => 'Mark',
+				'articles' => [
+					new Entity(['title' => 'First post']),
+					new Entity(['title' => 'Second post']),
+				]
+			]),
+		]);
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+			'table' => 'Articles',
+		]);
+
+		$result = $context->val('user.articles.0.title');
+		$this->assertEquals('First post', $result);
+
+		$result = $context->val('user.articles.1.title');
+		$this->assertEquals('Second post', $result);
+	}
+
+/**
  * Test validator as a string.
  *
  * @return void
@@ -594,6 +623,7 @@ class EntityContextTest extends TestCase {
 
 		$comments = TableRegistry::get('Comments');
 		$users = TableRegistry::get('Users');
+		$users->hasMany('Articles');
 
 		$articles->schema([
 			'id' => ['type' => 'integer', 'length' => 11, 'null' => false],

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Test\TestCase\View\Form;
 
+use ArrayIterator;
+use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Network\Request;
 use Cake\ORM\Entity;
@@ -22,8 +24,6 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
-use ArrayIterator;
-use ArrayObject;
 
 /**
  * Test stub.

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -83,7 +83,8 @@ class EntityContextTest extends TestCase {
 		$this->assertEquals([], $context->error('title'));
 		$this->assertEquals(
 			['length' => null, 'precision' => null],
-			$context->attributes('title'));
+			$context->attributes('title')
+		);
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -54,6 +54,19 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test an invalid table scope throws an error.
+ *
+ * @expectedException \RuntimeException
+ * @expectedExceptionMessage Unable to find table class for current entity
+ */
+	public function testInvalidTable() {
+		$row = new \StdClass();
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+		]);
+	}
+
+/**
  * Test operations that lack a table argument.
  *
  * @return void
@@ -295,6 +308,7 @@ class EntityContextTest extends TestCase {
 
 		$this->assertFalse($context->isRequired('Herp.derp.derp'));
 		$this->assertFalse($context->isRequired('nope'));
+		$this->assertFalse($context->isRequired(''));
 	}
 
 /**
@@ -326,6 +340,8 @@ class EntityContextTest extends TestCase {
 
 		$this->assertTrue($context->isRequired('comments.0.user_id'));
 		$this->assertFalse($context->isRequired('comments.0.other'));
+		$this->assertFalse($context->isRequired('user.0.other'));
+		$this->assertFalse($context->isRequired(''));
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -23,6 +23,12 @@ use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
 
 /**
+ * Test stub.
+ */
+class Article extends Entity {
+}
+
+/**
  * Entity context test case.
  */
 class EntityContextTest extends TestCase {
@@ -42,6 +48,29 @@ class EntityContextTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->request = new Request();
+	}
+
+/**
+ * Test operations that lack a table argument.
+ *
+ * @return void
+ */
+	public function testOperationsNoTableArg() {
+		$row = new Article([
+			'title' => 'Test entity',
+			'body' => 'Something new'
+		]);
+		$row->errors('title', ['Title is required.']);
+
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+		]);
+
+		$result = $context->val('title');
+		$this->assertEquals($row->title, $result);
+
+		$result = $context->error('title');
+		$this->assertEquals($row->errors('title'), $result);
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -67,6 +67,26 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test operations with no entity.
+ *
+ * @return void
+ */
+	public function testOperationsNoEntity() {
+		$context = new EntityContext($this->request, [
+			'table' => 'Articles'
+		]);
+
+		$this->assertNull($context->val('title'));
+		$this->assertFalse($context->isRequired('title'));
+		$this->assertFalse($context->hasError('title'));
+		$this->assertEquals('string', $context->type('title'));
+		$this->assertEquals([], $context->error('title'));
+		$this->assertEquals(
+			['length' => null, 'precision' => null],
+			$context->attributes('title'));
+	}
+
+/**
  * Test operations that lack a table argument.
  *
  * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -22,6 +22,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Validation\Validator;
 use Cake\View\Form\EntityContext;
+use ArrayIterator;
 use ArrayObject;
 
 /**
@@ -76,6 +77,24 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test collection operations that lack a table argument.
+ *
+ * @dataProvider collectionProvider
+ * @return void
+ */
+	public function testCollectionOperationsNoTableArg($collection) {
+		$context = new EntityContext($this->request, [
+			'entity' => $collection,
+		]);
+
+		$result = $context->val('0.title');
+		$this->assertEquals('First post', $result);
+
+		$result = $context->error('1.body');
+		$this->assertEquals(['Not long enough'], $result);
+	}
+
+/**
  * Data provider for testing collections.
  *
  * @return array
@@ -98,6 +117,7 @@ class EntityContextTest extends TestCase {
 		return [
 			'array' => [[$one, $two]],
 			'basic iterator' => [new ArrayObject([$one, $two])],
+			'array iterator' => [new ArrayIterator([$one, $two])],
 			'collection' => [new Collection([$one, $two])],
 		];
 	}


### PR DESCRIPTION
As part of #2267, this set of changes adds support for collectiions/arrays of entities to the EntityContext. Originally, I thought this was going to require a separate class, but it ended up being pretty simple to add to the existing code.

After this, I am going to start integrating the widgets and context classes into formhelper. 
