### PR TITLE
Linked to PHPUnit docs showing multiple options to install it globally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ And run `php composer.phar update`
 
 ## Running tests
 
-Assuming you have PHPUnit installed system wide via PEAR, you can run the tests for cakephp by doing the following:
+Assuming you have PHPUnit installed system wide using one of the methods stated
+[here](http://phpunit.de/manual/current/en/installation.html), you can run the
+tests for cakephp by doing the following:
 
 1. Copy `phpunit.xml.dist` to `phpunit.xml`
 2. Add the relevant database credentials to your phpunit.xml if you want to run tests against


### PR DESCRIPTION
Can we also remove phpunit from `require-dev` in composer config?
