### PR TITLE
Renamed CakeRequest::onlyAllow() to CakeRequest::allowMethod().

### DIFF
--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -392,6 +392,11 @@ class UpgradeShell extends AppShell {
 				'/(\$this->action\b(?!\())/',
 				'$this->request->action'
 			),
+			array(
+				'$this->request->onlyAllow() -> $this->request->allowMethod()',
+				'/\$this->request->onlyAllow\(/',
+				'$this->request->allowMethod('
+			)
 		);
 		$this->_filesRegexpUpdate($patterns);
 	}

--- a/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
+++ b/lib/Cake/Console/Templates/default/actions/controller_actions.ctp
@@ -135,7 +135,7 @@
 		if (!$this-><?php echo $currentModelName; ?>->exists()) {
 			throw new NotFoundException(__('Invalid <?php echo strtolower($singularHumanName); ?>'));
 		}
-		$this->request->onlyAllow('post', 'delete');
+		$this->request->allowMethod('post', 'delete');
 		if ($this-><?php echo $currentModelName; ?>->delete()) {
 <?php if ($wannaUseSession): ?>
 			$this->Session->setFlash(__('The <?php echo strtolower($singularHumanName); ?> has been deleted.'));

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -909,23 +909,23 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
- * Only allow certain HTTP request methods, if the request method does not match
+ * Allow only certain HTTP request methods. If the request method does not match
  * a 405 error will be shown and the required "Allow" response header will be set.
  *
  * Example:
  *
- * $this->request->onlyAllow('post', 'delete');
+ * $this->request->allowMethod('post', 'delete');
  * or
- * $this->request->onlyAllow(array('post', 'delete'));
+ * $this->request->allowMethod(array('post', 'delete'));
  *
  * If the request would be GET, response header "Allow: POST, DELETE" will be set
- * and a 405 error will be returned
+ * and a 405 error will be returned.
  *
- * @param string|array $methods Allowed HTTP request methods
+ * @param string|array $methods Allowed HTTP request methods.
  * @return boolean true
  * @throws MethodNotAllowedException
  */
-	public function onlyAllow($methods) {
+	public function allowMethod($methods) {
 		if (!is_array($methods)) {
 			$methods = func_get_args();
 		}
@@ -938,6 +938,22 @@ class CakeRequest implements ArrayAccess {
 		$e = new MethodNotAllowedException();
 		$e->responseHeader('Allow', $allowed);
 		throw $e;
+	}
+
+/**
+ * Alias of CakeRequest::allowMethod() for backwards compatibility.
+ *
+ * @see CakeRequest::allowMethod()
+ * @deprecated 2.5 Use CakeRequest::allowMethod() instead.
+ * @param string|array $methods Allowed HTTP request methods.
+ * @return boolean true
+ * @throws MethodNotAllowedException
+ */
+	public function onlyAllow($methods) {
+		if (!is_array($methods)) {
+			$methods = func_get_args();
+		}
+		return $this->allowMethod($methods);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2221,38 +2221,44 @@ XML;
 	}
 
 /**
- * Test onlyAllow method
+ * Test allowMethod method
  *
  * @return void
  */
-	public function testOnlyAllow() {
+	public function testAllowMethod() {
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$request = new CakeRequest('/posts/edit/1');
 
+		$this->assertTrue($request->allowMethod(array('put')));
+
+		// BC check
 		$this->assertTrue($request->onlyAllow(array('put')));
 
 		$_SERVER['REQUEST_METHOD'] = 'DELETE';
+		$this->assertTrue($request->allowMethod('post', 'delete'));
+
+		// BC check
 		$this->assertTrue($request->onlyAllow('post', 'delete'));
 	}
 
 /**
- * Test onlyAllow throwing exception
+ * Test allowMethod throwing exception
  *
  * @return void
  */
-	public function testOnlyAllowException() {
+	public function testAllowMethodException() {
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$request = new CakeRequest('/posts/edit/1');
 
 		try {
-			$request->onlyAllow('POST', 'DELETE');
+			$request->allowMethod('POST', 'DELETE');
 			$this->fail('An expected exception has not been raised.');
 		} catch (MethodNotAllowedException $e) {
 			$this->assertEquals(array('Allow' => 'POST, DELETE'), $e->responseHeader());
 		}
 
 		$this->setExpectedException('MethodNotAllowedException');
-		$request->onlyAllow('POST');
+		$request->allowMethod('POST');
 	}
 
 /**

--- a/lib/Cake/Test/bake_compare/Controller/ActionsUsingSessions.ctp
+++ b/lib/Cake/Test/bake_compare/Controller/ActionsUsingSessions.ctp
@@ -81,7 +81,7 @@
 		if (!$this->BakeArticle->exists()) {
 			throw new NotFoundException(__('Invalid bake article'));
 		}
-		$this->request->onlyAllow('post', 'delete');
+		$this->request->allowMethod('post', 'delete');
 		if ($this->BakeArticle->delete()) {
 			$this->Session->setFlash(__('The bake article has been deleted.'));
 		} else {

--- a/lib/Cake/Test/bake_compare/Controller/ActionsWithNoSessions.ctp
+++ b/lib/Cake/Test/bake_compare/Controller/ActionsWithNoSessions.ctp
@@ -75,7 +75,7 @@
 		if (!$this->BakeArticle->exists()) {
 			throw new NotFoundException(__('Invalid bake article'));
 		}
-		$this->request->onlyAllow('post', 'delete');
+		$this->request->allowMethod('post', 'delete');
 		if ($this->BakeArticle->delete()) {
 			return $this->flash(__('The bake article has been deleted.'), array('action' => 'index'));
 		} else {


### PR DESCRIPTION
Existing name is unintuitive and it's not easily apparent what
the method does. Closes #2803
