### PR TITLE
3.0 context improvements

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -36,6 +36,8 @@ use Cake\Utility\Hash;
  *   like maxlength, step and other HTML attributes.
  * - `errors` An array of validation errors. Errors should be nested following
  *   the dot separated paths you access your fields with.
+ * - `isCreate` A boolean that indicates whether or not this form should
+ *   be treated as a create operation. If false this form will be an update.
  */
 class ArrayContext {
 
@@ -66,8 +68,18 @@ class ArrayContext {
 			'required' => [],
 			'defaults' => [],
 			'errors' => [],
+			'create' => true,
 		];
 		$this->_context = $context;
+	}
+
+/**
+ * Returns whether or not this form is for a create operation.
+ *
+ * @return boolean
+ */
+	public function isCreate() {
+		return (bool)$this->_context['create'];
 	}
 
 /**

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -56,7 +56,7 @@ use Cake\Utility\Hash;
  *    ]
  *  ];
  */
-class ArrayContext {
+class ArrayContext implements ContextInterface {
 
 /**
  * The request object.

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -121,7 +121,7 @@ class ArrayContext implements ContextInterface {
 	public function isCreate() {
 		$primary = $this->primaryKey();
 		foreach ($primary as $column) {
-			if (!isset($this->_context['defaults'][$column])) {
+			if (!empty($this->_context['defaults'][$column])) {
 				return false;
 			}
 		}

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Form;
+
+/**
+ * Interface for FormHelper context implementations.
+ */
+interface ContextInterface {
+
+/**
+ * Get the fields used in the context as a primary key.
+ *
+ * @return array
+ */
+	public function primaryKey();
+
+/**
+ * Returns whether or not this form is for a create operation.
+ *
+ * @return boolean
+ */
+	public function isCreate();
+
+/**
+ * Get the current value for a given field.
+ *
+ * @param string $field A dot separated path to the field a value
+ *   is needed for.
+ * @return mixed
+ */
+	public function val($field);
+
+/**
+ * Check if a given field is 'required'.
+ *
+ * In this context class, this is simply defined by the 'required' array.
+ *
+ * @param string $field A dot separated path to check required-ness for.
+ * @return boolean
+ */
+	public function isRequired($field);
+
+/**
+ * Get the abstract field type for a given field name.
+ *
+ * @param string $field A dot separated path to get a schema type for.
+ * @return null|string An abstract data type or null.
+ * @see Cake\Database\Type
+ */
+	public function type($field);
+
+/**
+ * Get an associative array of other attributes for a field name.
+ *
+ * @param string $field A dot separated path to get additional data on.
+ * @return array An array of data describing the additional attributes on a field.
+ */
+	public function attributes($field);
+
+/**
+ * Check whether or not a field has an error attached to it
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return boolean Returns true if the errors for the field are not empty.
+ */
+	public function hasError($field);
+
+/**
+ * Get the errors for a given field
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return array An array of errors, an empty array will be returned when the
+ *    context has no errors.
+ */
+	public function error($field);
+
+}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -130,6 +130,28 @@ class EntityContext {
 	}
 
 /**
+ * Check whether or not this form is a create or update.
+ *
+ * If the context is for a single entity, the entity's isNew() method will
+ * be used. If isNew() returns null, a create operation will be assumed.
+ *
+ * If the context is for a collection or array the first object in the
+ * collection will be used.
+ *
+ * @return boolean
+ */
+	public function isCreate() {
+		$entity = $this->_context['entity'];
+		if (is_array($entity) || $entity instanceof Traversable) {
+			$entity = (new Collection($entity))->first();
+		}
+		if ($entity instanceof Entity) {
+			return $entity->isNew() !== false;
+		}
+		return true;
+	}
+
+/**
  * Get the value for a given path.
  *
  * Traverses the entity data and finds the value for $path.

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -20,6 +20,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
+use Cake\View\Form\ContextInterface;
 use Traversable;
 
 /**
@@ -42,7 +43,7 @@ use Traversable;
  *   Defaults to 'default'. Can be an array of table alias=>validators when
  *   dealing with associated forms.
  */
-class EntityContext {
+class EntityContext implements ContextInterface {
 
 /**
  * The request object.

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -130,6 +130,19 @@ class EntityContext {
 	}
 
 /**
+ * Get the primary key data for the context.
+ *
+ * Gets the primary key columns from the root entity's schema.
+ *
+ * @return boolean
+ */
+	public function primaryKey() {
+		$table = $this->_tables[$this->_rootName];
+		$schema = $table->schema();
+		return $schema->primaryKey();
+	}
+
+/**
  * Check whether or not this form is a create or update.
  *
  * If the context is for a single entity, the entity's isNew() method will

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -42,6 +42,15 @@ class NullContext {
 	}
 
 /**
+ * Returns whether or not this form is for a create operation.
+ *
+ * @return boolean
+ */
+	public function isCreate() {
+		return true;
+	}
+
+/**
  * Get the current value for a given field.
  *
  * This method will coalesce the current request data and the 'defaults'

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -15,6 +15,7 @@
 namespace Cake\View\Form;
 
 use Cake\Network\Request;
+use Cake\View\Form\ContextInterface;
 
 /**
  * Provides a context provider that does nothing.
@@ -22,7 +23,7 @@ use Cake\Network\Request;
  * This context provider simply fulfils the interface requirements
  * that FormHelper has and allows access to the request data.
  */
-class NullContext {
+class NullContext implements ContextInterface {
 
 /**
  * The request object.
@@ -42,86 +43,56 @@ class NullContext {
 	}
 
 /**
- * Get the fields used in the context as a primary key.
- *
- * @return array
+ * {@inheritDoc}
  */
 	public function primaryKey() {
 		return [];
 	}
 
 /**
- * Returns whether or not this form is for a create operation.
- *
- * @return boolean
+ * {@inheritDoc}
  */
 	public function isCreate() {
 		return true;
 	}
 
 /**
- * Get the current value for a given field.
- *
- * This method will coalesce the current request data and the 'defaults'
- * array.
- *
- * @param string $field A dot separated path to the field a value
- *   is needed for.
- * @return mixed
+ * {@inheritDoc}
  */
 	public function val($field) {
 		return $this->_request->data($field);
 	}
 
 /**
- * Check if a given field is 'required'.
- *
- * In this context class, this is simply defined by the 'required' array.
- *
- * @param string $field A dot separated path to check required-ness for.
- * @return boolean
+ * {@inheritDoc}
  */
 	public function isRequired($field) {
 		return false;
 	}
 
 /**
- * Get the abstract field type for a given field name.
- *
- * @param string $field A dot separated path to get a schema type for.
- * @return null|string An abstract data type or null.
- * @see Cake\Database\Type
+ * {@inheritDoc}
  */
 	public function type($field) {
 		return null;
 	}
 
 /**
- * Get an associative array of other attributes for a field name.
- *
- * @param string $field A dot separated path to get additional data on.
- * @return array An array of data describing the additional attributes on a field.
+ * {@inheritDoc}
  */
 	public function attributes($field) {
 		return [];
 	}
 
 /**
- * Check whether or not a field has an error attached to it
- *
- * @param string $field A dot separated path to check errors on.
- * @return boolean Returns true if the errors for the field are not empty.
+ * {@inheritDoc}
  */
 	public function hasError($field) {
 		return false;
 	}
 
 /**
- * Get the errors for a given field
- *
- * @param string $field A dot separated path to check errors on.
- * @return array An array of errors, an empty array will be returned when the
- *    context has no errors.
+ * {@inheritDoc}
  */
 	public function error($field) {
 		return [];

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Form;
+
+use Cake\Network\Request;
+
+/**
+ * Provides a context provider that does nothing.
+ *
+ * This context provider simply fulfils the interface requirements
+ * that FormHelper has and allows access to the request data.
+ */
+class NullContext {
+
+/**
+ * The request object.
+ *
+ * @var Cake\Network\Request
+ */
+	protected $_request;
+
+/**
+ * Constructor.
+ *
+ * @param Cake\Network\Request
+ * @param array
+ */
+	public function __construct(Request $request, array $context) {
+		$this->_request = $request;
+	}
+
+/**
+ * Get the current value for a given field.
+ *
+ * This method will coalesce the current request data and the 'defaults'
+ * array.
+ *
+ * @param string $field A dot separated path to the field a value
+ *   is needed for.
+ * @return mixed
+ */
+	public function val($field) {
+		return $this->_request->data($field);
+	}
+
+/**
+ * Check if a given field is 'required'.
+ *
+ * In this context class, this is simply defined by the 'required' array.
+ *
+ * @param string $field A dot separated path to check required-ness for.
+ * @return boolean
+ */
+	public function isRequired($field) {
+		return false;
+	}
+
+/**
+ * Get the abstract field type for a given field name.
+ *
+ * @param string $field A dot separated path to get a schema type for.
+ * @return null|string An abstract data type or null.
+ * @see Cake\Database\Type
+ */
+	public function type($field) {
+		return null;
+	}
+
+/**
+ * Get an associative array of other attributes for a field name.
+ *
+ * @param string $field A dot separated path to get additional data on.
+ * @return array An array of data describing the additional attributes on a field.
+ */
+	public function attributes($field) {
+		return [];
+	}
+
+/**
+ * Check whether or not a field has an error attached to it
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return boolean Returns true if the errors for the field are not empty.
+ */
+	public function hasError($field) {
+		return false;
+	}
+
+/**
+ * Get the errors for a given field
+ *
+ * @param string $field A dot separated path to check errors on.
+ * @return array An array of errors, an empty array will be returned when the
+ *    context has no errors.
+ */
+	public function error($field) {
+		return [];
+	}
+
+}

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -42,6 +42,15 @@ class NullContext {
 	}
 
 /**
+ * Get the fields used in the context as a primary key.
+ *
+ * @return array
+ */
+	public function primaryKey() {
+		return [];
+	}
+
+/**
  * Returns whether or not this form is for a create operation.
  *
  * @return boolean

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -81,20 +81,6 @@ class PaginatorHelper extends Helper {
 	}
 
 /**
- * Get/set templates to use.
- *
- * @param string|null|array $templates null or string allow reading templates. An array
- *   allows templates to be added.
- * @return void|string|array
- */
-	public function templates($templates = null) {
-		if ($templates === null || is_string($templates)) {
-			return $this->_templater->get($templates);
-		}
-		return $this->_templater->add($templates);
-	}
-
-/**
  * Before render callback. Overridden to merge passed args with URL options.
  *
  * @param Cake\Event\Event $event The event instance.

--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -38,8 +38,14 @@ trait StringTemplateTrait {
  */
 	public function initStringTemplates($templates = [], $templateClass = '\Cake\View\StringTemplate') {
 		$this->_templater = new $templateClass($templates);
-		if (isset($this->settings['templates'])) {
+		if (empty($this->settings['templates'])) {
+			return;
+		}
+		if (is_string($this->settings['templates'])) {
 			$this->_templater->load($this->settings['templates']);
+		}
+		if (is_array($this->settings['templates'])) {
+			$this->_templater->add($this->settings['templates']);
 		}
 	}
 

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -34,6 +34,35 @@ class ArrayContextTest extends TestCase {
 	}
 
 /**
+ * Test getting the primary key.
+ *
+ * @return void
+ */
+	public function testPrimaryKey() {
+		$context = new ArrayContext($this->request, []);
+		$this->assertEquals([], $context->primaryKey());
+
+		$context = new ArrayContext($this->request, [
+			'schema' => [
+				'_constraints' => 'mistake',
+			]
+		]);
+		$this->assertEquals([], $context->primaryKey());
+
+		$data = [
+			'schema' => [
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
+			],
+		];
+		$context = new ArrayContext($this->request, $data);
+
+		$expected = ['id'];
+		$this->assertEquals($expected, $context->primaryKey());
+	}
+
+/**
  * Test the isCreate method.
  *
  * @return void
@@ -42,14 +71,18 @@ class ArrayContextTest extends TestCase {
 		$context = new ArrayContext($this->request, []);
 		$this->assertTrue($context->isCreate());
 
-		$context = new ArrayContext($this->request, [
-			'create' => false,
-		]);
+		$data = [
+			'schema' => [
+				'_constraints' => [
+					'primary' => ['type' => 'primary', 'columns' => ['id']]
+				]
+			],
+		];
+		$context = new ArrayContext($this->request, $data);
 		$this->assertFalse($context->isCreate());
 
-		$context = new ArrayContext($this->request, [
-			'create' => true,
-		]);
+		$data['defaults'] = ['id' => 2];
+		$context = new ArrayContext($this->request, $data);
 		$this->assertTrue($context->isCreate());
 	}
 

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -34,6 +34,26 @@ class ArrayContextTest extends TestCase {
 	}
 
 /**
+ * Test the isCreate method.
+ *
+ * @return void
+ */
+	public function testIsCreate() {
+		$context = new ArrayContext($this->request, []);
+		$this->assertTrue($context->isCreate());
+
+		$context = new ArrayContext($this->request, [
+			'create' => false,
+		]);
+		$this->assertFalse($context->isCreate());
+
+		$context = new ArrayContext($this->request, [
+			'create' => true,
+		]);
+		$this->assertTrue($context->isCreate());
+	}
+
+/**
  * Test reading values from the request & defaults.
  */
 	public function testValPresent() {

--- a/tests/TestCase/View/Form/ArrayContextTest.php
+++ b/tests/TestCase/View/Form/ArrayContextTest.php
@@ -79,11 +79,11 @@ class ArrayContextTest extends TestCase {
 			],
 		];
 		$context = new ArrayContext($this->request, $data);
-		$this->assertFalse($context->isCreate());
+		$this->assertTrue($context->isCreate());
 
 		$data['defaults'] = ['id' => 2];
 		$context = new ArrayContext($this->request, $data);
-		$this->assertTrue($context->isCreate());
+		$this->assertFalse($context->isCreate());
 	}
 
 /**

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -54,6 +54,19 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test getting primary key data.
+ *
+ * @return void
+ */
+	public function testPrimaryKey() {
+		$row = new Article();
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+		]);
+		$this->assertEquals(['id'], $context->primaryKey());
+	}
+
+/**
  * Test isCreate on a single entity.
  *
  * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -54,6 +54,38 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Test isCreate on a single entity.
+ *
+ * @return void
+ */
+	public function testIsCreateSingle() {
+		$row = new Entity();
+		$context = new EntityContext($this->request, [
+			'entity' => $row,
+		]);
+		$this->assertTrue($context->isCreate());
+
+		$row->isNew(false);
+		$this->assertFalse($context->isCreate());
+
+		$row->isNew(true);
+		$this->assertTrue($context->isCreate());
+	}
+
+/**
+ * Test isCreate on a collection.
+ *
+ * @dataProvider collectionProvider
+ * @return void
+ */
+	public function testIsCreateCollection($collection) {
+		$context = new EntityContext($this->request, [
+			'entity' => $collection,
+		]);
+		$this->assertTrue($context->isCreate());
+	}
+
+/**
  * Test an invalid table scope throws an error.
  *
  * @expectedException \RuntimeException

--- a/tests/TestCase/View/Helper/StringTemplateTraitTest.php
+++ b/tests/TestCase/View/Helper/StringTemplateTraitTest.php
@@ -54,6 +54,25 @@ class StringTemplateTraitTest extends TestCase {
 	}
 
 /**
+ * test settings['templates']
+ *
+ * @return void
+ */
+	public function testInitStringTemplatesArrayForm() {
+		$this->Template->settings['templates'] = [
+			'text' => '<p>{{text}}</p>',
+		];
+		$this->Template->initStringTemplates();
+
+		$result = $this->Template->templates(null);
+		$this->assertEquals($result, [
+			'attribute' => '{{name}}="{{value}}"',
+			'compactAttribute' => '{{name}}="{{value}}"',
+			'text' => '<p>{{text}}</p>'
+		]);
+	}
+
+/**
  * testFormatStringTemplate
  *
  * @return void


### PR DESCRIPTION
As part of #2667, I started working on `FormHelper::create()` and noticed a few methods I needed from the context classes were missing. This set of changes fixes those gaps by adding primaryKey retrieval and whether or not the form is for an update.  Both of these are required for `FormHelper::create()` to continue behaving as it does today.

I've also added a NullContext. This class will be hooked up as the fallback context if the form's 'model' is not an ORM and doesn't smell like an array context. If you think this is a bit silly let me know and I can make the array context the fallback.
