### PR TITLE
Compile route before getName() to ensure same value is always returned. ...

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -224,6 +224,9 @@ class Route {
 		if (!empty($this->_name)) {
 			return $this->_name;
 		}
+		if (!$this->compiled()) {
+			$this->compile();
+		}
 		$name = '';
 		if (isset($this->defaults['plugin'])) {
 			$name = $this->defaults['plugin'] . '.';


### PR DESCRIPTION
Minor bug. The Route need to be compiled if want to avoid situation in which getName() returns a different value before and after the route is compiled.
