### PR TITLE
3.0 translation save

### DIFF
--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -88,7 +88,8 @@ class TupleComparison extends Comparison {
 			$type = $this->_type;
 			$multiType = is_array($type);
 			$isMulti = $this->isMulti($i, $type);
-			$type = $isMulti ? str_replace('[]', '', $type) : $type;
+			$type = $multiType ? $type : str_replace('[]', '', $type);
+			$type = $type ?: null;
 
 			if ($isMulti) {
 				$bound = [];

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -148,13 +148,15 @@ class TranslateBehavior extends Behavior {
 		}, $query::PREPEND);
 	}
 
-	public function beforeSave(Event $event, $entity) {
+	public function beforeSave(Event $event, $entity, $options) {
 		$locale = $entity->get('_locale') ?: $this->locale();
 
 		if (!$locale) {
 			return;
 		}
 
+		$newOptions = ['I18n' => ['validate' => false]];
+		$options['associated'] =  $newOptions + $options['associated'];
 		$values = $entity->extract($this->config()['fields'], true);
 		$fields = array_keys($values);
 		$key = $entity->get(current((array)$this->_table->primaryKey()));
@@ -162,6 +164,7 @@ class TranslateBehavior extends Behavior {
 		$preexistent = TableRegistry::get('I18n')->find()
 			->select(['id', 'field'])
 			->where(['field IN' => $fields, 'locale' => $locale, 'foreign_key' => $key])
+			->bufferResults(false)
 			->indexBy('field');
 
 		$modified = [];

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Model\Behavior;
 
+use ArrayObject;
 use Cake\Collection\Collection;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
@@ -148,7 +149,16 @@ class TranslateBehavior extends Behavior {
 		}, $query::PREPEND);
 	}
 
-	public function beforeSave(Event $event, $entity, $options) {
+/**
+ * Modifies the entity before it is saved so that translated fields are persisted
+ * in the database too.
+ *
+ * @param \Cake\Event\Event the beforeSave event that was fired
+ * @param \Cake\ORM\Entity the entity that is going to be saved
+ * @param \ArrayObject $options the options passed to the save method
+ * @return void
+ */
+	public function beforeSave(Event $event, Entity $entity, ArrayObject $options) {
 		$locale = $entity->get('_locale') ?: $this->locale();
 
 		if (!$locale) {

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -171,8 +171,9 @@ class TranslateBehavior extends Behavior {
 		}
 
 		$new = array_diff_key($values, $modified);
+		$model = $this->_table->alias();
 		foreach ($new as $field => $content) {
-			$new[$field] = new Entity(compact('locale', 'field', 'content'), [
+			$new[$field] = new Entity(compact('locale', 'field', 'content', 'model'), [
 				'useSetters' => false,
 				'markNew' => true
 			]);

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -149,7 +149,7 @@ class TranslateBehavior extends Behavior {
 	}
 
 	public function beforeSave(Event $event, $entity) {
-		$locale = $this->locale();
+		$locale = $entity->get('_locale') ?: $this->locale();
 
 		if (!$locale) {
 			return;
@@ -180,6 +180,8 @@ class TranslateBehavior extends Behavior {
 		}
 
 		$entity->set('_i18n', array_values($modified + $new));
+		$entity->set('_locale', $locale, ['setter' => false]);
+		$entity->dirty('_locale', false);
 
 		foreach ($fields as $field) {
 			$entity->dirty($field, false);

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -166,7 +166,7 @@ class TranslateBehavior extends Behavior {
 		}
 
 		$newOptions = ['I18n' => ['validate' => false]];
-		$options['associated'] =  $newOptions + $options['associated'];
+		$options['associated'] = $newOptions + $options['associated'];
 		$values = $entity->extract($this->config()['fields'], true);
 		$fields = array_keys($values);
 		$key = $entity->get(current((array)$this->_table->primaryKey()));

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -313,6 +313,7 @@ trait ExternalAssociationTrait {
  */
 	protected function _buildSubquery($query, $foreignKey) {
 		$filterQuery = clone $query;
+		$filterQuery->limit(null);
 		$filterQuery->contain([], true);
 		$joins = $filterQuery->join();
 		foreach ($joins as $i => $join) {

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -780,8 +780,7 @@ class Query extends DatabaseQuery {
 		if ($this->_dirty) {
 			$this->limit(1);
 		}
-		$this->_results = $this->all();
-		return $this->_results->first();
+		return $this->all()->first();
 	}
 
 /**

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -548,4 +548,25 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('First Article Body', $article->get('body'));
 	}
 
+/**
+ * Tests that translations are added to the whitelist of associations to be
+ * saved
+ *
+ * @return void
+ */
+	public function testSaveTranslationWithAssociationWhitelist() {
+		$table = TableRegistry::get('Articles');
+		$table->hasMany('Comments');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('fra');
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$article->set('title', 'Le titre');
+		$table->save($article, ['associated' => ['Comments']]);
+
+		$article = $table->find()->first();
+		$this->assertEquals('Le titre', $article->get('title'));
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -491,4 +491,33 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('A translated body', $article->get('body'));
 	}
 
+/**
+ * Tests adding new translation to a record
+ *
+ * @return void
+ */
+	public function testInsertNewTranslations() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('fra');
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$article->set('title', 'Le titre');
+		$table->save($article);
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('Le titre', $article->get('title'));
+		$this->assertEquals('First Article Body', $article->get('body'));
+
+		$article->set('title', 'Un autre titre');
+		$article->set('body', 'Le contenu');
+		$table->save($article);
+
+		$article = $table->find()->first();
+		$this->assertEquals('Un autre titre', $article->get('title'));
+		$this->assertEquals('Le contenu', $article->get('body'));
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -426,6 +426,7 @@ class TranslateBehaviorTest extends TestCase {
 
 		$results = $table->find()
 			->select(['title', 'body'])
+			->order(['title' => 'asc'])
 			->contain(['Authors' => function($q) {
 				return $q->select(['id', 'name']);
 			}]);

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -456,4 +456,39 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $results);
 	}
 
+/**
+ * Tests that updating an existing record translations work
+ *
+ * @return void
+ */
+	public function testUpdateSingleLocale() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$table->locale('eng');
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$article->set('title', 'New translated article');
+		$table->save($article);
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('New translated article', $article->get('title'));
+		$this->assertEquals('Content #1', $article->get('body'));
+
+		$table->locale(false);
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('First Article', $article->get('title'));
+
+		$table->locale('eng');
+		$article->set('title', 'Wow, such translated article');
+		$article->set('body', 'A translated body');
+		$table->save($article);
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('Wow, such translated article', $article->get('title'));
+		$this->assertEquals('A translated body', $article->get('body'));
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -505,6 +505,7 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals(1, $article->get('id'));
 		$article->set('title', 'Le titre');
 		$table->save($article);
+		$this->assertEquals('fra', $article->get('_locale'));
 
 		$article = $table->find()->first();
 		$this->assertEquals(1, $article->get('id'));
@@ -518,6 +519,33 @@ class TranslateBehaviorTest extends TestCase {
 		$article = $table->find()->first();
 		$this->assertEquals('Un autre titre', $article->get('title'));
 		$this->assertEquals('Le contenu', $article->get('body'));
+	}
+
+/**
+ * Tests that it is possible to use the _locale property to specify the language
+ * to use for saving an entity
+ *
+ * @return void
+ */
+	public function testUpdateTranslationWithLocaleInEntity() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$article->set('_locale', 'fra');
+		$article->set('title', 'Le titre');
+		$table->save($article);
+
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('First Article', $article->get('title'));
+		$this->assertEquals('First Article Body', $article->get('body'));
+
+		$table->locale('fra');
+		$article = $table->find()->first();
+		$this->assertEquals(1, $article->get('id'));
+		$this->assertEquals('Le titre', $article->get('title'));
+		$this->assertEquals('First Article Body', $article->get('body'));
 	}
 
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -885,7 +885,10 @@ class QueryTest extends TestCase {
 		$params = [$this->connection, $this->table];
 		$query = $this->getMock('\Cake\ORM\Query', ['execute'], $params);
 
-		$statement = $this->getMock('\Database\StatementInterface', ['fetch', 'closeCursor']);
+		$statement = $this->getMock(
+			'\Database\StatementInterface',
+			['fetch', 'closeCursor', 'rowCount']
+		);
 		$statement->expects($this->exactly(3))
 			->method('fetch')
 			->will($this->onConsecutiveCalls(['a' => 1], ['a' => 2], false));


### PR DESCRIPTION
As part of the changes for https://github.com/cakephp/cakephp/issues/2258 this adds support for saving translations for a single language using the TranslateBehavior
