### PR TITLE
Fix uploadError validation rule

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -2368,9 +2368,11 @@ class ValidationTest extends CakeTestCase {
 	public function testUploadError() {
 		$this->assertTrue(Validation::uploadError(0));
 		$this->assertTrue(Validation::uploadError(array('error' => 0)));
+		$this->assertTrue(Validation::uploadError(array('error' => '0')));
 
 		$this->assertFalse(Validation::uploadError(2));
 		$this->assertFalse(Validation::uploadError(array('error' => 2)));
+		$this->assertFalse(Validation::uploadError(array('error' => '2')));
 	}
 
 /**

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -964,7 +964,7 @@ class Validation {
 			$check = $check['error'];
 		}
 
-		return $check === UPLOAD_ERR_OK;
+		return (int)$check === UPLOAD_ERR_OK;
 	}
 
 /**


### PR DESCRIPTION
The error inside the upload array contains `(string)0` which would always fail due to the strict comparison against an integer 0.
This resolves it.

The initial test cases were an incorrect assumption (or only valid to a subset of OS), and due to non existent integration tests this was probably never detected.

Complete debug() dump of the upload post data of this key (OS Win8, PHP5.4):

``` php
array(
    'name' => 'codes.csv',
    'type' => 'application/octet-stream',
    'tmp_name' => '...\tmp\php6F13.tmp',
    'error' => '0',
    'size' => '20000'
)
```

var_dump()

```
array (size=5)
  'name' => string 'codes.csv' (length=9)
  'type' => string 'application/octet-stream' (length=24)
  'tmp_name' => string '...\tmp\phpB228.tmp' (length=27)
  'error' => string '0' (length=1)
  'size' => string '20000' (length=5)
```
