### PR TITLE
3.0 hidden input

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -190,7 +190,7 @@ class ArrayContext implements ContextInterface {
 		if (!is_array($this->_context['schema'])) {
 			return [];
 		}
-		$schema = Hash::get($this->_context['schema'], $field);
+		$schema = (array)Hash::get($this->_context['schema'], $field);
 		$whitelist = ['length' => null, 'precision' => null];
 		return array_intersect_key($schema, $whitelist);
 	}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -359,7 +359,7 @@ class EntityContext implements ContextInterface {
 		$parts = explode('.', $field);
 		list($entity, $prop) = $this->_getEntity($parts);
 		$table = $this->_getTable($prop);
-		$column = $table->schema()->column(array_pop($parts));
+		$column = (array)$table->schema()->column(array_pop($parts));
 		$whitelist = ['length' => null, 'precision' => null];
 		return array_intersect_key($column, $whitelist);
 	}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1596,7 +1596,7 @@ class FormHelper extends Helper {
 		));
 
 		if ($secure === true) {
-			$this->_secure(true, null, '' . $options['value']);
+			$this->_secure(true, null, '' . $options['val']);
 		}
 
 		$options['type'] = 'hidden';

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -428,7 +428,8 @@ class FormHelper extends Helper {
 			return '';
 		}
 		return $this->hidden('_csrfToken', array(
-			'value' => $this->request->params['_csrfToken'], 'id' => 'Token' . mt_rand(),
+			'value' => $this->request->params['_csrfToken'],
+			'id' => 'Token' . mt_rand(),
 			'secure' => static::SECURE_SKIP
 		));
 	}
@@ -2848,8 +2849,17 @@ class FormHelper extends Helper {
 			$options['disabled'] = true;
 		}
 
-		$options['val'] = $this->_context->val($field);
-		$options += $this->_context->attributes($field);
+		if (!isset($options['name'])) {
+			$options['name'] = $field;
+		}
+		if (isset($options['value']) && !isset($options['val'])) {
+			$options['val'] = $options['value'];
+			unset($options['value']);
+		}
+		if (!isset($options['val'])) {
+			$options['val'] = $this->_context->val($field);
+		}
+		$options += (array)$this->_context->attributes($field);
 
 		if ($this->_context->hasError($field)) {
 			$options = $this->addClass($options, $this->settings['errorClass']);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -63,6 +63,15 @@ class FormHelper extends Helper {
 	);
 
 /**
+ * Settings for the helper.
+ *
+ * @var array
+ */
+	public $settings = [
+		'errorClass' => 'form-error'
+	];
+
+/**
  * List of fields created, used with secure forms.
  *
  * @var array
@@ -163,6 +172,7 @@ class FormHelper extends Helper {
 		'formstart' => '<form{{attrs}}>',
 		'formend' => '</form>',
 		'hiddenblock' => '<div style="display:none;">{{content}}</div>',
+		'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
 	];
 
 /**
@@ -1588,7 +1598,8 @@ class FormHelper extends Helper {
 			$this->_secure(true, null, '' . $options['value']);
 		}
 
-		return $this->Html->useTag('hidden', $options['name'], array_diff_key($options, array('name' => null)));
+		$options['type'] = 'hidden';
+		return $this->widget('hidden', $options);
 	}
 
 /**
@@ -2808,7 +2819,7 @@ class FormHelper extends Helper {
 
 /**
  * Sets field defaults and adds field to form security input hash.
- * Will also add a 'form-error' class if the field contains validation errors.
+ * Will also add the error class if the field contains validation errors.
  *
  * ### Options
  *
@@ -2823,7 +2834,7 @@ class FormHelper extends Helper {
  * @param array $options Array of options to append options into.
  * @return array Array of options for the input.
  */
-	protected function _initInputField($field, $options = array()) {
+	protected function _initInputField($field, $options = []) {
 		if (isset($options['secure'])) {
 			$secure = $options['secure'];
 			unset($options['secure']);
@@ -2837,26 +2848,26 @@ class FormHelper extends Helper {
 			$options['disabled'] = true;
 		}
 
-		$result = parent::_initInputField($field, $options);
-		if ($this->tagIsInvalid() !== false) {
-			$result = $this->addClass($result, 'form-error');
+		$options['val'] = $this->_context->val($field);
+		$options += $this->_context->attributes($field);
+
+		if ($this->_context->hasError($field)) {
+			$options = $this->addClass($options, $this->settings['errorClass']);
 		}
-		if (!empty($result['disabled']) || $secure === static::SECURE_SKIP) {
-			return $result;
+		if (!empty($options['disabled']) || $secure === static::SECURE_SKIP) {
+			return $options;
 		}
 
-		if (!isset($result['required']) &&
-			$this->_introspectModel($this->model(), 'validates', $this->field())
-		) {
-			$result['required'] = true;
+		if (!isset($options['required']) && $this->_context->isRequired($field)) {
+			$options['required'] = true;
 		}
 
 		if ($secure === self::SECURE_SKIP) {
-			return $result;
+			return $options;
 		}
 
 		$this->_secure($secure, $this->_secureFieldName($options));
-		return $result;
+		return $options;
 	}
 
 /**
@@ -2981,8 +2992,7 @@ class FormHelper extends Helper {
  * @return void
  */
 	public function widget($name, array $data = []) {
-		$widget = $this->_registry->get($name);
-		return $widget->render($data);
+		return $this->_registry->get($name)->render($data);
 	}
 
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -599,7 +599,7 @@ class FormHelperTest extends TestCase {
  * @return array
  */
 	public function contextSelectionProvider() {
-		$entity = $this->getMock('Cake\ORM\Entity');
+		$entity = new Article();
 		$collection = $this->getMock('Cake\Collection\Collection', ['extract'], [[$entity]]);
 		$data = [
 			'schema' => [
@@ -623,6 +623,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testCreateContextSelectionBuiltIn($data, $class) {
+		$this->loadFixtures('Article');
 		$this->Form->create($data);
 		$this->assertInstanceOf($class, $this->Form->context());
 	}
@@ -1115,12 +1116,11 @@ class FormHelperTest extends TestCase {
 	public function testCreateWithSecurity() {
 		$this->Form->request->params['_csrfToken'] = 'testKey';
 		$encoding = strtolower(Configure::read('App.encoding'));
-		$article = new Article();
-		$result = $this->Form->create($article, [
-			'url' => '/contacts/add',
+		$result = $this->Form->create($this->article, [
+			'url' => '/articles/publish',
 		]);
 		$expected = array(
-			'form' => array('method' => 'post', 'action' => '/contacts/add', 'accept-charset' => $encoding),
+			'form' => array('method' => 'post', 'action' => '/articles/publish', 'accept-charset' => $encoding),
 			'div' => array('style' => 'display:none;'),
 			array('input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST')),
 			array('input' => array(
@@ -1130,7 +1130,7 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->create($article, ['url' => '/contacts/add', 'id' => 'MyForm']);
+		$result = $this->Form->create($this->article, ['url' => '/articles/publish', 'id' => 'MyForm']);
 		$expected['form']['id'] = 'MyForm';
 		$this->assertTags($result, $expected);
 	}
@@ -1163,7 +1163,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testCreateClearingFields() {
 		$this->Form->fields = array('model_id');
-		$this->Form->create(new Article());
+		$this->Form->create($this->article);
 		$this->assertEquals(array(), $this->Form->fields);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7829,12 +7829,14 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testHiddenField() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$Contact->validationErrors['field'] = 1;
-		$this->Form->request->data['Contact']['field'] = 'test';
-		$result = $this->Form->hidden('Contact.field', array('id' => 'theID'));
+		$this->article['errors'] = [
+			'field' => true
+		];
+		$this->Form->request->data['field'] = 'test';
+		$this->Form->create($this->article);
+		$result = $this->Form->hidden('field', array('id' => 'theID'));
 		$this->assertTags($result, array(
-			'input' => array('type' => 'hidden', 'class' => 'form-error', 'name' => 'Contact[field]', 'id' => 'theID', 'value' => 'test'))
+			'input' => array('type' => 'hidden', 'class' => 'form-error', 'name' => 'field', 'id' => 'theID', 'value' => 'test'))
 		);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7838,6 +7838,12 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, array(
 			'input' => array('type' => 'hidden', 'class' => 'form-error', 'name' => 'field', 'id' => 'theID', 'value' => 'test'))
 		);
+
+		$result = $this->Form->hidden('field', ['value' => 'my value']);
+		$expected = [
+			'input' => ['type' => 'hidden', 'class' => 'form-error', 'name' => 'field', 'value' => 'my value']
+		];
+		$this->assertTags($result, $expected);
 	}
 
 /**


### PR DESCRIPTION
Part of #2267. This set of changes update the hidden() method to use the new widget system. It also rebuilds some common internal helper method. Notably `_initInputField` which is where most of the magic in  FormHelper happened. It is far less magical now as it no longer calculates id attributes.

I've also made the previously hard-coded 'form-error' value a config option. I don't really relish having discussions around that value anymore. Making it an overridable default fits in well with all the tags being replaceable as well.

Next I'll work on the simpler input types like textarea, text, password and other simple HTML5 input types.
