### PR TITLE
3.0 textarea, text and password types

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1539,7 +1539,7 @@ class FormHelper extends Helper {
  * @throws Cake\Error\Exception When there are no params for the method call.
  */
 	public function __call($method, $params) {
-		$options = array();
+		$options = [];
 		if (empty($params)) {
 			throw new Error\Exception(sprintf('Missing field name for FormHelper::%s', $method));
 		}
@@ -1550,7 +1550,7 @@ class FormHelper extends Helper {
 			$options['type'] = $method;
 		}
 		$options = $this->_initInputField($params[0], $options);
-		return $this->Html->useTag('input', $options['name'], array_diff_key($options, array('name' => null)));
+		return $this->widget($options['type'], $options);
 	}
 
 /**
@@ -2861,6 +2861,7 @@ class FormHelper extends Helper {
 			$first = array_shift($parts);
 			$options['name'] = $first . ($parts ? '[' . implode('][', $parts) . ']' : '');
 		}
+
 		if (isset($options['value']) && !isset($options['val'])) {
 			$options['val'] = $options['value'];
 			unset($options['value']);
@@ -2868,6 +2869,11 @@ class FormHelper extends Helper {
 		if (!isset($options['val'])) {
 			$options['val'] = $context->val($field);
 		}
+		if (!isset($options['val']) && isset($options['default'])) {
+			$options['val'] = $options['default'];
+		}
+		unset($options['default']);
+
 		$options += (array)$context->attributes($field);
 
 		if ($context->hasError($field)) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -173,6 +173,7 @@ class FormHelper extends Helper {
 		'formend' => '</form>',
 		'hiddenblock' => '<div style="display:none;">{{content}}</div>',
 		'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
+		'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
 	];
 
 /**
@@ -1568,14 +1569,18 @@ class FormHelper extends Helper {
 		$options = $this->_initInputField($fieldName, $options);
 		$value = null;
 
-		if (array_key_exists('value', $options)) {
-			$value = $options['value'];
+		if (array_key_exists('val', $options)) {
+			$value = $options['val'];
 			if (!array_key_exists('escape', $options) || $options['escape'] !== false) {
 				$value = h($value);
 			}
-			unset($options['value']);
 		}
-		return $this->Html->useTag('textarea', $options['name'], array_diff_key($options, array('type' => null, 'name' => null)), $value);
+		unset($options['val']);
+		return $this->formatTemplate('textarea', [
+			'name' => $options['name'],
+			'value' => $value,
+			'attrs' => $this->_templater->formatAttributes($options, ['name']),
+		]);
 	}
 
 /**
@@ -2852,7 +2857,9 @@ class FormHelper extends Helper {
 		}
 
 		if (!isset($options['name'])) {
-			$options['name'] = $field;
+			$parts = explode('.', $field);
+			$first = array_shift($parts);
+			$options['name'] = $first . ($parts ? '[' . implode('][', $parts) . ']' : '');
 		}
 		if (isset($options['value']) && !isset($options['val'])) {
 			$options['val'] = $options['value'];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2833,20 +2833,25 @@ class FormHelper extends Helper {
  * - `secure` - boolean whether or not the field should be added to the security fields.
  *   Disabling the field using the `disabled` option, will also omit the field from being
  *   part of the hashed key.
+ * - `default` - mixed - The value to use if there is no value in the form's context.
+ * - `disabled` - mixed - Either a boolean indicating disabled state, or the string in
+ *   a numerically indexed value.
  *
- * This method will convert a numerically indexed 'disabled' into a associative
- * value. FormHelper's internals expect associative options.
+ * This method will convert a numerically indexed 'disabled' into an associative
+ * array value. FormHelper's internals expect associative options.
+ *
+ * The output of this function is a more complete set of input attributes that
+ * can be passed to a form widget to generate the actual input.
  *
  * @param string $field Name of the field to initialize options for.
  * @param array $options Array of options to append options into.
  * @return array Array of options for the input.
  */
 	protected function _initInputField($field, $options = []) {
+		$secure = !empty($this->request['_Token']);
 		if (isset($options['secure'])) {
 			$secure = $options['secure'];
 			unset($options['secure']);
-		} else {
-			$secure = (isset($this->request['_Token']) && !empty($this->request['_Token']));
 		}
 		$context = $this->_getContext();
 
@@ -2864,7 +2869,6 @@ class FormHelper extends Helper {
 
 		if (isset($options['value']) && !isset($options['val'])) {
 			$options['val'] = $options['value'];
-			unset($options['value']);
 		}
 		if (!isset($options['val'])) {
 			$options['val'] = $context->val($field);
@@ -2872,7 +2876,7 @@ class FormHelper extends Helper {
 		if (!isset($options['val']) && isset($options['default'])) {
 			$options['val'] = $options['default'];
 		}
-		unset($options['default']);
+		unset($options['value'], $options['default']);
 
 		$options += (array)$context->attributes($field);
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1280,12 +1280,14 @@ class FormHelperTest extends TestCase {
  */
 	public function testTextFieldGenerationForFloats() {
 		$this->markTestIncomplete('Need to revisit once models work again.');
-		$model->setSchema(array('foo' => array(
-			'type' => 'float',
-			'null' => false,
-			'default' => null,
-			'length' => 10
-		)));
+		$this->article['schema'] = [
+			'foo' => [
+				'type' => 'float',
+				'null' => false,
+				'default' => null,
+				'length' => 10
+			]
+		];
 
 		$this->Form->create('Contact');
 		$result = $this->Form->input('foo');
@@ -3299,10 +3301,9 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testInputWithLeadingInteger() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->text('0.Node.title');
 		$expected = array(
-			'input' => array('name' => '0[Node][title]', 'id' => '0NodeTitle', 'type' => 'text')
+			'input' => array('name' => '0[Node][title]', 'type' => 'text')
 		);
 		$this->assertTags($result, $expected);
 	}
@@ -3990,30 +3991,49 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testTextbox() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->text('Model.field');
-		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[field]', 'id' => 'ModelField')));
+		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[field]')));
 
 		$result = $this->Form->text('Model.field', array('type' => 'password'));
-		$this->assertTags($result, array('input' => array('type' => 'password', 'name' => 'Model[field]', 'id' => 'ModelField')));
+		$this->assertTags($result, array('input' => array('type' => 'password', 'name' => 'Model[field]')));
 
 		$result = $this->Form->text('Model.field', array('id' => 'theID'));
 		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[field]', 'id' => 'theID')));
+	}
+
+/**
+ * Test that text() hooks up with request data and error fields.
+ *
+ * @return void
+ */
+	public function testTextBoxDataAndError() {
+		$this->article['errors'] = [
+			'Contact' => ['text' => 'wrong']
+		];
+		$this->Form->create($this->article);
 
 		$this->Form->request->data['Model']['text'] = 'test <strong>HTML</strong> values';
 		$result = $this->Form->text('Model.text');
-		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[text]', 'value' => 'test &lt;strong&gt;HTML&lt;/strong&gt; values', 'id' => 'ModelText')));
+		$expected = [
+			'input' => [
+				'type' => 'text',
+				'name' => 'Model[text]',
+				'value' => 'test &lt;strong&gt;HTML&lt;/strong&gt; values',
+			]
+		];
+		$this->assertTags($result, $expected);
 
-		$Contact->validationErrors['text'] = array(true);
 		$this->Form->request->data['Contact']['text'] = 'test';
-		$result = $this->Form->text('Contact.text', array('id' => 'theID'));
-		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Contact[text]', 'value' => 'test', 'id' => 'theID', 'class' => 'form-error')));
-
-		$this->Form->request->data['Model']['0']['OtherModel']['field'] = 'My value';
-		$result = $this->Form->text('Model.0.OtherModel.field', array('id' => 'myId'));
-		$expected = array(
-			'input' => array('type' => 'text', 'name' => 'Model[0][OtherModel][field]', 'value' => 'My value', 'id' => 'myId')
-		);
+		$result = $this->Form->text('Contact.text', ['id' => 'theID']);
+		$expected = [
+			'input' => [
+				'type' => 'text',
+				'name' => 'Contact[text]',
+				'value' => 'test',
+				'id' => 'theID',
+				'class' => 'form-error'
+			]
+		];
 		$this->assertTags($result, $expected);
 	}
 
@@ -4024,15 +4044,16 @@ class FormHelperTest extends TestCase {
  *
  * @return void
  */
-	public function testDefaultValue() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
+	public function testTextDefaultValue() {
 		$this->Form->request->data['Model']['field'] = 'test';
 		$result = $this->Form->text('Model.field', array('default' => 'default value'));
-		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[field]', 'value' => 'test', 'id' => 'ModelField')));
+		$expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'test']];
+		$this->assertTags($result, $expected);
 
 		unset($this->Form->request->data['Model']['field']);
 		$result = $this->Form->text('Model.field', array('default' => 'default value'));
-		$this->assertTags($result, array('input' => array('type' => 'text', 'name' => 'Model[field]', 'value' => 'default value', 'id' => 'ModelField')));
+		$expected = ['input' => ['type' => 'text', 'name' => 'Model[field]', 'value' => 'default value']];
+		$this->assertTags($result, $expected);
 	}
 
 /**
@@ -4190,11 +4211,16 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testPassword() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$result = $this->Form->password('Contact.field');
-		$this->assertTags($result, array('input' => array('type' => 'password', 'name' => 'Contact[field]', 'id' => 'ContactField')));
+		$this->article['errors'] = [
+			'Contact' => [
+				'passwd' => 1
+			]
+		];
+		$this->Form->create($this->article);
 
-		$Contact->validationErrors['passwd'] = 1;
+		$result = $this->Form->password('Contact.field');
+		$this->assertTags($result, array('input' => array('type' => 'password', 'name' => 'Contact[field]')));
+
 		$this->Form->request->data['Contact']['passwd'] = 'test';
 		$result = $this->Form->password('Contact.passwd', array('id' => 'theID'));
 		$this->assertTags($result, array('input' => array('type' => 'password', 'name' => 'Contact[passwd]', 'value' => 'test', 'id' => 'theID', 'class' => 'form-error')));

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -9569,32 +9569,43 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testHtml5Inputs() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->email('User.email');
 		$expected = array(
-			'input' => array('type' => 'email', 'name' => 'User[email]', 'id' => 'UserEmail')
+			'input' => array('type' => 'email', 'name' => 'User[email]')
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->search('User.query');
 		$expected = array(
-			'input' => array('type' => 'search', 'name' => 'User[query]', 'id' => 'UserQuery')
+			'input' => array('type' => 'search', 'name' => 'User[query]')
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->search('User.query', array('value' => 'test'));
 		$expected = array(
-			'input' => array('type' => 'search', 'name' => 'User[query]', 'id' => 'UserQuery', 'value' => 'test')
+			'input' => array('type' => 'search', 'name' => 'User[query]', 'value' => 'test')
 		);
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->search('User.query', array('type' => 'text', 'value' => 'test'));
 		$expected = array(
-			'input' => array('type' => 'text', 'name' => 'User[query]', 'id' => 'UserQuery', 'value' => 'test')
+			'input' => array('type' => 'text', 'name' => 'User[query]', 'value' => 'test')
 		);
 		$this->assertTags($result, $expected);
+	}
 
-		$result = $this->Form->input('User.website', array('type' => 'url', 'value' => 'http://domain.tld', 'div' => false, 'label' => false));
+/**
+ * Test accessing htm5 inputs through input().
+ *
+ * @return void
+ */
+	public function testHtml5InputWithInput() {
+		$this->markTestIncomplete('Need to revisit once models work again.');
+		$result = $this->Form->input('User.website', array(
+			'type' => 'url',
+			'value' => 'http://domain.tld',
+			'div' => false,
+			'label' => false));
 		$expected = array(
 			'input' => array('type' => 'url', 'name' => 'User[website]', 'id' => 'UserWebsite', 'value' => 'http://domain.tld')
 		);
@@ -9602,12 +9613,12 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test errors when field name is missing.
  *
  * @expectedException Cake\Error\Exception
  * @return void
  */
 	public function testHtml5InputException() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->email();
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -7753,45 +7753,45 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testTextArea() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->data = array('Model' => array('field' => 'some test data'));
-		$result = $this->Form->textarea('Model.field');
+		$this->Form->request->data = array('field' => 'some test data');
+		$result = $this->Form->textarea('field');
 		$expected = array(
-			'textarea' => array('name' => 'Model[field]', 'id' => 'ModelField'),
+			'textarea' => array('name' => 'field'),
 			'some test data',
 			'/textarea',
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->textarea('Model.tmp');
+		$result = $this->Form->textarea('user.bio');
 		$expected = array(
-			'textarea' => array('name' => 'Model[tmp]', 'id' => 'ModelTmp'),
+			'textarea' => array('name' => 'user[bio]'),
 			'/textarea',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->request->data = array('Model' => array('field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars'));
-		$result = $this->Form->textarea('Model.field');
+		$this->Form->request->data = array('field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars');
+		$result = $this->Form->textarea('field');
 		$expected = array(
-			'textarea' => array('name' => 'Model[field]', 'id' => 'ModelField'),
+			'textarea' => array('name' => 'field'),
 			htmlentities('some <strong>test</strong> data with <a href="#">HTML</a> chars'),
 			'/textarea',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->request->data = array('Model' => array('field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars'));
-		$result = $this->Form->textarea('Model.field', array('escape' => false));
+		$this->Form->request->data = [
+			'Model' => ['field' => 'some <strong>test</strong> data with <a href="#">HTML</a> chars']
+		];
+		$result = $this->Form->textarea('Model.field', ['escape' => false]);
 		$expected = array(
-			'textarea' => array('name' => 'Model[field]', 'id' => 'ModelField'),
+			'textarea' => array('name' => 'Model[field]'),
 			'some <strong>test</strong> data with <a href="#">HTML</a> chars',
 			'/textarea',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->request->data['Model']['0']['OtherModel']['field'] = null;
-		$result = $this->Form->textarea('Model.0.OtherModel.field');
+		$result = $this->Form->textarea('0.OtherModel.field');
 		$expected = array(
-			'textarea' => array('name' => 'Model[0][OtherModel][field]', 'id' => 'Model0OtherModelField'),
+			'textarea' => array('name' => '0[OtherModel][field]'),
 			'/textarea'
 		);
 		$this->assertTags($result, $expected);
@@ -7805,21 +7805,16 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testTextAreaWithStupidCharacters() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->loadFixtures('Post');
-		$result = $this->Form->input('Post.content', array(
-			'label' => 'Current Text', 'value' => "GREAT®", 'rows' => '15', 'cols' => '75'
-		));
-		$expected = array(
-			'div' => array('class' => 'input textarea'),
-				'label' => array('for' => 'PostContent'),
-					'Current Text',
-				'/label',
-				'textarea' => array('name' => 'Post[content]', 'id' => 'PostContent', 'rows' => '15', 'cols' => '75'),
-				'GREAT®',
-				'/textarea',
-			'/div'
-		);
+		$result = $this->Form->textarea('Post.content', [
+			'value' => "GREAT®",
+			'rows' => '15',
+			'cols' => '75'
+		]);
+		$expected = [
+			'textarea' => ['name' => 'Post[content]', 'rows' => '15', 'cols' => '75'],
+			'GREAT®',
+			'/textarea',
+		];
 		$this->assertTags($result, $expected);
 	}
 


### PR DESCRIPTION
As part of #2667, this restores text, password and textarea input widget creation. They are all pretty simple which is nice. Next I'll start tackling the more tricky inputs like checkbox, and radio.
