### PR TITLE
3.0 translate behavior

### DIFF
--- a/src/Model/Behavior/Translate/TranslateTrait.php
+++ b/src/Model/Behavior/Translate/TranslateTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Model\Behavior\Translate;
+
+use Cake\ORM\Entity;
+
+/**
+ * Contains a translation method aimed to help managing multiple translations
+ * for an entity.
+ */
+trait TranslateTrait {
+
+/**
+ * Returns the entity containing the translated fields for this object and for
+ * the spedcified language. If the translation for the passed language is not
+ * present, a new empty entity will be created so that values can be added to
+ * it.
+ *
+ * @return void
+ */
+	public function translation($language) {
+		if ($language === $this->get('_locale')) {
+			return $this;
+		}
+
+		$i18n = $this->get('_translations');
+		$created = false;
+
+		if (empty($i18n)) {
+			$i18n = [];
+			$created = true;
+		}
+
+		if ($created || empty($i18n[$language]) || !($i18n[$language] instanceof Entity)) {
+			$i18n[$language] = new Entity();
+			$created = true;
+		}
+
+		if ($created) {
+			$this->set('_translations', $i18n);
+		}
+
+		// Assume the user will modify any of the internal translations, helps with saving
+		$this->dirty('_translations', true);
+		return $i18n[$language];
+	}
+
+}

--- a/src/Model/Behavior/Translate/TranslateTrait.php
+++ b/src/Model/Behavior/Translate/TranslateTrait.php
@@ -24,7 +24,7 @@ trait TranslateTrait {
 
 /**
  * Returns the entity containing the translated fields for this object and for
- * the spedcified language. If the translation for the passed language is not
+ * the specified language. If the translation for the passed language is not
  * present, a new empty entity will be created so that values can be added to
  * it.
  *

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -202,6 +202,22 @@ class TranslateBehavior extends Behavior {
 	}
 
 /**
+ * Deletes all translation for the entity that was recently deleted
+ *
+ * @param \Cake\Event\Event the afterDelete event that was fired
+ * @param \Cake\ORM\Entity the entity that was recently deleted
+ * @return void
+ */
+	public function afterDelete(Event $event, Entity $entity) {
+		$primary = (array)$this->_table->primaryKey();
+		$key = $entity->get(current($primary));
+		TableRegistry::get('I18n')->deleteAll([
+			'foreign_key' => $key,
+			'model' => $this->_table->alias()
+		]);
+	}
+
+/**
  * Sets all future finds for the bound table to also fetch translated fields for
  * the passed locale. If no value is passed, it returns the currently configured
  * locale

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -339,6 +339,14 @@ class TranslateBehavior extends Behavior {
 		});
 	}
 
+/**
+ * Helper method used to generated multiple translated field entities
+ * out fo the data found in the `_translations` property in the passed
+ * entity. The result will be put into its `_i18n` property
+ *
+ * @param \Cake\ORM\Entity $entity
+ * @return void
+ */
 	protected function _bundleTranslatedFields($entity) {
 		$translations = (array)$entity->get('_translations');
 
@@ -384,6 +392,13 @@ class TranslateBehavior extends Behavior {
 		$entity->set('_i18n', $contents);
 	}
 
+/**
+ * Returns the ids found for each of the condition arrays passed for the translations
+ * table. Each records is index by the corresponding position to the conditions array
+ *
+ * @param array $ruleSet an array of arary of conditions to be used for finding each
+ * @return array
+ */
 	protected function _findExistingTranslations($ruleSet) {
 		$association = $this->_table->association($this->config()['translationTable']);
 		$query = $association->find()

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -112,7 +112,8 @@ class TranslateBehavior extends Behavior {
 			'foreignKey' => 'foreign_key',
 			'strategy' => 'subquery',
 			'conditions' => ["$table.model" => $alias],
-			'propertyName' => '_i18n'
+			'propertyName' => '_i18n',
+			'dependent' => true
 		]);
 	}
 
@@ -215,23 +216,6 @@ class TranslateBehavior extends Behavior {
  */
 	public function afterSave(Event $event, Entity $entity) {
 		$entity->unsetProperty('_i18n');
-	}
-
-/**
- * Deletes all translation for the entity that was recently deleted
- *
- * @param \Cake\Event\Event the afterDelete event that was fired
- * @param \Cake\ORM\Entity the entity that was recently deleted
- * @return void
- */
-	public function afterDelete(Event $event, Entity $entity) {
-		$primary = (array)$this->_table->primaryKey();
-		$key = $entity->get(current($primary));
-		$table = $this->config()['translationTable'];
-		TableRegistry::get($table)->deleteAll([
-			'foreign_key' => $key,
-			'model' => $this->_table->alias()
-		]);
 	}
 
 /**
@@ -350,7 +334,7 @@ class TranslateBehavior extends Behavior {
 
 /**
  * Helper method used to generated multiple translated field entities
- * out fo the data found in the `_translations` property in the passed
+ * out of the data found in the `_translations` property in the passed
  * entity. The result will be put into its `_i18n` property
  *
  * @param \Cake\ORM\Entity $entity
@@ -403,7 +387,7 @@ class TranslateBehavior extends Behavior {
 
 /**
  * Returns the ids found for each of the condition arrays passed for the translations
- * table. Each records is index by the corresponding position to the conditions array
+ * table. Each records is indexed by the corresponding position to the conditions array
  *
  * @param array $ruleSet an array of arary of conditions to be used for finding each
  * @return array

--- a/src/Model/Behavior/TranslateBehavior.php
+++ b/src/Model/Behavior/TranslateBehavior.php
@@ -207,6 +207,17 @@ class TranslateBehavior extends Behavior {
 	}
 
 /**
+ * Unsets the temporary `_i18n` property after the entity has been saved
+ *
+ * @param \Cake\Event\Event the beforeSave event that was fired
+ * @param \Cake\ORM\Entity the entity that is going to be saved
+ * @return void
+ */
+	public function afterSave(Event $event, Entity $entity) {
+		$entity->unsetProperty('_i18n');
+	}
+
+/**
  * Deletes all translation for the entity that was recently deleted
  *
  * @param \Cake\Event\Event the afterDelete event that was fired
@@ -270,9 +281,7 @@ class TranslateBehavior extends Behavior {
 				}
 				return $q;
 			}])
-			->formatResults(function($results) {
-				return $this->_groupTranslations($results);
-			}, $query::PREPEND);
+			->formatResults([$this, 'groupTranslations'], $query::PREPEND);
 	}
 
 /**
@@ -316,7 +325,7 @@ class TranslateBehavior extends Behavior {
  * @param \Cake\ORM\ResultSetDecorator $results
  * @return \Cake\Collection\Collection
  */
-	protected function _groupTranslations($results) {
+	public function groupTranslations($results) {
 		return $results->map(function($row) {
 			$translations = (array)$row->get('_i18n');
 			$grouped = new Collection($translations);

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -231,4 +231,33 @@ class Associations {
 		}
 	}
 
+/**
+ * Returns an associative array of association names out a mixed
+ * array. If true is passed, then it returns all association names
+ * in this collection.
+ *
+ * @param boolean|array $keys the list of association names to normalize
+ * @return array
+ */
+	public function normalizeKeys($keys) {
+		if ($keys === true) {
+			$keys = $this->keys();
+		}
+
+		if (empty($keys)) {
+			return [];
+		}
+
+		$result = [];
+		foreach ($keys as $key => $value) {
+			if (is_int($key)) {
+				$key = $value;
+				$value = [];
+			}
+			$result[$key] = $value;
+		}
+
+		return $result;
+	}
+
 }

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -248,14 +248,7 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 				continue;
 			}
 
-			$markDirty = true;
-			if (isset($this->_properties[$p])) {
-				$markDirty = $value !== $this->_properties[$p];
-			}
-
-			if ($markDirty) {
-				$this->dirty($p, true);
-			}
+			$this->dirty($p, true);
 
 			if (!$options['setter']) {
 				$this->_properties[$p] = $value;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1421,6 +1421,8 @@ class Table implements EventListener {
 			throw new \InvalidArgumentException($msg);
 		}
 
+		$this->_associated->cascadeDelete($entity, $options->getArrayCopy());
+
 		$query = $this->query();
 		$statement = $query->delete()
 			->where($conditions)
@@ -1430,8 +1432,6 @@ class Table implements EventListener {
 		if (!$success) {
 			return $success;
 		}
-
-		$this->_associated->cascadeDelete($entity, $options->getArrayCopy());
 
 		$event = new Event('Model.afterDelete', $this, [
 			'entity' => $entity,

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1170,17 +1170,14 @@ class Table implements EventListener {
 			$entity->isNew(true);
 		}
 
-		if ($options['associated'] === true) {
-			$options['associated'] = $this->_associated->keys();
-		}
-		$associated = array_filter((array)$options['associated']);
+		$associated = $options['associated'];
 		$options['associated'] = [];
 
 		if (!$this->validate($entity, $options)) {
 			return false;
 		}
 
-		$options['associated'] = $associated;
+		$options['associated'] = $this->_associated->normalizeKeys($associated);
 		$event = new Event('Model.beforeSave', $this, compact('entity', 'options'));
 		$this->getEventManager()->dispatch($event);
 

--- a/tests/TestCase/Model/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/Model/Behavior/Translate/TranslateTraitTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v 3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Model\Behavior;
+
+use Cake\Model\Behavior\Translate\TranslateTrait;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+
+class TestEntity extends Entity {
+	use TranslateTrait;
+}
+
+/**
+ * Translate behavior test case
+ */
+class TranslateBehaviorTest extends TestCase {
+
+/**
+ * Tests that missing translation entries are created automatically
+ *
+ * @return void
+ */
+	public function testTranslationCreate() {
+		$entity = new TestEntity;
+		$entity->translation('eng')->set('title', 'My Title');
+		$this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+
+		$this->assertTrue($entity->dirty('_translations'));
+
+		$entity->translation('spa')->set('body', 'Contenido');
+		$this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+		$this->assertEquals('Contenido', $entity->translation('spa')->get('body'));
+	}
+
+/**
+ * Tests that modifying existing translation entries work
+ *
+ * @return void
+ */
+	public function testTranslationModify() {
+		$entity = new TestEntity;
+		$entity->set('_translations', [
+			'eng' => new Entity(['title' => 'My Title']),
+			'spa' => new Entity(['title' => 'Titulo'])
+		]);
+		$this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+		$this->assertEquals('Titulo', $entity->translation('spa')->get('title'));
+	}
+
+/**
+ * Tests that just accessing the translation will mark the property as dirty, this
+ * is to facilitate the saving process by not having to remember to mark the property
+ * manually
+ *
+ * @return void
+ */
+	public function testTranslationDirty() {
+		$entity = new TestEntity;
+		$entity->set('_translations', [
+			'eng' => new Entity(['title' => 'My Title']),
+			'spa' => new Entity(['title' => 'Titulo'])
+		]);
+		$entity->clean();
+		$this->assertEquals('My Title', $entity->translation('eng')->get('title'));
+		$this->assertTrue($entity->dirty('_translations'));
+	}
+
+}

--- a/tests/TestCase/Model/Behavior/Translate/TranslateTraitTest.php
+++ b/tests/TestCase/Model/Behavior/Translate/TranslateTraitTest.php
@@ -12,7 +12,7 @@
  * @since         CakePHP(tm) v 3.0.0
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-namespace Cake\Test\TestCase\Model\Behavior;
+namespace Cake\Test\TestCase\Model\Behavior\Translate;
 
 use Cake\Model\Behavior\Translate\TranslateTrait;
 use Cake\ORM\Entity;
@@ -25,7 +25,7 @@ class TestEntity extends Entity {
 /**
  * Translate behavior test case
  */
-class TranslateBehaviorTest extends TestCase {
+class TranslateTraitTest extends TestCase {
 
 /**
  * Tests that missing translation entries are created automatically

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -635,4 +635,5 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('Titulo', $translations['spa']->get('title'));
 		$this->assertEquals('Titre', $translations['fre']->get('title'));
 	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -610,4 +610,29 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('Another body', $translations['eng']->get('body'));
 	}
 
+/**
+ * Tests saving multiple existing translations and adding new ones
+ *
+ * @return void
+ */
+	public function testSaveMultipleNewTranslations() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$article = $results = $table->find('translations')->first();
+
+		$translations = $article->get('_translations');
+		$translations['deu']->set('title', 'Another title');
+		$translations['eng']->set('body', 'Another body');
+		$translations['spa'] = new Entity(['title' => 'Titulo']);
+		$translations['fre'] = new Entity(['title' => 'Titre']);
+		$article->set('_translations', $translations);
+		$table->save($article);
+
+		$article = $results = $table->find('translations')->first();
+		$translations = $article->get('_translations');
+		$this->assertEquals('Another title', $translations['deu']->get('title'));
+		$this->assertEquals('Another body', $translations['eng']->get('body'));
+		$this->assertEquals('Titulo', $translations['spa']->get('title'));
+		$this->assertEquals('Titre', $translations['fre']->get('title'));
+	}
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -597,6 +597,11 @@ class TranslateBehaviorTest extends TestCase {
 		$translations['eng']->set('body', 'Another body');
 		$article->set('_translations', $translations);
 		$table->save($article);
+
+		$article = $results = $table->find('translations')->first();
+		$translations = $article->get('_translations');
+		$this->assertEquals('Another title', $translations['deu']->get('title'));
+		$this->assertEquals('Another body', $translations['eng']->get('body'));
 	}
 
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -587,6 +587,12 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals(0, $translations);
 	}
 
+/**
+ * Tests saving multiple translations at once when the translations already
+ * exist in the database
+ *
+ * @return void
+ */
 	public function testSaveMultipleTranslations() {
 		$table = TableRegistry::get('Articles');
 		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -470,6 +470,7 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals(1, $article->get('id'));
 		$article->set('title', 'New translated article');
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $table->find()->first();
 		$this->assertEquals(1, $article->get('id'));
@@ -485,6 +486,7 @@ class TranslateBehaviorTest extends TestCase {
 		$article->set('title', 'Wow, such translated article');
 		$article->set('body', 'A translated body');
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $table->find()->first();
 		$this->assertEquals(1, $article->get('id'));
@@ -516,6 +518,7 @@ class TranslateBehaviorTest extends TestCase {
 		$article->set('title', 'Un autre titre');
 		$article->set('body', 'Le contenu');
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $table->find()->first();
 		$this->assertEquals('Un autre titre', $article->get('title'));
@@ -536,6 +539,7 @@ class TranslateBehaviorTest extends TestCase {
 		$article->set('_locale', 'fra');
 		$article->set('title', 'Le titre');
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $table->find()->first();
 		$this->assertEquals(1, $article->get('id'));
@@ -565,6 +569,7 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals(1, $article->get('id'));
 		$article->set('title', 'Le titre');
 		$table->save($article, ['associated' => ['Comments']]);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $table->find()->first();
 		$this->assertEquals('Le titre', $article->get('title'));
@@ -603,6 +608,7 @@ class TranslateBehaviorTest extends TestCase {
 		$translations['eng']->set('body', 'Another body');
 		$article->set('_translations', $translations);
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $results = $table->find('translations')->first();
 		$translations = $article->get('_translations');
@@ -627,6 +633,7 @@ class TranslateBehaviorTest extends TestCase {
 		$translations['fre'] = new Entity(['title' => 'Titre']);
 		$article->set('_translations', $translations);
 		$table->save($article);
+		$this->assertNull($article->get('_i18n'));
 
 		$article = $results = $table->find('translations')->first();
 		$translations = $article->get('_translations');

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -587,4 +587,16 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals(0, $translations);
 	}
 
+	public function testSaveMultipleTranslations() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$article = $results = $table->find('translations')->first();
+
+		$translations = $article->get('_translations');
+		$translations['deu']->set('title', 'Another title');
+		$translations['eng']->set('body', 'Another body');
+		$article->set('_translations', $translations);
+		$table->save($article);
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -570,4 +570,21 @@ class TranslateBehaviorTest extends TestCase {
 		$this->assertEquals('Le titre', $article->get('title'));
 	}
 
+/**
+ * Tests that after deleting a translated entity, all translations are also removed
+ *
+ * @return void
+ */
+	public function testDelete() {
+		$table = TableRegistry::get('Articles');
+		$table->addBehavior('Translate', ['fields' => ['title', 'body']]);
+		$article = $table->find()->first();
+		$this->assertTrue($table->delete($article));
+
+		$translations = TableRegistry::get('I18n')->find()
+			->where(['model' => 'Articles', 'foreign_key' => $article->id])
+			->count();
+		$this->assertEquals(0, $translations);
+	}
+
 }

--- a/tests/TestCase/ORM/AssociationsTest.php
+++ b/tests/TestCase/ORM/AssociationsTest.php
@@ -303,4 +303,24 @@ class AssociationsTest extends TestCase {
 		);
 	}
 
+/**
+ * Tests the normalizeKeys method
+ *
+ * @return void
+ */
+	public function testNormalizeKeys() {
+		$this->assertSame([], $this->associations->normalizeKeys([]));
+		$this->assertSame([], $this->associations->normalizeKeys(false));
+
+		$assocs = ['a', 'b', 'd' => ['something']];
+		$expected = ['a' => [], 'b' => [], 'd' => ['something']];
+		$this->assertSame($expected, $this->associations->normalizeKeys($assocs));
+
+		$belongsTo = new BelongsTo([]);
+		$this->associations->add('users', $belongsTo);
+		$this->associations->add('categories', $belongsTo);
+		$expected = ['users' => [], 'categories' => []];
+		$this->assertSame($expected, $this->associations->normalizeKeys(true));
+	}
+
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -507,13 +507,14 @@ class EntityTest extends TestCase {
 		$entity = new Entity([
 			'title' => 'Foo',
 		]);
+
 		$entity->dirty('title', false);
 		$this->assertFalse($entity->dirty('title'));
+
 		$entity->set('title', 'Foo');
-		$this->assertFalse($entity->dirty('title'));
+		$this->assertTrue($entity->dirty('title'));
+
 		$entity->set('title', 'Foo');
-		$this->assertFalse($entity->dirty('title'));
-		$entity->set('title', 'Something Else');
 		$this->assertTrue($entity->dirty('title'));
 
 		$entity->set('something', 'else');


### PR DESCRIPTION
This finishes the remaining features for the TranslateBehavior. Improvements and changes below:
- It is possible to provide a different translation table using configuration
- Translated fields are deleted if the entity they are associated with is deleted too
- Ability to save multiple translations at once
- Added trait to facilitate the management of multiple translations for a single entity

Additionally a couple things were changed in the ORM:
- When using `Entity::set` the property is marked as dirty immediately, old and new value is not compared anymore for determining the change.
- Moved some array normalization logic from `Table::save` to `Associations::normalizeKeys`
