### PR TITLE
3.0 entity pretty print

### DIFF
--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -703,4 +703,13 @@ class Entity implements \ArrayAccess, \JsonSerializable {
 		return $this;
 	}
 
+/**
+ * Returns a string representation of this object in a humna readable format.
+ *
+ * @return string
+ */
+	public function __toString() {
+		return json_encode($this, JSON_PRETTY_PRINT);
+	}
+
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -986,4 +986,14 @@ class EntityTest extends TestCase {
 		$this->assertEquals('Yes', $entity->body, 'Single set should bypass guards.');
 	}
 
+/**
+ * Tests the entity's __toString method
+ *
+ * @return void
+ */
+	public function testToString() {
+		$entity = new Entity(['foo' => 1, 'bar' => 2]);
+		$this->assertEquals(json_encode($entity, JSON_PRETTY_PRINT), (string)$entity);
+	}
+
 }


### PR DESCRIPTION
When unit testing I found myself doing this over and over:

``` php
debug(json_encode($entity));
```

This is because the json representation of the entity is several times more readable than the debug output. This PR makes it a bit easier for me and hopefully for anyone wanting to quickly inspect the results of a query:

``` php
debug((string)$entity);
//or
echo $entity;
```
