### PR TITLE
FormHelper, fixes fatal error in line 2879

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2869,14 +2869,15 @@ class FormHelper extends Helper {
 
 		if (isset($options['value']) && !isset($options['val'])) {
 			$options['val'] = $options['value'];
+			unset($options['value']);
 		}
 		if (!isset($options['val'])) {
 			$options['val'] = $context->val($field);
 		}
 		if (!isset($options['val']) && isset($options['default'])) {
 			$options['val'] = $options['default'];
+			unset($options['default']);
 		}
-		unset($options['value'], $options['default']);
 
 		$options += (array)$context->attributes($field);
 


### PR DESCRIPTION
When creating inputs with FormHelper::input i get this error:

Error: Cannot unset string offsets  
File /srv/www/restr-dev.elements.dk/www/vendor/cakephp/cakephp/src/View/Helper/FormHelper.php  
Line: 2879
