### PR TITLE
Use basics.php config() instead of include_once()

### DIFF
--- a/lib/Cake/Model/ConnectionManager.php
+++ b/lib/Cake/Model/ConnectionManager.php
@@ -64,7 +64,7 @@ class ConnectionManager {
  * @return void
  */
 	protected static function _init() {
-		include_once APP . 'Config' . DS . 'database.php';
+		config('database');
 		if (class_exists('DATABASE_CONFIG')) {
 			self::$config = new DATABASE_CONFIG();
 		}


### PR DESCRIPTION
That way basics.php config() can be overridden so for example the application can use different subfolder for host specific configuration files.
