### PR TITLE
2.5 debugger log

### DIFF
--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -470,6 +470,28 @@ TEXT;
 	}
 
 /**
+ * test log() depth
+ *
+ * @return void
+ */
+	public function testLogDepth() {
+		if (file_exists(LOGS . 'debug.log')) {
+			unlink(LOGS . 'debug.log');
+		}
+		CakeLog::config('file', array('engine' => 'File', 'path' => TMP . 'logs' . DS));
+
+		$val = [
+			'test' => ['key' => 'val']
+		];
+		Debugger::log($val, LOG_DEBUG, 0);
+		$result = file_get_contents(LOGS . 'debug.log');
+		$this->assertContains('DebuggerTest::testLog', $result);
+		$this->assertNotContains("/'val'/", $result);
+
+		unlink(LOGS . 'debug.log');
+	}
+
+/**
  * testDump method
  *
  * @return void

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -455,18 +455,18 @@ TEXT;
 
 		Debugger::log('cool');
 		$result = file_get_contents(LOGS . 'debug.log');
-		$this->assertRegExp('/DebuggerTest\:\:testLog/i', $result);
-		$this->assertRegExp("/'cool'/", $result);
+		$this->assertContains('DebuggerTest::testLog', $result);
+		$this->assertContains("'cool'", $result);
 
 		unlink(LOGS . 'debug.log');
 
 		Debugger::log(array('whatever', 'here'));
 		$result = file_get_contents(LOGS . 'debug.log');
-		$this->assertRegExp('/DebuggerTest\:\:testLog/i', $result);
-		$this->assertRegExp('/\[main\]/', $result);
-		$this->assertRegExp('/array/', $result);
-		$this->assertRegExp("/'whatever',/", $result);
-		$this->assertRegExp("/'here'/", $result);
+		$this->assertContains('DebuggerTest::testLog', $result);
+		$this->assertContains('[main]', $result);
+		$this->assertContains('array', $result);
+		$this->assertContains("'whatever',", $result);
+		$this->assertContains("'here'", $result);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -480,9 +480,9 @@ TEXT;
 		}
 		CakeLog::config('file', array('engine' => 'File', 'path' => TMP . 'logs' . DS));
 
-		$val = [
-			'test' => ['key' => 'val']
-		];
+		$val = array(
+			'test' => array('key' => 'val')
+		);
 		Debugger::log($val, LOG_DEBUG, 0);
 		$result = file_get_contents(LOGS . 'debug.log');
 		$this->assertContains('DebuggerTest::testLog', $result);

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -184,12 +184,13 @@ class Debugger {
  *
  * @param mixed $var Variable or content to log
  * @param integer $level type of log to use. Defaults to LOG_DEBUG
+ * @param int $depth The depth to output to. Defaults to 3.
  * @return void
  * @link http://book.cakephp.org/2.0/en/development/debugging.html#Debugger::log
  */
-	public static function log($var, $level = LOG_DEBUG) {
+	public static function log($var, $level = LOG_DEBUG, $depth = 3) {
 		$source = self::trace(array('start' => 1)) . "\n";
-		CakeLog::write($level, "\n" . $source . self::exportVar($var));
+		CakeLog::write($level, "\n" . $source . self::exportVar($var, $depth));
 	}
 
 /**


### PR DESCRIPTION
Add `$depth` to log(), this makes it work the same as `dump()` and fixes #2834.
