### PR TITLE
3.0 multicheckbox

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1848,7 +1848,7 @@ class FormHelper extends Helper {
 			'hiddenField' => true,
 			'multiple' => null,
 			'secure' => true,
-			'empty' => isset($attributes['multiple']) ? false : true
+			'empty' => false,
 		];
 
 		if ($attributes['multiple'] === 'checkbox') {

--- a/src/View/Widget/IdGeneratorTrait.php
+++ b/src/View/Widget/IdGeneratorTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         CakePHP(tm) v3.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Widget;
+
+use Cake\Utility\Inflector;
+
+/**
+ * A trait that provides id generating methods to be
+ * used in various widget classes.
+ */
+trait IdGeneratorTrait {
+
+/**
+ * A list of id suffixes used in the current rendering.
+ *
+ * @var array
+ */
+	protected $_idSuffixes = [];
+
+/**
+ * Clear the stored ID suffixes.
+ *
+ * @return void
+ */
+	protected function _clearIds() {
+		$this->_idSuffixes = [];
+	}
+
+/**
+ * Generate an ID attribute for a radio button.
+ *
+ * Ensures that id's for a given set of fields are unique.
+ *
+ * @param array $radio The radio properties.
+ * @return string Generated id.
+ */
+	protected function _id($name, $val) {
+		$name = mb_strtolower(Inflector::slug($name, '-'));
+		$idSuffix = mb_strtolower(str_replace(array('@', '<', '>', ' ', '"', '\''), '-', $val));
+		$count = 1;
+		$check = $idSuffix;
+		while (in_array($check, $this->_idSuffixes)) {
+			$check = $idSuffix . $count++;
+		}
+		$this->_idSuffixes[] = $check;
+		return trim($name . '-' . $check, '-');
+	}
+}

--- a/src/View/Widget/IdGeneratorTrait.php
+++ b/src/View/Widget/IdGeneratorTrait.php
@@ -48,7 +48,7 @@ trait IdGeneratorTrait {
  */
 	protected function _id($name, $val) {
 		$name = mb_strtolower(Inflector::slug($name, '-'));
-		$idSuffix = mb_strtolower(str_replace(array('@', '<', '>', ' ', '"', '\''), '-', $val));
+		$idSuffix = mb_strtolower(str_replace(array('/', '@', '<', '>', ' ', '"', '\''), '-', $val));
 		$count = 1;
 		$check = $idSuffix;
 		while (in_array($check, $this->_idSuffixes)) {

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -153,6 +153,9 @@ class MultiCheckbox implements WidgetInterface {
 			'text' => $checkbox['text'],
 			'input' => $input,
 		];
+		if (!empty($checkbox['checked']) && empty($labelAttrs['class'])) {
+			$labelAttrs['class'] = 'selected';
+		}
 		$label = $this->_label->render($labelAttrs);
 
 		return $this->_templates->format('checkboxContainer', [

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Widget;
 
-use Cake\Utility\Inflector;
+use Cake\View\Widget\IdGeneratorTrait;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -22,6 +22,8 @@ use Cake\View\Widget\WidgetInterface;
  *
  */
 class MultiCheckbox implements WidgetInterface {
+
+	use IdGeneratorTrait;
 
 /**
  * Template instance to use.
@@ -105,6 +107,7 @@ class MultiCheckbox implements WidgetInterface {
 			'val' => null,
 		];
 		$out = [];
+		$this->_clearIds();
 		foreach ($data['options'] as $key => $val) {
 			$checkbox = [
 				'value' => $key,
@@ -123,7 +126,7 @@ class MultiCheckbox implements WidgetInterface {
 				$checkbox['disabled'] = true;
 			}
 			if (empty($checkbox['id'])) {
-				$checkbox['id'] = mb_strtolower(Inflector::slug($checkbox['name'] . $checkbox['value'], '-'));
+				$checkbox['id'] = $this->_id($checkbox['name'], $checkbox['value']);
 			}
 
 			$out[] = $this->_renderInput($checkbox);

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\View\Widget;
 
-use Cake\Utility\Inflector;
+use Cake\View\Widget\IdGeneratorTrait;
 use Cake\View\Widget\WidgetInterface;
 use Traversable;
 
@@ -25,6 +25,8 @@ use Traversable;
  * of Cake\View\Helper\FormHelper and is not intended for direct use.
  */
 class Radio implements WidgetInterface {
+
+	use IdGeneratorTrait;
 
 /**
  * Template instance.
@@ -39,13 +41,6 @@ class Radio implements WidgetInterface {
  * @var Cake\View\Widget\Label
  */
 	protected $_label;
-
-/**
- * A list of id suffixes used in the current rendering.
- *
- * @var array
- */
-	protected $_idSuffixes = [];
 
 /**
  * Constructor
@@ -106,7 +101,7 @@ class Radio implements WidgetInterface {
 		}
 		unset($data['empty']);
 
-		$this->_idSuffixes = [];
+		$this->_clearIds();
 		$opts = [];
 		foreach ($options as $val => $text) {
 			$opts[] = $this->_renderInput($val, $text, $data);
@@ -151,7 +146,7 @@ class Radio implements WidgetInterface {
 		$radio['name'] = $data['name'];
 
 		if (empty($radio['id'])) {
-			$radio['id'] = $this->_id($radio);
+			$radio['id'] = $this->_id($radio['name'], $radio['value']);
 		}
 
 		if (isset($data['val']) && is_bool($data['val'])) {
@@ -212,26 +207,6 @@ class Radio implements WidgetInterface {
 			'input' => $input,
 		];
 		return $this->_label->render($labelAttrs);
-	}
-
-/**
- * Generate an ID attribute for a radio button.
- *
- * Ensures that id's for a given set of fields are unique.
- *
- * @param array $radio The radio properties.
- * @return string Generated id.
- */
-	protected function _id($radio) {
-		$value = mb_strtolower(Inflector::slug($radio['name'], '-'));
-		$idSuffix = mb_strtolower(str_replace(array('@', '<', '>', ' ', '"', '\''), '-', $radio['value']));
-		$count = 1;
-		$check = $idSuffix;
-		while (in_array($check, $this->_idSuffixes)) {
-			$check = $idSuffix . $count++;
-		}
-		$this->_idSuffixes[] = $check;
-		return trim($value . '-' . $check, '-');
 	}
 
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3880,37 +3880,44 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectAsCheckbox() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$result = $this->Form->select('Model.multi_field', array('first', 'second', 'third'), array('multiple' => 'checkbox', 'value' => array(0, 1)));
+		$result = $this->Form->select(
+			'Model.multi_field',
+			array('first', 'second', 'third'),
+			array('multiple' => 'checkbox', 'value' => array(0, 1))
+		);
 		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'ModelMultiField'),
+			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '0', 'id' => 'ModelMultiField0')),
-			array('label' => array('for' => 'ModelMultiField0', 'class' => 'selected')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '0', 'id' => 'model-multi-field-0')),
+			array('label' => array('for' => 'model-multi-field-0', 'class' => 'selected')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '1', 'id' => 'ModelMultiField1')),
-			array('label' => array('for' => 'ModelMultiField1', 'class' => 'selected')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'checked' => 'checked', 'value' => '1', 'id' => 'model-multi-field-1')),
+			array('label' => array('for' => 'model-multi-field-1', 'class' => 'selected')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'ModelMultiField2')),
-			array('label' => array('for' => 'ModelMultiField2')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '2', 'id' => 'model-multi-field-2')),
+			array('label' => array('for' => 'model-multi-field-2')),
 			'third',
 			'/label',
 			'/div',
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->select('Model.multi_field', array('1/2' => 'half'), array('multiple' => 'checkbox'));
+		$result = $this->Form->select(
+			'Model.multi_field',
+			array('1/2' => 'half'),
+			array('multiple' => 'checkbox')
+		);
 		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'ModelMultiField'),
+			'input' => array('type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1/2', 'id' => 'ModelMultiField1/22')),
-			array('label' => array('for' => 'ModelMultiField1/22')),
+			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1/2', 'id' => 'model-multi-field-1-2')),
+			array('label' => array('for' => 'model-multi-field-1-2')),
 			'half',
 			'/label',
 			'/div',
@@ -5212,74 +5219,26 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectCheckboxMultipleOverrideName() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$result = $this->Form->input('category', array(
-			'type' => 'select',
+		$result = $this->Form->select('category', ['1', '2'], [
 			'multiple' => 'checkbox',
 			'name' => 'fish',
-			'options' => array('1', '2'),
-			'div' => false,
-			'label' => false,
-		));
+		]);
 		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'fish', 'value' => '', 'id' => 'category'),
+			'input' => array('type' => 'hidden', 'name' => 'fish', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'Category0')),
-				array('label' => array('for' => 'Category0')), '1', '/label',
+				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish0')),
+				array('label' => array('for' => 'fish0')), '1', '/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'Category1')),
-				array('label' => array('for' => 'Category1')), '2', '/label',
+				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish1')),
+				array('label' => array('for' => 'fish1')), '2', '/label',
 			'/div'
 		);
 		$this->assertTags($result, $expected);
-	}
 
-/**
- * Test that 'id' overrides all the checkbox id's as well.
- *
- * @return void
- */
-	public function testSelectCheckboxMultipleId() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$result = $this->Form->select(
-			'Model.multi_field',
-			array('first', 'second', 'third'),
-			array('multiple' => 'checkbox', 'id' => 'CustomId')
-		);
-
-		$expected = array(
-			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'CustomId'
-			),
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '0', 'id' => 'CustomId0'
-			)),
-			array('label' => array('for' => 'CustomId0')),
-			'first',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '1', 'id' => 'CustomId1'
-			)),
-			array('label' => array('for' => 'CustomId1')),
-			'second',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '2', 'id' => 'CustomId2'
-			)),
-			array('label' => array('for' => 'CustomId2')),
-			'third',
-			'/label',
-			'/div'
-		);
+		$result = $this->Form->multiCheckbox('category', ['1', '2'], [
+			'name' => 'fish',
+		]);
 		$this->assertTags($result, $expected);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4699,7 +4699,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectMultipleCheckboxes() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->select(
 			'Model.multi_field',
 			array('first', 'second', 'third'),
@@ -4708,121 +4707,33 @@ class FormHelperTest extends TestCase {
 
 		$expected = array(
 			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'ModelMultiField'
+				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '0', 'id' => 'ModelMultiField0'
+				'value' => '0', 'id' => 'model-multi-field-0'
 			)),
-			array('label' => array('for' => 'ModelMultiField0')),
+			array('label' => array('for' => 'model-multi-field-0')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '1', 'id' => 'ModelMultiField1'
+				'value' => '1', 'id' => 'model-multi-field-1'
 			)),
-			array('label' => array('for' => 'ModelMultiField1')),
+			array('label' => array('for' => 'model-multi-field-1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '2', 'id' => 'ModelMultiField2'
+				'value' => '2', 'id' => 'model-multi-field-2'
 			)),
-			array('label' => array('for' => 'ModelMultiField2')),
+			array('label' => array('for' => 'model-multi-field-2')),
 			'third',
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->select(
-			'Model.multi_field',
-			array('a' => 'first', 'b' => 'second', 'c' => 'third'),
-			array('multiple' => 'checkbox')
-		);
-		$expected = array(
-			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'ModelMultiField'
-			),
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => 'a', 'id' => 'ModelMultiFieldA'
-			)),
-			array('label' => array('for' => 'ModelMultiFieldA')),
-			'first',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => 'b', 'id' => 'ModelMultiFieldB'
-			)),
-			array('label' => array('for' => 'ModelMultiFieldB')),
-			'second',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => 'c', 'id' => 'ModelMultiFieldC'
-			)),
-			array('label' => array('for' => 'ModelMultiFieldC')),
-			'third',
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->select(
-			'Model.multi_field', array('1' => 'first'), array('multiple' => 'checkbox')
-		);
-		$expected = array(
-			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => '', 'id' => 'ModelMultiField'
-			),
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
-				'value' => '1', 'id' => 'ModelMultiField1'
-			)),
-			array('label' => array('for' => 'ModelMultiField1')),
-			'first',
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->request->data = array('Model' => array('tags' => array(1)));
-		$result = $this->Form->select(
-			'Model.tags', array('1' => 'first', 'Array' => 'Array'), array('multiple' => 'checkbox')
-		);
-		$expected = array(
-			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[tags]', 'value' => '', 'id' => 'ModelTags'
-			),
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[tags][]',
-				'value' => '1', 'id' => 'ModelTags1', 'checked' => 'checked'
-			)),
-			array('label' => array('for' => 'ModelTags1', 'class' => 'selected')),
-			'first',
-			'/label',
-			'/div',
-
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array(
-				'type' => 'checkbox', 'name' => 'Model[tags][]',
-				'value' => 'Array', 'id' => 'ModelTagsArray'
-			)),
-			array('label' => array('for' => 'ModelTagsArray')),
-			'Array',
 			'/label',
 			'/div'
 		);
@@ -4835,32 +4746,32 @@ class FormHelperTest extends TestCase {
 		);
 		$expected = array(
 			'input' => array(
-				'type' => 'hidden', 'name' => 'data[Model][multi_field]', 'value' => '', 'id' => 'ModelMultiField'
+				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a+', 'id' => 'ModelMultiFieldA+'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a+', 'id' => 'model-multi-field-a+'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA+')),
+			array('label' => array('for' => 'model-multi-field-a+')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a++', 'id' => 'ModelMultiFieldA++'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a++', 'id' => 'model-multi-field-a++'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA++')),
+			array('label' => array('for' => 'model-multi-field-a++')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a+++', 'id' => 'ModelMultiFieldA+++'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a+++', 'id' => 'model-multi-field-a+++'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldA+++')),
+			array('label' => array('for' => 'model-multi-field-a+++')),
 			'third',
 			'/label',
 			'/div'
@@ -4874,32 +4785,32 @@ class FormHelperTest extends TestCase {
 		);
 		$expected = array(
 			'input' => array(
-				'type' => 'hidden', 'name' => 'data[Model][multi_field]', 'value' => '', 'id' => 'ModelMultiField'
+				'type' => 'hidden', 'name' => 'Model[multi_field]', 'value' => ''
 			),
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a&gt;b', 'id' => 'ModelMultiFieldAB2'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a&gt;b', 'id' => 'model-multi-field-a-b'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldAB2')),
+			array('label' => array('for' => 'model-multi-field-a-b')),
 			'first',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a&lt;b', 'id' => 'ModelMultiFieldAB1'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a&lt;b', 'id' => 'model-multi-field-a-b1'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldAB1')),
+			array('label' => array('for' => 'model-multi-field-a-b1')),
 			'second',
 			'/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
-				'type' => 'checkbox', 'name' => 'data[Model][multi_field][]',
-				'value' => 'a&quot;b', 'id' => 'ModelMultiFieldAB'
+				'type' => 'checkbox', 'name' => 'Model[multi_field][]',
+				'value' => 'a&quot;b', 'id' => 'model-multi-field-a-b2'
 			)),
-			array('label' => array('for' => 'ModelMultiFieldAB')),
+			array('label' => array('for' => 'model-multi-field-a-b2')),
 			'third',
 			'/label',
 			'/div'
@@ -4908,79 +4819,36 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
- * test multiple checkboxes with div styles.
+ * Ensure that multiCheckbox reads from the request data.
  *
  * @return void
  */
-	public function testSelectMultipleCheckboxDiv() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
+	public function testSelectMultipleCheckboxRequestData() {
+		$this->Form->request->data = array('Model' => array('tags' => array(1)));
 		$result = $this->Form->select(
-			'Model.tags',
-			array('first', 'second'),
-			array('multiple' => 'checkbox', 'class' => 'my-class')
+			'Model.tags', array('1' => 'first', 'Array' => 'Array'), array('multiple' => 'checkbox')
 		);
 		$expected = array(
 			'input' => array(
-				'type' => 'hidden', 'name' => 'Model[tags]', 'value' => '', 'id' => 'ModelTags'
+				'type' => 'hidden', 'name' => 'Model[tags]', 'value' => ''
 			),
-			array('div' => array('class' => 'my-class')),
+			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[tags][]',
-				'value' => '0', 'id' => 'ModelTags0'
+				'value' => '1', 'id' => 'model-tags-1', 'checked' => 'checked'
 			)),
-			array('label' => array('for' => 'ModelTags0')), 'first', '/label',
+			array('label' => array('for' => 'model-tags-1', 'class' => 'selected')),
+			'first',
+			'/label',
 			'/div',
 
-			array('div' => array('class' => 'my-class')),
+			array('div' => array('class' => 'checkbox')),
 			array('input' => array(
 				'type' => 'checkbox', 'name' => 'Model[tags][]',
-				'value' => '1', 'id' => 'ModelTags1'
+				'value' => 'Array', 'id' => 'model-tags-array'
 			)),
-			array('label' => array('for' => 'ModelTags1')), 'second', '/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('Model.tags', array(
-			'options' => array('first', 'second'),
-			'multiple' => 'checkbox',
-			'class' => 'my-class',
-			'div' => false,
-			'label' => false
-		));
-		$this->assertTags($result, $expected);
-
-		$Contact->validationErrors['tags'] = 'Select atleast one option';
-		$result = $this->Form->input('Contact.tags', array(
-			'options' => array('one'),
-			'multiple' => 'checkbox',
-			'label' => false,
-			'div' => false
-		));
-		$expected = array(
-			'input' => array('type' => 'hidden', 'class' => 'form-error', 'name' => 'Contact[tags]', 'value' => '', 'id' => 'ContactTags'),
-			array('div' => array('class' => 'checkbox form-error')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Contact[tags][]', 'value' => '0', 'id' => 'ContactTags0')),
-			array('label' => array('for' => 'ContactTags0')),
-			'one',
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('Contact.tags', array(
-			'options' => array('one'),
-			'multiple' => 'checkbox',
-			'class' => 'mycheckbox',
-			'label' => false,
-			'div' => false
-		));
-		$expected = array(
-			'input' => array('type' => 'hidden', 'class' => 'form-error', 'name' => 'Contact[tags]', 'value' => '', 'id' => 'ContactTags'),
-			array('div' => array('class' => 'mycheckbox form-error')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Contact[tags][]', 'value' => '0', 'id' => 'ContactTags0')),
-			array('label' => array('for' => 'ContactTags0')),
-			'one',
+			array('label' => array('for' => 'model-tags-array')),
+			'Array',
 			'/label',
 			'/div'
 		);
@@ -5226,12 +5094,12 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'fish', 'value' => ''),
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish0')),
-				array('label' => array('for' => 'fish0')), '1', '/label',
+				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '0', 'id' => 'fish-0')),
+				array('label' => array('for' => 'fish-0')), '1', '/label',
 			'/div',
 			array('div' => array('class' => 'checkbox')),
-				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish1')),
-				array('label' => array('for' => 'fish1')), '2', '/label',
+				array('input' => array('type' => 'checkbox', 'name' => 'fish[]', 'value' => '1', 'id' => 'fish-1')),
+				array('label' => array('for' => 'fish-1')), '2', '/label',
 			'/div'
 		);
 		$this->assertTags($result, $expected);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4335,8 +4335,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->select('Model.field', array());
 		$expected = array(
 			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => '')),
-			'/option',
 			'/select'
 		);
 		$this->assertTags($result, $expected);
@@ -4345,8 +4343,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->select('Model.field', array('value' => 'good', 'other' => 'bad'));
 		$expected = array(
 			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => '')),
-			'/option',
 			array('option' => array('value' => 'value', 'selected' => 'selected')),
 			'good',
 			'/option',
@@ -4361,8 +4357,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->select('Model.field', array('value' => 'good', 'other' => 'bad'));
 		$expected = array(
 			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => '')),
-			'/option',
 			array('option' => array('value' => 'value')),
 			'good',
 			'/option',
@@ -4448,7 +4442,6 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->select('Model.field', array('0' => 'No', '1' => 'Yes'));
 		$expected = array(
 			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => '')), '/option',
 			array('option' => array('value' => '0', 'selected' => 'selected')), 'No', '/option',
 			array('option' => array('value' => '1')), 'Yes', '/option',
 			'/select'
@@ -4472,7 +4465,6 @@ class FormHelperTest extends TestCase {
 				'name' => 'user_id',
 				'required' => 'required'
 			),
-			array('option' => array('value' => '')), '/option',
 			array('option' => array('value' => '0')), 'option A', '/option',
 			'/select'
 		);
@@ -4484,7 +4476,6 @@ class FormHelperTest extends TestCase {
 				'name' => 'user_id',
 				'disabled' => 'disabled'
 			),
-			array('option' => array('value' => '')), '/option',
 			array('option' => array('value' => '0')), 'option A', '/option',
 			'/select'
 		);
@@ -4861,7 +4852,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectMultipleCheckboxSecurity() {
-		$this->Form->request->params['_Token'] = 'foo';
+		$this->Form->request->params['_Token'] = 'testKey';
 		$this->assertEquals(array(), $this->Form->fields);
 
 		$result = $this->Form->select(
@@ -4882,7 +4873,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectMultipleSecureWithNoOptions() {
-		$this->Form->request->params['_Token'] = 'testkey';
 		$this->assertEquals(array(), $this->Form->fields);
 
 		$this->Form->select(
@@ -4892,6 +4882,7 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertEquals(array('Model.select'), $this->Form->fields);
 	}
+
 /**
  * When a select box has no options it should not be added to the fields list
  * as it always fail post validation.
@@ -4899,22 +4890,21 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectNoSecureWithNoOptions() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->params['_csrfToken'] = 'testkey';
-		$this->assertEquals(array(), $this->Form->fields);
+		$this->Form->request->params['_Token'] = 'testkey';
+		$this->assertEquals([], $this->Form->fields);
 
 		$this->Form->select(
 			'Model.select',
-			array()
+			[]
 		);
-		$this->assertEquals(array(), $this->Form->fields);
+		$this->assertEquals([], $this->Form->fields);
 
 		$this->Form->select(
-			'Model.select',
-			array(),
-			array('empty' => true)
+			'Model.user_id',
+			[],
+			['empty' => true]
 		);
-		$this->assertEquals(array('Model.select'), $this->Form->fields);
+		$this->assertEquals(array('Model.user_id'), $this->Form->fields);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5023,52 +5023,11 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSelectHiddenFieldOmission() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->select('Model.multi_field',
 			array('first', 'second'),
 			array('multiple' => 'checkbox', 'hiddenField' => false, 'value' => null)
 		);
-		$expected = array(
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '0', 'id' => 'ModelMultiField0')),
-			array('label' => array('for' => 'ModelMultiField0')),
-			'first',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1', 'id' => 'ModelMultiField1')),
-			array('label' => array('for' => 'ModelMultiField1')),
-			'second',
-			'/label',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('Model.multi_field', array(
-			'options' => array('first', 'second'),
-			'multiple' => 'checkbox',
-			'hiddenField' => false
-		));
-		$expected = array(
-			array('div' => array('class' => 'input select')),
-			array('label' => array('for' => 'ModelMultiField')),
-			'Multi Field',
-			'/label',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '0', 'id' => 'ModelMultiField0')),
-			array('label' => array('for' => 'ModelMultiField0')),
-			'first',
-			'/label',
-			'/div',
-			array('div' => array('class' => 'checkbox')),
-			array('input' => array('type' => 'checkbox', 'name' => 'Model[multi_field][]', 'value' => '1', 'id' => 'ModelMultiField1')),
-			array('label' => array('for' => 'ModelMultiField1')),
-			'second',
-			'/label',
-			'/div',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
+		$this->assertNotContains('type="hidden"', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxTest.php
@@ -185,7 +185,7 @@ class MultiCheckboxTest extends TestCase {
 				'id' => 'tags-id-1',
 				'checked' => 'checked'
 			]],
-			['label' => ['for' => 'tags-id-1']],
+			['label' => ['class' => 'selected', 'for' => 'tags-id-1']],
 			'CakePHP',
 			'/label',
 			'/div',


### PR DESCRIPTION
Part of #2267. This adds support for multicheckboxes. The old code is still kicking around and will be removed separately once datetime() and friends are fixed which is my next task.

I've split out a trait that helps widget classes generate ID's in a consistent way. I thought this approach was cleaner than using inheritance or a base class, but I'm open to reconsidering that decision.
