### PR TITLE
account for localized floats more robustly.

### DIFF
--- a/lib/Cake/Test/Case/Utility/ValidationTest.php
+++ b/lib/Cake/Test/Case/Utility/ValidationTest.php
@@ -1660,12 +1660,15 @@ class ValidationTest extends CakeTestCase {
  * @return void
  */
 	public function testDecimalLocaleSet() {
-		$this->skipIf(DS === '\\', 'The locale is not supported in Windows and affect the others tests.');
+		$this->skipIf(DS === '\\', 'The locale is not supported in Windows and affects other tests.');
 		$restore = setlocale(LC_NUMERIC, 0);
 		$this->skipIf(setlocale(LC_NUMERIC, 'de_DE') === false, "The German locale isn't available.");
 
-		$this->assertTrue(Validation::decimal(1.54));
-		$this->assertTrue(Validation::decimal('1.54'));
+		$this->assertTrue(Validation::decimal(1.54), '1.54 should be considered a valid float');
+		$this->assertTrue(Validation::decimal('1.54'), '"1.54" should be considered a valid float');
+
+		$this->assertTrue(Validation::decimal(12345.67), '12345.67 should be considered a valid float');
+		$this->assertTrue(Validation::decimal('12,345.67'), '"12,345.67" should be considered a valid float');
 
 		setlocale(LC_NUMERIC, $restore);
 	}

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -426,10 +426,11 @@ class Validation {
 			}
 		}
 
-		// Workaround localized floats.
-		if (is_float($check)) {
-			$check = str_replace(',', '.', strval($check));
-		}
+		// account for localized floats.
+		$data = localeconv();
+		$check = str_replace($data['thousands_sep'], '', $check);
+		$check = str_replace($data['decimal_point'], '.', $check);
+
 		return self::_check($check, $regex);
 	}
 


### PR DESCRIPTION
Normalize floats, strings too, so that they are validated as

```
dddddddddd.dd
```

ref #2853
