### PR TITLE
3.0 formhelper

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -551,8 +551,9 @@ class FormHelper extends Helper {
  * Populates $this->fields
  *
  * @param boolean $lock Whether this field should be part of the validation
- *     or excluded as part of the unlockedFields.
- * @param string $field Reference to field to be secured. Should be dot separated to indicate nesting.
+ *   or excluded as part of the unlockedFields.
+ * @param string|array $field Reference to field to be secured. Can be dot
+ *   separated string to indicate nesting or array of fieldname parts.
  * @param mixed $value Field value, if value should not be tampered with.
  * @return mixed|null Not used yet
  */
@@ -2780,10 +2781,12 @@ class FormHelper extends Helper {
  * Get the field name for use with _secure().
  *
  * Parses the name attribute to create a dot separated name value for use
- * in secured field hash.
+ * in secured field hash. If filename is of form Model[field] an array of
+ * fieldname parts like ['Model', 'field'] is returned.
  *
  * @param array $options An array of options possibly containing a name key.
- * @return string|null
+ * @return string|array|null Dot separated string like Foo.bar, array of filename
+ *   params like ['Model', 'field'] or null if options does not contain name.
  */
 	protected function _secureFieldName($options) {
 		if (!isset($options['name'])) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1503,7 +1503,7 @@ class FormHelper extends Helper {
 		));
 
 		if ($secure === true) {
-			$this->_secure(true, $options['name'], '' . $options['val']);
+			$this->_secure(true, $this->_secureFieldName($options), $options['val']);
 		}
 
 		$options['type'] = 'hidden';

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -331,9 +331,10 @@ class FormHelper extends Helper {
 			'encoding' => strtolower(Configure::read('App.encoding')),
 		];
 
-		$options['action'] = $this->_formUrl($context, $options);
-		unset($options['url']);
+		$action = $this->url($this->_formUrl($context, $options));
+		unset($options['url'], $options['action']);
 
+		$htmlAttributes = [];
 		switch (strtolower($options['type'])) {
 			case 'get':
 				$htmlAttributes['method'] = 'get';
@@ -356,8 +357,6 @@ class FormHelper extends Helper {
 		}
 		$this->requestType = strtolower($options['type']);
 
-		$htmlAttributes['action'] = $this->url($options['action']);
-
 		if (!$options['default']) {
 			if (!isset($options['onsubmit'])) {
 				$options['onsubmit'] = '';
@@ -368,7 +367,7 @@ class FormHelper extends Helper {
 		if (!empty($options['encoding'])) {
 			$htmlAttributes['accept-charset'] = $options['encoding'];
 		}
-		unset($options['type'], $options['action'], $options['encoding'], $options['default']);
+		unset($options['type'], $options['encoding'], $options['default']);
 
 		$htmlAttributes = array_merge($options, $htmlAttributes);
 
@@ -380,8 +379,9 @@ class FormHelper extends Helper {
 		if (!empty($append)) {
 			$append = $this->formatTemplate('hiddenblock', ['content' => $append]);
 		}
+		$actionAttr = $this->_templater->formatAttributes(['action' => $action, 'escape' => false]);
 		return $this->formatTemplate('formstart', [
-			'attrs' => $this->_templater->formatAttributes($htmlAttributes)
+			'attrs' => $this->_templater->formatAttributes($htmlAttributes) . $actionAttr
 		]) . $append;
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1906,11 +1906,13 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredRadio() {
+		$this->Form->request->params['_Token'] = 'testKey';
+
 		$this->assertEquals(array(), $this->Form->fields);
 		$options = array('1' => 'option1', '2' => 'option2');
 
 		$this->Form->radio('Test.test', $options);
-		$expected = array('Test[test]' => '');
+		$expected = array('Test.test');
 		$this->assertEquals($expected, $this->Form->fields);
 	}
 
@@ -1920,7 +1922,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredAndDisabledNotAssoc() {
-		$this->Form->request->params['_csrfToken'] = 'testKey';
+		$this->Form->request->params['_Token'] = 'testKey';
 
 		$this->Form->select('Model.select', array(1, 2), array('disabled'));
 		$this->Form->checkbox('Model.checkbox', array('disabled'));
@@ -1942,7 +1944,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredAndDisabled() {
-		$this->Form->request->params['_csrfToken'] = 'testKey';
+		$this->Form->request->params['_Token'] = 'testKey';
 
 		$this->Form->checkbox('Model.checkbox', array('disabled' => true));
 		$this->Form->text('Model.text', array('disabled' => true));

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -977,16 +977,6 @@ class FormHelperTest extends TestCase {
 				'?' => array('param1' => 'value1', 'param2' => 'value2')
 			)
 		));
-		$expected = array(
-			'form' => array(
-				'method' => 'post',
-				'action' => '/controller/action?param1=value1&amp;param2=value2',
-				'accept-charset' => $encoding
-			),
-			'div' => array('style' => 'display:none;'),
-			'input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST'),
-			'/div'
-		);
 		$this->assertTags($result, $expected);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -926,14 +926,13 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testCreateWithAcceptCharset() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$result = $this->Form->create('UserForm', array(
-				'type' => 'post', 'action' => 'login', 'encoding' => 'iso-8859-1'
+		$result = $this->Form->create($this->article, array(
+				'type' => 'post', 'action' => 'index', 'encoding' => 'iso-8859-1'
 			)
 		);
 		$expected = array(
 			'form' => array(
-				'method' => 'post', 'action' => '/user_forms/login', 'id' => 'UserFormLoginForm',
+				'method' => 'post', 'action' => '/articles',
 				'accept-charset' => 'iso-8859-1'
 			),
 			'div' => array('style' => 'display:none;'),
@@ -948,9 +947,8 @@ class FormHelperTest extends TestCase {
  *
  */
 	public function testCreateQuerystringrequest() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$encoding = strtolower(Configure::read('App.encoding'));
-		$result = $this->Form->create('Contact', array(
+		$result = $this->Form->create($this->article, array(
 			'type' => 'post',
 			'escape' => false,
 			'url' => array(
@@ -961,7 +959,6 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'form' => array(
-				'id' => 'ContactAddForm',
 				'method' => 'post',
 				'action' => '/controller/action?param1=value1&amp;param2=value2',
 				'accept-charset' => $encoding
@@ -972,7 +969,7 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->create('Contact', array(
+		$result = $this->Form->create($this->article, array(
 			'type' => 'post',
 			'url' => array(
 				'controller' => 'controller',
@@ -982,7 +979,6 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'form' => array(
-				'id' => 'ContactAddForm',
 				'method' => 'post',
 				'action' => '/controller/action?param1=value1&amp;param2=value2',
 				'accept-charset' => $encoding
@@ -1001,16 +997,14 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testCreateWithMultipleIdInData() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$encoding = strtolower(Configure::read('App.encoding'));
 
-		$this->Form->request->data['Contact']['id'] = array(1, 2);
-		$result = $this->Form->create('Contact');
+		$this->Form->request->data['Article']['id'] = array(1, 2);
+		$result = $this->Form->create($this->article);
 		$expected = array(
 			'form' => array(
-				'id' => 'ContactAddForm',
 				'method' => 'post',
-				'action' => '/contacts/add',
+				'action' => '/articles/add',
 				'accept-charset' => $encoding
 			),
 			'div' => array('style' => 'display:none;'),
@@ -1026,10 +1020,9 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testCreatePassedArgs() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$encoding = strtolower(Configure::read('App.encoding'));
-		$this->Form->request->data['Contact']['id'] = 1;
-		$result = $this->Form->create('Contact', array(
+		$this->Form->request->data['Article']['id'] = 1;
+		$result = $this->Form->create($this->article, array(
 			'type' => 'post',
 			'escape' => false,
 			'url' => array(
@@ -1039,9 +1032,8 @@ class FormHelperTest extends TestCase {
 		));
 		$expected = array(
 			'form' => array(
-				'id' => 'ContactAddForm',
 				'method' => 'post',
-				'action' => '/contacts/edit/myparam',
+				'action' => '/articles/edit/myparam',
 				'accept-charset' => $encoding
 			),
 			'div' => array('style' => 'display:none;'),
@@ -1057,28 +1049,27 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testGetFormCreate() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$encoding = strtolower(Configure::read('App.encoding'));
-		$result = $this->Form->create('Contact', array('type' => 'get'));
+		$result = $this->Form->create($this->article, array('type' => 'get'));
 		$this->assertTags($result, array('form' => array(
-			'id' => 'ContactAddForm', 'method' => 'get', 'action' => '/contacts/add',
+			'method' => 'get', 'action' => '/articles/add',
 			'accept-charset' => $encoding
 		)));
 
-		$result = $this->Form->text('Contact.name');
+		$result = $this->Form->text('title');
 		$this->assertTags($result, array('input' => array(
-			'name' => 'name', 'type' => 'text', 'id' => 'ContactName',
+			'name' => 'title', 'type' => 'text', 'required' => 'required'
 		)));
 
 		$result = $this->Form->password('password');
 		$this->assertTags($result, array('input' => array(
-			'name' => 'password', 'type' => 'password', 'id' => 'ContactPassword'
+			'name' => 'password', 'type' => 'password'
 		)));
 		$this->assertNotRegExp('/<input[^<>]+[^id|name|type|value]=[^<>]*>$/', $result);
 
 		$result = $this->Form->text('user_form');
 		$this->assertTags($result, array('input' => array(
-			'name' => 'user_form', 'type' => 'text', 'id' => 'ContactUserForm'
+			'name' => 'user_form', 'type' => 'text'
 		)));
 	}
 
@@ -1088,20 +1079,21 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testGetFormWithFalseModel() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$encoding = strtolower(Configure::read('App.encoding'));
 		$this->Form->request['controller'] = 'contact_test';
-		$result = $this->Form->create(false, array('type' => 'get', 'url' => array('controller' => 'contact_test')));
+		$result = $this->Form->create(false, array(
+			'type' => 'get', 'url' => array('controller' => 'contact_test')
+		));
 
 		$expected = array('form' => array(
-			'id' => 'addForm', 'method' => 'get', 'action' => '/contact_test/add',
+			'method' => 'get', 'action' => '/contact_test/add',
 			'accept-charset' => $encoding
 		));
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->text('reason');
 		$expected = array(
-			'input' => array('type' => 'text', 'name' => 'reason', 'id' => 'reason')
+			'input' => array('type' => 'text', 'name' => 'reason')
 		);
 		$this->assertTags($result, $expected);
 	}
@@ -1485,11 +1477,9 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSecuritySubmitNestedNamed() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$key = 'testKey';
-		$this->Form->request->params['_csrfToken'] = $key;
+		$this->Form->request->params['_Token'] = 'testKey';
 
-		$this->Form->create('Addresses');
+		$this->Form->create($this->article);
 		$this->Form->submit('Test', array('type' => 'submit', 'name' => 'Address[button]'));
 		$result = $this->Form->unlockField();
 		$this->assertEquals(array('Address.button'), $result);
@@ -1501,11 +1491,10 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSecuritySubmitImageNoName() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$key = 'testKey';
-		$this->Form->request->params['_csrfToken'] = $key;
+		$this->Form->request->params['_Token'] = 'testKey';
 
-		$this->Form->create('User');
+		$this->Form->create(false);
 		$result = $this->Form->submit('save.png');
 		$expected = array(
 			'div' => array('class' => 'submit'),
@@ -1522,11 +1511,9 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSecuritySubmitImageName() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$key = 'testKey';
-		$this->Form->request->params['_csrfToken'] = $key;
+		$this->Form->request->params['_Token'] = 'testKey';
 
-		$this->Form->create('User');
+		$this->Form->create(null);
 		$result = $this->Form->submit('save.png', array('name' => 'test'));
 		$expected = array(
 			'div' => array('class' => 'submit'),
@@ -1710,8 +1697,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecureWithCustomNameAttribute() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->params['_csrfToken'] = 'testKey';
+		$this->Form->request->params['_Token'] = 'testKey';
 
 		$this->Form->text('UserForm.published', array('name' => 'User[custom]'));
 		$this->assertEquals('User.custom', $this->Form->fields[0]);
@@ -1901,7 +1887,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredMultipleSelect() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->params['_csrfToken'] = 'testKey';
 		$this->assertEquals(array(), $this->Form->fields);
 		$options = array('1' => 'one', '2' => 'two');
@@ -1935,7 +1920,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredAndDisabledNotAssoc() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->params['_csrfToken'] = 'testKey';
 
 		$this->Form->select('Model.select', array(1, 2), array('disabled'));
@@ -1958,7 +1942,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormSecuredAndDisabled() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->params['_csrfToken'] = 'testKey';
 
 		$this->Form->checkbox('Model.checkbox', array('disabled' => true));
@@ -2014,12 +1997,9 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testUnlockFieldAddsToList() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->params['_csrfToken'] = 'testKey';
 		$this->Form->request['_Token'] = array(
 			'unlockedFields' => array()
 		);
-		$this->Form->create('Contact');
 		$this->Form->unlockField('Contact.name');
 		$this->Form->text('Contact.name');
 
@@ -2033,20 +2013,18 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testUnlockFieldRemovingFromFields() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->params['_csrfToken'] = 'testKey';
 		$this->Form->request['_Token'] = array(
 			'unlockedFields' => array()
 		);
-		$this->Form->create('Contact');
-		$this->Form->hidden('Contact.id', array('value' => 1));
-		$this->Form->text('Contact.name');
+		$this->Form->create($this->article);
+		$this->Form->hidden('Article.id', array('value' => 1));
+		$this->Form->text('Article.title');
 
-		$this->assertEquals(1, $this->Form->fields['Contact.id'], 'Hidden input should be secured.');
-		$this->assertTrue(in_array('Contact.name', $this->Form->fields), 'Field should be secured.');
+		$this->assertEquals(1, $this->Form->fields['Article.id'], 'Hidden input should be secured.');
+		$this->assertTrue(in_array('Article.title', $this->Form->fields), 'Field should be secured.');
 
-		$this->Form->unlockField('Contact.name');
-		$this->Form->unlockField('Contact.id');
+		$this->Form->unlockField('Article.title');
+		$this->Form->unlockField('Article.id');
 		$this->assertEquals(array(), $this->Form->fields);
 	}
 
@@ -4039,22 +4017,21 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testCheckboxDefaultValue() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->data['Model']['field'] = false;
 		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'id' => 'ModelField')));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
 
 		unset($this->Form->request->data['Model']['field']);
 		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'id' => 'ModelField', 'checked' => 'checked')));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
 
 		$this->Form->request->data['Model']['field'] = true;
 		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'id' => 'ModelField', 'checked' => 'checked')));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
 
 		unset($this->Form->request->data['Model']['field']);
 		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'id' => 'ModelField')));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
 	}
 
 /**
@@ -6912,7 +6889,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSubmitButton() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->submit('');
 		$expected = array(
 			'div' => array('class' => 'submit'),
@@ -7010,7 +6986,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSubmitImage() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->submit('http://example.com/cake.power.gif');
 		$expected = array(
 			'div' => array('class' => 'submit'),
@@ -7091,8 +7066,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSubmitUnlockedByDefault() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->request->params['_csrfToken'] = 'secured';
+		$this->Form->request->params['_Token'] = 'secured';
 		$this->Form->submit('Go go');
 		$this->Form->submit('Save', array('name' => 'save'));
 
@@ -7106,7 +7080,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testSubmitImageTimestamp() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		Configure::write('Asset.timestamp', 'force');
 
 		$result = $this->Form->submit('cake.power.gif');


### PR DESCRIPTION
~~The second assert for `testCreateQuerystringrequest()` is failing because the url generated is `/controller/action?param1=value1&amp;amp;param2=value2`. Note the extra `amp;`, not quite sure what's causing that.~~

Part of #2267.
