### PR TITLE
3.0 FormHelper error()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -575,8 +575,7 @@ class FormHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::isFieldError
  */
 	public function isFieldError($field) {
-		$this->setEntity($field);
-		return (bool)$this->tagIsInvalid();
+		return $this->_getContext()->hasError($field);
 	}
 
 /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -581,8 +581,8 @@ class FormHelper extends Helper {
 /**
  * Returns a formatted error message for given form field, '' if no errors.
  *
- * Uses the `error`, `errorList` and `errorItem` templates. The errorList and
- * errorItem templates are used to format multiple error messages per field.
+ * Uses the `error`, `errorList` and `errorItem` templates. The `errorList` and
+ * `errorItem` templates are used to format multiple error messages per field.
  *
  * ### Options:
  *

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -269,26 +269,6 @@ class FormHelper extends Helper {
 	}
 
 /**
- * Returns false if given form field described by the current entity has no errors.
- * Otherwise it returns the validation message
- *
- * @return mixed Either false when there are no errors, or an array of error
- *    strings. An error string could be ''.
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::tagIsInvalid
- */
-	public function tagIsInvalid() {
-		$entity = $this->entity();
-		$model = array_shift($entity);
-
-		// 0.Model.field. Fudge entity path
-		if (empty($model) || is_numeric($model)) {
-			array_splice($entity, 1, 0, $model);
-			$model = array_shift($entity);
-		}
-		return false;
-	}
-
-/**
  * Returns an HTML FORM element.
  *
  * ### Options:

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2021,48 +2021,6 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
- * testTagIsInvalid method
- *
- * @return void
- */
-	public function testTagIsInvalid() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$Contact->validationErrors[0]['email'] = $expected = array('Please provide an email');
-
-		$this->Form->setEntity('Contact.0.email');
-		$result = $this->Form->tagIsInvalid();
-		$this->assertEquals($expected, $result);
-
-		$this->Form->setEntity('Contact.1.email');
-		$result = $this->Form->tagIsInvalid();
-		$this->assertFalse($result);
-
-		$this->Form->setEntity('Contact.0.name');
-		$result = $this->Form->tagIsInvalid();
-		$this->assertFalse($result);
-	}
-
-/**
- * Test tagIsInvalid with validation errors from a saveMany
- *
- * @return void
- */
-	public function testTagIsInvalidSaveMany() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$Contact->validationErrors[0]['email'] = $expected = array('Please provide an email');
-
-		$this->Form->create('Contact');
-
-		$this->Form->setEntity('0.email');
-		$result = $this->Form->tagIsInvalid();
-		$this->assertEquals($expected, $result);
-
-		$this->Form->setEntity('0.Contact.email');
-		$result = $this->Form->tagIsInvalid();
-		$this->assertEquals($expected, $result);
-	}
-
-/**
  * Test validation errors.
  *
  * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4002,31 +4002,6 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
- * testCheckboxDefaultValue method
- *
- * Test default value setting on checkbox() method
- *
- * @return void
- */
-	public function testCheckboxDefaultValue() {
-		$this->Form->request->data['Model']['field'] = false;
-		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
-
-		unset($this->Form->request->data['Model']['field']);
-		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
-
-		$this->Form->request->data['Model']['field'] = true;
-		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
-
-		unset($this->Form->request->data['Model']['field']);
-		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
-		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
-	}
-
-/**
  * testError method
  *
  * Test field error generation
@@ -5049,6 +5024,31 @@ class FormHelperTest extends TestCase {
 			array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => 'myvalue', 'id' => 'theID'))
 		);
 		$this->assertTags($result, $expected);
+	}
+
+/**
+ * testCheckboxDefaultValue method
+ *
+ * Test default value setting on checkbox() method
+ *
+ * @return void
+ */
+	public function testCheckboxDefaultValue() {
+		$this->Form->request->data['Model']['field'] = false;
+		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
+
+		unset($this->Form->request->data['Model']['field']);
+		$result = $this->Form->checkbox('Model.field', array('default' => true, 'hiddenField' => false));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
+
+		$this->Form->request->data['Model']['field'] = true;
+		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1', 'checked' => 'checked')));
+
+		unset($this->Form->request->data['Model']['field']);
+		$result = $this->Form->checkbox('Model.field', array('default' => false, 'hiddenField' => false));
+		$this->assertTags($result, array('input' => array('type' => 'checkbox', 'name' => 'Model[field]', 'value' => '1')));
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4009,45 +4009,70 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testError() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$Contact->validationErrors['field'] = array(1);
-		$result = $this->Form->error('Contact.field');
-		$this->assertTags($result, array('div' => array('class' => 'error-message'), 'Error in field Field', '/div'));
+		$this->article['errors'] = [
+			'Article' => ['field' => 'email']
+		];
+		$this->Form->create($this->article);
 
-		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEquals('Error in field Field', $result);
+		$result = $this->Form->error('Article.field');
+		$expected = [
+			['div' => ['class' => 'error-message']],
+			'email',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
 
-		$Contact->validationErrors['field'] = array("This field contains invalid input");
-		$result = $this->Form->error('Contact.field', null, array('wrap' => false));
-		$this->assertEquals('This field contains invalid input', $result);
+		$result = $this->Form->error('Article.field', "<strong>Badness!</strong>");
+		$expected = [
+			['div' => ['class' => 'error-message']],
+			'&lt;strong&gt;Badness!&lt;/strong&gt;',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
 
-		$Contact->validationErrors['field'] = array("This field contains invalid input");
-		$result = $this->Form->error('Contact.field', null, array('wrap' => 'span'));
-		$this->assertTags($result, array('span' => array('class' => 'error-message'), 'This field contains invalid input', '/span'));
+		$result = $this->Form->error('Article.field', "<strong>Badness!</strong>", ['escape' => false]);
+		$expected = [
+			['div' => ['class' => 'error-message']],
+			'<strong', 'Badness!', '/strong',
+			'/div',
+		];
+		$this->assertTags($result, $expected);
+	}
 
-		$result = $this->Form->error('Contact.field', 'There is an error fool!', array('wrap' => 'span'));
-		$this->assertTags($result, array('span' => array('class' => 'error-message'), 'There is an error fool!', '/span'));
+/**
+ * Test error with nested lists.
+ *
+ * @return void
+ */
+	public function testErrorMessages() {
+		$this->article['errors'] = [
+			'Article' => ['field' => 'email']
+		];
+		$this->Form->create($this->article);
 
-		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false));
-		$this->assertEquals('&lt;strong&gt;Badness!&lt;/strong&gt;', $result);
-
-		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => true));
-		$this->assertEquals('&lt;strong&gt;Badness!&lt;/strong&gt;', $result);
-
-		$result = $this->Form->error('Contact.field', "<strong>Badness!</strong>", array('wrap' => false, 'escape' => false));
-		$this->assertEquals('<strong>Badness!</strong>', $result);
-
-		$Contact->validationErrors['field'] = array("email");
-		$result = $this->Form->error('Contact.field', array('attributes' => array('class' => 'field-error'), 'email' => 'No good!'));
+		$result = $this->Form->error('Article.field', array(
+			'email' => 'No good!'
+		));
 		$expected = array(
-			'div' => array('class' => 'field-error'),
+			'div' => array('class' => 'error-message'),
 			'No good!',
 			'/div'
 		);
 		$this->assertTags($result, $expected);
+	}
 
-		$Contact->validationErrors['field'] = array('notEmpty', 'email', 'Something else');
-		$result = $this->Form->error('Contact.field', array(
+/**
+ * test error() with multiple messages.
+ *
+ * @return void
+ */
+	public function testErrorMultipleMessages() {
+		$this->article['errors'] = [
+			'field' => ['notEmpty', 'email', 'Something else']
+		];
+		$this->Form->create($this->article);
+
+		$result = $this->Form->error('field', array(
 			'notEmpty' => 'Cannot be empty',
 			'email' => 'No good!'
 		));
@@ -4057,49 +4082,6 @@ class FormHelperTest extends TestCase {
 					'<li', 'Cannot be empty', '/li',
 					'<li', 'No good!', '/li',
 					'<li', 'Something else', '/li',
-				'/ul',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		// Testing error messages list options
-		$Contact->validationErrors['field'] = array('notEmpty', 'email');
-
-		$result = $this->Form->error('Contact.field', null, array('listOptions' => 'ol'));
-		$expected = array(
-			'div' => array('class' => 'error-message'),
-				'ol' => array(),
-					'<li', 'notEmpty', '/li',
-					'<li', 'email', '/li',
-				'/ol',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->error('Contact.field', null, array('listOptions' => array('tag' => 'ol')));
-		$expected = array(
-			'div' => array('class' => 'error-message'),
-				'ol' => array(),
-					'<li', 'notEmpty', '/li',
-					'<li', 'email', '/li',
-				'/ol',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->error('Contact.field', null, array(
-			'listOptions' => array(
-				'class' => 'ul-class',
-				'itemOptions' => array(
-					'class' => 'li-class'
-				)
-			)
-		));
-		$expected = array(
-			'div' => array('class' => 'error-message'),
-				'ul' => array('class' => 'ul-class'),
-					array('li' => array('class' => 'li-class')), 'notEmpty', '/li',
-					array('li' => array('class' => 'li-class')), 'email', '/li',
 				'/ul',
 			'/div'
 		);


### PR DESCRIPTION
Part of #2267. This updates FormHelper::error() to use 3.0 paradigms. Instead of the annoyingly complex array formatting options, templates are used.

I've also removed some 'features'
- Having a number as the error message no longer generates an error message. This is generally not helpful so I axed it.
- tagIsInvalid() was removed. It relied on setEntity() magic that is being removed. isFieldError() still lives on though.
