### PR TITLE
Made Debugger::outputError() more flexible so that it can be used later on

### DIFF
--- a/lib/Cake/Error/ErrorHandler.php
+++ b/lib/Cake/Error/ErrorHandler.php
@@ -216,7 +216,8 @@ class ErrorHandler {
 				'start' => 2,
 				'path' => Debugger::trimPath($file)
 			);
-			return Debugger::getInstance()->outputError($data);
+			echo $errorOutput = Debugger::getInstance()->outputError($data);
+			return $errorOutput;
 		}
 		$message = $error . ' (' . $code . '): ' . $description . ' in [' . $file . ', line ' . $line . ']';
 		if (!empty($errorConfig['trace'])) {

--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -799,7 +799,7 @@ class Debugger {
 		if (isset($tpl['callback']) && is_callable($tpl['callback'])) {
 			return call_user_func($tpl['callback'], $data, compact('links', 'info'));
 		}
-		echo String::insert($tpl['error'], compact('links', 'info') + $data, $insertOpts);
+		return String::insert($tpl['error'], compact('links', 'info') + $data, $insertOpts);
 	}
 
 /**


### PR DESCRIPTION
# readme first!

There were some valid comments on the echo in the errorHandler() method, please not that I moved it one level up. In the current stable version this echo can be found in the Debugger class itself! Which is even worse.
## context

I need the output of `Debugger::outputError();` in my custom ErrorHandler. To achieve this there had to be made a complex structure in order to achieve something rather simple. Let me explain how it would be done otherwise:
1. Create a custom ErrorHandler class called AppErrorHandler in the libs folder. Include it in the bootstrap and tell the core to use the custom class.
2. Create a method called handleError which can simply be copied from the default ErrorHandler
3. Create a custom Debugger class called AppDebugger in the libs folder. Include it in the AppErrorHandler instead of the default Debugger class.
4. Create a method called outputError() and copy the contents of the default Debugger::outputError() method.
5. Replace the "echo" with a return statement at the end of outputError()
6. Now you can use the output of Debugger the way you like in the custom errorHandler.

Then I thought: well, I can also throw in a pull-request which contains the edit itself. I did a search on the whole project and these were the only found usages of the text "outputError":
- `lib/Cake/Error/Errorhandler.php` line 221: of which the return is now replaced with an echo (it will return the result as well, just to keep the old functionality, read: backwards compatibility)
- `lib/Cake/Utility/Debugger.php` line 206: comment
- `lib/Cake/Utility/Debugger.php` line 258: deprecated showError method, which echoes the returned value of outputError as well. Meaning that when debug is true, it will echo twice (which I think was an accident)
- `lib/Cake/Utility/Debugger.php` line 665: comment
- `lib/Cake/Utility/Debugger.php` line 732: the definition of the method
## use case

At this moment we are having a fixed navbar and a floating menu of about 200px on the left. When a warning is thrown, for example for a missing index, it is hidden underneath that fixed navbar. Meaning that we, as developers, do not notice the warning. We wanted to resolve this by simply adding this to our css:

``` CSS
pre.cake-error {
    margin-left: 210px;
}
pre.cake-error:first-of-type {
   margin-top: 50px;
}
```

But since the `ErrorHandler` of cakephp is messing up the DOM quite badly (read: everything that should be in the `<head>`, is inside the `<body>` tag), the CSS isn't loaded properly resulting in an unchanged situation.

I am creating a simple custom `AppErrorHandler` in which I simply copied the `ErrorHandler::handleError()` method as starting point where I want to store the output of `Debugger::outputError()` in a protected static variable. Now I can simply create a method that echoes this variable which is called for the layout. So that it will be inside the `body > div.main-content` tag resulting in a properly rendered page.
## foot note

I hope I explained the thoughts behind this change well enough so that it can be merged. If there are any question, feel free to ask. I'd be happy to reply to them as quickly as possible.
