### PR TITLE
3.0 - Docblock updates

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -63,7 +63,7 @@ use Cake\Utility\Inflector;
  * @param string $name Name of the configuration
  * @param array $config Optional associative array of settings passed to the engine
  * @return array [engine, settings] on success, false on failure
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 class Cache {
 
@@ -103,7 +103,7 @@ class Cache {
 /**
  * Cache Registry used for creating and using cache adapters.
  *
- * @var Cake\Cache\CacheRegistry
+ * @var \Cake\Cache\CacheRegistry
  */
 	protected static $_registry;
 
@@ -111,7 +111,7 @@ class Cache {
  * Finds and builds the instance of the required engine class.
  *
  * @param string $name Name of the config array that needs an engine instance built
- * @throws Cake\Error\Exception When a cache engine cannot be created.
+ * @throws \Cake\Error\Exception When a cache engine cannot be created.
  */
 	protected static function _buildEngine($name) {
 		if (empty(static::$_registry)) {
@@ -140,7 +140,7 @@ class Cache {
  * triggered.
  *
  * @param string $config The configuration name you want an engine for.
- * @return Cake\Cache\Engine
+ * @return \Cake\Cache\Engine
  */
 	public static function engine($config) {
 		if (!static::$_enabled) {
@@ -345,7 +345,7 @@ class Cache {
  *
  * @param string $group group name or null to retrieve all group mappings
  * @return array map of group and all configuration that has the same group
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public static function groupConfigs($group = null) {
 		if ($group === null) {

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -200,7 +200,7 @@ abstract class CacheEngine {
  *
  * @param string $key the key passed over
  * @return mixed string $key or false
- * @throws InvalidArgumentException If key's value is empty
+ * @throws \InvalidArgumentException If key's value is empty
  */
 	protected function _key($key) {
 		$key = $this->key($key);

--- a/src/Cache/CacheEngine.php
+++ b/src/Cache/CacheEngine.php
@@ -148,7 +148,7 @@ abstract class CacheEngine {
  * to decide whether actually delete the keys or just simulate it to achieve
  * the same result.
  *
- * @param string $groups name of the group to be cleared
+ * @param string $group name of the group to be cleared
  * @return boolean
  */
 	public function clearGroup($group) {

--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -48,7 +48,7 @@ class CacheRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the cache is missing in.
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\Exception(sprintf('Cache engine %s is not available.', $class));
@@ -62,7 +62,7 @@ class CacheRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $config An array of settings to use for the cache engine.
  * @return CacheEngine The constructed CacheEngine class.
- * @throws Cake\Error\Exception when an object doesn't implement
+ * @throws \Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $config) {

--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -182,6 +182,7 @@ class ApcEngine extends CacheEngine {
  * Increments the group value to simulate deletion of all keys under a group
  * old values will remain in storage until they expire.
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -425,6 +425,7 @@ class FileEngine extends CacheEngine {
 /**
  * Recursively deletes all files under any directory named as $group
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Cache/Engine/FileEngine.php
+++ b/src/Cache/Engine/FileEngine.php
@@ -325,7 +325,7 @@ class FileEngine extends CacheEngine {
  * @param string $key
  * @param integer $offset
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function decrement($key, $offset = 1) {
 		throw new Error\Exception('Files cannot be atomically decremented.');
@@ -337,7 +337,7 @@ class FileEngine extends CacheEngine {
  * @param string $key
  * @param integer $offset
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function increment($key, $offset = 1) {
 		throw new Error\Exception('Files cannot be atomically incremented.');

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -95,7 +95,7 @@ class MemcachedEngine extends CacheEngine {
  *
  * @param array $config array of setting for the engine
  * @return boolean True if the engine has been successfully initialized, false if not
- * @throws Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
+ * @throws \Cake\Error\Exception when you try use authentication without Memcached compiled with SASL support
  */
 	public function init($config = []) {
 		if (!class_exists('Memcached')) {
@@ -151,7 +151,7 @@ class MemcachedEngine extends CacheEngine {
 /**
  * Settings the memcached instance
  *
- * @throws Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
+ * @throws \Cake\Error\Exception when the Memcached extension is not built with the desired serializer engine
  */
 	protected function _setOptions() {
 		$this->_Memcached->setOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE, true);
@@ -246,7 +246,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param integer $offset How much to increment
  * @return New incremented value, false otherwise
- * @throws Cake\Error\Exception when you try to increment with compress = true
+ * @throws \Cake\Error\Exception when you try to increment with compress = true
  */
 	public function increment($key, $offset = 1) {
 		$key = $this->_key($key);
@@ -260,7 +260,7 @@ class MemcachedEngine extends CacheEngine {
  * @param string $key Identifier for the data
  * @param integer $offset How much to subtract
  * @return New decremented value, false otherwise
- * @throws Cake\Error\Exception when you try to decrement with compress = true
+ * @throws \Cake\Error\Exception when you try to decrement with compress = true
  */
 	public function decrement($key, $offset = 1) {
 		$key = $this->_key($key);

--- a/src/Cache/Engine/MemcachedEngine.php
+++ b/src/Cache/Engine/MemcachedEngine.php
@@ -340,6 +340,7 @@ class MemcachedEngine extends CacheEngine {
  * Increments the group value to simulate deletion of all keys under a group
  * old values will remain in storage until they expire.
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Cache/Engine/RedisEngine.php
+++ b/src/Cache/Engine/RedisEngine.php
@@ -227,6 +227,7 @@ class RedisEngine extends CacheEngine {
  * Increments the group value to simulate deletion of all keys under a group
  * old values will remain in storage until they expire.
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -189,6 +189,7 @@ class WincacheEngine extends CacheEngine {
  * Increments the group value to simulate deletion of all keys under a group
  * old values will remain in storage until they expire.
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Cache/Engine/XcacheEngine.php
+++ b/src/Cache/Engine/XcacheEngine.php
@@ -184,6 +184,7 @@ class XcacheEngine extends CacheEngine {
  * Increments the group value to simulate deletion of all keys under a group
  * old values will remain in storage until they expire.
  *
+ * @param string $group name of the group to be cleared
  * @return boolean success
  */
 	public function clearGroup($group) {

--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -32,7 +32,6 @@ class Collection extends IteratorIterator implements JsonSerializable {
  * Constructor. You can provide an array or any traversable object
  *
  * @param array|\Traversable $items
- * @return void
  * @throws InvalidArgumentException if passed incorrect type for items.
  */
 	public function __construct($items) {

--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -665,7 +665,7 @@ trait CollectionTrait {
  * or a function returning the indexing key out of the provided element
  * @param callable|string $valuePath the column name path to use as the array value
  * or a function returning the value out of the provided element
- * @param callable|string $valuePath the column name path to use as the parent
+ * @param callable|string $groupPath the column name path to use as the parent
  * grouping key or a function returning the key out of the provided element
  * @return \Cake\Collection\Collection
  */

--- a/src/Collection/Iterator/ExtractIterator.php
+++ b/src/Collection/Iterator/ExtractIterator.php
@@ -49,7 +49,6 @@ class ExtractIterator extends Collection {
  * @param array|\Traversable $items The list of values to iterate
  * @param string $path a dot separated string symbolizing the path to follow
  * inside the hierarchy of each value so that the column can be extracted.
- * @return void
  */
 	public function __construct($items, $path) {
 		$this->_path = explode('.', $path);

--- a/src/Collection/Iterator/FilterIterator.php
+++ b/src/Collection/Iterator/FilterIterator.php
@@ -35,7 +35,6 @@ class FilterIterator extends Collection {
  *
  * @param Iterator $items the items to be filtered
  * @param callable $callback
- * @return void
  */
 	public function __construct(Iterator $items, callable $callback) {
 		$wrapper = new CallbackFilterIterator($items, $callback);

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -109,7 +109,6 @@ class MapReduce implements IteratorAggregate {
  * The first one is the list of values inside a bucket, second one is the name
  * of the bucket that was created during the mapping phase and third one is an
  * instance of this class.
- * @return void
  */
 	public function __construct(\Traversable $data, callable $mapper, callable $reducer = null) {
 		$this->_data = $data;

--- a/src/Collection/Iterator/ReplaceIterator.php
+++ b/src/Collection/Iterator/ReplaceIterator.php
@@ -39,7 +39,6 @@ class ReplaceIterator extends Collection {
  *
  * @param array|\Traversable $items the items to be filtered
  * @param callable $callback
- * @return void
  */
 	public function __construct($items, callable $callback) {
 		$this->_callback = $callback;

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -86,7 +86,6 @@ class SortIterator extends SplHeap {
  * @param integer $dir either SORT_DESC or SORT_ASC
  * @param integer $type the type of comparison to perform, either SORT_STRING
  * SORT_NUMERIC or SORT_NATURAL
- * @return void
  */
 	public function __construct($items, $c, $dir = SORT_DESC, $type = SORT_NUMERIC) {
 		$this->_items = $items;

--- a/src/Collection/Iterator/SortIterator.php
+++ b/src/Collection/Iterator/SortIterator.php
@@ -87,11 +87,11 @@ class SortIterator extends SplHeap {
  * @param integer $type the type of comparison to perform, either SORT_STRING
  * SORT_NUMERIC or SORT_NATURAL
  */
-	public function __construct($items, $c, $dir = SORT_DESC, $type = SORT_NUMERIC) {
+	public function __construct($items, $callback, $dir = SORT_DESC, $type = SORT_NUMERIC) {
 		$this->_items = $items;
 		$this->_dir = $dir;
 		$this->_type = $type;
-		$this->_callback = $this->_propertyExtractor($c);
+		$this->_callback = $this->_propertyExtractor($callback);
 	}
 
 /**

--- a/src/Configure/Engine/IniConfig.php
+++ b/src/Configure/Engine/IniConfig.php
@@ -186,17 +186,17 @@ class IniConfig implements ConfigEngineInterface {
  * @param mixed $value to export.
  * @return string String value for ini file.
  */
-	protected function _value($val) {
-		if ($val === null) {
+	protected function _value($value) {
+		if ($value === null) {
 			return 'null';
 		}
-		if ($val === true) {
+		if ($value === true) {
 			return 'true';
 		}
-		if ($val === false) {
+		if ($value === false) {
 			return 'false';
 		}
-		return (string)$val;
+		return (string)$value;
 	}
 
 /**

--- a/src/Configure/Engine/IniConfig.php
+++ b/src/Configure/Engine/IniConfig.php
@@ -94,7 +94,7 @@ class IniConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix. The chosen file must be on the engine's path.
  * @return array Parsed configuration values.
- * @throws Cake\Error\ConfigureException when files don't exist.
+ * @throws \Cake\Error\ConfigureException when files don't exist.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Configure/Engine/PhpConfig.php
+++ b/src/Configure/Engine/PhpConfig.php
@@ -57,7 +57,7 @@ class PhpConfig implements ConfigEngineInterface {
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix.
  * @return array Parsed configuration values.
- * @throws Cake\Error\ConfigureException when files don't exist or they don't contain `$config`.
+ * @throws \Cake\Error\ConfigureException when files don't exist or they don't contain `$config`.
  *  Or when files contain '..' as this could lead to abusive reads.
  */
 	public function read($key) {

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -45,7 +45,7 @@ class FixtureTask extends BakeTask {
 /**
  * Schema instance
  *
- * @var Cake\Model\Schema
+ * @var \Cake\Model\Schema
  */
 	protected $_Schema = null;
 

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -337,7 +337,7 @@ class TestTask extends BakeTask {
  * @param string $type The type of thing having a test generated.
  * @param string $plugin The plugin name.
  * @return string
- * @throws Cake\Error\Exception When invalid object types are requested.
+ * @throws \Cake\Error\Exception When invalid object types are requested.
  */
 	public function mapType($type, $plugin) {
 		$type = ucfirst($type);
@@ -357,7 +357,7 @@ class TestTask extends BakeTask {
  * @param string $type The type the class having a test
  *   generated for is in.
  * @return array Array of (class, type)
- * @throws Cake\Error\Exception on invalid types.
+ * @throws \Cake\Error\Exception on invalid types.
  */
 	public function getBaseType($type) {
 		if (empty($this->baseTypes[$type])) {

--- a/src/Console/Command/TestShell.php
+++ b/src/Console/Command/TestShell.php
@@ -167,7 +167,7 @@ class TestShell extends Shell {
  * Initialization method installs PHPUnit and loads all plugins
  *
  * @return void
- * @throws Exception
+ * @throws \Exception
  */
 	public function initialize() {
 		$this->_dispatcher = new TestSuiteDispatcher();
@@ -339,7 +339,7 @@ class TestShell extends Shell {
  * @param string $category
  * @param boolean $throwOnMissingFile
  * @return array [type, case]
- * @throws Exception
+ * @throws \Exception
  */
 	protected function _mapFileToCase($file, $category, $throwOnMissingFile = true) {
 		if (!$category || (substr($file, -4) !== '.php')) {

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -136,7 +136,7 @@ class ConsoleInputArgument {
  *
  * @param string $value
  * @return boolean
- * @throws Cake\Error\ConsoleException
+ * @throws \Cake\Error\ConsoleException
  */
 	public function validChoice($value) {
 		if (empty($this->_choices)) {

--- a/src/Console/ConsoleInputArgument.php
+++ b/src/Console/ConsoleInputArgument.php
@@ -154,8 +154,8 @@ class ConsoleInputArgument {
 /**
  * Append this arguments XML representation to the passed in SimpleXml object.
  *
- * @param SimpleXmlElement $parent The parent element.
- * @return SimpleXmlElement The parent with this argument appended.
+ * @param \SimpleXmlElement $parent The parent element.
+ * @return \SimpleXmlElement The parent with this argument appended.
  */
 	public function xml(\SimpleXmlElement $parent) {
 		$option = $parent->addChild('argument');

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -199,8 +199,8 @@ class ConsoleInputOption {
 /**
  * Append the option's xml into the parent.
  *
- * @param SimpleXmlElement $parent The parent element.
- * @return SimpleXmlElement The parent with this option appended.
+ * @param \SimpleXmlElement $parent The parent element.
+ * @return \SimpleXmlElement The parent with this option appended.
  */
 	public function xml(\SimpleXmlElement $parent) {
 		$option = $parent->addChild('option');

--- a/src/Console/ConsoleInputOption.php
+++ b/src/Console/ConsoleInputOption.php
@@ -77,7 +77,7 @@ class ConsoleInputOption {
  * @param boolean $boolean Whether this option is a boolean option. Boolean options don't consume extra tokens
  * @param string $default The default value for this option.
  * @param array $choices Valid choices for this option.
- * @throws Cake\Error\ConsoleException
+ * @throws \Cake\Error\ConsoleException
  */
 	public function __construct($name, $short = null, $help = '', $boolean = false, $default = '', $choices = []) {
 		if (is_array($name) && isset($name['name'])) {
@@ -181,7 +181,7 @@ class ConsoleInputOption {
  *
  * @param string $value
  * @return boolean
- * @throws Cake\Error\ConsoleException
+ * @throws \Cake\Error\ConsoleException
  */
 	public function validChoice($value) {
 		if (empty($this->_choices)) {

--- a/src/Console/ConsoleInputSubcommand.php
+++ b/src/Console/ConsoleInputSubcommand.php
@@ -107,8 +107,8 @@ class ConsoleInputSubcommand {
 /**
  * Append this subcommand to the Parent element
  *
- * @param SimpleXmlElement $parent The parent element.
- * @return SimpleXmlElement The parent with this subcommand appended.
+ * @param \SimpleXmlElement $parent The parent element.
+ * @return \SimpleXmlElement The parent with this subcommand appended.
  */
 	public function xml(\SimpleXmlElement $parent) {
 		$command = $parent->addChild('command');

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -453,7 +453,7 @@ class ConsoleOptionParser {
  * @param string $command The subcommand to use. If this parameter is a subcommand, that has a parser,
  *    That parser will be used to parse $argv instead.
  * @return Array [$params, $args]
- * @throws Cake\Error\ConsoleException When an invalid parameter is encountered.
+ * @throws \Cake\Error\ConsoleException When an invalid parameter is encountered.
  */
 	public function parse($argv, $command = null) {
 		if (isset($this->_subcommands[$command]) && $this->_subcommands[$command]->parser()) {
@@ -545,7 +545,7 @@ class ConsoleOptionParser {
  * @param string $option The option to parse.
  * @param array $params The params to append the parsed value into
  * @return array Params with $option added in.
- * @throws Cake\Error\ConsoleException When unknown short options are encountered.
+ * @throws \Cake\Error\ConsoleException When unknown short options are encountered.
  */
 	protected function _parseShortOption($option, $params) {
 		$key = substr($option, 1);
@@ -569,7 +569,7 @@ class ConsoleOptionParser {
  * @param string $name The name to parse.
  * @param array $params The params to append the parsed value into
  * @return array Params with $option added in.
- * @throws Cake\Error\ConsoleException
+ * @throws \Cake\Error\ConsoleException
  */
 	protected function _parseOption($name, $params) {
 		if (!isset($this->_options[$name])) {
@@ -616,7 +616,7 @@ class ConsoleOptionParser {
  * @param string $argument The argument to append
  * @param array $args The array of parsed args to append to.
  * @return array Args
- * @throws Cake\Error\ConsoleException
+ * @throws \Cake\Error\ConsoleException
  */
 	protected function _parseArg($argument, $args) {
 		if (empty($this->_args)) {

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -87,7 +87,7 @@ class ShellDispatcher {
  * Defines current working environment.
  *
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected function _initEnvironment() {
 		if (!$this->_bootstrap()) {
@@ -132,7 +132,7 @@ class ShellDispatcher {
  * Dispatch a request.
  *
  * @return boolean
- * @throws Cake\Error\MissingShellMethodException
+ * @throws \Cake\Error\MissingShellMethodException
  */
 	protected function _dispatch() {
 		$shell = $this->shiftArgs();
@@ -184,7 +184,7 @@ class ShellDispatcher {
  *
  * @param string $shell Optionally the name of a plugin
  * @return mixed An object
- * @throws Cake\Error\MissingShellException when errors are encountered.
+ * @throws \Cake\Error\MissingShellException when errors are encountered.
  */
 	protected function _getShell($shell) {
 		list($plugin, $shell) = pluginSplit($shell);

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -59,7 +59,7 @@ class TaskRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the task is missing in.
- * @throws Cake\Error\MissingTaskException
+ * @throws \Cake\Error\MissingTaskException
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingTaskException([

--- a/src/Controller/Component/Acl/AclInterface.php
+++ b/src/Controller/Component/Acl/AclInterface.php
@@ -66,7 +66,7 @@ interface AclInterface {
 /**
  * Initialization method for the Acl implementation
  *
- * @param AclComponent $component
+ * @param Component $component
  * @return void
  */
 	public function initialize(Component $component);

--- a/src/Controller/Component/Acl/IniAcl.php
+++ b/src/Controller/Component/Acl/IniAcl.php
@@ -45,7 +45,7 @@ class IniAcl extends Object implements AclInterface {
 /**
  * Initialize method
  *
- * @param AclBase $component
+ * @param Component $component
  * @return void
  */
 	public function initialize(Component $component) {

--- a/src/Controller/Component/Acl/PhpAcl.php
+++ b/src/Controller/Component/Acl/PhpAcl.php
@@ -102,7 +102,7 @@ class PhpAcl extends Object implements AclInterface {
  *
  * @param array $config configuration array, see docs
  * @return void
- * @throws Cake\Error\AclException When required keys are missing.
+ * @throws \Cake\Error\AclException When required keys are missing.
  */
 	public function build(array $config) {
 		if (empty($config['roles'])) {

--- a/src/Controller/Component/Acl/PhpAcl.php
+++ b/src/Controller/Component/Acl/PhpAcl.php
@@ -82,7 +82,7 @@ class PhpAcl extends Object implements AclInterface {
 /**
  * Initialize method
  *
- * @param AclComponent $Component Component instance
+ * @param Component $Component Component instance
  * @return void
  */
 	public function initialize(Component $Component) {

--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -62,7 +62,7 @@ class AclComponent extends Component {
  *
  * @param ComponentRegistry $collection
  * @param array $settings
- * @throws Cake\Error\Exception when Acl.classname could not be loaded.
+ * @throws \Cake\Error\Exception when Acl.classname could not be loaded.
  */
 	public function __construct(ComponentRegistry $collection, $settings = array()) {
 		parent::__construct($collection, $settings);
@@ -86,7 +86,7 @@ class AclComponent extends Component {
  *
  * @param AclInterface|string $adapter Instance of AclInterface or a string name of the class to use. (optional)
  * @return AclInterface|void either null, or the adapter implementation.
- * @throws Cake\Error\Exception when the given class is not an instance of AclInterface
+ * @throws \Cake\Error\Exception when the given class is not an instance of AclInterface
  */
 	public function adapter($adapter = null) {
 		if ($adapter) {

--- a/src/Controller/Component/Auth/ActionsAuthorize.php
+++ b/src/Controller/Component/Auth/ActionsAuthorize.php
@@ -31,7 +31,7 @@ class ActionsAuthorize extends BaseAuthorize {
  * Authorize a user using the AclComponent.
  *
  * @param array $user The user to authorize
- * @param Cake\Network\Request $request The request needing authorization.
+ * @param \Cake\Network\Request $request The request needing authorization.
  * @return boolean
  */
 	public function authorize($user, Request $request) {

--- a/src/Controller/Component/Auth/BaseAuthenticate.php
+++ b/src/Controller/Component/Auth/BaseAuthenticate.php
@@ -128,7 +128,7 @@ abstract class BaseAuthenticate {
  * Return password hasher object
  *
  * @return AbstractPasswordHasher Password hasher instance
- * @throws Cake\Error\Exception If password hasher class not found or
+ * @throws \Cake\Error\Exception If password hasher class not found or
  *   it does not extend AbstractPasswordHasher
  */
 	public function passwordHasher() {
@@ -161,8 +161,8 @@ abstract class BaseAuthenticate {
 /**
  * Authenticate a user based on the request information.
  *
- * @param Cake\Network\Request $request Request to get authentication information from.
- * @param Cake\Network\Response $response A response object that can have headers added.
+ * @param \Cake\Network\Request $request Request to get authentication information from.
+ * @param \Cake\Network\Response $response A response object that can have headers added.
  * @return mixed Either false on failure, or an array of user data on success.
  */
 	abstract public function authenticate(Request $request, Response $response);
@@ -184,7 +184,7 @@ abstract class BaseAuthenticate {
  * Get a user based on information in the request. Primarily used by stateless authentication
  * systems like basic and digest auth.
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return mixed Either false or an array of user information
  */
 	public function getUser(Request $request) {
@@ -196,8 +196,8 @@ abstract class BaseAuthenticate {
  * the unauthenticated request has been dealt with and no more action is required by
  * AuthComponent or void (default).
  *
- * @param Cake\Network\Request $request A request object.
- * @param Cake\Network\Response $response A response object.
+ * @param \Cake\Network\Request $request A request object.
+ * @param \Cake\Network\Response $response A response object.
  * @return void
  */
 	public function unauthenticated(Request $request, Response $response) {

--- a/src/Controller/Component/Auth/BaseAuthorize.php
+++ b/src/Controller/Component/Auth/BaseAuthorize.php
@@ -85,7 +85,7 @@ abstract class BaseAuthorize {
  * Checks user authorization.
  *
  * @param array $user Active user data
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return boolean
  */
 	abstract public function authorize($user, Request $request);
@@ -95,7 +95,7 @@ abstract class BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {
@@ -112,7 +112,7 @@ abstract class BaseAuthorize {
  * Get the action path for a given request. Primarily used by authorize objects
  * that need to get information about the plugin, controller, and action being invoked.
  *
- * @param Cake\Network\Request $request The request a path is needed for.
+ * @param \Cake\Network\Request $request The request a path is needed for.
  * @param string $path
  * @return string the action path for the given request.
  */

--- a/src/Controller/Component/Auth/BaseAuthorize.php
+++ b/src/Controller/Component/Auth/BaseAuthorize.php
@@ -72,7 +72,7 @@ abstract class BaseAuthorize {
  * Constructor
  *
  * @param ComponentRegistry $registry The controller for this request.
- * @param string $settings An array of settings. This class does not use any settings.
+ * @param array $settings An array of settings. This class does not use any settings.
  */
 	public function __construct(ComponentRegistry $registry, $settings = array()) {
 		$this->_registry = $registry;

--- a/src/Controller/Component/Auth/BasicAuthenticate.php
+++ b/src/Controller/Component/Auth/BasicAuthenticate.php
@@ -77,8 +77,8 @@ class BasicAuthenticate extends BaseAuthenticate {
 /**
  * Handles an unauthenticated access attempt by sending appropriate login headers
  *
- * @param CakeRequest $request A request object.
- * @param CakeResponse $response A response object.
+ * @param Request $request A request object.
+ * @param Response $response A response object.
  * @return void
  * @throws \Cake\Error\UnauthorizedException
  */

--- a/src/Controller/Component/Auth/BasicAuthenticate.php
+++ b/src/Controller/Component/Auth/BasicAuthenticate.php
@@ -50,8 +50,8 @@ class BasicAuthenticate extends BaseAuthenticate {
  * Authenticate a user using HTTP auth. Will use the configured User model and attempt a
  * login using HTTP auth.
  *
- * @param Cake\Network\Request $request The request to authenticate with.
- * @param Cake\Network\Response $response The response to add headers to.
+ * @param \Cake\Network\Request $request The request to authenticate with.
+ * @param \Cake\Network\Response $response The response to add headers to.
  * @return mixed Either false on failure, or an array of user data on success.
  */
 	public function authenticate(Request $request, Response $response) {
@@ -61,7 +61,7 @@ class BasicAuthenticate extends BaseAuthenticate {
 /**
  * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return mixed Either false or an array of user information
  */
 	public function getUser(Request $request) {
@@ -80,7 +80,7 @@ class BasicAuthenticate extends BaseAuthenticate {
  * @param CakeRequest $request A request object.
  * @param CakeResponse $response A response object.
  * @return void
- * @throws Cake\Error\UnauthorizedException
+ * @throws \Cake\Error\UnauthorizedException
  */
 	public function unauthenticated(Request $request, Response $response) {
 		$Exception = new Error\UnauthorizedException();
@@ -91,7 +91,7 @@ class BasicAuthenticate extends BaseAuthenticate {
 /**
  * Generate the login headers
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return string Headers for logging in.
  */
 	public function loginHeaders(Request $request) {

--- a/src/Controller/Component/Auth/ControllerAuthorize.php
+++ b/src/Controller/Component/Auth/ControllerAuthorize.php
@@ -46,7 +46,7 @@ class ControllerAuthorize extends BaseAuthorize {
  *
  * @param Controller $controller null to get, a controller to set.
  * @return mixed
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function controller(Controller $controller = null) {
 		if ($controller) {
@@ -61,7 +61,7 @@ class ControllerAuthorize extends BaseAuthorize {
  * Checks user authorization using a controller callback.
  *
  * @param array $user Active user data
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return boolean
  */
 	public function authorize($user, Request $request) {

--- a/src/Controller/Component/Auth/CrudAuthorize.php
+++ b/src/Controller/Component/Auth/CrudAuthorize.php
@@ -39,7 +39,7 @@ class CrudAuthorize extends BaseAuthorize {
  * Sets up additional actionMap values that match the configured `Routing.prefixes`.
  *
  * @param ComponentRegistry $registry The component registry from the controller.
- * @param string $settings An array of settings. This class does not use any settings.
+ * @param array $settings An array of settings. This class does not use any settings.
  */
 	public function __construct(ComponentRegistry $registry, $settings = array()) {
 		parent::__construct($registry, $settings);

--- a/src/Controller/Component/Auth/CrudAuthorize.php
+++ b/src/Controller/Component/Auth/CrudAuthorize.php
@@ -78,7 +78,7 @@ class CrudAuthorize extends BaseAuthorize {
  * Authorize a user using the mapped actions and the AclComponent.
  *
  * @param array $user The user to authorize
- * @param Cake\Network\Request $request The request needing authorization.
+ * @param \Cake\Network\Request $request The request needing authorization.
  * @return boolean
  */
 	public function authorize($user, Request $request) {

--- a/src/Controller/Component/Auth/DigestAuthenticate.php
+++ b/src/Controller/Component/Auth/DigestAuthenticate.php
@@ -96,7 +96,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 /**
  * Get a user based on information in the request. Used by cookie-less auth for stateless clients.
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return mixed Either false or an array of user information
  */
 	public function getUser(Request $request) {
@@ -122,7 +122,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 /**
  * Gets the digest headers from the request/environment.
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return array Array of digest information.
  */
 	protected function _getDigest(Request $request) {
@@ -195,7 +195,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 /**
  * Generate the login headers
  *
- * @param Cake\Network\Request $request Request object.
+ * @param \Cake\Network\Request $request Request object.
  * @return string Headers for logging in.
  */
 	public function loginHeaders(Request $request) {

--- a/src/Controller/Component/Auth/FormAuthenticate.php
+++ b/src/Controller/Component/Auth/FormAuthenticate.php
@@ -42,7 +42,7 @@ class FormAuthenticate extends BaseAuthenticate {
 /**
  * Checks the fields to ensure they are supplied.
  *
- * @param Cake\Network\Request $request The request that contains login information.
+ * @param \Cake\Network\Request $request The request that contains login information.
  * @param string $model The model used for login verification.
  * @param array $fields The fields to be checked.
  * @return boolean False if the fields have not been supplied. True if they exist.
@@ -65,8 +65,8 @@ class FormAuthenticate extends BaseAuthenticate {
  * to find POST data that is used to find a matching record in the `settings.userModel`. Will return false if
  * there is no post data, either username or password is missing, or if the scope conditions have not been met.
  *
- * @param Cake\Network\Request $request The request that contains login information.
- * @param Cake\Network\Response $response Unused response object.
+ * @param \Cake\Network\Request $request The request that contains login information.
+ * @param \Cake\Network\Response $response Unused response object.
  * @return mixed False on login failure.  An array of User data on success.
  */
 	public function authenticate(Request $request, Response $response) {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -243,14 +243,14 @@ class AuthComponent extends Component {
 /**
  * Request object
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	public $request;
 
 /**
  * Response object
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	public $response;
 
@@ -399,7 +399,7 @@ class AuthComponent extends Component {
  *
  * @param Controller $controller A reference to the controller object
  * @return boolean Returns false
- * @throws Cake\Error\ForbiddenException
+ * @throws \Cake\Error\ForbiddenException
  * @see AuthComponent::$unauthorizedRedirect
  */
 	protected function _unauthorized(Controller $controller) {
@@ -447,7 +447,7 @@ class AuthComponent extends Component {
  * be authorized for the request.
  *
  * @param array $user The user to check the authorization of. If empty the user in the session will be used.
- * @param Cake\Network\Request $request The request to authenticate for. If empty, the current request will be used.
+ * @param \Cake\Network\Request $request The request to authenticate for. If empty, the current request will be used.
  * @return boolean True if $user is authorized, otherwise false
  */
 	public function isAuthorized($user = null, Request $request = null) {
@@ -475,7 +475,7 @@ class AuthComponent extends Component {
  * Loads the authorization objects configured.
  *
  * @return mixed Either null when authorize is empty, or the loaded authorization objects.
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function constructAuthorize() {
 		if (empty($this->authorize)) {
@@ -730,8 +730,8 @@ class AuthComponent extends Component {
  * Use the configured authentication adapters, and attempt to identify the user
  * by credentials contained in $request.
  *
- * @param Cake\Network\Request $request The request that contains authentication data.
- * @param Cake\Network\Response $response The response
+ * @param \Cake\Network\Request $request The request that contains authentication data.
+ * @param \Cake\Network\Response $response The response
  * @return array User record data, or false, if the user could not be identified.
  */
 	public function identify(Request $request, Response $response) {
@@ -751,7 +751,7 @@ class AuthComponent extends Component {
  * Loads the configured authentication objects.
  *
  * @return mixed either null on empty authenticate value, or an array of loaded objects.
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function constructAuthenticate() {
 		if (empty($this->authenticate)) {

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -308,10 +308,10 @@ class CookieComponent extends Component {
 	}
 
 /**
- * Returns true if given variable is set in cookie.
+ * Returns true if given key is set in the cookie.
  *
- * @param string $var Variable name to check for
- * @return boolean True if variable is there
+ * @param string $key Key to check for
+ * @return boolean True if the key exists
  */
 	public function check($key = null) {
 		if (empty($key)) {

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -160,14 +160,14 @@ class CookieComponent extends Component {
 /**
  * A reference to the Controller's Cake\Network\Response object
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	protected $_response = null;
 
 /**
  * The request from the controller.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request;
 
@@ -393,7 +393,7 @@ class CookieComponent extends Component {
  *
  * @param string $type Encryption method
  * @return void
- * @throws Cake\Error\Exception When an unknown type is used.
+ * @throws \Cake\Error\Exception When an unknown type is used.
  */
 	public function type($type = 'aes') {
 		$availableTypes = [

--- a/src/Controller/Component/CsrfComponent.php
+++ b/src/Controller/Component/CsrfComponent.php
@@ -69,7 +69,7 @@ class CsrfComponent extends Component {
  * RequestAction requests do not get checked, nor will
  * they set a cookie should it be missing.
  *
- * @param Cake\Event\Event $event
+ * @param \Cake\Event\Event $event
  * @return void
  */
 	public function startup(Event $event) {
@@ -101,8 +101,8 @@ class CsrfComponent extends Component {
  * Also sets the request->params['_csrfToken'] so the newly minted
  * token is available in the request data.
  *
- * @param Cake\Network\Request $request The request object.
- * @param Cake\Network\Response $response The response object.
+ * @param \Cake\Network\Request $request The request object.
+ * @param \Cake\Network\Response $response The response object.
  */
 	protected function _setCookie(Request $request, Response $response) {
 		$settings = $this->settings;
@@ -120,8 +120,8 @@ class CsrfComponent extends Component {
 /**
  * Validate the request data against the cookie token.
  *
- * @param Cake\Network\Request $request The request to validate against.
- * @throws Cake\Error\ForbiddenException when the CSRF token is invalid or missing.
+ * @param \Cake\Network\Request $request The request to validate against.
+ * @throws \Cake\Error\ForbiddenException when the CSRF token is invalid or missing.
  * @return void
  */
 	protected function _validateToken(Request $request) {

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -129,7 +129,7 @@ class PaginatorComponent extends Component {
  * @param Table $object The table to paginate.
  * @param array $settings The settings/configuration used for pagination.
  * @return array Query results
- * @throws Cake\Error\NotFoundException
+ * @throws \Cake\Error\NotFoundException
  */
 	public function paginate($object, array $settings = []) {
 		$alias = $object->alias();

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -56,14 +56,14 @@ class RequestHandlerComponent extends Component {
 /**
  * Holds the reference to Controller::$request
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	public $request;
 
 /**
  * Holds the reference to Controller::$response
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	public $response;
 
@@ -247,7 +247,7 @@ class RequestHandlerComponent extends Component {
  *
  * @param Event $event The Controller.beforeRedirect event.
  * @param string|array $url A string or array containing the redirect location
- * @param Cake\Network\Response $response The response object.
+ * @param \Cake\Network\Response $response The response object.
  * @return void
  */
 	public function beforeRedirect(Event $event, $url, $response) {
@@ -625,7 +625,7 @@ class RequestHandlerComponent extends Component {
  *    be the handling callback, all other arguments should be additional parameters
  *    for the handler.
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function addInputType($type, $handler) {
 		if (!is_array($handler) || !isset($handler[0]) || !is_callable($handler[0])) {

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -124,7 +124,7 @@ class SecurityComponent extends Component {
 /**
  * Request object
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	public $request;
 
@@ -197,7 +197,7 @@ class SecurityComponent extends Component {
  * @return mixed If specified, controller blackHoleCallback's response, or no return otherwise
  * @see SecurityComponent::$blackHoleCallback
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#handling-blackhole-callbacks
- * @throws Cake\Error\BadRequestException
+ * @throws \Cake\Error\BadRequestException
  */
 	public function blackHole(Controller $controller, $error = '') {
 		if (!$this->blackHoleCallback) {
@@ -363,7 +363,7 @@ class SecurityComponent extends Component {
 /**
  * Manually add CSRF token information into the provided request object.
  *
- * @param Cake\Network\Request $request The request object to add into.
+ * @param \Cake\Network\Request $request The request object to add into.
  * @return boolean
  */
 	public function generateToken(Request $request) {
@@ -397,7 +397,7 @@ class SecurityComponent extends Component {
  * @param string $method Method to execute
  * @param array $params Parameters to send to method
  * @return mixed Controller callback method's response
- * @throws Cake\Error\BadRequestException When a the blackholeCallback is not callable.
+ * @throws \Cake\Error\BadRequestException When a the blackholeCallback is not callable.
  */
 	protected function _callback(Controller $controller, $method, $params = array()) {
 		if (!is_callable(array($controller, $method))) {

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -37,14 +37,14 @@ class ComponentRegistry extends ObjectRegistry {
 /**
  * The event manager to bind components to.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager = null;
 
 /**
  * Constructor.
  *
- * @param Cake\Controller\Controller $Controller
+ * @param \Cake\Controller\Controller $Controller
  */
 	public function __construct(Controller $Controller = null) {
 		if ($Controller) {
@@ -83,7 +83,7 @@ class ComponentRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the component is missing in.
- * @throws Cake\Error\MissingComponentException
+ * @throws \Cake\Error\MissingComponentException
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingComponentException([

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -107,7 +107,7 @@ class Controller extends Object implements EventListener {
  * This object contains all the information about a request and several methods for reading
  * additional information about the request.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  * @link http://book.cakephp.org/2.0/en/controllers/request-response.html#Request
  */
 	public $request;
@@ -115,7 +115,7 @@ class Controller extends Object implements EventListener {
 /**
  * An instance of a Response object that contains information about the impending response
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  * @link http://book.cakephp.org/2.0/en/controllers/request-response.html#cakeresponse
  */
 	public $response;
@@ -134,7 +134,7 @@ class Controller extends Object implements EventListener {
  * tables your controller will be paginating.
  *
  * @var array
- * @see Cake\Controller\Component\PaginatorComponent
+ * @see \Cake\Controller\Component\PaginatorComponent
  */
 	public $paginate = [];
 
@@ -172,7 +172,7 @@ class Controller extends Object implements EventListener {
 /**
  * The view theme to use.
  *
- * @see Cake\View\View::$theme
+ * @see \Cake\View\View::$theme
  * @var string
  */
 	public $theme = null;
@@ -221,7 +221,7 @@ class Controller extends Object implements EventListener {
  * Instance of the View created during rendering. Won't be set until after
  * Controller::render() is called.
  *
- * @var Cake\View\View
+ * @var \Cake\View\View
  */
 	public $View;
 
@@ -287,16 +287,16 @@ class Controller extends Object implements EventListener {
  * Instance of the Cake\Event\EventManager this controller is using
  * to dispatch inner events.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager = null;
 
 /**
  * Constructor.
  *
- * @param Cake\Network\Request $request Request object for this controller. Can be null for testing,
+ * @param \Cake\Network\Request $request Request object for this controller. Can be null for testing,
  *  but expect that features that use the request parameters will not work.
- * @param Cake\Network\Response $response Response object for this controller.
+ * @param \Cake\Network\Response $response Response object for this controller.
  */
 	public function __construct($request = null, $response = null) {
 		if ($this->name === null) {
@@ -358,7 +358,7 @@ class Controller extends Object implements EventListener {
  * - $this->autoRender - To false if $request->params['return'] == 1
  * - $this->passedArgs - The the combined results of params['named'] and params['pass]
  *
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return void
  */
 	public function setRequest(Request $request) {
@@ -381,10 +381,10 @@ class Controller extends Object implements EventListener {
  * Dispatches the controller action. Checks that the action
  * exists and isn't private.
  *
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return mixed The resulting response.
- * @throws Cake\Error\PrivateActionException When actions are not public or prefixed by _
- * @throws Cake\Error\MissingActionException When actions are not defined.
+ * @throws \Cake\Error\PrivateActionException When actions are not public or prefixed by _
+ * @throws \Cake\Error\MissingActionException When actions are not defined.
  */
 	public function invokeAction(Request $request) {
 		try {
@@ -415,7 +415,7 @@ class Controller extends Object implements EventListener {
  * or if the request is attempting to directly accessing a prefixed action.
  *
  * @param \ReflectionMethod $method The method to be invoked.
- * @param Cake\Network\Request $request The request to check.
+ * @param \Cake\Network\Request $request The request to check.
  * @return boolean
  */
 	protected function _isPrivateAction(\ReflectionMethod $method, Request $request) {
@@ -506,7 +506,7 @@ class Controller extends Object implements EventListener {
  * You can use this instance to register any new listeners or callbacks to the
  * controller events, or create your own events and trigger them at will.
  *
- * @return Cake\Event\EventManager
+ * @return \Cake\Event\EventManager
  */
 	public function getEventManager() {
 		if (empty($this->_eventManager)) {
@@ -520,7 +520,7 @@ class Controller extends Object implements EventListener {
  *
  * Useful for testing
  *
- * @param Cake\Event\EventManager $eventManager
+ * @param \Cake\Event\EventManager $eventManager
  * @return void
  */
 	public function setEventManager($eventManager) {
@@ -617,7 +617,7 @@ class Controller extends Object implements EventListener {
  *
  * @param string $view View to use for rendering
  * @param string $layout Layout to use
- * @return Cake\Network\Response A response object containing the rendered view.
+ * @return \Cake\Network\Response A response object containing the rendered view.
  * @link http://book.cakephp.org/2.0/en/controllers.html#Controller::render
  */
 	public function render($view = null, $layout = null) {

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -38,8 +38,8 @@ class ErrorController extends Controller {
 /**
  * Constructor
  *
- * @param Cake\Network\Request $request
- * @param Cake\Network\Response $response
+ * @param \Cake\Network\Request $request
+ * @param \Cake\Network\Response $response
  */
 	public function __construct($request = null, $response = null) {
 		parent::__construct($request, $response);

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -72,7 +72,7 @@ class App {
  * application/plugin, otherwise try to load from the CakePHP core
  *
  * @param string $class Classname
- * @param strign $type Type of class
+ * @param string $type Type of class
  * @param string $suffix Classname suffix
  * @return boolean|string False if the class is not found or namespaced classname
  */

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -235,7 +235,7 @@ class Configure {
  * @param string $config Name of the configured engine to use to read the resource identified by $key.
  * @param boolean $merge if config files should be merged instead of simply overridden
  * @return mixed false if file not found, void if load successful.
- * @throws Cake\Error\ConfigureException Will throw any exceptions the engine raises.
+ * @throws \Cake\Error\ConfigureException Will throw any exceptions the engine raises.
  */
 	public static function load($key, $config = 'default', $merge = true) {
 		$engine = static::_getEngine($config);
@@ -279,7 +279,7 @@ class Configure {
  * @param array $keys The name of the top-level keys you want to dump.
  *   This allows you save only some data stored in Configure.
  * @return boolean success
- * @throws Cake\Error\ConfigureException if the adapter does not implement a `dump` method.
+ * @throws \Cake\Error\ConfigureException if the adapter does not implement a `dump` method.
  */
 	public static function dump($key, $config = 'default', $keys = []) {
 		$engine = static::_getEngine($config);

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -108,7 +108,7 @@ class Plugin {
  *
  * @param string|array $plugin name of the plugin to be loaded in CamelCase format or array or plugins to load
  * @param array $config configuration options for the plugin
- * @throws Cake\Error\MissingPluginException if the folder for the plugin to be loaded is not found
+ * @throws \Cake\Error\MissingPluginException if the folder for the plugin to be loaded is not found
  * @return void
  */
 	public static function load($plugin, $config = []) {
@@ -195,7 +195,7 @@ class Plugin {
  *
  * @param string $plugin name of the plugin in CamelCase format
  * @return string path to the plugin folder
- * @throws Cake\Error\MissingPluginException if the folder for plugin was not found or plugin has not been loaded
+ * @throws \Cake\Error\MissingPluginException if the folder for plugin was not found or plugin has not been loaded
  */
 	public static function path($plugin) {
 		if (empty(static::$_plugins[$plugin])) {

--- a/src/Core/StaticConfigTrait.php
+++ b/src/Core/StaticConfigTrait.php
@@ -60,7 +60,7 @@ trait StaticConfigTrait {
  * @param string|array $key The name of the configuration, or an array of multiple configs.
  * @param array $config An array of name => configuration data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Error\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		// Read config.

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -139,8 +139,8 @@ class Connection {
  *
  * @param string|Driver $driver
  * @param array|null $config Either config for a new driver or null.
- * @throws Cake\Database\Exception\MissingDriverException When a driver class is missing.
- * @throws Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
+ * @throws \Cake\Database\Exception\MissingDriverException When a driver class is missing.
+ * @throws \Cake\Database\Exception\MissingExtensionException When a driver's PHP extension is missing.
  * @return Driver
  */
 	public function driver($driver = null, $config = null) {
@@ -162,7 +162,7 @@ class Connection {
 /**
  * Connects to the configured database
  *
- * @throws Cake\Database\Exception\MissingConnectionException if credentials are invalid
+ * @throws \Cake\Database\Exception\MissingConnectionException if credentials are invalid
  * @return boolean true on success or false if already connected.
  */
 	public function connect() {
@@ -195,7 +195,7 @@ class Connection {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|Cake\Database\Query $sql
+ * @param string|\Cake\Database\Query $sql
  * @return \Cake\Database\Statement
  */
 	public function prepare($sql) {
@@ -252,7 +252,7 @@ class Connection {
 /**
  * Get a Schema\Collection object for this connection.
  *
- * @return Cake\Database\Schema\Collection
+ * @return \Cake\Database\Schema\Collection
  */
 	public function schemaCollection() {
 		return new \Cake\Database\Schema\Collection($this);

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -103,8 +103,6 @@ class Connection {
  * Destructor
  *
  * Disconnects the driver to release the connection.
- *
- * @return void
  */
 	public function __destruct() {
 		unset($this->_driver);

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -53,7 +53,7 @@ trait MysqlDialectTrait {
  * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
- * @return Cake\Database\Schema\MysqlSchema
+ * @return \Cake\Database\Schema\MysqlSchema
  */
 	public function schemaDialect() {
 		if (!$this->_schemaDialect) {

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -64,8 +64,8 @@ trait PostgresDialectTrait {
  * Modifies the original insert query to append a "RETURNING *" epilogue
  * so that the latest insert id can be retrieved
  *
- * @param Cake\Database\Query $query
- * @return Cake\Database\Query
+ * @param \Cake\Database\Query $query
+ * @return \Cake\Database\Query
  */
 	protected function _insertQueryTranslator($query) {
 		if (!$query->clause('epilog')) {
@@ -91,7 +91,7 @@ trait PostgresDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param Cake\Database\Expression\FunctionExpression
+ * @param \Cake\Database\Expression\FunctionExpression
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {
@@ -128,7 +128,7 @@ trait PostgresDialectTrait {
  * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
- * @return Cake\Database\Schema\PostgresSchema
+ * @return \Cake\Database\Schema\PostgresSchema
  */
 	public function schemaDialect() {
 		if (!$this->_schemaDialect) {

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -70,7 +70,7 @@ trait SqliteDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param Cake\Database\Expression\FunctionExpression
+ * @param \Cake\Database\Expression\FunctionExpression
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {
@@ -103,8 +103,8 @@ trait SqliteDialectTrait {
  * Receives a TupleExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param Cake\Database\Expression\TupleComparison $expression
- * @param Cake\Database\Query $query
+ * @param \Cake\Database\Expression\TupleComparison $expression
+ * @param \Cake\Database\Query $query
  * @return void
  */
 	protected function _transformTupleComparison(TupleComparison $expression, $query) {
@@ -154,7 +154,7 @@ trait SqliteDialectTrait {
  * The way SQLite works with multi insert is by having multiple select statements
  * joined with UNION.
  *
- * @param Cake\Database\Query $query The query to translate
+ * @param \Cake\Database\Query $query The query to translate
  * @return Query
  */
 	protected function _insertQueryTranslator($query) {
@@ -197,7 +197,7 @@ trait SqliteDialectTrait {
  * Used by Cake\Database\Schema package to reflect schema and
  * generate schema.
  *
- * @return Cake\Database\Schema\SqliteSchema
+ * @return \Cake\Database\Schema\SqliteSchema
  */
 	public function schemaDialect() {
 		if (!$this->_schemaDialect) {

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -50,7 +50,6 @@ abstract class Driver {
  * Constructor
  *
  * @param array $config The configuration for the driver.
- * @return void
  */
 	public function __construct($config = []) {
 		$config += $this->_baseConfig;
@@ -246,8 +245,6 @@ abstract class Driver {
 
 /**
  * Destructor
- *
- * @return void
  */
 	public function __destruct() {
 		$this->_connection = null;

--- a/src/Database/Driver.php
+++ b/src/Database/Driver.php
@@ -93,8 +93,8 @@ abstract class Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|Cake\Database\Query $query
- * @return Cake\Database\Statement
+ * @param string|\Cake\Database\Query $query
+ * @return \Cake\Database\Statement
  */
 	public abstract function prepare($query);
 
@@ -166,7 +166,7 @@ abstract class Driver {
  * If all the tables that use this Driver specify their
  * own schemas, then this may return null.
  *
- * @return Cake\Database\Schema\BaseSchema
+ * @return \Cake\Database\Schema\BaseSchema
  */
 	public abstract function schemaDialect();
 

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -76,8 +76,8 @@ trait PDODriverTrait {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|Cake\Database\Query $query
- * @return Cake\Database\Statement
+ * @param string|\Cake\Database\Query $query
+ * @return \Cake\Database\Statement
  */
 	public function prepare($query) {
 		$this->connect();

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -85,8 +85,8 @@ class Sqlite extends \Cake\Database\Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|Cake\Database\Query $query
- * @return Cake\Database\Statement
+ * @param string|\Cake\Database\Query $query
+ * @return \Cake\Database\Statement
  */
 	public function prepare($query) {
 		$this->connect();

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -53,7 +53,6 @@ class Comparison extends QueryExpression {
  * @param mixed $value the value to be used in comparison
  * @param string $type the type name used to cast the value
  * @param string $conjunction the operator used for comparing field and value
- * @return void
  */
 	public function __construct($field, $value, $type, $conjuntion) {
 		$this->field($field);

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -110,7 +110,7 @@ class Comparison extends QueryExpression {
 /**
  * Convert the expression into a SQL fragment.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -54,10 +54,10 @@ class Comparison extends QueryExpression {
  * @param string $type the type name used to cast the value
  * @param string $conjunction the operator used for comparing field and value
  */
-	public function __construct($field, $value, $type, $conjuntion) {
+	public function __construct($field, $value, $type, $conjunction) {
 		$this->field($field);
 		$this->value($value);
-		$this->type($conjuntion);
+		$this->type($conjunction);
 
 		if (is_string($type)) {
 			$this->_type = $type;

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -57,7 +57,6 @@ class FunctionExpression extends QueryExpression {
  * If associative the key would be used as argument when value is 'literal'
  * @param array types associative array of types to be associated with the
  * passed arguments
- * @return void
  */
 	public function __construct($name, $params = [], $types = []) {
 		$this->_name = $name;

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -114,7 +114,7 @@ class FunctionExpression extends QueryExpression {
  * in their place placeholders are put and can be replaced by the quoted values
  * accordingly.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -64,7 +64,7 @@ class IdentifierExpression implements ExpressionInterface {
 /**
  * Converts the expression to its string representation
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -74,7 +74,7 @@ class IdentifierExpression implements ExpressionInterface {
  * This method is a no-op, this is a leaf type of expression,
  * hence there is nothing to traverse
  *
- * @param callable $visitor
+ * @param callable $callable
  * @return void
  */
 	public function traverse(callable $callable) {

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -36,7 +36,6 @@ class IdentifierExpression implements ExpressionInterface {
  * Constructor
  *
  * @param string $identifier The identifier this expression represents
- * @return void
  */
 	public function __construct($identifier) {
 		$this->setIdentifier($identifier);

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -35,7 +35,7 @@ class OrderByExpression extends QueryExpression {
 /**
  * Convert the expression into a SQL fragment.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -57,7 +57,6 @@ class QueryExpression implements ExpressionInterface, Countable {
  * @param string $conjunction the glue that will join all the string conditions at this
  * level of the expression tree. For example "AND", "OR", "XOR"...
  * @see QueryExpression::add() for more details on $conditions and $types
- * @return void
  */
 	public function __construct($conditions = [], $types = [], $conjunction = 'AND') {
 		$this->type(strtoupper($conjunction));

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -242,7 +242,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * "field IN (value1, value2)".
  *
  * @param string $field database field to be compared against value
- * @param array $value the value to be bound to $field for comparison
+ * @param array $values the value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -258,7 +258,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * "field NOT IN (value1, value2)".
  *
  * @param string $field database field to be compared against value
- * @param array $value the value to be bound to $field for comparison
+ * @param array $values the value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -100,7 +100,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * as conditions.
  * @param array $types associative array of fields pointing to the type of the
  * values that are being passed. Used for correctly binding values to statements.
- * @see Cake\Database\Query::where() for examples on conditions
+ * @see \Cake\Database\Query::where() for examples on conditions
  * @return QueryExpression
  */
 	public function add($conditions, $types = []) {
@@ -336,7 +336,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * in their place placeholders are put and can be replaced by the quoted values
  * accordingly.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -32,7 +32,6 @@ class TupleComparison extends Comparison {
  * @param array $types the types names to use for casting each of the values, only
  * one type per position in the value array in needed
  * @param string $conjunction the operator used for comparing field and value
- * @return void
  */
 	public function __construct($fields, $values, $types = [], $conjuntion = '=') {
 		parent::__construct($fields, $values, $types, $conjuntion);

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -33,8 +33,8 @@ class TupleComparison extends Comparison {
  * one type per position in the value array in needed
  * @param string $conjunction the operator used for comparing field and value
  */
-	public function __construct($fields, $values, $types = [], $conjuntion = '=') {
-		parent::__construct($fields, $values, $types, $conjuntion);
+	public function __construct($fields, $values, $types = [], $conjunction = '=') {
+		parent::__construct($fields, $values, $types, $conjunction);
 		$this->_type = (array)$types;
 	}
 

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -42,7 +42,7 @@ class TupleComparison extends Comparison {
 /**
  * Convert the expression into a SQL fragment.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -24,7 +24,7 @@ class UnaryExpression extends QueryExpression {
 /**
  * Converts the expression to its string representation
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -61,7 +61,6 @@ class ValuesExpression implements ExpressionInterface {
  *
  * @param array $columns The list of columns that are going to be part of the values.
  * @param array $types A dictionary of column -> type names
- * @return void
  */
 	public function __construct(array $columns, array $types = []) {
 		$this->_columns = $columns;

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -110,7 +110,7 @@ class ValuesExpression implements ExpressionInterface {
  * Sets the values to be inserted. If no params are passed, then it returns
  * the currently stored values
  *
- * @param array $cols arrays with values to be inserted
+ * @param array $values arrays with values to be inserted
  * @return array|ValuesExpression
  */
 	public function values($values = null) {

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -52,7 +52,7 @@ class ValuesExpression implements ExpressionInterface {
 /**
  * The Query object to use as a values expression
  *
- * @var Cake\Database\Query
+ * @var \Cake\Database\Query
  */
 	protected $_query = false;
 
@@ -74,7 +74,7 @@ class ValuesExpression implements ExpressionInterface {
  * @param array|Query $data Array of data to append into the insert, or
  *   a query for doing INSERT INTO .. SELECT style commands
  * @return void
- * @throws Cake\Error\Exception When mixing array + Query data types.
+ * @throws \Cake\Error\Exception When mixing array + Query data types.
  */
 	public function add($data) {
 		if (
@@ -127,8 +127,8 @@ class ValuesExpression implements ExpressionInterface {
  * to insert records in the table. If no params are passed, then it returns
  * the currently stored query
  *
- * @param Cake\Database\Query $query
- * @return Cake\Database\Query
+ * @param \Cake\Database\Query $query
+ * @return \Cake\Database\Query
  */
 	public function query(Query $query = null) {
 		if ($query === null) {
@@ -140,7 +140,7 @@ class ValuesExpression implements ExpressionInterface {
 /**
  * Convert the values into a SQL string with placeholders.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator) {

--- a/src/Database/ExpressionInterface.php
+++ b/src/Database/ExpressionInterface.php
@@ -24,7 +24,7 @@ interface ExpressionInterface {
 /**
  * Converts the Node into a SQL string fragment.
  *
- * @param Cake\Database\ValueBinder $generator Placeholder generator object
+ * @param \Cake\Database\ValueBinder $generator Placeholder generator object
  * @return string
  */
 	public function sql(ValueBinder $generator);

--- a/src/Database/FunctionsBuilder.php
+++ b/src/Database/FunctionsBuilder.php
@@ -141,8 +141,8 @@ class FunctionsBuilder {
  * @param array $types list of types to bind to the arguments
  * @return FunctionExpression
  */
-	public function dateDiff($dates, $types = []) {
-		return $this->_build('DATEDIFF', $dates, $types);
+	public function dateDiff($args, $types = []) {
+		return $this->_build('DATEDIFF', $args, $types);
 	}
 
 /**

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -37,7 +37,6 @@ class IdentifierQuoter {
  * Constructor
  *
  * @param \Cake\Database\Driver The driver instance used to do the identifier quoting
- * @return void
  */
 	public function __construct(Driver $driver) {
 		$this->_driver = $driver;

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -29,14 +29,14 @@ class IdentifierQuoter {
 /**
  * The driver instance used to do the identifier quoting
  *
- * @var Cake\Database\Driver
+ * @var \Cake\Database\Driver
  */
 	protected $_driver;
 
 /**
  * Constructor
  *
- * @param Cake\Database\Driver The driver instance used to do the identifier quoting
+ * @param \Cake\Database\Driver The driver instance used to do the identifier quoting
  * @return void
  */
 	public function __construct(Driver $driver) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -157,8 +157,6 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param \Cake\Database\Connection $connection The connection
  * object to be used for transforming and executing this query
- *
- * @return void
  */
 	public function __construct($connection) {
 		$this->connection($connection);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1330,7 +1330,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param array $columns The columns to insert into.
  * @param array $types A map between columns & their datatypes.
  * @return Query
- * @throws RuntimeException When there are 0 columns.
+ * @throws \RuntimeException When there are 0 columns.
  */
 	public function insert($columns, $types = []) {
 		if (empty($columns)) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1129,13 +1129,13 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param integer $num The page number you want.
  * @return Query
  */
-	public function page($page) {
+	public function page($num) {
 		$limit = $this->clause('limit');
 		if ($limit === null) {
 			$limit = 25;
 			$this->limit($limit);
 		}
-		$this->offset(($page - 1) * $limit);
+		$this->offset(($num - 1) * $limit);
 		return $this;
 	}
 
@@ -1304,7 +1304,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Helper function used to covert ExpressionInterface objects inside an array
  * into their string representation
  *
- * @param array $expression list of strings and ExpressionInterface objects
+ * @param array $expressions list of strings and ExpressionInterface objects
  * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return array
  */
@@ -1673,7 +1673,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * will create as many placeholders as values are in it. For example "string[]"
  * will create several placeholders of type string.
  *
- * @param string|integer $token placeholder to be replaced with quoted version
+ * @param string|integer $param placeholder to be replaced with quoted version
  * of $value
  * @param mixed $value the value to be bound
  * @param string|integer $type the mapped type name, used for casting when sending

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -155,7 +155,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
 /**
  * Constructor
  *
- * @param Cake\Database\Connection $connection The connection
+ * @param \Cake\Database\Connection $connection The connection
  * object to be used for transforming and executing this query
  *
  * @return void
@@ -168,8 +168,8 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Sets the connection instance to be used for executing and transforming this query
  * When called with a null argument, it will return the current connection instance
  *
- * @param Cake\Database\Connection $connection instance
- * @return Query|Cake\Database\Connection
+ * @param \Cake\Database\Connection $connection instance
+ * @return Query|\Cake\Database\Connection
  */
 	public function connection($connection = null) {
 		if ($connection === null) {
@@ -198,7 +198,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * This method can be overridden in query subclasses to decorate behavior
  * around query execution.
  *
- * @return Cake\Database\StatementInterface
+ * @return \Cake\Database\StatementInterface
  */
 	public function execute() {
 		$query = $this->_transformQuery();
@@ -472,7 +472,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * DISTINCT clause for the query.
  *
  * @param array $parts list of fields to be transformed to string
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string
  */
 	protected function _buildSelectPart($parts, $generator) {
@@ -556,7 +556,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * converting expression objects to string.
  *
  * @param array $parts list of tables to be transformed to string
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string
  */
 	protected function _buildFromPart($parts, $generator) {
@@ -655,7 +655,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param array|string $tables list of tables to be joined in the query
  * @param array $types associative array of type names used to bind values to query
  * @param boolean $overwrite whether to reset joins with passed list or not
- * @see Cake\Database\Type
+ * @see \Cake\Database\Type
  * @return Query
  */
 	public function join($tables = null, $types = [], $overwrite = false) {
@@ -698,7 +698,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * to be used
  *
  * @param array $parts list of joins to be transformed to string
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string
  */
 	protected function _buildJoinPart($parts, $generator) {
@@ -721,7 +721,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Helper function to generate SQL for SET expressions.
  *
  * @param array $parts List of keys & values to set.
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string
  */
 	protected function _buildSetPart($parts, $generator) {
@@ -848,8 +848,8 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
  * @param boolean $overwrite whether to reset conditions with passed list or not
- * @see Cake\Database\Type
- * @see Cake\Database\QueryExpression
+ * @see \Cake\Database\Type
+ * @see \Cake\Database\QueryExpression
  * @return Query
  */
 	public function where($conditions = null, $types = [], $overwrite = false) {
@@ -912,8 +912,8 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
- * @see Cake\Database\Query::where()
- * @see Cake\Database\Type
+ * @see \Cake\Database\Query::where()
+ * @see \Cake\Database\Type
  * @return Query
  */
 	public function andWhere($conditions, $types = []) {
@@ -973,8 +973,8 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
- * @see Cake\Database\Query::where()
- * @see Cake\Database\Type
+ * @see \Cake\Database\Query::where()
+ * @see \Cake\Database\Type
  * @return Query
  */
 	public function orWhere($conditions, $types = []) {
@@ -1076,7 +1076,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
  * @param boolean $overwrite whether to reset conditions with passed list or not
- * @see Cake\Database\Query::where()
+ * @see \Cake\Database\Query::where()
  * @return Query
  */
 	public function having($conditions = null, $types = [], $overwrite = false) {
@@ -1095,7 +1095,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
- * @see Cake\Database\Query::andWhere()
+ * @see \Cake\Database\Query::andWhere()
  * @return Query
  */
 	public function andHaving($conditions, $types = []) {
@@ -1111,7 +1111,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string|array|ExpressionInterface|callback $conditions
  * @param array $types associative array of type names used to bind values to query
- * @see Cake\Database\Query::orWhere()
+ * @see \Cake\Database\Query::orWhere()
  * @return Query
  */
 	public function orHaving($conditions, $types = []) {
@@ -1266,7 +1266,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * dialect.
  *
  * @param array $parts list of queries to be operated with UNION
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string
  */
 	protected function _buildUnionPart($parts, $generator) {
@@ -1282,7 +1282,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Builds the SQL fragment for INSERT INTO.
  *
  * @param array $parts
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string SQL fragment.
  */
 	protected function _buildInsertPart($parts, $generator) {
@@ -1295,7 +1295,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Builds the SQL fragment for INSERT INTO.
  *
  * @param array $parts
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return string SQL fragment.
  */
 	protected function _buildValuesPart($parts, $generator) {
@@ -1307,7 +1307,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * into their string representation
  *
  * @param array $expression list of strings and ExpressionInterface objects
- * @param Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
+ * @param \Cake\Database\ValueBinder $generator the placeholder generator to be used in expressions
  * @return array
  */
 	protected function _stringifyExpressions(array $expressions, ValueBinder $generator) {
@@ -1369,7 +1369,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param array|Query $data The data to insert.
  * @return Query
- * @throws Cake\Database\Exception if you try to set values before declaring columns.
+ * @throws \Cake\Database\Exception if you try to set values before declaring columns.
  *   Or if you try to set values on non-insert queries.
  */
 	public function values($data) {
@@ -1696,7 +1696,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param ValueBinder $binder new instance to be set. If no value is passed the
  * default one will be returned
- * @return Query|Cake\Database\ValueBinder
+ * @return Query|\Cake\Database\ValueBinder
  */
 	public function valueBinder($binder = null) {
 		if ($binder === null) {
@@ -1713,8 +1713,8 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Auxiliary function used to wrap the original statement from the driver with
  * any registered callbacks.
  *
- * @param Cake\Database\Statement $statement to be decorated
- * @return Cake\Database\Statement\CallbackStatement
+ * @param \Cake\Database\Statement $statement to be decorated
+ * @return \Cake\Database\Statement\CallbackStatement
  */
 	protected function _decorateStatement($statement) {
 		foreach ($this->_resultDecorators as $f) {
@@ -1755,7 +1755,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Traverses all QueryExpression objects stored in every relevant for this type
  * of query and binds every value to the statement object for each placeholder.
  *
- * @param Cake\Database\Statement $statement
+ * @param \Cake\Database\Statement $statement
  * @return void
  */
 	protected function _bindStatement($statement) {

--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -30,14 +30,14 @@ abstract class BaseSchema {
 /**
  * The driver instance being used.
  *
- * @var Cake\Database\Driver
+ * @var \Cake\Database\Driver
  */
 	protected $_driver;
 
 /**
  * Constructor
  *
- * @param Cake\Database\Driver $driver The driver to use.
+ * @param \Cake\Database\Driver $driver The driver to use.
  * @return void
  */
 	public function __construct(Driver $driver) {
@@ -84,7 +84,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL to drop a table.
  *
- * @param Cake\Database\Schema\Table $table Table instance
+ * @param \Cake\Database\Schema\Table $table Table instance
  * @return array SQL statements to drop a table.
  */
 	public function dropTableSql(Table $table) {
@@ -134,7 +134,7 @@ abstract class BaseSchema {
 /**
  * Convert field description results into abstract schema fields.
  *
- * @param Cake\Database\Schema\Table $table The table object to append fields to.
+ * @param \Cake\Database\Schema\Table $table The table object to append fields to.
  * @param array $row The row data from `describeTableSql`.
  * @return void
  */
@@ -143,7 +143,7 @@ abstract class BaseSchema {
 /**
  * Convert an index description results into abstract schema indexes or constraints.
  *
- * @param Cake\Database\Schema\Table $table The table object to append
+ * @param \Cake\Database\Schema\Table $table The table object to append
  *    an index or constraint to.
  * @param array $row The row data from `describeIndexSql`.
  * @return void
@@ -153,7 +153,7 @@ abstract class BaseSchema {
 /**
  * Convert a foreign key description into constraints on the Table object.
  *
- * @param Cake\Database\Schema\Table $table The table object to append
+ * @param \Cake\Database\Schema\Table $table The table object to append
  *    a constraint to.
  * @param array $row The row data from `describeForeignKeySql`.
  * @return void
@@ -163,7 +163,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL to create a table.
  *
- * @param Cake\Database\Schema\Table $table Table instance.
+ * @param \Cake\Database\Schema\Table $table Table instance.
  * @param array $columns The columns to go inside the table.
  * @param array $constraints The constraints for the table.
  * @param array $indexes The indexes for the table.
@@ -174,7 +174,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL fragment for a single column in a table.
  *
- * @param Cake\Database\Schema\Table $table The table instance the column is in.
+ * @param \Cake\Database\Schema\Table $table The table instance the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
@@ -183,7 +183,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL fragments for defining table constraints.
  *
- * @param Cake\Database\Schema\Table $table The table instance the column is in.
+ * @param \Cake\Database\Schema\Table $table The table instance the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
@@ -192,7 +192,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL fragment for a single index in a table.
  *
- * @param Cake\Database\Schema\Table $table The table object the column is in.
+ * @param \Cake\Database\Schema\Table $table The table object the column is in.
  * @param string $name The name of the column.
  * @return string SQL fragment.
  */
@@ -201,7 +201,7 @@ abstract class BaseSchema {
 /**
  * Generate the SQL to truncate a table.
  *
- * @param Cake\Database\Schema\Table $table Table instance.
+ * @param \Cake\Database\Schema\Table $table Table instance.
  * @return array SQL statements to truncate a table.
  */
 	abstract public function truncateTableSql(Table $table);

--- a/src/Database/Schema/BaseSchema.php
+++ b/src/Database/Schema/BaseSchema.php
@@ -38,7 +38,6 @@ abstract class BaseSchema {
  * Constructor
  *
  * @param \Cake\Database\Driver $driver The driver to use.
- * @return void
  */
 	public function __construct(Driver $driver) {
 		$this->_driver = $driver;

--- a/src/Database/Schema/Collection.php
+++ b/src/Database/Schema/Collection.php
@@ -32,14 +32,14 @@ class Collection {
 /**
  * Connection object
  *
- * @var Cake\Database\Connection
+ * @var \Cake\Database\Connection
  */
 	protected $_connection;
 
 /**
  * Schema dialect instance.
  *
- * @var Cake\Database\Schema\BaseSchema
+ * @var \Cake\Database\Schema\BaseSchema
  */
 	protected $_dialect;
 
@@ -54,7 +54,7 @@ class Collection {
 /**
  * Constructor.
  *
- * @param Cake\Database\Connection $connection
+ * @param \Cake\Database\Connection $connection
  */
 	public function __construct(Connection $connection) {
 		$this->_connection = $connection;
@@ -89,8 +89,8 @@ class Collection {
  * configuration options. Defaults to _cake_model_ when true.
  *
  * @param string $name The name of the table to describe.
- * @return Cake\Database\Schema\Table Object with column metadata.
- * @throws Cake\Database\Exception when table cannot be described.
+ * @return \Cake\Database\Schema\Table Object with column metadata.
+ * @throws \Cake\Database\Exception when table cannot be described.
  */
 	public function describe($name) {
 		$cacheConfig = $this->cacheMetadata();
@@ -156,8 +156,8 @@ class Collection {
  *
  * @param string $sql The sql to run.
  * @param array $params Parameters for the statement.
- * @return Cake\Database\Statement Prepared statement
- * @throws Cake\Database\Exception on query failure.
+ * @return \Cake\Database\Statement Prepared statement
+ * @throws \Cake\Database\Exception on query failure.
  */
 	protected function _executeSql($sql, $params) {
 		try {

--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -50,7 +50,7 @@ class MysqlSchema extends BaseSchema {
  *
  * @param string $column The column type + length
  * @return array Array of column information.
- * @throws Cake\Database\Exception When column type cannot be parsed.
+ * @throws \Cake\Database\Exception When column type cannot be parsed.
  */
 	protected function _convertColumn($column) {
 		preg_match('/([a-z]+)(?:\(([0-9,]+)\))?\s*([a-z]+)?/i', $column, $matches);

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -62,7 +62,7 @@ class PostgresSchema extends BaseSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @throws Cake\Database\Exception when column cannot be parsed.
+ * @throws \Cake\Database\Exception when column cannot be parsed.
  * @return array Array of column information.
  */
 	protected function _convertColumn($column) {

--- a/src/Database/Schema/SqliteSchema.php
+++ b/src/Database/Schema/SqliteSchema.php
@@ -29,7 +29,7 @@ class SqliteSchema extends BaseSchema {
  * Cake\Database\Type can handle.
  *
  * @param string $column The column type + length
- * @throws Cake\Database\Exception when unable to parse column type
+ * @throws \Cake\Database\Exception when unable to parse column type
  * @return array Array of column information.
  */
 	protected function _convertColumn($column) {
@@ -205,7 +205,7 @@ class SqliteSchema extends BaseSchema {
 /**
  * {@inheritdoc}
  *
- * @throws Cake\Database\Exception when the column type is unknown
+ * @throws \Cake\Database\Exception when the column type is unknown
  */
 	public function columnSql(Table $table, $name) {
 		$data = $table->column($name);

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -328,7 +328,7 @@ class Table {
  * @param string $name The name of the index.
  * @param array $attrs The attributes for the index.
  * @return Table $this
- * @throws Cake\Database\Exception
+ * @throws \Cake\Database\Exception
  */
 	public function addIndex($name, $attrs) {
 		if (is_string($attrs)) {
@@ -410,7 +410,7 @@ class Table {
  * @param string $name The name of the constraint.
  * @param array $attrs The attributes for the constraint.
  * @return Table $this
- * @throws Cake\Database\Exception
+ * @throws \Cake\Database\Exception
  */
 	public function addConstraint($name, $attrs) {
 		if (is_string($attrs)) {
@@ -444,7 +444,7 @@ class Table {
  *
  * @param array $attrs Attributes to set.
  * @return array
- * @throws Cake\Database\Exception When foreign key definition is not valid.
+ * @throws \Cake\Database\Exception When foreign key definition is not valid.
  */
 	protected function _checkForeignKey($attrs) {
 		if (count($attrs['references']) < 2) {

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -53,7 +53,7 @@ class BufferedStatement extends StatementDecorator {
 /**
  * Constructor
  *
- * @param Cake\Database\Driver instance $driver
+ * @param \Cake\Database\Driver instance $driver
  * @param Statement implementation such as PDOStatement
  * @return void
  */

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -55,7 +55,6 @@ class BufferedStatement extends StatementDecorator {
  *
  * @param \Cake\Database\Driver instance $driver
  * @param Statement implementation such as PDOStatement
- * @return void
  */
 	public function __construct($statement = null, $driver = null) {
 		parent::__construct($statement, $driver);

--- a/src/Database/Statement/CallbackStatement.php
+++ b/src/Database/Statement/CallbackStatement.php
@@ -34,8 +34,8 @@ class CallbackStatement extends StatementDecorator {
 /**
  * Constructor
  *
- * @param Cake\Database\StatementInterface $statement The statement to decorate.
- * @param Cake\Database\Driver $driver The driver instance used by the statement.
+ * @param \Cake\Database\StatementInterface $statement The statement to decorate.
+ * @param \Cake\Database\Driver $driver The driver instance used by the statement.
  * @param callable $callback The callback to apply to results before they are returned.
  */
 	public function __construct($statement, $driver, $callback) {

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -29,7 +29,7 @@ class PDOStatement extends StatementDecorator {
  * Constructor
  *
  * @param \PDOStatement original statement to be decorated
- * @param Cake\Database\Driver instance $driver
+ * @param \Cake\Database\Driver instance $driver
  * @return void
  */
 	public function __construct(Statement $statement = null, $driver = null) {

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -30,7 +30,6 @@ class PDOStatement extends StatementDecorator {
  *
  * @param \PDOStatement original statement to be decorated
  * @param \Cake\Database\Driver instance $driver
- * @return void
  */
 	public function __construct(Statement $statement = null, $driver = null) {
 		$this->_statement = $statement;

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -43,7 +43,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
 /**
  * Reference to the driver object associated to this statement
  *
- * @var Cake\Database\Driver
+ * @var \Cake\Database\Driver
  */
 	protected $_driver;
 
@@ -51,7 +51,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
  * Constructor
  *
  * @param Statement implementation such as PDOStatement
- * @param Cake\Database\Driver instance $driver
+ * @param \Cake\Database\Driver instance $driver
  * @return void
  */
 	public function __construct($statement = null, $driver = null) {

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -52,7 +52,6 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
  *
  * @param Statement implementation such as PDOStatement
  * @param \Cake\Database\Driver instance $driver
- * @return void
  */
 	public function __construct($statement = null, $driver = null) {
 		$this->_statement = $statement;

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -233,7 +233,7 @@ class Type {
  * when entities are inserted.
  *
  * @return mixed A new primary key value.
- * @see Cake\Database\Type\UuidType
+ * @see \Cake\Database\Type\UuidType
  */
 	public function newId() {
 		return null;

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -78,7 +78,6 @@ class Type {
  * Constructor
  *
  * @param string $name The name identifying this type
- * @return void
  */
 	public function __construct($name = null) {
 		$this->_name = $name;

--- a/src/Database/Type/BinaryType.php
+++ b/src/Database/Type/BinaryType.php
@@ -47,7 +47,7 @@ class BinaryType extends \Cake\Database\Type {
  * @param null|string|resource $value The value to convert.
  * @param Driver $driver The driver instance to convert with.
  * @return resource
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function toPHP($value, Driver $driver) {
 		if ($value === null) {

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -40,7 +40,7 @@ class ValueBinder {
 /**
  * Associates a query placeholder to a value and a type
  *
- * @param string|integer $token placeholder to be replaced with quoted version
+ * @param string|integer $param placeholder to be replaced with quoted version
  * of $value
  * @param mixed $value the value to be bound
  * @param string|integer $type the mapped type name, used for casting when sending

--- a/src/Datasource/ConnectionManager.php
+++ b/src/Datasource/ConnectionManager.php
@@ -50,7 +50,7 @@ class ConnectionManager {
 /**
  * The ConnectionRegistry used by the manager.
  *
- * @var Cake\Database\ConnectionRegistry
+ * @var \Cake\Database\ConnectionRegistry
  */
 	protected static $_registry = null;
 
@@ -59,12 +59,12 @@ class ConnectionManager {
  *
  * The connection will not be constructed until it is first used.
  *
- * @see Cake\Core\StaticConfigTrait::config()
+ * @see \Cake\Core\StaticConfigTrait::config()
  *
  * @param string|array $key The name of the connection config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Error\Exception When trying to modify an existing config.
  */
 	public static function config($key, $config = null) {
 		if (is_array($config)) {
@@ -89,7 +89,7 @@ class ConnectionManager {
  * @param string $from The connection to add an alias to.
  * @param string $to The alias to create. $from should return when loaded with get().
  * @return void
- * @throws Cake\Datasource\Error\MissingDatasourceConfigException When aliasing a
+ * @throws \Cake\Datasource\Error\MissingDatasourceConfigException When aliasing a
  * connection that does not exist.
  */
 	public static function alias($from, $to) {
@@ -124,7 +124,7 @@ class ConnectionManager {
  * @param string $name The connection name.
  * @param boolean $useAliases Set to false to not use aliased connections.
  * @return Connection A connection object.
- * @throws Cake\Datasource\Error\MissingDatasourceConfigException When config
+ * @throws \Cake\Datasource\Error\MissingDatasourceConfigException When config
  * data is missing.
  */
 	public static function get($name, $useAliases = true) {
@@ -148,7 +148,7 @@ class ConnectionManager {
  *
  * @param string $name The name of the DataSource, as defined in app/Config/datasources.php
  * @return DataSource Instance
- * @throws Cake\Error\MissingDatasourceConfigException
+ * @throws \Cake\Error\MissingDatasourceConfigException
  * @deprecated Will be removed in 3.0 stable.
  */
 	public static function getDataSource($name) {

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -23,7 +23,7 @@ use Cake\Utility\ObjectRegistry;
 /**
  * A registry object for connection instances.
  *
- * @see Cake\Database\ConnectionManager
+ * @see \Cake\Database\ConnectionManager
  */
 class ConnectionRegistry extends ObjectRegistry {
 
@@ -49,7 +49,7 @@ class ConnectionRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the driver is missing in.
- * @throws Cake\Datasource\Error\MissingDatasourceException
+ * @throws \Cake\Datasource\Error\MissingDatasourceException
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new MissingDatasourceException([

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -24,7 +24,7 @@ use Traversable;
  *
  * Used by Cake\Datasource\QueryTrait internally.
  *
- * @see Cake\Datasource\QueryTrait::cache() for the public interface.
+ * @see \Cake\Datasource\QueryTrait::cache() for the public interface.
  */
 class QueryCacher {
 

--- a/src/Datasource/QueryCacher.php
+++ b/src/Datasource/QueryCacher.php
@@ -99,7 +99,7 @@ class QueryCacher {
 /**
  * Get the cache engine.
  *
- * @return Cake\Cache\CacheEngine
+ * @return \Cake\Cache\CacheEngine
  */
 	protected function _resolveCacher() {
 		if (is_string($this->_config)) {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -63,7 +63,7 @@ trait QueryTrait {
 /**
  * A query cacher instance if this query has caching enabled.
  *
- * @var Cake\Datasource\QueryCacher
+ * @var \Cake\Datasource\QueryCacher
  */
 	protected $_cache;
 
@@ -102,8 +102,8 @@ trait QueryTrait {
  *
  * This method is most useful when combined with results stored in a persistent cache.
  *
- * @param Cake\ORM\ResultSet $results The results this query should return.
- * @return Query The query instance.
+ * @param \Cake\ORM\ResultSet $results The results this query should return.
+ * @return \Cake\ORM\Query The query instance.
  */
 	public function setResult($results) {
 		$this->_results = $results;
@@ -116,7 +116,7 @@ trait QueryTrait {
  * iterated without having to call execute() manually, thus making it look like
  * a result set instead of the query itself.
  *
- * @return Iterator
+ * @return \Iterator
  */
 	public function getIterator() {
 		return $this->all();
@@ -157,7 +157,7 @@ trait QueryTrait {
  *   When using a function, this query instance will be supplied as an argument.
  * @param string|CacheEngine $config Either the name of the cache config to use, or
  *   a cache config instance.
- * @return QueryTrait This same object
+ * @return \Cake\Datasource\QueryTrait This same object
  */
 	public function cache($key, $config = 'default') {
 		if ($key === false) {
@@ -177,7 +177,7 @@ trait QueryTrait {
  * ResultSetDecorator is a travesable object that implements the methods found
  * on Cake\Collection\Collection.
  *
- * @return Cake\ORM\ResultSetDecorator
+ * @return \Cake\ORM\ResultSetDecorator
  */
 	public function all() {
 		if (isset($this->_results)) {
@@ -230,8 +230,8 @@ trait QueryTrait {
  * @param callable $mapper
  * @param callable $reducer
  * @param boolean $overwrite
- * @return Cake\Datasource\QueryTrait|array
- * @see Cake\Collection\Iterator\MapReduce for details on how to use emit data to the map reducer.
+ * @return \Cake\Datasource\QueryTrait|array
+ * @see \Cake\Collection\Iterator\MapReduce for details on how to use emit data to the map reducer.
  */
 	public function mapReduce(callable $mapper = null, callable $reducer = null, $overwrite = false) {
 		if ($overwrite) {
@@ -281,7 +281,7 @@ trait QueryTrait {
  *
  * @param callable $formatter
  * @param boolean|integer $mode
- * @return Cake\Datasource\QueryTrait|array
+ * @return \Cake\Datasource\QueryTrait|array
  */
 	public function formatResults(callable $formatter = null, $mode = self::APPEND) {
 		if ($mode === self::OVERWRITE) {
@@ -360,7 +360,7 @@ trait QueryTrait {
  * This is handy for passing all query clauses at once.
  *
  * @param array $options the options to be applied
- * @return Cake\Datasource\QueryTrait this object
+ * @return \Cake\Datasource\QueryTrait this object
  */
 	abstract public function applyOptions(array $options);
 

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -52,7 +52,7 @@ interface RepositoryInterface {
  *
  * @param mixed primary key value to find
  * @param array $options options accepted by `Table::find()`
- * @throws Cake\ORM\Error\RecordNotFoundException if the record with such id
+ * @throws \Cake\ORM\Error\RecordNotFoundException if the record with such id
  * could not be found
  * @return \Cake\Datasource\EntityInterface
  * @see RepositoryInterface::find()
@@ -146,7 +146,7 @@ interface RepositoryInterface {
  * @param array $data The data to build an entity with.
  * @param array $associations A whitelist of associations
  *   to hydrate. Defaults to all associations
- * @return Cake\Datasource\EntityInterface
+ * @return \Cake\Datasource\EntityInterface
  */
 	public function newEntity(array $data = [], $associations = null);
 

--- a/src/Error/BadRequestException.php
+++ b/src/Error/BadRequestException.php
@@ -27,7 +27,7 @@ class BadRequestException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Bad Request' will be the message
- * @param string $code Status code, defaults to 400
+ * @param integer $code Status code, defaults to 400
  */
 	public function __construct($message = null, $code = 400) {
 		if (empty($message)) {

--- a/src/Error/Exception.php
+++ b/src/Error/Exception.php
@@ -47,7 +47,7 @@ class Exception extends BaseException {
  *
  * @param string|array $message Either the string of the error message, or an array of attributes
  *   that are made available in the view, and sprintf()'d into Exception::$_messageTemplate
- * @param string $code The code of the error, is also the HTTP status code for the error.
+ * @param integer $code The code of the error, is also the HTTP status code for the error.
  */
 	public function __construct($message, $code = 500) {
 		if (is_array($message)) {

--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -171,7 +171,7 @@ class ExceptionRenderer {
 /**
  * Generic handler for the internal framework errors CakePHP can generate.
  *
- * @param Cake\Error\Exception $error
+ * @param \Cake\Error\Exception $error
  * @return void
  */
 	protected function _cakeError(Exception $error) {

--- a/src/Error/ForbiddenException.php
+++ b/src/Error/ForbiddenException.php
@@ -27,7 +27,7 @@ class ForbiddenException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Forbidden' will be the message
- * @param string $code Status code, defaults to 403
+ * @param integer $code Status code, defaults to 403
  */
 	public function __construct($message = null, $code = 403) {
 		if (empty($message)) {

--- a/src/Error/InternalErrorException.php
+++ b/src/Error/InternalErrorException.php
@@ -27,7 +27,7 @@ class InternalErrorException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Internal Server Error' will be the message
- * @param string $code Status code, defaults to 500
+ * @param integer $code Status code, defaults to 500
  */
 	public function __construct($message = null, $code = 500) {
 		if (empty($message)) {

--- a/src/Error/MethodNotAllowedException.php
+++ b/src/Error/MethodNotAllowedException.php
@@ -27,7 +27,7 @@ class MethodNotAllowedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Method Not Allowed' will be the message
- * @param string $code Status code, defaults to 405
+ * @param integer $code Status code, defaults to 405
  */
 	public function __construct($message = null, $code = 405) {
 		if (empty($message)) {

--- a/src/Error/NotFoundException.php
+++ b/src/Error/NotFoundException.php
@@ -27,7 +27,7 @@ class NotFoundException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Not Found' will be the message
- * @param string $code Status code, defaults to 404
+ * @param integer $code Status code, defaults to 404
  */
 	public function __construct($message = null, $code = 404) {
 		if (empty($message)) {

--- a/src/Error/PrivateActionException.php
+++ b/src/Error/PrivateActionException.php
@@ -33,7 +33,7 @@ class PrivateActionException extends Exception {
  *
  * @param string $message Excception message
  * @param integer $code Exception code
- * @param \Exception $previous Previous exception
+ * @param Exception $previous Previous exception
  */
 	public function __construct($message, $code = 404, Exception $previous = null) {
 		parent::__construct($message, $code, $previous);

--- a/src/Error/UnauthorizedException.php
+++ b/src/Error/UnauthorizedException.php
@@ -27,7 +27,7 @@ class UnauthorizedException extends HttpException {
  * Constructor
  *
  * @param string $message If no message is given 'Unauthorized' will be the message
- * @param string $code Status code, defaults to 401
+ * @param integer $code Status code, defaults to 401
  */
 	public function __construct($message = null, $code = 401) {
 		if (empty($message)) {

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -93,7 +93,7 @@ class EventManager {
  * the order of insertion.
  *
  * @return void
- * @throws InvalidArgumentException When event key is missing or callable is not an
+ * @throws \InvalidArgumentException When event key is missing or callable is not an
  *   instance of Cake\Event\EventListener.
  */
 	public function attach($callable, $eventKey = null, $options = array()) {

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -36,7 +36,7 @@ class EventManager {
 /**
  * The globally available instance, used for dispatching events attached from any scope
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected static $_generalManager = null;
 
@@ -62,8 +62,8 @@ class EventManager {
  *
  * If called with the first parameter, it will be set as the globally available instance
  *
- * @param Cake\Event\EventManager $manager
- * @return Cake\Event\EventManager the global event manager
+ * @param \Cake\Event\EventManager $manager
+ * @return \Cake\Event\EventManager the global event manager
  */
 	public static function instance($manager = null) {
 		if ($manager instanceof EventManager) {
@@ -80,7 +80,7 @@ class EventManager {
 /**
  * Adds a new listener to an event.
  *
- * @param callback|Cake\Event\EventListener $callable PHP valid callback type or instance of Cake\Event\EventListener to be called
+ * @param callback|\Cake\Event\EventListener $callable PHP valid callback type or instance of Cake\Event\EventListener to be called
  * when the event named with $eventKey is triggered. If a Cake\Event\EventListener instance is passed, then the `implementedEvents`
  * method will be called on the object to register the declared events individually as methods to be managed by this class.
  * It is possible to define multiple event handlers per event name.
@@ -114,7 +114,7 @@ class EventManager {
  * Auxiliary function to attach all implemented callbacks of a Cake\Event\EventListener class instance
  * as individual methods on this manager
  *
- * @param Cake\Event\EventListener $subscriber
+ * @param \Cake\Event\EventListener $subscriber
  * @return void
  */
 	protected function _attachSubscriber(EventListener $subscriber) {
@@ -142,7 +142,7 @@ class EventManager {
  * from the return value of the `implementedEvents` method on a Cake\Event\EventListener
  *
  * @param array $function the array taken from a handler definition for an event
- * @param Cake\Event\EventListener $object The handler object
+ * @param \Cake\Event\EventListener $object The handler object
  * @return callback
  */
 	protected function _extractCallable($function, $object) {
@@ -158,7 +158,7 @@ class EventManager {
 /**
  * Removes a listener from the active listeners.
  *
- * @param callback|Cake\Event\EventListener $callable any valid PHP callback type or an instance of EventListener
+ * @param callback|\Cake\Event\EventListener $callable any valid PHP callback type or an instance of EventListener
  * @param string $eventKey The event unique identifier name with which the callback has been associated
  * @return void
  */
@@ -188,7 +188,7 @@ class EventManager {
 /**
  * Auxiliary function to help detach all listeners provided by an object implementing EventListener
  *
- * @param Cake\Event\EventListener $subscriber the subscriber to be detached
+ * @param \Cake\Event\EventListener $subscriber the subscriber to be detached
  * @param string $eventKey optional event key name to unsubscribe the listener from
  * @return void
  */
@@ -217,7 +217,7 @@ class EventManager {
 /**
  * Dispatches a new event to all configured listeners
  *
- * @param string|Cake\Event\Event $event the event key name or instance of Event
+ * @param string|\Cake\Event\Event $event the event key name or instance of Event
  * @return void
  */
 	public function dispatch($event) {

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -138,7 +138,7 @@ class I18n {
  * @param string $plural Plural string (if any)
  * @param string $domain Domain The domain of the translation. Domains are often used by plugin translations.
  *    If null, the default domain will be used.
- * @param string $category Category The integer value of the category to use.
+ * @param integer $category Category The integer value of the category to use.
  * @param integer $count Count Count is used with $plural to choose the correct plural form.
  * @param string $language Language to translate string to.
  *    If null it checks for language in session followed by Config.language configuration variable.

--- a/src/I18n/I18n.php
+++ b/src/I18n/I18n.php
@@ -102,14 +102,14 @@ class I18n {
 /**
  * Request object instance
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request = null;
 
 /**
  * Constructor, use I18n::getInstance() to get the i18n translation object.
  *
- * @param Cake\Network\Request $request Request object
+ * @param \Cake\Network\Request $request Request object
  */
 	public function __construct(Request $request) {
 		$this->_request = $request;
@@ -143,7 +143,7 @@ class I18n {
  * @param string $language Language to translate string to.
  *    If null it checks for language in session followed by Config.language configuration variable.
  * @return string translated string.
- * @throws Cake\Error\Exception When '' is provided as a domain.
+ * @throws \Cake\Error\Exception When '' is provided as a domain.
  */
 	public static function translate($singular, $plural = null, $domain = null, $category = 6, $count = null, $language = null) {
 		$_this = I18n::getInstance();

--- a/src/I18n/L10n.php
+++ b/src/I18n/L10n.php
@@ -80,7 +80,7 @@ class L10n {
 /**
  * Request object instance
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request = null;
 
@@ -332,7 +332,7 @@ class L10n {
 /**
  * Class constructor
  *
- * @param Cake\Network\Request $request Request object
+ * @param \Cake\Network\Request $request Request object
  */
 	public function __construct(Request $request) {
 		$this->_request = $request;

--- a/src/Log/Engine/ConsoleLog.php
+++ b/src/Log/Engine/ConsoleLog.php
@@ -28,7 +28,7 @@ class ConsoleLog extends BaseLog {
 /**
  * Output stream
  *
- * @var Cake\Console\ConsoleOutput
+ * @var \Cake\Console\ConsoleOutput
  */
 	protected $_output = null;
 
@@ -43,7 +43,7 @@ class ConsoleLog extends BaseLog {
  * - `outputAs` integer or ConsoleOutput::[RAW|PLAIN|COLOR]
  *
  * @param array $config Options for the FileLog, see above.
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public function __construct($config = array()) {
 		parent::__construct($config);

--- a/src/Log/Engine/FileLog.php
+++ b/src/Log/Engine/FileLog.php
@@ -75,7 +75,7 @@ class FileLog extends BaseLog {
  * - `mask` A mask is applied when log files are created. Left empty no chmod
  *   is made.
  *
- * @param array $options Options for the FileLog, see above.
+ * @param array $config Options for the FileLog, see above.
  */
 	public function __construct($config = array()) {
 		$config = Hash::merge($this->_defaults, $config);

--- a/src/Log/Log.php
+++ b/src/Log/Log.php
@@ -254,7 +254,7 @@ class Log {
  * @param string|array $key The name of the logger config, or an array of multiple configs.
  * @param array $config An array of name => config data for adapter.
  * @return mixed null when adding configuration and an array of configuration data when reading.
- * @throws Cake\Error\Exception When trying to modify an existing config.
+ * @throws \Cake\Error\Exception When trying to modify an existing config.
  * @see App/Config/logging.php
  */
 	public static function config($key, $config = null) {
@@ -325,7 +325,7 @@ class Log {
  * @param string|array $scope The scope(s) a log message is being created in.
  *    See Cake\Log\Log::config() for more information on logging scopes.
  * @return boolean Success
- * @throws Cake\Error\Exception If invalid level is passed.
+ * @throws \Cake\Error\Exception If invalid level is passed.
  */
 	public static function write($level, $message, $scope = array()) {
 		static::_init();

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -47,7 +47,7 @@ class LogEngineRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the logger is missing in.
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\Exception(sprintf('Could not load class %s', $class));
@@ -61,7 +61,7 @@ class LogEngineRegistry extends ObjectRegistry {
  * @param string $alias The alias of the object.
  * @param array $settings An array of settings to use for the logger.
  * @return LogEngine The constructed logger class.
- * @throws Cake\Error\Exception when an object doesn't implement
+ * @throws \Cake\Error\Exception when an object doesn't implement
  *    the correct interface.
  */
 	protected function _create($class, $alias, $settings) {

--- a/src/Network/Email/AbstractTransport.php
+++ b/src/Network/Email/AbstractTransport.php
@@ -32,7 +32,7 @@ abstract class AbstractTransport {
 /**
  * Send mail
  *
- * @param Cake\Network\Email\Email $email
+ * @param \Cake\Network\Email\Email $email
  * @return array
  */
 	abstract public function send(Email $email);

--- a/src/Network/Email/DebugTransport.php
+++ b/src/Network/Email/DebugTransport.php
@@ -26,7 +26,7 @@ class DebugTransport extends AbstractTransport {
 /**
  * Send mail
  *
- * @param Cake\Network\Email\Email $email Cake Email
+ * @param \Cake\Network\Email\Email $email Cake Email
  * @return array
  */
 	public function send(Email $email) {

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -378,8 +378,8 @@ class Email {
  *
  * @param string|array $email
  * @param string $name
- * @return array|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function from($email = null, $name = null) {
 		if ($email === null) {
@@ -393,8 +393,8 @@ class Email {
  *
  * @param string|array $email
  * @param string $name
- * @return array|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function sender($email = null, $name = null) {
 		if ($email === null) {
@@ -408,8 +408,8 @@ class Email {
  *
  * @param string|array $email
  * @param string $name
- * @return array|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function replyTo($email = null, $name = null) {
 		if ($email === null) {
@@ -423,8 +423,8 @@ class Email {
  *
  * @param string|array $email
  * @param string $name
- * @return array|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function readReceipt($email = null, $name = null) {
 		if ($email === null) {
@@ -438,8 +438,8 @@ class Email {
  *
  * @param string|array $email
  * @param string $name
- * @return array|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function returnPath($email = null, $name = null) {
 		if ($email === null) {
@@ -453,7 +453,7 @@ class Email {
  *
  * @param string|array $email Null to get, String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function to($email = null, $name = null) {
 		if ($email === null) {
@@ -467,7 +467,7 @@ class Email {
  *
  * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return Cake\Network\Email\Email $this
+ * @return \Cake\Network\Email\Email $this
  */
 	public function addTo($email, $name = null) {
 		return $this->_addEmail('_to', $email, $name);
@@ -478,7 +478,7 @@ class Email {
  *
  * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function cc($email = null, $name = null) {
 		if ($email === null) {
@@ -492,7 +492,7 @@ class Email {
  *
  * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return Cake\Network\Email\Email $this
+ * @return \Cake\Network\Email\Email $this
  */
 	public function addCc($email, $name = null) {
 		return $this->_addEmail('_cc', $email, $name);
@@ -503,7 +503,7 @@ class Email {
  *
  * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function bcc($email = null, $name = null) {
 		if ($email === null) {
@@ -517,7 +517,7 @@ class Email {
  *
  * @param string|array $email String with email, Array with email as key, name as value or email as value (without name)
  * @param string $name
- * @return Cake\Network\Email\Email $this
+ * @return \Cake\Network\Email\Email $this
  */
 	public function addBcc($email, $name = null) {
 		return $this->_addEmail('_bcc', $email, $name);
@@ -573,8 +573,8 @@ class Email {
  * @param string $varName
  * @param string|array $email
  * @param string $name
- * @return Cake\Network\Email\Email $this
- * @throws Cake\Error\SocketException
+ * @return \Cake\Network\Email\Email $this
+ * @throws \Cake\Error\SocketException
  */
 	protected function _setEmail($varName, $email, $name) {
 		if (!is_array($email)) {
@@ -602,7 +602,7 @@ class Email {
  *
  * @param string $email Email address to validate
  * @return void
- * @throws Cake\Error\SocketException If email address does not validate
+ * @throws \Cake\Error\SocketException If email address does not validate
  */
 	protected function _validateEmail($email) {
 		$valid = (($this->_emailPattern !== null &&
@@ -621,8 +621,8 @@ class Email {
  * @param string|array $email
  * @param string $name
  * @param string $throwMessage
- * @return Cake\Network\Email\Email $this
- * @throws Cake\Error\SocketException
+ * @return \Cake\Network\Email\Email $this
+ * @throws \Cake\Error\SocketException
  */
 	protected function _setEmailSingle($varName, $email, $name, $throwMessage) {
 		$current = $this->{$varName};
@@ -640,8 +640,8 @@ class Email {
  * @param string $varName
  * @param string|array $email
  * @param string $name
- * @return Cake\Network\Email\Email $this
- * @throws Cake\Error\SocketException
+ * @return \Cake\Network\Email\Email $this
+ * @throws \Cake\Error\SocketException
  */
 	protected function _addEmail($varName, $email, $name) {
 		if (!is_array($email)) {
@@ -668,7 +668,7 @@ class Email {
  * Get/Set Subject.
  *
  * @param string $subject
- * @return string|Cake\Network\Email\Email
+ * @return string|\Cake\Network\Email\Email
  */
 	public function subject($subject = null) {
 		if ($subject === null) {
@@ -682,8 +682,8 @@ class Email {
  * Sets headers for the message
  *
  * @param array $headers Associative array containing headers to be set.
- * @return Cake\Network\Email\Email $this
- * @throws Cake\Error\SocketException
+ * @return \Cake\Network\Email\Email $this
+ * @throws \Cake\Error\SocketException
  */
 	public function setHeaders($headers) {
 		if (!is_array($headers)) {
@@ -698,7 +698,7 @@ class Email {
  *
  * @param array $headers
  * @return object $this
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	public function addHeaders($headers) {
 		if (!is_array($headers)) {
@@ -823,7 +823,7 @@ class Email {
  *
  * @param boolean|string $template Template name or null to not use
  * @param boolean|string $layout Layout name or null to not use
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function template($template = false, $layout = false) {
 		if ($template === false) {
@@ -843,7 +843,7 @@ class Email {
  * View class for render
  *
  * @param string $viewClass
- * @return string|Cake\Network\Email\Email
+ * @return string|\Cake\Network\Email\Email
  */
 	public function viewRender($viewClass = null) {
 		if ($viewClass === null) {
@@ -857,7 +857,7 @@ class Email {
  * Variables to be set on render
  *
  * @param array $viewVars
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function viewVars($viewVars = null) {
 		if ($viewVars === null) {
@@ -871,7 +871,7 @@ class Email {
  * Theme to use when rendering
  *
  * @param string $theme
- * @return string|Cake\Network\Email\Email
+ * @return string|\Cake\Network\Email\Email
  */
 	public function theme($theme = null) {
 		if ($theme === null) {
@@ -885,7 +885,7 @@ class Email {
  * Helpers to be used in render
  *
  * @param array $helpers
- * @return array|Cake\Network\Email\Email
+ * @return array|\Cake\Network\Email\Email
  */
 	public function helpers($helpers = null) {
 		if ($helpers === null) {
@@ -899,8 +899,8 @@ class Email {
  * Email format
  *
  * @param string $format
- * @return string|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return string|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function emailFormat($format = null) {
 		if ($format === null) {
@@ -921,8 +921,8 @@ class Email {
  *
  * @param string|AbstractTransport $name Either the name of a configured
  *   transport, or a transport instance.
- * @return AbstractTransport|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException When the chosen transport lacks a send method.
+ * @return AbstractTransport|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException When the chosen transport lacks a send method.
  */
 	public function transport($name = null) {
 		if ($name === null) {
@@ -947,7 +947,7 @@ class Email {
  *
  * @param string $name The transport configuration name to build.
  * @return AbstracTransport
- * @throws Cake\Error\Exception When transport configuration is missing or invalid.
+ * @throws \Cake\Error\Exception When transport configuration is missing or invalid.
  */
 	protected function _constructTransport($name) {
 		if (!isset(static::$_transportConfig[$name]['className'])) {
@@ -970,8 +970,8 @@ class Email {
  * Message-ID
  *
  * @param boolean|string $message True to generate a new Message-ID, False to ignore (not send in email), String to set as Message-ID
- * @return boolean|string|Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return boolean|string|\Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public function messageId($message = null) {
 		if ($message === null) {
@@ -992,7 +992,7 @@ class Email {
  * Domain as top level (the part after @)
  *
  * @param string $domain Manually set the domain for CLI mailing
- * @return string|Cake\Network\Email\Email
+ * @return string|\Cake\Network\Email\Email
  */
 	public function domain($domain = null) {
 		if ($domain === null) {
@@ -1046,8 +1046,8 @@ class Email {
  * attachment compatibility with outlook email clients.
  *
  * @param string|array $attachments String with the filename or array with filenames
- * @return array|Cake\Network\Email\Email Either the array of attachments when getting or $this when setting.
- * @throws Cake\Error\SocketException
+ * @return array|\Cake\Network\Email\Email Either the array of attachments when getting or $this when setting.
+ * @throws \Cake\Error\SocketException
  */
 	public function attachments($attachments = null) {
 		if ($attachments === null) {
@@ -1088,9 +1088,9 @@ class Email {
  * Add attachments
  *
  * @param string|array $attachments String with the filename or array with filenames
- * @return Cake\Network\Email\Email $this
- * @throws Cake\Error\SocketException
- * @see Cake\Network\Email\Email::attachments()
+ * @return \Cake\Network\Email\Email $this
+ * @throws \Cake\Error\SocketException
+ * @see \Cake\Network\Email\Email::attachments()
  */
 	public function addAttachments($attachments) {
 		$current = $this->_attachments;
@@ -1134,7 +1134,7 @@ class Email {
  * @param array|Closure|AbstractTransport Either an array of configuration
  *   data, a Closure factory function, or a transport instance.
  * @return mixed Either null when setting or an array of data when reading.
- * @throws Cake\Error\Exception When modifying an existing configuration.
+ * @throws \Cake\Error\Exception When modifying an existing configuration.
  */
 	public static function configTransport($key, $config = null) {
 		if ($config === null && is_string($key)) {
@@ -1170,7 +1170,7 @@ class Email {
  *
  * @param null|string|array $config String with configuration name, or
  *    an array with config or null to return current config.
- * @return string|array|Cake\Network\Email\Email
+ * @return string|array|\Cake\Network\Email\Email
  */
 	public function profile($config = null) {
 		if ($config === null) {
@@ -1188,7 +1188,7 @@ class Email {
  *
  * @param string|array $content String with message or array with messages
  * @return array
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	public function send($content = null) {
 		if (empty($this->_from)) {
@@ -1233,8 +1233,8 @@ class Email {
  * @param string|array $message String with message or array with variables to be used in render
  * @param string|array $transportConfig String to use config from EmailConfig or array with configs
  * @param boolean $send Send the email or just return the instance pre-configured
- * @return Cake\Network\Email\Email Instance of Cake\Network\Email\Email
- * @throws Cake\Error\SocketException
+ * @return \Cake\Network\Email\Email Instance of Cake\Network\Email\Email
+ * @throws \Cake\Error\SocketException
  */
 	public static function deliver($to = null, $subject = null, $message = null, $transportConfig = 'fast', $send = true) {
 		$class = __CLASS__;
@@ -1264,7 +1264,7 @@ class Email {
  *
  * @param string|array $config
  * @return void
- * @throws Cake\Error\Exception When using a configuration that doesn't exist.
+ * @throws \Cake\Error\Exception When using a configuration that doesn't exist.
  */
 	protected function _applyConfig($config) {
 		if (is_string($config)) {
@@ -1314,7 +1314,7 @@ class Email {
 /**
  * Reset all the internal variables to be able to send out a new email.
  *
- * @return Cake\Network\Email\Email $this
+ * @return \Cake\Network\Email\Email $this
  */
 	public function reset() {
 		$this->_to = array();

--- a/src/Network/Email/MailTransport.php
+++ b/src/Network/Email/MailTransport.php
@@ -27,7 +27,7 @@ class MailTransport extends AbstractTransport {
 /**
  * Send mail
  *
- * @param Cake\Network\Email\Email $email Cake Email
+ * @param \Cake\Network\Email\Email $email Cake Email
  * @return array
  * @throws SocketException When mail cannot be sent.
  */
@@ -61,7 +61,7 @@ class MailTransport extends AbstractTransport {
  * @param string $message email's body
  * @param string $headers email's custom headers
  * @param string $params additional params for sending email
- * @throws Cake\Error\SocketException if mail could not be sent
+ * @throws \Cake\Error\SocketException if mail could not be sent
  * @return void
  */
 	protected function _mail($to, $subject, $message, $headers, $params = null) {

--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -27,14 +27,14 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Socket to SMTP server
  *
- * @var Cake\Network\Socket
+ * @var \Cake\Network\Socket
  */
 	protected $_socket;
 
 /**
  * Email Instance
  *
- * @var Cake\Network\Email\Email
+ * @var \Cake\Network\Email\Email
  */
 	protected $_cakeEmail;
 
@@ -48,9 +48,9 @@ class SmtpTransport extends AbstractTransport {
 /**
  * Send mail
  *
- * @param Cake\Network\Email\Email $email Cake Email
+ * @param \Cake\Network\Email\Email $email Cake Email
  * @return array
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	public function send(Email $email) {
 		$this->_cakeEmail = $email;
@@ -91,7 +91,7 @@ class SmtpTransport extends AbstractTransport {
  * Connect to SMTP Server
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _connect() {
 		$this->_generateSocket();
@@ -131,7 +131,7 @@ class SmtpTransport extends AbstractTransport {
  * Send authentication
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _auth() {
 		if (isset($this->_config['username']) && isset($this->_config['password'])) {
@@ -155,7 +155,7 @@ class SmtpTransport extends AbstractTransport {
  * Send emails
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _sendRcpt() {
 		$from = $this->_cakeEmail->returnPath();
@@ -177,7 +177,7 @@ class SmtpTransport extends AbstractTransport {
  * Send Data
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _sendData() {
 		$this->_smtpSend('DATA', '354');
@@ -202,7 +202,7 @@ class SmtpTransport extends AbstractTransport {
  * Disconnect
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _disconnect() {
 		$this->_smtpSend('QUIT', false);
@@ -213,7 +213,7 @@ class SmtpTransport extends AbstractTransport {
  * Helper method to generate socket
  *
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _generateSocket() {
 		$this->_socket = new Socket($this->_config);
@@ -225,7 +225,7 @@ class SmtpTransport extends AbstractTransport {
  * @param string $data data to be sent to SMTP server
  * @param string|boolean $checkCode code to check for in server response, false to skip
  * @return void
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	protected function _smtpSend($data, $checkCode = '250') {
 		if ($data !== null) {

--- a/src/Network/Http/Adapter/Stream.php
+++ b/src/Network/Http/Adapter/Stream.php
@@ -57,7 +57,7 @@ class Stream {
 /**
  * Send a request and get a response back.
  *
- * @param Cake\Network\Http\Request $request The request object to send.
+ * @param \Cake\Network\Http\Request $request The request object to send.
  * @param array $options Array of options for the stream.
  * @return array Array of populated Response objects
  */
@@ -100,7 +100,7 @@ class Stream {
 /**
  * Build the stream context out of the request object.
  *
- * @param Cake\Network\Http\Request $request The request to build context from.
+ * @param \Cake\Network\Http\Request $request The request to build context from.
  * @param array $options Additional request options.
  * @return void
  */
@@ -124,7 +124,7 @@ class Stream {
  *
  * Creates cookies & headers.
  *
- * @param Cake\Network\Http\Request $request The request being sent.
+ * @param \Cake\Network\Http\Request $request The request being sent.
  * @param array $options Array of options to use.
  * @return void
  */
@@ -150,7 +150,7 @@ class Stream {
  * If the $request->body() is a string, it will be used as is.
  * Array data will be processed with Cake\Network\Http\FormData
  *
- * @param Cake\Network\Http\Request $request The request being sent.
+ * @param \Cake\Network\Http\Request $request The request being sent.
  * @param array $options Array of options to use.
  * @return void
  */
@@ -177,7 +177,7 @@ class Stream {
 /**
  * Build miscellaneous options for the request.
  *
- * @param Cake\Network\Http\Request $request The request being sent.
+ * @param \Cake\Network\Http\Request $request The request being sent.
  * @param array $options Array of options to use.
  * @return void
  */
@@ -197,7 +197,7 @@ class Stream {
 /**
  * Build SSL options for the request.
  *
- * @param Cake\Network\Http\Request $request The request being sent.
+ * @param \Cake\Network\Http\Request $request The request being sent.
  * @param array $options Array of options to use.
  * @return void
  */
@@ -231,7 +231,7 @@ class Stream {
  *
  * @param Request $request
  * @return array Array of populated Response objects
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected function _send(Request $request) {
 		$url = $request->url();
@@ -258,7 +258,7 @@ class Stream {
  *
  * @param string $url The url to connect to.
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected function _open($url) {
 		set_error_handler([$this, '_connectionErrorHandler']);

--- a/src/Network/Http/Auth/Basic.php
+++ b/src/Network/Http/Auth/Basic.php
@@ -41,8 +41,8 @@ class Basic {
 /**
  * Proxy Authentication
  *
- * @param HttpSocket $http
- * @param array $proxyInfo
+ * @param Request $request
+ * @param array $credentials
  * @return void
  * @see http://www.ietf.org/rfc/rfc2617.txt
  */

--- a/src/Network/Http/Auth/Digest.php
+++ b/src/Network/Http/Auth/Digest.php
@@ -27,14 +27,14 @@ class Digest {
 /**
  * Instance of Cake\Network\Http\Client
  *
- * @var Cake\Network\Http\Client
+ * @var \Cake\Network\Http\Client
  */
 	protected $_client;
 
 /**
  * Constructor
  *
- * @param Cake\Network\Http\Client $client
+ * @param \Cake\Network\Http\Client $client
  * @param array $options
  */
 	public function __construct(Client $client, $options = null) {

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -35,7 +35,7 @@ class Oauth {
  * @param Request $request
  * @param array $options
  * @return void
- * @throws Cake\Error\Exception On invalid signature types.
+ * @throws \Cake\Error\Exception On invalid signature types.
  */
 	public function authentication(Request $request, $credentials) {
 		$hasKeys = isset(
@@ -162,7 +162,7 @@ class Oauth {
  *
  * @param string $url
  * @return string Normalized URL
- * @throws Cake\Error\Exception On invalid URLs
+ * @throws \Cake\Error\Exception On invalid URLs
  */
 	protected function _normalizedUrl($url) {
 		$parts = parse_url($url);

--- a/src/Network/Http/Auth/Oauth.php
+++ b/src/Network/Http/Auth/Oauth.php
@@ -33,7 +33,7 @@ class Oauth {
  * Add headers for Oauth authorization.
  *
  * @param Request $request
- * @param array $options
+ * @param array $credentials
  * @return void
  * @throws \Cake\Error\Exception On invalid signature types.
  */
@@ -228,7 +228,7 @@ class Oauth {
 /**
  * Builds the Oauth Authorization header value.
  *
- * @param array $values The oauth_* values to build
+ * @param array $data The oauth_* values to build
  * @return string
  */
 	protected function _buildAuth($data) {

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -109,7 +109,7 @@ class Client {
  * Cookies are indexed by the cookie's domain or
  * request host name.
  *
- * @var Cake\Network\Http\Cookies
+ * @var \Cake\Network\Http\Cookies
  */
 	protected $_cookies;
 
@@ -117,7 +117,7 @@ class Client {
  * Adapter for sending requests. Defaults to
  * Cake\Network\Http\Stream
  *
- * @var Cake\Network\Http\Stream
+ * @var \Cake\Network\Http\Stream
  */
 	protected $_adapter;
 
@@ -186,7 +186,7 @@ class Client {
  *
  * Returns an array of cookie data arrays.
  *
- * @return Cake\Network\Http\Cookies
+ * @return \Cake\Network\Http\Cookies
  */
 	public function cookies() {
 		return $this->_cookies;
@@ -203,7 +203,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The query data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function get($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -227,7 +227,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The post data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function post($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -241,7 +241,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The request data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function put($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -255,7 +255,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The request data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function patch($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -269,7 +269,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The request data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function delete($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -283,7 +283,7 @@ class Client {
  * @param string $url The url or path you want to request.
  * @param array $data The query string data you want to send.
  * @param array $options Additional options for the request.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function head($url, $data = [], $options = []) {
 		$options = $this->_mergeOptions($options);
@@ -298,7 +298,7 @@ class Client {
  * @param string $url URL to request.
  * @param mixed $data The request body.
  * @param array $options The options to use. Contains auth, proxy etc.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	protected function _doRequest($method, $url, $data, $options) {
 		$request = $this->_createRequest(
@@ -326,9 +326,9 @@ class Client {
  * Used internally by other methods, but can also be used to send
  * handcrafted Request objects.
  *
- * @param Cake\Network\Http\Request $request The request to send.
+ * @param \Cake\Network\Http\Request $request The request to send.
  * @param array $options Additional options to use.
- * @return Cake\Network\Http\Response
+ * @return \Cake\Network\Http\Response
  */
 	public function send(Request $request, $options = []) {
 		$responses = $this->_adapter->send($request, $options);
@@ -383,7 +383,7 @@ class Client {
  * @param string $url The url including query string.
  * @param mixed $data The request body.
  * @param array $options The options to use. Contains auth, proxy etc.
- * @return Cake\Network\Http\Request
+ * @return \Cake\Network\Http\Request
  */
 	protected function _createRequest($method, $url, $data, $options) {
 		$request = new Request();
@@ -415,7 +415,7 @@ class Client {
  *
  * @param string $type short type alias or full mimetype.
  * @return array Headers to set on the request.
- * @throws Cake\Error\Exception When an unknown type alias is used.
+ * @throws \Cake\Error\Exception When an unknown type alias is used.
  */
 	protected function _typeHeaders($type) {
 		if (strpos($type, '/') !== false) {
@@ -478,7 +478,7 @@ class Client {
  * @param array $auth The authentication options to use.
  * @param array $options The overall request options to use.
  * @return mixed Authentication strategy instance.
- * @throws Cake\Error\Exception when an invalid stratgey is chosen.
+ * @throws \Cake\Error\Exception when an invalid stratgey is chosen.
  */
 	protected function _createAuth($auth, $options) {
 		if (empty($auth['type'])) {

--- a/src/Network/Http/FormData.php
+++ b/src/Network/Http/FormData.php
@@ -57,7 +57,7 @@ class FormData implements \Countable {
  *
  * @param string $name The name of the part.
  * @param string $value The value to add.
- * @return Cake\Network\Http\FormData\Part
+ * @return \Cake\Network\Http\FormData\Part
  */
 	public function newPart($name, $value) {
 		return new Part($name, $value);

--- a/src/Network/Http/FormData/Part.php
+++ b/src/Network/Http/FormData/Part.php
@@ -77,7 +77,6 @@ class Part {
  * @param string $name The name of the data.
  * @param string $value The value of the data.
  * @param string $disposition The type of disposition to use, defaults to form-data.
- * @return void
  */
 	public function __construct($name, $value, $disposition = 'form-data') {
 		$this->_name = $name;

--- a/src/Network/Http/Request.php
+++ b/src/Network/Http/Request.php
@@ -60,7 +60,7 @@ class Request extends Message {
  *
  * @param string|null $method The method for the request.
  * @return mixed Either this or the current method.
- * @throws Cake\Error\Exception On invalid methods.
+ * @throws \Cake\Error\Exception On invalid methods.
  */
 	public function method($method = null) {
 		if ($method === null) {

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -384,7 +384,7 @@ class Request implements \ArrayAccess {
 /**
  * Process uploaded files and move things onto the post data.
  *
- * @param array $data Post data to merge files onto.
+ * @param array $post Post data to merge files onto.
  * @param array $files Uploaded files to merge in.
  * @return array merged post + file data.
  */

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -151,7 +151,7 @@ class Request implements \ArrayAccess {
  * Uses the $_GET, $_POST, $_FILES, $_COOKIE, $_SERVER, $_ENV and php://input data to construct
  * the request.
  *
- * @return Cake\Network\Request
+ * @return \Cake\Network\Request
  */
 	public static function createFromGlobals() {
 		list($base, $webroot) = static::_base();
@@ -483,7 +483,7 @@ class Request implements \ArrayAccess {
  * @param string $name The method called
  * @param array $params Array of parameters for the method call
  * @return mixed
- * @throws Cake\Error\Exception when an invalid method is called.
+ * @throws \Cake\Error\Exception when an invalid method is called.
  */
 	public function __call($name, $params) {
 		if (strpos($name, 'is') === 0) {
@@ -656,7 +656,7 @@ class Request implements \ArrayAccess {
  * Provides an easy way to modify, here, webroot and base.
  *
  * @param array $paths Array of paths to merge in
- * @return Cake\Network\Request the current object, you can chain this method.
+ * @return \Cake\Network\Request the current object, you can chain this method.
  */
 	public function addPaths($paths) {
 		foreach (array('webroot', 'here', 'base') as $element) {
@@ -993,7 +993,7 @@ class Request implements \ArrayAccess {
  *
  * @param string $key The key you want to read/write from/to.
  * @param string $value Value to set. Default null.
- * @return null|string|Cake\Network\Request Request instance if used as setter,
+ * @return null|string|\Cake\Network\Request Request instance if used as setter,
  *   if used as getter either the environment value, or null if the value doesn't exist.
  */
 	public function env($key, $value = null) {
@@ -1024,7 +1024,7 @@ class Request implements \ArrayAccess {
  *
  * @param string|array $methods Allowed HTTP request methods.
  * @return boolean true
- * @throws Cake\Error\MethodNotAllowedException
+ * @throws \Cake\Error\MethodNotAllowedException
  */
 	public function allowMethod($methods) {
 		if (!is_array($methods)) {

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -619,7 +619,7 @@ class Response {
  *
  * @param integer $code the HTTP status code
  * @return integer current status code
- * @throws Cake\Error\Exception When an unknown status code is reached.
+ * @throws \Cake\Error\Exception When an unknown status code is reached.
  */
 	public function statusCode($code = null) {
 		if ($code === null) {
@@ -660,7 +660,7 @@ class Response {
  *
  * @return mixed associative array of the HTTP codes as keys, and the message
  *    strings as values, or null of the given $code does not exist.
- * @throws Cake\Error\Exception If an attempt is made to add an invalid status code
+ * @throws \Cake\Error\Exception If an attempt is made to add an invalid status code
  */
 	public function httpCodes($code = null) {
 		if (empty($code)) {
@@ -1261,7 +1261,7 @@ class Response {
  * ### Whitelist of URIs
  * e.g `cors($request, array('http://www.cakephp.org', '*.google.com', 'https://myproject.github.io'));`
  *
- * @param Cake\Network\Request $request Request object
+ * @param \Cake\Network\Request $request Request object
  * @param string|array $allowedDomains List of allowed domains, see method description for more details
  * @param string|array $allowedMethods List of HTTP verbs allowed
  * @param string|array $allowedHeaders List of HTTP headers allowed
@@ -1324,7 +1324,7 @@ class Response {
  * @param string $path Path to file
  * @param array $options Options See above.
  * @return void
- * @throws Cake\Error\NotFoundException
+ * @throws \Cake\Error\NotFoundException
  */
 	public function file($path, $options = array()) {
 		$options += array(

--- a/src/Network/Response.php
+++ b/src/Network/Response.php
@@ -1034,14 +1034,14 @@ class Response {
  *
  * If no parameters are passed, current Etag header is returned.
  *
- * @param string $hash the unique has that identifies this response
+ * @param string $hash the unique hash that identifies this response
  * @param boolean $weak whether the response is semantically the same as
  *   other with the same hash or not
  * @return string
  */
-	public function etag($tag = null, $weak = false) {
-		if ($tag !== null) {
-			$this->_headers['Etag'] = sprintf('%s"%s"', ($weak) ? 'W/' : null, $tag);
+	public function etag($hash = null, $weak = false) {
+		if ($hash !== null) {
+			$this->_headers['Etag'] = sprintf('%s"%s"', ($weak) ? 'W/' : null, $hash);
 		}
 		if (isset($this->_headers['Etag'])) {
 			return $this->_headers['Etag'];
@@ -1142,7 +1142,7 @@ class Response {
  * the Last-Modified etag response header before calling this method. Otherwise
  * a comparison will not be possible.
  *
- * @param CakeRequest $request Request object
+ * @param Request $request Request object
  * @return boolean whether the response was marked as not modified or not.
  */
 	public function checkNotModified(Request $request) {

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -104,7 +104,7 @@ class Session {
  * This feature is only used when config value `Session.autoRegenerate` is set to true.
  *
  * @var integer
- * @see Cake\Network\Session::_checkValid()
+ * @see \Cake\Network\Session::_checkValid()
  */
 	protected static $_requestCountdown = 10;
 
@@ -454,7 +454,7 @@ class Session {
  * Sessions can be configured with a few shortcut names as well as have any number of ini settings declared.
  *
  * @return void
- * @throws Cake\Error\Exception Throws exceptions when ini_set() fails.
+ * @throws \Cake\Error\Exception Throws exceptions when ini_set() fails.
  */
 	protected static function _configureSession() {
 		$sessionConfig = Configure::read('Session');
@@ -549,7 +549,7 @@ class Session {
  *
  * @param string $class
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected static function _getHandler($class) {
 		$class = App::className($class, 'Network/Session');

--- a/src/Network/Session/CacheSession.php
+++ b/src/Network/Session/CacheSession.php
@@ -23,7 +23,7 @@ use SessionHandlerInterface;
 /**
  * CacheSession provides method for saving sessions into a Cache engine. Used with Session
  *
- * @see Cake\Model\Datasource\Session for configuration information.
+ * @see \Cake\Model\Datasource\Session for configuration information.
  */
 class CacheSession implements SessionHandlerInterface {
 

--- a/src/Network/Session/CacheSession.php
+++ b/src/Network/Session/CacheSession.php
@@ -30,8 +30,8 @@ class CacheSession implements SessionHandlerInterface {
 /**
  * Method called on open of a database session.
  *
- * @param The path where to store/retrieve the session.
- * @param The session name.
+ * @param string $savePath The path where to store/retrieve the session.
+ * @param string $name The session name.
  * @return boolean Success
  */
 	public function open($savePath, $name) {

--- a/src/Network/Session/DatabaseSession.php
+++ b/src/Network/Session/DatabaseSession.php
@@ -63,8 +63,8 @@ class DatabaseSession implements SessionHandlerInterface {
 /**
  * Method called on open of a database session.
  *
- * @param The path where to store/retrieve the session.
- * @param The session name.
+ * @param string $savePath The path where to store/retrieve the session.
+ * @param string $name The session name.
  * @return boolean Success
  */
 	public function open($savePath, $name) {

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -125,7 +125,7 @@ class Socket {
  * Connect the socket to the given host and port.
  *
  * @return boolean Success
- * @throws Cake\Error\SocketException
+ * @throws \Cake\Error\SocketException
  */
 	public function connect() {
 		if ($this->connection) {
@@ -363,7 +363,7 @@ class Socket {
  * @param boolean $enable enable or disable encryption. Default is true (enable)
  * @return boolean True on success
  * @throws InvalidArgumentException When an invalid encryption scheme is chosen.
- * @throws Cake\Error\SocketException When attempting to enable SSL/TLS fails
+ * @throws \Cake\Error\SocketException When attempting to enable SSL/TLS fails
  * @see stream_socket_enable_crypto
  */
 	public function enableCrypto($type, $clientOrServer = 'client', $enable = true) {

--- a/src/Network/Socket.php
+++ b/src/Network/Socket.php
@@ -362,7 +362,7 @@ class Socket {
  * @param string $clientOrServer can be one of 'client', 'server'. Default is 'client'
  * @param boolean $enable enable or disable encryption. Default is true (enable)
  * @return boolean True on success
- * @throws InvalidArgumentException When an invalid encryption scheme is chosen.
+ * @throws \InvalidArgumentException When an invalid encryption scheme is chosen.
  * @throws \Cake\Error\SocketException When attempting to enable SSL/TLS fails
  * @see stream_socket_enable_crypto
  */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -445,7 +445,7 @@ abstract class Association {
  * Correctly nests a result row associated values into the correct array keys inside the
  * source results.
  *
- * @param array $result
+ * @param array $row
  * @return array
  */
 	public function transformRow($row) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -127,14 +127,14 @@ abstract class Association {
 /**
  * Source table instance
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_sourceTable;
 
 /**
  * Target table instance
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_targetTable;
 
@@ -213,8 +213,8 @@ abstract class Association {
  * Sets the table instance for the source side of the association. If no arguments
  * are passed, the current configured table instance is returned
  *
- * @param Cake\ORM\Table $table the instance to be assigned as source side
- * @return Cake\ORM\Table
+ * @param \Cake\ORM\Table $table the instance to be assigned as source side
+ * @return \Cake\ORM\Table
  */
 	public function source(Table $table = null) {
 		if ($table === null) {
@@ -227,8 +227,8 @@ abstract class Association {
  * Sets the table instance for the target side of the association. If no arguments
  * are passed, the current configured table instance is returned
  *
- * @param Cake\ORM\Table $table the instance to be assigned as target side
- * @return Cake\ORM\Table
+ * @param \Cake\ORM\Table $table the instance to be assigned as target side
+ * @return \Cake\ORM\Table
  */
 	public function target(Table $table = null) {
 		if ($table === null && $this->_targetTable) {
@@ -254,7 +254,7 @@ abstract class Association {
  * the target association. If no parameters are passed the current list is returned
  *
  * @param array $conditions list of conditions to be used
- * @see Cake\Database\Query::where() for examples on the format of the array
+ * @see \Cake\Database\Query::where() for examples on the format of the array
  * @return array
  */
 	public function conditions($conditions = null) {
@@ -598,7 +598,7 @@ abstract class Association {
  * Each implementing class should handle the cascaded delete as
  * required.
  *
- * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return boolean Success
  */

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -167,7 +167,6 @@ abstract class Association {
  *
  * @param string $name The name given to the association
  * @param array $options A list of properties to be set on this object
- * @return void
  */
 	public function __construct($name, array $options = []) {
 		$defaults = [

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -61,7 +61,7 @@ class BelongsTo extends Association {
  *
  * BelongsTo associations are never cleared in a cascading delete scenario.
  *
- * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return boolean Success.
  */

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -74,7 +74,7 @@ class BelongsToMany extends Association {
 /**
  * Junction table instance
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_junctionTable;
 
@@ -137,8 +137,8 @@ class BelongsToMany extends Association {
  * Sets the table instance for the junction relation. If no arguments
  * are passed, the current configured table instance is returned
  *
- * @param string|Cake\ORM\Table $table Name or instance for the join table
- * @return Cake\ORM\Table
+ * @param string|\Cake\ORM\Table $table Name or instance for the join table
+ * @return \Cake\ORM\Table
  */
 	public function junction($table = null) {
 		$target = $this->target();
@@ -325,7 +325,7 @@ class BelongsToMany extends Association {
 /**
  * Clear out the data in the junction table for a given entity.
  *
- * @param Cake\ORM\Entity $entity The entity that started the cascading delete.
+ * @param \Cake\ORM\Entity $entity The entity that started the cascading delete.
  * @param array $options The options for the original delete.
  * @return boolean Success.
  */

--- a/src/ORM/Association/DependentDeleteTrait.php
+++ b/src/ORM/Association/DependentDeleteTrait.php
@@ -28,7 +28,7 @@ trait DependentDeleteTrait {
  *
  * This method does nothing if the association is not dependent.
  *
- * @param Cake\ORM\Entity $entity The entity that started the cascaded delete.
+ * @param \Cake\ORM\Entity $entity The entity that started the cascaded delete.
  * @param array $options The options for the original delete.
  * @return boolean Success.
  */

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -151,7 +151,7 @@ trait ExternalAssociationTrait {
  * Returns a callable to be used for each row in a query result set
  * for injecting the eager loaded rows
  *
- * @param Cake\ORM\Query $fetchQuery the Query used to fetch results
+ * @param \Cake\ORM\Query $fetchQuery the Query used to fetch results
  * @param array $resultMap an array with the foreignKey as keys and
  * the corresponding target table results as value.
  * @return \Closure
@@ -212,7 +212,7 @@ trait ExternalAssociationTrait {
  * the source table
  *
  * @param array $options options accepted by eagerLoader()
- * @return Cake\ORM\Query
+ * @return \Cake\ORM\Query
  * @throws \InvalidArgumentException When a key is required for associations but not selected.
  */
 	protected function _buildQuery($options) {
@@ -307,9 +307,9 @@ trait ExternalAssociationTrait {
  * target table, it is constructed by cloning the original query that was used
  * to load records in the source table.
  *
- * @param Cake\ORM\Query $query the original query used to load source records
+ * @param \Cake\ORM\Query $query the original query used to load source records
  * @param strong $foreignKey the field to be selected in the query
- * @return Cake\ORM\Query
+ * @return \Cake\ORM\Query
  */
 	protected function _buildSubquery($query, $foreignKey) {
 		$filterQuery = clone $query;

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -92,7 +92,7 @@ trait ExternalAssociationTrait {
  * Correctly nests a result row associated values into the correct array keys inside the
  * source results.
  *
- * @param array $result
+ * @param array $row
  * @return array
  */
 	public function transformRow($row) {

--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -171,7 +171,7 @@ class Associations {
  * @param boolean $owningSide Compared with association classes'
  *   isOwningSide method.
  * @return boolean Success
- * @throws InvalidArgumentException When an unknown alias is used.
+ * @throws \InvalidArgumentException When an unknown alias is used.
  */
 	protected function _saveAssociations($table, $entity, $associations, $options, $owningSide) {
 		unset($options['associated']);

--- a/src/ORM/Behavior.php
+++ b/src/ORM/Behavior.php
@@ -87,8 +87,8 @@ use Cake\Event\EventListener;
  * }}}
  *
  *
- * @see Cake\ORM\Table::addBehavior()
- * @see Cake\Event\EventManager
+ * @see \Cake\ORM\Table::addBehavior()
+ * @see \Cake\Event\EventManager
  */
 class Behavior implements EventListener {
 
@@ -148,7 +148,7 @@ class Behavior implements EventListener {
  * Check that implemented* keys contain values pointing at callable
  *
  * @return void
- * @throws Cake\Error\Exception if config are invalid
+ * @throws \Cake\Error\Exception if config are invalid
  */
 	public function verifyConfig() {
 		$keys = ['implementedFinders', 'implementedMethods'];

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -31,7 +31,7 @@ class BehaviorRegistry extends ObjectRegistry {
 /**
  * The table using this registry.
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_table;
 
@@ -40,7 +40,7 @@ class BehaviorRegistry extends ObjectRegistry {
  *
  * Behaviors constructed by this object will be subscribed to this manager.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager;
 
@@ -61,7 +61,7 @@ class BehaviorRegistry extends ObjectRegistry {
 /**
  * Constructor
  *
- * @param Cake\ORM\Table $table
+ * @param \Cake\ORM\Table $table
  */
 	public function __construct(Table $table) {
 		$this->_table = $table;
@@ -87,7 +87,7 @@ class BehaviorRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the behavior is missing in.
- * @throws Cake\Error\MissingBehaviorException
+ * @throws \Cake\Error\MissingBehaviorException
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingBehaviorException([
@@ -126,11 +126,11 @@ class BehaviorRegistry extends ObjectRegistry {
  * Methods starting with `_` will be ignored, as will methods
  * declared on Cake\ORM\Behavior
  *
- * @param Cake\ORM\Behavior $instance
+ * @param \Cake\ORM\Behavior $instance
  * @param string $class The classname that is missing.
  * @param string $alias The alias of the object.
  * @return void
- * @throws Cake\Error\Exception when duplicate methods are connected.
+ * @throws \Cake\Error\Exception when duplicate methods are connected.
  */
 	protected function _getMethods(Behavior $instance, $class, $alias) {
 		$finders = array_change_key_case($instance->implementedFinders());
@@ -201,7 +201,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $method The method to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws Cake\Error\Exception When the method is unknown.
+ * @throws \Cake\Error\Exception When the method is unknown.
  */
 	public function call($method, array $args = []) {
 		$method = strtolower($method);
@@ -219,7 +219,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @param string $type The finder type to invoke.
  * @param array $args The arguments you want to invoke the method with.
  * @return mixed The return value depends on the underlying behavior method.
- * @throws Cake\Error\Exception When the method is unknown.
+ * @throws \Cake\Error\Exception When the method is unknown.
  */
 	public function callFinder($type, array $args = []) {
 		$type = strtolower($type);

--- a/src/ORM/EntityValidator.php
+++ b/src/ORM/EntityValidator.php
@@ -116,10 +116,10 @@ class EntityValidator {
  * associations to also be validated.
  * @return boolean true if all validations passed, false otherwise
  */
-	public function many(array $entities, $include = []) {
+	public function many(array $entities, $options = []) {
 		$valid = true;
 		foreach ($entities as $entity) {
-			$valid = $this->one($entity, $include) && $valid;
+			$valid = $this->one($entity, $options) && $valid;
 		}
 		return $valid;
 	}

--- a/src/ORM/EntityValidator.php
+++ b/src/ORM/EntityValidator.php
@@ -19,22 +19,22 @@ use Cake\Event\Event;
 /**
  * Contains logic for validating entities and their associations
  *
- * @see Cake\ORM\Table::validate()
- * @see Cake\ORM\Table::validateMany()
+ * @see \Cake\ORM\Table::validate()
+ * @see \Cake\ORM\Table::validateMany()
  */
 class EntityValidator {
 
 /**
  * The table instance this validator is for.
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_table;
 
 /**
  * Constructor.
  *
- * @param Cake\ORM\Table $table
+ * @param \Cake\ORM\Table $table
  */
 	public function __construct(Table $table) {
 		$this->_table = $table;

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -23,8 +23,8 @@ use Cake\ORM\Table;
  *
  * Useful when converting request data into entities.
  *
- * @see Cake\ORM\Table::newEntity()
- * @see Cake\ORM\Table::newEntities()
+ * @see \Cake\ORM\Table::newEntity()
+ * @see \Cake\ORM\Table::newEntities()
  */
 class Marshaller {
 
@@ -38,14 +38,14 @@ class Marshaller {
 /**
  * The table instance this marshaller is for.
  *
- * @var Cake\ORM\Table
+ * @var \Cake\ORM\Table
  */
 	protected $_table;
 
 /**
  * Constructor.
  *
- * @param Cake\ORM\Table $table
+ * @param \Cake\ORM\Table $table
  * @param boolean Whether or not this masrhaller is in safe mode
  */
 	public function __construct(Table $table, $safe = false) {
@@ -83,8 +83,8 @@ class Marshaller {
  *
  * @param array $data The data to hydrate.
  * @param array $include The associations to include.
- * @return Cake\ORM\Entity
- * @see Cake\ORM\Table::newEntity()
+ * @return \Cake\ORM\Entity
+ * @see \Cake\ORM\Table::newEntity()
  */
 	public function one(array $data, $include = []) {
 		$propertyMap = $this->_buildPropertyMap($include);
@@ -113,7 +113,7 @@ class Marshaller {
 /**
  * Create a new sub-marshaller and marshal the associated data.
  *
- * @param Cake\ORM\Association $assoc
+ * @param \Cake\ORM\Association $assoc
  * @param array $value The data to hydrate
  * @param array $include The associations to include.
  * @return mixed
@@ -136,7 +136,7 @@ class Marshaller {
  * @param array $data The data to hydrate.
  * @param array $include The associations to include.
  * @return array An array of hydrated records.
- * @see Cake\ORM\Table::newEntities()
+ * @see \Cake\ORM\Table::newEntities()
  */
 	public function many(array $data, $include = []) {
 		$output = [];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -153,7 +153,7 @@ class Marshaller {
  * for junction table entities.
  *
  * @param Association $assoc The association to marshall.
- * @param array $values The data to convert into entities.
+ * @param array $data The data to convert into entities.
  * @param array $include The nested associations to convert.
  * @return array An array of built entities.
  */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -98,8 +98,8 @@ class Query extends DatabaseQuery {
 /**
  * Constuctor
  *
- * @param Cake\Database\Connection $connection
- * @param Cake\ORM\Table $table
+ * @param \Cake\Database\Connection $connection
+ * @param \Cake\ORM\Table $table
  */
 	public function __construct($connection, $table) {
 		$this->connection($connection);
@@ -428,7 +428,7 @@ class Query extends DatabaseQuery {
  * - join: Maps to the join method
  * - join: Maps to the page method
  *
- * @return Cake\ORM\Query
+ * @return \Cake\ORM\Query
  */
 	public function applyOptions(array $options) {
 		$valid = [
@@ -505,7 +505,7 @@ class Query extends DatabaseQuery {
  * query itself.
  *
  * @param callable $counter
- * @return Cake\ORM\Query
+ * @return \Cake\ORM\Query
  */
 	public function counter($counter) {
 		$this->_counter = $counter;
@@ -572,8 +572,8 @@ class Query extends DatabaseQuery {
  * any registered callbacks. This will also setup the correct statement class
  * in order to eager load deep associations.
  *
- * @param Cake\Database\Statement $statement to be decorated
- * @return Cake\Database\Statement
+ * @param \Cake\Database\Statement $statement to be decorated
+ * @return \Cake\Database\Statement
  */
 	protected function _decorateStatement($statement) {
 		$statement = parent::_decorateStatement($statement);
@@ -587,7 +587,7 @@ class Query extends DatabaseQuery {
  * specified and applies the joins required to eager load associations defined
  * using `contain`
  *
- * @see Cake\Database\Query::execute()
+ * @see \Cake\Database\Query::execute()
  * @return Query
  */
 	protected function _transformQuery() {
@@ -638,8 +638,8 @@ class Query extends DatabaseQuery {
  *
  * @param string $finder The finder method to use.
  * @param array $options The options for the finder.
- * @return Cake\ORM\Query Returns a modified query.
- * @see Cake\ORM\Table::find()
+ * @return \Cake\ORM\Query Returns a modified query.
+ * @see \Cake\ORM\Table::find()
  */
 	public function find($finder, $options = []) {
 		return $this->repository()->callFinder($finder, $this, $options);

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -125,7 +125,6 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
  *
  * @param Query from where results come
  * @param \Cake\Database\StatementInterface $statement
- * @return void
  */
 	public function __construct($query, $statement) {
 		$this->_query = $query;

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -179,7 +179,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
  *
  * Part of Iterator interface.
  *
- * @throws Cake\Database\Exception
+ * @throws \Cake\Database\Exception
  * @return void
  */
 	public function rewind() {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -280,7 +280,7 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * Returns the table alias or sets a new one
  *
- * @param string $table the new table alias
+ * @param string $alias the new table alias
  * @return string
  */
 	public function alias($alias = null) {
@@ -947,18 +947,18 @@ class Table implements RepositoryInterface, EventListener {
  * @param \Cake\Validation\Validator $validator
  * @return \Cake\Validation\Validator
  */
-	public function validator($name = 'default', Validator $instance = null) {
-		if ($instance === null && isset($this->_validators[$name])) {
+	public function validator($name = 'default', Validator $validator = null) {
+		if ($validator === null && isset($this->_validators[$name])) {
 			return $this->_validators[$name];
 		}
 
-		if ($instance === null) {
-			$instance = new Validator();
-			$instance = $this->{'validation' . ucfirst($name)}($instance);
+		if ($validator === null) {
+			$validator = new Validator();
+			$validator = $this->{'validation' . ucfirst($name)}($validator);
 		}
 
-		$instance->provider('table', $this);
-		return $this->_validators[$name] = $instance;
+		$validator->provider('table', $this);
+		return $this->_validators[$name] = $validator;
 	}
 
 /**
@@ -1391,7 +1391,7 @@ class Table implements RepositoryInterface, EventListener {
  *
  * @param string $type name of the finder to be called
  * @param \Cake\ORM\Query $query The query object to apply the finder options to
- * @param array $args List of options to pass to the finder
+ * @param array $options List of options to pass to the finder
  * @return \Cake\ORM\Query
  * @throws \BadMethodCallException
  */

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -187,7 +187,6 @@ class Table implements RepositoryInterface, EventListener {
  * - behaviors: A BehaviorRegistry. Generally not used outside of tests.
  *
  * @param array config Lsit of options for this table
- * @return void
  */
 	public function __construct(array $config = []) {
 		if (!empty($config['table'])) {

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -87,7 +87,7 @@ use Cake\Validation\Validator;
  *   By stopping this event you will abort the delete operation.
  * - `afterDelete($event, $entity, $options)` - Fired after an entity has been deleted.
  *
- * @see Cake\Event\EventManager for reference on the events system.
+ * @see \Cake\Event\EventManager for reference on the events system.
  */
 class Table implements RepositoryInterface, EventListener {
 
@@ -137,7 +137,7 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * The associations container for this Table.
  *
- * @var Cake\ORM\Associations
+ * @var \Cake\ORM\Associations
  */
 	protected $_associated;
 
@@ -146,14 +146,14 @@ class Table implements RepositoryInterface, EventListener {
  *
  * All model/behavior callbacks will be dispatched on this manager.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager;
 
 /**
  * BehaviorRegistry for this table
  *
- * @var Cake\ORM\BehaviorRegistry
+ * @var \Cake\ORM\BehaviorRegistry
  */
 	protected $_behaviors;
 
@@ -231,7 +231,7 @@ class Table implements RepositoryInterface, EventListener {
  * instance is created through the TableRegistry without a connection.
  *
  * @return string
- * @see Cake\ORM\TableRegistry::get()
+ * @see \Cake\ORM\TableRegistry::get()
  */
 	public static function defaultConnectionName() {
 		return 'default';
@@ -312,7 +312,7 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * Get the event manager for this Table.
  *
- * @return Cake\Event\EventManager
+ * @return \Cake\Event\EventManager
  */
 	public function getEventManager() {
 		return $this->_eventManager;
@@ -474,7 +474,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $name The name of the behavior. Can be a short class reference.
  * @param array $options The options for the behavior to use.
  * @return void
- * @see Cake\ORM\Behavior
+ * @see \Cake\ORM\Behavior
  */
 	public function addBehavior($name, $options = []) {
 		$this->_behaviors->load($name, $options);
@@ -506,7 +506,7 @@ class Table implements RepositoryInterface, EventListener {
  * Returns a association objected configured for the specified alias if any
  *
  * @param string $name the alias used for the association
- * @return Cake\ORM\Association
+ * @return \Cake\ORM\Association
  */
 	public function association($name) {
 		return $this->_associated->get($name);
@@ -515,7 +515,7 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * Get the associations collection for this table.
  *
- * @return Cake\ORM\Associations
+ * @return \Cake\ORM\Associations
  */
 	public function associations() {
 		return $this->_associated;
@@ -545,7 +545,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $associated the alias for the target table. This is used to
  * uniquely identify the association
  * @param array $options list of options to configure the association definition
- * @return Cake\ORM\Association\BelongsTo
+ * @return \Cake\ORM\Association\BelongsTo
  */
 	public function belongsTo($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
@@ -582,7 +582,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $associated the alias for the target table. This is used to
  * uniquely identify the association
  * @param array $options list of options to configure the association definition
- * @return Cake\ORM\Association\HasOne
+ * @return \Cake\ORM\Association\HasOne
  */
 	public function hasOne($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
@@ -623,7 +623,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $associated the alias for the target table. This is used to
  * uniquely identify the association
  * @param array $options list of options to configure the association definition
- * @return Cake\ORM\Association\HasMany
+ * @return \Cake\ORM\Association\HasMany
  */
 	public function hasMany($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
@@ -667,7 +667,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $associated the alias for the target table. This is used to
  * uniquely identify the association
  * @param array $options list of options to configure the association definition
- * @return Cake\ORM\Association\BelongsToMany
+ * @return \Cake\ORM\Association\BelongsToMany
  */
 	public function belongsToMany($associated, array $options = []) {
 		$options += ['sourceTable' => $this];
@@ -862,7 +862,7 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * {@inheritdoc}
  *
- * @throws Cake\ORM\Error\RecordNotFoundException if no record can be found give
+ * @throws \Cake\ORM\Error\RecordNotFoundException if no record can be found give
  * such primary key value.
  */
 	public function get($primaryKey, $options = []) {
@@ -1419,7 +1419,7 @@ class Table implements RepositoryInterface, EventListener {
  * @param string $method The method name that was fired.
  * @param array $args List of arguments passed to the function.
  * @return mixed
- * @throws Cake\Error\Exception when there are missing arguments, or when
+ * @throws \Cake\Error\Exception when there are missing arguments, or when
  *  and & or are combined.
  */
 	protected function _dynamicFinder($method, $args) {
@@ -1507,8 +1507,8 @@ class Table implements RepositoryInterface, EventListener {
  *
  * @param boolean $safe Whether or not this marshaller
  *   should be in safe mode.
- * @return Cake\ORM\Marhsaller
- * @see Cake\ORM\Marshaller
+ * @return \Cake\ORM\Marhsaller
+ * @see \Cake\ORM\Marshaller
  */
 	public function marshaller($safe = false) {
 		return new Marshaller($this, $safe);

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -131,7 +131,7 @@ class TableRegistry {
  * @param string $alias The alias you want to get.
  * @param array $options The options you want to build the table with.
  *   If a table has already been loaded the options will be ignored.
- * @return Cake\Database\Table
+ * @return \Cake\Database\Table
  * @throws RuntimeException When you try to configure an alias that already exists.
  */
 	public static function get($alias, $options = []) {
@@ -179,7 +179,7 @@ class TableRegistry {
  * Set an instance.
  *
  * @param string $alias The alias to set.
- * @param Cake\ORM\Table The table to set.
+ * @param \Cake\ORM\Table The table to set.
  * @return void
  */
 	public static function set($alias, Table $object) {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -43,7 +43,7 @@ class Dispatcher implements EventListener {
 /**
  * Event manager, used to handle dispatcher filters
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager;
 
@@ -62,7 +62,7 @@ class Dispatcher implements EventListener {
  * Returns the Cake\Event\EventManager instance or creates one if none was
  * created. Attaches the default listeners and filters
  *
- * @return Cake\Event\EventManager
+ * @return \Cake\Event\EventManager
  */
 	public function getEventManager() {
 		if (!$this->_eventManager) {
@@ -86,9 +86,9 @@ class Dispatcher implements EventListener {
  * Attaches all event listeners for this dispatcher instance. Loads the
  * dispatcher filters from the configured locations.
  *
- * @param Cake\Event\EventManager $manager
+ * @param \Cake\Event\EventManager $manager
  * @return void
- * @throws Cake\Error\MissingDispatcherFilterException
+ * @throws \Cake\Error\MissingDispatcherFilterException
  */
 	protected function _attachFilters($manager) {
 		$filters = Configure::read('Dispatcher.filters');
@@ -134,11 +134,11 @@ class Dispatcher implements EventListener {
  * If no controller of given name can be found, invoke() will throw an exception.
  * If the controller is found, and the action is not found an exception will be thrown.
  *
- * @param Cake\Network\Request $request Request object to dispatch.
- * @param Cake\Network\Response $response Response object to put the results of the dispatch into.
+ * @param \Cake\Network\Request $request Request object to dispatch.
+ * @param \Cake\Network\Response $response Response object to put the results of the dispatch into.
  * @param array $additionalParams Settings array ("bare", "return") which is melded with the GET and POST params
  * @return string|void if `$request['return']` is set then it returns response body, null otherwise
- * @throws Cake\Error\MissingControllerException When the controller is missing.
+ * @throws \Cake\Error\MissingControllerException When the controller is missing.
  */
 	public function dispatch(Request $request, Response $response, $additionalParams = array()) {
 		$beforeEvent = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response', 'additionalParams'));
@@ -179,9 +179,9 @@ class Dispatcher implements EventListener {
  * Otherwise the return value of the controller action are returned.
  *
  * @param Controller $controller Controller to invoke
- * @param Cake\Network\Request $request The request object to invoke the controller for.
- * @param Cake\Network\Response $response The response object to receive the output
- * @return Cake\Network\Response the resulting response object
+ * @param \Cake\Network\Request $request The request object to invoke the controller for.
+ * @param \Cake\Network\Response $response The response object to receive the output
+ * @return \Cake\Network\Response the resulting response object
  */
 	protected function _invoke(Controller $controller, Request $request, Response $response) {
 		$controller->constructClasses();
@@ -208,7 +208,7 @@ class Dispatcher implements EventListener {
  * Applies Routing and additionalParameters to the request to be dispatched.
  * If Routes have not been loaded they will be loaded, and app/Config/routes.php will be run.
  *
- * @param Cake\Event\Event $event containing the request, response and additional params
+ * @param \Cake\Event\Event $event containing the request, response and additional params
  * @return void
  */
 	public function parseParams($event) {
@@ -228,8 +228,8 @@ class Dispatcher implements EventListener {
 /**
  * Get controller to use, either plugin controller or application controller
  *
- * @param Cake\Network\Request $request Request object
- * @param Cake\Network\Response $response Response for the controller.
+ * @param \Cake\Network\Request $request Request object
+ * @param \Cake\Network\Response $response Response for the controller.
  * @return mixed name of controller if not loaded, or object if loaded
  */
 	protected function _getController($request, $response) {
@@ -247,7 +247,7 @@ class Dispatcher implements EventListener {
 /**
  * Load controller and return controller class name
  *
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return string|boolean Name of controller class name
  */
 	protected function _loadController($request) {

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -46,7 +46,7 @@ abstract class DispatcherFilter implements EventListener {
 /**
  * Constructor.
  *
- * @param string $setting Configuration settings for the filter.
+ * @param array $settings Configuration settings for the filter.
  */
 	public function __construct($settings = array()) {
 		$this->settings = Hash::merge($this->settings, $settings);

--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -80,7 +80,7 @@ abstract class DispatcherFilter implements EventListener {
  * If false is returned, the event will be stopped and no more listeners will be notified.
  * Alternatively you can call `$event->stopPropagation()` to achieve the same result.
  *
- * @param Cake\Event\Event $event container object having the `request`, `response` and `additionalParams`
+ * @param \Cake\Event\Event $event container object having the `request`, `response` and `additionalParams`
  *    keys in the data property.
  */
 	public function beforeDispatch(Event $event) {
@@ -94,7 +94,7 @@ abstract class DispatcherFilter implements EventListener {
  * If false is returned, the event will be stopped and no more listeners will be notified.
  * Alternatively you can call `$event->stopPropagation()` to achieve the same result.
  *
- * @param Cake\Event\Event $event container object having the `request` and  `response`
+ * @param \Cake\Event\Event $event container object having the `request` and  `response`
  *    keys in the data property.
  */
 	public function afterDispatch(Event $event) {

--- a/src/Routing/Filter/AssetDispatcher.php
+++ b/src/Routing/Filter/AssetDispatcher.php
@@ -43,8 +43,8 @@ class AssetDispatcher extends DispatcherFilter {
 /**
  * Checks if a requested asset exists and sends it to the browser
  *
- * @param Cake\Event\Event $event containing the request and response object
- * @return Cake\Network\Response if the client is requesting a recognized asset, null otherwise
+ * @param \Cake\Event\Event $event containing the request and response object
+ * @return \Cake\Network\Response if the client is requesting a recognized asset, null otherwise
  */
 	public function beforeDispatch(Event $event) {
 		$request = $event->data['request'];
@@ -101,8 +101,8 @@ class AssetDispatcher extends DispatcherFilter {
 /**
  * Sends an asset file to the client
  *
- * @param Cake\Network\Request $request The request object to use.
- * @param Cake\Network\Response $response The response object to use.
+ * @param \Cake\Network\Request $request The request object to use.
+ * @param \Cake\Network\Response $response The response object to use.
  * @param string $assetFile Path to the asset file in the file system
  * @param string $ext The extension of the file to determine its mime type
  * @return void

--- a/src/Routing/Filter/CacheDispatcher.php
+++ b/src/Routing/Filter/CacheDispatcher.php
@@ -38,8 +38,8 @@ class CacheDispatcher extends DispatcherFilter {
 /**
  * Checks whether the response was cached and set the body accordingly.
  *
- * @param Cake\Event\Event $event containing the request and response object
- * @return Cake\NetworkResponse with cached content if found, null otherwise
+ * @param \Cake\Event\Event $event containing the request and response object
+ * @return \Cake\NetworkResponse with cached content if found, null otherwise
  */
 	public function beforeDispatch(Event $event) {
 		if (Configure::read('Cache.check') !== true) {

--- a/src/Routing/Route/PluginShortRoute.php
+++ b/src/Routing/Route/PluginShortRoute.php
@@ -44,6 +44,9 @@ class PluginShortRoute extends Route {
  * are not the same the match is an auto fail.
  *
  * @param array $url Array of parameters to convert to a string.
+ * @param array $context An array of the current request context.
+ *   Contains information such as the current host, scheme, port, and base
+ *   directory.
  * @return mixed either false or a string URL.
  */
 	public function match($url, $context = array()) {

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -116,7 +116,7 @@ class RedirectRoute extends Route {
  * Stop execution of the current script. Wraps exit() making
  * testing easier.
  *
- * @param integer|string $status see http://php.net/exit for values
+ * @param integer|string $code see http://php.net/exit for values
  * @return void
  */
 	protected function _stop($code = 0) {

--- a/src/Routing/Route/RedirectRoute.php
+++ b/src/Routing/Route/RedirectRoute.php
@@ -29,7 +29,7 @@ class RedirectRoute extends Route {
 /**
  * A Response object
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	public $response = null;
 

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -57,7 +57,7 @@ class RouteCollection implements \Countable {
  * Add a route to the collection.
  *
  * Appends the route to the list of routes, and the route hashtable.
- * @param Cake\Routing\Route\Route $route The route to add
+ * @param \Cake\Routing\Route\Route $route The route to add
  * @return void
  */
 	public function add(Route $route) {
@@ -238,7 +238,7 @@ class RouteCollection implements \Countable {
  * Populate the request context used to generate URL's
  * Generally set to the last/most recent request.
  *
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return void
  */
 	public function setContext(Request $request) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -42,7 +42,7 @@ class Router {
 /**
  * RouteCollection object containing all the connected routes.
  *
- * @var Cake\Routing\RouteCollection
+ * @var \Cake\Routing\RouteCollection
  */
 	protected static $_routes;
 
@@ -190,7 +190,7 @@ class Router {
  *
  * @param string $routeClass to set as default
  * @return mixed void|string
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public static function defaultRouteClass($routeClass = null) {
 		if ($routeClass === null) {
@@ -205,7 +205,7 @@ class Router {
  *
  * @param string $routeClass Route class name
  * @return string
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	protected static function _validateRouteClass($routeClass) {
 		if (
@@ -326,7 +326,7 @@ class Router {
  *   custom routing class.
  * @see routes
  * @return void
- * @throws Cake\Error\Exception
+ * @throws \Cake\Error\Exception
  */
 	public static function connect($route, $defaults = array(), $options = array()) {
 		static::$initialized = true;
@@ -511,7 +511,7 @@ class Router {
 /**
  * Set the route collection object Router should use.
  *
- * @param Cake\Routing\RouteCollection $routes
+ * @param \Cake\Routing\RouteCollection $routes
  * @return void
  */
 	public static function setRouteCollection(RouteCollection $routes) {
@@ -529,7 +529,7 @@ class Router {
  * Will accept either a Cake\Network\Request object or an array of arrays. Support for
  * accepting arrays may be removed in the future.
  *
- * @param Cake\Network\Request|array $request Parameters and path information or a Cake\Network\Request object.
+ * @param \Cake\Network\Request|array $request Parameters and path information or a Cake\Network\Request object.
  * @return void
  */
 	public static function setRequestInfo($request) {
@@ -553,7 +553,7 @@ class Router {
  * Push a request onto the request stack. Pushing a request
  * sets the request context used when generating URLs.
  *
- * @param Cake\Network\Request $request
+ * @param \Cake\Network\Request $request
  * @return void
  */
 	public static function pushRequest(Request $request) {
@@ -564,7 +564,7 @@ class Router {
 /**
  * Pops a request off of the request stack.  Used when doing requestAction
  *
- * @return Cake\Network\Request The request removed from the stack.
+ * @return \Cake\Network\Request The request removed from the stack.
  * @see Router::pushRequest()
  * @see Object::requestAction()
  */
@@ -582,7 +582,7 @@ class Router {
  * Get the either the current request object, or the first one.
  *
  * @param boolean $current Whether you want the request from the top of the stack or the first one.
- * @return Cake\Network\Request or null.
+ * @return \Cake\Network\Request or null.
  */
 	public static function getRequest($current = false) {
 		if ($current) {
@@ -707,7 +707,7 @@ class Router {
  *   If an array accepts the following keys.  If used with a named route you can provide
  *   a list of query string parameters.
  * @return string Full translated URL with base path.
- * @throws Cake\Error\Exception When the route name is not found
+ * @throws \Cake\Error\Exception When the route name is not found
  */
 	public static function url($url = null, $options = array()) {
 		if (!static::$initialized) {
@@ -874,7 +874,7 @@ class Router {
  * This will strip out 'autoRender', 'bare', 'requested', and 'return' param names as those
  * are used for CakePHP internals and should not normally be part of an output URL.
  *
- * @param Cake\Network\Request|array $params The params array or
+ * @param \Cake\Network\Request|array $params The params array or
  *     Cake\Network\Request object that needs to be reversed.
  * @param boolean $full Set to true to include the full URL including the
  *     protocol when reversing the URL.

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -179,7 +179,7 @@ abstract class ControllerTestCase extends TestCase {
  * @param string $name The name of the function
  * @param array $arguments Array of arguments
  * @return the return of _testAction
- * @throws Cake\Error\BadMethodCallException when you call methods that don't exist.
+ * @throws \Cake\Error\BadMethodCallException when you call methods that don't exist.
  */
 	public function __call($name, $arguments) {
 		if ($name === 'testAction') {
@@ -304,8 +304,8 @@ abstract class ControllerTestCase extends TestCase {
  * @param string $controller Controller name
  * @param array $mocks List of classes and methods to mock
  * @return Controller Mocked controller
- * @throws Cake\Error\MissingControllerException When controllers could not be created.
- * @throws Cake\Error\MissingComponentException When components could not be created.
+ * @throws \Cake\Error\MissingControllerException When controllers could not be created.
+ * @throws \Cake\Error\MissingComponentException When components could not be created.
  */
 	public function generate($controller, $mocks = array()) {
 		$classname = App::classname($controller, 'Controller', 'Controller');

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -47,6 +47,8 @@ class ControllerTestDispatcher extends Dispatcher {
 /**
  * Returns the test controller
  *
+ * @param \Cake\Network\Request $request Request object
+ * @param \Cake\Network\Response $response Response for the controller.
  * @return Controller
  */
 	protected function _getController($request, $response) {

--- a/src/TestSuite/Coverage/BaseCoverageReport.php
+++ b/src/TestSuite/Coverage/BaseCoverageReport.php
@@ -63,7 +63,7 @@ abstract class BaseCoverageReport {
  * Constructor
  *
  * @param array $coverage Array of coverage data from PHPUnit_Test_Result
- * @param Cake\TestSuite\Reporter\BaseReporter $reporter A reporter to use for the coverage report.
+ * @param \Cake\TestSuite\Reporter\BaseReporter $reporter A reporter to use for the coverage report.
  */
 	public function __construct($coverage, BaseReporter $reporter) {
 		$this->_rawCoverage = $coverage;
@@ -73,7 +73,7 @@ abstract class BaseCoverageReport {
 /**
  * Pulls params out of the reporter.
  *
- * @param Cake\TestSuite\Reporter\BaseReporter $reporter Reporter to suck params out of.
+ * @param \Cake\TestSuite\Reporter\BaseReporter $reporter Reporter to suck params out of.
  * @return void
  */
 	protected function _setParams(BaseReporter $reporter) {

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -41,7 +41,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * Constructor. Save internally the reference to the passed fixture manager
  *
  * @param \Cake\TestSuite\Fixture\FixtureManager $manager
- * @return void
  */
 	public function __construct(FixtureManager $manager) {
 		$this->_fixtureManager = $manager;

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -99,7 +99,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * Not Implemented
  *
  * @param PHPUnit_Framework_Test $test
- * @param PHPUnit_Framework_AssertionFailedError $e
+ * @param Exception $e
  * @param float $time
  * @return void
  */
@@ -139,6 +139,9 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
 /**
  * Not Implemented
  *
+ * @param PHPUnit_Framework_Test $test
+ * @param Exception $e
+ * @param float $time
  * @return void
  */
 	public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -40,7 +40,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
 /**
  * Constructor. Save internally the reference to the passed fixture manager
  *
- * @param Cake\TestSuite\Fixture\FixtureManager $manager
+ * @param \Cake\TestSuite\Fixture\FixtureManager $manager
  * @return void
  */
 	public function __construct(FixtureManager $manager) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -56,7 +56,7 @@ class FixtureManager {
 /**
  * Inspects the test to look for unloaded fixtures and loads them
  *
- * @param Cake\TestSuite\TestCase $test the test case to inspect
+ * @param \Cake\TestSuite\TestCase $test the test case to inspect
  * @return void
  */
 	public function fixturize($test) {
@@ -117,7 +117,7 @@ class FixtureManager {
 /**
  * Looks for fixture files and instantiates the classes accordingly
  *
- * @param Cake\TestSuite\Testcase $test The test suite to load fixtures for.
+ * @param \Cake\TestSuite\Testcase $test The test suite to load fixtures for.
  * @return void
  * @throws UnexpectedValueException when a referenced fixture does not exist.
  */
@@ -163,7 +163,7 @@ class FixtureManager {
 /**
  * Runs the drop and create commands on the fixtures if necessary.
  *
- * @param Cake\TestSuite\Fixture\TestFixture $fixture the fixture object to create
+ * @param \Cake\TestSuite\Fixture\TestFixture $fixture the fixture object to create
  * @param Connection $db the datasource instance to use
  * @param boolean $drop whether drop the fixture if it is already created or not
  * @return void
@@ -199,9 +199,9 @@ class FixtureManager {
 /**
  * Creates the fixtures tables and inserts data on them.
  *
- * @param Cake\TestSuite\TestCase $test the test to inspect for fixture loading
+ * @param \Cake\TestSuite\TestCase $test the test to inspect for fixture loading
  * @return void
- * @throws Cake\Error\Exception When fixture records cannot be inserted.
+ * @throws \Cake\Error\Exception When fixture records cannot be inserted.
  */
 	public function load(TestCase $test) {
 		if (empty($test->fixtures)) {
@@ -240,7 +240,7 @@ class FixtureManager {
 /**
  * Truncates the fixtures tables
  *
- * @param Cake\TestSuite\TestCase $test the test to inspect for fixture unloading
+ * @param \Cake\TestSuite\TestCase $test the test to inspect for fixture unloading
  * @return void
  */
 	public function unload(TestCase $test) {

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -119,7 +119,7 @@ class FixtureManager {
  *
  * @param \Cake\TestSuite\Testcase $test The test suite to load fixtures for.
  * @return void
- * @throws UnexpectedValueException when a referenced fixture does not exist.
+ * @throws \UnexpectedValueException when a referenced fixture does not exist.
  */
 	protected function _loadFixtures($test) {
 		if (empty($test->fixtures)) {
@@ -265,7 +265,7 @@ class FixtureManager {
  * @param DataSource $db DataSource instance or leave null to get DataSource from the fixture
  * @param boolean $dropTables Whether or not tables should be dropped and re-created.
  * @return void
- * @throws UnexpectedValueException if $name is not a previously loaded class
+ * @throws \UnexpectedValueException if $name is not a previously loaded class
  */
 	public function loadSingle($name, $db = null, $dropTables = true) {
 		if (isset($this->_fixtureMap[$name])) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -313,7 +313,7 @@ class TestFixture {
  * Truncates the current fixture. Can be overwritten by classes extending
  * CakeFixture to trigger other events before / after truncate.
  *
- * @param Connection DboSource $db A reference to a db instance
+ * @param Connection $db A reference to a db instance
  * @return boolean
  */
 	public function truncate(Connection $db) {

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -83,14 +83,14 @@ class TestFixture {
 /**
  * The Cake\Database\Schema\Table for this fixture.
  *
- * @var Cake\Database\Schema\Table
+ * @var \Cake\Database\Schema\Table
  */
 	protected $_schema;
 
 /**
  * Instantiate the fixture.
  *
- * @throws Cake\Error\Exception on invalid datasource usage.
+ * @throws \Cake\Error\Exception on invalid datasource usage.
  */
 	public function __construct() {
 		$connection = 'test';
@@ -112,7 +112,7 @@ class TestFixture {
  * Initialize the fixture.
  *
  * @return void
- * @throws Cake\Error\MissingModelException Whe importing from a model that does not exist.
+ * @throws \Cake\Error\MissingModelException Whe importing from a model that does not exist.
  */
 	public function init() {
 		if ($this->table === null) {
@@ -176,7 +176,7 @@ class TestFixture {
  * Build fixture schema from a table in another datasource.
  *
  * @return void
- * @throws Cake\Error\Exception when trying to import from an empty table.
+ * @throws \Cake\Error\Exception when trying to import from an empty table.
  */
 	protected function _schemaFromImport() {
 		if (!is_array($this->import)) {
@@ -200,8 +200,8 @@ class TestFixture {
 /**
  * Get/Set the Cake\Database\Schema\Table instance used by this fixture.
  *
- * @param Cake\Database\Schema\Table $schema The table to set.
- * @return Cake\Database\Schema\Table|null
+ * @param \Cake\Database\Schema\Table $schema The table to set.
+ * @return \Cake\Database\Schema\Table|null
  */
 	public function schema(Table $schema = null) {
 		if ($schema) {

--- a/src/TestSuite/Reporter/BaseReporter.php
+++ b/src/TestSuite/Reporter/BaseReporter.php
@@ -130,9 +130,9 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * An error occurred.
  *
- * @param  PHPUnit_Framework_Test $test
- * @param  Exception              $e
- * @param  float                  $time
+ * @param \PHPUnit_Framework_Test $test
+ * @param \Exception $e
+ * @param float $time
  */
 	public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time) {
 		$this->paintException($e, $test);
@@ -141,9 +141,9 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * A failure occurred.
  *
- * @param  PHPUnit_Framework_Test $test
- * @param  PHPUnit_Framework_AssertionFailedError $e
- * @param  float $time
+ * @param \PHPUnit_Framework_Test $test
+ * @param \PHPUnit_Framework_AssertionFailedError $e
+ * @param float $time
  */
 	public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time) {
 		$this->paintFail($e, $test);
@@ -152,9 +152,9 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * Incomplete test.
  *
- * @param  PHPUnit_Framework_Test $test
- * @param  Exception $e
- * @param  float $time
+ * @param \PHPUnit_Framework_Test $test
+ * @param \Exception $e
+ * @param float $time
  */
 	public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {
 		$this->paintSkip($e, $test);
@@ -163,9 +163,9 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * Skipped test.
  *
- * @param  PHPUnit_Framework_Test $test
- * @param  Exception $e
- * @param  float $time
+ * @param \PHPUnit_Framework_Test $test
+ * @param \Exception $e
+ * @param float $time
  */
 	public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time) {
 		$this->paintSkip($e, $test);
@@ -174,7 +174,7 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * A test suite started.
  *
- * @param  PHPUnit_Framework_TestSuite $suite
+ * @param \PHPUnit_Framework_TestSuite $suite
  */
 	public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {
 		if (!$this->_headerSent) {
@@ -186,7 +186,7 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * A test suite ended.
  *
- * @param  PHPUnit_Framework_TestSuite $suite
+ * @param \PHPUnit_Framework_TestSuite $suite
  */
 	public function endTestSuite(\PHPUnit_Framework_TestSuite $suite) {
 	}
@@ -194,7 +194,7 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * A test started.
  *
- * @param  PHPUnit_Framework_Test $test
+ * @param \PHPUnit_Framework_Test $test
  */
 	public function startTest(\PHPUnit_Framework_Test $test) {
 	}
@@ -202,8 +202,8 @@ class BaseReporter extends \PHPUnit_TextUI_ResultPrinter {
 /**
  * A test ended.
  *
- * @param  PHPUnit_Framework_Test $test
- * @param  float $time
+ * @param \PHPUnit_Framework_Test $test
+ * @param float $time
  */
 	public function endTest(\PHPUnit_Framework_Test $test, $time) {
 		$this->numAssertions += $test->getNumAssertions();

--- a/src/TestSuite/Reporter/HtmlReporter.php
+++ b/src/TestSuite/Reporter/HtmlReporter.php
@@ -280,7 +280,7 @@ class HtmlReporter extends BaseReporter {
  * trail of the nesting test suites below the
  * top level test.
  *
- * @param PHPUnit_Framework_Test test method that just passed
+ * @param \PHPUnit_Framework_Test test method that just passed
  * @param float $time time spent to run the test method
  * @return void
  */
@@ -301,14 +301,14 @@ class HtmlReporter extends BaseReporter {
  * @param mixed $test
  * @return void
  */
-	public function paintException($message, $test) {
-		$trace = $this->_getStackTrace($message);
+	public function paintException($exception, $test) {
+		$trace = $this->_getStackTrace($exception);
 		$testName = get_class($test) . '(' . $test->getName() . ')';
 
 		echo "<li class='fail'>\n";
-		echo "<span>" . get_class($message) . "</span>";
+		echo "<span>" . get_class($exception) . "</span>";
 
-		echo "<div class='msg'>" . $this->_htmlEntities($message->getMessage()) . "</div>\n";
+		echo "<div class='msg'>" . $this->_htmlEntities($exception->getMessage()) . "</div>\n";
 		echo "<div class='msg'>" . sprintf('Test case: %s', $testName) . "</div>\n";
 		echo "<div class='msg'>" . 'Stack trace:' . '<br />' . $trace . "</div>\n";
 		echo "</li>\n";
@@ -351,7 +351,7 @@ class HtmlReporter extends BaseReporter {
 /**
  * Gets a formatted stack trace.
  *
- * @param Exception $e Exception to get a stack trace for.
+ * @param \Exception $e Exception to get a stack trace for.
  * @return string Generated stack trace.
  */
 	protected function _getStackTrace(\Exception $e) {
@@ -372,7 +372,7 @@ class HtmlReporter extends BaseReporter {
 /**
  * A test suite started.
  *
- * @param PHPUnit_Framework_TestSuite $suite
+ * @param \PHPUnit_Framework_TestSuite $suite
  * @return void
  */
 	public function startTestSuite(\PHPUnit_Framework_TestSuite $suite) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 /**
  * The class responsible for managing the creation, loading and removing of fixtures
  *
- * @var Cake\TestSuite\Fixture\FixtureManager
+ * @var \Cake\TestSuite\Fixture\FixtureManager
  */
 	public $fixtureManager = null;
 
@@ -193,7 +193,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  * Chooses which fixtures to load for a given test
  *
  * @return void
- * @see Cake\TestSuite\TestCase::$autoFixtures
+ * @see \Cake\TestSuite\TestCase::$autoFixtures
  * @throws \Exception when no fixture manager is available.
  */
 	public function loadFixtures() {
@@ -592,7 +592,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  * @param string $alias
  * @param mixed $methods
  * @param array $options
- * @throws Cake\ORM\Error\MissingTableClassException
+ * @throws \Cake\ORM\Error\MissingTableClassException
  * @return Model
  */
 	public function getMockForModel($alias, $methods = array(), $options = array()) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -74,9 +74,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  * If no TestResult object is passed a new one will be created.
  * This method is run for each test method in this class
  *
- * @param PHPUnit_Framework_TestResult $result
- * @return PHPUnit_Framework_TestResult
- * @throws InvalidArgumentException
+ * @param \PHPUnit_Framework_TestResult $result
+ * @return \PHPUnit_Framework_TestResult
  */
 	public function run(\PHPUnit_Framework_TestResult $result = null) {
 		if (!empty($this->fixtureManager)) {
@@ -212,7 +211,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  *
  * @param string $expected The expected value.
  * @param string $result The actual value.
- * @param message The message to use for failure.
+ * @param string message The message to use for failure.
  * @return boolean
  */
 	public function assertTextNotEquals($expected, $result, $message = '') {
@@ -227,7 +226,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  *
  * @param string $expected The expected value.
  * @param string $result The actual value.
- * @param message The message to use for failure.
+ * @param string message The message to use for failure.
  * @return boolean
  */
 	public function assertTextEquals($expected, $result, $message = '') {
@@ -546,7 +545,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 /**
  * Compatibility wrapper function for setExpectedException
  *
- * @param mixed $expected the name of the Exception
+ * @param mixed $name the name of the Exception
  * @param string $message the text to display if the assertion is not correct
  * @deprecated This is a compatiblity wrapper for 1.x. It will be removed in 3.0
  * @return void

--- a/src/TestSuite/TestPermutationDecorator.php
+++ b/src/TestSuite/TestPermutationDecorator.php
@@ -38,8 +38,8 @@ class TestPermutationDecorator extends PHPUnit_Extensions_TestDecorator {
 /**
  * Constructor
  *
- * @param \PHPUnit_Framework_Test The test or suite to decorate
- * @param array $permutation  An array containing callable methods that will
+ * @param PHPUnit_Framework_Test $test The test or suite to decorate
+ * @param array $permutations An array containing callable methods that will
  * be executed before the test suite is run
  */
 	public function __construct(PHPUnit_Framework_Test $test, array $permutations) {

--- a/src/TestSuite/TestPermutationDecorator.php
+++ b/src/TestSuite/TestPermutationDecorator.php
@@ -41,7 +41,6 @@ class TestPermutationDecorator extends PHPUnit_Extensions_TestDecorator {
  * @param \PHPUnit_Framework_Test The test or suite to decorate
  * @param array $permutation  An array containing callable methods that will
  * be executed before the test suite is run
- * @return void
  */
 	public function __construct(PHPUnit_Framework_Test $test, array $permutations) {
 		parent::__construct($test);

--- a/src/TestSuite/TestRunner.php
+++ b/src/TestSuite/TestRunner.php
@@ -41,7 +41,7 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner {
 /**
  * Actually run a suite of tests. Cake initializes fixtures here using the chosen fixture manager
  *
- * @param PHPUnit_Framework_Test $suite
+ * @param \PHPUnit_Framework_Test $suite
  * @param array $arguments
  * @return void
  */

--- a/src/TestSuite/TestRunner.php
+++ b/src/TestSuite/TestRunner.php
@@ -91,7 +91,7 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner {
  *
  * @param array $arguments
  * @return mixed instance of a fixture manager.
- * @throws RuntimeException When fixture manager class cannot be loaded.
+ * @throws \RuntimeException When fixture manager class cannot be loaded.
  */
 	protected function _getFixtureManager($arguments) {
 		if (isset($arguments['fixtureManager'])) {

--- a/src/TestSuite/TestSuiteCommand.php
+++ b/src/TestSuite/TestSuiteCommand.php
@@ -32,7 +32,7 @@ class TestSuiteCommand extends \PHPUnit_TextUI_Command {
  *
  * @param mixed $loader
  * @param array $params list of options to be used for this run
- * @throws Cake\Error\MissingTestLoaderException When a loader class could not be found.
+ * @throws \Cake\Error\MissingTestLoaderException When a loader class could not be found.
  */
 	public function __construct($loader, $params = array()) {
 		if ($loader && !class_exists($loader)) {
@@ -108,7 +108,7 @@ class TestSuiteCommand extends \PHPUnit_TextUI_Command {
  * Create a runner for the command.
  *
  * @param mixed $loader The loader to be used for the test run.
- * @return Cake\TestSuite\TestRunner
+ * @return \Cake\TestSuite\TestRunner
  */
 	public function getRunner($loader) {
 		return new TestRunner($loader, $this->_params);

--- a/src/TestSuite/TestSuiteDispatcher.php
+++ b/src/TestSuite/TestSuiteDispatcher.php
@@ -70,7 +70,7 @@ class TestSuiteDispatcher {
 /**
  * reporter instance used for the request
  *
- * @var Cake\TestSuite\Reporter\BaseReporter
+ * @var \Cake\TestSuite\Reporter\BaseReporter
  */
 	protected static $_Reporter = null;
 

--- a/src/Utility/Debugger.php
+++ b/src/Utility/Debugger.php
@@ -618,7 +618,7 @@ class Debugger {
  * @param string $format The format you want errors to be output as.
  *   Leave null to get the current format.
  * @return mixed Returns null when setting. Returns the current format when getting.
- * @throws Cake\Error\Exception when choosing a format that doesn't exist.
+ * @throws \Cake\Error\Exception when choosing a format that doesn't exist.
  */
 	public static function outputAs($format = null) {
 		$self = Debugger::getInstance();

--- a/src/Utility/File.php
+++ b/src/Utility/File.php
@@ -216,7 +216,7 @@ class File {
  *
  * @param string $data Data to write to this File.
  * @param string $mode Mode of writing. {@link http://php.net/fwrite See fwrite()}.
- * @param string $force Force the file to open
+ * @param boolean $force Force the file to open
  * @return boolean Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::write
  */
@@ -243,7 +243,7 @@ class File {
  * Append given data string to this file.
  *
  * @param string $data Data to write
- * @param string $force Force the file to open
+ * @param boolean $force Force the file to open
  * @return boolean Success
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#File::append
  */

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -430,7 +430,7 @@ class Hash {
  * The `$format` string can use any format options that `vsprintf()` and `sprintf()` do.
  *
  * @param array $data Source array from which to extract the data
- * @param string $paths An array containing one or more Hash::extract()-style key paths
+ * @param array $paths An array containing one or more Hash::extract()-style key paths
  * @param string $format Format string into which values will be inserted, see sprintf()
  * @return array An array of strings extracted from `$path` and formatted with `$format`
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::format
@@ -661,7 +661,7 @@ class Hash {
 /**
  * Checks to see if all the values in the array are numeric
  *
- * @param array $array The array to check.
+ * @param array $data The array to check.
  * @return boolean true if values are numeric, false otherwise
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::numeric
  */
@@ -679,7 +679,7 @@ class Hash {
  * If you have an un-even or heterogenous array, consider using Hash::maxDimensions()
  * to get the dimensions of the array.
  *
- * @param array $array Array to count dimensions on
+ * @param array $data Array to count dimensions on
  * @return integer The number of dimensions in $data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::dimensions
  */

--- a/src/Utility/ModelAwareTrait.php
+++ b/src/Utility/ModelAwareTrait.php
@@ -70,8 +70,8 @@ trait ModelAwareTrait {
  * @param string $type The type of repository to load. Defaults to 'Table' which
  *   delegates to Cake\ORM\TableRegistry.
  * @return boolean True when single repository found and instance created.
- * @throws Cake\Error\MissingModelException if the model class cannot be found.
- * @throws Cake\Error\Exception When using a type that has not been registered.
+ * @throws \Cake\Error\MissingModelException if the model class cannot be found.
+ * @throws \Cake\Error\Exception When using a type that has not been registered.
  */
 	public function loadModel($modelClass = null, $type = 'Table') {
 		if ($modelClass === null) {

--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -133,7 +133,7 @@ class Number {
  * @param string $size Size in human readable string like '5MB', '5M', '500B', '50kb' etc.
  * @param mixed $default Value to be returned when invalid size was used, for example 'Unknown type'
  * @return mixed Number of bytes as integer on success, `$default` on failure if not false
- * @throws Cake\Error\Exception On invalid Unit type.
+ * @throws \Cake\Error\Exception On invalid Unit type.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::fromReadableSize
  */
 	public static function fromReadableSize($size, $default = false) {

--- a/src/Utility/ObjectCollection.php
+++ b/src/Utility/ObjectCollection.php
@@ -86,14 +86,14 @@ abstract class ObjectCollection {
  *    Defaults to false.
  *
  *
- * @param string $callback|Cake\Event\Event Method to fire on all the objects. Its assumed all the objects implement
+ * @param string $callback|\Cake\Event\Event Method to fire on all the objects. Its assumed all the objects implement
  *   the method you are calling. If an instance of Cake\Event\Event is provided, then then Event name will parsed to
  *   get the callback name. This is done by getting the last word after any dot in the event name
  *   (eg. `Model.afterSave` event will trigger the `afterSave` callback)
  * @param array $params Array of parameters for the triggered callback.
  * @param array $options Array of options.
  * @return mixed Either the last result or all results if collectReturn is on.
- * @throws Cake\Error\Exception when modParams is used with an index that does not exist.
+ * @throws \Cake\Error\Exception when modParams is used with an index that does not exist.
  */
 	public function trigger($callback, $params = array(), $options = array()) {
 		if (empty($this->_enabled)) {

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -24,9 +24,9 @@ namespace Cake\Utility;
  * from previous versions of CakePHP.
  *
  * @since CakePHP 3.0
- * @see Cake\Controller\ComponentRegistry
- * @see Cake\View\HelperRegistry
- * @see Cake\Console\TaskRegistry
+ * @see \Cake\Controller\ComponentRegistry
+ * @see \Cake\View\HelperRegistry
+ * @see \Cake\Console\TaskRegistry
  */
 abstract class ObjectRegistry {
 

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -93,7 +93,7 @@ abstract class ObjectRegistry {
  *
  * @param string $class The class that is missing.
  * @param string $plugin The plugin $class is missing from.
- * @throw Cake\Exception
+ * @throws \Cake\Error\Exception
  */
 	abstract protected function _throwMissingClassError($class, $plugin);
 

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -57,7 +57,7 @@ abstract class ObjectRegistry {
  *
  * All calls to the `Email` component would use `AliasedEmail` instead.
  *
- * @param string $name The name/class of the object to load.
+ * @param string $objectName The name/class of the object to load.
  * @param array $settings Additional settings to use when loading the object.
  * @return mixed
  */

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -135,7 +135,7 @@ class Security {
  *
  * @param integer $cost Valid values are 4-31
  * @return void
- * @throws Cake\Error\Exception When cost is invalid.
+ * @throws \Cake\Error\Exception When cost is invalid.
  */
 	public static function setCost($cost) {
 		if ($cost < 4 || $cost > 31) {
@@ -153,7 +153,7 @@ class Security {
  * @param string $text Encrypted string to decrypt, normal string to encrypt
  * @param string $key Key to use as the encryption key for encrypted data.
  * @param string $operation Operation to perform, encrypt or decrypt
- * @throws Cake\Error\Exception When there are errors.
+ * @throws \Cake\Error\Exception When there are errors.
  * @return string Encrypted/Decrypted string
  */
 	public static function rijndael($text, $key, $operation) {
@@ -204,7 +204,7 @@ class Security {
  * @param string $password The string to be encrypted.
  * @param mixed $salt false to generate a new salt or an existing salt.
  * @return string The hashed string or an empty string on error.
- * @throws Cake\Error\Exception on invalid salt values.
+ * @throws \Cake\Error\Exception on invalid salt values.
  */
 	protected static function _crypt($password, $salt = false) {
 		if ($salt === false) {
@@ -232,7 +232,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Encrypted data.
- * @throws Cake\Error\Exception On invalid data or key.
+ * @throws \Cake\Error\Exception On invalid data or key.
  */
 	public static function encrypt($plain, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'encrypt()');
@@ -260,7 +260,7 @@ class Security {
  * @param string $key
  * @param string $method The method the key is being checked for.
  * @return void
- * @throws Cake\Error\Exception When key length is not 256 bit/32 bytes
+ * @throws \Cake\Error\Exception When key length is not 256 bit/32 bytes
  */
 	protected static function _checkKey($key, $method) {
 		if (strlen($key) < 32) {
@@ -275,7 +275,7 @@ class Security {
  * @param string $key The 256 bit/32 byte key to use as a cipher key.
  * @param string $hmacSalt The salt to use for the HMAC process. Leave null to use Security.salt.
  * @return string Decrypted data. Any trailing null bytes will be removed.
- * @throws Cake\Error\Exception On invalid data or key.
+ * @throws \Cake\Error\Exception On invalid data or key.
  */
 	public static function decrypt($cipher, $key, $hmacSalt = null) {
 		self::_checkKey($key, 'decrypt()');

--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -34,7 +34,7 @@ class Time {
  * `strftime` (http://php.net/manual/en/function.strftime.php)
  *
  * @var string
- * @see Cake\Utility\Time::format()
+ * @see \Cake\Utility\Time::format()
  */
 	public static $niceFormat = '%a, %b %eS %Y, %H:%M';
 
@@ -43,7 +43,7 @@ class Time {
  * and the difference is more than `Cake\Utility\Time::$wordEnd`
  *
  * @var string
- * @see Cake\Utility\Time::timeAgoInWords()
+ * @see \Cake\Utility\Time::timeAgoInWords()
  */
 	public static $wordFormat = 'j/n/y';
 
@@ -52,7 +52,7 @@ class Time {
  * and the difference is less than `Cake\Utility\Time::$wordEnd`
  *
  * @var array
- * @see Cake\Utility\Time::timeAgoInWords()
+ * @see \Cake\Utility\Time::timeAgoInWords()
  */
 	public static $wordAccuracy = array(
 		'year' => "day",
@@ -68,7 +68,7 @@ class Time {
  * The end of relative time telling
  *
  * @var string
- * @see Cake\Utility\Time::timeAgoInWords()
+ * @see \Cake\Utility\Time::timeAgoInWords()
  */
 	public static $wordEnd = '+1 month';
 
@@ -919,7 +919,7 @@ class Time {
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
  * @return string Formatted date string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::format
- * @see Cake\Utility\Time::i18nFormat()
+ * @see \Cake\Utility\Time::i18nFormat()
  */
 	public static function format($date, $format = null, $default = false, $timezone = null) {
 		//Backwards compatible params re-order test

--- a/src/Utility/Xml.php
+++ b/src/Utility/Xml.php
@@ -84,7 +84,7 @@ class Xml {
  * @param string|array $input XML string, a path to a file, a URL or an array
  * @param array $options The options to use
  * @return SimpleXMLElement|DOMDocument SimpleXMLElement or DOMDocument
- * @throws Cake\Error\XmlException
+ * @throws \Cake\Error\XmlException
  */
 	public static function build($input, $options = array()) {
 		if (!is_array($options)) {
@@ -125,7 +125,7 @@ class Xml {
  * @param string $input The input to load.
  * @param array $options The options to use. See Xml::build()
  * @return SimpleXmlElement|DOMDocument
- * @throws Cake\Error\XmlException
+ * @throws \Cake\Error\XmlException
  */
 	protected static function _loadXml($input, $options) {
 		$hasDisable = function_exists('libxml_disable_entity_loader');
@@ -189,7 +189,7 @@ class Xml {
  * @param array $input Array with data
  * @param array $options The options to use
  * @return SimpleXMLElement|DOMDocument SimpleXMLElement or DOMDocument
- * @throws Cake\Error\XmlException
+ * @throws \Cake\Error\XmlException
  */
 	public static function fromArray($input, $options = array()) {
 		if (!is_array($input) || count($input) !== 1) {
@@ -233,7 +233,7 @@ class Xml {
  * @param array $data Array of data to append to the $node.
  * @param string $format Either 'attribute' or 'tags'. This determines where nested keys go.
  * @return void
- * @throws Cake\Error\XmlException
+ * @throws \Cake\Error\XmlException
  */
 	protected static function _fromArray($dom, $node, &$data, $format) {
 		if (empty($data) || !is_array($data)) {
@@ -331,7 +331,7 @@ class Xml {
  *
  * @param SimpleXMLElement|DOMDocument|DOMNode $obj SimpleXMLElement, DOMDocument or DOMNode instance
  * @return array Array representation of the XML structure.
- * @throws Cake\Error\XmlException
+ * @throws \Cake\Error\XmlException
  */
 	public static function toArray($obj) {
 		if ($obj instanceof \DOMNode) {

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -930,7 +930,7 @@ class Validation {
  * @param string|array $check
  * @param array|string $mimeTypes Array of mime types or regex pattern to check.
  * @return boolean Success
- * @throws Cake\Error\Exception when mime type can not be determined.
+ * @throws \Cake\Error\Exception when mime type can not be determined.
  */
 	public static function mimeType($check, $mimeTypes = array()) {
 		if (is_array($check) && isset($check['tmp_name'])) {

--- a/src/Validation/ValidationSet.php
+++ b/src/Validation/ValidationSet.php
@@ -81,7 +81,7 @@ class ValidationSet implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Gets a rule for a given name if exists
  *
  * @param string $name
- * @return Cake\Validation\ValidationRule
+ * @return \Cake\Validation\ValidationRule
  */
 	public function rule($name) {
 		if (!empty($this->_rules[$name])) {
@@ -133,7 +133,7 @@ class ValidationSet implements \ArrayAccess, \IteratorAggregate, \Countable {
  * }}}
  *
  * @param string $name The name under which the rule should be unset
- * @return Cake\Validation\ValidationSet this instance
+ * @return \Cake\Validation\ValidationSet this instance
  */
 	public function remove($name) {
 		unset($this->_rules[$name]);
@@ -154,7 +154,7 @@ class ValidationSet implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Returns a rule object by its index
  *
  * @param string $index name of the rule
- * @return Cake\Validation\ValidationRule
+ * @return \Cake\Validation\ValidationRule
  */
 	public function offsetGet($index) {
 		return $this->_rules[$index];
@@ -164,7 +164,7 @@ class ValidationSet implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Sets or replace a validation rule
  *
  * @param string $index name of the rule
- * @param Cake\Validation\ValidationRule|array rule to add to $index
+ * @param \Cake\Validation\ValidationRule|array rule to add to $index
  * @return void
  */
 	public function offsetSet($index, $rule) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -102,7 +102,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  *
  * @param string $name [optional] The fieldname to fetch.
  * @param \Cake\Validation\ValidationSet $set The set of rules for field
- * @return Cake\Validation\ValidationSet
+ * @return \Cake\Validation\ValidationSet
  */
 	public function field($name, ValidationSet $set = null) {
 		if (empty($this->_fields[$name])) {
@@ -153,7 +153,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Sets the I18n domain for validation messages. This method is chainable.
  *
  * @param string $validationDomain The validation domain to be used.
- * @return Cake\Validation
+ * @return \Cake\Validation
  */
 	public function setValidationDomain($validationDomain) {
 		$this->_validationDomain = $validationDomain;
@@ -174,7 +174,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Returns the rule set for a field
  *
  * @param string $field name of the field to check
- * @return Cake\Validation\ValidationSet
+ * @return \Cake\Validation\ValidationSet
  */
 	public function offsetGet($field) {
 		return $this->field($field);
@@ -184,7 +184,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * Sets the rule set for a field
  *
  * @param string $field name of the field to set
- * @param array|Cake\Validation\ValidationSet $rules set of rules to apply to field
+ * @param array|\Cake\Validation\ValidationSet $rules set of rules to apply to field
  * @return void
  */
 	public function offsetSet($field, $rules) {
@@ -245,7 +245,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  *
  * @param string $field The name of the field from wich the rule will be removed
  * @param array|string $name The alias for a single rule or multiple rules array
- * @param array|Cake\Validation\ValidationRule $rule the rule to add
+ * @param array|\Cake\Validation\ValidationRule $rule the rule to add
  * @return Validator this instance
  */
 	public function add($field, $name, $rule = []) {

--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -62,7 +62,7 @@ class ArrayContext implements ContextInterface {
 /**
  * The request object.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request;
 
@@ -76,7 +76,7 @@ class ArrayContext implements ContextInterface {
 /**
  * Constructor.
  *
- * @param Cake\Network\Request
+ * @param \Cake\Network\Request
  * @param array
  */
 	public function __construct(Request $request, array $context) {
@@ -171,7 +171,7 @@ class ArrayContext implements ContextInterface {
  *
  * @param string $field A dot separated path to get a schema type for.
  * @return null|string An abstract data type or null.
- * @see Cake\Database\Type
+ * @see \Cake\Database\Type
  */
 	public function type($field) {
 		if (!is_array($this->_context['schema'])) {

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -57,7 +57,7 @@ interface ContextInterface {
  *
  * @param string $field A dot separated path to get a schema type for.
  * @return null|string An abstract data type or null.
- * @see Cake\Database\Type
+ * @see \Cake\Database\Type
  */
 	public function type($field);
 

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -48,7 +48,7 @@ class EntityContext implements ContextInterface {
 /**
  * The request object.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request;
 
@@ -84,7 +84,7 @@ class EntityContext implements ContextInterface {
 /**
  * Constructor.
  *
- * @param Cake\Network\Request
+ * @param \Cake\Network\Request
  * @param array
  */
 	public function __construct(Request $request, array $context) {
@@ -314,7 +314,7 @@ class EntityContext implements ContextInterface {
  * Get the table instance
  *
  * @param string $prop The property name to get a table for.
- * @return Cake\ORM\Table The table instance.
+ * @return \Cake\ORM\Table The table instance.
  */
 	protected function _getTable($prop) {
 		if (isset($this->_tables[$prop])) {
@@ -339,7 +339,7 @@ class EntityContext implements ContextInterface {
  *
  * @param string $field A dot separated path to get a schema type for.
  * @return null|string An abstract data type or null.
- * @see Cake\Database\Type
+ * @see \Cake\Database\Type
  */
 	public function type($field) {
 		$parts = explode('.', $field);

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -28,14 +28,14 @@ class NullContext implements ContextInterface {
 /**
  * The request object.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	protected $_request;
 
 /**
  * Constructor.
  *
- * @param Cake\Network\Request
+ * @param \Cake\Network\Request
  * @param array
  */
 	public function __construct(Request $request, array $context) {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -79,7 +79,7 @@ class Helper extends Object implements EventListener {
 /**
  * Request object
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	public $request = null;
 

--- a/src/View/Helper/CacheHelper.php
+++ b/src/View/Helper/CacheHelper.php
@@ -65,7 +65,7 @@ class CacheHelper extends Helper {
 /**
  * Parses the view file and stores content for cache file building.
  *
- * @param Cake\Event\Event $event The event instance.
+ * @param \Cake\Event\Event $event The event instance.
  * @param string $viewFile
  * @param string $output The output for the file.
  * @return string Updated content.
@@ -79,7 +79,7 @@ class CacheHelper extends Helper {
 /**
  * Parses the layout file and stores content for cache file building.
  *
- * @param Cake\Event\Event $event The event instance.
+ * @param \Cake\Event\Event $event The event instance.
  * @param string $layoutFile
  * @return void
  */

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2798,7 +2798,7 @@ class FormHelper extends Helper {
  *
  * @param mixed $data The data to get a context provider for.
  * @return mixed Context provider.
- * @throws RuntimeException when the context class does not implement the
+ * @throws \RuntimeException when the context class does not implement the
  *   ContextInterface.
  */
 	protected function _getContext($data = []) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -144,14 +144,14 @@ class FormHelper extends Helper {
 /**
  * Registry for input widgets.
  *
- * @var Cake\View\Widget\InputRegistry
+ * @var \Cake\View\Widget\InputRegistry
  */
 	protected $_registry;
 
 /**
  * Context for the current form.
  *
- * @var Cake\View\Form\Context
+ * @var \Cake\View\Form\Context
  */
 	protected $_context;
 
@@ -193,7 +193,7 @@ class FormHelper extends Helper {
 /**
  * Copies the validationErrors variable from the View object into this instance
  *
- * @param Cake\View\View $View The View this helper is being attached to.
+ * @param \Cake\View\View $View The View this helper is being attached to.
  * @param array $settings Configuration settings for the helper.
  */
 	public function __construct(View $View, $settings = array()) {
@@ -210,9 +210,9 @@ class FormHelper extends Helper {
 /**
  * Set the input registry the helper will use.
  *
- * @param Cake\View\Widget\InputRegistry $instance The registry instance to set.
+ * @param \Cake\View\Widget\InputRegistry $instance The registry instance to set.
  * @param array $widgets An array of widgets
- * @return Cake\View\Widget\InputRegistry
+ * @return \Cake\View\Widget\InputRegistry
  */
 	public function inputRegistry(InputRegistry $instance = null, $widgets = []) {
 		if ($instance === null) {
@@ -251,7 +251,7 @@ class FormHelper extends Helper {
 /**
  * Returns if a field is required to be filled based on validation properties from the validating object.
  *
- * @param Cake\Validation\ValidationSet $validationRules
+ * @param \Cake\Validation\ValidationSet $validationRules
  * @return boolean true if field is required to be filled, false otherwise
  */
 	protected function _isRequiredField($validationRules) {
@@ -371,7 +371,7 @@ class FormHelper extends Helper {
 /**
  * Create the URL for a form based on the options.
  *
- * @param Cake\View\Form\ContextInterface $context The context object to use.
+ * @param \Cake\View\Form\ContextInterface $context The context object to use.
  * @param array $options An array of options from create()
  * @return string The action attribute for the form.
  */
@@ -1392,7 +1392,7 @@ class FormHelper extends Helper {
  * @param string $method Method name / input type to make.
  * @param array $params Parameters for the method call
  * @return string Formatted input method.
- * @throws Cake\Error\Exception When there are no params for the method call.
+ * @throws \Cake\Error\Exception When there are no params for the method call.
  */
 	public function __call($method, $params) {
 		$options = [];
@@ -1781,7 +1781,7 @@ class FormHelper extends Helper {
  * @param array $attributes The HTML attributes of the select element.
  * @return string Formatted SELECT element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
- * @see Cake\View\Helper\FormHelper::multiCheckbox() for creating multiple checkboxes.
+ * @see \Cake\View\Helper\FormHelper::multiCheckbox() for creating multiple checkboxes.
  */
 	public function select($fieldName, $options = [], $attributes = []) {
 		$attributes += [
@@ -1845,7 +1845,7 @@ class FormHelper extends Helper {
  *   checkboxes element.
  * @param array $attributes The HTML attributes of the select element.
  * @return string Formatted SELECT element
- * @see Cake\View\Helper\FormHelper::select() for supported option formats.
+ * @see \Cake\View\Helper\FormHelper::select() for supported option formats.
  */
 	public function multiCheckbox($fieldName, $options, $attributes = []) {
 		$attributes += [
@@ -2785,7 +2785,7 @@ class FormHelper extends Helper {
  *
  * If there is no active form null will be returned.
  *
- * @return null|Cake\View\Form\ContextInterface The context for the form.
+ * @return null|\Cake\View\Form\ContextInterface The context for the form.
  */
 	public function context() {
 		return $this->_getContext();

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -38,7 +38,7 @@ class HtmlHelper extends Helper {
 /**
  * Reference to the Response object
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	public $response;
 
@@ -1191,7 +1191,7 @@ class HtmlHelper extends Helper {
  * @param string|array $configFile String with the config file (load using PhpConfig) or an array with file and engine name
  * @param string $path Path with config file
  * @return mixed False to error or loaded configs
- * @throws Cake\Error\ConfigureException
+ * @throws \Cake\Error\ConfigureException
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#changing-the-tags-output-by-htmlhelper
  */
 	public function loadConfig($configFile, $path = null) {

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -67,6 +67,8 @@ class NumberHelper extends Helper {
 /**
  * Call methods from Cake\Utility\Number utility class
  *
+ * @param string $method Method to invoke
+ * @param array $params Array of params for the method.
  * @return mixed Whatever is returned by called method, or false on failure
  */
 	public function __call($method, $params) {

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -30,14 +30,14 @@ use Cake\View\View;
  * Methods to make numbers more readable.
  *
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html
- * @see Cake\Utility\Number
+ * @see \Cake\Utility\Number
  */
 class NumberHelper extends Helper {
 
 /**
  * Cake\Utility\Number instance
  *
- * @var Cake\Utility\Number
+ * @var \Cake\Utility\Number
  */
 	protected $_engine = null;
 
@@ -51,7 +51,7 @@ class NumberHelper extends Helper {
  *
  * @param View $View The View this helper is being attached to.
  * @param array $settings Configuration settings for the helper
- * @throws Cake\Error\Exception When the engine class could not be found.
+ * @throws \Cake\Error\Exception When the engine class could not be found.
  */
 	public function __construct(View $View, $settings = array()) {
 		$settings = Hash::merge(array('engine' => 'Cake\Utility\Number'), $settings);
@@ -76,7 +76,7 @@ class NumberHelper extends Helper {
 /**
  * Formats a number with a level of precision.
  *
- * @see Cake\Utility\Number::precision()
+ * @see \Cake\Utility\Number::precision()
  *
  * @param float $number A floating point number.
  * @param integer $precision The precision of the returned number.
@@ -90,7 +90,7 @@ class NumberHelper extends Helper {
 /**
  * Returns a formatted-for-humans file size.
  *
- * @see Cake\Utility\Number::toReadableSize()
+ * @see \Cake\Utility\Number::toReadableSize()
  *
  * @param integer $size Size in bytes
  * @return string Human readable size
@@ -107,7 +107,7 @@ class NumberHelper extends Helper {
  *
  * - `multiply`: Multiply the input value by 100 for decimal percentages.
  *
- * @see Cake\Utility\Number::toPercentage()
+ * @see \Cake\Utility\Number::toPercentage()
  *
  * @param float $number A floating point number
  * @param integer $precision The precision of the returned number
@@ -122,7 +122,7 @@ class NumberHelper extends Helper {
 /**
  * Formats a number into a currency format.
  *
- * @see Cake\Utility\Number::format()
+ * @see \Cake\Utility\Number::format()
  *
  * @param float $number A floating point number
  * @param integer $options If integer then places, if string then before, if (,.-) then use it
@@ -164,7 +164,7 @@ class NumberHelper extends Helper {
  *   By default all currencies contain utf-8 symbols and don't need this changed. If you require
  *   non HTML encoded symbols you will need to update the settings with the correct bytes.
  *
- * @see Cake\Utility\Number::currency()
+ * @see \Cake\Utility\Number::currency()
  *
  * @param float $number
  * @param string $currency Shortcut to default options. Valid values are 'USD', 'EUR', 'GBP', otherwise
@@ -191,7 +191,7 @@ class NumberHelper extends Helper {
  * Added formats are merged with the defaults defined in Cake\Utility\Number::$_currencyDefaults
  * See Cake\Utility\Number::currency() for more information on the various options and their function.
  *
- * @see Cake\Utility\Number::addFormat()
+ * @see \Cake\Utility\Number::addFormat()
  *
  * @param string $formatName The format name to be used in the future.
  * @param array $options The array of options for this format.
@@ -206,7 +206,7 @@ class NumberHelper extends Helper {
 /**
  * Getter/setter for default currency
  *
- * @see  Cake\Utility\Number::defaultCurrency()
+ * @see  \Cake\Utility\Number::defaultCurrency()
  *
  * @param string $currency The currency to be used in the future.
  * @return void

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -83,7 +83,7 @@ class PaginatorHelper extends Helper {
 /**
  * Before render callback. Overridden to merge passed args with URL options.
  *
- * @param Cake\Event\Event $event The event instance.
+ * @param \Cake\Event\Event $event The event instance.
  * @param string $viewFile
  * @return void
  */

--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -25,7 +25,7 @@ trait StringTemplateTrait {
 /**
  * StringTemplate instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templater;
 

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -67,7 +67,7 @@ class TextHelper extends Helper {
  *
  * @param View $View the view object the helper is attached to.
  * @param array $settings Settings array Settings array
- * @throws Cake\Error\Exception when the engine class could not be found.
+ * @throws \Cake\Error\Exception when the engine class could not be found.
  */
 	public function __construct(View $View, $settings = array()) {
 		$settings = Hash::merge(array('engine' => 'Cake\Utility\String'), $settings);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -82,6 +82,9 @@ class TextHelper extends Helper {
 
 /**
  * Call methods from String utility class
+ *
+ * @param string $method Method to invoke
+ * @param array $params Array of params for the method.
  * @return mixed Whatever is returned by called method, or false on failure
  */
 	public function __call($method, $params) {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -66,6 +66,8 @@ class TimeHelper extends Helper {
 /**
  * Call methods from Cake\Utility\Time utility class
  *
+ * @param string $method Method to invoke
+ * @param array $params Array of params for the method.
  * @return mixed Whatever is returned by called method, or false on failure
  */
 	public function __call($method, $params) {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -29,14 +29,14 @@ use Cake\View\View;
  * Manipulation of time data.
  *
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html
- * @see Cake\Utility\Time
+ * @see \Cake\Utility\Time
  */
 class TimeHelper extends Helper {
 
 /**
  * Cake\Utility\Time instance
  *
- * @var Cake\Utility\Time
+ * @var \Cake\Utility\Time
  */
 	protected $_engine = null;
 
@@ -50,7 +50,7 @@ class TimeHelper extends Helper {
  *
  * @param View $View the view object the helper is attached to.
  * @param array $settings Settings array
- * @throws Cake\Error\Exception When the engine class could not be found.
+ * @throws \Cake\Error\Exception When the engine class could not be found.
  */
 	public function __construct(View $View, $settings = array()) {
 		$settings = Hash::merge(array('engine' => 'Cake\Utility\Time'), $settings);
@@ -76,7 +76,7 @@ class TimeHelper extends Helper {
  * Converts a string representing the format for the function strftime and returns a
  * windows safe and i18n aware format.
  *
- * @see Cake\Utility\Time::convertSpecifiers()
+ * @see \Cake\Utility\Time::convertSpecifiers()
  *
  * @param string $format Format with specifiers for strftime function.
  *    Accepts the special specifier %S which mimics the modifier S for date()
@@ -91,7 +91,7 @@ class TimeHelper extends Helper {
 /**
  * Converts given time (in server's time zone) to user's local time, given his/her timezone.
  *
- * @see Cake\Utility\Time::convert()
+ * @see \Cake\Utility\Time::convert()
  *
  * @param string $serverTime UNIX timestamp
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -105,7 +105,7 @@ class TimeHelper extends Helper {
 /**
  * Returns a UNIX timestamp, given either a UNIX timestamp or a valid strtotime() date string.
  *
- * @see Cake\Utility\Time::fromString()
+ * @see \Cake\Utility\Time::fromString()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -119,7 +119,7 @@ class TimeHelper extends Helper {
 /**
  * Returns a nicely formatted date string for given Datetime string.
  *
- * @see Cake\Utility\Time::nice()
+ * @see \Cake\Utility\Time::nice()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -134,7 +134,7 @@ class TimeHelper extends Helper {
 /**
  * Returns a partial SQL string to search for all records between two dates.
  *
- * @see Cake\Utility\Time::daysAsSql()
+ * @see \Cake\Utility\Time::daysAsSql()
  *
  * @param integer|string|DateTime $begin UNIX timestamp, strtotime() valid string or DateTime object
  * @param integer|string|DateTime $end UNIX timestamp, strtotime() valid string or DateTime object
@@ -151,7 +151,7 @@ class TimeHelper extends Helper {
  * Returns a partial SQL string to search for all records between two times
  * occurring on the same day.
  *
- * @see Cake\Utility\Time::dayAsSql()
+ * @see \Cake\Utility\Time::dayAsSql()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $fieldName Name of database field to compare with
@@ -166,7 +166,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string is today.
  *
- * @see Cake\Utility\Time::isToday()
+ * @see \Cake\Utility\Time::isToday()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -180,7 +180,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string is within this week.
  *
- * @see Cake\Utility\Time::isThisWeek()
+ * @see \Cake\Utility\Time::isThisWeek()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -194,7 +194,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string is within this month
  *
- * @see Cake\Utility\Time::isThisMonth()
+ * @see \Cake\Utility\Time::isThisMonth()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -208,7 +208,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string is within current year.
  *
- * @see Cake\Utility\Time::isThisYear()
+ * @see \Cake\Utility\Time::isThisYear()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -222,7 +222,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string was yesterday.
  *
- * @see Cake\Utility\Time::wasYesterday()
+ * @see \Cake\Utility\Time::wasYesterday()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -237,7 +237,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if given datetime string is tomorrow.
  *
- * @see Cake\Utility\Time::isTomorrow()
+ * @see \Cake\Utility\Time::isTomorrow()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -251,7 +251,7 @@ class TimeHelper extends Helper {
 /**
  * Returns the quarter
  *
- * @see Cake\Utility\Time::toQuarter()
+ * @see \Cake\Utility\Time::toQuarter()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param boolean $range if true returns a range in Y-m-d format
@@ -265,7 +265,7 @@ class TimeHelper extends Helper {
 /**
  * Returns a UNIX timestamp from a textual datetime description. Wrapper for PHP function strtotime().
  *
- * @see Cake\Utility\Time::toUnix()
+ * @see \Cake\Utility\Time::toUnix()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -279,7 +279,7 @@ class TimeHelper extends Helper {
 /**
  * Returns a date formatted for Atom RSS feeds.
  *
- * @see Cake\Utility\Time::toAtom()
+ * @see \Cake\Utility\Time::toAtom()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -293,7 +293,7 @@ class TimeHelper extends Helper {
 /**
  * Formats date for RSS feeds
  *
- * @see Cake\Utility\Time::toRSS()
+ * @see \Cake\Utility\Time::toRSS()
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone User's timezone string or DateTimeZone object
@@ -307,7 +307,7 @@ class TimeHelper extends Helper {
 /**
  * Formats date for RSS feeds
  *
- * @see Cake\Utility\Time::timeAgoInWords()
+ * @see \Cake\Utility\Time::timeAgoInWords()
  *
  * ## Additional options
  *
@@ -356,7 +356,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if specified datetime was within the interval specified, else false.
  *
- * @see Cake\Utility\Time::wasWithinLast()
+ * @see \Cake\Utility\Time::wasWithinLast()
  *
  * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
@@ -372,7 +372,7 @@ class TimeHelper extends Helper {
 /**
  * Returns true if specified datetime is within the interval specified, else false.
  *
- * @see Cake\Utility\Time::isWithinLast()
+ * @see \Cake\Utility\Time::isWithinLast()
  *
  * @param string|integer $timeInterval the numeric value with space then time type.
  *    Example of valid types: 6 hours, 2 days, 1 minute.
@@ -388,7 +388,7 @@ class TimeHelper extends Helper {
 /**
  * Returns gmt as a UNIX timestamp.
  *
- * @see Cake\Utility\Time::gmt()
+ * @see \Cake\Utility\Time::gmt()
  *
  * @param integer|string|DateTime $string UNIX timestamp, strtotime() valid string or DateTime object
  * @return integer UNIX timestamp
@@ -414,7 +414,7 @@ class TimeHelper extends Helper {
  *   $this->Time->format('2012-02-15 23:01:01', '%c', 'N/A', 'America/New_York'); // converts passed date to timezone
  * }}}
  *
- * @see Cake\Utility\Time::format()
+ * @see \Cake\Utility\Time::format()
  *
  * @param integer|string|DateTime $format date format string (or a UNIX timestamp, strtotime() valid string or DateTime object)
  * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object (or a date format string)
@@ -431,7 +431,7 @@ class TimeHelper extends Helper {
  * Returns a formatted date string, given either a UNIX timestamp or a valid strtotime() date string.
  * It takes into account the default date format for the current language if a LC_TIME file is used.
  *
- * @see Cake\Utility\Time::i18nFormat()
+ * @see \Cake\Utility\Time::i18nFormat()
  *
  * @param integer|string|DateTime $date UNIX timestamp, strtotime() valid string or DateTime object
  * @param string $format strftime format string.

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -38,7 +38,7 @@ class HelperRegistry extends ObjectRegistry {
  *
  * Helpers constructed by this object will be subscribed to this manager.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager;
 
@@ -118,7 +118,7 @@ class HelperRegistry extends ObjectRegistry {
  *
  * @param string $class The classname that is missing.
  * @param string $plugin The plugin the helper is missing in.
- * @throws Cake\Error\MissingHelperException
+ * @throws \Cake\Error\MissingHelperException
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingHelperException([

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -59,7 +59,7 @@ class HelperRegistry extends ObjectRegistry {
  *
  * @param string $helper The helper name to be loaded
  * @return boolean whether the helper could be loaded or not
- * @throws MissingHelperException When a helper could not be found.
+ * @throws \Cake\Error\MissingHelperException When a helper could not be found.
  *    App helpers are searched, and then plugin helpers.
  */
 	public function __isset($helper) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -865,7 +865,7 @@ class View extends Object {
 /**
  * Sandbox method to evaluate a template / view script in.
  *
- * @param string $viewFn Filename of the view
+ * @param string $viewFile Filename of the view
  * @param array $dataForView Data to include in rendered view.
  *    If empty the current View::$viewVars will be used.
  * @return string Rendered output

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -199,14 +199,14 @@ class View extends Object {
  * This object contains all the information about a request and several methods for reading
  * additional information about the request.
  *
- * @var Cake\Network\Request
+ * @var \Cake\Network\Request
  */
 	public $request;
 
 /**
  * Reference to the Response object
  *
- * @var Cake\Network\Response
+ * @var \Cake\Network\Response
  */
 	public $response;
 
@@ -288,7 +288,7 @@ class View extends Object {
  * the controller, so it it possible to register view events in
  * the controller layer.
  *
- * @var Cake\Event\EventManager
+ * @var \Cake\Event\EventManager
  */
 	protected $_eventManager = null;
 
@@ -348,7 +348,7 @@ class View extends Object {
  * You can use this instance to register any new listeners or callbacks to the
  * controller events, or create your own events and trigger them at will.
  *
- * @return Cake\Event\EventManager
+ * @return \Cake\Event\EventManager
  */
 	public function getEventManager() {
 		if (empty($this->_eventManager)) {
@@ -362,7 +362,7 @@ class View extends Object {
  *
  * Primarily useful for testing.
  *
- * @param Cake\Event\EventManager $eventManager.
+ * @param \Cake\Event\EventManager $eventManager.
  * @return void
  */
 	public function setEventManager(EventManager $eventManager) {
@@ -448,7 +448,7 @@ class View extends Object {
  * @param string $view Name of view file to use
  * @param string $layout Layout to use.
  * @return string|null Rendered content or null if content already rendered and returned earlier.
- * @throws Cake\Error\Exception If there is an error in the view.
+ * @throws \Cake\Error\Exception If there is an error in the view.
  */
 	public function render($view = null, $layout = null) {
 		if ($this->hasRendered) {
@@ -494,7 +494,7 @@ class View extends Object {
  * @param string $content Content to render in a view, wrapped by the surrounding layout.
  * @param string $layout Layout name
  * @return mixed Rendered output, or false on error
- * @throws Cake\Error\Exception if there is an error in the view.
+ * @throws \Cake\Error\Exception if there is an error in the view.
  */
 	public function renderLayout($content, $layout = null) {
 		$layoutFileName = $this->_getLayoutFileName($layout);
@@ -825,7 +825,7 @@ class View extends Object {
  * @param string $viewFile Filename of the view
  * @param array $data Data to include in rendered view. If empty the current View::$viewVars will be used.
  * @return string Rendered output
- * @throws Cake\Error\Exception when a block is left open.
+ * @throws \Cake\Error\Exception when a block is left open.
  */
 	protected function _render($viewFile, $data = array()) {
 		if (empty($data)) {
@@ -900,7 +900,7 @@ class View extends Object {
  *
  * @param string $name Controller action to find template filename for
  * @return string Template filename
- * @throws Cake\Error\MissingViewException when a view file could not be found.
+ * @throws \Cake\Error\MissingViewException when a view file could not be found.
  */
 	protected function _getViewFileName($name = null) {
 		$subDir = null;
@@ -979,7 +979,7 @@ class View extends Object {
  *
  * @param string $name The name of the layout to find.
  * @return string Filename for layout file (.ctp).
- * @throws Cake\Error\MissingLayoutException when a layout cannot be located
+ * @throws \Cake\Error\MissingLayoutException when a layout cannot be located
  */
 	protected function _getLayoutFileName($name = null) {
 		if ($name === null) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -690,8 +690,8 @@ class View extends Object {
  *
  * @param string $name The view or element to 'extend' the current one with.
  * @return void
- * @throws LogicException when you extend a view with itself or make extend loops.
- * @throws LogicException when you extend an element which doesn't exist
+ * @throws \LogicException when you extend a view with itself or make extend loops.
+ * @throws \LogicException when you extend an element which doesn't exist
  */
 	public function extend($name) {
 		if ($name[0] === '/' || $this->_currentType === static::TYPE_VIEW) {

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -74,7 +74,7 @@ class ViewBlock {
  * using View::get();
  *
  * @param string $name The name of the block to capture for.
- * @throws Cake\Error\Exception When starting a block twice
+ * @throws \Cake\Error\Exception When starting a block twice
  * @return void
  */
 	public function start($name) {

--- a/src/View/Widget/Basic.php
+++ b/src/View/Widget/Basic.php
@@ -28,7 +28,7 @@ class Basic implements WidgetInterface {
 /**
  * StringTemplate instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 

--- a/src/View/Widget/Button.php
+++ b/src/View/Widget/Button.php
@@ -28,7 +28,7 @@ class Button implements WidgetInterface {
 /**
  * StringTemplate instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 

--- a/src/View/Widget/Checkbox.php
+++ b/src/View/Widget/Checkbox.php
@@ -24,14 +24,14 @@ class Checkbox implements WidgetInterface {
 /**
  * Template instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 
 /**
  * Constructor
  *
- * @param Cake\View\StringTemplate $templates
+ * @param \Cake\View\StringTemplate $templates
  */
 	public function __construct($templates) {
 		$this->_templates = $templates;

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -29,7 +29,7 @@ class DateTime implements WidgetInterface {
 /**
  * Select box widget.
  *
- * @var Cake\View\Widget\Select
+ * @var \Cake\View\Widget\Select
  */
 	protected $_select;
 
@@ -58,8 +58,8 @@ class DateTime implements WidgetInterface {
 /**
  * Constructor
  *
- * @param Cake\View\StringTemplate $templates
- * @param Cake\View\Widget\SelectBox $selectBox
+ * @param \Cake\View\StringTemplate $templates
+ * @param \Cake\View\Widget\SelectBox $selectBox
  */
 	public function __construct($templates, $selectBox) {
 		$this->_select = $selectBox;

--- a/src/View/Widget/File.php
+++ b/src/View/Widget/File.php
@@ -27,7 +27,7 @@ class File implements WidgetInterface {
 /**
  * Constructor
  *
- * @param Cake\View\StringTemplate $templates
+ * @param \Cake\View\StringTemplate $templates
  */
 	public function __construct($templates) {
 		$this->_templates = $templates;

--- a/src/View/Widget/IdGeneratorTrait.php
+++ b/src/View/Widget/IdGeneratorTrait.php
@@ -43,7 +43,8 @@ trait IdGeneratorTrait {
  *
  * Ensures that id's for a given set of fields are unique.
  *
- * @param array $radio The radio properties.
+ * @param string $name The ID attribute name.
+ * @param mixed $val The ID attribute value.
  * @return string Generated id.
  */
 	protected function _id($name, $val) {

--- a/src/View/Widget/InputRegistry.php
+++ b/src/View/Widget/InputRegistry.php
@@ -55,7 +55,7 @@ class InputRegistry {
 /**
  * Templates to use.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 

--- a/src/View/Widget/InputRegistry.php
+++ b/src/View/Widget/InputRegistry.php
@@ -104,7 +104,7 @@ class InputRegistry {
  * the `_default` widget is undefined.
  *
  * @param string $name The widget name to get.
- * @return mixed WidgetInterface widget interface class.
+ * @return WidgetInterface widget interface class.
  * @throws \RuntimeException when widget is undefined.
  */
 	public function get($name) {

--- a/src/View/Widget/Label.php
+++ b/src/View/Widget/Label.php
@@ -27,7 +27,7 @@ class Label implements WidgetInterface {
 /**
  * Templates
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 
@@ -39,7 +39,7 @@ class Label implements WidgetInterface {
  * - `label` Used to generate the label for a radio button.
  *   Can use the following variables `attrs`, `text` and `input`.
  *
- * @param Cake\View\StringTemplate $templates
+ * @param \Cake\View\StringTemplate $templates
  */
 	public function __construct($templates) {
 		$this->_templates = $templates;

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -28,14 +28,14 @@ class MultiCheckbox implements WidgetInterface {
 /**
  * Template instance to use.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 
 /**
  * Label widget instance.
  *
- * @var Cake\View\Widget\Label
+ * @var \Cake\View\Widget\Label
  */
 	protected $_label;
 
@@ -50,8 +50,8 @@ class MultiCheckbox implements WidgetInterface {
  *   a checkbox and its label. Accepts the `input`, and `label`
  *   variables.
  *
- * @param Cake\View\StringTemplate $templates
- * @param Cake\View\Widget\Label $label
+ * @param \Cake\View\StringTemplate $templates
+ * @param \Cake\View\Widget\Label $label
  */
 	public function __construct($templates, $label) {
 		$this->_templates = $templates;

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -31,14 +31,14 @@ class Radio implements WidgetInterface {
 /**
  * Template instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 
 /**
  * Label instance.
  *
- * @var Cake\View\Widget\Label
+ * @var \Cake\View\Widget\Label
  */
 	protected $_label;
 
@@ -53,8 +53,8 @@ class Radio implements WidgetInterface {
  *   the radio + input element. Can use the `input` and `label`
  *   variables.
  *
- * @param Cake\View\StringTemplate $templates
- * @param Cake\View\Widget\Label $label
+ * @param \Cake\View\StringTemplate $templates
+ * @param \Cake\View\Widget\Label $label
  */
 	public function __construct($templates, $label) {
 		$this->_templates = $templates;

--- a/src/View/Widget/SelectBox.php
+++ b/src/View/Widget/SelectBox.php
@@ -28,14 +28,14 @@ class SelectBox implements WidgetInterface {
 /**
  * Template instance.
  *
- * @var Cake\View\StringTemplate
+ * @var \Cake\View\StringTemplate
  */
 	protected $_templates;
 
 /**
  * Constructor
  *
- * @param Cake\View\StringTemplate $templates
+ * @param \Cake\View\StringTemplate $templates
  */
 	public function __construct($templates) {
 		$this->_templates = $templates;

--- a/src/View/Widget/Textarea.php
+++ b/src/View/Widget/Textarea.php
@@ -27,7 +27,7 @@ class Textarea implements WidgetInterface {
 /**
  * Constructor
  *
- * @param Cake\View\StringTemplate $templates
+ * @param \Cake\View\StringTemplate $templates
  */
 	public function __construct($templates) {
 		$this->_templates = $templates;

--- a/tests/Fixture/FixturizedTestCase.php
+++ b/tests/Fixture/FixturizedTestCase.php
@@ -55,7 +55,7 @@ class FixturizedTestCase extends TestCase {
  * test that a fixtures are unoaded even if the test throws exceptions
  *
  * @return void
- * @throws Exception
+ * @throws \Exception
  */
 	public function testThrowException() {
 		throw new \Exception();

--- a/tests/TestCase/Cache/CacheTest.php
+++ b/tests/TestCase/Cache/CacheTest.php
@@ -97,7 +97,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testWriteNonExistingConfig() {
@@ -107,7 +107,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testIncrementNonExistingConfig() {
@@ -117,7 +117,7 @@ class CacheTest extends TestCase {
 /**
  * Test write from a config that is undefined.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testDecrementNonExistingConfig() {
@@ -163,7 +163,7 @@ class CacheTest extends TestCase {
 /**
  * testConfigInvalidEngine method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigInvalidEngine() {
@@ -175,7 +175,7 @@ class CacheTest extends TestCase {
 /**
  * test that trying to configure classes that don't extend CacheEngine fail.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigInvalidObject() {
@@ -189,7 +189,7 @@ class CacheTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a cache adapter.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {
@@ -267,7 +267,7 @@ class CacheTest extends TestCase {
 
 /**
  * testGroupConfigsThrowsException method
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testGroupConfigsThrowsException() {
 		Cache::groupConfigs('bogus');

--- a/tests/TestCase/Cache/Engine/ApcEngineTest.php
+++ b/tests/TestCase/Cache/Engine/ApcEngineTest.php
@@ -56,6 +56,7 @@ class ApcEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -62,6 +62,7 @@ class FileEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
+++ b/tests/TestCase/Cache/Engine/MemcachedEngineTest.php
@@ -69,6 +69,7 @@ class MemcachedEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Cache/Engine/RedisEngineTest.php
+++ b/tests/TestCase/Cache/Engine/RedisEngineTest.php
@@ -56,6 +56,7 @@ class RedisEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -52,6 +52,7 @@ class WincacheEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Cache/Engine/XcacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/XcacheEngineTest.php
@@ -43,6 +43,7 @@ class XcacheEngineTest extends TestCase {
 /**
  * Helper method for testing.
  *
+ * @param array $config
  * @return void
  */
 	protected function _configCache($config = []) {

--- a/tests/TestCase/Configure/Engine/IniConfigTest.php
+++ b/tests/TestCase/Configure/Engine/IniConfigTest.php
@@ -168,7 +168,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .ini extension.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -179,7 +179,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -201,7 +201,7 @@ class IniConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Configure/Engine/PhpConfigTest.php
+++ b/tests/TestCase/Configure/Engine/PhpConfigTest.php
@@ -75,7 +75,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that exist without .php extension.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithExistentFileWithoutExtension() {
@@ -86,7 +86,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test an exception is thrown by reading files that don't exist.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithNonExistentFile() {
@@ -97,7 +97,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading an empty file.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadEmptyFile() {
@@ -108,7 +108,7 @@ class PhpConfigTest extends TestCase {
 /**
  * Test reading keys with ../ doesn't work.
  *
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  * @return void
  */
 	public function testReadWithDots() {

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -162,7 +162,7 @@ class ConsoleOptionParserTest extends TestCase {
  * Test that adding an option using a two letter short value causes an exception.
  * As they will not parse correctly.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  * @return void
  */
 	public function testAddOptionShortOneLetter() {
@@ -260,7 +260,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test parsing options that do not exist.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  */
 	public function testOptionThatDoesNotExist() {
 		$parser = new ConsoleOptionParser('test', false);
@@ -272,7 +272,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test parsing short options that do not exist.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  */
 	public function testShortOptionThatDoesNotExist() {
 		$parser = new ConsoleOptionParser('test', false);
@@ -284,7 +284,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test that options with choices enforce them.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  * @return void
  */
 	public function testOptionWithChoices() {
@@ -373,7 +373,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test parsing arguments.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  * @return void
  */
 	public function testParseArgumentTooMany() {
@@ -404,7 +404,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test that when there are not enough arguments an exception is raised
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  * @return void
  */
 	public function testPositionalArgNotEnough() {
@@ -418,7 +418,7 @@ class ConsoleOptionParserTest extends TestCase {
 /**
  * test that arguments with choices enforce them.
  *
- * @expectedException Cake\Error\ConsoleException
+ * @expectedException \Cake\Error\ConsoleException
  * @return void
  */
 	public function testPositionalArgWithChoices() {

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -88,7 +88,7 @@ class TestShellDispatcher extends ShellDispatcher {
 /**
  * _getShell
  *
- * @param string $plugin
+ * @param string $shell
  * @return mixed
  */
 	protected function _getShell($shell) {

--- a/tests/TestCase/Console/TaskRegistryTest.php
+++ b/tests/TestCase/Console/TaskRegistryTest.php
@@ -63,7 +63,7 @@ class TaskRegistryTest extends TestCase {
 /**
  * test missingtask exception
  *
- * @expectedException Cake\Error\MissingTaskException
+ * @expectedException \Cake\Error\MissingTaskException
  * @return void
  */
 	public function testLoadMissingTask() {

--- a/tests/TestCase/Controller/Component/AclComponentTest.php
+++ b/tests/TestCase/Controller/Component/AclComponentTest.php
@@ -56,7 +56,7 @@ class AclComponentTest extends TestCase {
  * test that constructor throws an exception when Acl.classname is a
  * non-existent class
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConstrutorException() {
@@ -81,7 +81,7 @@ class AclComponentTest extends TestCase {
 /**
  * test that adapter() whines when the class is not an AclBase
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testAdapterException() {

--- a/tests/TestCase/Controller/Component/Auth/BasicAuthenticateTest.php
+++ b/tests/TestCase/Controller/Component/Auth/BasicAuthenticateTest.php
@@ -181,7 +181,7 @@ class BasicAuthenticateTest extends TestCase {
 /**
  * test scope failure.
  *
- * @expectedException Cake\Error\UnauthorizedException
+ * @expectedException \Cake\Error\UnauthorizedException
  * @expectedExceptionCode 401
  * @return void
  */

--- a/tests/TestCase/Controller/Component/Auth/ControllerAuthorizeTest.php
+++ b/tests/TestCase/Controller/Component/Auth/ControllerAuthorizeTest.php
@@ -51,7 +51,7 @@ class ControllerAuthorizeTest extends TestCase {
 	}
 
 /**
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testControllerErrorOnMissingMethod() {
 		$this->auth->controller(new Controller());

--- a/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -94,7 +94,7 @@ class DigestAuthenticateTest extends TestCase {
 /**
  * test the authenticate method
  *
- * @expectedException Cake\Error\UnauthorizedException
+ * @expectedException \Cake\Error\UnauthorizedException
  * @expectedExceptionCode 401
  * @return void
  */
@@ -179,7 +179,7 @@ DIGEST;
 /**
  * test scope failure.
  *
- * @expectedException Cake\Error\UnauthorizedException
+ * @expectedException \Cake\Error\UnauthorizedException
  * @expectedExceptionCode 401
  * @return void
  */

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -226,7 +226,7 @@ class AuthComponentTest extends TestCase {
 	}
 
 /**
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testIsAuthorizedMissingFile() {
@@ -313,7 +313,7 @@ class AuthComponentTest extends TestCase {
 	}
 
 /**
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testLoadAuthenticateNoFile() {
@@ -796,7 +796,7 @@ class AuthComponentTest extends TestCase {
 
 /**
  * Throw ForbiddenException if AuthComponent::$unauthorizedRedirect set to false
- * @expectedException Cake\Error\ForbiddenException
+ * @expectedException \Cake\Error\ForbiddenException
  * @return void
  */
 	public function testForbiddenException() {
@@ -1238,7 +1238,7 @@ class AuthComponentTest extends TestCase {
 /**
  * testStatelessAuthNoRedirect method
  *
- * @expectedException Cake\Error\UnauthorizedException
+ * @expectedException \Cake\Error\UnauthorizedException
  * @expectedExceptionCode 401
  * @return void
  */

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -707,7 +707,8 @@ class CookieComponentTest extends TestCase {
 /**
  * Helper method for generating old style encoded cookie values.
  *
- * @return string.
+ * @param array $array
+ * @return string
  */
 	protected function _oldImplode(array $array) {
 		$string = '';

--- a/tests/TestCase/Controller/Component/CsrfComponentTest.php
+++ b/tests/TestCase/Controller/Component/CsrfComponentTest.php
@@ -107,7 +107,7 @@ class CsrfComponentTest extends TestCase {
  * Test that the X-CSRF-Token works with the various http methods.
  *
  * @dataProvider httpMethodProvider
- * @expectedException Cake\Error\ForbiddenException
+ * @expectedException \Cake\Error\ForbiddenException
  * @return void
  */
 	public function testInvalidTokenInHeader($method) {
@@ -149,7 +149,7 @@ class CsrfComponentTest extends TestCase {
  * Test that request data works with the various http methods.
  *
  * @dataProvider httpMethodProvider
- * @expectedException Cake\Error\ForbiddenException
+ * @expectedException \Cake\Error\ForbiddenException
  * @return void
  */
 	public function testInvalidTokenRequestData($method) {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -733,6 +733,7 @@ class PaginatorComponentTest extends TestCase {
 /**
  * Helper method for making mocks.
  *
+ * @param array $methods
  * @return Table
  */
 	protected function _getMockPosts($methods = []) {

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -433,7 +433,7 @@ class PaginatorComponentTest extends TestCase {
 /**
  * Test that a really REALLY large page number gets clamped to the max page size.
  *
- * @expectedException Cake\Error\NotFoundException
+ * @expectedException \Cake\Error\NotFoundException
  * @return void
  */
 	public function testOutOfVeryBigPageNumberGetsClamped() {

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -805,7 +805,7 @@ class RequestHandlerComponentTest extends TestCase {
 	}
 
 /**
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testAddInputTypeException() {

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -85,7 +85,7 @@ class SecurityTestController extends Controller {
  * redirect method
  *
  * @param string|array $url
- * @param mixed $code
+ * @param mixed $status
  * @param mixed $exit
  * @return void
  */
@@ -665,7 +665,7 @@ class SecurityComponentTest extends TestCase {
 /**
  * Test that validatePost fails when unlocked fields are changed.
  *
- * @return
+ * @return void
  */
 	public function testValidatePostFailDisabledFieldTampering() {
 		$event = new Event('Controller.startup', $this->Controller);

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -164,7 +164,7 @@ class SecurityComponentTest extends TestCase {
  * Test that requests are still blackholed when controller has incorrect
  * visibility keyword in the blackhole callback
  *
- * @expectedException Cake\Error\BadRequestException
+ * @expectedException \Cake\Error\BadRequestException
  */
 	public function testBlackholeWithBrokenCallback() {
 		$request = new Request('posts/index');

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -113,7 +113,7 @@ class ComponentRegistryTest extends TestCase {
 /**
  * test missingcomponent exception
  *
- * @expectedException Cake\Error\MissingComponentException
+ * @expectedException \Cake\Error\MissingComponentException
  * @return void
  */
 	public function testLoadMissingComponent() {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -89,7 +89,7 @@ class TestController extends ControllerTestAppController {
  * index method
  *
  * @param mixed $testId
- * @param mixed $test2Id
+ * @param mixed $testTwoId
  * @return void
  */
 	public function index($testId, $testTwoId) {
@@ -103,7 +103,7 @@ class TestController extends ControllerTestAppController {
  * view method
  *
  * @param mixed $testId
- * @param mixed $test2Id
+ * @param mixed $testTwoId
  * @return void
  */
 	public function view($testId, $testTwoId) {
@@ -149,6 +149,7 @@ class TestComponent extends Component {
 /**
  * initialize method
  *
+ * @param Event $event
  * @return void
  */
 	public function initialize(Event $event) {
@@ -157,6 +158,7 @@ class TestComponent extends Component {
 /**
  * startup method
  *
+ * @param Event $event
  * @return void
  */
 	public function startup(Event $event) {
@@ -165,6 +167,7 @@ class TestComponent extends Component {
 /**
  * shutdown method
  *
+ * @param Event $event
  * @return void
  */
 	public function shutdown(Event $event) {
@@ -173,6 +176,7 @@ class TestComponent extends Component {
 /**
  * beforeRender callback
  *
+ * @param Event $event
  * @return void
  */
 	public function beforeRender(Event $event) {

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -714,7 +714,7 @@ class ControllerTest extends TestCase {
 /**
  * testMissingAction method
  *
- * @expectedException Cake\Error\MissingActionException
+ * @expectedException \Cake\Error\MissingActionException
  * @expectedExceptionMessage Action TestController::missing() could not be found.
  * @return void
  */
@@ -730,7 +730,7 @@ class ControllerTest extends TestCase {
 /**
  * test invoking private methods.
  *
- * @expectedException Cake\Error\PrivateActionException
+ * @expectedException \Cake\Error\PrivateActionException
  * @expectedExceptionMessage Private Action TestController::private_m() is not directly accessible.
  * @return void
  */
@@ -746,7 +746,7 @@ class ControllerTest extends TestCase {
 /**
  * test invoking protected methods.
  *
- * @expectedException Cake\Error\PrivateActionException
+ * @expectedException \Cake\Error\PrivateActionException
  * @expectedExceptionMessage Private Action TestController::protected_m() is not directly accessible.
  * @return void
  */
@@ -762,7 +762,7 @@ class ControllerTest extends TestCase {
 /**
  * test invoking hidden methods.
  *
- * @expectedException Cake\Error\PrivateActionException
+ * @expectedException \Cake\Error\PrivateActionException
  * @expectedExceptionMessage Private Action TestController::_hidden() is not directly accessible.
  * @return void
  */
@@ -778,7 +778,7 @@ class ControllerTest extends TestCase {
 /**
  * test invoking controller methods.
  *
- * @expectedException Cake\Error\PrivateActionException
+ * @expectedException \Cake\Error\PrivateActionException
  * @expectedExceptionMessage Private Action TestController::redirect() is not directly accessible.
  * @return void
  */
@@ -794,7 +794,7 @@ class ControllerTest extends TestCase {
 /**
  * test invoking controller methods.
  *
- * @expectedException Cake\Error\PrivateActionException
+ * @expectedException \Cake\Error\PrivateActionException
  * @expectedExceptionMessage Private Action TestController::admin_add() is not directly accessible.
  * @return void
  */

--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -52,7 +52,7 @@ class PagesControllerTest extends TestCase {
 /**
  * Test that missing view renders 404 page in production
  *
- * @expectedException Cake\Error\NotFoundException
+ * @expectedException \Cake\Error\NotFoundException
  * @expectedExceptionCode 404
  * @return void
  */
@@ -65,7 +65,7 @@ class PagesControllerTest extends TestCase {
 /**
  * Test that missing view in debug mode renders missing_view error page
  *
- * @expectedException Cake\Error\MissingViewException
+ * @expectedException \Cake\Error\MissingViewException
  * @expectedExceptionCode 500
  * @return void
  */

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -428,7 +428,7 @@ class ConfigureTest extends TestCase {
 	}
 
 /**
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  */
 	public function testDumpNoAdapter() {
 		Configure::dump(TMP . 'test.php', 'does_not_exist');

--- a/tests/TestCase/Core/ObjectTest.php
+++ b/tests/TestCase/Core/ObjectTest.php
@@ -150,6 +150,7 @@ class TestObject extends Object {
 /**
  * undocumented function
  *
+ * @param array $properties
  * @return void
  */
 	public function set($properties = array()) {

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -207,7 +207,7 @@ class PluginTest extends TestCase {
  * Tests that Plugin::load() throws an exception on unknown plugin
  *
  * @return void
- * @expectedException Cake\Error\MissingPluginException
+ * @expectedException \Cake\Error\MissingPluginException
  */
 	public function testLoadNotFound() {
 		Plugin::load('MissingPlugin');
@@ -231,7 +231,7 @@ class PluginTest extends TestCase {
  * Tests that Plugin::path() throws an exception on unknown plugin
  *
  * @return void
- * @expectedException Cake\Error\MissingPluginException
+ * @expectedException \Cake\Error\MissingPluginException
  */
 	public function testPathNotFound() {
 		Plugin::path('TestPlugin');

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -65,7 +65,7 @@ class ConnectionTest extends TestCase {
 /**
  * Tests creating a connection using an invalid driver throws an exception
  *
- * @expectedException Cake\Database\Exception\MissingDriverException
+ * @expectedException \Cake\Database\Exception\MissingDriverException
  * @expectedExceptionMessage Database driver \Foo\InvalidDriver could not be found.
  * @return void
  */
@@ -76,7 +76,7 @@ class ConnectionTest extends TestCase {
 /**
  * Tests trying to use a disabled driver throws an exception
  *
- * @expectedException Cake\Database\Exception\MissingExtensionException
+ * @expectedException \Cake\Database\Exception\MissingExtensionException
  * @expectedExceptionMessage Database driver DriverMock cannot be used due to a missing PHP extension or unmet dependency
  * @return void
  */

--- a/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
+++ b/tests/TestCase/Database/Expression/IdentifierExpressionTest.php
@@ -28,7 +28,7 @@ class IdentifierExpressionTest extends TestCase {
 /**
  * Tests getting and setting the field
  *
- * @return
+ * @return void
  */
 	public function testGetAndSet() {
 		$expression = new IdentifierExpression('foo');

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2402,6 +2402,7 @@ class QueryTest extends TestCase {
  * @param string $table
  * @param integer $count
  * @param array $rows
+ * @param array $conditions
  * @return void
  */
 	public function assertTable($table, $count, $rows, $conditions = []) {

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1849,7 +1849,7 @@ class QueryTest extends TestCase {
 /**
  * You cannot call values() before insert() it causes all sorts of pain.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testInsertValuesBeforeInsertFailure() {
@@ -2030,7 +2030,7 @@ class QueryTest extends TestCase {
 /**
  * Test that an exception is raised when mixing query + array types.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testInsertFailureMixingTypesArrayFirst() {
 		$query = new Query($this->connection);
@@ -2043,7 +2043,7 @@ class QueryTest extends TestCase {
 /**
  * Test that an exception is raised when mixing query + array types.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testInsertFailureMixingTypesQueryFirst() {
 		$query = new Query($this->connection);

--- a/tests/TestCase/Database/Schema/CollectionTest.php
+++ b/tests/TestCase/Database/Schema/CollectionTest.php
@@ -61,7 +61,7 @@ class CollectionTest extends TestCase {
  * Tests for positive describe() calls are in each platformSchema
  * test case.
  *
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  * @return void
  */
 	public function testDescribeIncorrectTable() {

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -176,6 +176,7 @@ class MysqlSchemaTest extends TestCase {
 /**
  * Helper method for testing methods.
  *
+ * @param \Cake\Database\Connection $connection
  * @return void
  */
 	protected function _createTables($connection) {

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -39,6 +39,7 @@ class PostgresSchemaTest extends TestCase {
 /**
  * Helper method for testing methods.
  *
+ * @param \Cake\Database\Connection $connection
  * @return void
  */
 	protected function _createTables($connection) {

--- a/tests/TestCase/Database/Schema/TableTest.php
+++ b/tests/TestCase/Database/Schema/TableTest.php
@@ -175,7 +175,7 @@ class TableTest extends TestCase {
  * are added for fields that do not exist.
  *
  * @dataProvider addConstaintErrorProvider
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  * @return void
  */
 	public function testAddConstraintError($props) {
@@ -226,7 +226,7 @@ class TableTest extends TestCase {
  * are added for fields that do not exist.
  *
  * @dataProvider addIndexErrorProvider
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  * @return void
  */
 	public function testAddIndexError($props) {
@@ -345,7 +345,7 @@ class TableTest extends TestCase {
  * Add a foreign key constraint with bad data
  *
  * @dataProvider badForeignKeyProvider
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  * @return void
  */
 	public function testAddConstraintForeignKeyBadData($data) {

--- a/tests/TestCase/Datasource/ConnectionManagerTest.php
+++ b/tests/TestCase/Datasource/ConnectionManagerTest.php
@@ -73,7 +73,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test invalid classes cause exceptions
  *
- * @expectedException Cake\Datasource\Error\MissingDatasourceException
+ * @expectedException \Cake\Datasource\Error\MissingDatasourceException
  */
 	public function testConfigInvalidOptions() {
 		ConnectionManager::config('test_variant', [
@@ -85,7 +85,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test for errors on duplicate config.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot reconfigure existing key "test_variant"
  * @return void
  */
@@ -101,7 +101,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test get() failing on missing config.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage The datasource configuration "test_variant" was not found.
  * @return void
  */
@@ -127,7 +127,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test loading connections without aliases
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage The datasource configuration "other_name" was not found.
  * @return void
  */
@@ -208,7 +208,7 @@ class ConnectionManagerTest extends TestCase {
 /**
  * Test alias() raises an error when aliasing an undefined connection.
  *
- * @expectedException Cake\Datasource\Error\MissingDatasourceConfigException
+ * @expectedException \Cake\Datasource\Error\MissingDatasourceConfigException
  * @return void
  */
 	public function testAliasError() {

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -43,6 +43,7 @@ class BlueberryComponent extends Component {
 /**
  * initialize method
  *
+ * @param Event $event
  * @return void
  */
 	public function initialize(Event $event) {

--- a/tests/TestCase/Event/EventManagerTest.php
+++ b/tests/TestCase/Event/EventManagerTest.php
@@ -51,7 +51,7 @@ class EventTestListener {
 /**
  * Auxiliary function to help in stopPropagation testing
  *
- * @param Cake\Event\Event $event
+ * @param \Cake\Event\Event $event
  * @return void
  */
 	public function stopListener($event) {

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -1876,6 +1876,8 @@ class I18nTest extends TestCase {
 /**
  * Singular method
  *
+ * @param string $domain
+ * @param integer $category
  * @return void
  */
 	protected function _domainCategorySingular($domain = 'test_plugin', $category = 3) {
@@ -1886,6 +1888,8 @@ class I18nTest extends TestCase {
 /**
  * Plural method
  *
+ * @param string $domain
+ * @param integer $category
  * @return void
  */
 	protected function _domainCategoryPlural($domain = 'test_plugin', $category = 3) {
@@ -1899,6 +1903,7 @@ class I18nTest extends TestCase {
 /**
  * Singular method
  *
+ * @param string $domain
  * @return void
  */
 	protected function _domainSingular($domain = 'test_plugin') {
@@ -1909,6 +1914,7 @@ class I18nTest extends TestCase {
 /**
  * Plural method
  *
+ * @param string $domain
  * @return void
  */
 	protected function _domainPlural($domain = 'test_plugin') {
@@ -1922,6 +1928,7 @@ class I18nTest extends TestCase {
 /**
  * category method
  *
+ * @param integer $category
  * @return void
  */
 	protected function _category($category = 3) {

--- a/tests/TestCase/I18n/I18nTest.php
+++ b/tests/TestCase/I18n/I18nTest.php
@@ -1854,7 +1854,7 @@ class I18nTest extends TestCase {
 /**
  * Test that the '' domain causes exceptions.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testTranslateEmptyDomain() {

--- a/tests/TestCase/Log/Engine/FileLogTest.php
+++ b/tests/TestCase/Log/Engine/FileLogTest.php
@@ -183,6 +183,7 @@ class FileLogTest extends TestCase {
 /**
  * helper function to clears all log files in specified directory
  *
+ * @param string $dir
  * @return void
  */
 	protected function _deleteLogs($dir) {

--- a/tests/TestCase/Log/LogTest.php
+++ b/tests/TestCase/Log/LogTest.php
@@ -64,7 +64,7 @@ class LogTest extends TestCase {
 /**
  * test all the errors from failed logger imports
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testImportingLoggerFailure() {
@@ -86,7 +86,7 @@ class LogTest extends TestCase {
 /**
  * test that loggers have to implement the correct interface.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testNotImplementingInterface() {
@@ -117,7 +117,7 @@ class LogTest extends TestCase {
 /**
  * test config() with valid key name
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testInvalidLevel() {
@@ -161,7 +161,7 @@ class LogTest extends TestCase {
  * Test that config() throws an exception when adding an
  * adapter with the wrong type.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigInjectErrorOnWrongType() {
@@ -190,7 +190,7 @@ class LogTest extends TestCase {
 /**
  * Ensure you cannot reconfigure a log adapter.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnReconfigure() {

--- a/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TranslateBehaviorTest.php
@@ -46,6 +46,7 @@ class TranslateBehaviorTest extends TestCase {
 /**
  * Returns an array with all the translations found for a set of records
  *
+ * @param array|\Traversable $data
  * @return Collection
  */
 	protected function _extractTranslations($data) {

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -245,7 +245,7 @@ class EmailTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidEmails
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testInvalidEmail($value) {
@@ -256,7 +256,7 @@ class EmailTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidEmails
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testInvalidEmailAdd($value) {
@@ -449,7 +449,7 @@ class EmailTest extends TestCase {
  * testMessageIdInvalid method
  *
  * @return void
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  */
 	public function testMessageIdInvalid() {
 		$this->CakeEmail->messageId('my-email@localhost');
@@ -630,7 +630,7 @@ class EmailTest extends TestCase {
  * testInvalidHeaders
  *
  * @dataProvider invalidHeaders
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testInvalidHeaders($value) {
@@ -641,7 +641,7 @@ class EmailTest extends TestCase {
  * testInvalidAddHeaders
  *
  * @dataProvider invalidHeaders
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testInvalidAddHeaders($value) {
@@ -761,7 +761,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using unknown transports fails.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testTransportInvalid() {
 		$this->CakeEmail->transport('Invalid');
@@ -770,7 +770,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using classes with no send method fails.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testTransportInstanceInvalid() {
 		$this->CakeEmail->transport(new \StdClass());
@@ -819,7 +819,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised when duplicate transports are configured.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testConfigTransportErrorOnDuplicate() {
 		Email::dropTransport('debug');
@@ -875,7 +875,7 @@ class EmailTest extends TestCase {
 /**
  * Test that exceptions are raised on duplicate config set.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testConfigErrorOnDuplicate() {
@@ -906,7 +906,7 @@ class EmailTest extends TestCase {
 /**
  * Test that using an invalid profile fails.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Unknown email configuration "derp".
  */
 	public function testProfileInvalid() {

--- a/tests/TestCase/Network/Email/SmtpTransportTest.php
+++ b/tests/TestCase/Network/Email/SmtpTransportTest.php
@@ -133,7 +133,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectEhloTlsOnNonTlsServer method
  *
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testConnectEhloTlsOnNonTlsServer() {
@@ -153,7 +153,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectEhloNoTlsOnRequiredTlsServer method
  *
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testConnectEhloNoTlsOnRequiredTlsServer() {
@@ -192,7 +192,7 @@ class SmtpTransportTest extends TestCase {
 /**
  * testConnectFail method
  *
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testConnectFail() {

--- a/tests/TestCase/Network/Email/SmtpTransportTest.php
+++ b/tests/TestCase/Network/Email/SmtpTransportTest.php
@@ -30,7 +30,7 @@ class SmtpTestTransport extends SmtpTransport {
 /**
  * Helper to change the socket
  *
- * @param object $socket
+ * @param Socket $socket
  * @return void
  */
 	public function setSocket(Socket $socket) {

--- a/tests/TestCase/Network/Http/Auth/OauthTest.php
+++ b/tests/TestCase/Network/Http/Auth/OauthTest.php
@@ -23,7 +23,7 @@ use Cake\TestSuite\TestCase;
 class OauthTest extends TestCase {
 
 /**
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testExceptionUnknownSigningMethod() {
 		$auth = new Oauth();

--- a/tests/TestCase/Network/Http/ClientTest.php
+++ b/tests/TestCase/Network/Http/ClientTest.php
@@ -244,7 +244,7 @@ class ClientTest extends TestCase {
 /**
  * Test invalid authentication types throw exceptions.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testInvalidAuthenticationType() {
@@ -388,7 +388,7 @@ class ClientTest extends TestCase {
 /**
  * Test that exceptions are raised on invalid types.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testExceptionOnUnknownType() {

--- a/tests/TestCase/Network/Http/RequestTest.php
+++ b/tests/TestCase/Network/Http/RequestTest.php
@@ -48,7 +48,7 @@ class RequestTest extends TestCase {
 /**
  * test invalid method.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testMethodInvalid() {

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -827,7 +827,7 @@ class RequestTest extends TestCase {
 /**
  * Test __call exceptions
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testMagicCallExceptionOnUnknownMethod() {

--- a/tests/TestCase/Network/ResponseTest.php
+++ b/tests/TestCase/Network/ResponseTest.php
@@ -110,7 +110,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the statusCode method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testStatusCode() {
 		$response = new Response();
@@ -385,7 +385,7 @@ class ResponseTest extends TestCase {
 /**
  * Tests the httpCodes method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  */
 	public function testHttpCodes() {
 		$response = new Response();
@@ -1140,7 +1140,7 @@ class ResponseTest extends TestCase {
 /**
  * testFileNotFound
  *
- * @expectedException Cake\Error\NotFoundException
+ * @expectedException \Cake\Error\NotFoundException
  * @return void
  */
 	public function testFileNotFound() {

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -254,7 +254,7 @@ class SocketTest extends TestCase {
 /**
  * testEnableCryptoSocketExceptionNoTls
  *
- * @expectedException Cake\Error\SocketException
+ * @expectedException \Cake\Error\SocketException
  * @return void
  */
 	public function testEnableCryptoSocketExceptionNoTls() {

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -109,7 +109,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() on undefined class
  *
- * @expectedException Cake\Error\MissingBehaviorException
+ * @expectedException \Cake\Error\MissingBehaviorException
  * @return void
  */
 	public function testLoadMissingClass() {
@@ -119,7 +119,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test load() duplicate method error
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage TestApp\Model\Behavior\DuplicateBehavior contains duplicate method "slugify"
  * @return void
  */
@@ -195,7 +195,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot call "nope"
  */
 	public function testCallError() {
@@ -229,7 +229,7 @@ class BehaviorRegistryTest extends TestCase {
 /**
  * Test errors on unknown methods.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot call finder "nope"
  */
 	public function testCallFinderError() {

--- a/tests/TestCase/ORM/BehaviorTest.php
+++ b/tests/TestCase/ORM/BehaviorTest.php
@@ -311,7 +311,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedFindersInvalid
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage The method findNotDefined is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void
@@ -348,7 +348,7 @@ class BehaviorTest extends TestCase {
 /**
  * testVerifyImplementedMethodsInvalid
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage The method iDoNotExist is not callable on class Cake\Test\TestCase\ORM\Test2Behavior
  *
  * @return void

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -969,7 +969,7 @@ class EntityTest extends TestCase {
 /**
  * Test that accessible() and single property setting works.
  *
- * @return
+ * @return void
  */
 	public function testSetWithAccessibleSingleProperty() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -486,7 +486,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test that exceptions from the Query bubble up.
  *
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  */
 	public function testUpdateAllFailure() {
 		$table = $this->getMock(
@@ -527,7 +527,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test that exceptions from the Query bubble up.
  *
- * @expectedException Cake\Database\Exception
+ * @expectedException \Cake\Database\Exception
  */
 	public function testDeleteAllFailure() {
 		$table = $this->getMock(
@@ -842,7 +842,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * Tests that using a simple string for entityClass will throw an exception
  * when the class does not exist in the namespace
  *
- * @expectedException Cake\ORM\Error\MissingEntityException
+ * @expectedException \Cake\ORM\Error\MissingEntityException
  * @expectedExceptionMessage Entity class FooUser could not be found.
  * @return void
  */
@@ -1003,7 +1003,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Ensure exceptions are raised on missing behaviors.
  *
- * @expectedException Cake\Error\MissingBehaviorException
+ * @expectedException \Cake\Error\MissingBehaviorException
  */
 	public function testAddBehaviorMissing() {
 		$table = TableRegistry::get('article');
@@ -2025,7 +2025,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 0 required 1
  * @return void
  */
@@ -2038,7 +2038,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors on missing arguments.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Not enough arguments to magic finder. Got 1 required 2
  * @return void
  */
@@ -2051,7 +2051,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 /**
  * Test magic findByXX errors when there is a mix of or & and.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot mix "and" & "or" in a magic finder. Use find() instead.
  * @return void
  */

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -57,9 +57,9 @@ class TestDispatcher extends Dispatcher {
 /**
  * invoke method
  *
- * @param Cake\Controller\Controller $controller
- * @param Cake\Network\Request $request
- * @param Cake\Network\Response $response
+ * @param \Cake\Controller\Controller $controller
+ * @param \Cake\Network\Request $request
+ * @param \Cake\Network\Response $response
  * @return void
  */
 	protected function _invoke(Controller $controller, Request $request, Response $response) {
@@ -70,7 +70,7 @@ class TestDispatcher extends Dispatcher {
 /**
  * Helper function to test single method attaching for dispatcher filters
  *
- * @param Cake\Event\Event $event
+ * @param \Cake\Event\Event $event
  * @return void
  */
 	public function filterTest($event) {
@@ -80,7 +80,7 @@ class TestDispatcher extends Dispatcher {
 /**
  * Helper function to test single method attaching for dispatcher filters
  *
- * @param Cake\Event\Event
+ * @param \Cake\Event\Event
  * @return void
  */
 	public function filterTest2($event) {
@@ -335,7 +335,7 @@ class DispatcherTest extends TestCase {
 /**
  * testMissingController method
  *
- * @expectedException Cake\Error\MissingControllerException
+ * @expectedException \Cake\Error\MissingControllerException
  * @expectedExceptionMessage Controller class SomeController could not be found.
  * @return void
  */
@@ -353,7 +353,7 @@ class DispatcherTest extends TestCase {
 /**
  * testMissingControllerInterface method
  *
- * @expectedException Cake\Error\MissingControllerException
+ * @expectedException \Cake\Error\MissingControllerException
  * @expectedExceptionMessage Controller class DispatcherTestInterface could not be found.
  * @return void
  */
@@ -371,7 +371,7 @@ class DispatcherTest extends TestCase {
 /**
  * testMissingControllerInterface method
  *
- * @expectedException Cake\Error\MissingControllerException
+ * @expectedException \Cake\Error\MissingControllerException
  * @expectedExceptionMessage Controller class Abstract could not be found.
  * @return void
  */
@@ -611,7 +611,7 @@ class DispatcherTest extends TestCase {
 /**
  * Tests that attaching an inexistent class as filter will throw an exception
  *
- * @expectedException Cake\Error\MissingDispatcherFilterException
+ * @expectedException \Cake\Error\MissingDispatcherFilterException
  * @return void
  */
 	public function testDispatcherFilterSuscriberMissing() {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -976,7 +976,7 @@ class RouterTest extends TestCase {
 /**
  * Test that using invalid names causes exceptions.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testNamedRouteException() {
@@ -2276,7 +2276,7 @@ class RouterTest extends TestCase {
 /**
  * test that route classes must extend \Cake\Routing\Route\Route
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testCustomRouteException() {
@@ -2645,7 +2645,7 @@ class RouterTest extends TestCase {
 /**
  * Test that route classes must extend Cake\Routing\Route\Route
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testDefaultRouteException() {
@@ -2656,7 +2656,7 @@ class RouterTest extends TestCase {
 /**
  * Test that route classes must extend Cake\Routing\Route\Route
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testSettingInvalidDefaultRouteException() {
@@ -2666,7 +2666,7 @@ class RouterTest extends TestCase {
 /**
  * Test that class must exist
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testSettingNonExistentDefaultRouteException() {

--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -275,7 +275,7 @@ class ControllerTestCaseTest extends TestCase {
 /**
  * Tests not using loaded routes during tests
  *
- * @expectedException Cake\Error\MissingActionException
+ * @expectedException \Cake\Error\MissingActionException
  */
 	public function testSkipRoutes() {
 		Router::connect('/:controller/:action/*');

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -211,7 +211,7 @@ class DebuggerTest extends TestCase {
 /**
  * Test that choosing a non-existent format causes an exception
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testOutputAsException() {

--- a/tests/TestCase/Utility/NumberTest.php
+++ b/tests/TestCase/Utility/NumberTest.php
@@ -751,7 +751,7 @@ class NumberTest extends TestCase {
 /**
  * testFromReadableSize
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testFromReadableSizeException() {

--- a/tests/TestCase/Utility/ObjectCollectionTest.php
+++ b/tests/TestCase/Utility/ObjectCollectionTest.php
@@ -341,7 +341,7 @@ class ObjectCollectionTest extends TestCase {
 /**
  * test that setting modParams to an index that doesn't exist doesn't cause errors.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testTriggerModParamsInvalidIndex() {

--- a/tests/TestCase/Utility/SecurityTest.php
+++ b/tests/TestCase/Utility/SecurityTest.php
@@ -46,7 +46,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashInvalidSalt method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testHashInvalidSalt() {
@@ -56,7 +56,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashAnotherInvalidSalt
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testHashAnotherInvalidSalt() {
@@ -66,7 +66,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashYetAnotherInvalidSalt
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testHashYetAnotherInvalidSalt() {
@@ -76,7 +76,7 @@ class SecurityTest extends TestCase {
 /**
  * testHashInvalidCost method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testHashInvalidCost() {
@@ -200,7 +200,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidOperation method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidOperation() {
@@ -212,7 +212,7 @@ class SecurityTest extends TestCase {
 /**
  * testRijndaelInvalidKey method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testRijndaelInvalidKey() {
@@ -283,7 +283,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Invalid key for encrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -320,7 +320,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that short keys cause errors
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Invalid key for decrypt(), key must be at least 256 bits (32 bytes) long.
  * @return void
  */
@@ -333,7 +333,7 @@ class SecurityTest extends TestCase {
 /**
  * Test that empty data cause errors
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage The data to decrypt cannot be empty.
  * @return void
  */

--- a/tests/TestCase/Utility/TimeTest.php
+++ b/tests/TestCase/Utility/TimeTest.php
@@ -61,7 +61,6 @@ class TimeTest extends TestCase {
 /**
  * Restored the original system timezone
  *
- * @param string $timezoneIdentifier Timezone string
  * @return void
  */
 	protected function _restoreSystemTimezone() {

--- a/tests/TestCase/Utility/XmlTest.php
+++ b/tests/TestCase/Utility/XmlTest.php
@@ -132,7 +132,7 @@ class XmlTest extends TestCase {
  * testBuildInvalidData
  *
  * @dataProvider invalidDataProvider
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testBuildInvalidData($value) {
@@ -143,7 +143,7 @@ class XmlTest extends TestCase {
 /**
  * Test that building SimpleXmlElement with invalid XML causes the right exception.
  *
- * @expectedException Cake\Error\XmlException
+ * @expectedException \Cake\Error\XmlException
  * @return void
  */
 	public function testBuildInvalidDataSimpleXml() {
@@ -1070,7 +1070,7 @@ XML;
  * testToArrayFail method
  *
  * @dataProvider invalidToArrayDataProvider
- * @expectedException Cake\Error\XmlException
+ * @expectedException \Cake\Error\XmlException
  */
 	public function testToArrayFail($value) {
 		Xml::toArray($value);

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2386,7 +2386,7 @@ class ValidationTest extends TestCase {
 /**
  * testMimeTypeFalse method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testMimeTypeFalse() {

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -30,7 +30,7 @@ class CustomValidator {
 /**
  * Makes sure that a given $email address is valid and unique
  *
- * @param string $email
+ * @param string $check
  * @return boolean
  */
 	public static function customValidate($check) {
@@ -60,6 +60,7 @@ class TestNlValidation {
 /**
  * ssn function for testing ssn pass through
  *
+ * @param string $check
  * @return void
  */
 	public static function ssn($check) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -333,6 +333,7 @@ class ValidateUsersTable extends Table {
 /**
  * beforeValidate method
  *
+ * @param array $options
  * @return void
  */
 	public function beforeValidate($options = array()) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -8127,7 +8127,7 @@ class FormHelperTest extends TestCase {
 /**
  * Test errors when field name is missing.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testHtml5InputException() {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -2107,7 +2107,7 @@ class HtmlHelperTest extends TestCase {
  * testLoadConfigWrongFile method
  *
  * @return void
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  */
 	public function testLoadConfigWrongFile() {
 		$this->Html->loadConfig('wrong_file');
@@ -2117,7 +2117,7 @@ class HtmlHelperTest extends TestCase {
  * testLoadConfigWrongEngine method
  *
  * @return void
- * @expectedException Cake\Error\ConfigureException
+ * @expectedException \Cake\Error\ConfigureException
  */
 	public function testLoadConfigWrongEngine() {
 		$path = TEST_APP . 'TestApp/Config/';

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -95,7 +95,7 @@ class HelperRegistryTest extends TestCase {
 /**
  * test lazy loading of helpers
  *
- * @expectedException Cake\Error\MissingHelperException
+ * @expectedException \Cake\Error\MissingHelperException
  * @return void
  */
 	public function testLazyLoadException() {
@@ -161,7 +161,7 @@ class HelperRegistryTest extends TestCase {
 /**
  * test missinghelper exception
  *
- * @expectedException Cake\Error\MissingHelperException
+ * @expectedException \Cake\Error\MissingHelperException
  * @return void
  */
 	public function testLoadMissingHelper() {

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -120,7 +120,7 @@ class StringTemplateTest extends TestCase {
 /**
  * Test that loading non-existing templates causes errors.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Could not load configuration file
  */
 	public function testLoadErrorNoFile() {

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -527,7 +527,7 @@ class ViewTest extends TestCase {
 /**
  * Test for missing views
  *
- * @expectedException Cake\Error\MissingViewException
+ * @expectedException \Cake\Error\MissingViewException
  * @return void
  */
 	public function testMissingView() {
@@ -556,7 +556,7 @@ class ViewTest extends TestCase {
 /**
  * Test for missing layouts
  *
- * @expectedException Cake\Error\MissingLayoutException
+ * @expectedException \Cake\Error\MissingLayoutException
  * @return void
  */
 	public function testMissingLayout() {
@@ -1167,7 +1167,7 @@ class ViewTest extends TestCase {
 /**
  * testBadExt method
  *
- * @expectedException Cake\Error\MissingViewException
+ * @expectedException \Cake\Error\MissingViewException
  * @return void
  */
 	public function testBadExt() {
@@ -1193,7 +1193,7 @@ class ViewTest extends TestCase {
 /**
  * testAltBadExt method
  *
- * @expectedException Cake\Error\MissingViewException
+ * @expectedException \Cake\Error\MissingViewException
  * @return void
  */
 	public function testAltBadExt() {
@@ -1467,7 +1467,7 @@ class ViewTest extends TestCase {
 /**
  * Test that starting the same block twice throws an exception
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testStartBlocksTwice() {
@@ -1479,7 +1479,7 @@ class ViewTest extends TestCase {
  * Test that an exception gets thrown when you leave a block open at the end
  * of a view.
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException \Cake\Error\Exception
  * @return void
  */
 	public function testExceptionOnOpenBlock() {

--- a/tests/test_app/Plugin/TestPlugin/Datasource/TestSource.php
+++ b/tests/test_app/Plugin/TestPlugin/Datasource/TestSource.php
@@ -13,8 +13,6 @@ class TestSource {
 
 /**
  * Constructor
- *
- * @return void
  */
 	public function __construct(array $settings) {
 		$this->settings = $settings;

--- a/tests/test_app/TestApp/Controller/AjaxAuthController.php
+++ b/tests/test_app/TestApp/Controller/AjaxAuthController.php
@@ -50,6 +50,7 @@ class AjaxAuthController extends Controller {
 /**
  * beforeFilter method
  *
+ * @param Event $event
  * @return void
  */
 	public function beforeFilter(Event $event) {

--- a/tests/test_app/TestApp/Controller/AuthTestController.php
+++ b/tests/test_app/TestApp/Controller/AuthTestController.php
@@ -49,8 +49,6 @@ class AuthTestController extends Controller {
 
 /**
  * construct method
- *
- * @return void
  */
 	public function __construct($request = null, $response = null) {
 		$request->addParams(Router::parse('/auth_test'));

--- a/tests/test_app/TestApp/Controller/PagesController.php
+++ b/tests/test_app/TestApp/Controller/PagesController.php
@@ -50,8 +50,8 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
- * @throws \Cake\Error\NotFoundException When the view file could not be found
- *	or Cake\Error\MissingViewException in debug mode.
+ * @throws \Cake\Error\NotFoundException When the view file could not be found.
+ * @throws \Cake\Error\MissingViewException in debug mode.
  */
 	public function display() {
 		$path = func_get_args();

--- a/tests/test_app/TestApp/Controller/PagesController.php
+++ b/tests/test_app/TestApp/Controller/PagesController.php
@@ -50,8 +50,8 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
- * @throws \Cake\Error\NotFoundException When the view file could not be found.
- * @throws \Cake\Error\MissingViewException in debug mode.
+ * @throws Cake\Error\NotFoundException When the view file could not be found
+ *	or Cake\Error\MissingViewException in debug mode.
  */
 	public function display() {
 		$path = func_get_args();

--- a/tests/test_app/TestApp/Controller/PagesController.php
+++ b/tests/test_app/TestApp/Controller/PagesController.php
@@ -50,7 +50,7 @@ class PagesController extends AppController {
  *
  * @param mixed What page to display
  * @return void
- * @throws Cake\Error\NotFoundException When the view file could not be found
+ * @throws \Cake\Error\NotFoundException When the view file could not be found
  *	or Cake\Error\MissingViewException in debug mode.
  */
 	public function display() {

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -44,6 +44,8 @@ class RequestHandlerTestController extends Controller {
 /**
  * test method for ajax redirection + parameter parsing
  *
+ * @param string $one
+ * @param string $two
  * @return void
  */
 	public function param_method($one = null, $two = null) {

--- a/tests/test_app/TestApp/Controller/SomePagesController.php
+++ b/tests/test_app/TestApp/Controller/SomePagesController.php
@@ -51,7 +51,7 @@ class SomePagesController extends Controller {
 /**
  * Test method for returning responses.
  *
- * @return Cake\Network\Response
+ * @return \Cake\Network\Response
  */
 	public function responseGenerator() {
 		return new Response(array('body' => 'new response'));

--- a/tests/test_app/TestApp/Controller/SomePostsController.php
+++ b/tests/test_app/TestApp/Controller/SomePostsController.php
@@ -39,6 +39,7 @@ class SomePostsController extends Controller {
 /**
  * beforeFilter method
  *
+ * @param Event $event
  * @return void
  */
 	public function beforeFilter(Event $event) {

--- a/tests/test_app/TestApp/Controller/TestCachedPagesController.php
+++ b/tests/test_app/TestApp/Controller/TestCachedPagesController.php
@@ -69,6 +69,7 @@ class TestCachedPagesController extends Controller {
 /**
  * view method
  *
+ * @param $id
  * @return void
  */
 	public function view($id = null) {


### PR DESCRIPTION
This updates/fixes a bunch of docblock and docblock related problems like missing leading backslashes for fully qualified namespaces, parameter name typos, wrong parameter types, missing parameter tags, invalid/wrong/missing return types, unnecessary `@return` in de/constructors, etc... see also #2870

Pretty much all of this was found using automated inspections, and some of it was also modified automatically, so I most probably didn't catched everything. Also these changes aren't 100% docblock exclusive, some code was changed too, but only method arguments because of typos or mismatches with the docblock, respectively inconsistencies with other/related methods.

I left some of the problems I've found unchanged because I'm not sure how they should be handled. These problems can be split into two categories:

**1. Using `false` for optional parameters and not providing `boolean` as a type in the `@param` tag**

In some places `false` seems to be used for optional parameters, but the possible boolean value isn't set in the `@param` tag.

I'm not sure about the overall intention of the usage of `false` over `null` (seems to make sense here and there, `Inflector::_cache()` for example may actually cache `null`, not sure), also changing it may require modifying the logic, and the modified signatures would probably break things, so I haven't touched that.

Examples for it are the following methods:

```
File::read()
FixtureTask::bake()
Folder::__construct()
Folder::chmod()
Folder::create()
HtmlHelper::link()
Inflector::_cache()
NumberHelper::format()
Number::format()
```

**2. Intentionally left out `@param` tags that are defined in overwritten methods.**

It looks like Apigen is smart enough to handle this, however I'm not sure about IDEs and other documentation generators. What I can tell for sure is that NetBeans and PhpStorm have problems with it. 

PhpStorms docblock inspections really do not like that, they only understand completely inherited docblocks, so one ends up with docblocks marked as errors, and in NetBeans the autocomplete description popups will lack these parameters as they are not being inherited.

Examples can be found here:

```
ApcEngine::clearGroup()
FileEngine::clearGroup()
MemcachedEngine::clearGroup()
RedisEngine::clearGroup()
WincacheEngine::clearGroup()
XcacheEngine::clearGroup()
```
