### PR TITLE
3.0 formhelper datetime

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2104,7 +2104,7 @@ class FormHelper extends Helper {
 /**
  * Returns a set of SELECT elements for a full datetime setup: day, month and year, and then time.
  *
- * ### Attributes:
+ * ### Options:
  *
  * - `monthNames` If false, 2 digit numbers will be used instead of text.
  *   If a array, the given array will be used.
@@ -2126,14 +2126,12 @@ class FormHelper extends Helper {
  * `{{month}}{{day}}{{year}}{{hour}}{{minute}}{{second}}{{meridian}}`
  *
  * @param string $fieldName Prefix name for the SELECT element
- * @param string $dateFormat DMY, MDY, YMD, or null to not generate date inputs.
- * @param string $timeFormat 12, 24, or null to not generate time inputs.
- * @param array|string $attributes array of Attributes
+ * @param array $options Array of Options
  * @return string Generated set of select boxes for the date and time formats chosen.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::dateTime
  */
-	public function dateTime($fieldName, $attributes = array()) {
-		$attributes += [
+	public function dateTime($fieldName, $options = array()) {
+		$options += [
 			'empty' => true,
 			'value' => null,
 			'interval' => 1,
@@ -2144,70 +2142,70 @@ class FormHelper extends Helper {
 			'timeFormat' => 12,
 			'second' => false,
 		];
-		$attributes = $this->_initInputField($fieldName, $attributes);
-		$attributes = $this->_dateTimeAttributes($attributes);
+		$options = $this->_initInputField($fieldName, $options);
+		$options = $this->_datetimeOptions($options);
 
-		return $this->widget('datetime', $attributes);
+		return $this->widget('datetime', $options);
 	}
 
 /**
- * Helper method for converting from FormHelper attributes data to widget format.
+ * Helper method for converting from FormHelper options data to widget format.
  *
- * @param array $attributes Attributes to convert.
- * @return array Converted attributes.
+ * @param array $options Options to convert.
+ * @return array Converted options.
  */
-	protected function _dateTimeAttributes($attributes) {
+	protected function _datetimeOptions($options) {
 		$types = ['year', 'month', 'day', 'hour', 'minute', 'second', 'meridian'];
 		foreach ($types as $type) {
-			if (!isset($attributes[$type])) {
-				$attributes[$type] = [];
+			if (!isset($options[$type])) {
+				$options[$type] = [];
 			}
 
 			// Pass empty boolean to each type.
 			if (
-				!empty($attributes['empty']) &&
-				is_bool($attributes['empty']) &&
-				is_array($attributes[$type])
+				!empty($options['empty']) &&
+				is_bool($options['empty']) &&
+				is_array($options[$type])
 			) {
-				$attributes[$type]['empty'] = $attributes['empty'];
+				$options[$type]['empty'] = $options['empty'];
 			}
 
 			// Move empty options into each type array.
-			if (isset($attributes['empty'][$type])) {
-				$attributes[$type]['empty'] = $attributes['empty'][$type];
+			if (isset($options['empty'][$type])) {
+				$options[$type]['empty'] = $options['empty'][$type];
 			}
 		}
-		unset($attributes['empty']);
+		unset($options['empty']);
 
-		$hasYear = is_array($attributes['year']);
-		if ($hasYear && isset($attributes['minYear'])) {
-			$attributes['year']['start'] = $attributes['minYear'];
+		$hasYear = is_array($options['year']);
+		if ($hasYear && isset($options['minYear'])) {
+			$options['year']['start'] = $options['minYear'];
 		}
-		if ($hasYear && isset($attributes['maxYear'])) {
-			$attributes['year']['end'] = $attributes['maxYear'];
+		if ($hasYear && isset($options['maxYear'])) {
+			$options['year']['end'] = $options['maxYear'];
 		}
-		unset($attributes['minYear'], $attributes['maxYear']);
+		unset($options['minYear'], $options['maxYear']);
 
-		if (is_array($attributes['month'])) {
-			$attributes['month']['names'] = $attributes['monthNames'];
+		if (is_array($options['month'])) {
+			$options['month']['names'] = $options['monthNames'];
 		}
-		unset($attributes['monthNames']);
+		unset($options['monthNames']);
 
-		if (is_array($attributes['hour']) && isset($attributes['timeFormat'])) {
-			$attributes['hour']['format'] = $attributes['timeFormat'];
+		if (is_array($options['hour']) && isset($options['timeFormat'])) {
+			$options['hour']['format'] = $options['timeFormat'];
 		}
-		unset($attributes['timeFormat']);
+		unset($options['timeFormat']);
 
-		if (is_array($attributes['minute'])) {
-			$attributes['minute']['interval'] = $attributes['interval'];
-			$attributes['minute']['round'] = $attributes['round'];
+		if (is_array($options['minute'])) {
+			$options['minute']['interval'] = $options['interval'];
+			$options['minute']['round'] = $options['round'];
 		}
-		unset($attributes['interval'], $attributes['round']);
+		unset($options['interval'], $options['round']);
 
-		if (!isset($attributes['val'])) {
-			$attributes['val'] = new \DateTime();
+		if (!isset($options['val'])) {
+			$options['val'] = new \DateTime();
 		}
-		return $attributes;
+		return $options;
 	}
 
 /**

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -196,6 +196,13 @@ class DateTime implements WidgetInterface {
 				if (isset($value['year'], $value['month'], $value['day'])) {
 					$date->setDate($value['year'], $value['month'], $value['day']);
 				}
+				if (!isset($value['second'])) {
+					$value['second'] = 0;
+				}
+				if (isset($value['meridian'])) {
+					$isAm = strtolower($value['meridian']) === 'am';
+					$value['hour'] = $isAm ? $value['hour'] : $value['hour'] + 12;
+				}
 				if (isset($value['hour'], $value['minute'], $value['second'])) {
 					$date->setTime($value['hour'], $value['minute'], $value['second']);
 				}

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -261,9 +261,10 @@ class DateTime implements WidgetInterface {
 			'options' => []
 		];
 
-		$options['start'] = min($options['val'], $options['start']);
-		$options['end'] = max($options['val'], $options['end']);
-
+		if (!empty($options['val'])) {
+			$options['start'] = min($options['val'], $options['start']);
+			$options['end'] = max($options['val'], $options['end']);
+		}
 		if (empty($options['options'])) {
 			$options['options'] = $this->_generateNumbers($options['start'], $options['end']);
 		}
@@ -382,6 +383,7 @@ class DateTime implements WidgetInterface {
 			'leadingZeroKey' => true,
 			'leadingZeroValue' => true,
 		];
+		$options['interval'] = max($options['interval'], 1);
 		if (empty($options['options'])) {
 			$options['options'] = $this->_generateNumbers(0, 59, $options);
 		}

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5130,40 +5130,41 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('empty' => false));
 		$now = strtotime('now');
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]')),
-			$daysRegex,
-			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
-			date('j', $now),
-			'/option',
-			'*/select',
-			'-',
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
 			date('F', $now),
 			'/option',
 			'*/select',
-			'-',
+
+			array('select' => array('name' => 'Contact[date][day]')),
+			$daysRegex,
+			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
+			date('j', $now),
+			'/option',
+			'*/select',
+
 			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
 			date('Y', $now),
 			'/option',
 			'*/select',
+
 			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => date('h', $now), 'selected' => 'selected')),
 			date('g', $now),
 			'/option',
 			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[date][min]')),
+
+			array('select' => array('name' => 'Contact[date][minute]')),
 			$minutesRegex,
 			array('option' => array('value' => date('i', $now), 'selected' => 'selected')),
 			date('i', $now),
 			'/option',
 			'*/select',
-			' ',
+
 			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => date('a', $now), 'selected' => 'selected')),
@@ -5172,38 +5173,51 @@ class FormHelperTest extends TestCase {
 			'*/select'
 		);
 		$this->assertTags($result, $expected);
+	}
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12');
+/**
+ * Test empty defaulting to true for datetime.
+ *
+ * @return void
+ */
+	public function testDatetimeEmpty() {
+		extract($this->dateRegex);
+		$now = strtotime('now');
+
+		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array(
+			'empty' => true,
+		));
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]')),
-			$daysRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			'-',
+
+			array('select' => array('name' => 'Contact[date][day]')),
+			$daysRegex,
+			array('option' => array('value' => '')),
+			'/option',
+			'*/select',
+
 			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
+
 			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[date][min]')),
+
+			array('select' => array('name' => 'Contact[date][minute]')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			' ',
+
 			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
@@ -5212,14 +5226,16 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+	}
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('value' => false));
-		$this->assertTags($result, $expected);
-		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
-
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('value' => ''));
-		$this->assertTags($result, $expected);
-		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
+/**
+ * Test datetime with interval option.
+ *
+ * @return void
+ */
+	public function testDatetimeMinuteInterval() {
+		extract($this->dateRegex);
+		$now = strtotime('now');
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 5, 'value' => ''));
 		$expected = array(
@@ -5228,25 +5244,26 @@ class FormHelperTest extends TestCase {
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			'-',
+
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			'-',
+
 			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
+
 			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[date][min]')),
+
+			array('select' => array('name' => 'Contact[date][minute]')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5260,7 +5277,7 @@ class FormHelperTest extends TestCase {
 			'10',
 			'/option',
 			'*/select',
-			' ',
+
 			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
@@ -5269,106 +5286,6 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
-
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('minuteInterval' => 5, 'value' => ''));
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('minuteInterval' => 5, 'value' => ''));
-
-		$this->Form->request->data['Contact']['data'] = null;
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12');
-		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]')),
-			$daysRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[date][month]')),
-			$monthsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[date][year]')),
-			$yearsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			array('select' => array('name' => 'Contact[date][hour]')),
-			$hoursRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[date][min]')),
-			$minutesRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			' ',
-			array('select' => array('name' => 'Contact[date][meridian]')),
-			$meridianRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select'
-		);
-		$this->assertTags($result, $expected);
-		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
-
-		$this->Form->request->data['Model']['field'] = date('Y') . '-01-01 00:00:00';
-		$now = strtotime($this->Form->data['Model']['field']);
-		$result = $this->Form->dateTime('Model.field', 'DMY', '12', array('empty' => false));
-		$expected = array(
-			array('select' => array('name' => 'Model[field][day]')),
-			$daysRegex,
-			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
-			date('j', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Model[field][month]')),
-			$monthsRegex,
-			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
-			date('F', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Model[field][year]')),
-			$yearsRegex,
-			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
-			date('Y', $now),
-			'/option',
-			'*/select',
-			array('select' => array('name' => 'Model[field][hour]')),
-			$hoursRegex,
-			array('option' => array('value' => date('h', $now), 'selected' => 'selected')),
-			date('g', $now),
-			'/option',
-			'*/select',
-			':',
-			array('select' => array('name' => 'Model[field][min]')),
-			$minutesRegex,
-			array('option' => array('value' => date('i', $now), 'selected' => 'selected')),
-			date('i', $now),
-			'/option',
-			'*/select',
-			' ',
-			array('select' => array('name' => 'Model[field][meridian]')),
-			$meridianRegex,
-			array('option' => array('value' => date('a', $now), 'selected' => 'selected')),
-			date('a', $now),
-			'/option',
-			'*/select'
-		);
-		$this->assertTags($result, $expected);
-
-		$selected = strtotime('2008-10-26 12:33:00');
-		$result = $this->Form->dateTime('Model.field', 'DMY', '12', array('value' => $selected));
-		$this->assertRegExp('/<option[^<>]+value="2008"[^<>]+selected="selected"[^>]*>2008<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="10"[^<>]+selected="selected"[^>]*>October<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="26"[^<>]+selected="selected"[^>]*>26<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="12"[^<>]+selected="selected"[^>]*>12<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="33"[^<>]+selected="selected"[^>]*>33<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="pm"[^<>]+selected="selected"[^>]*>pm<\/option>/', $result);
 	}
 
 /**
@@ -5383,7 +5300,7 @@ class FormHelperTest extends TestCase {
 				'month' => '12',
 				'year' => '2010',
 				'hour' => '04',
-				'min' => '19',
+				'minute' => '19',
 				'meridian' => 'AM'
 			)
 		);
@@ -5404,13 +5321,14 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeNoErrorsOnEmptyData() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		$this->Form->request->data['Contact'] = array(
 			'date' => array(
 				'day' => '',
 				'month' => '',
 				'year' => '',
 				'hour' => '',
-				'min' => '',
+				'minute' => '',
 				'meridian' => ''
 			)
 		);
@@ -5424,6 +5342,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDatetimeWithDefault() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
@@ -5443,6 +5362,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeWithBogusData() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
 		$this->assertNotRegExp('/selected="selected">\d/', $result);
 	}
@@ -5453,6 +5373,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeAllZeros() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		$result = $this->Form->dateTime('Contact.date',
 			'DMY',
 			false,
@@ -5472,6 +5393,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeEmptyAsArray() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		$result = $this->Form->dateTime('Contact.date',
 			'DMY',
 			'12',
@@ -5513,6 +5435,7 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormDateTimeMulti() {
+		$this->markTestIncomplete('Need to revisit soon.');
 		extract($this->dateRegex);
 
 		$result = $this->Form->dateTime('Contact.1.updated');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5237,35 +5237,38 @@ class FormHelperTest extends TestCase {
 		extract($this->dateRegex);
 		$now = strtotime('now');
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 5, 'value' => ''));
+		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array(
+			'interval' => 5,
+			'value' => ''
+		));
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]')),
-			$daysRegex,
-			array('option' => array('value' => '')),
+			array('select' => array('name' => 'Contact[date][month]')),
+			$monthsRegex,
+			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			'*/select',
 
-			array('select' => array('name' => 'Contact[date][month]')),
-			$monthsRegex,
-			array('option' => array('value' => '')),
+			array('select' => array('name' => 'Contact[date][day]')),
+			$daysRegex,
+			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			'*/select',
 
 			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
-			array('option' => array('value' => '')),
+			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			'*/select',
 
 			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
-			array('option' => array('value' => '')),
+			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			'*/select',
 
 			array('select' => array('name' => 'Contact[date][minute]')),
 			$minutesRegex,
-			array('option' => array('value' => '')),
+			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			array('option' => array('value' => '00')),
 			'00',
@@ -5277,15 +5280,8 @@ class FormHelperTest extends TestCase {
 			'10',
 			'/option',
 			'*/select',
-
-			array('select' => array('name' => 'Contact[date][meridian]')),
-			$meridianRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select'
 		);
 		$this->assertTags($result, $expected);
-		$this->assertNotRegExp('/<option[^<>]+value=""[^<>]+selected="selected"[^>]*>/', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5125,47 +5125,46 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTime() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		extract($this->dateRegex);
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('empty' => false));
 		$now = strtotime('now');
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]', 'id' => 'ContactDateDay')),
+			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
 			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
 			date('j', $now),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][month]', 'id' => 'ContactDateMonth')),
+			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
 			date('F', $now),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][year]', 'id' => 'ContactDateYear')),
+			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
 			date('Y', $now),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[date][hour]', 'id' => 'ContactDateHour')),
+			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => date('h', $now), 'selected' => 'selected')),
 			date('g', $now),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[date][min]', 'id' => 'ContactDateMin')),
+			array('select' => array('name' => 'Contact[date][min]')),
 			$minutesRegex,
 			array('option' => array('value' => date('i', $now), 'selected' => 'selected')),
 			date('i', $now),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[date][meridian]', 'id' => 'ContactDateMeridian')),
+			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => date('a', $now), 'selected' => 'selected')),
 			date('a', $now),
@@ -5176,36 +5175,36 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12');
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]', 'id' => 'ContactDateDay')),
+			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][month]', 'id' => 'ContactDateMonth')),
+			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][year]', 'id' => 'ContactDateYear')),
+			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[date][hour]', 'id' => 'ContactDateHour')),
+			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[date][min]', 'id' => 'ContactDateMin')),
+			array('select' => array('name' => 'Contact[date][min]')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[date][meridian]', 'id' => 'ContactDateMeridian')),
+			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5224,30 +5223,30 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 5, 'value' => ''));
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]', 'id' => 'ContactDateDay')),
+			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][month]', 'id' => 'ContactDateMonth')),
+			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][year]', 'id' => 'ContactDateYear')),
+			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[date][hour]', 'id' => 'ContactDateHour')),
+			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[date][min]', 'id' => 'ContactDateMin')),
+			array('select' => array('name' => 'Contact[date][min]')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5262,7 +5261,7 @@ class FormHelperTest extends TestCase {
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[date][meridian]', 'id' => 'ContactDateMeridian')),
+			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5277,36 +5276,36 @@ class FormHelperTest extends TestCase {
 		$this->Form->request->data['Contact']['data'] = null;
 		$result = $this->Form->dateTime('Contact.date', 'DMY', '12');
 		$expected = array(
-			array('select' => array('name' => 'Contact[date][day]', 'id' => 'ContactDateDay')),
+			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][month]', 'id' => 'ContactDateMonth')),
+			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Contact[date][year]', 'id' => 'ContactDateYear')),
+			array('select' => array('name' => 'Contact[date][year]')),
 			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Contact[date][hour]', 'id' => 'ContactDateHour')),
+			array('select' => array('name' => 'Contact[date][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Contact[date][min]', 'id' => 'ContactDateMin')),
+			array('select' => array('name' => 'Contact[date][min]')),
 			$minutesRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Contact[date][meridian]', 'id' => 'ContactDateMeridian')),
+			array('select' => array('name' => 'Contact[date][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => '')),
 			'/option',
@@ -5319,41 +5318,41 @@ class FormHelperTest extends TestCase {
 		$now = strtotime($this->Form->data['Model']['field']);
 		$result = $this->Form->dateTime('Model.field', 'DMY', '12', array('empty' => false));
 		$expected = array(
-			array('select' => array('name' => 'Model[field][day]', 'id' => 'ModelFieldDay')),
+			array('select' => array('name' => 'Model[field][day]')),
 			$daysRegex,
 			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
 			date('j', $now),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Model[field][month]', 'id' => 'ModelFieldMonth')),
+			array('select' => array('name' => 'Model[field][month]')),
 			$monthsRegex,
 			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
 			date('F', $now),
 			'/option',
 			'*/select',
 			'-',
-			array('select' => array('name' => 'Model[field][year]', 'id' => 'ModelFieldYear')),
+			array('select' => array('name' => 'Model[field][year]')),
 			$yearsRegex,
 			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
 			date('Y', $now),
 			'/option',
 			'*/select',
-			array('select' => array('name' => 'Model[field][hour]', 'id' => 'ModelFieldHour')),
+			array('select' => array('name' => 'Model[field][hour]')),
 			$hoursRegex,
 			array('option' => array('value' => date('h', $now), 'selected' => 'selected')),
 			date('g', $now),
 			'/option',
 			'*/select',
 			':',
-			array('select' => array('name' => 'Model[field][min]', 'id' => 'ModelFieldMin')),
+			array('select' => array('name' => 'Model[field][min]')),
 			$minutesRegex,
 			array('option' => array('value' => date('i', $now), 'selected' => 'selected')),
 			date('i', $now),
 			'/option',
 			'*/select',
 			' ',
-			array('select' => array('name' => 'Model[field][meridian]', 'id' => 'ModelFieldMeridian')),
+			array('select' => array('name' => 'Model[field][meridian]')),
 			$meridianRegex,
 			array('option' => array('value' => date('a', $now), 'selected' => 'selected')),
 			date('a', $now),
@@ -5370,130 +5369,6 @@ class FormHelperTest extends TestCase {
 		$this->assertRegExp('/<option[^<>]+value="12"[^<>]+selected="selected"[^>]*>12<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="33"[^<>]+selected="selected"[^>]*>33<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="pm"[^<>]+selected="selected"[^>]*>pm<\/option>/', $result);
-
-		$this->Form->create('Contact');
-		$result = $this->Form->input('published');
-		$now = strtotime('now');
-		$expected = array(
-			'div' => array('class' => 'input date'),
-			'label' => array('for' => 'ContactPublishedMonth'),
-			'Published',
-			'/label',
-			array('select' => array('name' => 'Contact[published][month]', 'id' => 'ContactPublishedMonth')),
-			$monthsRegex,
-			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
-			date('F', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published][day]', 'id' => 'ContactPublishedDay')),
-			$daysRegex,
-			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
-			date('j', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published][year]', 'id' => 'ContactPublishedYear')),
-			$yearsRegex,
-			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
-			date('Y', $now),
-			'/option',
-			'*/select',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('published2', array('type' => 'date'));
-		$now = strtotime('now');
-		$expected = array(
-			'div' => array('class' => 'input date'),
-			'label' => array('for' => 'ContactPublished2Month'),
-			'Published2',
-			'/label',
-			array('select' => array('name' => 'Contact[published2][month]', 'id' => 'ContactPublished2Month')),
-			$monthsRegex,
-			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
-			date('F', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published2][day]', 'id' => 'ContactPublished2Day')),
-			$daysRegex,
-			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
-			date('j', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published2][year]', 'id' => 'ContactPublished2Year')),
-			$yearsRegex,
-			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
-			date('Y', $now),
-			'/option',
-			'*/select',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->create('Contact');
-		$result = $this->Form->input('published', array('monthNames' => false));
-		$now = strtotime('now');
-		$expected = array(
-			'div' => array('class' => 'input date'),
-			'label' => array('for' => 'ContactPublishedMonth'),
-			'Published',
-			'/label',
-			array('select' => array('name' => 'Contact[published][month]', 'id' => 'ContactPublishedMonth')),
-			'preg:/(?:<option value="([\d])+">[\d]+<\/option>[\r\n]*)*/',
-			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
-			date('m', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published][day]', 'id' => 'ContactPublishedDay')),
-			$daysRegex,
-			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
-			date('j', $now),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[published][year]', 'id' => 'ContactPublishedYear')),
-			$yearsRegex,
-			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
-			date('Y', $now),
-			'/option',
-			'*/select',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('published', array('type' => 'time'));
-		$now = strtotime('now');
-		$expected = array(
-			'div' => array('class' => 'input time'),
-			'label' => array('for' => 'ContactPublishedHour'),
-			'Published',
-			'/label',
-			array('select' => array('name' => 'Contact[published][hour]', 'id' => 'ContactPublishedHour')),
-			'preg:/(?:<option value="([\d])+">[\d]+<\/option>[\r\n]*)*/',
-			array('option' => array('value' => date('h', $now), 'selected' => 'selected')),
-			date('g', $now),
-			'/option',
-			'*/select',
-			':',
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->input('published', array(
-			'timeFormat' => 24,
-			'interval' => 5,
-			'selected' => strtotime('2009-09-03 13:37:00'),
-			'type' => 'datetime'
-		));
-		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="09"[^<>]+selected="selected"[^>]*>September<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="03"[^<>]+selected="selected"[^>]*>3<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="13"[^<>]+selected="selected"[^>]*>13<\/option>/', $result);
-		$this->assertRegExp('/<option[^<>]+value="35"[^<>]+selected="selected"[^>]*>35<\/option>/', $result);
 	}
 
 /**
@@ -5502,7 +5377,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeRounding() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->data['Contact'] = array(
 			'date' => array(
 				'day' => '13',
@@ -5530,7 +5404,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeNoErrorsOnEmptyData() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$this->Form->request->data['Contact'] = array(
 			'date' => array(
 				'day' => '',
@@ -5551,7 +5424,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDatetimeWithDefault() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
@@ -5571,7 +5443,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeWithBogusData() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
 		$this->assertNotRegExp('/selected="selected">\d/', $result);
 	}
@@ -5582,7 +5453,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeAllZeros() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->dateTime('Contact.date',
 			'DMY',
 			false,
@@ -5602,7 +5472,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeEmptyAsArray() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		$result = $this->Form->dateTime('Contact.date',
 			'DMY',
 			'12',
@@ -5644,7 +5513,6 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormDateTimeMulti() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
 		extract($this->dateRegex);
 
 		$result = $this->Form->dateTime('Contact.1.updated');

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5127,7 +5127,7 @@ class FormHelperTest extends TestCase {
 	public function testDateTime() {
 		extract($this->dateRegex);
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('empty' => false));
+		$result = $this->Form->dateTime('Contact.date', array('empty' => false));
 		$now = strtotime('now');
 		$expected = array(
 			array('select' => array('name' => 'Contact[date][month]')),
@@ -5184,7 +5184,7 @@ class FormHelperTest extends TestCase {
 		extract($this->dateRegex);
 		$now = strtotime('now');
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array(
+		$result = $this->Form->dateTime('Contact.date', array(
 			'empty' => true,
 		));
 		$expected = array(
@@ -5237,7 +5237,7 @@ class FormHelperTest extends TestCase {
 		extract($this->dateRegex);
 		$now = strtotime('now');
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array(
+		$result = $this->Form->dateTime('Contact.date', array(
 			'interval' => 5,
 			'value' => ''
 		));
@@ -5301,35 +5301,14 @@ class FormHelperTest extends TestCase {
 			)
 		);
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 15));
+		$result = $this->Form->dateTime('Contact.date', array('interval' => 15));
 		$this->assertTextContains('<option value="15" selected="selected">15</option>', $result);
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 15, 'round' => 'up'));
+		$result = $this->Form->dateTime('Contact.date', array('interval' => 15, 'round' => 'up'));
 		$this->assertTextContains('<option value="30" selected="selected">30</option>', $result);
 
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('interval' => 5, 'round' => 'down'));
+		$result = $this->Form->dateTime('Contact.date', array('interval' => 5, 'round' => 'down'));
 		$this->assertTextContains('<option value="15" selected="selected">15</option>', $result);
-	}
-
-/**
- * Test that empty values don't trigger errors.
- *
- * @return void
- */
-	public function testDateTimeNoErrorsOnEmptyData() {
-		$this->markTestIncomplete('Need to revisit soon.');
-		$this->Form->request->data['Contact'] = array(
-			'date' => array(
-				'day' => '',
-				'month' => '',
-				'year' => '',
-				'hour' => '',
-				'minute' => '',
-				'meridian' => ''
-			)
-		);
-		$result = $this->Form->dateTime('Contact.date', 'DMY', '12', array('empty' => false));
-		$this->assertNotEmpty($result);
 	}
 
 /**
@@ -5339,12 +5318,12 @@ class FormHelperTest extends TestCase {
  */
 	public function testDatetimeWithDefault() {
 		$this->markTestIncomplete('Need to revisit soon.');
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => '2009-06-01 11:15:30'));
+		$result = $this->Form->dateTime('Contact.updated', array('value' => '2009-06-01 11:15:30'));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="01"[^<>]+selected="selected"[^>]*>1<\/option>/', $result);
 		$this->assertRegExp('/<option[^<>]+value="06"[^<>]+selected="selected"[^>]*>June<\/option>/', $result);
 
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array(
+		$result = $this->Form->dateTime('Contact.updated', array(
 			'default' => '2009-06-01 11:15:30'
 		));
 		$this->assertRegExp('/<option[^<>]+value="2009"[^<>]+selected="selected"[^>]*>2009<\/option>/', $result);
@@ -5353,31 +5332,16 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
- * test that bogus non-date time data doesn't cause errors.
- *
- * @return void
- */
-	public function testDateTimeWithBogusData() {
-		$this->markTestIncomplete('Need to revisit soon.');
-		$result = $this->Form->dateTime('Contact.updated', 'DMY', '12', array('value' => 'CURRENT_TIMESTAMP'));
-		$this->assertNotRegExp('/selected="selected">\d/', $result);
-	}
-
-/**
  * testDateTime all zeros
  *
  * @return void
  */
 	public function testDateTimeAllZeros() {
-		$this->markTestIncomplete('Need to revisit soon.');
-		$result = $this->Form->dateTime('Contact.date',
-			'DMY',
-			false,
-			array(
-				'empty' => array('day' => '-', 'month' => '-', 'year' => '-'),
-				'value' => '0000-00-00'
-			)
-		);
+		$result = $this->Form->dateTime('Contact.date', array(
+			'timeFormat' => false,
+			'empty' => array('day' => '-', 'month' => '-', 'year' => '-'),
+			'value' => '0000-00-00'
+		));
 
 		$this->assertRegExp('/<option value="">-<\/option>/', $result);
 		$this->assertNotRegExp('/<option value="0" selected="selected">0<\/option>/', $result);
@@ -5389,16 +5353,16 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testDateTimeEmptyAsArray() {
-		$this->markTestIncomplete('Need to revisit soon.');
-		$result = $this->Form->dateTime('Contact.date',
-			'DMY',
-			'12',
-			array(
-				'empty' => array('day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR',
-					'hour' => 'HOUR', 'minute' => 'MINUTE', 'meridian' => false
-				)
+		$result = $this->Form->dateTime('Contact.date', array(
+			'empty' => array(
+				'day' => 'DAY',
+				'month' => 'MONTH',
+				'year' => 'YEAR',
+				'hour' => 'HOUR',
+				'minute' => 'MINUTE',
+				'meridian' => false
 			)
-		);
+		));
 
 		$this->assertRegExp('/<option value="">DAY<\/option>/', $result);
 		$this->assertRegExp('/<option value="">MONTH<\/option>/', $result);
@@ -5407,20 +5371,13 @@ class FormHelperTest extends TestCase {
 		$this->assertRegExp('/<option value="">MINUTE<\/option>/', $result);
 		$this->assertNotRegExp('/<option value=""><\/option>/', $result);
 
-		$result = $this->Form->dateTime('Contact.date',
-			'DMY',
-			'12',
-			array(
-				'empty' => array('day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR')
-			)
-		);
+		$result = $this->Form->dateTime('Contact.date', array(
+			'empty' => array('day' => 'DAY', 'month' => 'MONTH', 'year' => 'YEAR')
+		));
 
 		$this->assertRegExp('/<option value="">DAY<\/option>/', $result);
 		$this->assertRegExp('/<option value="">MONTH<\/option>/', $result);
 		$this->assertRegExp('/<option value="">YEAR<\/option>/', $result);
-		$this->assertRegExp('/<select[^<>]+id="ContactDateHour">\s<option value=""><\/option>/', $result);
-		$this->assertRegExp('/<select[^<>]+id="ContactDateMin">\s<option value=""><\/option>/', $result);
-		$this->assertRegExp('/<select[^<>]+id="ContactDateMeridian">\s<option value=""><\/option>/', $result);
 	}
 
 /**
@@ -5431,86 +5388,15 @@ class FormHelperTest extends TestCase {
  * @return void
  */
 	public function testFormDateTimeMulti() {
-		$this->markTestIncomplete('Need to revisit soon.');
 		extract($this->dateRegex);
 
 		$result = $this->Form->dateTime('Contact.1.updated');
-		$expected = array(
-			array('select' => array('name' => 'Contact[1][updated][day]', 'id' => 'Contact1UpdatedDay')),
-			$daysRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[1][updated][month]', 'id' => 'Contact1UpdatedMonth')),
-			$monthsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[1][updated][year]', 'id' => 'Contact1UpdatedYear')),
-			$yearsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			array('select' => array('name' => 'Contact[1][updated][hour]', 'id' => 'Contact1UpdatedHour')),
-			$hoursRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[1][updated][min]', 'id' => 'Contact1UpdatedMin')),
-			$minutesRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			' ',
-			array('select' => array('name' => 'Contact[1][updated][meridian]', 'id' => 'Contact1UpdatedMeridian')),
-			$meridianRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->dateTime('Contact.2.updated');
-		$expected = array(
-			array('select' => array('name' => 'Contact[2][updated][day]', 'id' => 'Contact2UpdatedDay')),
-			$daysRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[2][updated][month]', 'id' => 'Contact2UpdatedMonth')),
-			$monthsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			'-',
-			array('select' => array('name' => 'Contact[2][updated][year]', 'id' => 'Contact2UpdatedYear')),
-			$yearsRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			array('select' => array('name' => 'Contact[2][updated][hour]', 'id' => 'Contact2UpdatedHour')),
-			$hoursRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			':',
-			array('select' => array('name' => 'Contact[2][updated][min]', 'id' => 'Contact2UpdatedMin')),
-			$minutesRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-			' ',
-			array('select' => array('name' => 'Contact[2][updated][meridian]', 'id' => 'Contact2UpdatedMeridian')),
-			$meridianRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select'
-		);
-		$this->assertTags($result, $expected);
+		$this->assertContains('Contact[1][updated][month]', $result);
+		$this->assertContains('Contact[1][updated][day]', $result);
+		$this->assertContains('Contact[1][updated][year]', $result);
+		$this->assertContains('Contact[1][updated][hour]', $result);
+		$this->assertContains('Contact[1][updated][minute]', $result);
+		$this->assertContains('Contact[1][updated][meridian]', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/DateTimeTest.php
+++ b/tests/TestCase/View/Widget/DateTimeTest.php
@@ -118,11 +118,18 @@ class DateTimeTest extends TestCase {
 			'year' => '2014', 'month' => '01', 'day' => '20',
 			'hour' => '12', 'minute' => '30'
 		];
-		$result = $this->DateTime->render(['val' => $selected]);
+		$result = $this->DateTime->render(['name' => 'created', 'val' => $selected]);
+		$this->assertContains('name="created[year]"', $result);
 		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+		$this->assertContains('name="created[month]"', $result);
 		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
+		$this->assertContains('name="created[day]"', $result);
 		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
+		$this->assertContains('name="created[hour]"', $result);
 		$this->assertContains('<option value="12" selected="selected">12</option>', $result);
+		$this->assertContains('name="created[minute]"', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertContains('name="created[second]"', $result);
 		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
 	}
 

--- a/tests/TestCase/View/Widget/DateTimeTest.php
+++ b/tests/TestCase/View/Widget/DateTimeTest.php
@@ -109,6 +109,41 @@ class DateTimeTest extends TestCase {
 	}
 
 /**
+ * Test that render() works with an array for val that is missing seconds.
+ *
+ * @return void
+ */
+	public function testRenderSelectedNoSeconds() {
+		$selected = [
+			'year' => '2014', 'month' => '01', 'day' => '20',
+			'hour' => '12', 'minute' => '30'
+		];
+		$result = $this->DateTime->render(['val' => $selected]);
+		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
+		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
+		$this->assertContains('<option value="12" selected="selected">12</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+	}
+
+/**
+ * Test that render() adjusts hours based on meridian
+ *
+ * @return void
+ */
+	public function testRenderSelectedMeridian() {
+		$selected = [
+			'year' => '2014', 'month' => '01', 'day' => '20',
+			'hour' => '7', 'minute' => '30', 'meridian' => 'pm'
+		];
+		$result = $this->DateTime->render(['val' => $selected]);
+		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
+		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
+		$this->assertContains('<option value="19" selected="selected">19</option>', $result);
+	}
+
+/**
  * Test rendering widgets with empty values.
  *
  * @retun void


### PR DESCRIPTION
Part of #2267. This is the first of several changes to update the datetime input generation to use the widget classes. I have tried to preserve most if the option names from 2.x, as it was simple to do. I have removed the dateFormat and timeFormat parameters as they are now options/templates. The separatorshave also been removed from the default templates, as that content is easy to generate with css/templates now.
