### PR TITLE
Allows to use a two level array data on 'data' parameter for Form->postLink()

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1779,14 +1779,21 @@ class FormHelper extends AppHelper {
 
 		$fields = array();
 		if (isset($options['data']) && is_array($options['data'])) {
-			foreach ($options['data'] as $key => $value) {
-				$fields[$key] = $value;
-				$out .= $this->hidden($key, array('value' => $value, 'id' => false));
-			}
-			unset($options['data']);
-		}
-		$out .= $this->secure($fields);
-		$out .= $this->Html->useTag('formend');
+            foreach ($options['data'] as $key => $value) {
+                if( is_array( $value ) ) {
+                    foreach( $value as $key2 => $value ) {
+                        $fields[$key.$key2] = $value;
+                        $out .= $this->hidden($key.".".$key2, array('value' => $value, 'id' => false));
+                    }
+                } else {
+                    $fields[$key] = $value;
+                    $out .= $this->hidden($key, array('value' => $value, 'id' => false));
+                }
+            }
+            unset($options['data']);
+        }
+        $out .= $this->secure($fields);
+        $out .= $this->Html->useTag('formend');
 
 		$url = '#';
 		$onClick = 'document.' . $formName . '.submit();';


### PR DESCRIPTION
This allow to make use of 

``` php
echo $this->Form->postLink( " Export to PDF", array( 'action' => 'imprimir.pdf' ),array( 'data' => $this->Paginator->params() ) );
and recive an array such as:
array(
    'page' => '1',
    'current' => '127',
    'count' => '127',
    'prevPage' => '',
    'nextPage' => '',
    'pageCount' => '1',
    'order' => array(
        'Gasto' => array(
            'fecha' => 'desc'
        )
    ),
    'limit' => '10000',
    'paramType' => 'named'
)
```

on the action.
Before the change, the order field throw a warning about converting array to string.
