### PR TITLE
3.0 - Remove unused variable, remove unnecessary variable initialization

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1182,7 +1182,6 @@ class FormHelper extends Helper {
 	public function radio($fieldName, $options = [], $attributes = []) {
 		$attributes = $this->_initInputField($fieldName, $attributes);
 
-		$out = [];
 		$hiddenField = isset($attributes['hiddenField']) ? $attributes['hiddenField'] : true;
 		unset($attributes['hiddenField']);
 
@@ -1484,7 +1483,6 @@ class FormHelper extends Helper {
 		if (!is_string($caption) && empty($caption)) {
 			$caption = __d('cake', 'Submit');
 		}
-		$out = null;
 		$div = true;
 
 		if (isset($options['div'])) {


### PR DESCRIPTION
`$out` isn't used in `radio()`.  And, there is no reason to initialize `$out` in `submit()` since concatenation is not being applied to it, nor is it being used for any logic.
