### PR TITLE
3.0 remove deep merging from mergeVars

### DIFF
--- a/src/Utility/MergeVariablesTrait.php
+++ b/src/Utility/MergeVariablesTrait.php
@@ -80,19 +80,37 @@ trait MergeVariablesTrait {
 		}
 		foreach ($parentClasses as $class) {
 			$parentProperties = get_class_vars($class);
-			if (!isset($parentProperties[$property])) {
+			if (empty($parentProperties[$property])) {
 				continue;
 			}
 			$parentProperty = $parentProperties[$property];
-			if (empty($parentProperty) || $parentProperty === true) {
+			if (!is_array($parentProperty)) {
 				continue;
 			}
-			if ($isAssoc) {
-				$parentProperty = Hash::normalize($parentProperty);
-			}
-			$thisValue = Hash::merge($parentProperty, $thisValue);
+			$thisValue = $this->_mergePropertyData($thisValue, $parentProperty, $isAssoc);
 		}
 		$this->{$property} = $thisValue;
+	}
+
+/**
+ * Merge each of the keys in a property together.
+ *
+ * @param array $current The current merged value.
+ * @param array $parent The parent class' value.
+ * @param boolean $isAssoc Whether or not the merging should be done in associative mode.
+ * @return mixed The updated value.
+ */
+	protected function _mergePropertyData($current, $parent, $isAssoc) {
+		if (!$isAssoc) {
+			return array_merge($parent, $current);
+		}
+		$parent = Hash::normalize($parent);
+		foreach ($parent as $key => $value) {
+			if (!isset($current[$key])) {
+				$current[$key] = $value;
+			}
+		}
+		return $current;
 	}
 
 }

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -44,6 +44,15 @@ class Child extends Base {
 		'Orange'
 	];
 
+	public $nestedProperty = [
+		'Red' => [
+			'apple' => 'gala',
+		],
+		'Green' => [
+			'citrus' => 'lime'
+		],
+	];
+
 }
 
 class Grandchild extends Child {
@@ -53,6 +62,16 @@ class Grandchild extends Child {
 	public $assocProperty = [
 		'Green' => ['apple'],
 		'Yellow' => ['banana']
+	];
+
+	public $nestedProperty = [
+		'Red' => [
+			'apple' => 'mcintosh',
+			'citrus' => 'blood orange',
+		],
+		'Green' => [
+			'citrus' => 'key lime'
+		],
 	];
 }
 
@@ -76,7 +95,7 @@ class MergeVariablesTraitTest extends TestCase {
 	}
 
 /**
- * Test merging vars as an assoc list.
+ * Test merging vars as an associative list.
  *
  * @return void
  */
@@ -93,7 +112,31 @@ class MergeVariablesTraitTest extends TestCase {
 	}
 
 /**
+ * Test merging variable in associated properties that contain
+ * additional keys.
+ *
+ * @return void
+ */
+	public function testMergeVarsAsAssocWithKeyValues() {
+		$object = new Grandchild();
+		$object->mergeVars(['nestedProperty'], ['associative' => ['nestedProperty']]);
+
+		$expected = [
+			'Red' => [
+				'apple' => 'mcintosh',
+				'citrus' => 'blood orange',
+			],
+			'Green' => [
+				'citrus' => 'key lime',
+			],
+		];
+		$this->assertEquals($expected, $object->nestedProperty);
+	}
+
+/**
  * Test merging vars with mixed modes.
+ *
+ * @return void
  */
 	public function testMergeVarsMixedModes() {
 		$object = new Grandchild();

--- a/tests/TestCase/Utility/MergeVariablesTraitTest.php
+++ b/tests/TestCase/Utility/MergeVariablesTraitTest.php
@@ -66,7 +66,6 @@ class Grandchild extends Child {
 
 	public $nestedProperty = [
 		'Red' => [
-			'apple' => 'mcintosh',
 			'citrus' => 'blood orange',
 		],
 		'Green' => [
@@ -105,7 +104,7 @@ class MergeVariablesTraitTest extends TestCase {
 		$expected = [
 			'Red' => null,
 			'Orange' => null,
-			'Green' => ['lime', 'apple'],
+			'Green' => ['apple'],
 			'Yellow' => ['banana'],
 		];
 		$this->assertEquals($expected, $object->assocProperty);
@@ -123,7 +122,6 @@ class MergeVariablesTraitTest extends TestCase {
 
 		$expected = [
 			'Red' => [
-				'apple' => 'mcintosh',
 				'citrus' => 'blood orange',
 			],
 			'Green' => [
@@ -144,7 +142,7 @@ class MergeVariablesTraitTest extends TestCase {
 		$expected = [
 			'Red' => null,
 			'Orange' => null,
-			'Green' => ['lime', 'apple'],
+			'Green' => ['apple'],
 			'Yellow' => ['banana'],
 		];
 		$this->assertEquals($expected, $object->assocProperty);


### PR DESCRIPTION
As per #2914. This removes deep merging from the MergeVariablesTrait. Instead only the top level keys are merged for associative properties. 
List style properties are still simply merged.

Hopefully, this new behavior makes merged properties simpler to understand with more predictable results.
