### PR TITLE
Fix verification of expected invocations

### DIFF
--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -481,7 +481,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 		$methods = get_class_methods('Object');
 		array_push($methods, 'main', 'initdb', 'initialize', 'loadTasks', 'startup', '_secret');
-		$Shell = $this->getMock('Object', $methods, array(), 'MockWithMainNotAShell');
+		$Shell = $this->getMock('Object', $methods);
 
 		$Shell->expects($this->never())->method('initialize');
 		$Shell->expects($this->once())->method('startup');
@@ -493,7 +493,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$this->assertEquals(array(), $Dispatcher->args);
 
-		$Shell = $this->getMock('Object', $methods, array(), 'MockWithMainNotAShell');
+		$Shell = $this->getMock('Object', $methods);
 		$Shell->expects($this->once())->method('initdb')->will($this->returnValue(true));
 		$Shell->expects($this->once())->method('startup');
 		$Dispatcher->TestShell = $Shell;
@@ -512,7 +512,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$Dispatcher = new TestShellDispatcher();
 		$methods = get_class_methods('Object');
 		array_push($methods, 'main', 'initdb', 'initialize', 'loadTasks', 'startup', '_secret');
-		$Shell = $this->getMock('Object', $methods, array(&$Dispatcher), 'MockWithoutMainNotAShell');
+		$Shell = $this->getMock('Object', $methods);
 
 		$Shell->expects($this->never())->method('initialize');
 		$Shell->expects($this->once())->method('startup');
@@ -524,7 +524,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$this->assertEquals(array(), $Dispatcher->args);
 
-		$Shell = $this->getMock('Object', $methods, array(&$Dispatcher), 'MockWithoutMainNotAShell');
+		$Shell = $this->getMock('Object', $methods);
 		$Shell->expects($this->once())->method('initdb')->will($this->returnValue(true));
 		$Shell->expects($this->once())->method('startup');
 		$Dispatcher->TestShell = $Shell;

--- a/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
+++ b/lib/Cake/Test/Case/Console/ShellDispatcherTest.php
@@ -436,14 +436,14 @@ class ShellDispatcherTest extends CakeTestCase {
  */
 	public function testDispatchShellWithMain() {
 		$Dispatcher = new TestShellDispatcher();
-		$Mock = $this->getMock('Shell', array(), array(), 'MockWithMainShell');
+		$Shell = $this->getMock('Shell');
 
-		$Mock->expects($this->once())->method('initialize');
-		$Mock->expects($this->once())->method('runCommand')
+		$Shell->expects($this->once())->method('initialize');
+		$Shell->expects($this->once())->method('runCommand')
 			->with(null, array())
 			->will($this->returnValue(true));
 
-		$Dispatcher->TestShell = $Mock;
+		$Dispatcher->TestShell = $Shell;
 
 		$Dispatcher->args = array('mock_with_main');
 		$result = $Dispatcher->dispatch();
@@ -458,10 +458,7 @@ class ShellDispatcherTest extends CakeTestCase {
  */
 	public function testDispatchShellWithoutMain() {
 		$Dispatcher = new TestShellDispatcher();
-		$Shell = $this->getMock('Shell', array(), array(), 'MockWithoutMainShell');
-
-		$Shell = new MockWithoutMainShell();
-		$this->mockObjects[] = $Shell;
+		$Shell = $this->getMock('Shell');
 
 		$Shell->expects($this->once())->method('initialize');
 		$Shell->expects($this->once())->method('runCommand')
@@ -496,8 +493,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$this->assertEquals(array(), $Dispatcher->args);
 
-		$Shell = new MockWithMainNotAShell($Dispatcher);
-		$this->mockObjects[] = $Shell;
+		$Shell = $this->getMock('Object', $methods, array(), 'MockWithMainNotAShell');
 		$Shell->expects($this->once())->method('initdb')->will($this->returnValue(true));
 		$Shell->expects($this->once())->method('startup');
 		$Dispatcher->TestShell = $Shell;
@@ -528,8 +524,7 @@ class ShellDispatcherTest extends CakeTestCase {
 		$this->assertTrue($result);
 		$this->assertEquals(array(), $Dispatcher->args);
 
-		$Shell = new MockWithoutMainNotAShell($Dispatcher);
-		$this->mockObjects[] = $Shell;
+		$Shell = $this->getMock('Object', $methods, array(&$Dispatcher), 'MockWithoutMainNotAShell');
 		$Shell->expects($this->once())->method('initdb')->will($this->returnValue(true));
 		$Shell->expects($this->once())->method('startup');
 		$Dispatcher->TestShell = $Shell;

--- a/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
@@ -33,7 +33,9 @@ class AclComponentTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->MockAclImplementation = $this->getMock('AclInterface', array(), array(), 'MockAclImplementation');
+		if (!class_exists('MockAclImplementation', false)) {
+			$this->getMock('AclInterface', array(), array(), 'MockAclImplementation');
+		}
 		Configure::write('Acl.classname', 'MockAclImplementation');
 		$Collection = new ComponentCollection();
 		$this->Acl = new AclComponent($Collection);
@@ -68,10 +70,11 @@ class AclComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testAdapter() {
-		$this->MockAclImplementation->expects($this->once())->method('initialize')->with($this->Acl);
-		$this->assertNull($this->Acl->adapter($this->MockAclImplementation));
+		$Adapter = $this->getMock('AclInterface');
+		$Adapter->expects($this->once())->method('initialize')->with($this->Acl);
 
-		$this->assertEquals($this->Acl->adapter(), $this->MockAclImplementation, 'Returned object is different %s');
+		$this->assertNull($this->Acl->adapter($Adapter));
+		$this->assertEquals($this->Acl->adapter(), $Adapter, 'Returned object is different %s');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
@@ -33,9 +33,7 @@ class AclComponentTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		if (!class_exists('MockAclImplementation', false)) {
-			$this->getMock('AclInterface', array(), array(), 'MockAclImplementation');
-		}
+		$this->MockAclImplementation = $this->getMock('AclInterface', array(), array(), 'MockAclImplementation');
 		Configure::write('Acl.classname', 'MockAclImplementation');
 		$Collection = new ComponentCollection();
 		$this->Acl = new AclComponent($Collection);
@@ -70,11 +68,10 @@ class AclComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testAdapter() {
-		$implementation = new MockAclImplementation();
-		$implementation->expects($this->once())->method('initialize')->with($this->Acl);
-		$this->assertNull($this->Acl->adapter($implementation));
+		$this->MockAclImplementation->expects($this->once())->method('initialize')->with($this->Acl);
+		$this->assertNull($this->Acl->adapter($this->MockAclImplementation));
 
-		$this->assertEquals($this->Acl->adapter(), $implementation, 'Returned object is different %s');
+		$this->assertEquals($this->Acl->adapter(), $this->MockAclImplementation, 'Returned object is different %s');
 	}
 
 /**

--- a/lib/Cake/Test/Case/Model/ModelDeleteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelDeleteTest.php
@@ -443,9 +443,7 @@ class ModelDeleteTest extends BaseModelTest {
  */
 	public function testDeleteAllFailedFind() {
 		$this->loadFixtures('Article');
-		$this->getMock('Article', array('find'), array(), 'ArticleDeleteAll');
-
-		$TestModel = new ArticleDeleteAll();
+		$TestModel = $this->getMock('Article', array('find'));
 		$TestModel->expects($this->once())
 			->method('find')
 			->will($this->returnValue(null));

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -30,7 +30,7 @@ class TestAuthor extends Author {
 
 	public $hasMany = array(
 		'Post' => array(
-			'className' => 'Recipe'
+			'className' => 'TestPost'
 		)
 	);
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -24,6 +24,80 @@ App::uses('MockAssociatedTransactionDboSource', 'Model/Datasource');
 require_once dirname(__FILE__) . DS . 'ModelTestBase.php';
 
 /**
+ * Helper class for testing with mocked datasources
+ */
+class TestAuthor extends Author {
+
+	public $hasMany = array(
+		'Post' => array(
+			'className' => 'Recipe'
+		)
+	);
+
+	protected $_dataSourceObject;
+
+/**
+ * Helper method to set a datasource object
+ *
+ * @param Object $object The datasource object
+ */
+	public function setDataSourceObject($object) {
+		$this->_dataSourceObject = $object;
+	}
+
+/**
+ * Overwritten in order to return the directly set datasource object if
+ * available
+ *
+ * @return DataSource
+ */
+	public function getDataSource() {
+		if ($this->_dataSourceObject !== null) {
+			return $this->_dataSourceObject;
+		}
+		return parent::getDataSource();
+	}
+
+}
+
+/**
+ * Helper class for testing with mocked datasources
+ */
+class TestPost extends Post {
+
+	public $belongsTo = array(
+		'Author' => array(
+			'className' => 'TestAuthor'
+		)
+	);
+
+	protected $_dataSourceObject;
+
+/**
+ * Helper method to set a datasource object
+ *
+ * @param Object $object The datasource object
+ */
+	public function setDataSourceObject($object) {
+		$this->_dataSourceObject = $object;
+	}
+
+/**
+ * Overwritten in order to return the directly set datasource object if
+ * available
+ *
+ * @return DataSource
+ */
+	public function getDataSource() {
+		if ($this->_dataSourceObject !== null) {
+			return $this->_dataSourceObject;
+		}
+		return parent::getDataSource();
+	}
+
+}
+
+/**
  * ModelWriteTest
  *
  * @package       Cake.Test.Case.Model
@@ -4046,17 +4120,15 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllManyRowsTransactionNoRollback() {
 		$this->loadFixtures('Post');
 
-		$this->getMock('DboSource', array('connect', 'rollback', 'describe'), array(), 'MockTransactionDboSource');
-		$db = ConnectionManager::create('mock_transaction', array(
-			'datasource' => 'MockTransactionDboSource',
-		));
+		$db = $this->getMock('DboSource', array('begin', 'connect', 'rollback', 'describe'));
 
 		$db->expects($this->once())
 			->method('describe')
 			->will($this->returnValue(array()));
 		$db->expects($this->once())->method('rollback');
 
-		$Post = new Post('mock_transaction');
+		$Post = new TestPost();
+		$Post->setDataSourceObject($db);
 
 		$Post->validate = array(
 			'title' => array('rule' => array('notEmpty'))
@@ -4066,7 +4138,7 @@ class ModelWriteTest extends BaseModelTest {
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => '')
 		);
-		$Post->saveAll($data, array('atomic' => true));
+		$Post->saveAll($data, array('atomic' => true, 'validate' => true));
 	}
 
 /**
@@ -4077,16 +4149,7 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAllAssociatedTransactionNoRollback() {
 		$testDb = ConnectionManager::getDataSource('test');
 
-		$this->getMock(
-			'DboSource',
-			array('connect', 'rollback', 'describe', 'create', 'update', 'begin'),
-			array(),
-			'MockTransactionAssociatedDboSource'
-		);
-		$db = ConnectionManager::create('mock_transaction_assoc', array(
-			'datasource' => 'MockTransactionAssociatedDboSource',
-		));
-		$this->mockObjects[] = $db;
+		$db = $this->getMock('DboSource', array('connect', 'rollback', 'describe', 'create', 'update', 'begin'));
 		$db->columns = $testDb->columns;
 
 		$db->expects($this->once())->method('rollback');
@@ -4098,9 +4161,9 @@ class ModelWriteTest extends BaseModelTest {
 				'published' => array('type' => 'string')
 			)));
 
-		$Post = new Post();
-		$Post->useDbConfig = 'mock_transaction_assoc';
-		$Post->Author->useDbConfig = 'mock_transaction_assoc';
+		$Post = new TestPost();
+		$Post->setDataSourceObject($db);
+		$Post->Author->setDataSourceObject($db);
 
 		$Post->Author->validate = array(
 			'user' => array('rule' => array('notEmpty'))
@@ -5490,17 +5553,15 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveManyTransactionNoRollback() {
 		$this->loadFixtures('Post');
 
-		$this->getMock('DboSource', array('connect', 'rollback', 'describe'), array(), 'MockManyTransactionDboSource');
-		$db = ConnectionManager::create('mock_many_transaction', array(
-			'datasource' => 'MockManyTransactionDboSource',
-		));
+		$db = $this->getMock('DboSource', array('begin', 'connect', 'rollback', 'describe'));
 
 		$db->expects($this->once())
 			->method('describe')
 			->will($this->returnValue(array()));
 		$db->expects($this->once())->method('rollback');
 
-		$Post = new Post('mock_many_transaction');
+		$Post = new TestPost();
+		$Post->setDataSourceObject($db);
 
 		$Post->validate = array(
 			'title' => array('rule' => array('notEmpty'))
@@ -5510,7 +5571,7 @@ class ModelWriteTest extends BaseModelTest {
 			array('author_id' => 1, 'title' => 'New Fourth Post'),
 			array('author_id' => 1, 'title' => '')
 		);
-		$Post->saveMany($data);
+		$Post->saveMany($data, array('validate' => true));
 	}
 
 /**
@@ -5521,17 +5582,7 @@ class ModelWriteTest extends BaseModelTest {
 	public function testSaveAssociatedTransactionNoRollback() {
 		$testDb = ConnectionManager::getDataSource('test');
 
-		$this->getMock(
-			'DboSource',
-			array('connect', 'rollback', 'describe', 'create', 'begin'),
-			array(),
-			'MockAssociatedTransactionDboSource',
-			false
-		);
-		$db = ConnectionManager::create('mock_assoc_transaction', array(
-			'datasource' => 'MockAssociatedTransactionDboSource',
-		));
-		$this->mockObjects[] = $db;
+		$db = $this->getMock('DboSource', array('connect', 'rollback', 'describe', 'create', 'begin'));
 		$db->columns = $testDb->columns;
 
 		$db->expects($this->once())->method('rollback');
@@ -5543,9 +5594,9 @@ class ModelWriteTest extends BaseModelTest {
 				'published' => array('type' => 'string')
 			)));
 
-		$Post = new Post();
-		$Post->useDbConfig = 'mock_assoc_transaction';
-		$Post->Author->useDbConfig = 'mock_assoc_transaction';
+		$Post = new TestPost();
+		$Post->setDataSourceObject($db);
+		$Post->Author->setDataSourceObject($db);
 
 		$Post->Author->validate = array(
 			'user' => array('rule' => array('notEmpty'))

--- a/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/DebugTransportTest.php
@@ -42,8 +42,7 @@ class DebugTransportTest extends CakeTestCase {
  * @return void
  */
 	public function testSend() {
-		$this->getMock('CakeEmail', array('message'), array(), 'DebugCakeEmail');
-		$email = new DebugCakeEmail();
+		$email = $this->getMock('CakeEmail', array('message'), array(), 'DebugCakeEmail');
 		$email->from('noreply@cakephp.org', 'CakePHP Test');
 		$email->to('cake@cakephp.org', 'CakePHP');
 		$email->cc(array('mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso'));
@@ -52,7 +51,7 @@ class DebugTransportTest extends CakeTestCase {
 		$email->subject('Testing Message');
 		$date = date(DATE_RFC2822);
 		$email->setHeaders(array('X-Mailer' => DebugCakeEmail::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
+		$email->expects($this->once())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
 
 		$headers = "From: CakePHP Test <noreply@cakephp.org>\r\n";
 		$headers .= "To: CakePHP <cake@cakephp.org>\r\n";

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -229,7 +229,7 @@ class SmtpTransportTest extends CakeTestCase {
  * @return void
  */
 	public function testAuthNoAuth() {
-		$this->socket->expects($this->any())->method('write')->with(new PHPUnit_Framework_Constraint_Not("AUTH LOGIN\r\n"));
+		$this->socket->expects($this->any())->method('write')->with($this->logicalNot($this->stringContains('AUTH LOGIN')));
 
 		$this->SmtpTransport->config(array('username' => null, 'password' => null));
 		$this->SmtpTransport->auth();

--- a/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
+++ b/lib/Cake/Test/Case/Network/Email/SmtpTransportTest.php
@@ -81,10 +81,7 @@ class SmtpTransportTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		if (!class_exists('MockSocket')) {
-			$this->getMock('CakeSocket', array('read', 'write', 'connect', 'enableCrypto'), array(), 'MockSocket');
-		}
-		$this->socket = new MockSocket();
+		$this->socket = $this->getMock('CakeSocket', array('read', 'write', 'connect', 'enableCrypto'));
 
 		$this->SmtpTransport = new SmtpTestTransport();
 		$this->SmtpTransport->setSocket($this->socket);
@@ -122,7 +119,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(5))->method('write')->with("STARTTLS\r\n");
 		$this->socket->expects($this->at(6))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(7))->method('read')->will($this->returnValue("220 Server ready\r\n"));
-		$this->socket->expects($this->at(8))->method('other')->with('tls')->will($this->returnValue(true));
+		$this->socket->expects($this->at(8))->method('enableCrypto')->with('tls')->will($this->returnValue(true));
 		$this->socket->expects($this->at(9))->method('write')->with("EHLO localhost\r\n");
 		$this->socket->expects($this->at(10))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(11))->method('read')->will($this->returnValue("250 Accepted\r\n"));
@@ -163,7 +160,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$this->socket->expects($this->at(2))->method('write')->with("EHLO localhost\r\n");
 		$this->socket->expects($this->at(3))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(4))->method('read')->will($this->returnValue("250 Accepted\r\n"));
-		$this->socket->expects($this->at(5))->method('read')->with("AUTH LOGIN\r\n");
+		$this->socket->expects($this->at(5))->method('write')->with("AUTH LOGIN\r\n");
 		$this->socket->expects($this->at(6))->method('read')->will($this->returnValue(false));
 		$this->socket->expects($this->at(7))->method('read')->will($this->returnValue("504 5.7.4 Unrecognized authentication type\r\n"));
 		$this->SmtpTransport->connect();
@@ -232,7 +229,8 @@ class SmtpTransportTest extends CakeTestCase {
  * @return void
  */
 	public function testAuthNoAuth() {
-		$this->socket->expects($this->never())->method('write')->with("AUTH LOGIN\r\n");
+		$this->socket->expects($this->any())->method('write')->with(new PHPUnit_Framework_Constraint_Not("AUTH LOGIN\r\n"));
+
 		$this->SmtpTransport->config(array('username' => null, 'password' => null));
 		$this->SmtpTransport->auth();
 	}
@@ -297,8 +295,7 @@ class SmtpTransportTest extends CakeTestCase {
  * @return void
  */
 	public function testSendData() {
-		$this->getMock('CakeEmail', array('message'), array(), 'SmtpCakeEmail');
-		$email = new SmtpCakeEmail();
+		$email = $this->getMock('CakeEmail', array('message'), array(), 'SmtpCakeEmail');
 		$email->from('noreply@cakephp.org', 'CakePHP Test');
 		$email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
 		$email->to('cake@cakephp.org', 'CakePHP');
@@ -308,7 +305,7 @@ class SmtpTransportTest extends CakeTestCase {
 		$email->subject('Testing SMTP');
 		$date = date(DATE_RFC2822);
 		$email->setHeaders(array('X-Mailer' => SmtpCakeEmail::EMAIL_CLIENT, 'Date' => $date));
-		$email->expects($this->any())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
+		$email->expects($this->once())->method('message')->will($this->returnValue(array('First Line', 'Second Line', '.Third Line', '')));
 
 		$data = "From: CakePHP Test <noreply@cakephp.org>\r\n";
 		$data .= "To: CakePHP <cake@cakephp.org>\r\n";

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -192,13 +192,8 @@ class HttpSocketTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		if (!class_exists('MockHttpSocket')) {
-			$this->getMock('TestHttpSocket', array('read', 'write', 'connect'), array(), 'MockHttpSocket');
-			$this->getMock('TestHttpSocket', array('read', 'write', 'connect', 'request'), array(), 'MockHttpSocketRequests');
-		}
-
-		$this->Socket = new MockHttpSocket();
-		$this->RequestSocket = new MockHttpSocketRequests();
+		$this->Socket = $this->getMock('TestHttpSocket', array('read', 'write', 'connect'));
+		$this->RequestSocket = $this->getMock('TestHttpSocket', array('read', 'write', 'connect', 'request'));
 	}
 
 /**
@@ -635,12 +630,12 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->reset();
 		$request = array('uri' => 'htpp://www.cakephp.org/');
 		$number = mt_rand(0, 9999999);
-		$this->Socket->expects($this->once())->method('connect')->will($this->returnValue(true));
+		$this->Socket->expects($this->any())->method('connect')->will($this->returnValue(true));
 		$serverResponse = "HTTP/1.x 200 OK\r\nDate: Mon, 16 Apr 2007 04:14:16 GMT\r\nServer: CakeHttp Server\r\nContent-Type: text/html\r\n\r\n<h1>Hello, your lucky number is " . $number . "</h1>";
+		$this->Socket->expects($this->at(0))->method('write')
+			->with("GET / HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n");
 		$this->Socket->expects($this->at(0))->method('read')->will($this->returnValue(false));
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
-		$this->Socket->expects($this->once())->method('write')
-			->with("GET / HTTP/1.1\r\nHost: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\n\r\n");
 		$response = (string)$this->Socket->request($request);
 		$this->assertEquals($response, "<h1>Hello, your lucky number is " . $number . "</h1>");
 	}
@@ -684,7 +679,7 @@ class HttpSocketTest extends CakeTestCase {
 				)
 			)
 		);
-		$http = new MockHttpSocketRequests($request);
+		$http = $this->getMock('TestHttpSocket', array('read', 'write', 'connect', 'request'), array($request));
 
 		$expected = array('method' => 'GET', 'uri' => '/_test');
 		$http->expects($this->at(0))->method('request')->with($expected);
@@ -1056,20 +1051,19 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testAuth() {
-		$socket = new MockHttpSocket();
-		$socket->get('http://mark:secret@example.com/test');
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
+		$this->Socket->get('http://mark:secret@example.com/test');
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
-		$socket->configAuth(false);
-		$socket->get('http://example.com/test');
-		$this->assertFalse(strpos($socket->request['header'], 'Authorization:'));
+		$this->Socket->configAuth(false);
+		$this->Socket->get('http://example.com/test');
+		$this->assertFalse(strpos($this->Socket->request['header'], 'Authorization:'));
 
-		$socket->configAuth('Test', 'mark', 'passwd');
-		$socket->get('http://example.com/test');
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Test mark.passwd') !== false);
+		$this->Socket->configAuth('Test', 'mark', 'passwd');
+		$this->Socket->get('http://example.com/test');
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Test mark.passwd') !== false);
 
-		$socket->configAuth(false);
-		$socket->request(array(
+		$this->Socket->configAuth(false);
+		$this->Socket->request(array(
 			'method' => 'GET',
 			'uri' => 'http://example.com/test',
 			'auth' => array(
@@ -1078,8 +1072,8 @@ class HttpSocketTest extends CakeTestCase {
 				'pass' => 'hunter2'
 			)
 		));
-		$this->assertEquals($socket->request['auth'], array('Basic' => array('user' => 'joel', 'pass' => 'hunter2')));
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic am9lbDpodW50ZXIy') !== false);
+		$this->assertEquals($this->Socket->request['auth'], array('Basic' => array('user' => 'joel', 'pass' => 'hunter2')));
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic am9lbDpodW50ZXIy') !== false);
 	}
 
 /**
@@ -1088,17 +1082,16 @@ class HttpSocketTest extends CakeTestCase {
  * @return void
  */
 	public function testConsecutiveGetResetsAuthCredentials() {
-		$socket = new MockHttpSocket();
-		$socket->get('http://mark:secret@example.com/test');
-		$this->assertEquals('mark', $socket->request['uri']['user']);
-		$this->assertEquals('secret', $socket->request['uri']['pass']);
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
+		$this->Socket->get('http://mark:secret@example.com/test');
+		$this->assertEquals('mark', $this->Socket->request['uri']['user']);
+		$this->assertEquals('secret', $this->Socket->request['uri']['pass']);
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
-		$socket->get('/test2');
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
+		$this->Socket->get('/test2');
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 
-		$socket->get('/test3');
-		$this->assertTrue(strpos($socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
+		$this->Socket->get('/test3');
+		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic bWFyazpzZWNyZXQ=') !== false);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
+++ b/lib/Cake/Test/Case/Utility/ObjectCollectionTest.php
@@ -96,6 +96,27 @@ class GenericObjectCollection extends ObjectCollection {
 		return $this->_loaded[$name];
 	}
 
+/**
+ * Helper method for adding/overwriting enabled objects including
+ * settings
+ *
+ * @param string $name Name of the object
+ * @param Object $object The object to use
+ * @param array $settings Settings to apply for the object
+ * @return array Loaded objects
+ */
+	public function setObject($name, $object, $settings = array()) {
+		$this->_loaded[$name] = $object;
+		if (isset($settings['priority'])) {
+			$this->setPriority($name, $settings['priority']);
+		}
+		$enable = isset($settings['enabled']) ? $settings['enabled'] : true;
+		if ($enable === true) {
+			$this->enable($name);
+		}
+		return $this->_loaded;
+	}
+
 }
 
 class ObjectCollectionTest extends CakeTestCase {
@@ -188,15 +209,9 @@ class ObjectCollectionTest extends CakeTestCase {
  * @return void
  */
 	protected function _makeMockClasses() {
-		if (!class_exists('TriggerMockFirstGenericObject')) {
-			$this->getMock('FirstGenericObject', array(), array(), 'TriggerMockFirstGenericObject', false);
-		}
-		if (!class_exists('TriggerMockSecondGenericObject')) {
-			$this->getMock('SecondGenericObject', array(), array(), 'TriggerMockSecondGenericObject', false);
-		}
-		if (!class_exists('TriggerMockThirdGenericObject')) {
-			$this->getMock('ThirdGenericObject', array(), array(), 'TriggerMockThirdGenericObject', false);
-		}
+		$this->FirstGenericObject = $this->getMock('FirstGenericObject', array(), array(), '', false);
+		$this->SecondGenericObject = $this->getMock('SecondGenericObject', array(), array(), '', false);
+		$this->ThirdGenericObject = $this->getMock('ThirdGenericObject', array(), array(), '', false);
 	}
 
 /**
@@ -206,11 +221,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTrigger() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -229,11 +241,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerWithDisabledObjects() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject, array('enabled' => false));
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -241,8 +250,6 @@ class ObjectCollectionTest extends CakeTestCase {
 		$this->Objects->TriggerMockSecond->expects($this->never())
 			->method('callback')
 			->will($this->returnValue(true));
-
-		$this->Objects->disable('TriggerMockSecond');
 
 		$this->assertTrue($this->Objects->trigger('callback', array()));
 	}
@@ -254,11 +261,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerWithCollectReturn() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -282,11 +286,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerWithBreak() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -309,11 +310,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerWithModParams() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -341,11 +339,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerModParamsInvalidIndex() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->never())
 			->method('callback');
@@ -367,11 +362,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerModParamsNullIgnored() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$this->Objects->TriggerMockFirst->expects($this->once())
 			->method('callback')
@@ -398,11 +390,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testTriggerPriority() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond', array('priority' => 5));
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject, array('priority' => 5));
 
 		$this->Objects->TriggerMockFirst->expects($this->any())
 			->method('callback')
@@ -418,8 +407,7 @@ class ObjectCollectionTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 
-		$this->Objects->load('TriggerMockThird', array('priority' => 7));
-		$this->mockObjects[] = $this->Objects->TriggerMockThird;
+		$this->Objects->setObject('TriggerMockThird', $this->ThirdGenericObject, array('priority' => 7));
 		$this->Objects->TriggerMockThird->expects($this->any())
 			->method('callback')
 			->will($this->returnValue('3rd'));
@@ -542,11 +530,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testDispatchEventWithSubject() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$subjectClass = new Object();
 		$this->Objects->TriggerMockFirst->expects($this->once())
@@ -570,11 +555,8 @@ class ObjectCollectionTest extends CakeTestCase {
  */
 	public function testDispatchEventNoSubject() {
 		$this->_makeMockClasses();
-		$this->Objects->load('TriggerMockFirst');
-		$this->Objects->load('TriggerMockSecond');
-
-		$this->mockObjects[] = $this->Objects->TriggerMockFirst;
-		$this->mockObjects[] = $this->Objects->TriggerMockSecond;
+		$this->Objects->setObject('TriggerMockFirst', $this->FirstGenericObject);
+		$this->Objects->setObject('TriggerMockSecond', $this->SecondGenericObject);
 
 		$subjectClass = new Object();
 		$this->Objects->TriggerMockFirst->expects($this->once())

--- a/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/JsHelperTest.php
@@ -174,13 +174,8 @@ class JsHelperTest extends CakeTestCase {
 	protected function _useMock() {
 		$request = new CakeRequest(null, false);
 
-		if (!class_exists('TestJsEngineHelper', false)) {
-			$this->getMock('JsBaseEngineHelper', array(), array($this->View), 'TestJsEngineHelper');
-		}
-
 		$this->Js = new JsHelper($this->View, array('TestJs'));
-		$this->Js->TestJsEngine = new TestJsEngineHelper($this->View);
-		$this->mockObjects[] = $this->Js->TestJsEngine;
+		$this->Js->TestJsEngine = $this->getMock('JsBaseEngineHelper', array(), array($this->View));
 		$this->Js->request = $request;
 		$this->Js->Html = new HtmlHelper($this->View);
 		$this->Js->Html->request = $request;
@@ -369,7 +364,7 @@ class JsHelperTest extends CakeTestCase {
 
 		Configure::write('Cache.disable', false);
 		$this->Js->request->webroot = '/';
-		$this->Js->JsBaseEngine = new TestJsEngineHelper($this->View);
+		$this->Js->JsBaseEngine = $this->getMock('JsBaseEngineHelper', array(), array($this->View));
 		$this->Js->buffer('one = 1;');
 		$this->Js->buffer('two = 2;');
 		$result = $this->Js->writeBuffer(array('onDomReady' => false, 'cache' => true));

--- a/lib/Cake/Test/Case/View/ViewTest.php
+++ b/lib/Cake/Test/Case/View/ViewTest.php
@@ -708,15 +708,17 @@ class ViewTest extends CakeTestCase {
  * Test that elements can have callbacks
  */
 	public function testElementCallbacks() {
-		$this->getMock('Helper', array(), array($this->View), 'ElementCallbackMockHtmlHelper');
+		$Helper = $this->getMock('Helper', array(), array($this->View), 'ElementCallbackMockHtmlHelper');
 		$this->View->helpers = array('ElementCallbackMockHtml');
 		$this->View->loadHelpers();
+
+		$this->View->Helpers->set('ElementCallbackMockHtml', $Helper);
+		$this->View->ElementCallbackMockHtml = $Helper;
 
 		$this->View->ElementCallbackMockHtml->expects($this->at(0))->method('beforeRender');
 		$this->View->ElementCallbackMockHtml->expects($this->at(1))->method('afterRender');
 
 		$this->View->element('test_element', array(), array('callbacks' => true));
-		$this->mockObjects[] = $this->View->ElementCallbackMockHtml;
 	}
 
 /**


### PR DESCRIPTION
With a few exceptions outlined underneath, I've fixed everything that I found so far by searching for `new .*?Mock.*?` and `getMock\(\s*.*?,\s*array\(.*?\),\s*array\(.*?\),\s*('|").+?('|")` (this should find all usages of `getMock` where a classname is passed), I then made my way through the affected test files to see if there's anything that the search didn't revealed, however I'm not 100% sure if I catched everything.

Additionally to fixing the tests that failed after switching to non-manual instantiated mocks, I've also changed some of the `expects` defintions, mostly occourences of `any` where I could tell that testing for `once` or similar should be fine. Also I've removed the classname parameter from some of the `getMock()` calls in case the classnames weren't used anywhere.

Some usages of implicitly instantiated mock objects have been left unchanged because it seems to be working fine, mostly since the tests do not rely on the "after test validation", but for example on the mocked method result values or similar, see for example `AclComponentTest::setUp()`, `AuthComponentTest::testLogin()` or `RouterTest::testUsingCustomRouteClass()`. I'm unsure whether they should be changed too.

Last but not least I'm a little unsure about the fix for `HttpSocketTest::testRequest2()`. The problem is the mocked `connect` method never being invoked [as mentioned](https://github.com/cakephp/cakephp/issues/2919#issuecomment-36413279) in #2919, I've changed it from `once` to `any` for now, but that's not optimal.
