### PR TITLE
3.0 datetime marshall

### DIFF
--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -37,7 +37,6 @@ class Type {
 		'date' => 'Cake\Database\Type\DateType',
 		'datetime' => 'Cake\Database\Type\DateTimeType',
 		'timestamp' => 'Cake\Database\Type\DateTimeType',
-		'time' => 'Cake\Database\Type\TimeType',
 		'uuid' => 'Cake\Database\Type\UuidType',
 	];
 

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -238,4 +238,17 @@ class Type {
 		return null;
 	}
 
+/**
+ * Marshalls flat data into PHP objects.
+ *
+ * Most useful for converting request data into PHP objects
+ * that make sense for the rest of the ORM/Database layers.
+ *
+ * @param mixed $value The value to convert.
+ * @return mixed Converted value.
+ */
+	public function marshall($value) {
+		return $value;
+	}
+
 }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -55,4 +55,42 @@ class DateTimeType extends \Cake\Database\Type {
 		return $value;
 	}
 
+/**
+ * Convert request data into a datetime object.
+ *
+ * @param mixed $value Request data
+ * @return \DateTime
+ */
+	public function marshall($value) {
+		try {
+			if ($value === '' || $value === null || $value === false || $value === true) {
+				return $value;
+			} elseif (is_numeric($value)) {
+				$date = new DateTime('@' . $value);
+			} elseif (is_string($value)) {
+				$date = new DateTime($value);
+			}
+			if (isset($date)) {
+				return $date;
+			}
+		} catch (\Exception $e) {
+			return $value;
+		}
+
+		$value += ['second' => 0];
+
+		$date = new DateTime();
+		$date->setTime(0, 0, 0);
+		if (isset($value['year'], $value['month'], $value['day'])) {
+			$date->setDate($value['year'], $value['month'], $value['day']);
+		}
+		if (isset($value['hour'], $value['minute'])) {
+			if (isset($value['meridian'])) {
+				$value['hour'] = strtolower($value['meridian']) === 'am' ? $value['hour'] : $value['hour'] + 12;
+			}
+			$date->setTime($value['hour'], $value['minute'], $value['second']);
+		}
+		return $date;
+	}
+
 }

--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -81,14 +81,17 @@ class DateTimeType extends \Cake\Database\Type {
 
 		$date = new DateTime();
 		$date->setTime(0, 0, 0);
-		if (isset($value['year'], $value['month'], $value['day'])) {
+		if (
+			isset($value['year'], $value['month'], $value['day']) &&
+			(is_numeric($value['year']) & is_numeric($value['month']) && is_numeric($value['day']))
+		) {
 			$date->setDate($value['year'], $value['month'], $value['day']);
 		}
 		if (isset($value['hour'], $value['minute'])) {
 			if (isset($value['meridian'])) {
 				$value['hour'] = strtolower($value['meridian']) === 'am' ? $value['hour'] : $value['hour'] + 12;
 			}
-			$date->setTime($value['hour'], $value['minute'], $value['second']);
+			$date->setTime((int)$value['hour'], (int)$value['minute'], (int)$value['second']);
 		}
 		return $date;
 	}

--- a/src/Database/Type/DateType.php
+++ b/src/Database/Type/DateType.php
@@ -49,5 +49,38 @@ class DateType extends \Cake\Database\Type {
 		return DateTime::createFromFormat('Y-m-d', $value);
 	}
 
-}
+/**
+ * Convert request data into a datetime object.
+ *
+ * @param mixed $value Request data
+ * @return \DateTime
+ */
+	public function marshall($value) {
+		try {
+			if ($value === '' || $value === null || $value === false || $value === true) {
+				return $value;
+			} elseif (is_numeric($value)) {
+				$date = new DateTime('@' . $value);
+			} elseif (is_string($value)) {
+				$date = new DateTime($value);
+			}
+			if (isset($date)) {
+				$date->setTime(0, 0, 0);
+				return $date;
+			}
+		} catch (\Exception $e) {
+			return $value;
+		}
 
+		$date = new DateTime();
+		if (
+			isset($value['year'], $value['month'], $value['day']) &&
+			(is_numeric($value['year']) & is_numeric($value['month']) && is_numeric($value['day']))
+		) {
+			$date->setDate($value['year'], $value['month'], $value['day']);
+		}
+		$date->setTime(0, 0, 0);
+		return $date;
+	}
+
+}

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -15,6 +15,7 @@
 namespace Cake\ORM;
 
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\Type;
 use Cake\ORM\Association;
 use Cake\ORM\Table;
 
@@ -89,6 +90,7 @@ class Marshaller {
 	public function one(array $data, $include = []) {
 		$propertyMap = $this->_buildPropertyMap($include);
 
+		$schema = $this->_table->schema();
 		$tableName = $this->_table->alias();
 		$entityClass = $this->_table->entityClass();
 		$entity = new $entityClass();
@@ -99,10 +101,14 @@ class Marshaller {
 
 		$properties = [];
 		foreach ($data as $key => $value) {
+			$columnType = $schema->columnType($key);
 			if (isset($propertyMap[$key])) {
 				$assoc = $propertyMap[$key]['association'];
 				$nested = $propertyMap[$key]['nested'];
 				$value = $this->_marshalAssociation($assoc, $value, $nested);
+			} elseif ($columnType) {
+				$converter = Type::build($columnType);
+				$value = $converter->marshall($value);
 			}
 			$properties[$key] = $value;
 		}

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -74,7 +74,7 @@ class DateTimeTypeTest extends TestCase {
  *
  * @return array
  */
-	public static function marshallProvider() {
+	public function marshallProvider() {
 		return [
 			// invalid types.
 			[null, null],

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -69,4 +69,60 @@ class DateTimeTypeTest extends TestCase {
 		$this->assertEquals('2013-08-12 15:16:17', $result);
 	}
 
+/**
+ * Data provider for marshall()
+ *
+ * @return array
+ */
+	public static function marshallProvider() {
+		return [
+			// invalid types.
+			[null, null],
+			[false, false],
+			[true, true],
+			['', ''],
+			['derpy', 'derpy'],
+			['2013-nope!', '2013-nope!'],
+
+			// valid string types
+			['1392387900', new \DateTime('@1392387900')],
+			[1392387900, new \DateTime('@1392387900')],
+			['2014-02-14', new \DateTime('2014-02-14')],
+			['2014-02-14 13:14:15', new \DateTime('2014-02-14 13:14:15')],
+
+			// valid array types
+			[
+				['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15],
+				new \DateTime('2014-02-14 13:14:15')
+			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+					'hour' => 1, 'minute' => 14, 'second' => 15,
+					'meridian' => 'am'
+				],
+				new \DateTime('2014-02-14 01:14:15')
+			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+					'hour' => 1, 'minute' => 14, 'second' => 15,
+					'meridian' => 'pm'
+				],
+				new \DateTime('2014-02-14 13:14:15')
+			],
+		];
+	}
+
+/**
+ * test marshalling data.
+ *
+ * @dataProvider marshallProvider
+ * @return void
+ */
+	public function testMarshall($value, $expected) {
+		$result = $this->type->marshall($value);
+		$this->assertEquals($expected, $result);
+	}
+
 }

--- a/tests/TestCase/Database/Type/DateTimeTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTimeTypeTest.php
@@ -111,6 +111,29 @@ class DateTimeTypeTest extends TestCase {
 				],
 				new \DateTime('2014-02-14 13:14:15')
 			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+
+			// Invalid array types
+			[
+				['year' => 'farts', 'month' => 'derp'],
+				new \DateTime(date('Y-m-d 00:00:00'))
+			],
+			[
+				['year' => 'farts', 'month' => 'derp', 'day' => 'farts'],
+				new \DateTime(date('Y-m-d 00:00:00'))
+			],
+			[
+				[
+					'year' => '2014', 'month' => '02', 'day' => '14',
+					'hour' => 'farts', 'minute' => 'farts'
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
 		];
 	}
 

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -73,4 +73,86 @@ class DateTypeTest extends TestCase {
 		$this->assertEquals('2013-08-12', $result);
 	}
 
+/**
+ * Data provider for marshall()
+ *
+ * @return array
+ */
+	public static function marshallProvider() {
+		$date = new \DateTime('@1392387900');
+		$date->setTime(0, 0, 0);
+
+		return [
+			// invalid types.
+			[null, null],
+			[false, false],
+			[true, true],
+			['', ''],
+			['derpy', 'derpy'],
+			['2013-nope!', '2013-nope!'],
+
+			// valid string types
+			['1392387900', $date],
+			[1392387900, $date],
+			['2014-02-14', new \DateTime('2014-02-14')],
+			['2014-02-14 13:14:15', new \DateTime('2014-02-14 00:00:00')],
+
+			// valid array types
+			[
+				['year' => 2014, 'month' => 2, 'day' => 14, 'hour' => 13, 'minute' => 14, 'second' => 15],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+					'hour' => 1, 'minute' => 14, 'second' => 15,
+					'meridian' => 'am'
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+					'hour' => 1, 'minute' => 14, 'second' => 15,
+					'meridian' => 'pm'
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+			[
+				[
+					'year' => 2014, 'month' => 2, 'day' => 14,
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+
+			// Invalid array types
+			[
+				['year' => 'farts', 'month' => 'derp'],
+				new \DateTime(date('Y-m-d 00:00:00'))
+			],
+			[
+				['year' => 'farts', 'month' => 'derp', 'day' => 'farts'],
+				new \DateTime(date('Y-m-d 00:00:00'))
+			],
+			[
+				[
+					'year' => '2014', 'month' => '02', 'day' => '14',
+					'hour' => 'farts', 'minute' => 'farts'
+				],
+				new \DateTime('2014-02-14 00:00:00')
+			],
+		];
+	}
+
+/**
+ * test marshalling data.
+ *
+ * @dataProvider marshallProvider
+ * @return void
+ */
+	public function testMarshall($value, $expected) {
+		$result = $this->type->marshall($value);
+		$this->assertEquals($expected, $result);
+	}
+
 }

--- a/tests/TestCase/Database/Type/DateTypeTest.php
+++ b/tests/TestCase/Database/Type/DateTypeTest.php
@@ -78,7 +78,7 @@ class DateTypeTest extends TestCase {
  *
  * @return array
  */
-	public static function marshallProvider() {
+	public function marshallProvider() {
 		$date = new \DateTime('@1392387900');
 		$date->setTime(0, 0, 0);
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -48,7 +48,7 @@ class ProtectedArticle extends Entity {
  */
 class MarshallerTest extends TestCase {
 
-	public $fixtures = ['core.tag', 'core.article', 'core.user', 'core.comment'];
+	public $fixtures = ['core.tag', 'core.articles_tag', 'core.article', 'core.user', 'core.comment'];
 
 /**
  * setup
@@ -110,6 +110,55 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data, $result->toArray());
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
 		$this->assertNull($result->isNew(), 'Should be detached');
+	}
+
+/**
+ * Test marshalling datetime/date field.
+ *
+ * @return void
+ */
+	public function testOneWithDatetimeField() {
+		$data = [
+			'comment' => 'My Comment text',
+			'created' => [
+				'year' => '2014',
+				'month' => '2',
+				'day' => 14
+			]
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->one($data, []);
+
+		$this->assertEquals(new \DateTime('2014-02-14 00:00:00'), $result->created);
+
+		$data['created'] = [
+			'year' => '2014',
+			'month' => '2',
+			'day' => 14,
+			'hour' => 9,
+			'minute' => 25,
+			'meridian' => 'pm'
+		];
+		$result = $marshall->one($data, []);
+		$this->assertEquals(new \DateTime('2014-02-14 21:25:00'), $result->created);
+
+		$data['created'] = [
+			'year' => '2014',
+			'month' => '2',
+			'day' => 14,
+			'hour' => 9,
+			'minute' => 25,
+		];
+		$result = $marshall->one($data, []);
+		$this->assertEquals(new \DateTime('2014-02-14 09:25:00'), $result->created);
+
+		$data['created'] = '2014-02-14 09:25:00';
+		$result = $marshall->one($data, []);
+		$this->assertEquals(new \DateTime('2014-02-14 09:25:00'), $result->created);
+
+		$data['created'] = 1392387900;
+		$result = $marshall->one($data, []);
+		$this->assertEquals($data['created'], $result->created->getTimestamp());
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3117,6 +3117,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = $this->getMock('\Cake\ORM\Table', ['entityValidator']);
 		$table->belongsTo('users');
 		$table->hasMany('articles');
+		$table->schema([]);
+
 		$entityValidator = $this->getMock('\Cake\ORM\EntityValidator', [], [$table]);
 		$entity = $table->newEntity([]);
 
@@ -3136,6 +3138,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testValidateWithCustomOptions() {
 		$table = $this->getMock('\Cake\ORM\Table', ['entityValidator']);
+		$table->schema([]);
+
 		$entityValidator = $this->getMock('\Cake\ORM\EntityValidator', [], [$table]);
 		$entity = $table->newEntity([]);
 		$options = ['associated' => ['users'], 'validate' => 'foo'];
@@ -3158,6 +3162,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = $this->getMock('\Cake\ORM\Table', ['entityValidator']);
 		$table->belongsTo('users');
 		$table->hasMany('articles');
+		$table->schema([]);
+
 		$entityValidator = $this->getMock('\Cake\ORM\EntityValidator', [], [$table]);
 		$entities = ['a', 'b'];
 
@@ -3177,6 +3183,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testValidateManyWithCustomOptions() {
 		$table = $this->getMock('\Cake\ORM\Table', ['entityValidator']);
+		$table->schema([]);
+
 		$entityValidator = $this->getMock('\Cake\ORM\EntityValidator', [], [$table]);
 		$entities = ['a', 'b', 'c'];
 		$options = ['associated' => ['users'], 'validate' => 'foo'];


### PR DESCRIPTION
Implements the changes required for #2643.  I thought that marshalling from request to PHP equivalents is very similar to the other type conversions done in the `Database\Type` system. I've integrated it into the marshaller, and each type class can implement custom marshalling functions.
