### PR TITLE
3.0 marshaller merge

### DIFF
--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -169,4 +169,43 @@ interface RepositoryInterface {
  */
 	public function newEntities(array $data, $associations = null);
 
+/**
+ * Merges the passed `$data` into `$entity` respecting the accessible
+ * fields as configured for it. Returns the same entity after being
+ * altered.
+ *
+ * This is most useful when editing an existing entity using request data:
+ *
+ * {{{
+ * $article = $this->Articles->patchEntity($article, $this->request->data());
+ * }}}
+ *
+ * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
+ * data merged in
+ * @param array $data key value list of fields to be merged into the entity
+ * @param array $include The list of associations to be merged
+ * @return \Cake\Datasource\EntityInterface
+ */
+	public function  patchEntity(EntityInterface $entity, array $data, $associations = null);
+
+/**
+ * Merges the each for the elements passed in `$data` into each of the entities
+ * found in `$entities` respecting the accessible fields as configured for it.
+ * Merging is done by matching the primary key in each of the elements in `$data`
+ * and `$entities`.
+ *
+ * This is most useful when editing a list of existing entities using request data:
+ *
+ * {{{
+ * $article = $this->Articles->patchEntities($articles, $this->request->data());
+ * }}}
+ *
+ * @param array|\Traversable $entities the entities that will get the
+ * data merged in
+ * @param array $data list of arrays to be merged into the entities
+ * @param array $include The list of associations to be merged
+ * @return array
+ */
+	public function  patchEntities($entities, array $data, $associations = null);
+
 }

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -171,7 +171,7 @@ interface RepositoryInterface {
 
 /**
  * Merges the passed `$data` into `$entity` respecting the accessible
- * fields as configured for it. Returns the same entity after being
+ * fields configured on the entity. Returns the same entity after being
  * altered.
  *
  * This is most useful when editing an existing entity using request data:
@@ -189,8 +189,8 @@ interface RepositoryInterface {
 	public function  patchEntity(EntityInterface $entity, array $data, $associations = null);
 
 /**
- * Merges the each for the elements passed in `$data` into each of the entities
- * found in `$entities` respecting the accessible fields as configured for it.
+ * Merges each of the elements passed in `$data` into the entities
+ * found in `$entities` respecting the accessible fields configured on the entities.
  * Merging is done by matching the primary key in each of the elements in `$data`
  * and `$entities`.
  *

--- a/src/Datasource/RepositoryInterface.php
+++ b/src/Datasource/RepositoryInterface.php
@@ -186,7 +186,7 @@ interface RepositoryInterface {
  * @param array $include The list of associations to be merged
  * @return \Cake\Datasource\EntityInterface
  */
-	public function  patchEntity(EntityInterface $entity, array $data, $associations = null);
+	public function patchEntity(EntityInterface $entity, array $data, $associations = null);
 
 /**
  * Merges each of the elements passed in `$data` into the entities
@@ -206,6 +206,6 @@ interface RepositoryInterface {
  * @param array $include The list of associations to be merged
  * @return array
  */
-	public function  patchEntities($entities, array $data, $associations = null);
+	public function patchEntities($entities, array $data, $associations = null);
 
 }

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -220,8 +220,8 @@ class Marshaller {
 
 /**
  * Merges `$data` into `$entity` and recursively does the same for each one of
- * the association names passed in `$include`. When merging association, if an
- * entity is not present in the parent entity for such association, a new one
+ * the association names passed in `$include`. When merging associations, if an
+ * entity is not present in the parent entity for a given association, a new one
  * will be created.
  *
  * When merging HasMany or BelongsToMany associations, all the entities in the
@@ -262,11 +262,11 @@ class Marshaller {
 /**
  * Merges each of the elements from `$data` into each of the entities in `$entities
  * and recursively does the same for each one of the association names passed in
- * `$include`. When merging association, if an entity is not present in the parent
+ * `$include`. When merging associations, if an entity is not present in the parent
  * entity for such association, a new one will be created.
  *
  * Records in `$data` are matched against the entities by using the primary key
- * column. Those entries in `$entities` that cannot be matched to any record in
+ * column. Entries in `$entities` that cannot be matched to any record in
  * `$data` will be discarded. Records in `$data` that could not be matched will
  * be marshalled as a new entity.
  *

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -244,7 +244,7 @@ class Marshaller {
 	public function mergeMany($entities, array $data, $include = []) {
 		$primary = (array)$this->_table->primaryKey();
 		$indexed = (new Collection($data))->groupBy($primary[0])->toArray();
-		$new = [$indexed[null]];
+		$new = isset($indexed[null]) ? [$indexed[null]] : [];
 		unset($indexed[null]);
 		$output = [];
 
@@ -317,7 +317,7 @@ class Marshaller {
 			$hash = spl_object_hash($record);
 			$data = $record->get('_joinData');
 			if (isset($extra[$hash])) {
-				$record->set('_joinData', $marshaller->merge($extra[$hash], (array)$data));
+				$record->set('_joinData', $marshaller->merge($extra[$hash], (array)$data, $nested));
 			} else {
 				$joinData = $marshaller->one($data, $nested);
 				$record->set('_joinData', $joinData);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -28,6 +28,8 @@ use Cake\ORM\Table;
  *
  * @see \Cake\ORM\Table::newEntity()
  * @see \Cake\ORM\Table::newEntities()
+ * @see \Cake\ORM\Table::patchEntity()
+ * @see \Cake\ORM\Table::patchEntities()
  */
 class Marshaller {
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -224,7 +224,7 @@ class Marshaller {
  *
  * When merging HasMany or BelongsToMany associations, all the entities in the
  * `$data` array will appear, those that can be matched by primary key will get
- * the data merged, but those that cannot,  will be discarded.
+ * the data merged, but those that cannot, will be discarded.
  *
  * @param \Cake\Datasource\EntityInterface $entity the entity that will get the
  * data merged in
@@ -266,11 +266,11 @@ class Marshaller {
  * Records in `$data` are matched against the entities by using the primary key
  * column. Those entries in `$entities` that cannot be matched to any record in
  * `$data` will be discarded. Records in `$data` that could not be matched will
- * be marshaled as a new entity.
+ * be marshalled as a new entity.
  *
  * When merging HasMany or BelongsToMany associations, all the entities in the
  * `$data` array will appear, those that can be matched by primary key will get
- * the data merged, but those that cannot,  will be discarded.
+ * the data merged, but those that cannot, will be discarded.
  *
  * @param array|\Traversable $entities the entities that will get the
  * data merged in

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -355,7 +355,7 @@ class Marshaller {
 		$extra = [];
 		foreach ($original as $entity) {
 			$joinData = $entity->get('_joinData');
-			if ($joinData) {
+			if ($joinData && $joinData instanceof EntityInterface) {
 				$extra[spl_object_hash($entity)] = $joinData;
 			}
 		}

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -243,7 +243,9 @@ class Marshaller {
 
 	public function mergeMany($entities, array $data, $include = []) {
 		$primary = (array)$this->_table->primaryKey();
-		$indexed = (new Collection($data))->indexBy($primary[0]);
+		$indexed = (new Collection($data))->groupBy($primary[0])->toArray();
+		$new = [$indexed[null]];
+		unset($indexed[null]);
 		$output = [];
 
 		foreach ($entities as $entity) {
@@ -251,12 +253,14 @@ class Marshaller {
 			if ($key === null || !isset($indexed[$key])) {
 				continue;
 			}
-			$output[] = $this->merge($entity, $indexed[$key], $include);
+			$output[] = $this->merge($entity, $indexed[$key][0], $include);
 			unset($indexed[$key]);
 		}
 
-		foreach ($indexed as $record) {
-			$output[] = $this->one($record, $include);
+		foreach (array_merge($indexed, $new) as $record) {
+			foreach ($record as $value) {
+				$output[] = $this->one($value, $include);
+			}
 		}
 		return $output;
 	}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1572,6 +1572,40 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
+ * {@inheritdoc}
+ *
+ * When merging HasMany or BelongsToMany associations, all the entities in the
+ * `$data` array will appear, those that can be matched by primary key will get
+ * the data merged, but those that cannot, will be discarded.
+ */
+	public function patchEntity(EntityInterface $entity, array $data, $associations = null) {
+		if ($associations === null) {
+			$associations = $this->_associated->keys();
+		}
+		$marshaller = $this->marshaller();
+		return $marshaller->merge($entity, $data, $associations);
+	}
+
+/**
+ * {@inheritdoc}
+ *
+ * Those entries in `$entities` that cannot be matched to any record in
+ * `$data` will be discarded. Records in `$data` that could not be matched will
+ * be marshalled as a new entity.
+ *
+ * When merging HasMany or BelongsToMany associations, all the entities in the
+ * `$data` array will appear, those that can be matched by primary key will get
+ * the data merged, but those that cannot, will be discarded.
+ */
+	public function patchEntities($entities, array $data, $associations = null) {
+		if ($associations === null) {
+			$associations = $this->_associated->keys();
+		}
+		$marshaller = $this->marshaller();
+		return $marshaller->mergeMany($entities, $data, $associations);
+	}
+
+/**
  * Validates a single entity based on the passed options and validates
  * any nested entity for this table associations as requested in the
  * options array.

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -752,7 +752,7 @@ class MarshallerTest extends TestCase {
 				['tag' => 'new tag', '_joinData' => ['active' => 1, 'foo' => 'baz']]
 			]
 		];
-		
+
 		$tag1 = $entity->tags[0];
 		$result = $marshall->merge($entity, $data, $options);
 		$this->assertEquals($data['title'], $result->title);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -848,4 +848,33 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals('ber', $entity->tags[1]->_joinData->user->username);
 	}
 
+/**
+ * Test mergeMany() with a simple set of data.
+ *
+ * @return void
+ */
+	public function testMergeManySimple() {
+		$entities = [
+			new OpenEntity(['id' => 1, 'comment' => 'First post', 'user_id' => 2]),
+			new OpenEntity(['id' => 2, 'comment' => 'Second post', 'user_id' => 2])
+		];
+		$entities[0]->clean();
+		$entities[1]->clean();
+
+		$data = [
+			['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
+			['id' => 1, 'comment' => 'Changed 1', 'user_id' => 1]
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->mergeMany($entities, $data);
+
+		$this->assertSame($entities[0], $result[0]);
+		$this->assertSame($entities[1], $result[1]);
+		$this->assertEquals('Changed 1', $result[0]->comment);
+		$this->assertEquals(1, $result[0]->user_id);
+		$this->assertEquals('Changed 2', $result[1]->comment);
+		$this->assertTrue($result[0]->dirty('user_id'));
+		$this->assertFalse($result[1]->dirty('user_id'));
+	}
+
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -682,4 +682,34 @@ class MarshallerTest extends TestCase {
 		);
 	}
 
+/**
+ * Tests that merging data to an entity containing belongsToMany and _ids
+ * will just overwrite the data
+ *
+ * @return void
+ */
+	public function testMergeBelongsToManyEntitiesFromIds() {
+		$entity = new Entity([
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
+			'tags' => [
+				new Entity(['id' => 1, 'name' => 'Cake']),
+				new Entity(['id' => 2, 'name' => 'PHP'])
+			]
+		]);
+
+		$data = [
+			'title' => 'Haz moar tags',
+			'tags' => ['_ids' => [1, 2, 3]]
+		];
+		$entity->accessible('*', true);
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->merge($entity, $data, ['Tags']);
+
+		$this->assertCount(3, $result->tags);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[1]);
+		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
+	}
+
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -712,4 +712,64 @@ class MarshallerTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
 	}
 
+/**
+ * Test merging the _joinData entity for belongstomany associations.
+ *
+ * @return void
+ */
+	public function testMergeBelongsToManyJoinData() {
+		$data = [
+			'title' => 'My title',
+			'body' => 'My content',
+			'author_id' => 1,
+			'tags' => [
+				[
+					'id' => 1,
+					'tag' => 'news',
+					'_joinData' => [
+						'active' => 0
+					]
+				],
+				[
+					'id' => 2,
+					'tag' => 'cakephp',
+					'_joinData' => [
+						'active' => 0
+					]
+				],
+			],
+		];
+
+		$options = ['Tags' => ['associated' => ['_joinData']]];
+		$marshall = new Marshaller($this->articles);
+		$entity = $marshall->one($data, $options);
+		$entity->accessible('*', true);
+
+		$data = [
+			'title' => 'Haz data',
+			'tags' => [
+				['id' => 1, 'tag' => 'Cake', '_joinData' => ['foo' => 'bar']],
+				['tag' => 'new tag', '_joinData' => ['active' => 1, 'foo' => 'baz']]
+			]
+		];
+		
+		$tag1 = $entity->tags[0];
+		$result = $marshall->merge($entity, $data, $options);
+		$this->assertEquals($data['title'], $result->title);
+		$this->assertEquals('My content', $result->body);
+		$this->assertSame($tag1, $entity->tags[0]);
+		$this->assertSame($tag1->_joinData, $entity->tags[0]->_joinData);
+		$this->assertSame(
+			['active' => 0, 'foo' => 'bar'],
+			$entity->tags[0]->_joinData->toArray()
+		);
+		$this->assertSame(
+			['active' => 1, 'foo' => 'baz'],
+			$entity->tags[1]->_joinData->toArray()
+		);
+		$this->assertEquals('new tag', $entity->tags[1]->tag);
+		$this->assertTrue($entity->tags[0]->dirty('_joinData'));
+		$this->assertTrue($entity->tags[1]->dirty('_joinData'));
+	}
+
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -592,7 +592,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->merge($entity, $data, ['Users']);
+		$marshall->merge($entity, $data, ['Users']);
 		$this->assertEquals('My Content', $entity->body);
 		$this->assertSame($user, $entity->user);
 		$this->assertEquals('mark', $entity->user->username);
@@ -619,7 +619,7 @@ class MarshallerTest extends TestCase {
 			]
 		];
 		$marshall = new Marshaller($this->articles);
-		$result = $marshall->merge($entity, $data, ['Users']);
+		$marshall->merge($entity, $data, ['Users']);
 		$this->assertEquals('My Content', $entity->body);
 		$this->assertInstanceOf('Cake\ORM\Entity', $entity->user);
 		$this->assertEquals('mark', $entity->user->username);
@@ -902,8 +902,6 @@ class MarshallerTest extends TestCase {
 		$this->assertNotSame($entities[0], $result[0]);
 		$this->assertSame($entities[1], $result[0]);
 		$this->assertEquals('Changed 2', $result[0]->comment);
-
 	}
-
 
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -877,4 +877,33 @@ class MarshallerTest extends TestCase {
 		$this->assertFalse($result[1]->dirty('user_id'));
 	}
 
+/**
+ * Tests that only records found in the data array are returned, those that cannot
+ * be matched are discarded
+ *
+ * @return void
+ */
+	public function testMergeManyWithAppend() {
+		$entities = [
+			new OpenEntity(['comment' => 'First post', 'user_id' => 2]),
+			new OpenEntity(['id' => 2, 'comment' => 'Second post', 'user_id' => 2])
+		];
+		$entities[0]->clean();
+		$entities[1]->clean();
+
+		$data = [
+			['id' => 2, 'comment' => 'Changed 2', 'user_id' => 2],
+			['id' => 1, 'comment' => 'Comment 1', 'user_id' => 1]
+		];
+		$marshall = new Marshaller($this->comments);
+		$result = $marshall->mergeMany($entities, $data);
+
+		$this->assertCount(2, $result);
+		$this->assertNotSame($entities[0], $result[0]);
+		$this->assertSame($entities[1], $result[0]);
+		$this->assertEquals('Changed 2', $result[0]->comment);
+
+	}
+
+
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3197,4 +3197,50 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertFalse($table->validateMany($entities, $options));
 	}
 
+/**
+ * Tests that patchEntity delegates the task to the marshaller and passed
+ * all associations
+ *
+ * @return void
+ */
+	public function testPatchEntity() {
+		$table = $this->getMock('Cake\ORM\Table', ['marshaller']);
+		$marshaller = $this->getMock('Cake\ORM\Marshaller', [], [$table]);
+		$table->belongsTo('users');
+		$table->hasMany('articles');
+		$table->expects($this->once())->method('marshaller')
+			->will($this->returnValue($marshaller));
+
+		$entity = new \Cake\ORM\Entity;
+		$data = ['foo' => 'bar'];
+		$marshaller->expects($this->once())
+			->method('merge')
+			->with($entity, $data, ['users', 'articles'])
+			->will($this->returnValue($entity));
+		$table->patchEntity($entity, $data);
+	}
+
+/**
+ * Tests that patchEntities delegates the task to the marshaller and passed
+ * all associations
+ *
+ * @return void
+ */
+	public function testPatchEntities() {
+		$table = $this->getMock('Cake\ORM\Table', ['marshaller']);
+		$marshaller = $this->getMock('Cake\ORM\Marshaller', [], [$table]);
+		$table->belongsTo('users');
+		$table->hasMany('articles');
+		$table->expects($this->once())->method('marshaller')
+			->will($this->returnValue($marshaller));
+
+		$entities = [new \Cake\ORM\Entity];
+		$data = [['foo' => 'bar']];
+		$marshaller->expects($this->once())
+			->method('mergeMany')
+			->with($entities, $data, ['users', 'articles'])
+			->will($this->returnValue($entities));
+		$table->patchEntities($entities, $data);
+	}
+
 }


### PR DESCRIPTION
This adds the ability to merge request data into an existing entity, including its associations. Closes https://github.com/cakephp/cakephp/issues/2868

~~Once this is merged, I will add the corresponding methods in the Table class.~~
