### PR TITLE
3.0 - Bail early if Junction table is already instanciated and  is not specified.

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -154,21 +154,21 @@ class BelongsToMany extends Association {
 		$tAlias = $target->alias();
 
 		if ($table === null) {
-			if (empty($this->_junctionTable)) {
-				if (!empty($this->_through)) {
-					$table = $this->_through;
-				} else {
-					$tableName = $this->_junctionTableName();
-					$tableAlias = Inflector::camelize($tableName);
-
-					$config = [];
-					if (!TableRegistry::exists($tableAlias)) {
-						$config = ['table' => $tableName];
-					}
-					$table = TableRegistry::get($tableAlias, $config);
-				}
-			} else {
+			if (!empty($this->_junctionTable)) {
 				return $this->_junctionTable;
+			}
+
+			if (!empty($this->_through)) {
+				$table = $this->_through;
+			} else {
+				$tableName = $this->_junctionTableName();
+				$tableAlias = Inflector::camelize($tableName);
+
+				$config = [];
+				if (!TableRegistry::exists($tableAlias)) {
+					$config = ['table' => $tableName];
+				}
+				$table = TableRegistry::get($tableAlias, $config);
 			}
 		}
 


### PR DESCRIPTION
From https://github.com/cakephp/cakephp/pull/2934#discussion_r10199264

Not much but removed the indentation level created by https://github.com/cakephp/cakephp/pull/2934
