### PR TITLE
Allow the passing parameter escape of the getCrumbList method

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -753,6 +753,7 @@ class HtmlHelper extends AppHelper {
  * Prepends startText to crumbs array if set
  *
  * @param string $startText Text to prepend
+ * @param boolean $escape If the output should be escaped or not
  * @return array Crumb list including startText (if provided)
  */
 	protected function _prepareCrumbs($startText, $escape = true) {
@@ -767,7 +768,7 @@ class HtmlHelper extends AppHelper {
 			$startText += array('url' => '/', 'text' => __d('cake', 'Home'));
 			list($url, $text) = array($startText['url'], $startText['text']);
 			unset($startText['url'], $startText['text']);
-			array_unshift($crumbs, array($text, $url, $startText + array('escape' => $escape));
+            array_unshift($crumbs, array($text, $url, $startText + array('escape' => $escape)));
 		}
 		return $crumbs;
 	}

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -713,14 +713,15 @@ class HtmlHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
 	public function getCrumbList($options = array(), $startText = false) {
-		$defaults = array('firstClass' => 'first', 'lastClass' => 'last', 'separator' => '');
+		$defaults = array('firstClass' => 'first', 'lastClass' => 'last', 'separator' => '', 'escape' => true);
 		$options = array_merge($defaults, (array)$options);
 		$firstClass = $options['firstClass'];
 		$lastClass = $options['lastClass'];
 		$separator = $options['separator'];
+		$escape = $options['escape'];
 		unset($options['firstClass'], $options['lastClass'], $options['separator']);
 
-		$crumbs = $this->_prepareCrumbs($startText);
+		$crumbs = $this->_prepareCrumbs($startText, $escape);
 		if (empty($crumbs)) {
 			return null;
 		}
@@ -754,7 +755,7 @@ class HtmlHelper extends AppHelper {
  * @param string $startText Text to prepend
  * @return array Crumb list including startText (if provided)
  */
-	protected function _prepareCrumbs($startText) {
+	protected function _prepareCrumbs($startText, $escape = true) {
 		$crumbs = $this->_crumbs;
 		if ($startText) {
 			if (!is_array($startText)) {
@@ -766,7 +767,7 @@ class HtmlHelper extends AppHelper {
 			$startText += array('url' => '/', 'text' => __d('cake', 'Home'));
 			list($url, $text) = array($startText['url'], $startText['text']);
 			unset($startText['url'], $startText['text']);
-			array_unshift($crumbs, array($text, $url, $startText));
+			array_unshift($crumbs, array($text, $url, $startText + array('escape' => $escape));
 		}
 		return $crumbs;
 	}

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -764,7 +764,7 @@ class HtmlHelper extends AppHelper {
 					'url' => '/',
 					'text' => $startText
 				);
-	}
+			}
 			$startText += array('url' => '/', 'text' => __d('cake', 'Home'));
 			list($url, $text) = array($startText['url'], $startText['text']);
 			unset($startText['url'], $startText['text']);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -719,7 +719,7 @@ class HtmlHelper extends AppHelper {
 		$lastClass = $options['lastClass'];
 		$separator = $options['separator'];
 		$escape = $options['escape'];
-		unset($options['firstClass'], $options['lastClass'], $options['separator']);
+		unset($options['firstClass'], $options['lastClass'], $options['separator'], $options['escape']);
 
 		$crumbs = $this->_prepareCrumbs($startText, $escape);
 		if (empty($crumbs)) {
@@ -764,11 +764,11 @@ class HtmlHelper extends AppHelper {
 					'url' => '/',
 					'text' => $startText
 				);
-			}
+	}
 			$startText += array('url' => '/', 'text' => __d('cake', 'Home'));
 			list($url, $text) = array($startText['url'], $startText['text']);
 			unset($startText['url'], $startText['text']);
-            array_unshift($crumbs, array($text, $url, $startText + array('escape' => $escape)));
+			array_unshift($crumbs, array($text, $url, $startText + array('escape' => $escape)));
 		}
 		return $crumbs;
 	}


### PR DESCRIPTION
Allow the passing parameter escape of the getCrumbList method and reflecting that into the outputted link too

When I pass ['escape' => false] as an option my getCrumbList method I see no escaped output. That is needed when I want an icon along with the text.
