### PR TITLE
3.0 FormHelper submit

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1463,8 +1463,6 @@ class FormHelper extends Helper {
  *
  * ### Options
  *
- * - `div` - Include a wrapping div?  Defaults to true. Accepts sub options similar to
- *   FormHelper::input().
  * - `type` - Set to 'reset' for reset inputs. Defaults to 'submit'
  * - Other attributes will be assigned to the input element.
  *
@@ -1476,11 +1474,11 @@ class FormHelper extends Helper {
  * @return string A HTML submit button
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::submit
  */
-	public function submit($caption = null, $options = array()) {
+	public function submit($caption = null, $options = []) {
 		if (!is_string($caption) && empty($caption)) {
 			$caption = __d('cake', 'Submit');
 		}
-		$options += array('type' => 'submit', 'secure' => false);
+		$options += ['type' => 'submit', 'secure' => false];
 
 		if (isset($options['name'])) {
 			$this->_secure($options['secure'], $this->_secureFieldName($options));
@@ -1496,9 +1494,10 @@ class FormHelper extends Helper {
 		if ($isUrl || $isImage) {
 			$unlockFields = array('x', 'y');
 			if (isset($options['name'])) {
-				$unlockFields = array(
-					$options['name'] . '_x', $options['name'] . '_y'
-				);
+				$unlockFields = [
+					$options['name'] . '_x',
+					$options['name'] . '_y'
+				];
 			}
 			foreach ($unlockFields as $ignore) {
 				$this->unlockField($ignore);

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -157,7 +157,8 @@ class FormHelper extends Helper {
 		'formGroup' => '{{label}}{{input}}',
 		'checkboxFormGroup' => '{{input}}{{label}}',
 		'groupContainer' => '<div class="input {{type}}{{required}}">{{content}}</div>',
-		'groupContainerError' => '<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>'
+		'groupContainerError' => '<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>',
+		'submitContainer' => '<div class="submit">{{content}}</div>',
 	];
 
 /**
@@ -1466,12 +1467,6 @@ class FormHelper extends Helper {
  * - `type` - Set to 'reset' for reset inputs. Defaults to 'submit'
  * - Other attributes will be assigned to the input element.
  *
- * ### Options
- *
- * - `div` - Include a wrapping div?  Defaults to true. Accepts sub options similar to
- *   FormHelper::input().
- * - Other attributes will be assigned to the input element.
- *
  * @param string $caption The label appearing on the button OR if string contains :// or the
  *  extension .jpg, .jpe, .jpeg, .gif, .png use an image if the extension
  *  exists, AND the first character is /, image is relative to webroot,
@@ -1484,24 +1479,7 @@ class FormHelper extends Helper {
 		if (!is_string($caption) && empty($caption)) {
 			$caption = __d('cake', 'Submit');
 		}
-		$div = true;
-
-		if (isset($options['div'])) {
-			$div = $options['div'];
-			unset($options['div']);
-		}
-		$options += array('type' => 'submit', 'before' => null, 'after' => null, 'secure' => false);
-		$divOptions = array('tag' => 'div');
-
-		if ($div === true) {
-			$divOptions['class'] = 'submit';
-		} elseif ($div === false) {
-			unset($divOptions);
-		} elseif (is_string($div)) {
-			$divOptions['class'] = $div;
-		} elseif (is_array($div)) {
-			$divOptions = array_merge(array('class' => 'submit', 'tag' => 'div'), $div);
-		}
+		$options += array('type' => 'submit', 'secure' => false);
 
 		if (isset($options['name'])) {
 			$this->_secure($options['secure'], $this->_secureFieldName($options));
@@ -1541,12 +1519,9 @@ class FormHelper extends Helper {
 		}
 		$out = $tag;
 
-		if (isset($divOptions)) {
-			$tag = $divOptions['tag'];
-			unset($divOptions['tag']);
-			$out = $this->Html->tag($tag, $out, $divOptions);
-		}
-		return $out;
+		return $this->formatTemplate('submitContainer', [
+			'content' => $tag
+		]);
 	}
 
 /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1463,8 +1463,6 @@ class FormHelper extends Helper {
  *
  * - `div` - Include a wrapping div?  Defaults to true. Accepts sub options similar to
  *   FormHelper::input().
- * - `before` - Content to include before the input.
- * - `after` - Content to include after the input.
  * - `type` - Set to 'reset' for reset inputs. Defaults to 'submit'
  * - Other attributes will be assigned to the input element.
  *
@@ -1506,14 +1504,9 @@ class FormHelper extends Helper {
 		}
 
 		if (isset($options['name'])) {
-			$name = str_replace(array('[', ']'), array('.', ''), $options['name']);
 			$this->_secure($options['secure'], $this->_secureFieldName($options));
 		}
 		unset($options['secure']);
-
-		$before = $options['before'];
-		$after = $options['after'];
-		unset($options['before'], $options['after']);
 
 		$isUrl = strpos($caption, '://') !== false;
 		$isImage = preg_match('/\.(jpg|jpe|jpeg|gif|png|ico)$/', $caption);
@@ -1546,7 +1539,7 @@ class FormHelper extends Helper {
 			$options['value'] = $caption;
 			$tag = $this->Html->useTag('submit', $options);
 		}
-		$out = $before . $tag . $after;
+		$out = $tag;
 
 		if (isset($divOptions)) {
 			$tag = $divOptions['tag'];

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -146,6 +146,7 @@ class FormHelper extends Helper {
 		'formend' => '</form>',
 		'hiddenblock' => '<div style="display:none;">{{content}}</div>',
 		'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
+		'inputsubmit' => '<input type="{{type}}"{{attrs}}>',
 		'label' => '<label{{attrs}}>{{text}}</label>',
 		'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 		'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
@@ -1489,6 +1490,9 @@ class FormHelper extends Helper {
 		$isUrl = strpos($caption, '://') !== false;
 		$isImage = preg_match('/\.(jpg|jpe|jpeg|gif|png|ico)$/', $caption);
 
+		$type = $options['type'];
+		unset($options['type']);
+
 		if ($isUrl || $isImage) {
 			$unlockFields = array('x', 'y');
 			if (isset($options['name'])) {
@@ -1499,28 +1503,30 @@ class FormHelper extends Helper {
 			foreach ($unlockFields as $ignore) {
 				$this->unlockField($ignore);
 			}
+			$type = 'image';
 		}
 
 		if ($isUrl) {
-			unset($options['type']);
-			$tag = $this->Html->useTag('submitimage', $caption, $options);
+			$options['src'] = $caption;
 		} elseif ($isImage) {
-			unset($options['type']);
 			if ($caption{0} !== '/') {
 				$url = $this->webroot(Configure::read('App.imageBaseUrl') . $caption);
 			} else {
 				$url = $this->webroot(trim($caption, '/'));
 			}
 			$url = $this->assetTimestamp($url);
-			$tag = $this->Html->useTag('submitimage', $url, $options);
+			$options['src'] = $url;
 		} else {
 			$options['value'] = $caption;
-			$tag = $this->Html->useTag('submit', $options);
 		}
-		$out = $tag;
+
+		$input = $this->formatTemplate('inputsubmit', [
+			'type' => $type,
+			'attrs' => $this->_templater->formatAttributes($options),
+		]);
 
 		return $this->formatTemplate('submitContainer', [
-			'content' => $tag
+			'content' => $input
 		]);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5253,14 +5253,6 @@ class FormHelperTest extends TestCase {
 		$expected = array('input' => array('type' => 'submit', 'value' => 'Test Submit', 'class' => 'save'));
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->submit('Test Submit', array('div' => array('id' => 'SaveButton')));
-		$expected = array(
-			'div' => array('class' => 'submit', 'id' => 'SaveButton'),
-			'input' => array('type' => 'submit', 'value' => 'Test Submit'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
 		$result = $this->Form->submit('Next >');
 		$expected = array(
 			'div' => array('class' => 'submit'),
@@ -5281,36 +5273,6 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'div' => array('class' => 'submit'),
 			'input' => array('type' => 'reset', 'value' => 'Reset!'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$before = '--before--';
-		$after = '--after--';
-		$result = $this->Form->submit('Test', array('before' => $before));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'--before--',
-			'input' => array('type' => 'submit', 'value' => 'Test'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('Test', array('after' => $after));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'input' => array('type' => 'submit', 'value' => 'Test'),
-			'--after--',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('Test', array('before' => $before, 'after' => $after));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'--before--',
-			'input' => array('type' => 'submit', 'value' => 'Test'),
-			'--after--',
 			'/div'
 		);
 		$this->assertTags($result, $expected);
@@ -5350,46 +5312,6 @@ class FormHelperTest extends TestCase {
 		$expected = array(
 			'div' => array('class' => 'submit'),
 			'input' => array('type' => 'submit', 'value' => 'Not.an.image'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$after = '--after--';
-		$before = '--before--';
-		$result = $this->Form->submit('cake.power.gif', array('after' => $after));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'input' => array('type' => 'image', 'src' => 'img/cake.power.gif'),
-			'--after--',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('cake.power.gif', array('before' => $before));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'--before--',
-			'input' => array('type' => 'image', 'src' => 'img/cake.power.gif'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('cake.power.gif', array('before' => $before, 'after' => $after));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'--before--',
-			'input' => array('type' => 'image', 'src' => 'img/cake.power.gif'),
-			'--after--',
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('Not.an.image', array('before' => $before, 'after' => $after));
-		$expected = array(
-			'div' => array('class' => 'submit'),
-			'--before--',
-			'input' => array('type' => 'submit', 'value' => 'Not.an.image'),
-			'--after--',
 			'/div'
 		);
 		$this->assertTags($result, $expected);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5241,18 +5241,6 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->submit('Test Submit', array('div' => array('tag' => 'span')));
-		$expected = array(
-			'span' => array('class' => 'submit'),
-			'input' => array('type' => 'submit', 'value' => 'Test Submit'),
-			'/span'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->submit('Test Submit', array('class' => 'save', 'div' => false));
-		$expected = array('input' => array('type' => 'submit', 'value' => 'Test Submit', 'class' => 'save'));
-		$this->assertTags($result, $expected);
-
 		$result = $this->Form->submit('Next >');
 		$expected = array(
 			'div' => array('class' => 'submit'),


### PR DESCRIPTION
Part of #2267. When the tests for this method were re-enabled the method was not cleaned up and made consistent with other parts of the helper. These changes help address that and make the submit() method use templates like other parts of FormHelper.
