### PR TITLE
3.0 Update FormHelper::inputs()

### DIFF
--- a/src/View/Form/ArrayContext.php
+++ b/src/View/Form/ArrayContext.php
@@ -175,6 +175,15 @@ class ArrayContext implements ContextInterface {
 	}
 
 /**
+ * {@inheritDoc}
+ */
+	public function fieldNames() {
+		$schema = $this->_context['schema'];
+		unset($schema['_constraints'], $schema['_indexes']);
+		return array_keys($schema);
+	}
+
+/**
  * Get the abstract field type for a given field name.
  *
  * @param string $field A dot separated path to get a schema type for.

--- a/src/View/Form/ContextInterface.php
+++ b/src/View/Form/ContextInterface.php
@@ -62,6 +62,13 @@ interface ContextInterface {
 	public function isRequired($field);
 
 /**
+ * Get the fieldnames of the top level object in this context.
+ *
+ * @return array A list of the field names in the context.
+ */
+	public function fieldNames();
+
+/**
  * Get the abstract field type for a given field name.
  *
  * @param string $field A dot separated path to get a schema type for.

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -318,6 +318,18 @@ class EntityContext implements ContextInterface {
 	}
 
 /**
+ * Get the field names from the top level entity.
+ *
+ * If the context is for an array of entities, the 0th index will be used.
+ *
+ * @return array Array of fieldnames in the table/entity.
+ */
+	public function fieldNames() {
+		$table = $this->_getTable('0');
+		return $table->schema()->columns();
+	}
+
+/**
  * Get the validator associated to an entity based on naming
  * conventions.
  *

--- a/src/View/Form/NullContext.php
+++ b/src/View/Form/NullContext.php
@@ -80,6 +80,13 @@ class NullContext implements ContextInterface {
 /**
  * {@inheritDoc}
  */
+	public function fieldNames() {
+		return [];
+	}
+
+/**
+ * {@inheritDoc}
+ */
 	public function type($field) {
 		return null;
 	}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -142,11 +142,13 @@ class FormHelper extends Helper {
 		'errorList' => '<ul>{{content}}</ul>',
 		'errorItem' => '<li>{{text}}</li>',
 		'file' => '<input type="file" name="{{name}}"{{attrs}}>',
+		'fieldset' => '<fieldset>{{content}}</fieldset>',
 		'formstart' => '<form{{attrs}}>',
 		'formend' => '</form>',
 		'hiddenblock' => '<div style="display:none;">{{content}}</div>',
 		'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
 		'label' => '<label{{attrs}}>{{text}}</label>',
+		'legend' => '<legend>{{text}}</legend>',
 		'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 		'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
 		'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>',
@@ -724,8 +726,7 @@ class FormHelper extends Helper {
  * @param array $fields An array of fields to generate inputs for, or null.
  * @param array $blacklist A simple array of fields to not create inputs for.
  * @param array $options Options array. Valid keys are:
- * - `fieldset` Set to false to disable the fieldset. If a string is supplied it will be used as
- *    the class name for the fieldset element.
+ * - `fieldset` Set to false to disable the fieldset.
  * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
  *    to customize the legend text.
  * @return string Completed form inputs.
@@ -794,18 +795,11 @@ class FormHelper extends Helper {
 			$out .= $this->input($name, $options);
 		}
 
-		if (is_string($fieldset)) {
-			$fieldsetClass = sprintf(' class="%s"', $fieldset);
-		} else {
-			$fieldsetClass = '';
-		}
-
-		// TODO cleanup HTML helper usage.
 		if ($fieldset) {
 			if ($legend) {
-				$out = $this->Html->useTag('legend', $legend) . $out;
+				$out = $this->formatTemplate('legend', ['text' => $legend]) . $out;
 			}
-			$out = $this->Html->useTag('fieldset', $fieldsetClass, $out);
+			$out = $this->formatTemplate('fieldset', ['content' => $out]);
 		}
 		return $out;
 	}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -736,7 +736,9 @@ class FormHelper extends Helper {
 		$model = false;
 		$fieldset = $legend = true;
 		$context = $this->_getContext();
-		// TODO add context->fields()
+
+		$modelFields = $context->fieldNames();
+
 		if (is_array($fields)) {
 			if (array_key_exists('legend', $fields) && !in_array('legend', $modelFields)) {
 				$legend = $fields['legend'];
@@ -755,15 +757,14 @@ class FormHelper extends Helper {
 			$fields = array();
 		}
 
+		if (empty($fields)) {
+			$fields = $modelFields;
+		}
 		if (isset($options['legend'])) {
 			$legend = $options['legend'];
 		}
 		if (isset($options['fieldset'])) {
 			$fieldset = $options['fieldset'];
-		}
-
-		if (empty($fields)) {
-			$fields = $modelFields;
 		}
 
 		if ($legend === true) {
@@ -799,6 +800,7 @@ class FormHelper extends Helper {
 			$fieldsetClass = '';
 		}
 
+		// TODO cleanup HTML helper usage.
 		if ($fieldset) {
 			if ($legend) {
 				$out = $this->Html->useTag('legend', $legend) . $out;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -732,12 +732,11 @@ class FormHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
 	public function inputs($fields = null, $blacklist = null, $options = array()) {
+		$modelFields = [];
+		$model = false;
 		$fieldset = $legend = true;
-		$modelFields = array();
-		$model = $this->model();
-		if ($model) {
-			$modelFields = array_keys((array)$this->_introspectModel($model, 'fields'));
-		}
+		$context = $this->_getContext();
+		// TODO add context->fields()
 		if (is_array($fields)) {
 			if (array_key_exists('legend', $fields) && !in_array('legend', $modelFields)) {
 				$legend = $fields['legend'];
@@ -769,6 +768,7 @@ class FormHelper extends Helper {
 
 		if ($legend === true) {
 			$actionName = __d('cake', 'New %s');
+			$isCreate = $context->isCreate();
 			$isEdit = (
 				strpos($this->request->params['action'], 'update') !== false ||
 				strpos($this->request->params['action'], 'edit') !== false

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -720,8 +720,6 @@ class FormHelper extends Helper {
  * In addition to controller fields output, `$fields` can be used to control legend
  * and fieldset rendering.
  * `$this->Form->inputs('My legend');` Would generate an input set with a custom legend.
- * Passing `fieldset` and `legend` key in `$fields` array has been deprecated since 2.3,
- * for more fine grained control use the `fieldset` and `legend` keys in `$options` param.
  *
  * @param array $fields An array of fields to generate inputs for, or null.
  * @param array $blacklist A simple array of fields to not create inputs for.
@@ -740,22 +738,12 @@ class FormHelper extends Helper {
 
 		$modelFields = $context->fieldNames();
 
-		if (is_array($fields)) {
-			if (array_key_exists('legend', $fields) && !in_array('legend', $modelFields)) {
-				$legend = $fields['legend'];
-				unset($fields['legend']);
-			}
-
-			if (isset($fields['fieldset']) && !in_array('fieldset', $modelFields)) {
-				$fieldset = $fields['fieldset'];
-				unset($fields['fieldset']);
-			}
-		} elseif ($fields !== null) {
+		if (is_string($fields)) {
+			$legend = $fields;
+			$fields = [];
+		} elseif (is_bool($fields)) {
 			$fieldset = $legend = $fields;
-			if (!is_bool($fieldset)) {
-				$fieldset = true;
-			}
-			$fields = array();
+			$fields = [];
 		}
 
 		if (empty($fields)) {
@@ -782,7 +770,7 @@ class FormHelper extends Helper {
 		foreach ($fields as $name => $options) {
 			if (is_numeric($name) && !is_array($options)) {
 				$name = $options;
-				$options = array();
+				$options = [];
 			}
 			$entity = explode('.', $name);
 			$blacklisted = (
@@ -792,7 +780,7 @@ class FormHelper extends Helper {
 			if ($blacklisted) {
 				continue;
 			}
-			$out .= $this->input($name, $options);
+			$out .= $this->input($name, (array)$options);
 		}
 
 		if ($fieldset) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -769,15 +769,11 @@ class FormHelper extends Helper {
 		if ($legend === true) {
 			$actionName = __d('cake', 'New %s');
 			$isCreate = $context->isCreate();
-			$isEdit = (
-				strpos($this->request->params['action'], 'update') !== false ||
-				strpos($this->request->params['action'], 'edit') !== false
-			);
-			if ($isEdit) {
+			if (!$isCreate) {
 				$actionName = __d('cake', 'Edit %s');
 			}
-			$modelName = Inflector::humanize(Inflector::underscore($model));
-			$legend = sprintf($actionName, __($modelName));
+			$modelName = Inflector::humanize(Inflector::singularize($this->request->params['controller']));
+			$legend = sprintf($actionName, $modelName);
 		}
 
 		$out = null;

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -712,17 +712,26 @@ class FormHelper extends Helper {
  *
  * You can customize individual inputs through `$fields`.
  * {{{
- *	$this->Form->inputs(array(
- *		'name' => array('label' => 'custom label')
- *	));
+ * $this->Form->inputs([
+ *   'name' => ['label' => 'custom label']
+ * ]);
  * }}}
+ *
+ * You can exclude fields using the `$blacklist` parameter:
+ *
+ * {{{
+ * $this->Form->inputs(null, ['title']);
+ * }}}
+ *
+ * In the above example, no field would be generated for the title field.
  *
  * In addition to controller fields output, `$fields` can be used to control legend
  * and fieldset rendering.
  * `$this->Form->inputs('My legend');` Would generate an input set with a custom legend.
  *
- * @param array $fields An array of fields to generate inputs for, or null.
- * @param array $blacklist A simple array of fields to not create inputs for.
+ * @param array $fields An array of customizations for the fields that will be
+ *   generated. This array allows you to set custom types, labels, or other options.
+ * @param array $blacklist A list of fields to not create inputs for.
  * @param array $options Options array. Valid keys are:
  * - `fieldset` Set to false to disable the fieldset.
  * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
@@ -731,8 +740,6 @@ class FormHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
 	public function inputs($fields = null, $blacklist = null, $options = array()) {
-		$modelFields = [];
-		$model = false;
 		$fieldset = $legend = true;
 		$context = $this->_getContext();
 
@@ -746,9 +753,11 @@ class FormHelper extends Helper {
 			$fields = [];
 		}
 
-		if (empty($fields)) {
-			$fields = $modelFields;
-		}
+		$fields = array_merge(
+			Hash::normalize($modelFields),
+			Hash::normalize((array)$fields)
+		);
+
 		if (isset($options['legend'])) {
 			$legend = $options['legend'];
 		}

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -819,4 +819,18 @@ class EntityContextTest extends TestCase {
 		$comments->validator('custom', $validator);
 	}
 
+/**
+ * Test the fieldnames method.
+ *
+ * @return void
+ */
+	public function testFieldNames() {
+		$context = new EntityContext($this->request, [
+			'entity' => new Entity(),
+			'table' => 'Articles',
+		]);
+		$articles = TableRegistry::get('Articles');
+		$this->assertEquals($articles->schema()->columns(), $context->fieldNames());
+	}
+
 }

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2534,7 +2534,7 @@ class FormHelperTest extends TestCase {
 		$expected = [
 			'<fieldset',
 			'<legend',
-			'Edit Article',
+			'New Article',
 			'/legend',
 			'*/fieldset',
 		];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2550,165 +2550,93 @@ class FormHelperTest extends TestCase {
 		$this->Form->create($this->article);
 		$result = $this->Form->inputs(['id', 'title', 'body']);
 		$expected = array(
+			'<fieldset',
+			'<legend', 'New Article', '/legend',
 			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
-			array('div' => array('class' => 'input text')),
+			array('div' => array('class' => 'input text required')),
 			'*/div',
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input textarea')),
-			'*/div',
+			'/fieldset',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
-		$result = $this->Form->inputs(array('fieldset' => false, 'legend' => false));
+		$this->Form->create($this->article);
+		$result = $this->Form->inputs(['id', 'title', 'body'], null, array('fieldset' => false, 'legend' => false));
 		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input text required')),
+			'*/div',
 			array('div' => array('class' => 'input text')),
-			'*/div',
-			array('div' => array('class' => 'input email')),
-			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
 			'*/div',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs(null, null, array('fieldset' => false));
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs(array('fieldset' => true, 'legend' => false));
 		$expected = array(
 			'fieldset' => array(),
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input email')),
-			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
+			array('div' => array('class' => 'input text')),
 			'*/div',
 			'/fieldset'
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs(array('fieldset' => false, 'legend' => 'Hello'));
 		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input email')),
-			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
+			array('div' => array('class' => 'input text')),
 			'*/div',
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => 'Hello'));
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs('Hello');
 		$expected = array(
 			'fieldset' => array(),
 			'legend' => array(),
 			'Hello',
 			'/legend',
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input email')),
-			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
+			array('div' => array('class' => 'input text')),
 			'*/div',
 			'/fieldset'
 		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
 		$result = $this->Form->inputs(array('legend' => 'Hello'));
-		$expected = array(
-			'fieldset' => array(),
-			'legend' => array(),
-			'Hello',
-			'/legend',
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
-			array('div' => array('class' => 'input text')),
-			'*/div',
-			array('div' => array('class' => 'input email')),
-			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
-			'*/div',
-			'/fieldset'
-		);
 		$this->assertTags($result, $expected);
 
-		$this->Form->create('Contact');
 		$result = $this->Form->inputs(null, null, array('legend' => 'Hello'));
 		$this->assertTags($result, $expected);
-		$this->Form->end();
 
 		$this->Form->create(false);
 		$expected = array(

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2573,10 +2573,6 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs(null, null, array('fieldset' => false));
-		$this->assertTags($result, $expected);
-
-		$this->Form->create($this->article);
 		$result = $this->Form->inputs(array('fieldset' => true, 'legend' => false));
 		$expected = array(
 			'fieldset' => array(),

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2525,6 +2525,20 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => 'classy-stuff'));
 		$this->assertTags($result, $expected);
+
+		$this->Form->create($this->article);
+		$this->Form->request->params['prefix'] = 'admin';
+		$this->Form->request->params['action'] = 'admin_edit';
+		$this->Form->request->params['controller'] = 'articles';
+		$result = $this->Form->inputs();
+		$expected = [
+			'<fieldset',
+			'<legend',
+			'Edit Article',
+			'/legend',
+			'*/fieldset',
+		];
+		$this->assertTags($result, $expected);
 	}
 
 /**
@@ -2534,39 +2548,14 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputs() {
 		$this->Form->create($this->article);
-		$this->Form->request['prefix'] = 'admin';
-		$this->Form->request['action'] = 'admin_edit';
-		$result = $this->Form->inputs();
+		$result = $this->Form->inputs(['id', 'title', 'body']);
 		$expected = array(
-			'<fieldset',
-			'<legend',
-			'Edit Article',
-			'/legend',
-			'*/fieldset',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->create('Contact');
-		$result = $this->Form->inputs(false);
-		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'Contact[id]', 'id' => 'ContactId'),
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
 			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input email')),
+			array('div' => array('class' => 'input text')),
 			'*/div',
-			array('div' => array('class' => 'input tel')),
-			'*/div',
-			array('div' => array('class' => 'input password')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input date')),
-			'*/div',
-			array('div' => array('class' => 'input datetime')),
-			'*/div',
-			array('div' => array('class' => 'input number')),
-			'*/div',
-			array('div' => array('class' => 'input select')),
+			array('div' => array('class' => 'input textarea')),
 			'*/div',
 		);
 		$this->assertTags($result, $expected);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2510,9 +2510,9 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs(array('legend' => 'Field of Dreams', 'fieldset' => 'classy-stuff'));
+		$result = $this->Form->inputs(array('legend' => 'Field of Dreams', 'fieldset' => true));
 		$expected = array(
-			'fieldset' => array('class' => 'classy-stuff'),
+			'<fieldset',
 			'<legend',
 			'Field of Dreams',
 			'/legend',
@@ -2520,10 +2520,10 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs(null, null, array('legend' => 'Field of Dreams', 'fieldset' => 'classy-stuff'));
+		$result = $this->Form->inputs(null, null, array('legend' => 'Field of Dreams', 'fieldset' => true));
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => 'classy-stuff'));
+		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => true));
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2498,9 +2498,8 @@ class FormHelperTest extends TestCase {
  *
  * @return void
  */
-	public function testFormInputs() {
-		$this->markTestIncomplete('Need to revisit once models work again.');
-		$this->Form->create('Cake\Test\TestCase\View\Helper\Contact');
+	public function testFormInputsLegendFieldset() {
+		$this->Form->create($this->article);
 		$result = $this->Form->inputs('The Legend');
 		$expected = array(
 			'<fieldset',
@@ -2526,15 +2525,22 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => 'classy-stuff'));
 		$this->assertTags($result, $expected);
+	}
 
-		$this->Form->create('Contact');
+/**
+ * Test the inputs() method.
+ *
+ * @return void
+ */
+	public function testFormInputs() {
+		$this->Form->create($this->article);
 		$this->Form->request['prefix'] = 'admin';
 		$this->Form->request['action'] = 'admin_edit';
 		$result = $this->Form->inputs();
 		$expected = array(
 			'<fieldset',
 			'<legend',
-			'Edit Contact',
+			'Edit Article',
 			'/legend',
 			'*/fieldset',
 		);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2548,14 +2548,37 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputs() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs(['id', 'title', 'body']);
+		$result = $this->Form->inputs();
 		$expected = array(
 			'<fieldset',
 			'<legend', 'New Article', '/legend',
 			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
 			array('div' => array('class' => 'input text required')),
 			'*/div',
 			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			'/fieldset',
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->inputs([
+			'published' => ['type' => 'boolean']
+		]);
+		$expected = array(
+			'<fieldset',
+			'<legend', 'New Article', '/legend',
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input boolean')),
 			'*/div',
 			'/fieldset',
 		);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2510,21 +2510,21 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs(array('legend' => 'Field of Dreams', 'fieldset' => true));
-		$expected = array(
-			'<fieldset',
-			'<legend',
-			'Field of Dreams',
-			'/legend',
-			'*/fieldset'
-		);
-		$this->assertTags($result, $expected);
-
 		$result = $this->Form->inputs(null, null, array('legend' => 'Field of Dreams', 'fieldset' => true));
-		$this->assertTags($result, $expected);
+		$this->assertContains('<legend>Field of Dreams</legend>', $result);
+		$this->assertContains('<fieldset>', $result);
 
 		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => true));
-		$this->assertTags($result, $expected);
+		$this->assertContains('<legend>Field of Dreams</legend>', $result);
+		$this->assertContains('<fieldset>', $result);
+
+		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => false));
+		$this->assertNotContains('<legend>', $result);
+		$this->assertNotContains('<fieldset>', $result);
+
+		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => 'Hello'));
+		$this->assertNotContains('<legend>', $result);
+		$this->assertNotContains('<fieldset>', $result);
 
 		$this->Form->create($this->article);
 		$this->Form->request->params['prefix'] = 'admin';
@@ -2562,53 +2562,6 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs(['id', 'title', 'body'], null, array('fieldset' => false, 'legend' => false));
-		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
-			array('div' => array('class' => 'input text required')),
-			'*/div',
-			array('div' => array('class' => 'input text')),
-			'*/div',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->create($this->article);
-		$result = $this->Form->inputs(array('fieldset' => true, 'legend' => false));
-		$expected = array(
-			'fieldset' => array(),
-			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
-			array('div' => array('class' => 'input select required')),
-			'*/div',
-			array('div' => array('class' => 'input text required')),
-			'*/div',
-			array('div' => array('class' => 'input text')),
-			'*/div',
-			array('div' => array('class' => 'input text')),
-			'*/div',
-			'/fieldset'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->create($this->article);
-		$result = $this->Form->inputs(array('fieldset' => false, 'legend' => 'Hello'));
-		$expected = array(
-			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
-			array('div' => array('class' => 'input select required')),
-			'*/div',
-			array('div' => array('class' => 'input text required')),
-			'*/div',
-			array('div' => array('class' => 'input text')),
-			'*/div',
-			array('div' => array('class' => 'input text')),
-			'*/div',
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->create($this->article);
-		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => 'Hello'));
-		$this->assertTags($result, $expected);
-
-		$this->Form->create($this->article);
 		$result = $this->Form->inputs('Hello');
 		$expected = array(
 			'fieldset' => array(),
@@ -2626,12 +2579,6 @@ class FormHelperTest extends TestCase {
 			'*/div',
 			'/fieldset'
 		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->inputs(array('legend' => 'Hello'));
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->inputs(null, null, array('legend' => 'Hello'));
 		$this->assertTags($result, $expected);
 
 		$this->Form->create(false);


### PR DESCRIPTION
Part of #2267. This unskips the test for inputs(). I've had to expand the ContextInterface a bit as inputs() needed access to all the fieldnames before it could autogenerate inputs.

I've removed a bunch of magic in the method, and deprecated parameters. It has also been updated to use templates instead of HtmlHelper.
