### PR TITLE
Add the ability to set the maxDepth in Hash::flatten

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -360,6 +360,73 @@ class HashTest extends CakeTestCase {
 		);
 		$this->assertEquals($expected, $result);
 	}
+	
+/**
+ * Test flatten() with the maxDepth set
+ * 
+ * @return void
+ */
+	public function testFlattenWithMaxDepth() {
+		$data = array(
+			array(
+				'Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post'),
+				'Author' => array('id' => '1', 'user' => 'nate', 'password' => 'foo'),
+			),
+			array(
+				'Post' => array('id' => '2', 'author_id' => '3', 'title' => 'Second Post', 'body' => 'Second Post Body'),
+				'Author' => array('id' => '3', 'user' => array('larry', 'jim'), 'password' => null),
+			)
+		);
+		
+		$result = Hash::flatten($data, '.', 1);
+		$this->assertEquals($data, $result);
+		
+		$result = Hash::flatten($data, '.', 4);
+		$expected = array(
+			'0.Post.id' => '1',
+			'0.Post.author_id' => '1',
+			'0.Post.title' => 'First Post',
+			'0.Author.id' => '1',
+			'0.Author.user' => 'nate',
+			'0.Author.password' => 'foo',
+			'1.Post.id' => '2',
+			'1.Post.author_id' => '3',
+			'1.Post.title' => 'Second Post',
+			'1.Post.body' => 'Second Post Body',
+			'1.Author.id' => '3',
+			'1.Author.user.0' => 'larry',
+			'1.Author.user.1' => 'jim',
+			'1.Author.password' => null
+		);
+		$this->assertEquals($expected, $result);
+
+		$result = Hash::flatten($data, '.', 2);
+		$expected = array(
+			'0.Post' => array('id' => '1', 'author_id' => '1', 'title' => 'First Post'),
+			'0.Author' => array('id' => '1', 'user' => 'nate', 'password' => 'foo'),
+			'1.Post' => array('id' => '2', 'author_id' => '3', 'title' => 'Second Post', 'body' => 'Second Post Body'),
+			'1.Author' => array('id' => '3', 'user' => array('larry','jim'), 'password' => null)
+		);
+		$this->assertEquals($expected, $result);
+		
+		$result = Hash::flatten($data, '.', 3);
+		$expected = array(
+			'0.Post.id' => '1',
+			'0.Post.author_id' => '1',
+			'0.Post.title' => 'First Post',
+			'0.Author.id' => '1',
+			'0.Author.user' => 'nate',
+			'0.Author.password' => 'foo',
+			'1.Post.id' => '2',
+			'1.Post.author_id' => '3',
+			'1.Post.title' => 'Second Post',
+			'1.Post.body' => 'Second Post Body',
+			'1.Author.id' => '3',
+			'1.Author.user' => array('larry', 'jim'),
+			'1.Author.password' => null
+		);
+		$this->assertEquals($expected, $result);
+	}
 
 /**
  * Test diff();

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -525,13 +525,15 @@ class Hash {
  *
  * @param array $data Array to flatten
  * @param string $separator String used to separate array key elements in a path, defaults to '.'
+ * @param int $maxDepth The max depth the function will go into the array
  * @return array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::flatten
  */
-	public static function flatten(array $data, $separator = '.') {
+	public static function flatten(array $data, $separator = '.', $maxDepth = 20) {
 		$result = array();
 		$stack = array();
 		$path = null;
+		$depth = 1;
 
 		reset($data);
 		while (!empty($data)) {
@@ -539,10 +541,11 @@ class Hash {
 			$element = $data[$key];
 			unset($data[$key]);
 
-			if (is_array($element) && !empty($element)) {
+			if (is_array($element) && !empty($element) && $depth < $maxDepth) {
 				if (!empty($data)) {
-					$stack[] = array($data, $path);
+					$stack[] = array($data, $path, $depth);
 				}
+				$depth += 1;
 				$data = $element;
 				reset($data);
 				$path .= $key . $separator;
@@ -551,7 +554,7 @@ class Hash {
 			}
 
 			if (empty($data) && !empty($stack)) {
-				list($data, $path) = array_pop($stack);
+				list($data, $path, $depth) = array_pop($stack);
 				reset($data);
 			}
 		}


### PR DESCRIPTION
Allows you to set the max depth the Hash::flatten function will "recurse" down into the array.  I'm using this for the utility of it, but it would also add a limit to prevent excessive iterations down into the array.

I've set the default maxDepth to 20.  Technically, this could be breaking.  Realistically, I cannot see a practical reason to flatten an array with a depth larger than 20.
