### PR TITLE
3.0 - Avoid decorating COUNT statements.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -559,25 +559,15 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Executes this query and returns a ResultSet object containing the results
+ * Executes this query and returns a ResultSet object containing the results.
+ * This will also setup the correct statement class in order to eager load deep
+ * associations.
  *
  * @return \Cake\ORM\ResultSet
  */
 	protected function _execute() {
-		return new ResultSet($this, $this->execute());
-	}
-
-/**
- * Auxiliary function used to wrap the original statement from the driver with
- * any registered callbacks. This will also setup the correct statement class
- * in order to eager load deep associations.
- *
- * @param \Cake\Database\Statement $statement to be decorated
- * @return \Cake\Database\Statement
- */
-	protected function _decorateStatement($statement) {
-		$statement = parent::_decorateStatement($statement);
-		return $this->eagerLoader()->loadExternal($this, $statement);
+		$statement = $this->eagerLoader()->loadExternal($this, $this->execute());
+		return new ResultSet($this, $statement);
 	}
 
 /**

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -239,6 +239,37 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to count results containing hasMany associations
+ * both hydrating and not hydrating the results.
+ *
+ * @dataProvider strategiesProvider
+ * @return void
+ */
+	public function testHasManyEagerLoadingCount($strategy) {
+		$table = TableRegistry::get('authors');
+		TableRegistry::get('articles');
+		$table->hasMany('articles', [
+			'property' => 'articles',
+			'strategy' => $strategy,
+			'sort' => ['articles.id' => 'asc']
+		]);
+		$query = new Query($this->connection, $table);
+
+		$query = $query->select()
+			->contain('articles');
+
+		$expected = 4;
+
+		$results = $query->hydrate(false)
+			->count();
+		$this->assertEquals($expected, $results);
+
+		$results = $query->hydrate(true)
+			->count();
+		$this->assertEquals($expected, $results);
+	}
+
+/**
  * Tests that it is possible to set fields & order in a hasMany result set
  *
  * @dataProvider strategiesProvider


### PR DESCRIPTION
Because they only return a number, the decorators will fail expecting
non existent keys.

Fixes https://github.com/cakephp/cakephp/issues/2947
