### PR TITLE
Sqlserver->describe failing for models with a schemaName

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -201,7 +201,8 @@ class Sqlserver extends DboSource {
 			return $cache;
 		}
 		$fields = array();
-		$table = $this->fullTableName($model, false);
+		$table = $this->fullTableName($model, false, false);
+		$schema = $model->schemaName;
 		$cols = $this->_execute(
 			"SELECT
 				COLUMN_NAME as Field,
@@ -212,7 +213,7 @@ class Sqlserver extends DboSource {
 				COLUMNPROPERTY(OBJECT_ID('" . $table . "'), COLUMN_NAME, 'IsIdentity') as [Key],
 				NUMERIC_SCALE as Size
 			FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = '" . $table . "'"
+			WHERE TABLE_NAME = '" . $table . "'".($schema?" AND TABLE_SCHEMA = '" . $schema . "'":'')
 		);
 		if (!$cols) {
 			throw new CakeException(__d('cake_dev', 'Could not describe table for %s', $table));

--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -213,7 +213,7 @@ class Sqlserver extends DboSource {
 				COLUMNPROPERTY(OBJECT_ID('" . $table . "'), COLUMN_NAME, 'IsIdentity') as [Key],
 				NUMERIC_SCALE as Size
 			FROM INFORMATION_SCHEMA.COLUMNS
-			WHERE TABLE_NAME = '" . $table . "'".($schema?" AND TABLE_SCHEMA = '" . $schema . "'":'')
+			WHERE TABLE_NAME = '" . $table . "'" . ($schema ? " AND TABLE_SCHEMA = '" . $schema . "'" : '')
 		);
 		if (!$cols) {
 			throw new CakeException(__d('cake_dev', 'Could not describe table for %s', $table));


### PR DESCRIPTION
When models have a schemaName set it was searching for TABLE_NAME = 'schema_name.table_name'.
Instead it should search for TABLE_NAME = 'table_name' AND TABLE_SCHEMA = 'schema_name'
