### PR TITLE
Allow Behaviour's underscored methods to be mixed in with Model's methods.

### DIFF
--- a/lib/Cake/Model/BehaviorCollection.php
+++ b/lib/Cake/Model/BehaviorCollection.php
@@ -157,7 +157,7 @@ class BehaviorCollection extends ObjectCollection implements CakeEventListener {
 		foreach ($methods as $m) {
 			if (!isset($parentMethods[$m])) {
 				$methodAllowed = (
-					$m[0] !== '_' && !array_key_exists($m, $this->_methods) &&
+					!array_key_exists($m, $this->_methods) &&
 					!in_array($m, $callbacks)
 				);
 				if ($methodAllowed) {


### PR DESCRIPTION
Is there a reason why a behaviour's underscored methods are not added to the model's methods?

This prevents a behaviour from adding custom find types that start with '_find' which I would very much like to do.
