### PR TITLE
3.0 nest input

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -841,12 +841,6 @@ class FormHelper extends Helper {
 		$this->templates($options['templates']);
 		unset($options['templates']);
 
-		$label = $this->_getLabel($fieldName, $options);
-
-		if ($options['type'] !== 'radio') {
-			unset($options['label']);
-		}
-
 		$template = 'groupContainer';
 		$error = null;
 		if ($options['type'] !== 'hidden' && $options['error'] !== false) {
@@ -855,8 +849,15 @@ class FormHelper extends Helper {
 			unset($options['error']);
 		}
 
-		$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
+		$label = $options['label'];
+		if ($options['type'] !== 'radio') {
+			unset($options['label']);
+		}
+
 		$input = $this->_getInput($fieldName, $options);
+		$label = $this->_getLabel($fieldName, compact('input', 'label') + $options);
+
+		$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
 		$result = $this->formatTemplate($groupTemplate, compact('input', 'label'));
 
 		if ($options['type'] !== 'hidden') {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -630,31 +630,41 @@ class FormHelper extends Helper {
  * The text and for attribute are generated off of the fieldname
  *
  * {{{
- * echo $this->Form->label('Post.published');
+ * echo $this->Form->label('published');
  * <label for="PostPublished">Published</label>
  * }}}
  *
  * Custom text:
  *
  * {{{
- * echo $this->Form->label('Post.published', 'Publish');
- * <label for="PostPublished">Publish</label>
+ * echo $this->Form->label('published', 'Publish');
+ * <label for="published">Publish</label>
  * }}}
  *
  * Custom class name:
  *
  * {{{
- * echo $this->Form->label('Post.published', 'Publish', 'required');
- * <label for="PostPublished" class="required">Publish</label>
+ * echo $this->Form->label('published', 'Publish', 'required');
+ * <label for="published" class="required">Publish</label>
  * }}}
  *
  * Custom attributes:
  *
  * {{{
- * echo $this->Form->label('Post.published', 'Publish', array(
+ * echo $this->Form->label('published', 'Publish', array(
  *   'for' => 'post-publish'
  * ));
  * <label for="post-publish">Publish</label>
+ * }}}
+ *
+ * Nesting an input tag:
+ *
+ * {{{
+ * echo $this->Form->label('published', 'Publish', array(
+ *   'for' => 'published',
+ *   'input' => $this->text('published')
+ * ));
+ * <label for="post-publish">Publish <input type="text" name="published"></label>
  * }}}
  *
  * @param string $fieldName This should be "Modelname.fieldname"

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1105,9 +1105,10 @@ class FormHelper extends Helper {
 			$labelText = $label;
 		}
 
-		if (isset($options['id']) && is_string($options['id'])) {
-			$labelAttributes = array_merge($labelAttributes, array('for' => $options['id']));
-		}
+		$labelAttributes = array_merge($labelAttributes, [
+			'for' => isset($options['id']) ? $options['id'] : null,
+			'input' => isset($options['input']) ? $options['input'] : null
+		]);
 		return $this->label($fieldName, $labelText, $labelAttributes);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -5581,4 +5581,26 @@ class FormHelperTest extends TestCase {
 		$this->assertContains('required', $result);
 	}
 
+/**
+ * Tests that it is possible to nest inputs inside labels
+ *
+ * @return void
+ */
+	public function testNestInputInLabel() {
+		$this->Form->templates([
+			'label' => '<label{{attrs}}>{{text}}{{input}}</label>',
+			'formGroup' => '{{label}}'
+		]);
+		$result = $this->Form->input('foo');
+		$expected = array(
+			'div' => array('class' => 'input text'),
+			'label' => array('for' => 'foo'),
+				'Foo',
+				'input' => array('type' => 'text', 'name' => 'foo', 'id' => 'foo'),
+			'/label',
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
 }


### PR DESCRIPTION
This adds the possibility of nesting an input field inside a label, which is used by both bootstrap and foundation
