### PR TITLE
3.0 debug info

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -672,7 +672,7 @@ trait EntityTrait {
 	}
 
 /**
- * Returns an array that can be used to describe the internal estate of this
+ * Returns an array that can be used to describe the internal state of this
  * object.
  *
  * @return array

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -671,4 +671,21 @@ trait EntityTrait {
 		return json_encode($this, JSON_PRETTY_PRINT);
 	}
 
+/**
+ * Returns an array that can be used to describe the internal estate of this
+ * object.
+ *
+ * @return array
+ */
+	public function __debugInfo() {
+		return [
+			'new' => $this->isNew(),
+			'accessible' => array_filter($this->_accessible),
+			'properties' => $this->_properties,
+			'dirty' => $this->_dirty,
+			'virtual' => $this->_virtual,
+			'errors' => $this->_errors
+		];
+	}
+
 }

--- a/src/Utility/Debugger.php
+++ b/src/Utility/Debugger.php
@@ -537,7 +537,7 @@ class Debugger {
 		$replace = array_intersect_key($secrets, $var);
 		$var = $replace + $var;
 
-		$out = "array(";
+		$out = "[";
 		$break = $end = null;
 		if (!empty($var)) {
 			$break = "\n" . str_repeat("\t", $indent);
@@ -560,7 +560,7 @@ class Debugger {
 		} else {
 			$vars[] = $break . '[maximum depth reached]';
 		}
-		return $out . implode(',', $vars) . $end . ')';
+		return $out . implode(',', $vars) . $end . ']';
 	}
 
 /**
@@ -578,10 +578,16 @@ class Debugger {
 
 		$className = get_class($var);
 		$out .= 'object(' . $className . ') {';
+		$break = "\n" . str_repeat("\t", $indent);
+		$end = "\n" . str_repeat("\t", $indent - 1);
+
+		if (method_exists($var, '__debugInfo')) {
+			return $out . "\n" .
+				substr(static::_array($var->__debugInfo(), $depth - 1, $indent), 1, -1) .
+				$end . '}';
+		}
 
 		if ($depth > 0) {
-			$end = "\n" . str_repeat("\t", $indent - 1);
-			$break = "\n" . str_repeat("\t", $indent);
 			$objectVars = get_object_vars($var);
 			foreach ($objectVars as $key => $value) {
 				$value = static::_export($value, $depth - 1, $indent);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -996,4 +996,25 @@ class EntityTest extends TestCase {
 		$this->assertEquals(json_encode($entity, JSON_PRETTY_PRINT), (string)$entity);
 	}
 
+/**
+ * Tests __debugInfo
+ *
+ * @return void
+ */
+	public function testDebugInfo() {
+		$entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
+		$entity->accessible('name', true);
+		$entity->virtualProperties(['baz']);
+		$entity->errors('foo', ['An error']);
+		$result = $entity->__debugInfo();
+		$expected = [
+			'new' => true,
+			'accessible' => ['name'],
+			'properties' => ['foo' => 'bar'],
+			'dirty' => ['foo' => true],
+			'virtual' => ['baz'],
+			'errors' => ['foo' => ['An error']]
+		];
+	}
+
 }

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -28,6 +28,14 @@ use Cake\View\View;
 class DebuggerTestCaseDebugger extends Debugger {
 }
 
+class DebuggableThing {
+
+	public function __debugInfo() {
+		return ['foo' => 'bar', 'inner' => new self()];
+	}
+
+}
+
 /**
  * DebuggerTest class
  *
@@ -623,4 +631,28 @@ TEXT;
 		));
 		$this->assertNotRegExp('/^Cake\\\Test\\\TestCase\\\Utility\\\DebuggerTest::testTraceExclude/', $result);
 	}
+
+/**
+ * Tests that __debugInfo is used when available
+ *
+ * @return void
+ */
+	public function testDebugInfo() {
+		$object = new DebuggableThing();
+		$result = Debugger::exportVar($object, 2);
+		$expected =<<<eos
+object(Cake\Test\TestCase\Utility\DebuggableThing) {
+
+	'foo' => 'bar',
+	'inner' => object(Cake\Test\TestCase\Utility\DebuggableThing) {
+
+		[maximum depth reached]
+	
+	}
+
+}
+eos;
+		$this->assertEquals($expected, $result);
+	}
+
 }

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -640,7 +640,7 @@ TEXT;
 	public function testDebugInfo() {
 		$object = new DebuggableThing();
 		$result = Debugger::exportVar($object, 2);
-		$expected =<<<eos
+		$expected = <<<eos
 object(Cake\Test\TestCase\Utility\DebuggableThing) {
 
 	'foo' => 'bar',

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -313,11 +313,11 @@ object(Cake\View\View) {
 	Blocks => object(Cake\View\ViewBlock) {}
 	plugin => null
 	name => ''
-	passedArgs => array()
-	helpers => array(
+	passedArgs => []
+	helpers => [
 		(int) 0 => 'Html',
 		(int) 1 => 'Form'
-	)
+	]
 	viewPath => ''
 	view => null
 	layout => 'default'
@@ -326,20 +326,20 @@ object(Cake\View\View) {
 	subDir => null
 	theme => null
 	cacheAction => false
-	validationErrors => array()
+	validationErrors => []
 	hasRendered => false
-	uuids => array()
+	uuids => []
 	request => object(Cake\Network\Request) {}
 	response => object(Cake\Network\Response) {}
 	elementCache => 'default'
-	elementCacheSettings => array()
-	viewVars => array()
+	elementCacheSettings => []
+	viewVars => []
 	Html => object(Cake\View\Helper\HtmlHelper) {}
 	Form => object(Cake\View\Helper\FormHelper) {}
 	int => (int) 2
 	float => (float) 1.333
 	[protected] _ext => '.ctp'
-	[protected] _passedVars => array(
+	[protected] _passedVars => [
 		(int) 0 => 'viewVars',
 		(int) 1 => 'autoLayout',
 		(int) 2 => 'helpers',
@@ -353,13 +353,13 @@ object(Cake\View\View) {
 		(int) 10 => 'plugin',
 		(int) 11 => 'passedArgs',
 		(int) 12 => 'cacheAction'
-	)
-	[protected] _scripts => array()
-	[protected] _paths => array()
-	[protected] _parents => array()
+	]
+	[protected] _scripts => []
+	[protected] _paths => []
+	[protected] _parents => []
 	[protected] _current => null
 	[protected] _currentType => ''
-	[protected] _stack => array()
+	[protected] _stack => []
 	[protected] _eventManager => object(Cake\Event\EventManager) {}
 }
 TEXT;
@@ -372,10 +372,10 @@ TEXT;
 		);
 		$result = Debugger::exportVar($data);
 		$expected = <<<TEXT
-array(
+[
 	(int) 1 => 'Index one',
 	(int) 5 => 'Index five'
-)
+]
 TEXT;
 		$this->assertTextEquals($expected, $result);
 
@@ -386,11 +386,11 @@ TEXT;
 		);
 		$result = Debugger::exportVar($data, 1);
 		$expected = <<<TEXT
-array(
-	'key' => array(
+[
+	'key' => [
 		[maximum depth reached]
-	)
-)
+	]
+]
 TEXT;
 		$this->assertTextEquals($expected, $result);
 
@@ -422,13 +422,13 @@ TEXT;
 		);
 		$result = Debugger::exportVar($data);
 		$expected = <<<TEXT
-array(
+[
 	'nothing' => '',
 	'null' => null,
 	'false' => false,
 	'szero' => '0',
 	'zero' => (int) 0
-)
+]
 TEXT;
 		$this->assertTextEquals($expected, $result);
 	}
@@ -454,7 +454,6 @@ TEXT;
 			->with('debug', $this->logicalAnd(
 				$this->stringContains('DebuggerTest::testLog'),
 				$this->stringContains('[main]'),
-				$this->stringContains('array'),
 				$this->stringContains("'whatever',"),
 				$this->stringContains("'here'")
 			));
@@ -513,20 +512,20 @@ TEXT;
 		$open = php_sapi_name() == 'cli' ? "\n" : '<pre>';
 		$close = php_sapi_name() == 'cli' ? "\n" : '</pre>';
 		$expected = <<<TEXT
-{$open}array(
-	'People' => array(
-		(int) 0 => array(
+{$open}[
+	'People' => [
+		(int) 0 => [
 			'name' => 'joeseph',
 			'coat' => 'technicolor',
 			'hair_color' => 'brown'
-		),
-		(int) 1 => array(
+		],
+		(int) 1 => [
 			'name' => 'Shaft',
 			'coat' => 'black',
 			'hair' => 'black'
-		)
-	)
-){$close}
+		]
+	]
+]{$close}
 TEXT;
 		$this->assertTextEquals($expected, $result);
 
@@ -537,11 +536,11 @@ TEXT;
 		$open = php_sapi_name() == 'cli' ? "\n" : '<pre>';
 		$close = php_sapi_name() == 'cli' ? "\n" : '</pre>';
 		$expected = <<<TEXT
-{$open}array(
-	'People' => array(
+{$open}[
+	'People' => [
 		[maximum depth reached]
-	)
-){$close}
+	]
+]{$close}
 TEXT;
 		$this->assertTextEquals($expected, $result);
 	}


### PR DESCRIPTION
As part of https://github.com/cakephp/cakephp/issues/2835, this adds support for `__debugInfo` in `Debugger`.

Additionally added a `__debugInfo` method to Entity to show how it can be used. In future PRs I will be adding the method to other classes.
