### PR TITLE
Add MySQL language support (again)

### DIFF
--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -49,6 +49,11 @@
  * encoding =>
  * For MySQL, Postgres specifies the character encoding to use when connecting to the
  * database. Uses database default not specified.
+ * 
+ * language =>
+ * For MySQL, specifies the language to use when connecting to the database.
+ * The set of locales supported by MySQL can be found on
+ * https://dev.mysql.com/doc/refman/5.0/en/locale-support.html
  *
  * unix_socket =>
  * For MySQL to connect via socket specify the `unix_socket` parameter instead of `host` and `port`
@@ -72,6 +77,7 @@ class DATABASE_CONFIG {
 		'password' => 'password',
 		'database' => 'database_name',
 		'prefix' => '',
+		//'language' => 'fr_FR',
 		//'encoding' => 'utf8',
 	);
 

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -161,6 +161,9 @@ class Mysql extends DboSource {
 		if (!empty($config['encoding'])) {
 			$flags[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $config['encoding'];
 		}
+		if (!empty($config['language'])) {
+			$flags[PDO::MYSQL_ATTR_INIT_COMMAND] = (empty($flags[PDO::MYSQL_ATTR_INIT_COMMAND]) ? 'SET ' : ' ,') . 'lc_time_names = \'' . $config['language'] . '\'';
+		}
 		if (!empty($config['ssl_key']) && !empty($config['ssl_cert'])) {
 			$flags[PDO::MYSQL_ATTR_SSL_KEY] = $config['ssl_key'];
 			$flags[PDO::MYSQL_ATTR_SSL_CERT] = $config['ssl_cert'];


### PR DESCRIPTION
Hi again.
I redo my pull request on the good branch "2.5" instead of branch "master".
I fixed the bug with the MySQL's URL and spaces.

> Hi, it probably already exists, but I added a MySQL language support.
> This is useful when you want the day name or the month name (for exemple) in a date if you have a blog.

Thank you for your reading.

(Sorry, bad english)
