### PR TITLE
Remove FormHelper:create() options relating to ajax forms.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -253,10 +253,6 @@ class FormHelper extends Helper {
  *   don't need to change the controller from the current request's controller.
  * - `url` The URL the form submits to. Can be a string or a URL array. If you use 'url'
  *    you should leave 'action' undefined.
- * - `default` Allows for the creation of Ajax forms. Set this to false to prevent the default event handler.
- *   Will create an onsubmit attribute if it doesn't not exist. If it does, default action suppression
- *   will be appended.
- * - `onsubmit` Used in conjunction with 'default' to create ajax forms.
  * - `encoding` Set the accept-charset encoding for the form. Defaults to `Configure::read('App.encoding')`
  * - `context` Additional options for the context class. For example the EntityContext accepts a 'table'
  *   option that allows you to set the specific Table class the form should be based on.
@@ -284,7 +280,6 @@ class FormHelper extends Helper {
 			'type' => $isCreate ? 'post' : 'put',
 			'action' => null,
 			'url' => null,
-			'default' => true,
 			'encoding' => strtolower(Configure::read('App.encoding')),
 		];
 
@@ -313,17 +308,10 @@ class FormHelper extends Helper {
 		}
 		$this->requestType = strtolower($options['type']);
 
-		if (!$options['default']) {
-			if (!isset($options['onsubmit'])) {
-				$options['onsubmit'] = '';
-			}
-			$htmlAttributes['onsubmit'] = $options['onsubmit'] . 'event.returnValue = false; return false;';
-		}
-
 		if (!empty($options['encoding'])) {
 			$htmlAttributes['accept-charset'] = $options['encoding'];
 		}
-		unset($options['type'], $options['encoding'], $options['default']);
+		unset($options['type'], $options['encoding']);
 
 		$htmlAttributes = array_merge($options, $htmlAttributes);
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -385,48 +385,6 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
- * Test the onsubmit option for create()
- *
- * @return void
- */
-	public function testCreateOnSubmit() {
-		$this->Form->request->data = [];
-		$this->Form->request['controller'] = 'articles';
-		$result = $this->Form->create($this->article, ['url' => ['action' => 'index', 'param'], 'default' => false]);
-		$expected = array(
-			'form' => array(
-				'method' => 'post', 'onsubmit' => 'event.returnValue = false; return false;', 'action' => '/articles/index/param',
-				'accept-charset' => 'utf-8'
-			),
-			'div' => array('style' => 'display:none;'),
-			'input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-
-		$this->Form->request->data = [];
-		$this->Form->request['controller'] = 'articles';
-		$result = $this->Form->create($this->article, array(
-			'url' => array('action' => 'index', 'param'),
-			'default' => false,
-			'onsubmit' => 'someFunction();'
-		));
-
-		$expected = array(
-			'form' => array(
-				'method' => 'post',
-				'onsubmit' => 'someFunction();event.returnValue = false; return false;',
-				'action' => '/articles/index/param',
-				'accept-charset' => 'utf-8'
-			),
-			'div' => array('style' => 'display:none;'),
-			'input' => array('type' => 'hidden', 'name' => '_method', 'value' => 'POST'),
-			'/div'
-		);
-		$this->assertTags($result, $expected);
-	}
-
-/**
  * test create() with automatic url generation
  *
  * @return void


### PR DESCRIPTION
I don't see why these wacky options need to exist. One should use proper javascript event binding or set all required js code for onsubmit.
