### PR TITLE
3.0 form time type

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -887,8 +887,6 @@ class FormHelper extends Helper {
 			case 'url':
 				$options = $this->_initInputField($fieldName, $options);
 				return $this->widget($options['type'], $options);
-			case 'date':
-				return $this->dateTime($fieldName, $options);
 			default:
 				return $this->{$options['type']}($fieldName, $options);
 		}
@@ -1986,14 +1984,10 @@ class FormHelper extends Helper {
  * - `timeFormat` The time format to use, either 12 or 24.
  * - `second` Set to true to enable seconds drop down.
  *
- * To control the order of inputs, and any elements/content between the inputs you
- * can override the `dateWidget` template. By default the `dateWidget` template is:
- *
- * `{{month}}{{day}}{{year}}{{hour}}{{minute}}{{second}}{{meridian}}`
- *
  * @param string $fieldName Prefix name for the SELECT element
  * @param array $options Array of Options
  * @return string Generated set of select boxes for time formats chosen.
+ * @see Cake\View\Helper\FormHelper::dateTime() for templating options.
  */
 	public function time($fieldName, $options = []) {
 		$options += [
@@ -2005,6 +1999,44 @@ class FormHelper extends Helper {
 			'second' => false,
 		];
 		$options['year'] = $options['month'] = $options['day'] = false;
+		$options = $this->_initInputField($fieldName, $options);
+		$options = $this->_datetimeOptions($options);
+
+		return $this->widget('datetime', $options);
+	}
+
+/**
+ * Generate date inputs.
+ *
+ * ### Options:
+ *
+ * ### Options:
+ *
+ * - `monthNames` If false, 2 digit numbers will be used instead of text.
+ *   If a array, the given array will be used.
+ * - `minYear` The lowest year to use in the year select
+ * - `maxYear` The maximum year to use in the year select
+ * - `empty` - If true, the empty select option is shown. If a string,
+ *   that string is displayed as the empty element.
+ * - `value` | `default` The default value to be used by the input. A value in `$this->data`
+ *   matching the field name will override this value. If no default is provided `time()` will be used.
+ *
+ * @param string $fieldName Prefix name for the SELECT element
+ * @param array $options Array of Options
+ * @return string Generated set of select boxes for time formats chosen.
+ * @see Cake\View\Helper\FormHelper::dateTime() for templating options.
+ */
+	public function date($fieldName, $options = []) {
+		$options += [
+			'empty' => true,
+			'value' => null,
+			'monthNames' => true,
+			'minYear' => null,
+			'maxYear' => null,
+			'orderYear' => 'desc',
+		];
+		$options['hour'] = $options['minute'] = false;
+		$options['meridian'] = $options['second'] = false;
 		$options = $this->_initInputField($fieldName, $options);
 		$options = $this->_datetimeOptions($options);
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1973,6 +1973,45 @@ class FormHelper extends Helper {
 	}
 
 /**
+ * Generate time inputs.
+ *
+ * ### Options:
+ *
+ * - `interval` The interval for the minutes select. Defaults to 1
+ * - `empty` - If true, the empty select option is shown. If a string,
+ *   that string is displayed as the empty element.
+ * - `round` - Set to `up` or `down` if you want to force rounding in either direction. Defaults to null.
+ * - `value` | `default` The default value to be used by the input. A value in `$this->data`
+ *   matching the field name will override this value. If no default is provided `time()` will be used.
+ * - `timeFormat` The time format to use, either 12 or 24.
+ * - `second` Set to true to enable seconds drop down.
+ *
+ * To control the order of inputs, and any elements/content between the inputs you
+ * can override the `dateWidget` template. By default the `dateWidget` template is:
+ *
+ * `{{month}}{{day}}{{year}}{{hour}}{{minute}}{{second}}{{meridian}}`
+ *
+ * @param string $fieldName Prefix name for the SELECT element
+ * @param array $options Array of Options
+ * @return string Generated set of select boxes for time formats chosen.
+ */
+	public function time($fieldName, $options = []) {
+		$options += [
+			'empty' => true,
+			'value' => null,
+			'interval' => 1,
+			'round' => null,
+			'timeFormat' => 12,
+			'second' => false,
+		];
+		$options['year'] = $options['month'] = $options['day'] = false;
+		$options = $this->_initInputField($fieldName, $options);
+		$options = $this->_datetimeOptions($options);
+
+		return $this->widget('datetime', $options);
+	}
+
+/**
  * Sets field defaults and adds field to form security input hash.
  * Will also add the error class if the field contains validation errors.
  *

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1742,7 +1742,7 @@ class FormHelper extends Helper {
  * ### Options:
  *
  * - `monthNames` - If false, 2 digit numbers will be used instead of text.
- *   If a array, the given array will be used.
+ *   If an array, the given array will be used.
  * - `empty` - If true, the empty select option is shown. If a string,
  *   that string is displayed as the empty element.
  * - `value` The selected value of the input.
@@ -1854,24 +1854,28 @@ class FormHelper extends Helper {
 /**
  * Returns a set of SELECT elements for a full datetime setup: day, month and year, and then time.
  *
- * ### Options:
+ * ### Date Options:
  *
  * - `empty` - If true, the empty select option is shown. If a string,
  *   that string is displayed as the empty element.
+ * - `value` | `default` The default value to be used by the input. A value in `$this->data`
+ *   matching the field name will override this value. If no default is provided `time()` will be used.
  * - `monthNames` If false, 2 digit numbers will be used instead of text.
- *   If a array, the given array will be used.
- * - `minYear` - The lowest year to use in the year select
- * - `maxYear` - The maximum year to use in the year select
+ *   If an array, the given array will be used.
+ * - `minYear` The lowest year to use in the year select
+ * - `maxYear` The maximum year to use in the year select
  * - `orderYear` - Order of year values in select options.
  *   Possible values 'asc', 'desc'. Default 'desc'.
- * - `interval` - The interval for the minutes select. Defaults to 1
- * - `round` - Set to `up` or `down` if you want to force rounding in either
- *   direction. Defaults to null.
- * - `value` | `default` - The default value to be used by the input.
- *   A value in `$this->data` matching the field name will override this value.
- *   If no default is provided `time()` will be used.
- * - `timeFormat` - The time format to use, either 12 or 24.
- * - `second` - Set to true to enable seconds drop down.
+ *
+ * ### Time options:
+ *
+ * - `empty` - If true, the empty select option is shown. If a string,
+ * - `value` | `default` The default value to be used by the input. A value in `$this->data`
+ *   matching the field name will override this value. If no default is provided `time()` will be used.
+ * - `timeFormat` The time format to use, either 12 or 24.
+ * - `interval` The interval for the minutes select. Defaults to 1
+ * - `round` - Set to `up` or `down` if you want to force rounding in either direction. Defaults to null.
+ * - `second` Set to true to enable seconds drop down.
  *
  * To control the order of inputs, and any elements/content between the inputs you
  * can override the `dateWidget` template. By default the `dateWidget` template is:
@@ -1975,14 +1979,7 @@ class FormHelper extends Helper {
  *
  * ### Options:
  *
- * - `interval` The interval for the minutes select. Defaults to 1
- * - `empty` - If true, the empty select option is shown. If a string,
- *   that string is displayed as the empty element.
- * - `round` - Set to `up` or `down` if you want to force rounding in either direction. Defaults to null.
- * - `value` | `default` The default value to be used by the input. A value in `$this->data`
- *   matching the field name will override this value. If no default is provided `time()` will be used.
- * - `timeFormat` The time format to use, either 12 or 24.
- * - `second` Set to true to enable seconds drop down.
+ * See dateTime() for time options.
  *
  * @param string $fieldName Prefix name for the SELECT element
  * @param array $options Array of Options
@@ -2010,16 +2007,7 @@ class FormHelper extends Helper {
  *
  * ### Options:
  *
- * ### Options:
- *
- * - `monthNames` If false, 2 digit numbers will be used instead of text.
- *   If a array, the given array will be used.
- * - `minYear` The lowest year to use in the year select
- * - `maxYear` The maximum year to use in the year select
- * - `empty` - If true, the empty select option is shown. If a string,
- *   that string is displayed as the empty element.
- * - `value` | `default` The default value to be used by the input. A value in `$this->data`
- *   matching the field name will override this value. If no default is provided `time()` will be used.
+ * See dateTime() for date options.
  *
  * @param string $fieldName Prefix name for the SELECT element
  * @param array $options Array of Options

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3821,6 +3821,24 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test the date type.
+ *
+ * @return void
+ */
+	public function testDate() {
+		$result = $this->Form->date('start_day', array(
+			'value' => array('year' => '2014', 'month' => '03', 'day' => '08')
+		));
+		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
+		$this->assertContains('<option value="03" selected="selected">March</option>', $result);
+		$this->assertContains('<option value="08" selected="selected">8</option>', $result);
+		$this->assertNotContains('hour', $result);
+		$this->assertNotContains('minute', $result);
+		$this->assertNotContains('second', $result);
+		$this->assertNotContains('meridian', $result);
+	}
+
+/**
  * testDateTime method
  *
  * Test generation of date/time select elements

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -698,7 +698,7 @@ class FormHelperTest extends TestCase {
 		]);
 		$this->assertNotContains('testKey', $result);
 
-		$result = $this->Form->end('Save');
+		$result = $this->Form->end();
 		$this->assertNotContains('testKey', $result);
 	}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3790,6 +3790,37 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test the time type.
+ *
+ * @return void
+ */
+	public function testTime() {
+		$result = $this->Form->time('start_time', array(
+			'timeFormat' => 12,
+			'interval' => 5,
+			'value' => array('hour' => '4', 'minute' => '30', 'meridian' => 'pm')
+		));
+		$this->assertContains('<option value="04" selected="selected">4</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertContains('<option value="pm" selected="selected">pm</option>', $result);
+		$this->assertNotContains('year', $result);
+		$this->assertNotContains('month', $result);
+		$this->assertNotContains('day', $result);
+
+		$result = $this->Form->time('start_time', array(
+			'timeFormat' => 12,
+			'interval' => 5,
+			'value' => '2014-03-08 16:30:00'
+		));
+		$this->assertContains('<option value="04" selected="selected">4</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertContains('<option value="pm" selected="selected">pm</option>', $result);
+		$this->assertNotContains('year', $result);
+		$this->assertNotContains('month', $result);
+		$this->assertNotContains('day', $result);
+	}
+
+/**
  * testDateTime method
  *
  * Test generation of date/time select elements

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1170,7 +1170,7 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Form->secure($expected);
+		$result = $this->Form->secure($expected, ['data-foo' => 'bar']);
 
 		$hash = '2981c38990f3f6ba935e6561dc77277966fabd6d%3AAddresses.id';
 		$expected = array(
@@ -1178,12 +1178,14 @@ class FormHelperTest extends TestCase {
 			array('input' => array(
 				'type' => 'hidden',
 				'name' => '_Token[fields]',
-				'value' => $hash
+				'value' => $hash,
+				'data-foo' => 'bar',
 			)),
 			array('input' => array(
 				'type' => 'hidden',
 				'name' => '_Token[unlocked]',
 				'value' => 'address%7Cfirst_name',
+				'data-foo' => 'bar',
 			)),
 			'/div'
 		);


### PR DESCRIPTION
Restore the `date` and `time` types to FormHelper. These were removed by accident when I was working on datetime inputs. 
