### PR TITLE
Controller view vars. Refs #2970.

### DIFF
--- a/src/Error/ExceptionRenderer.php
+++ b/src/Error/ExceptionRenderer.php
@@ -292,7 +292,7 @@ class ExceptionRenderer {
 		$this->controller->layout = 'error';
 		$this->controller->helpers = array('Form', 'Html', 'Session');
 
-		$view = new View($this->controller);
+		$view = $this->controller->createView();
 		$this->controller->response->body($view->render($template, 'error'));
 		$this->controller->response->type('html');
 		$this->controller->response->send();

--- a/src/Utility/ViewVarsTrait.php
+++ b/src/Utility/ViewVarsTrait.php
@@ -49,5 +49,4 @@ trait ViewVarsTrait {
 		}
 		$this->viewVars = $data + $this->viewVars;
 	}
-
 }

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -16,6 +16,8 @@ namespace Cake\View;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Cake\Network\Request;
 use Cake\Network\Response;
 
 /**
@@ -64,12 +66,17 @@ class JsonView extends View {
 /**
  * Constructor
  *
- * @param Controller $controller
+ * @param Request $request
+ * @param Response $response
+ * @param EventManager $eventManager
+ * @param array $viewOptions
  */
-	public function __construct(Controller $controller = null) {
-		parent::__construct($controller);
-		if (isset($controller->response) && $controller->response instanceof Response) {
-			$controller->response->type('json');
+	public function __construct(Request $request = null, Response $response = null,
+		EventManager $eventManager = null, array $viewOptions = []) {
+		parent::__construct($request, $response, $eventManager, $viewOptions);
+
+		if ($response && $response instanceof Response) {
+			$response->type('json');
 		}
 	}
 

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -16,6 +16,8 @@ namespace Cake\View;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Set;
 use Cake\Utility\Xml;
@@ -63,14 +65,17 @@ class XmlView extends View {
 
 /**
  * Constructor
- *
- * @param Controller $controller
+ * @param Request $request
+ * @param Response $response
+ * @param EventManager $eventManager
+ * @param array $viewOptions
  */
-	public function __construct(Controller $controller = null) {
-		parent::__construct($controller);
+	public function __construct(Request $request = null, Response $response = null,
+		EventManager $eventManager = null, array $viewOptions = []) {
+		parent::__construct($request, $response, $eventManager, $viewOptions);
 
-		if (isset($controller->response) && $controller->response instanceof Response) {
-			$controller->response->type('xml');
+		if ($response && $response instanceof Response) {
+			$response->type('xml');
 		}
 	}
 

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -695,9 +695,8 @@ class ExceptionRendererTest extends TestCase {
 
 		$ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', array('render'));
 		$ExceptionRenderer->controller->helpers = array('Fail', 'Boom');
-		$ExceptionRenderer->controller->layoutPath = 'json';
-		$ExceptionRenderer->controller->subDir = 'json';
-		$ExceptionRenderer->controller->viewClass = 'Json';
+		$ExceptionRenderer->controller->layoutPath = 'boom';
+		$ExceptionRenderer->controller->subDir = 'boom';
 		$ExceptionRenderer->controller->request = new Request;
 
 		$ExceptionRenderer->controller->expects($this->once())

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -310,7 +310,7 @@ class DebuggerTest extends TestCase {
 	public function testExportVar() {
 		$Controller = new Controller();
 		$Controller->helpers = array('Html', 'Form');
-		$View = new View($Controller);
+		$View = $Controller->createView();
 		$View->int = 2;
 		$View->float = 1.333;
 
@@ -357,10 +357,9 @@ object(Cake\View\View) {
 		(int) 6 => 'theme',
 		(int) 7 => 'layoutPath',
 		(int) 8 => 'viewPath',
-		(int) 9 => 'request',
-		(int) 10 => 'plugin',
-		(int) 11 => 'passedArgs',
-		(int) 12 => 'cacheAction'
+		(int) 9 => 'plugin',
+		(int) 10 => 'passedArgs',
+		(int) 11 => 'cacheAction'
 	]
 	[protected] _scripts => []
 	[protected] _paths => []

--- a/tests/TestCase/View/Helper/CacheHelperTest.php
+++ b/tests/TestCase/View/Helper/CacheHelperTest.php
@@ -83,7 +83,7 @@ class CacheHelperTest extends TestCase {
 		$_GET = [];
 		$request = new Request();
 		$this->Controller = new CacheTestController($request);
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$this->Cache = new CacheHelper($View);
 		Configure::write('Cache.check', true);
 		Cache::enable();
@@ -116,7 +116,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->request->action = 'cache_parsing';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 		$this->assertNotContains('cake:nocache', $result);
 		$this->assertNotContains('<?php echo', $result);
@@ -148,7 +148,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/posts/view/風街ろまん';
 		$this->Controller->action = 'view';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$View->render('index');
 
 		$filename = CACHE . 'views/posts_view_風街ろまん.php';
@@ -173,7 +173,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->action = 'cache_parsing';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('test_nocache_tags');
 		$this->assertNotRegExp('/cake:nocache/', $result);
 		$this->assertNotRegExp('/php echo/', $result);
@@ -206,7 +206,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->action = 'cache_parsing';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('multiple_nocache');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -232,13 +232,13 @@ class CacheHelperTest extends TestCase {
 			'action' => 'cache_complex',
 			'pass' => array(),
 		));
-		$this->Controller->cacheAction = array('cache_complex' => 21600);
-		$this->Controller->request->here = '/cacheTest/cache_complex';
 		$this->Controller->action = 'cache_complex';
+		$this->Controller->request->here = '/cacheTest/cache_complex';
+		$this->Controller->cacheAction = array('cache_complex' => 21600);
 		$this->Controller->layout = 'multi_cache';
 		$this->Controller->viewPath = 'Posts';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('sequencial_nocache');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -294,7 +294,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->cacheAction = 21600;
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 		$this->assertNotRegExp('/cake:nocache/', $result);
 		$this->assertNotRegExp('/php echo/', $result);
@@ -324,13 +324,12 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->cacheAction = array(
 			'cache_parsing' => array(
 				'duration' => 21600,
-				'callbacks' => true
-			)
+				'callbacks' => true)
 		);
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->cache_parsing();
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$View->render('index');
 
 		$filename = CACHE . 'views/cachetest_cache_parsing.php';
@@ -361,7 +360,7 @@ class CacheHelperTest extends TestCase {
 
 		$this->Controller->cache_parsing();
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -389,7 +388,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/cacheTest/cache_parsing';
 		$this->Controller->cache_parsing();
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -419,7 +418,7 @@ class CacheHelperTest extends TestCase {
 		);
 		$this->Controller->request->here = '/cache_test/cache_parsing/1/2/name:mark/ice:cream';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -445,12 +444,12 @@ class CacheHelperTest extends TestCase {
 			'pass' => array(),
 		));
 		$this->Controller->request->query = array('q' => 'cakephp');
+		$this->Controller->request->here = '/cache_test/cache_parsing';
 		$this->Controller->cacheAction = array(
 			'cache_parsing' => 21600
 		);
-		$this->Controller->request->here = '/cache_test/cache_parsing';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -483,7 +482,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->request->here = '/en/cache_test/cache_parsing';
 		$this->Controller->action = 'cache_parsing';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -517,7 +516,7 @@ class CacheHelperTest extends TestCase {
 		$request->here = '/cache/cacheTest/cache_name';
 		$request->base = '/cache';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('index');
 
 		$this->assertNotRegExp('/cake:nocache/', $result);
@@ -535,7 +534,7 @@ class CacheHelperTest extends TestCase {
  */
 	public function testAfterRenderConditions() {
 		Configure::write('Cache.check', true);
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$View->cacheAction = '+1 day';
 		$View->assign('content', 'test');
 
@@ -556,7 +555,7 @@ class CacheHelperTest extends TestCase {
  */
 	public function testAfterLayoutConditions() {
 		Configure::write('Cache.check', true);
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$View->cacheAction = '+1 day';
 		$View->set('content', 'test');
 
@@ -597,7 +596,7 @@ class CacheHelperTest extends TestCase {
 		$this->Controller->layout = 'cache_empty_sections';
 		$this->Controller->viewPath = 'Posts';
 
-		$View = new View($this->Controller);
+		$View = $this->Controller->createView();
 		$result = $View->render('cache_empty_sections');
 		$this->assertNotContains('nocache', $result);
 		$this->assertNotContains('<?php echo', $result);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -140,7 +140,7 @@ class FormHelperTest extends TestCase {
 		Configure::write('App.base', '');
 		Configure::write('App.namespace', 'Cake\Test\TestCase\View\Helper');
 		Configure::delete('Asset');
-		$this->View = new View(null);
+		$this->View = new View();
 
 		$this->Form = new FormHelper($this->View);
 		$this->Form->request = new Request('articles/add');
@@ -2205,7 +2205,7 @@ class FormHelperTest extends TestCase {
 		$this->Form = $this->getMock(
 			'Cake\View\Helper\FormHelper',
 			['datetime'],
-			[new View(null)]
+			[new View()]
 		);
 		$this->Form->expects($this->once())->method('datetime')
 			->with('prueba', [
@@ -2244,7 +2244,7 @@ class FormHelperTest extends TestCase {
 		$this->Form = $this->getMock(
 			'Cake\View\Helper\FormHelper',
 			['datetime'],
-			[new View(null)]
+			[new View()]
 		);
 
 		$this->Form->create(false, ['idPrefix' => 'prefix']);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -66,7 +66,7 @@ class HtmlHelperTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$controller = $this->getMock('Cake\Controller\Controller');
-		$this->View = $this->getMock('Cake\View\View', array('append'), array($controller));
+		$this->View = $this->getMock('Cake\View\View', array('append'));
 		$this->Html = new HtmlHelper($this->View);
 		$this->Html->request = new Request();
 		$this->Html->request->webroot = '';

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -57,7 +57,7 @@ class NumberHelperTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->View = new View(null);
+		$this->View = new View();
 
 		$this->_appNamespace = Configure::read('App.namespace');
 		Configure::write('App.namespace', 'TestApp');

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -37,8 +37,7 @@ class PaginatorHelperTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Configure::write('Config.language', 'eng');
-		$controller = null;
-		$this->View = new View($controller);
+		$this->View = new View();
 		$this->Paginator = new PaginatorHelper($this->View);
 		$this->Paginator->Js = $this->getMock('Cake\View\Helper\PaginatorHelper', array(), array($this->View));
 		$this->Paginator->request = new Request();

--- a/tests/TestCase/View/Helper/RssHelperTest.php
+++ b/tests/TestCase/View/Helper/RssHelperTest.php
@@ -36,8 +36,7 @@ class RssHelperTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$controller = null;
-		$this->View = new View($controller);
+		$this->View = new View();
 		$this->Rss = new RssHelper($this->View);
 	}
 

--- a/tests/TestCase/View/Helper/SessionHelperTest.php
+++ b/tests/TestCase/View/Helper/SessionHelperTest.php
@@ -37,8 +37,7 @@ class SessionHelperTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$controller = null;
-		$this->View = new View($controller);
+		$this->View = new View();
 		$this->Session = new SessionHelper($this->View);
 		Session::start();
 

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -59,7 +59,7 @@ class TextHelperTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->View = new View(null);
+		$this->View = new View();
 		$this->Text = new TextHelper($this->View);
 
 		$this->_appNamespace = Configure::read('App.namespace');

--- a/tests/TestCase/View/Helper/TimeHelperTest.php
+++ b/tests/TestCase/View/Helper/TimeHelperTest.php
@@ -63,7 +63,7 @@ class TimeHelperTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->View = new View(null);
+		$this->View = new View();
 
 		$this->_appNamespace = Configure::read('App.namespace');
 		Configure::write('App.namespace', 'TestApp');

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -44,7 +44,7 @@ class HelperRegistryTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->View = new View(null);
+		$this->View = new View();
 		$this->Events = $this->View->getEventManager();
 		$this->Helpers = new HelperRegistry($this->View);
 	}

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -177,8 +177,7 @@ class HelperTest extends TestCase {
 		parent::setUp();
 
 		Router::reload();
-		$null = null;
-		$this->View = new View($null);
+		$this->View = new View();
 		$this->Helper = new Helper($this->View);
 		$this->Helper->request = new Request();
 	}

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -212,7 +212,8 @@ class JsonViewTest extends TestCase {
 		$Controller->set($data);
 		$Controller->set('_serialize', $serialize);
 		$Controller->set('_jsonOptions', $jsonOptions);
-		$View = new JsonView($Controller);
+		$Controller->viewClass = 'Json';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 
 		$this->assertSame($expected, $output);
@@ -233,7 +234,8 @@ class JsonViewTest extends TestCase {
 			'tags' => array('cakephp', 'framework'),
 			'_serialize' => 'tags'
 		));
-		$View = new JsonView($Controller);
+		$Controller->viewClass = 'Json';
+		$View = $Controller->createView();
 		$View->render();
 
 		$this->assertFalse(isset($View->Html), 'No helper loaded.');
@@ -255,7 +257,8 @@ class JsonViewTest extends TestCase {
 			'_serialize' => 'data',
 			'_jsonp' => true
 		));
-		$View = new JsonView($Controller);
+		$Controller->viewClass = 'Json';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 
 		$this->assertSame(json_encode($data), $output);
@@ -283,7 +286,8 @@ class JsonViewTest extends TestCase {
 		$Request = new Request();
 		$Response = new Response();
 		$Controller = new Controller($Request, $Response);
-		$Controller->name = $Controller->viewPath = 'Posts';
+		$Controller->name = 'Posts';
+		$Controller->viewPath = 'Posts';
 
 		$data = array(
 			'User' => array(
@@ -295,7 +299,8 @@ class JsonViewTest extends TestCase {
 			)
 		);
 		$Controller->set('user', $data);
-		$View = new JsonView($Controller);
+		$Controller->viewClass = 'Json';
+		$View = $Controller->createView();
 		$output = $View->render('index');
 
 		$expected = json_encode(array('user' => 'fake', 'list' => array('item1', 'item2'), 'paging' => null));

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -261,14 +261,14 @@ class ViewTest extends TestCase {
 		$this->PostsController = new ViewPostsController($request);
 		$this->PostsController->viewPath = 'Posts';
 		$this->PostsController->index();
-		$this->View = new View($this->PostsController);
+		$this->View = $this->PostsController->createView();
 
 		$themeRequest = new Request('posts/index');
 		$this->ThemeController = new Controller($themeRequest);
 		$this->ThemePostsController = new ThemePostsController($themeRequest);
-		$this->ThemePostsController->viewPath = 'posts';
+		$this->ThemePostsController->viewPath = 'Posts';
 		$this->ThemePostsController->index();
-		$this->ThemeView = new View($this->ThemePostsController);
+		$this->ThemeView = $this->ThemePostsController->createView();
 
 		App::objects('Plugin', null, false);
 
@@ -298,13 +298,17 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testGetTemplate() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Pages';
-		$this->Controller->viewPath = 'Pages';
-		$this->Controller->request->action = 'display';
-		$this->Controller->request->params['pass'] = array('home');
+		$request = $this->getMock('Cake\Network\Request');
+		$response = $this->getMock('Cake\Network\Response');
 
-		$ThemeView = new TestThemeView($this->Controller);
+		$viewOptions = [ 'plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages'
+		];
+		$request->action = 'display';
+		$request->params['pass'] = array('home');
+
+		$ThemeView = new TestThemeView(null, null, null, $viewOptions);
 		$ThemeView->theme = 'TestTheme';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
 		$result = $ThemeView->getViewFileName('home');
@@ -335,12 +339,13 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testPluginGetTemplate() {
-		$this->Controller->plugin = 'TestPlugin';
-		$this->Controller->name = 'TestPlugin';
-		$this->Controller->viewPath = 'Tests';
-		$this->Controller->action = 'index';
+		$viewOptions = ['plugin' => 'TestPlugin',
+			'name' => 'TestPlugin',
+			'viewPath' => 'Tests',
+			'view' => 'index'
+		];
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 
 		$expected = Plugin::path('TestPlugin') . 'Template' . DS . 'Tests' . DS . 'index.ctp';
 		$result = $View->getViewFileName('index');
@@ -357,13 +362,14 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testPluginThemedGetTemplate() {
-		$this->Controller->plugin = 'TestPlugin';
-		$this->Controller->name = 'TestPlugin';
-		$this->Controller->viewPath = 'Tests';
-		$this->Controller->action = 'index';
-		$this->Controller->theme = 'TestTheme';
+		$viewOptions = ['plugin' => 'TestPlugin',
+			'name' => 'TestPlugin',
+			'viewPath' => 'Tests',
+			'view' => 'index',
+			'theme' => 'TestTheme'
+		];
 
-		$ThemeView = new TestThemeView($this->Controller);
+		$ThemeView = new TestThemeView(null, null, null, $viewOptions);
 		$themePath = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Themed' . DS . 'TestTheme' . DS;
 
 		$expected = $themePath . 'Plugin' . DS . 'TestPlugin' . DS . 'Tests' . DS . 'index.ctp';
@@ -385,12 +391,13 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testPluginPathGeneration() {
-		$this->Controller->plugin = 'TestPlugin';
-		$this->Controller->name = 'TestPlugin';
-		$this->Controller->viewPath = 'Tests';
-		$this->Controller->action = 'index';
+		$viewOptions = ['plugin' => 'TestPlugin',
+			'name' => 'TestPlugin',
+			'viewPath' => 'Tests',
+			'view' => 'index'
+		];
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 		$paths = $View->paths();
 		$expected = array_merge(App::path('Template'), App::core('Template'));
 		$this->assertEquals($expected, $paths);
@@ -412,12 +419,13 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testCamelCasePluginGetTemplate() {
-		$this->Controller->plugin = 'TestPlugin';
-		$this->Controller->name = 'TestPlugin';
-		$this->Controller->viewPath = 'Tests';
-		$this->Controller->action = 'index';
+		$viewOptions = ['plugin' => 'TestPlugin',
+			'name' => 'TestPlugin',
+			'viewPath' => 'Tests',
+			'view' => 'index'
+		];
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 
 		$pluginPath = Plugin::path('TestPlugin');
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Tests' . DS . 'index.ctp';
@@ -435,13 +443,14 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testGetViewFileNames() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Pages';
-		$this->Controller->viewPath = 'Pages';
-		$this->Controller->request->action = 'display';
-		$this->Controller->request->params['pass'] = array('home');
+		$viewOptions = ['plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages'
+		];
+		$request = $this->getMock('Cake\Network\Request');
+		$response = $this->getMock('Cake\Network\Response');
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
 		$result = $View->getViewFileName('home');
@@ -476,12 +485,13 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testGetLayoutFileName() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Pages';
-		$this->Controller->viewPath = 'Pages';
-		$this->Controller->action = 'display';
+		$viewOptions = ['plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages',
+			'action' => 'display'
+		];
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
@@ -504,12 +514,13 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testGetLayoutFileNamePlugin() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Pages';
-		$this->Controller->viewPath = 'Pages';
-		$this->Controller->action = 'display';
+		$viewOptions = ['plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages',
+			'action' => 'display'
+		];
 
-		$View = new TestView($this->Controller);
+		$View = new TestView(null, null, null, $viewOptions);
 		Plugin::load('TestPlugin');
 
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
@@ -529,26 +540,17 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testMissingView() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Pages';
-		$this->Controller->viewPath = 'Pages';
-		$this->Controller->request->action = 'display';
-		$this->Controller->request->params['pass'] = array('home');
+		$viewOptions = ['plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages'
+		];
+		$request = $this->getMock('Cake\Network\Request');
+		$response = $this->getMock('Cake\Network\Response');
 
-		$View = new TestView($this->Controller);
+		$View = new TestView($request, $response, null, $viewOptions);
 		ob_start();
 		$View->getViewFileName('does_not_exist');
-
-		$this->ThemeController->plugin = null;
-		$this->ThemeController->name = 'Pages';
-		$this->ThemeController->viewPath = 'Pages';
-		$this->ThemeController->action = 'display';
-		$this->ThemeController->theme = 'my_theme';
-
-		$this->ThemeController->request->params['pass'] = array('home');
-
-		$View = new TestThemeView($this->ThemeController);
-		$View->getViewFileName('does_not_exist');
+		ob_get_clean();
 	}
 
 /**
@@ -558,24 +560,15 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testMissingLayout() {
-		$this->Controller->plugin = null;
-		$this->Controller->name = 'Posts';
-		$this->Controller->viewPath = 'Posts';
-		$this->Controller->layout = 'whatever';
-
-		$View = new TestView($this->Controller);
+		$viewOptions = ['plugin' => null,
+			'name' => 'Pages',
+			'viewPath' => 'Pages',
+			'layout' => 'whatever'
+		];
+		$View = new TestView(null, null, null, $viewOptions);
 		ob_start();
 		$View->getLayoutFileName();
 		ob_get_clean();
-
-		$this->ThemeController->plugin = null;
-		$this->ThemeController->name = 'Posts';
-		$this->ThemeController->viewPath = 'posts';
-		$this->ThemeController->layout = 'whatever';
-		$this->ThemeController->theme = 'my_theme';
-
-		$View = new TestThemeView($this->ThemeController);
-		$View->getLayoutFileName();
 	}
 
 /**
@@ -610,7 +603,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testAddInlineScripts() {
-		$View = new TestView($this->Controller);
+		$View = new TestView();
 		$View->addScript('prototype.js');
 		$View->addScript('prototype.js');
 		$this->assertEquals(array('prototype.js'), $View->scripts());
@@ -704,7 +697,7 @@ class ViewTest extends TestCase {
 		$Controller = new ViewPostsController();
 		$Controller->helpers = array('Form');
 
-		$View = new View($Controller);
+		$View = $Controller->createView();
 		$result = $View->element('type_check', array('form' => 'string'), array('callbacks' => true));
 		$this->assertEquals('string', $result);
 
@@ -720,7 +713,7 @@ class ViewTest extends TestCase {
  */
 	public function testElementCacheHelperNoCache() {
 		$Controller = new ViewPostsController();
-		$View = new TestView($Controller);
+		$View = $Controller->createView();
 		$View->loadHelpers();
 		$result = $View->element('test_element', array('ram' => 'val', 'test' => array('foo', 'bar')));
 		$this->assertEquals('this is the test element', $result);
@@ -741,7 +734,7 @@ class ViewTest extends TestCase {
 		]);
 		Cache::clear(true, 'test_view');
 
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView();
 		$View->elementCache = 'test_view';
 
 		$result = $View->element('test_element', array(), array('cache' => true));
@@ -786,7 +779,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testMagicGetAndAddHelper() {
-		$View = new View($this->PostsController);
+		$View = new View();
 		$View->addHelper('Html');
 		$this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 	}
@@ -797,7 +790,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testLoadHelpers() {
-		$View = new View($this->PostsController);
+		$View = new View();
 
 		$View->helpers = array('Html', 'Form');
 		$View->loadHelpers();
@@ -812,7 +805,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testLazyLoadHelpers() {
-		$View = new View($this->PostsController);
+		$View = new View();
 
 		$View->helpers = array();
 		$this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html, 'Object type is wrong.');
@@ -825,7 +818,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testHelperCallbackTriggering() {
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 
 		$manager = $this->getMock('Cake\Event\EventManager');
 		$View->setEventManager($manager);
@@ -916,7 +909,7 @@ class ViewTest extends TestCase {
 			'TestBeforeAfter' => array('className' => __NAMESPACE__ . '\TestBeforeAfterHelper'),
 			'Html'
 		);
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 		$View->render('index');
 		$this->assertEquals('Valuation', $View->helpers()->TestBeforeAfter->property);
 	}
@@ -934,7 +927,7 @@ class ViewTest extends TestCase {
 		);
 		$this->PostsController->set('variable', 'values');
 
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 
 		$content = 'This is my view output';
 		$result = $View->renderLayout($content, 'default');
@@ -949,7 +942,7 @@ class ViewTest extends TestCase {
  */
 	public function testRenderLoadHelper() {
 		$this->PostsController->helpers = array('Session', 'Html', 'Form', 'Number');
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
@@ -958,7 +951,7 @@ class ViewTest extends TestCase {
 		$this->assertEquals(array('Session', 'Html', 'Form', 'Number'), $attached);
 
 		$this->PostsController->helpers = array('Html', 'Form', 'Number', 'TestPlugin.PluggedHelper');
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
@@ -974,7 +967,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testRender() {
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$result = $View->render('index');
 
 		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/>\s*<title>/", $result);
@@ -984,7 +977,7 @@ class ViewTest extends TestCase {
 		$this->assertTrue(isset($View->viewVars['content_for_layout']), 'content_for_layout should be a view var');
 		$this->assertTrue(isset($View->viewVars['scripts_for_layout']), 'scripts_for_layout should be a view var');
 
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$result = $View->render(false, 'ajax2');
 
 		$this->assertRegExp('/Ajax\!/', $result);
@@ -997,7 +990,7 @@ class ViewTest extends TestCase {
 		$this->PostsController->request->params['action'] = 'index';
 		Configure::write('Cache.check', true);
 
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$result = $View->render('index');
 
 		$this->assertRegExp("/<meta http-equiv=\"Content-Type\" content=\"text\/html; charset=utf-8\" \/>\s*<title>/", $result);
@@ -1011,7 +1004,7 @@ class ViewTest extends TestCase {
  */
 	public function testRenderUsingViewProperty() {
 		$this->PostsController->view = 'cache_form';
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 
 		$this->assertEquals('cache_form', $View->view);
 		$result = $View->render();
@@ -1026,11 +1019,10 @@ class ViewTest extends TestCase {
  */
 	public function testGetViewFileNameSubdirWithPluginAndViewPath() {
 		$this->PostsController->plugin = 'TestPlugin';
-		$this->PostsController->viewPath = 'Element';
 		$this->PostsController->name = 'Posts';
-		$View = new TestView($this->PostsController);
+		$this->PostsController->viewPath = 'Element';
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 		$pluginPath = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
-
 		$result = $View->getViewFileName('sub_dir/sub_element');
 		$expected = $pluginPath . 'Template' . DS . 'Element' . DS . 'sub_dir' . DS . 'sub_element.ctp';
 		$this->assertEquals($expected, $result);
@@ -1046,7 +1038,7 @@ class ViewTest extends TestCase {
 		$Controller = new ViewPostsController();
 		$Controller->helpers = array('Session', 'Html');
 		$Controller->set('html', 'I am some test html');
-		$View = new View($Controller);
+		$View = $Controller->createView();
 		$result = $View->render('helper_overwrite', false);
 
 		$this->assertRegExp('/I am some test html/', $result);
@@ -1059,7 +1051,7 @@ class ViewTest extends TestCase {
  * @return void
  */
 	public function testViewFileName() {
-		$View = new TestView($this->PostsController);
+		$View = $this->PostsController->createView('Cake\Test\TestCase\View\TestView');
 
 		$result = $View->getViewFileName('index');
 		$this->assertRegExp('/Posts(\/|\\\)index.ctp/', $result);
@@ -1090,7 +1082,7 @@ class ViewTest extends TestCase {
 		$this->skipIf(!is_writable(CACHE . 'views/'), 'CACHE/views dir is not writable, cannot test renderCache.');
 
 		$view = 'test_view';
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 		$path = CACHE . 'views/view_cache_' . $view;
 
 		$cacheText = '<!--cachetime:' . time() . '-->some cacheText';
@@ -1124,7 +1116,7 @@ class ViewTest extends TestCase {
  */
 	public function testRenderStrippingNoCacheTagsOnlyCacheHelper() {
 		Configure::write('Cache.check', false);
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 		$View->set(array('superman' => 'clark', 'variable' => 'var'));
 		$View->helpers = array('Html', 'Form', 'Cache');
 		$View->layout = 'cache_layout';
@@ -1139,7 +1131,7 @@ class ViewTest extends TestCase {
  */
 	public function testRenderStrippingNoCacheTagsOnlyCacheCheck() {
 		Configure::write('Cache.check', true);
-		$View = new View($this->PostsController);
+		$View = $this->PostsController->createView();
 		$View->set(array('superman' => 'clark', 'variable' => 'var'));
 		$View->helpers = array('Html', 'Form');
 		$View->layout = 'cache_layout';
@@ -1524,11 +1516,11 @@ TEXT;
 	public function testMemoryLeakInPaths() {
 		$this->ThemeController->plugin = null;
 		$this->ThemeController->name = 'Posts';
-		$this->ThemeController->viewPath = 'posts';
+		$this->ThemeController->viewPath = 'Posts';
 		$this->ThemeController->layout = 'whatever';
 		$this->ThemeController->theme = 'TestTheme';
 
-		$View = new View($this->ThemeController);
+		$View = $this->ThemeController->createView();
 		$View->element('test_element');
 
 		$start = memory_get_usage();

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -47,7 +47,8 @@ class XmlViewTest extends TestCase {
 		$Controller = new Controller($Request, $Response);
 		$data = array('users' => array('user' => array('user1', 'user2')));
 		$Controller->set(array('users' => $data, '_serialize' => 'users'));
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 
 		$this->assertSame(Xml::build($data)->asXML(), $output);
@@ -66,14 +67,16 @@ class XmlViewTest extends TestCase {
 			)
 		);
 		$Controller->set(array('users' => $data, '_serialize' => 'users'));
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 
 		$expected = Xml::build(array('response' => array('users' => $data)))->asXML();
 		$this->assertSame($expected, $output);
 
 		$Controller->set('_rootNode', 'custom_name');
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 
 		$expected = Xml::build(array('custom_name' => array('users' => $data)))->asXML();
@@ -94,7 +97,8 @@ class XmlViewTest extends TestCase {
 			'_serialize' => 'tags',
 			'tags' => array('cakephp', 'framework')
 		));
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$View->render();
 		$this->assertFalse(isset($View->Html), 'No helper loaded.');
 	}
@@ -111,7 +115,8 @@ class XmlViewTest extends TestCase {
 		$data = array('no' => 'nope', 'user' => 'fake', 'list' => array('item1', 'item2'));
 		$Controller->set($data);
 		$Controller->set('_serialize', array('no', 'user'));
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$this->assertSame('application/xml', $Response->type());
 		$output = $View->render(false);
 		$expected = array(
@@ -120,7 +125,8 @@ class XmlViewTest extends TestCase {
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
 
 		$Controller->set('_rootNode', 'custom_name');
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 		$expected = array(
 			'custom_name' => array('no' => $data['no'], 'user' => $data['user'])
@@ -140,7 +146,8 @@ class XmlViewTest extends TestCase {
 		$data = array('original_name' => 'my epic name', 'user' => 'fake', 'list' => array('item1', 'item2'));
 		$Controller->set($data);
 		$Controller->set('_serialize', array('new_name' => 'original_name', 'user'));
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$this->assertSame('application/xml', $Response->type());
 		$output = $View->render(false);
 		$expected = array(
@@ -149,7 +156,8 @@ class XmlViewTest extends TestCase {
 		$this->assertSame(Xml::build($expected)->asXML(), $output);
 
 		$Controller->set('_rootNode', 'custom_name');
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render(false);
 		$expected = array(
 			'custom_name' => array('new_name' => $data['original_name'], 'user' => $data['user'])
@@ -166,7 +174,8 @@ class XmlViewTest extends TestCase {
 		$Request = new Request();
 		$Response = new Response();
 		$Controller = new Controller($Request, $Response);
-		$Controller->name = $Controller->viewPath = 'Posts';
+		$Controller->name = 'Posts';
+		$Controller->viewPath = 'Posts';
 
 		$data = array(
 			array(
@@ -181,7 +190,8 @@ class XmlViewTest extends TestCase {
 			)
 		);
 		$Controller->set('users', $data);
-		$View = new XmlView($Controller);
+		$Controller->viewClass = 'Xml';
+		$View = $Controller->createView();
 		$output = $View->render('index');
 
 		$expected = array(

--- a/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
+++ b/tests/test_app/TestApp/Controller/RequestHandlerTestController.php
@@ -59,9 +59,7 @@ class RequestHandlerTestController extends Controller {
  * @return void
  */
 	public function ajax2_layout() {
-		if ($this->autoLayout) {
-			$this->layout = 'ajax2';
-		}
+		$this->layout = 'ajax2';
 		$this->destination();
 	}
 }


### PR DESCRIPTION
Rewrite of the way Controller passes View vars to view on  construction. Refs #2970.

NOTE: this ticket originally proposed deprecating setting view options on Controller and instead  providing a setter method `Controller::setViewOption()` or `Controller::viewOption()`. This was to avoid Controller clobbering View's default fields, which essentially made the default values in View or any subclass meaningless. On review this PR still aims to address the clobbering issue but does not deprecate setting view options on Controller and  does not add said setter method. View Options are now only passed to the View if explicitly set on Controller. The View constructor also changes to:

```
public function __construct(Request $request = null, Response $response = null,
    EventManager $eventManager = null, array $viewOptions = []) {
```

The other minor change is that the protected Controller::_getViewObject() is now a public View factory called Controller::createView(). This is how you should now create a View that relies on defaults set in a controller (not `$view new View(Controller $c);`).

Deprecating setting view options on controller may be addressed later in a another ticket.
