### PR TITLE
Fixed incorrect matching of named elements beginning with same string

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -138,6 +138,10 @@ class CakeRoute {
 		$parsed = preg_quote($this->template, '#');
 
 		preg_match_all('#:([A-Za-z0-9_-]+[A-Z0-9a-z])#', $route, $namedElements);
+
+		// Sort the named elements in reverse order by length to prevent incorrect matching
+		uasort($namedElements[1], array($this, '_sortNamedElements'));
+
 		foreach ($namedElements[1] as $i => $name) {
 			$search = '\\' . $namedElements[0][$i];
 			if (isset($this->options[$name])) {
@@ -173,6 +177,17 @@ class CakeRoute {
 		foreach ($this->keys as $key) {
 			unset($this->defaults[$key]);
 		}
+	}
+
+/**
+ * Comparison method for sorting named elements in reverse order by length.
+ *
+ * @param $a
+ * @param $b
+ * @return int
+ */
+	protected function _sortNamedElements($a, $b) {
+		return strlen($a) > strlen($b) ? -1 : 1;
 	}
 
 /**

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -160,7 +160,11 @@ class CakeRoute {
 			}
 			$names[$i] = $name;
 		}
+
+		// Put names back in their correct order
 		ksort($names);
+		$names = array_values($names);
+
 		if (preg_match('#\/\*\*$#', $route)) {
 			$parsed = preg_replace('#/\\\\\*\\\\\*$#', '(?:/(?P<_trailing_>.*))?', $parsed);
 			$this->_greedy = true;

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -158,8 +158,9 @@ class CakeRoute {
 			} else {
 				$routeParams[$search] = '(?:(?P<' . $name . '>[^/]+))';
 			}
-			$names[] = $name;
+			$names[$i] = $name;
 		}
+		ksort($names);
 		if (preg_match('#\/\*\*$#', $route)) {
 			$parsed = preg_replace('#/\\\\\*\\\\\*$#', '(?:/(?P<_trailing_>.*))?', $parsed);
 			$this->_greedy = true;


### PR DESCRIPTION
Where a route contains a named element which starts with the name of a previous named element, the router is matching these incorrectly.

For example:

```
Router::connect('/:product/:productsPart', array('controller' => 'products', 'action' => 'view'));
echo Router::url(array('controller' => 'products', 'action' => 'view', 'product' => 'widget', 'productsPart' => 2));
```

gives /widget/widgetsPart when it should give /widget/2

I have fixed this by simply ordering the params in reverse length order before checking for matches.
