### PR TITLE
Fixed incorrect replacement of route elements beginning with same string

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -518,10 +518,10 @@ class CakeRoute {
 		$out = $this->template;
 
 		$search = $replace = array();
-		$keys = $this->keys;
 
-		// Sort the keys in reverse order by length to prevent mismatches
-		uasort($keys, array($this, '_sortKeys'));
+		$lengths = array_map('strlen', $this->keys);
+		$keys = array_combine($lengths, $this->keys);
+		krsort($keys);
 
 		foreach ($keys as $key) {
 			$string = null;
@@ -540,17 +540,6 @@ class CakeRoute {
 		}
 		$out = str_replace('//', '/', $out);
 		return $out;
-	}
-
-	/**
-	 * Comparison method for sorting keys in reverse order by length.
-	 *
-	 * @param $a
-	 * @param $b
-	 * @return int
-	 */
-	protected function _sortKeys($a, $b) {
-		return strlen($a) > strlen($b) ? -1 : 1;
 	}
 
 }

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -518,7 +518,12 @@ class CakeRoute {
 		$out = $this->template;
 
 		$search = $replace = array();
-		foreach ($this->keys as $key) {
+		$keys = $this->keys;
+
+		// Sort the keys in reverse order by length to prevent mismatches
+		uasort($keys, array($this, '_sortKeys'));
+
+		foreach ($keys as $key) {
 			$string = null;
 			if (isset($params[$key])) {
 				$string = $params[$key];
@@ -535,6 +540,17 @@ class CakeRoute {
 		}
 		$out = str_replace('//', '/', $out);
 		return $out;
+	}
+
+	/**
+	 * Comparison method for sorting keys in reverse order by length.
+	 *
+	 * @param $a
+	 * @param $b
+	 * @return int
+	 */
+	protected function _sortKeys($a, $b) {
+		return strlen($a) > strlen($b) ? -1 : 1;
 	}
 
 }

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -520,8 +520,9 @@ class CakeRoute {
 		$search = $replace = array();
 
 		$lengths = array_map('strlen', $this->keys);
-		$keys = array_combine($lengths, $this->keys);
-		krsort($keys);
+		$flipped = array_combine($this->keys, $lengths);
+		arsort($flipped);
+		$keys = array_flip($flipped);
 
 		foreach ($keys as $key) {
 			$string = null;

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -517,28 +517,28 @@ class CakeRoute {
 		}
 		$out = $this->template;
 
-		$search = $replace = array();
+		if(!empty($this->keys)) {
 
-		if(empty($this->keys)) {
-			$keys = array();
-		} else {
+			$search = $replace = array();
+
 			$lengths = array_map('strlen', $this->keys);
 			$flipped = array_combine($this->keys, $lengths);
 			arsort($flipped);
 			$keys = array_keys($flipped);
-		}
 
-		foreach ($keys as $key) {
-			$string = null;
-			if (isset($params[$key])) {
-				$string = $params[$key];
-			} elseif (strpos($out, $key) != strlen($out) - strlen($key)) {
-				$key .= '/';
+			foreach ($keys as $key) {
+				$string = null;
+				if (isset($params[$key])) {
+					$string = $params[$key];
+				} elseif (strpos($out, $key) != strlen($out) - strlen($key)) {
+					$key .= '/';
+				}
+				$search[] = ':' . $key;
+				$replace[] = $string;
 			}
-			$search[] = ':' . $key;
-			$replace[] = $string;
+			$out = str_replace($search, $replace, $out);
+
 		}
-		$out = str_replace($search, $replace, $out);
 
 		if (strpos($this->template, '*')) {
 			$out = str_replace('*', $params['pass'], $out);

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -517,7 +517,7 @@ class CakeRoute {
 		}
 		$out = $this->template;
 
-		if(!empty($this->keys)) {
+		if (!empty($this->keys)) {
 
 			$search = $replace = array();
 

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -522,7 +522,7 @@ class CakeRoute {
 		$lengths = array_map('strlen', $this->keys);
 		$flipped = array_combine($this->keys, $lengths);
 		arsort($flipped);
-		$keys = array_flip($flipped);
+		$keys = array_keys($flipped);
 
 		foreach ($keys as $key) {
 			$string = null;

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -519,10 +519,14 @@ class CakeRoute {
 
 		$search = $replace = array();
 
-		$lengths = array_map('strlen', $this->keys);
-		$flipped = array_combine($this->keys, $lengths);
-		arsort($flipped);
-		$keys = array_keys($flipped);
+		if(empty($this->keys)) {
+			$keys = array();
+		} else {
+			$lengths = array_map('strlen', $this->keys);
+			$flipped = array_combine($this->keys, $lengths);
+			arsort($flipped);
+			$keys = array_keys($flipped);
+		}
 
 		foreach ($keys as $key) {
 			$string = null;

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -517,7 +517,7 @@ class CakeRoute {
 		}
 		$out = $this->template;
 
-		if (!empty($this->keys)) {
+		if ($this->keys !== array()) {
 
 			$search = $replace = array();
 

--- a/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
+++ b/lib/Cake/Test/Case/Routing/Route/CakeRouteTest.php
@@ -856,6 +856,24 @@ class CakeRouteTest extends CakeTestCase {
 	}
 
 /**
+ * Test matching of parameters where one parameter name starts with another parameter name
+ *
+ * @return void
+ */
+	public function testMatchSimilarParameters() {
+		$route = new CakeRoute('/:thisParam/:thisParamIsLonger');
+
+		$url = array(
+			'thisParam' => 'foo',
+			'thisParamIsLonger' => 'bar'
+		);
+
+		$result = $route->match($url);
+		$expected = '/foo/bar';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test restructuring args with pass key
  *
  * @return void
@@ -941,4 +959,5 @@ class CakeRouteTest extends CakeTestCase {
 		$expected = array('section' => 'weblog', 'plugin' => 'blogs', 'controller' => 'posts', 'action' => 'index', 'pass' => array(), 'named' => array());
 		$this->assertEquals($expected, $result);
 	}
+
 }


### PR DESCRIPTION
Where a route contains a named element which starts with the name of a previous named element, the router is matching these incorrectly.

For example:

```
Router::connect('/:product/:productsPart', array('controller' => 'products', 'action' => 'view'));
echo Router::url(array('controller' => 'products', 'action' => 'view', 'product' => 'widget', 'productsPart' => 2));
```

gives /widget/widgetsPart when it should give /widget/2

I have fixed this by simply ordering the params in reverse length order before checking for matches.
