### PR TITLE
3.0 phpunit 4

### DIFF
--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -625,7 +625,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testMobileDeviceDetection() {
-		$request = $this->getMock('Cake\Network\Request', ['mobile']);
+		$request = $this->getMock('Cake\Network\Request', ['is']);
 		$request->expects($this->once())->method('is')
 			->with('mobile')
 			->will($this->returnValue(true));

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -272,7 +272,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$extensions = Router::extensions();
 		Router::parseExtensions('xml');
 
-		$this->Controller->request = $this->getMock('Cake\Network\Request');
+		$this->Controller->request = $this->getMock('Cake\Network\Request', ['accepts']);
 		$this->Controller->request->expects($this->any())
 			->method('accepts')
 			->will($this->returnValue(array('application/json')));
@@ -465,7 +465,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testRenderAsWithAttachment() {
-		$this->RequestHandler->request = $this->getMock('Cake\Network\Request');
+		$this->RequestHandler->request = $this->getMock('Cake\Network\Request', ['parseAccept']);
 		$this->RequestHandler->request->expects($this->any())
 			->method('parseAccept')
 			->will($this->returnValue(array('1.0' => array('application/xml'))));
@@ -516,7 +516,7 @@ class RequestHandlerComponentTest extends TestCase {
 			array(&$this->Controller->Components)
 		);
 		$this->RequestHandler->response = $this->getMock('Cake\Network\Response', array('type', 'download'));
-		$this->RequestHandler->request = $this->getMock('Cake\Network\Request');
+		$this->RequestHandler->request = $this->getMock('Cake\Network\Request', ['parseAccept']);
 
 		$this->RequestHandler->request->expects($this->once())
 			->method('parseAccept')
@@ -625,7 +625,7 @@ class RequestHandlerComponentTest extends TestCase {
  * @return void
  */
 	public function testMobileDeviceDetection() {
-		$request = $this->getMock('Cake\Network\Request');
+		$request = $this->getMock('Cake\Network\Request', ['mobile']);
 		$request->expects($this->once())->method('is')
 			->with('mobile')
 			->will($this->returnValue(true));
@@ -715,7 +715,7 @@ class RequestHandlerComponentTest extends TestCase {
 			array('_stop'),
 			array(&$this->Controller->Components)
 		);
-		$this->Controller->request = $this->getMock('Cake\Network\Request');
+		$this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
 		$this->Controller->response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
 		$this->Controller->RequestHandler->request = $this->Controller->request;
 		$this->Controller->RequestHandler->response = $this->Controller->response;
@@ -748,7 +748,7 @@ class RequestHandlerComponentTest extends TestCase {
 			array('_stop'),
 			array(&$this->Controller->Components)
 		);
-		$this->Controller->request = $this->getMock('Cake\Network\Request');
+		$this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
 		$this->Controller->response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
 		$this->Controller->RequestHandler->request = $this->Controller->request;
 		$this->Controller->RequestHandler->response = $this->Controller->response;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -579,7 +579,7 @@ class ControllerTest extends TestCase {
 		$request = $this->getMock('Cake\Network\Request', ['referer']);
 		$request->expects($this->any())->method('referer')
 			->with(true)
-			->will($this->returnValue('/'));
+			->will($this->returnValue('/posts/index'));
 		$Controller = new Controller($request);
 		$result = $Controller->referer(array('controller' => 'posts', 'action' => 'index'), true);
 		$this->assertEquals('/posts/index', $result);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -368,7 +368,7 @@ class ControllerTest extends TestCase {
  */
 	public function testBeforeRenderCallbackChangingViewClass() {
 		Configure::write('App.namespace', 'TestApp');
-		$Controller = new Controller($this->getMock('Cake\Network\Request'), new Response());
+		$Controller = new Controller(new Request, new Response());
 
 		$Controller->getEventManager()->attach(function ($event) {
 			$controller = $event->subject();
@@ -392,7 +392,7 @@ class ControllerTest extends TestCase {
  * @return void
  */
 	public function testBeforeRenderEventCancelsRender() {
-		$Controller = new Controller($this->getMock('Cake\Network\Request'), new Response());
+		$Controller = new Controller(new Request, new Response());
 
 		$Controller->getEventManager()->attach(function ($event) {
 			return false;
@@ -567,8 +567,7 @@ class ControllerTest extends TestCase {
  * @return void
  */
 	public function testReferer() {
-		$request = $this->getMock('Cake\Network\Request');
-
+		$request = $this->getMock('Cake\Network\Request', ['referer']);
 		$request->expects($this->any())->method('referer')
 			->with(true)
 			->will($this->returnValue('/posts/index'));
@@ -577,12 +576,15 @@ class ControllerTest extends TestCase {
 		$result = $Controller->referer(null, true);
 		$this->assertEquals('/posts/index', $result);
 
+		$request = $this->getMock('Cake\Network\Request', ['referer']);
+		$request->expects($this->any())->method('referer')
+			->with(true)
+			->will($this->returnValue('/'));
 		$Controller = new Controller($request);
-		$request->setReturnValue('referer', '/', array(true));
 		$result = $Controller->referer(array('controller' => 'posts', 'action' => 'index'), true);
 		$this->assertEquals('/posts/index', $result);
 
-		$request = $this->getMock('Cake\Network\Request');
+		$request = $this->getMock('Cake\Network\Request', ['referer']);
 
 		$request->expects($this->any())->method('referer')
 			->with(false)

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -19,6 +19,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use TestApp\Core\TestApp;
 
 /**
  * AppTest class
@@ -46,21 +47,18 @@ class AppTest extends TestCase {
  */
 	public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
 		Configure::write('App.namespace', 'TestApp');
-		$mock = $this->getMockClass('Cake\Core\App', ['_classExistsInBase']);
-
-		$mock::staticExpects($this->at(0))
-			->method('_classExistsInBase')
-			->will($this->returnValue($existsInBase));
-
-		$checkCake = (!$existsInBase || strpos('.', $class));
-		if ($checkCake) {
-			$existsInCake = (bool)$expected;
-			$mock::staticExpects($this->at(1))
-				->method('_classExistsInBase')
-				->will($this->returnValue($existsInCake));
-		}
-
-		$return = $mock::classname($class, $type, $suffix);
+		$i = 0;
+		TestApp::$existsInBaseCallback = function($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
+			if ($i++ === 0) {
+				return $existsInBase;
+			}
+			$checkCake = (!$existsInBase || strpos('.', $class));
+			if ($checkCake) {
+				return (bool)$expected;
+			}
+			return false;
+		};
+		$return = TestApp::classname($class, $type, $suffix);
 		$this->assertSame($expected, $return);
 	}
 

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -44,7 +44,7 @@ class AppTest extends TestCase {
  * @dataProvider classnameProvider
  * @return void
  */
-	public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
+	public function _testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
 		Configure::write('App.namespace', 'TestApp');
 		$mock = $this->getMockClass('Cake\Core\App', ['_classExistsInBase']);
 

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -44,7 +44,7 @@ class AppTest extends TestCase {
  * @dataProvider classnameProvider
  * @return void
  */
-	public function _testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
+	public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
 		Configure::write('App.namespace', 'TestApp');
 		$mock = $this->getMockClass('Cake\Core\App', ['_classExistsInBase']);
 

--- a/tests/TestCase/DatabaseSuite.php
+++ b/tests/TestCase/DatabaseSuite.php
@@ -33,11 +33,19 @@ class DatabaseSuite extends TestSuite {
  * @return void
  */
 	public static function suite() {
-		$suite = new TestSuite('Database related tests');
+		$suite = new self('Database related tests');
 		$suite->addTestDirectoryRecursive(__DIR__ . DS . 'Database');
 		$suite->addTestDirectoryRecursive(__DIR__ . DS . 'ORM');
 		$suite->addTestDirectoryRecursive(__DIR__ . DS . 'Model');
+		return $suite;
+	}
 
+/**
+ * Returns an iterator for this test suite.
+ *
+ * @return ArrayIterator
+ */
+	public function getIterator() {
 		$permutations = [
 			'Identifier Quoting' => function() {
 				ConnectionManager::get('test')->driver()->autoQuoting(true);
@@ -47,8 +55,12 @@ class DatabaseSuite extends TestSuite {
 			}
 		];
 
-		$suite = new TestPermutationDecorator($suite, $permutations);
-		return $suite;
+		$tests = [];
+		foreach (parent::getIterator() as $test) {
+			$tests[] = new TestPermutationDecorator($test, $permutations);
+		}
+
+		return new \ArrayIterator($tests);
 	}
 
 }

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -643,7 +643,7 @@ class ExceptionRendererTest extends TestCase {
 
 		$ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', array('render'));
 		$ExceptionRenderer->controller->helpers = array('Fail', 'Boom');
-		$ExceptionRenderer->controller->request = $this->getMock('Cake\Network\Request');
+		$ExceptionRenderer->controller->request = new Request;
 		$ExceptionRenderer->controller->expects($this->at(0))
 			->method('render')
 			->with('missingHelper')
@@ -670,7 +670,7 @@ class ExceptionRendererTest extends TestCase {
 		$ExceptionRenderer = new ExceptionRenderer($exception);
 
 		$ExceptionRenderer->controller = $this->getMock('Cake\Controller\Controller', array('beforeRender'));
-		$ExceptionRenderer->controller->request = $this->getMock('Cake\Network\Request');
+		$ExceptionRenderer->controller->request = new Request;
 		$ExceptionRenderer->controller->expects($this->any())
 			->method('beforeRender')
 			->will($this->throwException($exception));
@@ -698,7 +698,7 @@ class ExceptionRendererTest extends TestCase {
 		$ExceptionRenderer->controller->layoutPath = 'json';
 		$ExceptionRenderer->controller->subDir = 'json';
 		$ExceptionRenderer->controller->viewClass = 'Json';
-		$ExceptionRenderer->controller->request = $this->getMock('Cake\Network\Request');
+		$ExceptionRenderer->controller->request = new Request;
 
 		$ExceptionRenderer->controller->expects($this->once())
 			->method('render')

--- a/tests/TestCase/ORM/TableRegistryTest.php
+++ b/tests/TestCase/ORM/TableRegistryTest.php
@@ -169,15 +169,12 @@ class TableRegistryTest extends TestCase {
 		$this->assertInstanceOf('\TestApp\Model\Table\AuthorsTable', $table);
 
 		$class = $this->getMockClass('\Cake\ORM\Table');
-		$class::staticExpects($this->once())
-			->method('defaultConnectionName')
-			->will($this->returnValue('test'));
 
 		if (!class_exists('MyPlugin\Model\Table\SuperTestsTable')) {
 			class_alias($class, 'MyPlugin\Model\Table\SuperTestsTable');
 		}
 
-		$table = TableRegistry::get('MyPlugin.SuperTests');
+		$table = TableRegistry::get('MyPlugin.SuperTests', ['connection' => 'test']);
 		$this->assertInstanceOf($class, $table);
 	}
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -258,7 +258,7 @@ class ViewTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$request = $this->getMock('Cake\Network\Request');
+		$request = new Request();
 		$this->Controller = new Controller($request);
 		$this->PostsController = new ViewPostsController($request);
 		$this->PostsController->viewPath = 'Posts';

--- a/tests/test_app/TestApp/Core/TestApp.php
+++ b/tests/test_app/TestApp/Core/TestApp.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Core;
+
+use Cake\Core\App;
+
+class TestApp extends App {
+
+	public static $existsInBaseCallback;
+
+	protected static function _classExistsInBase($name, $namespace) {
+		$callback = static::$existsInBaseCallback;
+		return $callback($name, $namespace);
+	}
+
+}


### PR DESCRIPTION
Changed some tests to avoid fatal errors in PHPunit 4. We cannot start using it right away, though,  without fixing several problems:
- Anything touching the session with error out, despite using --stderr. This calls for an urgent Session rewrite
-  App::classname() cannot be tested as it is static and PHPunit removed the support for mocking statics. A solution to this would be to either make App non-static and/or remove the namespace fallbacking feature from the core. That is, you will need to be explicit when loading classes using short name:  `Cake.Auth` vs `Auth` in components,  for example
