### PR TITLE
Fix DigestAuthenticate component userModel setting

### DIFF
--- a/src/Controller/Component/Auth/DigestAuthenticate.php
+++ b/src/Controller/Component/Auth/DigestAuthenticate.php
@@ -64,7 +64,7 @@ class DigestAuthenticate extends BasicAuthenticate {
  * Settings for this object.
  *
  * - `fields` The fields to use to identify a user by.
- * - `userModel` The model name of the User, defaults to User.
+ * - `userModel` The model name of the User, defaults to Users.
  * - `scope` Additional conditions to use when looking up and authenticating users,
  *    i.e. `array('User.is_active' => 1).`
  * - `recursive` The value of the recursive key passed to find(). Defaults to 0.
@@ -82,7 +82,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 			'username' => 'username',
 			'password' => 'password'
 		),
-		'userModel' => 'User',
+		'userModel' => 'Users',
 		'scope' => array(),
 		'recursive' => 0,
 		'contain' => null,

--- a/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -46,8 +46,6 @@ class DigestAuthenticateTest extends TestCase {
 
 		$this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
 		$this->auth = new DigestAuthenticate($this->Collection, array(
-			'fields' => array('username' => 'username', 'password' => 'password'),
-			'userModel' => 'Users',
 			'realm' => 'localhost',
 			'nonce' => 123,
 			'opaque' => '123abc'
@@ -68,11 +66,11 @@ class DigestAuthenticateTest extends TestCase {
 	public function testConstructor() {
 		$object = new DigestAuthenticate($this->Collection, array(
 			'userModel' => 'AuthUser',
-			'fields' => array('username' => 'user', 'password' => 'password'),
+			'fields' => array('username' => 'user', 'password' => 'pass'),
 			'nonce' => 123456
 		));
 		$this->assertEquals('AuthUser', $object->settings['userModel']);
-		$this->assertEquals(array('username' => 'user', 'password' => 'password'), $object->settings['fields']);
+		$this->assertEquals(array('username' => 'user', 'password' => 'pass'), $object->settings['fields']);
 		$this->assertEquals(123456, $object->settings['nonce']);
 		$this->assertEquals(env('SERVER_NAME'), $object->settings['realm']);
 	}


### PR DESCRIPTION
DigestAuthenticate component's userModel setting incorrectly defaulted
to User instead of Users. Fixes issue `#2998`.
