### PR TITLE
Allow chaining in the addCrumb method

### DIFF
--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -180,6 +180,7 @@ class HtmlHelper extends AppHelper {
  */
 	public function addCrumb($name, $link = null, $options = null) {
 		$this->_crumbs[] = array($name, $link, $options);
+		return $this;
 	}
 
 /**

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -174,7 +174,7 @@ class HtmlHelper extends AppHelper {
  * @param string $name Text for link
  * @param string $link URL for link (if empty it won't be a link)
  * @param string|array $options Link attributes e.g. array('id' => 'selected')
- * @return void
+ * @return this HtmlHelper
  * @see HtmlHelper::link() for details on $options that can be used.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */


### PR DESCRIPTION
For convenience I think it might be valuable to allow addCrumb (and possibly other similar functions) to return $this to permit chained calls such as this:

```
$this->Html->addCrumb('Admin', '/admin')->addCrumb('Blogs', '/admin/users')->addCrumb('Add');
```

as opposed to the considerably more verbose version that needs to be used now:

```
$this->Html->addCrumb('Admin', '/admin');
$this->Html->addCrumb('Blogs', '/admin/users');
$this->Html->addCrumb('Add');
```

I'm not sure if this violates some API conventions for helpers but it does seem rather more convenient to work with to me.
