### PR TITLE
Allow sub-directories in Fixture folder

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -117,11 +117,11 @@ class CakeFixtureManager {
 				$fixture = substr($fixture, strlen('app.'));
 				$additionalPath = '';
 				$pathTokenArray = explode('.', $fixture);
-				foreach($pathTokenArray as $pathToken) {
+				foreach ($pathTokenArray as $pathToken) {
 					$additionalPath .= DS . $pathToken;
 				}
 				$fixturePaths = array(
-					TESTS . 'Fixture' . $additionalPath,
+					TESTS . 'Fixture' . $additionalPath
 				);
 			} elseif (strpos($fixture, 'plugin.') === 0) {
 				$parts = explode('.', $fixture, 3);

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -115,8 +115,13 @@ class CakeFixtureManager {
 				$fixturePaths[] = CAKE . 'Test' . DS . 'Fixture';
 			} elseif (strpos($fixture, 'app.') === 0) {
 				$fixture = substr($fixture, strlen('app.'));
+				$additionalPath = '';
+				$pathTokenArray = explode('.', $fixture);
+				foreach($pathTokenArray as $pathToken) {
+					$additionalPath .= DS . $pathToken;
+				}
 				$fixturePaths = array(
-					TESTS . 'Fixture'
+					TESTS . 'Fixture' . $additionalPath,
 				);
 			} elseif (strpos($fixture, 'plugin.') === 0) {
 				$parts = explode('.', $fixture, 3);

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -114,22 +114,28 @@ class CakeFixtureManager {
 				$fixture = substr($fixture, strlen('core.'));
 				$fixturePaths[] = CAKE . 'Test' . DS . 'Fixture';
 			} elseif (strpos($fixture, 'app.') === 0) {
-				$fixture = substr($fixture, strlen('app.'));
+				$fixturePrefixLess = substr($fixture, strlen('app.'));
+				$pathTokenArray = explode('.', $fixturePrefixLess);
+				$fixture = array_pop($pathTokenArray);
 				$additionalPath = '';
-				$pathTokenArray = explode('.', $fixture);
-				foreach ($pathTokenArray as $pathToken) {
+				foreach($pathTokenArray as $pathToken) {
 					$additionalPath .= DS . $pathToken;
 				}
 				$fixturePaths = array(
-					TESTS . 'Fixture' . $additionalPath
+					TESTS . 'Fixture' . $additionalPath,
 				);
 			} elseif (strpos($fixture, 'plugin.') === 0) {
-				$parts = explode('.', $fixture, 3);
-				$pluginName = $parts[1];
-				$fixture = $parts[2];
+				$fixturePrefixLess = substr($fixture, strlen('plugin.'));
+				$pathTokenArray = explode('.', $fixturePrefixLess);
+				$pluginName = array_shift($pathTokenArray);
+				$fixture = array_pop($pathTokenArray);
+				$additionalPath = '';
+				foreach($pathTokenArray as $pathToken) {
+					$additionalPath .= DS . $pathToken;
+				}				
 				$fixturePaths = array(
-					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture',
-					TESTS . 'Fixture'
+					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture' . $additionalPath,
+					TESTS . 'Fixture' . $additionalPath
 				);
 			} else {
 				$fixturePaths = array(


### PR DESCRIPTION
It can be very painful to have all fixtures in one directory.
I think it would be great to be able to create sub-directories for a better file organisation.

Currently, it is 'app.my_fixture' for Fixture/MyFixtureFixture.php

If you want to add n subdirectories, you can by doing so :
'app.myFolder.mySecFolder.myThirdFolder.my_fixture' 
for 
Fixture/myFolder/mySecFolder/myThirdFolder/MyFixtureFixture.php
