### PR TITLE
Allow sub-directories in Fixture folder

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -114,17 +114,28 @@ class CakeFixtureManager {
 				$fixture = substr($fixture, strlen('core.'));
 				$fixturePaths[] = CAKE . 'Test' . DS . 'Fixture';
 			} elseif (strpos($fixture, 'app.') === 0) {
-				$fixture = substr($fixture, strlen('app.'));
+				$fixturePrefixLess = substr($fixture, strlen('app.'));
+				$pathTokenArray = explode('/', $fixturePrefixLess);
+				$fixture = array_pop($pathTokenArray);
+				$additionalPath = '';
+				foreach ($pathTokenArray as $pathToken) {
+					$additionalPath .= DS . $pathToken;
+				}
 				$fixturePaths = array(
-					TESTS . 'Fixture'
+					TESTS . 'Fixture' . $additionalPath
 				);
 			} elseif (strpos($fixture, 'plugin.') === 0) {
-				$parts = explode('.', $fixture, 3);
-				$pluginName = $parts[1];
-				$fixture = $parts[2];
+				$explodedFixture = explode('.', $fixturePrefixLess,3);
+				$pluginName = $explodedFixture[1];
+				$pathTokenArray = explode('/', $explodedFixture[2]);
+				$fixture = array_pop($pathTokenArray);
+				$additionalPath = '';
+				foreach ($pathTokenArray as $pathToken) {
+					$additionalPath .= DS . $pathToken;
+				}
 				$fixturePaths = array(
-					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture',
-					TESTS . 'Fixture'
+					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture' . $additionalPath,
+					TESTS . 'Fixture' . $additionalPath
 				);
 			} else {
 				$fixturePaths = array(

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -101,15 +101,14 @@ class CakeFixtureManager {
  * 
  * @param string $fixturePath the fixture path to parse
  * @return array containing fixture class name and optional additional path
- */	
- 	protected function _parseFixturePath($fixturePath) {
+ */
+	protected function _parseFixturePath($fixturePath) {
 		$pathTokenArray = explode('/', $fixturePath);
 		$fixture = array_pop($pathTokenArray);
 		$additionalPath = '';
 		foreach ($pathTokenArray as $pathToken) {
 			$additionalPath .= DS . $pathToken;
 		}
-		
 		return array('fixture' => $fixture, 'additionalPath' => $additionalPath);
 	}
 

--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -96,6 +96,24 @@ class CakeFixtureManager {
 	}
 
 /**
+ * Parse the fixture path included in test cases, to get the fixture class name, and the
+ * real fixture path including sub-directories
+ * 
+ * @param string $fixturePath the fixture path to parse
+ * @return array containing fixture class name and optional additional path
+ */	
+ 	protected function _parseFixturePath($fixturePath) {
+		$pathTokenArray = explode('/', $fixturePath);
+		$fixture = array_pop($pathTokenArray);
+		$additionalPath = '';
+		foreach ($pathTokenArray as $pathToken) {
+			$additionalPath .= DS . $pathToken;
+		}
+		
+		return array('fixture' => $fixture, 'additionalPath' => $additionalPath);
+	}
+
+/**
  * Looks for fixture files and instantiates the classes accordingly
  *
  * @param array $fixtures the fixture names to load using the notation {type}.{name}
@@ -115,27 +133,19 @@ class CakeFixtureManager {
 				$fixturePaths[] = CAKE . 'Test' . DS . 'Fixture';
 			} elseif (strpos($fixture, 'app.') === 0) {
 				$fixturePrefixLess = substr($fixture, strlen('app.'));
-				$pathTokenArray = explode('/', $fixturePrefixLess);
-				$fixture = array_pop($pathTokenArray);
-				$additionalPath = '';
-				foreach ($pathTokenArray as $pathToken) {
-					$additionalPath .= DS . $pathToken;
-				}
+				$fixtureParsedPath = $this->_parseFixturePath($fixturePrefixLess);
+				$fixture = $fixtureParsedPath['fixture'];
 				$fixturePaths = array(
-					TESTS . 'Fixture' . $additionalPath
+					TESTS . 'Fixture' . $fixtureParsedPath['additionalPath']
 				);
 			} elseif (strpos($fixture, 'plugin.') === 0) {
-				$explodedFixture = explode('.', $fixturePrefixLess,3);
+				$explodedFixture = explode('.', $fixture, 3);
 				$pluginName = $explodedFixture[1];
-				$pathTokenArray = explode('/', $explodedFixture[2]);
-				$fixture = array_pop($pathTokenArray);
-				$additionalPath = '';
-				foreach ($pathTokenArray as $pathToken) {
-					$additionalPath .= DS . $pathToken;
-				}
+				$fixtureParsedPath = $this->_parseFixturePath($explodedFixture[2]);
+				$fixture = $fixtureParsedPath['fixture'];
 				$fixturePaths = array(
-					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture' . $additionalPath,
-					TESTS . 'Fixture' . $additionalPath
+					CakePlugin::path(Inflector::camelize($pluginName)) . 'Test' . DS . 'Fixture' . $fixtureParsedPath['additionalPath'],
+					TESTS . 'Fixture' . $fixtureParsedPath['additionalPath']
 				);
 			} else {
 				$fixturePaths = array(


### PR DESCRIPTION
Based on #3004 .

Corrections made : 
Coding standards corrected.
Separator becomes `/` instead of `.` to avoid conflicts.
