### PR TITLE
3.0 - Only the primary query should be marked as such.

### DIFF
--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -185,7 +185,7 @@ trait QueryTrait {
 		}
 
 		$table = $this->repository();
-		$event = new Event('Model.beforeFind', $table, [$this, $this->_options, $this->primary()]);
+		$event = new Event('Model.beforeFind', $table, [$this, $this->_options, $this->eagerLoaded()]);
 		$table->getEventManager()->dispatch($event);
 
 		if (isset($this->_results)) {

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -185,7 +185,7 @@ trait QueryTrait {
 		}
 
 		$table = $this->repository();
-		$event = new Event('Model.beforeFind', $table, [$this, $this->_options, true]);
+		$event = new Event('Model.beforeFind', $table, [$this, $this->_options, $this->primary()]);
 		$table->getEventManager()->dispatch($event);
 
 		if (isset($this->_results)) {

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -418,7 +418,7 @@ abstract class Association {
 		}
 
 		$options['conditions'] = $query->newExpr()->add($options['conditions']);
-		$dummy = $target->query();
+		$dummy = $target->query()->primary(false);
 
 		if (!empty($options['queryBuilder'])) {
 			$dummy = $options['queryBuilder']($dummy);

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -418,7 +418,7 @@ abstract class Association {
 		}
 
 		$options['conditions'] = $query->newExpr()->add($options['conditions']);
-		$dummy = $target->query()->primary(false);
+		$dummy = $target->query()->eagerLoaded(false);
 
 		if (!empty($options['queryBuilder'])) {
 			$dummy = $options['queryBuilder']($dummy);

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -228,7 +228,7 @@ trait ExternalAssociationTrait {
 		$fetchQuery = $this
 			->find('all')
 			->where($options['conditions'])
-			->primary(false)
+			->eagerLoaded(false)
 			->hydrate($options['query']->hydrate());
 		$fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
 

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -228,6 +228,7 @@ trait ExternalAssociationTrait {
 		$fetchQuery = $this
 			->find('all')
 			->where($options['conditions'])
+			->primary(false)
 			->hydrate($options['query']->hydrate());
 		$fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
 

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -96,6 +96,13 @@ class Query extends DatabaseQuery {
 	protected $_eagerLoader;
 
 /**
+ * Whether the query is the primary query or a byproduct.
+ *
+ * @var boolean
+ */
+	protected $_primary = true;
+
+/**
  * Constuctor
  *
  * @param \Cake\Database\Connection $connection
@@ -644,6 +651,21 @@ class Query extends DatabaseQuery {
 	protected function _dirty() {
 		$this->_results = null;
 		parent::_dirty();
+	}
+
+/**
+ * Sets the query instance to be the primary query. If no argument is passed,
+ * the current configured query `_primary` value is returned.
+ *
+ * @param boolean $value
+ * @return \Cake\ORM\Query
+ */
+	public function primary($value = null) {
+		if ($value === null) {
+			return $this->_primary;
+		}
+		$this->_primary = $value;
+		return $this;
 	}
 
 /**

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -100,7 +100,7 @@ class Query extends DatabaseQuery {
  *
  * @var boolean
  */
-	protected $_primary = true;
+	protected $_eagerLoaded = true;
 
 /**
  * Constuctor
@@ -654,17 +654,17 @@ class Query extends DatabaseQuery {
 	}
 
 /**
- * Sets the query instance to be the primary query. If no argument is passed,
- * the current configured query `_primary` value is returned.
+ * Sets the query instance to be the eager loaded query. If no argument is
+ * passed, the current configured query `_eagerLoaded` value is returned.
  *
  * @param boolean $value
  * @return \Cake\ORM\Query
  */
-	public function primary($value = null) {
+	public function eagerLoaded($value = null) {
 		if ($value === null) {
-			return $this->_primary;
+			return $this->_eagerLoaded;
 		}
-		$this->_primary = $value;
+		$this->_eagerLoaded = $value;
 		return $this;
 	}
 

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -73,7 +73,7 @@ use Cake\Validation\Validator;
  * Table objects provide a few callbacks/events you can hook into to augment/replace
  * find operations. Each event uses the standard event subsystem in CakePHP
  *
- * - `beforeFind($event, $query, $options, $primary)` - Fired before each find operation.
+ * - `beforeFind($event, $query, $options, $eagerLoaded)` - Fired before each find operation.
  *   By stopping the event and supplying a return value you can bypass the find operation
  *   entirely. Any changes done to the $query instance will be retained for the rest of the find.
  * - `beforeValidate($event, $entity, $options, $validator)` - Fired before an entity is validated.


### PR DESCRIPTION
This makes callbacks like `beforeFind()` receive the `$primary` parameter as expected:

The query for the primary model gets `$primary = true` and all subsequent queries will have the value set as `$primary = false`.

My apologies, but I don't know how to test this without incurring in constructing tables with associations, and setting `beforeFind()` callbacks to every table, and later testing `$primary` inside every one of them. There should be an easier way I believe.
