### PR TITLE
3.0 - Allow generating REST resources using a default extension.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -39,7 +39,8 @@ class Request implements \ArrayAccess {
 		'plugin' => null,
 		'controller' => null,
 		'action' => null,
-		'pass' => [],
+		'_ext' => null,
+		'pass' => []
 	);
 
 /**

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -160,6 +160,7 @@ class Dispatcher implements EventListener {
 				'class' => Inflector::camelize($request->params['controller']),
 				'plugin' => empty($request->params['plugin']) ? null : Inflector::camelize($request->params['plugin']),
 				'prefix' => empty($request->params['prefix']) ? null : Inflector::camelize($request->params['prefix']),
+				'_ext' => empty($request->params['_ext']) ? null : $request->params['_ext']
 			));
 		}
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -320,7 +320,7 @@ class Route {
 			unset($route['_trailing_']);
 		}
 
-		if ($ext && empty($route['_ext'])) {
+		if (!empty($ext)) {
 			$route['_ext'] = $ext;
 		}
 

--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -33,21 +33,21 @@ class Route {
  *
  * @var array
  */
-	public $keys = array();
+	public $keys = [];
 
 /**
  * An array of additional parameters for the Route.
  *
  * @var array
  */
-	public $options = array();
+	public $options = [];
 
 /**
  * Default parameters for a Route
  *
  * @var array
  */
-	public $defaults = array();
+	public $defaults = [];
 
 /**
  * The routes template string.
@@ -83,18 +83,18 @@ class Route {
  *
  * @var array
  */
-	protected $_headerMap = array(
+	protected $_headerMap = [
 		'type' => 'content_type',
 		'method' => 'request_method',
 		'server' => 'server_name'
-	);
+	];
 
 /**
  * List of connected extensions for this route.
  *
  * @var array
  */
-	protected $_extensions = array();
+	protected $_extensions = [];
 
 /**
  * Constructor for a Route
@@ -110,7 +110,7 @@ class Route {
  * @param array $defaults Array of defaults for the route.
  * @param array $options Array of additional options for the Route
  */
-	public function __construct($template, $defaults = array(), $options = array()) {
+	public function __construct($template, $defaults = [], $options = []) {
 		$this->template = $template;
 		$this->defaults = (array)$defaults;
 		$this->options = (array)$options;
@@ -168,11 +168,11 @@ class Route {
 	protected function _writeRoute() {
 		if (empty($this->template) || ($this->template === '/')) {
 			$this->_compiledRoute = '#^/*$#';
-			$this->keys = array();
+			$this->keys = [];
 			return;
 		}
 		$route = $this->template;
-		$names = $routeParams = array();
+		$names = $routeParams = [];
 		$parsed = preg_quote($this->template, '#');
 
 		preg_match_all('#:([A-Za-z0-9_-]+[A-Z0-9a-z])#', $route, $namedElements);
@@ -295,7 +295,7 @@ class Route {
 		for ($i = 0; $i <= $count; $i++) {
 			unset($route[$i]);
 		}
-		$route['pass'] = array();
+		$route['pass'] = [];
 
 		// Assign defaults, set passed args to pass
 		foreach ($this->defaults as $key => $value) {
@@ -373,7 +373,7 @@ class Route {
  * @return array Array of passed args.
  */
 	protected function _parseArgs($args, $context) {
-		$pass = array();
+		$pass = [];
 		$args = explode('/', $args);
 
 		foreach ($args as $param) {
@@ -398,7 +398,7 @@ class Route {
  *   directory.
  * @return mixed Either a string url for the parameters if they match or false.
  */
-	public function match($url, $context = array()) {
+	public function match($url, $context = []) {
 		if (!$this->compiled()) {
 			$this->compile();
 		}
@@ -434,7 +434,7 @@ class Route {
 		}
 
 		// Missing defaults is a fail.
-		if (array_diff_key($defaults, $url) !== array()) {
+		if (array_diff_key($defaults, $url) !== []) {
 			return false;
 		}
 
@@ -449,8 +449,8 @@ class Route {
 			return false;
 		}
 
-		$pass = array();
-		$query = array();
+		$pass = [];
+		$query = [];
 
 		foreach ($url as $key => $value) {
 			// keys that exist in the defaults and have different values is a match failure.
@@ -506,12 +506,12 @@ class Route {
  * @param array $query An array of parameters
  * @return string Composed route string.
  */
-	protected function _writeUrl($params, $pass = array(), $query = array()) {
+	protected function _writeUrl($params, $pass = [], $query = []) {
 		$pass = implode('/', array_map('rawurlencode', $pass));
 		$out = $this->template;
 
 		if (!empty($this->keys)) {
-			$search = $replace = array();
+			$search = $replace = [];
 
 			foreach ($this->keys as $key) {
 				$string = null;

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -30,7 +30,7 @@ class RouteCollection implements \Countable {
  *
  * @var array
  */
-	protected $_routeTable = array();
+	protected $_routeTable = [];
 
 /**
  * A list of routes connected, in the order they were connected.
@@ -38,7 +38,7 @@ class RouteCollection implements \Countable {
  *
  * @var array
  */
-	protected $_routes = array();
+	protected $_routes = [];
 
 /**
  * The top most request's context. Updated whenever
@@ -46,12 +46,12 @@ class RouteCollection implements \Countable {
  *
  * @var array
  */
-	protected $_requestContext = array(
+	protected $_requestContext = [
 		'_base' => '',
 		'_port' => 80,
 		'_scheme' => 'http',
 		'_host' => 'localhost',
-	);
+	];
 
 /**
  * Add a route to the collection.
@@ -63,7 +63,7 @@ class RouteCollection implements \Countable {
 	public function add(Route $route) {
 		$name = $route->getName();
 		if (!isset($this->_routeTable[$name])) {
-			$this->_routeTable[$name] = array();
+			$this->_routeTable[$name] = [];
 		}
 		$this->_routeTable[$name][] = $route;
 		$this->_routes[] = $route;
@@ -123,22 +123,22 @@ class RouteCollection implements \Countable {
 		if (isset($url['plugin'])) {
 			$plugin = $url['plugin'];
 		}
-		$fallbacks = array(
+		$fallbacks = [
 			'%2$s:%3$s',
 			'%2$s:_action',
 			'_controller:%3$s',
 			'_controller:_action'
-		);
+		];
 		if ($plugin) {
-			$fallbacks = array(
+			$fallbacks = [
 				'%1$s.%2$s:%3$s',
 				'%1$s.%2$s:_action',
 				'%1$s._controller:%3$s',
 				'%1$s._controller:_action',
 				'_plugin._controller:%3$s',
 				'_plugin._controller:_action',
-				'_controller:_action',
-			);
+				'_controller:_action'
+			];
 		}
 		foreach ($fallbacks as $i => $template) {
 			$fallbacks[$i] = sprintf($template, $plugin, $url['controller'], $url['action']);
@@ -219,7 +219,7 @@ class RouteCollection implements \Countable {
  */
 	public function get($index) {
 		if (is_string($index)) {
-			$routes = isset($this->_routeTable[$index]) ? $this->_routeTable[$index] : array(null);
+			$routes = isset($this->_routeTable[$index]) ? $this->_routeTable[$index] : [null];
 			return $routes[0];
 		}
 		return isset($this->_routes[$index]) ? $this->_routes[$index] : null;
@@ -242,12 +242,12 @@ class RouteCollection implements \Countable {
  * @return void
  */
 	public function setContext(Request $request) {
-		$this->_requestContext = array(
+		$this->_requestContext = [
 			'_base' => $request->base,
 			'_port' => $request->port(),
 			'_scheme' => $request->scheme(),
 			'_host' => $request->host()
-		);
+		];
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -67,14 +67,14 @@ class Router {
  *
  * @var array
  */
-	protected static $_prefixes = array();
+	protected static $_prefixes = [];
 
 /**
  * List of valid extensions to parse from a URL. If null, any extension is allowed.
  *
  * @var array
  */
-	protected static $_validExtensions = array();
+	protected static $_validExtensions = [];
 
 /**
  * Regular expression for action names
@@ -151,7 +151,7 @@ class Router {
  *
  * @var array
  */
-	protected static $_resourceMapped = array();
+	protected static $_resourceMapped = [];
 
 /**
  * Maintains the request object stack for the current request.
@@ -159,7 +159,7 @@ class Router {
  *
  * @var array
  */
-	protected static $_requests = array();
+	protected static $_requests = [];
 
 /**
  * Initial state is populated the first time reload() is called which is at the bottom
@@ -168,7 +168,7 @@ class Router {
  *
  * @var array
  */
-	protected static $_initialState = array();
+	protected static $_initialState = [];
 
 /**
  * The stack of URL filters to apply against routing URLs before passing the
@@ -176,7 +176,7 @@ class Router {
  *
  * @var array
  */
-	protected static $_urlFilters = array();
+	protected static $_urlFilters = [];
 
 /**
  * Default route class to use
@@ -450,9 +450,13 @@ class Router {
 			if ($plugin) {
 				$plugin = Inflector::underscore($plugin);
 			}
-			$prefix = '';
+
+			$prefix = $ext = null;
 			if (!empty($options['prefix'])) {
 				$prefix = $options['prefix'];
+			}
+			if (!empty($options['_ext'])) {
+				$ext = $options['_ext'];
 			}
 
 			foreach (static::$_resourceMap as $params) {
@@ -463,6 +467,7 @@ class Router {
 					'controller' => $urlName,
 					'action' => $params['action'],
 					'[method]' => $params['method'],
+					'_ext' => $ext
 				);
 				if ($prefix) {
 					$params['prefix'] = $prefix;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -328,10 +328,10 @@ class Router {
  * @return void
  * @throws \Cake\Error\Exception
  */
-	public static function connect($route, $defaults = array(), $options = array()) {
+	public static function connect($route, $defaults = [], $options = []) {
 		static::$initialized = true;
 
-		$defaults += array('plugin' => null);
+		$defaults += ['plugin' => null];
 		if (empty($options['action'])) {
 			$defaults += array('action' => 'index');
 		}
@@ -382,7 +382,7 @@ class Router {
  * @see routes
  * @return array Array of routes
  */
-	public static function redirect($route, $url, $options = array()) {
+	public static function redirect($route, $url, $options = []) {
 		$options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
 		if (is_string($url)) {
 			$url = array('redirect' => $url);
@@ -434,7 +434,7 @@ class Router {
  * @param array $options Options to use when generating REST routes
  * @return array Array of mapped resources
  */
-	public static function mapResources($controller, $options = array()) {
+	public static function mapResources($controller, $options = []) {
 		$options = array_merge(array(
 			'connectOptions' => [],
 			'id' => static::ID . '|' . static::UUID
@@ -541,7 +541,7 @@ class Router {
 			static::pushRequest($request);
 		} else {
 			$requestData = $request;
-			$requestData += array(array(), array());
+			$requestData += array([], []);
 			$requestData[0] += array(
 				'controller' => false,
 				'action' => false,
@@ -713,14 +713,14 @@ class Router {
  * @return string Full translated URL with base path.
  * @throws \Cake\Error\Exception When the route name is not found
  */
-	public static function url($url = null, $options = array()) {
+	public static function url($url = null, $options = []) {
 		if (!static::$initialized) {
 			static::_loadRoutes();
 		}
 
 		$full = false;
 		if (is_bool($options)) {
-			list($full, $options) = array($options, array());
+			list($full, $options) = array($options, []);
 		}
 		$urlType = gettype($url);
 		$hasLeadingSlash = $plainString = false;
@@ -888,14 +888,14 @@ class Router {
  * @return string The string that is the reversed result of the array
  */
 	public static function reverse($params, $full = false) {
-		$url = array();
+		$url = [];
 		if ($params instanceof Request) {
 			$url = $params->query;
 			$params = $params->params;
 		} elseif (isset($params['url'])) {
 			$url = $params['url'];
 		}
-		$pass = isset($params['pass']) ? $params['pass'] : array();
+		$pass = isset($params['pass']) ? $params['pass'] : [];
 
 		unset(
 			$params['pass'], $params['paging'], $params['models'], $params['url'], $url['url'],
@@ -1016,13 +1016,13 @@ class Router {
  * @param array $options The array of options.
  * @return \Cake\Network\Request The modified request
  */
-	public static function parseNamedParams(Request $request, $options = array()) {
+	public static function parseNamedParams(Request $request, $options = []) {
 		$options += array('separator' => ':');
 		if (empty($request->params['pass'])) {
-			$request->params['named'] = array();
+			$request->params['named'] = [];
 			return $request;
 		}
-		$named = array();
+		$named = [];
 		foreach ($request->params['pass'] as $key => $value) {
 			if (strpos($value, $options['separator']) === false) {
 				continue;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -743,7 +743,8 @@ class Router {
 		$params = array(
 			'plugin' => null,
 			'controller' => null,
-			'action' => 'index'
+			'action' => 'index',
+			'_ext' => null
 		);
 		$here = $base = $output = $frag = null;
 
@@ -801,9 +802,11 @@ class Router {
 			}
 
 			$url += array(
-				'controller' => $params['controller'],
 				'plugin' => $params['plugin'],
-				'action' => 'index'
+				'controller' => $params['controller'],
+				'action' => 'index',
+				'_ext' => $params['_ext']
+
 			);
 			$url = static::_applyUrlFilters($url);
 			$output = static::$_routes->match($url);

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -119,7 +119,7 @@ class MyPluginController extends MyPluginAppController {
  *
  * @var array
  */
-	public $uses = array();
+	public $uses = [];
 
 /**
  * index method
@@ -169,7 +169,7 @@ class OtherPagesController extends MyPluginAppController {
  *
  * @var array
  */
-	public $uses = array();
+	public $uses = [];
 
 /**
  * display method
@@ -217,7 +217,7 @@ class ArticlesTestController extends ArticlesTestAppController {
  *
  * @var array
  */
-	public $uses = array();
+	public $uses = [];
 
 /**
  * admin_index method
@@ -252,7 +252,7 @@ class DispatcherTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$_GET = array();
+		$_GET = [];
 
 		Configure::write('App.base', false);
 		Configure::write('App.baseUrl', false);
@@ -273,7 +273,7 @@ class DispatcherTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		Plugin::unload();
-		Configure::write('Dispatcher.filters', array());
+		Configure::write('Dispatcher.filters', []);
 	}
 
 /**
@@ -932,7 +932,7 @@ class DispatcherTest extends TestCase {
 		$event = new Event(__CLASS__, $dispatcher, array('request' => $request));
 		$dispatcher->parseParams($event);
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'add',
@@ -1012,7 +1012,7 @@ class DispatcherTest extends TestCase {
 		$event = new Event(__CLASS__, $dispatcher, array('request' => $request));
 		$dispatcher->parseParams($event);
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'add',
@@ -1053,7 +1053,7 @@ class DispatcherTest extends TestCase {
 		foreach ($_SERVER as $key => $val) {
 			unset($_SERVER[$key]);
 		}
-		Configure::write('App', array());
+		Configure::write('App', []);
 	}
 
 /**

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -659,7 +659,7 @@ class DispatcherTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response', array('send'));
 		$dispatcher->dispatch($request, $response);
 		$this->assertEmpty($dispatcher->controller);
-		$expected = array('controller' => null, 'action' => null, 'plugin' => null, 'pass' => array());
+		$expected = array('controller' => null, 'action' => null, 'plugin' => null, '_ext' => null, 'pass' => []);
 		$this->assertEquals($expected, $request->params);
 
 		$dispatcher = new TestDispatcher();

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -113,37 +113,79 @@ class RouterTest extends TestCase {
 		$resources = Router::mapResources('Posts');
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$expected = [
+			'pass' => [],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'index',
+			'[method]' => 'GET',
+			'_ext' => null
+		];
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => [], 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
-		$this->assertEquals($resources, array('posts'));
+		$this->assertEquals($expected, $result);
+		$this->assertEquals($resources, ['posts']);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$expected = [
+			'pass' => ['13'],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'view',
+			'id' => '13',
+			'[method]' => 'GET',
+			'_ext' => null
+		];
 		$result = Router::parse('/posts/13');
-		$this->assertEquals($result, array('pass' => array('13'), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => '13', '[method]' => 'GET'));
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => [], 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
-
-		$_SERVER['REQUEST_METHOD'] = 'PUT';
-		$result = Router::parse('/posts/13');
-		$expected = array('pass' => array('13'), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => '13', '[method]' => 'PUT');
 		$this->assertEquals($expected, $result);
 
-		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
-		$expected = array(
-			'pass' => array('475acc39-a328-44d3-95fb-015000000000'),
-			'plugin' => '',
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$expected = [
+			'pass' => [],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'add',
+			'[method]' => 'POST',
+			'_ext' => null
+		];
+		$result = Router::parse('/posts');
+		$this->assertEquals($expected, $result);
+
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$expected = [
+			'pass' => ['13'],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'edit',
+			'id' => '13',
+			'[method]' => 'PUT',
+			'_ext' => null
+		];
+		$result = Router::parse('/posts/13');
+		$this->assertEquals($expected, $result);
+
+		$expected = [
+			'pass' => ['475acc39-a328-44d3-95fb-015000000000'],
+			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'edit',
 			'id' => '475acc39-a328-44d3-95fb-015000000000',
-			'[method]' => 'PUT'
-		);
+			'[method]' => 'PUT',
+			'_ext' => null
+		];
+		$result = Router::parse('/posts/475acc39-a328-44d3-95fb-015000000000');
 		$this->assertEquals($expected, $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'DELETE';
+		$expected = [
+			'pass' => ['13'],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'delete',
+			'id' => '13',
+			'[method]' => 'DELETE',
+			'_ext' => null
+		];
 		$result = Router::parse('/posts/13');
-		$expected = array('pass' => array('13'), 'plugin' => '', 'controller' => 'posts', 'action' => 'delete', 'id' => '13', '[method]' => 'DELETE');
 		$this->assertEquals($expected, $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -151,16 +193,34 @@ class RouterTest extends TestCase {
 		$this->assertSame([], $result);
 
 		Router::reload();
-		$resources = Router::mapResources('Posts', array('id' => '[a-z0-9_]+'));
-		$this->assertEquals(array('posts'), $resources);
+		$result = Router::mapResources('Posts', ['id' => '[a-z0-9_]+']);
+		$this->assertEquals(['posts'], $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$expected = [
+			'pass' => ['add'],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'view',
+			'id' => 'add',
+			'[method]' => 'GET',
+			'_ext' => null
+		];
 		$result = Router::parse('/posts/add');
-		$this->assertEquals(array('pass' => array('add'), 'plugin' => '', 'controller' => 'posts', 'action' => 'view', 'id' => 'add', '[method]' => 'GET'), $result);
+		$this->assertEquals($expected, $result);
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		$expected = [
+			'pass' => ['name'],
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'edit',
+			'id' => 'name',
+			'[method]' => 'PUT',
+			'_ext' => null
+		];
 		$result = Router::parse('/posts/name');
-		$this->assertEquals(array('pass' => array('name'), 'plugin' => '', 'controller' => 'posts', 'action' => 'edit', 'id' => 'name', '[method]' => 'PUT'), $result);
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -178,7 +238,8 @@ class RouterTest extends TestCase {
 			'plugin' => 'test_plugin',
 			'controller' => 'test_plugin',
 			'action' => 'index',
-			'[method]' => 'GET'
+			'[method]' => 'GET',
+			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertEquals(array('test_plugin'), $resources);
@@ -191,7 +252,8 @@ class RouterTest extends TestCase {
 			'controller' => 'test_plugin',
 			'action' => 'view',
 			'id' => '13',
-			'[method]' => 'GET'
+			'[method]' => 'GET',
+			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -215,6 +277,7 @@ class RouterTest extends TestCase {
 			'pass' => [],
 			'prefix' => 'api',
 			'[method]' => 'GET',
+			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -292,7 +355,8 @@ class RouterTest extends TestCase {
 			'controller' => 'test_plugin',
 			'prefix' => 'api',
 			'action' => 'index',
-			'[method]' => 'GET'
+			'[method]' => 'GET',
+			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
 		$this->assertEquals(array('test_plugin'), $resources);
@@ -308,6 +372,7 @@ class RouterTest extends TestCase {
 			'action' => 'index',
 			'[method]' => 'GET',
 			'prefix' => 'api',
+			'_ext' => null
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -324,7 +389,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts');
 		$expected = array(
 			'pass' => [],
-			'plugin' => '',
+			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
 			'[method]' => array('GET', 'POST')
@@ -335,7 +400,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts');
 		$expected = array(
 			'pass' => [],
-			'plugin' => '',
+			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
 			'[method]' => array('GET', 'POST')
@@ -1126,7 +1191,7 @@ class RouterTest extends TestCase {
 			'othervalue' => '01',
 			'controller' => 'posts',
 			'action' => 'view',
-			'plugin' => '',
+			'plugin' => null,
 			'pass' => array('0' => 'title-of-post-here')
 		);
 		$this->assertEquals($expected, $result);
@@ -1144,7 +1209,7 @@ class RouterTest extends TestCase {
 			'day' => '01',
 			'controller' => 'posts',
 			'action' => 'view',
-			'plugin' => '',
+			'plugin' => null,
 			'pass' => array('0' => 'title-of-post-here')
 		);
 		$this->assertEquals($expected, $result);
@@ -1162,7 +1227,7 @@ class RouterTest extends TestCase {
 			'month' => '08',
 			'controller' => 'posts',
 			'action' => 'view',
-			'plugin' => '',
+			'plugin' => null,
 			'pass' => array('0' => 'title-of-post-here')
 		);
 		$this->assertEquals($expected, $result);
@@ -1180,7 +1245,7 @@ class RouterTest extends TestCase {
 			'year' => '2007',
 			'controller' => 'posts',
 			'action' => 'view',
-			'plugin' => '',
+			'plugin' => null,
 			'pass' => array('0' => 'title-of-post-here')
 		);
 		$this->assertEquals($expected, $result);
@@ -1197,7 +1262,7 @@ class RouterTest extends TestCase {
 			'day' => '01',
 			'controller' => 'posts',
 			'action' => 'view',
-			'plugin' => '',
+			'plugin' => null,
 			'pass' => array('0' => 'title-of-post-here')
 		);
 		$this->assertEquals($expected, $result);
@@ -2737,6 +2802,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
+			'_ext' => null,
 			'pass' => array('home'),
 			'named' => array(
 				'one' => 'two',

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -39,7 +39,7 @@ class RouterTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Configure::write('Routing', array('admin' => null, 'prefixes' => array()));
+		Configure::write('Routing', array('admin' => null, 'prefixes' => []));
 		Router::reload();
 		Router::fullbaseUrl('');
 		Configure::write('App.fullBaseUrl', 'http://localhost');
@@ -114,7 +114,7 @@ class RouterTest extends TestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
+		$this->assertEquals($result, array('pass' => [], 'plugin' => '', 'controller' => 'posts', 'action' => 'index', '[method]' => 'GET'));
 		$this->assertEquals($resources, array('posts'));
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
@@ -123,7 +123,7 @@ class RouterTest extends TestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
-		$this->assertEquals($result, array('pass' => array(), 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
+		$this->assertEquals($result, array('pass' => [], 'plugin' => '', 'controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
 
 		$_SERVER['REQUEST_METHOD'] = 'PUT';
 		$result = Router::parse('/posts/13');
@@ -148,7 +148,7 @@ class RouterTest extends TestCase {
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts/add');
-		$this->assertSame(array(), $result);
+		$this->assertSame([], $result);
 
 		Router::reload();
 		$resources = Router::mapResources('Posts', array('id' => '[a-z0-9_]+'));
@@ -174,7 +174,7 @@ class RouterTest extends TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/test_plugin/test_plugin');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => 'test_plugin',
 			'controller' => 'test_plugin',
 			'action' => 'index',
@@ -212,7 +212,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
-			'pass' => array(),
+			'pass' => [],
 			'prefix' => 'api',
 			'[method]' => 'GET',
 		);
@@ -287,7 +287,7 @@ class RouterTest extends TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/api/test_plugin/test_plugin');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => 'test_plugin',
 			'controller' => 'test_plugin',
 			'prefix' => 'api',
@@ -302,7 +302,7 @@ class RouterTest extends TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/api/posts');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => null,
 			'controller' => 'posts',
 			'action' => 'index',
@@ -323,7 +323,7 @@ class RouterTest extends TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$result = Router::parse('/posts');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => '',
 			'controller' => 'posts',
 			'action' => 'index',
@@ -334,7 +334,7 @@ class RouterTest extends TestCase {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$result = Router::parse('/posts');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => '',
 			'controller' => 'posts',
 			'action' => 'index',
@@ -556,7 +556,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::connect('/:controller/:action/:id', array(), array('id' => $ID));
+		Router::connect('/:controller/:action/:id', [], array('id' => $ID));
 		Router::parse('/');
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 'id' => '1'));
@@ -677,7 +677,7 @@ class RouterTest extends TestCase {
 		);
 
 		Router::connect('/:language/:controller/:action/*',
-			array(),
+			[],
 			array('language' => '[a-z]{3}')
 		);
 
@@ -694,7 +694,7 @@ class RouterTest extends TestCase {
 			array('controller' => 'pages', 'action' => 'index'),
 			array('language' => '[a-z]{3}')
 		);
-		Router::connect('/:language/:controller/:action/*', array(), array('language' => '[a-z]{3}'));
+		Router::connect('/:language/:controller/:action/*', [], array('language' => '[a-z]{3}'));
 
 		$result = Router::url(array('language' => 'eng', 'action' => 'index', 'controller' => 'pages'));
 		$expected = '/eng/pages';
@@ -777,7 +777,7 @@ class RouterTest extends TestCase {
 		$request->webroot = '/';
 		Router::setRequestInfo($request);
 
-		$result = Router::url(array());
+		$result = Router::url([]);
 		$expected = '/admin/registrations/index';
 		$this->assertEquals($expected, $result);
 
@@ -1091,7 +1091,7 @@ class RouterTest extends TestCase {
 		$request = new Request();
 		Router::setRequestInfo(
 			$request->addParams(array(
-				'pass' => array(),
+				'pass' => [],
 				'prefix' => 'admin',
 				'plugin' => 'this',
 				'action' => 'index',
@@ -1233,7 +1233,7 @@ class RouterTest extends TestCase {
 		);
 		$result = Router::parse('/eng/contact');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'language' => 'eng',
 			'plugin' => 'contact',
 			'controller' => 'contact',
@@ -1262,7 +1262,7 @@ class RouterTest extends TestCase {
 		Router::connect('/:controller/:action/*');
 		Router::connect('/', array('plugin' => 'pages', 'controller' => 'pages', 'action' => 'display'));
 		$result = Router::parse('/');
-		$expected = array('pass' => array(), 'controller' => 'pages', 'action' => 'display', 'plugin' => 'pages');
+		$expected = array('pass' => [], 'controller' => 'pages', 'action' => 'display', 'plugin' => 'pages');
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/posts/edit/0');
@@ -1351,7 +1351,7 @@ class RouterTest extends TestCase {
 		);
 		$result = Router::parse('/subjects/add/4795d601-19c8-49a6-930e-06a8b01d17b7');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'category_id' => '4795d601-19c8-49a6-930e-06a8b01d17b7',
 			'plugin' => null,
 			'controller' => 'subjects',
@@ -1374,7 +1374,7 @@ class RouterTest extends TestCase {
 
 		$result = Router::parse('/some_extra/page/this_is_the_slug');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => null,
 			'controller' => 'pages',
 			'action' => 'view',
@@ -1385,7 +1385,7 @@ class RouterTest extends TestCase {
 
 		$result = Router::parse('/page/this_is_the_slug');
 		$expected = array(
-			'pass' => array(),
+			'pass' => [],
 			'plugin' => null,
 			'controller' => 'pages',
 			'action' => 'view',
@@ -1432,7 +1432,7 @@ class RouterTest extends TestCase {
  * @dataProvider parseReverseSymmetryData
  */
 	public function testParseReverseSymmetry($url) {
-		$this->assertSame($url, Router::reverse(Router::parse($url) + array('url' => array())));
+		$this->assertSame($url, Router::reverse(Router::parse($url) + array('url' => [])));
 	}
 
 /**
@@ -1602,7 +1602,7 @@ class RouterTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'index',
 			'_ext' => 'rss',
-			'pass' => array()
+			'pass' => []
 		);
 		$this->assertEquals($expected, $result);
 
@@ -1630,7 +1630,7 @@ class RouterTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'index',
 			'_ext' => 'xml',
-			'pass' => array()
+			'pass' => []
 		);
 		$this->assertEquals($expected, $result);
 
@@ -1639,7 +1639,7 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'posts.atom',
 			'action' => 'index',
-			'pass' => array(),
+			'pass' => [],
 			'?' => array('hello' => 'goodbye')
 		);
 		$this->assertEquals($expected, $result);
@@ -1647,7 +1647,7 @@ class RouterTest extends TestCase {
 		Router::reload();
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', '_ext' => 'rss'));
 		$result = Router::parse('/controller/action');
-		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, '_ext' => 'rss', 'pass' => array());
+		$expected = array('controller' => 'controller', 'action' => 'action', 'plugin' => null, '_ext' => 'rss', 'pass' => []);
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
@@ -1658,7 +1658,7 @@ class RouterTest extends TestCase {
 			'action' => 'action',
 			'plugin' => null,
 			'_ext' => 'rss',
-			'pass' => array()
+			'pass' => []
 		);
 		$this->assertEquals($expected, $result);
 
@@ -1671,7 +1671,7 @@ class RouterTest extends TestCase {
 			'action' => 'action',
 			'plugin' => null,
 			'_ext' => 'rss',
-			'pass' => array()
+			'pass' => []
 		);
 		$this->assertEquals($expected, $result);
 	}
@@ -2018,12 +2018,12 @@ class RouterTest extends TestCase {
 			'plugin' => null,
 			'controller' => 'blog_posts',
 			'action' => 'other',
-			'pass' => array(),
+			'pass' => [],
 		);
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/blog/foobar');
-		$this->assertSame(array(), $result);
+		$this->assertSame([], $result);
 
 		$result = Router::url(array('controller' => 'blog_posts', 'action' => 'foo'));
 		$this->assertEquals('/', $result);
@@ -2038,7 +2038,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testParsingWithLiteralPrefixes() {
-		Configure::write('Routing.prefixes', array());
+		Configure::write('Routing.prefixes', []);
 		Router::reload();
 		$adminParams = array('prefix' => 'admin');
 		Router::connect('/admin/:controller', $adminParams);
@@ -2057,7 +2057,7 @@ class RouterTest extends TestCase {
 		);
 
 		$result = Router::parse('/admin/posts/');
-		$expected = array('pass' => array(), 'prefix' => 'admin', 'plugin' => null, 'controller' => 'posts', 'action' => 'index');
+		$expected = array('pass' => [], 'prefix' => 'admin', 'plugin' => null, 'controller' => 'posts', 'action' => 'index');
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/admin/posts');
@@ -2068,7 +2068,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = Router::prefixes();
-		$expected = array();
+		$expected = [];
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
@@ -2090,7 +2090,7 @@ class RouterTest extends TestCase {
 		);
 
 		$result = Router::parse('/members/posts/index');
-		$expected = array('pass' => array(), 'prefix' => 'members', 'plugin' => null, 'controller' => 'posts', 'action' => 'index');
+		$expected = array('pass' => [], 'prefix' => 'members', 'plugin' => null, 'controller' => 'posts', 'action' => 'index');
 		$this->assertEquals($expected, $result);
 
 		$result = Router::url(array('prefix' => 'members', 'controller' => 'users', 'action' => 'add'));
@@ -2194,17 +2194,17 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testRegexRouteMatching() {
-		Router::connect('/:locale/:controller/:action/*', array(), array('locale' => 'dan|eng'));
+		Router::connect('/:locale/:controller/:action/*', [], array('locale' => 'dan|eng'));
 
 		$result = Router::parse('/eng/test/test_action');
-		$expected = array('pass' => array(), 'locale' => 'eng', 'controller' => 'test', 'action' => 'test_action', 'plugin' => null);
+		$expected = array('pass' => [], 'locale' => 'eng', 'controller' => 'test', 'action' => 'test_action', 'plugin' => null);
 		$this->assertEquals($expected, $result);
 
 		$result = Router::parse('/badness/test/test_action');
-		$this->assertSame(array(), $result);
+		$this->assertSame([], $result);
 
 		Router::reload();
-		Router::connect('/:locale/:controller/:action/*', array(), array('locale' => 'dan|eng'));
+		Router::connect('/:locale/:controller/:action/*', [], array('locale' => 'dan|eng'));
 
 		$request = new Request();
 		Router::setRequestInfo(
@@ -2257,7 +2257,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/plugin_js/js_file');
 		$expected = array(
 			'plugin' => 'plugin_js', 'controller' => 'js_file', 'action' => 'index',
-			'pass' => array()
+			'pass' => []
 		);
 		$this->assertEquals($expected, $result);
 
@@ -2269,7 +2269,7 @@ class RouterTest extends TestCase {
 			'plugin' => 'test_plugin',
 			'controller' => 'test_plugin',
 			'action' => 'index',
-			'pass' => array()
+			'pass' => []
 		);
 
 		$this->assertEquals($expected, $result, 'Plugin shortcut route broken.');
@@ -2282,7 +2282,7 @@ class RouterTest extends TestCase {
  */
 	public function testUsingCustomRouteClass() {
 		$routes = $this->getMock('Cake\Routing\RouteCollection');
-		$this->getMock('Cake\Routing\Route\Route', array(), array(), 'MockConnectedRoute', false);
+		$this->getMock('Cake\Routing\Route\Route', [], [], 'MockConnectedRoute', false);
 		Router::setRouteCollection($routes);
 
 		$routes->expects($this->once())
@@ -2319,7 +2319,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testCustomRouteException() {
-		Router::connect('/:controller', array(), array('routeClass' => 'Object'));
+		Router::connect('/:controller', [], array('routeClass' => 'Object'));
 	}
 
 /**
@@ -2335,7 +2335,7 @@ class RouterTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'view',
 			'pass' => array(1),
-			'url' => array(),
+			'url' => [],
 			'autoRender' => 1,
 			'bare' => 1,
 			'return' => 1,
@@ -2346,7 +2346,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals('/posts/view/1', $result);
 
 		Router::reload();
-		Router::connect('/:lang/:controller/:action/*', array(), array('lang' => '[a-z]{3}'));
+		Router::connect('/:lang/:controller/:action/*', [], array('lang' => '[a-z]{3}'));
 		$params = array(
 			'lang' => 'eng',
 			'controller' => 'posts',
@@ -2373,8 +2373,8 @@ class RouterTest extends TestCase {
 			'action' => 'view',
 			'pass' => array(1),
 			'url' => array('url' => 'eng/posts/view/1', 'foo' => 'bar', 'baz' => 'quu'),
-			'paging' => array(),
-			'models' => array()
+			'paging' => [],
+			'models' => []
 		);
 		$result = Router::reverse($params);
 		$this->assertEquals('/eng/posts/view/1?foo=bar&baz=quu', $result);
@@ -2418,7 +2418,7 @@ class RouterTest extends TestCase {
 			'pass' => array(1),
 			'ext' => 'json',
 		));
-		$request->query = array();
+		$request->query = [];
 		$result = Router::reverse($request);
 		$expected = '/posts/view/1.json';
 		$this->assertEquals($expected, $result);
@@ -2577,7 +2577,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals('/blog/actions/', $result);
 
 		$result = $route->parse('/blog/other');
-		$expected = array('controller' => 'blog_posts', 'action' => 'other', 'pass' => array());
+		$expected = array('controller' => 'blog_posts', 'action' => 'other', 'pass' => []);
 		$this->assertEquals($expected, $result);
 
 		$result = $route->parse('/blog/foobar');
@@ -2646,7 +2646,7 @@ class RouterTest extends TestCase {
 			array('_sendHeader')
 		);
 		Router::parse('/not-a-match');
-		$this->assertSame(array(), $routes->get(0)->response->header());
+		$this->assertSame([], $routes->get(0)->response->header());
 	}
 
 /**
@@ -2656,7 +2656,7 @@ class RouterTest extends TestCase {
  */
 	public function testDefaultRouteClass() {
 		$routes = $this->getMock('Cake\Routing\RouteCollection');
-		$this->getMock('Cake\Routing\Route\Route', array(), array('/test'), 'TestDefaultRouteClass');
+		$this->getMock('Cake\Routing\Route\Route', [], array('/test'), 'TestDefaultRouteClass');
 
 		$routes->expects($this->once())
 			->method('add')
@@ -2689,7 +2689,7 @@ class RouterTest extends TestCase {
  */
 	public function testDefaultRouteException() {
 		Router::defaultRouteClass('');
-		Router::connect('/:controller', array());
+		Router::connect('/:controller', []);
 	}
 
 /**
@@ -2724,7 +2724,7 @@ class RouterTest extends TestCase {
 			'action' => 'index',
 		));
 		$result = Router::parseNamedParams($request);
-		$this->assertSame(array(), $result->params['named']);
+		$this->assertSame([], $result->params['named']);
 
 		$request = new Request();
 		$request->addParams(array(

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -220,6 +220,45 @@ class RouterTest extends TestCase {
 	}
 
 /**
+ * Test mapResources with a default extension.
+ *
+ * @return void
+ */
+	public function testMapResourcesWithExtension() {
+		$resources = Router::mapResources('Posts', ['_ext' => 'json']);
+		$this->assertEquals(['posts'], $resources);
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		Router::parseExtensions('json', 'xml');
+
+		$expected = array(
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'index',
+			'pass' => [],
+			'[method]' => 'GET',
+			'_ext' => 'json',
+		);
+
+		$result = Router::parse('/posts');
+		$this->assertEquals($expected, $result);
+
+		$result = Router::parse('/posts.json');
+		$this->assertEquals($expected, $result);
+
+		$expected = array(
+			'plugin' => null,
+			'controller' => 'posts',
+			'action' => 'index',
+			'pass' => [],
+			'[method]' => 'GET',
+			'_ext' => 'xml',
+		);
+		$result = Router::parse('/posts.xml');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testMapResources with custom connectOptions
  */
 	public function testMapResourcesConnectOptions() {

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -416,36 +416,36 @@ class RouterTest extends TestCase {
 	public function testGenerateUrlResourceRoute() {
 		Router::mapResources('Posts');
 
-		$result = Router::url(array(
+		$result = Router::url([
 			'controller' => 'posts',
 			'action' => 'index',
 			'[method]' => 'GET'
-		));
+		]);
 		$expected = '/posts';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array(
+		$result = Router::url([
 			'controller' => 'posts',
 			'action' => 'view',
 			'[method]' => 'GET',
 			'id' => 10
-		));
+		]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array('controller' => 'posts', 'action' => 'add', '[method]' => 'POST'));
+		$result = Router::url(['controller' => 'posts', 'action' => 'add', '[method]' => 'POST']);
 		$expected = '/posts';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', '[method]' => 'PUT', 'id' => 10));
+		$result = Router::url(['controller' => 'posts', 'action' => 'edit', '[method]' => 'PUT', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array('controller' => 'posts', 'action' => 'delete', '[method]' => 'DELETE', 'id' => 10));
+		$result = Router::url(['controller' => 'posts', 'action' => 'delete', '[method]' => 'DELETE', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 
-		$result = Router::url(array('controller' => 'posts', 'action' => 'edit', '[method]' => 'POST', 'id' => 10));
+		$result = Router::url(['controller' => 'posts', 'action' => 'edit', '[method]' => 'POST', 'id' => 10]);
 		$expected = '/posts/10';
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -309,14 +309,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts.json');
 		$this->assertEquals($expected, $result);
 
-		$expected = array(
-			'plugin' => null,
-			'controller' => 'posts',
-			'action' => 'index',
-			'pass' => [],
-			'[method]' => 'GET',
-			'_ext' => 'xml',
-		);
+		$expected['_ext'] = 'xml';
 		$result = Router::parse('/posts.xml');
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
This permits writing routes without the need to specify the extension.

If no extension is found, the default will be used.
If an extension is found, that extension will be used.

It is useful when you always want those resources to be identified as a specific type.

So after a call like:

```
Router::mapResources(['categories'], ['_ext' => 'json']);
Router::parseExtensions('json', 'xml');
```

the following two will render JSON:

```
http://example.com/categories/1
http://example.com/categories/1.json
```

and

```
http://example.com/categories/1.xml
```

will still be returning XML.

If the parseExtension() call is omitted, the non-extension URL:

```
http://example.com/categories/1
```

will still be rendering JSON.
