### PR TITLE
Replacing the usage of PHPUnit static mock on App::classname()

### DIFF
--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -19,6 +19,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
+use TestApp\Core\TestApp;
 
 /**
  * AppTest class
@@ -46,21 +47,18 @@ class AppTest extends TestCase {
  */
 	public function testClassname($class, $type, $suffix = '', $existsInBase = false, $expected = false) {
 		Configure::write('App.namespace', 'TestApp');
-		$mock = $this->getMockClass('Cake\Core\App', ['_classExistsInBase']);
-
-		$mock::staticExpects($this->at(0))
-			->method('_classExistsInBase')
-			->will($this->returnValue($existsInBase));
-
-		$checkCake = (!$existsInBase || strpos('.', $class));
-		if ($checkCake) {
-			$existsInCake = (bool)$expected;
-			$mock::staticExpects($this->at(1))
-				->method('_classExistsInBase')
-				->will($this->returnValue($existsInCake));
-		}
-
-		$return = $mock::classname($class, $type, $suffix);
+		$i = 0;
+		TestApp::$existsInBaseCallback = function($name, $namespace) use ($existsInBase, $class, $expected, &$i) {
+			if ($i++ === 0) {
+				return $existsInBase;
+			}
+			$checkCake = (!$existsInBase || strpos('.', $class));
+			if ($checkCake) {
+				return (bool)$expected;
+			}
+			return false;
+		};
+		$return = TestApp::classname($class, $type, $suffix);
 		$this->assertSame($expected, $return);
 	}
 

--- a/tests/test_app/TestApp/Core/TestApp.php
+++ b/tests/test_app/TestApp/Core/TestApp.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Core;
+
+use Cake\Core\App;
+
+class TestApp extends App {
+
+	public static $existsInBaseCallback;
+
+	protected static function _classExistsInBase($name, $namespace) {
+		$callback = static::$existsInBaseCallback;
+		return $callback($name, $namespace);
+	}
+
+}


### PR DESCRIPTION
Just an improvement to help on the PHPUnit 4 support.
