### PR TITLE
3.0 - SMTP transport - Extensibility and response access

### DIFF
--- a/src/Network/Email/SmtpTransport.php
+++ b/src/Network/Email/SmtpTransport.php
@@ -152,24 +152,90 @@ class SmtpTransport extends AbstractTransport {
 	}
 
 /**
+ * Prepares the `MAIL FROM` SMTP command.
+ *
+ * @param string $email The email address to send with the command.
+ * @return string
+ */
+	protected function _prepareFromCmd($email) {
+		return 'MAIL FROM:<' . $email . '>';
+	}
+
+/**
+ * Prepares the `RCPT TO` SMTP command.
+ *
+ * @param string $email The email address to send with the command.
+ * @return string
+ */
+	protected function _prepareRcptCmd($email) {
+		return 'RCPT TO:<' . $email . '>';
+	}
+
+/**
+ * Prepares the `from` email address.
+ *
+ * @return array
+ */
+	protected function _prepareFromAddress() {
+		$from = $this->_cakeEmail->returnPath();
+		if (empty($from)) {
+			$from = $this->_cakeEmail->from();
+		}
+		return $from;
+	}
+
+/**
+ * Prepares the recipient email addresses.
+ *
+ * @return array
+ */
+	protected function _prepareRecipientAddresses() {
+		$to = $this->_cakeEmail->to();
+		$cc = $this->_cakeEmail->cc();
+		$bcc = $this->_cakeEmail->bcc();
+		return array_merge(array_keys($to), array_keys($cc), array_keys($bcc));
+	}
+
+/**
+ * Prepares the message headers.
+ *
+ * @return array
+ */
+	protected function _prepareMessageHeaders() {
+		return $this->_cakeEmail->getHeaders(array('from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject'));
+	}
+
+/**
+ * Prepares the message body.
+ *
+ * @return string
+ */
+	protected function _prepareMessage() {
+		$lines = $this->_cakeEmail->message();
+		$messages = array();
+		foreach ($lines as $line) {
+			if ((!empty($line)) && ($line[0] === '.')) {
+				$messages[] = '.' . $line;
+			} else {
+				$messages[] = $line;
+			}
+		}
+		return implode("\r\n", $messages);
+	}
+
+/**
  * Send emails
  *
  * @return void
  * @throws \Cake\Error\SocketException
  */
 	protected function _sendRcpt() {
-		$from = $this->_cakeEmail->returnPath();
-		if (empty($from)) {
-			$from = $this->_cakeEmail->from();
-		}
-		$this->_smtpSend('MAIL FROM:<' . key($from) . '>');
+		$from = $this->_prepareFromAddress();
+		$this->_smtpSend($this->_prepareFromCmd(key($from)));
 
-		$to = $this->_cakeEmail->to();
-		$cc = $this->_cakeEmail->cc();
-		$bcc = $this->_cakeEmail->bcc();
-		$emails = array_merge(array_keys($to), array_keys($cc), array_keys($bcc));
+		$emails = $this->_prepareRecipientAddresses();
 		foreach ($emails as $email) {
-			$this->_smtpSend('RCPT TO:<' . $email . '>');
+			$this->_smtpSend($this->_prepareRcptCmd($email));
 		}
 	}
 
@@ -182,18 +248,9 @@ class SmtpTransport extends AbstractTransport {
 	protected function _sendData() {
 		$this->_smtpSend('DATA', '354');
 
-		$headers = $this->_cakeEmail->getHeaders(array('from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject'));
-		$headers = $this->_headersToString($headers);
-		$lines = $this->_cakeEmail->message();
-		$messages = array();
-		foreach ($lines as $line) {
-			if ((!empty($line)) && ($line[0] === '.')) {
-				$messages[] = '.' . $line;
-			} else {
-				$messages[] = $line;
-			}
-		}
-		$message = implode("\r\n", $messages);
+		$headers = $this->_headersToString($this->_prepareMessageHeaders());
+		$message = $this->_prepareMessage();
+
 		$this->_smtpSend($headers . "\r\n\r\n" . $message . "\r\n\r\n\r\n.");
 		$this->_content = array('headers' => $headers, 'message' => $message);
 	}


### PR DESCRIPTION
So I had to extend transports pretty often, namely the SMTP transport, and most often I ended up overriding and reimplementing a lot of code, which is a bit annoying, maintenance wise.

Take this extended transport for example: https://gist.github.com/ndm2/2426342a8f4685d6c26e

It implements persistent connections (something I'd like to suggest later on too), DSN features, access to responses and functionality to check for supported SMTP extensions. The changes in the overriden methods are rather small, but still they require to reimplement their parents whole code.

So in order to make this a little more extensibility friendly I'd like to suggest to refactor some of the code into overridable methods, and to expose responses.

ps. I'm a little unsure about the tests. Except for `getLastResponse()` and `_bufferResponseLines()` which have their own tests, all the other new methods are implicitly covered by the existing tests. Personally I tend to adding separate tests for every single method, and also tests that check whether the methods are being properly invoked, just to make sure everything's covered even when other tests are being changed. However I'm not sure about this projects conventions?
