### PR TITLE
2.5 - Dbosource bc fix

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1644,6 +1644,10 @@ class DboSource extends DataSource {
 	public function generateAssociationQuery(Model $Model, $LinkModel, $type, $association, $assocData, &$queryData, $external) {
 		$assocData = $this->_scrubQueryData($assocData);
 
+		if ($LinkModel === null) {
+			return '';
+		}
+
 		if ($external && !empty($assocData['finderQuery'])) {
 			return $assocData['finderQuery'];
 		}

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1641,7 +1641,7 @@ class DboSource extends DataSource {
  *   String representing a query.
  *   True, when $external is false and association $type is 'hasOne' or 'belongsTo'.
  */
-	public function generateAssociationQuery(Model $Model, Model $LinkModel, $type, $association, $assocData, &$queryData, $external) {
+	public function generateAssociationQuery(Model $Model, $LinkModel, $type, $association, $assocData, &$queryData, $external) {
 		$assocData = $this->_scrubQueryData($assocData);
 
 		if ($external && !empty($assocData['finderQuery'])) {


### PR DESCRIPTION
@dereuromark Pointed out that recent changes in DboSource have caused community plugins to break because of the additional type hints. Removing those typehints should address the problem. I've changed the method to return '' when $LinkModel is null as it would generate a warning previously.
