### PR TITLE
changed regexp for response code

### DIFF
--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -159,7 +159,7 @@ class HttpSocketResponse implements ArrayAccess {
 		$this->raw = $message;
 		$this->body = (string)substr($message, strlen($match[0]));
 
-		if (preg_match("/(.+) ([0-9]{3}) (.+)\r\n/DU", $statusLine, $match)) {
+		if (preg_match("/(.+) ([0-9]{3}) (.*)\r\n/DU", $statusLine, $match)) {
 			$this->httpVersion = $match[1];
 			$this->code = $match[2];
 			$this->reasonPhrase = $match[3];


### PR DESCRIPTION
Facebook servers have now HTTP response without status string. The use 
"HTTP/1.1 200 "
while CakePHP needs 
"HTTP/1.1 200 Ok"
because preg_match() in code use + instead *

Please fix the line.
