### PR TITLE
3.0 paginator revisit

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -163,8 +163,7 @@ class PaginatorComponent extends Component {
 			$query = $object->find($type);
 		}
 
-		$limit = $query->clause('limit');
-		$query->applyOptions(array_filter(compact('limit')) + $options);
+		$query->applyOptions($options);
 		$results = $query->all();
 		$numResults = count($results);
 		$count = $numResults ? $query->count() : 0;

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -133,24 +133,22 @@ class PaginatorComponent extends Component {
  * @throws \Cake\Error\NotFoundException
  */
 	public function paginate($object, array $settings = []) {
-		$query = $object;
-		$type = 'all';
-
-		if ($object instanceof RepositoryInterface) {
-			$type = !empty($settings['findType']) ? $settings['findType'] : $type;
-			$query = $object->find();
-		}
-
 		$alias = $object->alias();
 		$options = $this->mergeOptions($alias, $settings);
 		$options = $this->validateSort($object, $options);
 		$options = $this->checkLimit($options);
+
 		$options += ['page' => 1];
 		$options['page'] = intval($options['page']) < 1 ? 1 : (int)$options['page'];
+
+		$type = !empty($options['findType']) ? $options['findType'] : 'all';
 		unset($options['findType'], $options['maxLimit']);
 
-		$query->applyOptions($options);
+		if ($object instanceof RepositoryInterface) {
+			$query = $object->find($type);
+		}
 
+		$query->applyOptions($options);
 		$results = $query->all();
 		$numResults = count($results);
 

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -128,6 +128,15 @@ class PaginatorComponent extends Component {
  *
  * Would paginate using the `find('popular')` method.
  *
+ * You can also pass an already created instance of a query to this method:
+ *
+ * {{{
+ * $query = $this->Articles->find('popular')->matching('Tags', function($q) {
+ *	return $q->where(['name' => 'CakePHP'])
+ * });
+ * $results = $paginator->paginate($query);
+ * }}}
+ *
  * @param Cake\Datasource\RepositoryInterface|Cake\ORM\Query $object The table or query to paginate.
  * @param array $settings The settings/configuration used for pagination.
  * @return array Query results

--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -128,7 +128,7 @@ class PaginatorComponent extends Component {
  *
  * Would paginate using the `find('popular')` method.
  *
- * @param Table $object The table to paginate.
+ * @param Cake\Datasource\RepositoryInterface|Cake\ORM\Query $object The table or query to paginate.
  * @param array $settings The settings/configuration used for pagination.
  * @return array Query results
  * @throws \Cake\Error\NotFoundException
@@ -154,7 +154,8 @@ class PaginatorComponent extends Component {
 			$query = $object->find($type);
 		}
 
-		$query->applyOptions($options);
+		$limit = $query->clause('limit');
+		$query->applyOptions(array_filter(compact('limit')) + $options);
 		$results = $query->all();
 		$numResults = count($results);
 		$count = $numResults ? $query->count() : 0;
@@ -169,12 +170,7 @@ class PaginatorComponent extends Component {
 		$page = max(min($page, $pageCount), 1);
 		$request = $this->_registry->getController()->request;
 
-		$order = $options['order'];
-		if (!is_array($options)) {
-			$order = (array)$order;
-		}
-
-		reset($order);
+		$order = (array)$options['order'];
 		$sortDefault = $directionDefault = false;
 		if (!empty($defaults['order']) && count($defaults['order']) == 1) {
 			$sortDefault = key($defaults['order']);
@@ -197,7 +193,7 @@ class PaginatorComponent extends Component {
 		);
 
 		if (!isset($request['paging'])) {
-			$request['paging'] = array();
+			$request['paging'] = [];
 		}
 		$request['paging'] = array_merge(
 			(array)$request['paging'],

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -656,7 +656,8 @@ class Controller extends Object implements EventListener {
  *
  * This method will also make the PaginatorHelper available in the view.
  *
- * @param Table|string $object Table to paginate (e.g: Table instance, or 'Model')
+ * @param Table|string|Query $object Table to paginate
+ * (e.g: Table instance, 'TableName' or a Query object)
  * @return ORM\ResultSet Query results
  * @link http://book.cakephp.org/3.0/en/controllers.html#Controller::paginate
  */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -426,7 +426,7 @@ class Query extends DatabaseQuery {
  * - having: Maps to the having method
  * - contain: Maps to the contain options for eager loading
  * - join: Maps to the join method
- * - join: Maps to the page method
+ * - page: Maps to the page method
  *
  * @return \Cake\ORM\Query
  */

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -761,6 +761,39 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
+ * Tests that passing a query object with a limit clause set will not
+ * overwrite it with the passed defaults.
+ *
+ * @return void
+ */
+	public function testPaginateQueryWithLimit() {
+		$this->request->query = array('page' => '-1');
+		$settings = array(
+			'PaginatorPosts' => array(
+				'contain' => array('PaginatorAuthor'),
+				'maxLimit' => 10,
+				'limit' => 5,
+				'group' => 'PaginatorPosts.published',
+				'order' => array('PaginatorPosts.id' => 'ASC')
+			)
+		);
+		$table = $this->_getMockPosts(['find']);
+		$query = $this->_getMockFindQuery($table);
+		$query->limit(2);
+		$table->expects($this->never())->method('find');
+		$query->expects($this->once())
+			->method('applyOptions')
+			->with([
+				'contain' => ['PaginatorAuthor'],
+				'group' => 'PaginatorPosts.published',
+				'limit' => 2,
+				'order' => ['PaginatorPosts.id' => 'ASC'],
+				'page' => 1,
+			]);
+		$this->Paginator->paginate($query, $settings);
+	}
+
+/**
  * Helper method for making mocks.
  *
  * @param array $methods

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -46,7 +46,14 @@ class PaginatorComponentTest extends TestCase {
  *
  * @var array
  */
-	public $fixtures = array('core.post', 'core.author');
+	public $fixtures = array('core.post');
+
+/**
+ * Don't load data for fixtures for all tests
+ *
+ * @var boolean
+ */
+	public $autoFixtures = false;
 
 /**
  * setup
@@ -418,6 +425,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testOutOfRangePageNumberGetsClamped() {
+		$this->loadFixtures('Post');
 		$this->request->query['page'] = 3000;
 
 		$table = TableRegistry::get('PaginatorPosts');
@@ -631,6 +639,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFind() {
+		$this->loadFixtures('Post');
 		$idExtractor = function ($result) {
 			$ids = [];
 			foreach ($result as $record) {
@@ -680,6 +689,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateCustomFindFieldsArray() {
+		$this->loadFixtures('Post');
 		$table = TableRegistry::get('PaginatorPosts');
 		$data = array('author_id' => 3, 'title' => 'Fourth Article', 'body' => 'Article Body, unpublished', 'published' => 'N');
 		$table->save(new \Cake\ORM\Entity($data));
@@ -803,7 +813,18 @@ class PaginatorComponentTest extends TestCase {
 		return $this->getMock(
 			'TestApp\Model\Table\PaginatorPostsTable',
 			$methods,
-			[['connection' => ConnectionManager::get('test'), 'alias' => 'PaginatorPosts']]
+			[[
+				'connection' => ConnectionManager::get('test'),
+				'alias' => 'PaginatorPosts',
+				'schema' => [
+					'id' => ['type' => 'integer'],
+					'author_id' => ['type' => 'integer', 'null' => false],
+					'title' => ['type' => 'string', 'null' => false],
+					'body' => 'text',
+					'published' => ['type' => 'string', 'length' => 1, 'default' => 'N'],
+					'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+				]
+			]]
 		);
 	}
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -118,17 +118,18 @@ class PaginatorComponentTest extends TestCase {
 		$query = $this->_getMockFindQuery();
 		$table->expects($this->once())
 			->method('find')
-			->with('all', [
-				'conditions' => [],
+			->with('all')
+			->will($this->returnValue($query));
+
+		$query->expects($this->once())
+			->method('applyOptions')
+			->with([
 				'contain' => ['PaginatorAuthor'],
-				'fields' => null,
 				'group' => 'PaginatorPosts.published',
 				'limit' => 10,
 				'order' => ['PaginatorPosts.id' => 'ASC'],
 				'page' => 1,
-			])
-			->will($this->returnValue($query));
-
+			]);
 		$this->Paginator->paginate($table, $settings);
 	}
 
@@ -173,14 +174,15 @@ class PaginatorComponentTest extends TestCase {
 
 		$table->expects($this->once())
 			->method('find')
-			->with('all', [
-				'conditions' => [],
-				'fields' => null,
+			->with('all')
+			->will($this->returnValue($query));
+		$query->expects($this->once())
+			->method('applyOptions')
+			->with([
 				'limit' => 10,
 				'page' => 1,
 				'order' => ['PaginatorPosts.id' => 'DESC']
-			])
-			->will($this->returnValue($query));
+			]);
 
 		$this->Paginator->paginate($table, $settings);
 	}
@@ -201,14 +203,15 @@ class PaginatorComponentTest extends TestCase {
 
 		$table->expects($this->once())
 			->method('find')
-			->with('all', [
-				'conditions' => [],
-				'fields' => null,
+			->with('all')
+			->will($this->returnValue($query));
+		$query->expects($this->once())
+			->method('applyOptions')
+			->with([
 				'limit' => 10,
 				'page' => 1,
 				'order' => ['PaginatorPosts.id' => 'DESC']
-			])
-			->will($this->returnValue($query));
+			]);
 
 		$this->Paginator->paginate($table, $settings);
 		$this->assertEquals('PaginatorPosts.id', $this->request->params['paging']['PaginatorPosts']['sortDefault']);
@@ -370,14 +373,14 @@ class PaginatorComponentTest extends TestCase {
 
 		$table->expects($this->once())
 			->method('find')
-			->with('all', [
-				'fields' => null,
-				'limit' => 20,
-				'conditions' => [],
-				'page' => 1,
-				'order' => ['PaginatorPosts.id' => 'asc'],
-			])
+			->with('all')
 			->will($this->returnValue($query));
+		$query->expects($this->once())->method('applyOptions')
+			->with([
+				'limit' => 20,
+				'page' => 1,
+				'order' => ['PaginatorPosts.id' => 'asc']
+			]);
 
 		$this->request->query = [
 			'page' => 1,
@@ -718,15 +721,11 @@ class PaginatorComponentTest extends TestCase {
 		$query = $this->_getMockFindQuery();
 		$table->expects($this->once())
 			->method('find')
-			->with('published', [
-				'conditions' => [],
-				'order' => [],
-				'limit' => 2,
-				'fields' => null,
-				'page' => 1,
-			])
+			->with('published')
 			->will($this->returnValue($query));
 
+		$query->expects($this->once())->method('applyOptions')
+			->with(['limit' => 2, 'page' => 1, 'order' => []]);
 		$this->Paginator->paginate($table, $settings);
 	}
 
@@ -751,7 +750,7 @@ class PaginatorComponentTest extends TestCase {
  */
 	protected function _getMockFindQuery() {
 		$query = $this->getMockBuilder('Cake\ORM\Query')
-			->setMethods(['total', 'all', 'count'])
+			->setMethods(['total', 'all', 'count', 'applyOptions'])
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -761,7 +761,7 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
- * Tests that passing a query object with a limit clause set will not
+ * Tests that passing a query object with a limit clause set will
  * overwrite it with the passed defaults.
  *
  * @return void
@@ -786,7 +786,7 @@ class PaginatorComponentTest extends TestCase {
 			->with([
 				'contain' => ['PaginatorAuthor'],
 				'group' => 'PaginatorPosts.published',
-				'limit' => 2,
+				'limit' => 5,
 				'order' => ['PaginatorPosts.id' => 'ASC'],
 				'page' => 1,
 			]);

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -730,6 +730,37 @@ class PaginatorComponentTest extends TestCase {
 	}
 
 /**
+ * Tests that it is possible to pass an already made query object to
+ * paginate()
+ *
+ * @return void
+ */
+	public function testPaginateQuery() {
+		$this->request->query = array('page' => '-1');
+		$settings = array(
+			'PaginatorPosts' => array(
+				'contain' => array('PaginatorAuthor'),
+				'maxLimit' => 10,
+				'group' => 'PaginatorPosts.published',
+				'order' => array('PaginatorPosts.id' => 'ASC')
+			)
+		);
+		$table = $this->_getMockPosts(['find']);
+		$query = $this->_getMockFindQuery($table);
+		$table->expects($this->never())->method('find');
+		$query->expects($this->once())
+			->method('applyOptions')
+			->with([
+				'contain' => ['PaginatorAuthor'],
+				'group' => 'PaginatorPosts.published',
+				'limit' => 10,
+				'order' => ['PaginatorPosts.id' => 'ASC'],
+				'page' => 1,
+			]);
+		$this->Paginator->paginate($query, $settings);
+	}
+
+/**
  * Helper method for making mocks.
  *
  * @param array $methods
@@ -748,7 +779,7 @@ class PaginatorComponentTest extends TestCase {
  *
  * @return Query
  */
-	protected function _getMockFindQuery() {
+	protected function _getMockFindQuery($table = null) {
 		$query = $this->getMockBuilder('Cake\ORM\Query')
 			->setMethods(['total', 'all', 'count', 'applyOptions'])
 			->disableOriginalConstructor()
@@ -767,6 +798,7 @@ class PaginatorComponentTest extends TestCase {
 			->method('count')
 			->will($this->returnValue(2));
 
+		$query->repository($table);
 		return $query;
 	}
 


### PR DESCRIPTION
This add the ability to pass an already created query instance to `paginate()`

``` php
function index() {
  $query = $this->Articles->find('popular')->matching('Tags', function($q) {
    return $q->where(['Tags.name' => 'CakePHP'])
  });
  $this->set('articles', $this->paginate($query));
}
```
