### PR TITLE
Fixed bug where select query in deleteAll could return wrong table name

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2703,8 +2703,9 @@ class Model extends Object implements CakeEventListener {
 		}
 
 		$ids = $this->find('all', array_merge(array(
-			'fields' => "DISTINCT {$this->alias}.{$this->primaryKey}",
+			'fields' => "{$this->alias}.{$this->primaryKey}",
 			'order' => false,
+			'group' => "{$this->alias}.{$this->primaryKey}",
 			'recursive' => 0), compact('conditions'))
 		);
 


### PR DESCRIPTION
Fixed bug where select query in deleteAll could return wrong table name.

PDOStatement::getColumnMeta (in mysql.php) sometimes returns the actual table name when using a MySQL view with the distinct select query, and not the alias table name. By returning the actual table name the records could not be removed.
By the way PDOStatement::getColumnMeta is an experimental function, perhaps it's better to avoid it.
