### PR TITLE
Plain entities cannot be used at this point as root in FormHelper

### DIFF
--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -120,7 +120,7 @@ class EntityContext implements ContextInterface {
 			if (is_array($entity) || $entity instanceof Traversable) {
 				$entity = (new Collection($entity))->first();
 			}
-			if ($entity instanceof Entity) {
+			if ($entity instanceof Entity && get_class($entity) !== 'Cake\ORM\Entity') {
 				list($ns, $entityClass) = namespaceSplit(get_class($entity));
 				$table = Inflector::pluralize($entityClass);
 			}

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -92,7 +92,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testIsCreateSingle() {
-		$row = new Entity();
+		$row = new Article();
 		$context = new EntityContext($this->request, [
 			'entity' => $row,
 		]);
@@ -128,6 +128,18 @@ class EntityContextTest extends TestCase {
 		$row = new \StdClass();
 		$context = new EntityContext($this->request, [
 			'entity' => $row,
+		]);
+	}
+
+/**
+ * Tests that passing a plain entity will give an error as it cannot be matched
+ *
+ * @expectedException \RuntimeException
+ * @expectedExceptionMessage Unable to find table class for current entity
+ */
+	public function testDefaultEntityError() {
+		$context = new EntityContext($this->request, [
+			'entity' => new \Cake\ORM\Entity,
 		]);
 	}
 
@@ -200,14 +212,14 @@ class EntityContextTest extends TestCase {
  * @return array
  */
 	public static function collectionProvider() {
-		$one = new Entity([
+		$one = new Article([
 			'title' => 'First post',
 			'body' => 'Stuff',
 			'user' => new Entity(['username' => 'mark'])
 		]);
 		$one->errors('title', 'Required field');
 
-		$two = new Entity([
+		$two = new Article([
 			'title' => 'Second post',
 			'body' => 'Some text',
 			'user' => new Entity(['username' => 'jose'])
@@ -359,7 +371,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValBasic() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'body' => 'Something new'
 		]);
@@ -387,7 +399,7 @@ class EntityContextTest extends TestCase {
 			'title' => 'New title',
 			'notInEntity' => 'yes',
 		];
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'body' => 'Something new'
 		]);
@@ -406,7 +418,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociated() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -444,14 +456,14 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedHasMany() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
 				'fname' => 'Mark',
 				'articles' => [
-					new Entity(['title' => 'First post']),
-					new Entity(['title' => 'Second post']),
+					new Article(['title' => 'First post']),
+					new Article(['title' => 'Second post']),
 				]
 			]),
 		]);
@@ -473,7 +485,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedDefaultIds() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -499,7 +511,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedCustomIds() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -558,7 +570,7 @@ class EntityContextTest extends TestCase {
 			'rule' => 'numeric',
 		]);
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'comments' => [
 				new Entity(['comment' => 'First comment']),
@@ -585,7 +597,7 @@ class EntityContextTest extends TestCase {
 	public function testIsRequiredAssociatedValidator() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'comments' => [
 				new Entity(['comment' => 'First comment']),
@@ -615,7 +627,7 @@ class EntityContextTest extends TestCase {
 	public function testIsRequiredAssociatedBelongsTo() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -640,7 +652,7 @@ class EntityContextTest extends TestCase {
 	public function testType() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'body' => 'Some content',
 		]);
@@ -663,7 +675,7 @@ class EntityContextTest extends TestCase {
 	public function testTypeAssociated() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -685,7 +697,7 @@ class EntityContextTest extends TestCase {
 	public function testAttributes() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -718,7 +730,7 @@ class EntityContextTest extends TestCase {
 	public function testHasError() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -744,7 +756,7 @@ class EntityContextTest extends TestCase {
 	public function testHasErrorAssociated() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -769,7 +781,7 @@ class EntityContextTest extends TestCase {
 	public function testError() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);


### PR DESCRIPTION
Trying to do so was throwing exceptions because it tried to find a table
called 'entities'. Disallowing this usage until we find a better
solution
