### PR TITLE
3.0 entity context fixes

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1135,7 +1135,11 @@ class Query implements ExpressionInterface, IteratorAggregate {
 			$limit = 25;
 			$this->limit($limit);
 		}
-		$this->offset(($num - 1) * $limit);
+		$offset = ($num - 1) * $limit;
+		if (PHP_INT_MAX <= $offset) {
+			$offset = PHP_INT_MAX;
+		}
+		$this->offset((int)$offset);
 		return $this;
 	}
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -98,12 +98,11 @@ trait EntityTrait {
 	protected $_accessible = [];
 
 /**
- * An array containing the alias and full table classname from which
- * this entity comes.
+ * The alias of the repository this entity came from
  *
- * @var array
+ * @var string
  */
-	protected $_repositoryInfo = [];
+	protected $_repositoryAlias;
 
 /**
  * Magic getter to access properties that has be set in this entity
@@ -671,19 +670,19 @@ trait EntityTrait {
 	}
 
 /**
- * Returns an array containing the alias and classname of the repository
- * this entity came from, if it is known.
+ * Returns the alias of the repository from wich this entity came from.
  *
- * If an array is passed, the repository info will be set to it.
+ * If called with no arguments, it returns the alias of the repository
+ * this entity came from if it is known.
  *
- * @param array $info the repository info to store
- * @return array
+ * @param string the alias of the repository
+ * @return string
  */
-	public function source(array $info = null) {
-		if ($info === null) {
-			return $this->_repositoryInfo;
+	public function source($alias = null) {
+		if ($alias === null) {
+			return $this->_repositoryAlias;
 		}
-		$this->_repositoryInfo = $info;
+		$this->_repositoryAlias = $alias;
 	}
 
 /**
@@ -709,7 +708,7 @@ trait EntityTrait {
 			'dirty' => $this->_dirty,
 			'virtual' => $this->_virtual,
 			'errors' => $this->_errors,
-			'repository' => $this->_repositoryInfo
+			'repository' => $this->_repositoryAlias
 		];
 	}
 

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -98,6 +98,14 @@ trait EntityTrait {
 	protected $_accessible = [];
 
 /**
+ * An array containing the alias and full table classname from which
+ * this entity comes.
+ *
+ * @var array
+ */
+	protected $_repositoryInfo = [];
+
+/**
  * Magic getter to access properties that has be set in this entity
  *
  * @param string $property name of the property to access
@@ -663,6 +671,22 @@ trait EntityTrait {
 	}
 
 /**
+ * Returns an array containing the alias and classname of the repository
+ * this entity came from, if it is known.
+ *
+ * If an array is passed, the repository info will be set to it.
+ *
+ * @param array $info the repository info to store
+ * @return array
+ */
+	public function source(array $info = null) {
+		if ($info === null) {
+			return $this->_repositoryInfo;
+		}
+		$this->_repositoryInfo = $info;
+	}
+
+/**
  * Returns a string representation of this object in a human readable format.
  *
  * @return string
@@ -684,7 +708,8 @@ trait EntityTrait {
 			'properties' => $this->_properties,
 			'dirty' => $this->_dirty,
 			'virtual' => $this->_virtual,
-			'errors' => $this->_errors
+			'errors' => $this->_errors,
+			'repository' => $this->_repositoryInfo
 		];
 	}
 

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -514,10 +514,7 @@ class BelongsToMany extends Association {
 		$targetPrimaryKey = (array)$target->primaryKey();
 		$sourcePrimaryKey = (array)$source->primaryKey();
 		$jointProperty = $this->_junctionProperty;
-		$junctionInfo = [
-			'alias' => $junction->alias(),
-			'className' => get_class($junction)
-		];
+		$junctionAlias = $junction->alias();
 
 		foreach ($targetEntities as $k => $e) {
 			$joint = $e->get($jointProperty);
@@ -539,7 +536,7 @@ class BelongsToMany extends Association {
 
 			$e->set($jointProperty, $joint);
 			$e->dirty($jointProperty, false);
-			$joint->source($junctionInfo);
+			$joint->source($junctionAlias);
 		}
 
 		return true;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -514,6 +514,10 @@ class BelongsToMany extends Association {
 		$targetPrimaryKey = (array)$target->primaryKey();
 		$sourcePrimaryKey = (array)$source->primaryKey();
 		$jointProperty = $this->_junctionProperty;
+		$junctionInfo = [
+			'alias' => $junction->alias(),
+			'className' => get_class($junction)
+		];
 
 		foreach ($targetEntities as $k => $e) {
 			$joint = $e->get($jointProperty);
@@ -535,6 +539,7 @@ class BelongsToMany extends Association {
 
 			$e->set($jointProperty, $joint);
 			$e->dirty($jointProperty, false);
+			$joint->source($junctionInfo);
 		}
 
 		return true;

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -43,8 +43,7 @@ class Entity implements EntityInterface {
  * - markClean: whether to mark all properties as clean after setting them
  * - markNew: whether this instance has not yet been persisted
  * - guard: whether to prevent inaccessible properties from being set (default: false)
- * - source: An array containing the 'alias' and 'className' keys, describing the
- *   repository this entity came from.
+ * - source: A string representing the alias of the repository this entity came from
  */
 	public function __construct(array $properties = [], array $options = []) {
 		$options += [
@@ -52,7 +51,7 @@ class Entity implements EntityInterface {
 			'markClean' => false,
 			'markNew' => null,
 			'guard' => false,
-			'source' => []
+			'source' => null
 		];
 		$this->_className = get_class($this);
 		$this->set($properties, [

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -43,13 +43,16 @@ class Entity implements EntityInterface {
  * - markClean: whether to mark all properties as clean after setting them
  * - markNew: whether this instance has not yet been persisted
  * - guard: whether to prevent inaccessible properties from being set (default: false)
+ * - source: An array containing the 'alias' and 'className' keys, describing the
+ *   repository this entity came from.
  */
 	public function __construct(array $properties = [], array $options = []) {
 		$options += [
 			'useSetters' => true,
 			'markClean' => false,
 			'markNew' => null,
-			'guard' => false
+			'guard' => false,
+			'source' => []
 		];
 		$this->_className = get_class($this);
 		$this->set($properties, [
@@ -63,6 +66,10 @@ class Entity implements EntityInterface {
 
 		if ($options['markNew'] !== null) {
 			$this->isNew($options['markNew']);
+		}
+
+		if (!empty($options['source'])) {
+			$this->source($options['source']);
 		}
 	}
 

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -98,10 +98,7 @@ class Marshaller {
 		$tableName = $this->_table->alias();
 		$entityClass = $this->_table->entityClass();
 		$entity = new $entityClass();
-		$entity->source([
-			'alias' => $this->_table->alias(),
-			'className' => get_class($this->_table)
-		]);
+		$entity->source($this->_table->alias());
 
 		if (isset($data[$tableName])) {
 			$data = $data[$tableName];

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -98,6 +98,10 @@ class Marshaller {
 		$tableName = $this->_table->alias();
 		$entityClass = $this->_table->entityClass();
 		$entity = new $entityClass();
+		$entity->source([
+			'alias' => $this->_table->alias(),
+			'className' => get_class($this->_table)
+		]);
 
 		if (isset($data[$tableName])) {
 			$data = $data[$tableName];

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -381,11 +381,11 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			if (!isset($results[$alias])) {
 				continue;
 			}
-			$target = $instance->target();
 			$instance = $assoc['instance'];
+			$target = $instance->target();
 			$results[$alias] = $this->_castValues($target, $results[$alias]);
 			$options['source'] = [
-				'alias' => $instance->alias(),
+				'alias' => $target->alias(),
 				'className' => get_class($target)
 			];
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -121,13 +121,6 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	protected $_count;
 
 /**
- * Contains information about the default table that is used for hydrating
- *
- * @var array
- */
-	protected $_sourceInfo = [];
-
-/**
  * Constructor
  *
  * @param Query from where results come
@@ -142,10 +135,6 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 		$this->_hydrate = $this->_query->hydrate();
 		$this->_entityClass = $repository->entityClass();
 		$this->_useBuffering = $query->bufferResults();
-		$this->_sourceInfo = [
-			'alias' => $repository->alias(),
-			'className' => get_class($repository)
-		];
 
 		if ($statement) {
 			$this->count();
@@ -358,7 +347,6 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
  */
 	protected function _groupResult($row) {
 		$defaultAlias = $this->_defaultTable->alias();
-		$defaultClass = get_class($this->_defaultTable);
 		$results = [];
 		foreach ($row as $key => $value) {
 			$table = $defaultAlias;
@@ -396,10 +384,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			$instance = $assoc['instance'];
 			$target = $instance->target();
 			$results[$alias] = $this->_castValues($target, $results[$alias]);
-			$options['source'] = [
-				'alias' => $target->alias(),
-				'className' => get_class($target)
-			];
+			$options['source'] = $target->alias();
 
 			if ($this->_hydrate && $assoc['canBeJoined']) {
 				$entity = new $assoc['entityClass']($results[$alias], $options);
@@ -409,7 +394,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			$results = $instance->transformRow($results);
 		}
 
-		$options['source'] = $this->_sourceInfo;
+		$options['source'] = $defaultAlias;
 		$results = $results[$defaultAlias];
 		if ($this->_hydrate && !($results instanceof Entity)) {
 			$results = new $this->_entityClass($results, $options);

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -346,6 +346,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
  */
 	protected function _groupResult($row) {
 		$defaultAlias = $this->_defaultTable->alias();
+		$defaultClass = get_class($this->_defaultTable);
 		$results = [];
 		foreach ($row as $key => $value) {
 			$table = $defaultAlias;
@@ -380,8 +381,13 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			if (!isset($results[$alias])) {
 				continue;
 			}
+			$target = $instance->target();
 			$instance = $assoc['instance'];
-			$results[$alias] = $this->_castValues($instance->target(), $results[$alias]);
+			$results[$alias] = $this->_castValues($target, $results[$alias]);
+			$options['source'] = [
+				'alias' => $instance->alias(),
+				'className' => get_class($target)
+			];
 
 			if ($this->_hydrate && $assoc['canBeJoined']) {
 				$entity = new $assoc['entityClass']($results[$alias], $options);
@@ -391,6 +397,10 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			$results = $instance->transformRow($results);
 		}
 
+		$options['source'] = [
+			'alias' => $defaultAlias,
+			'className' => $defaultClass
+		];
 		$results = $results[$defaultAlias];
 		if ($this->_hydrate && !($results instanceof Entity)) {
 			$results = new $this->_entityClass($results, $options);

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -121,19 +121,31 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	protected $_count;
 
 /**
+ * Contains information about the default table that is used for hydrating
+ *
+ * @var array
+ */
+	protected $_sourceInfo = [];
+
+/**
  * Constructor
  *
  * @param Query from where results come
  * @param \Cake\Database\StatementInterface $statement
  */
 	public function __construct($query, $statement) {
+		$repository = $query->repository();
 		$this->_query = $query;
 		$this->_statement = $statement;
 		$this->_defaultTable = $this->_query->repository();
 		$this->_calculateAssociationMap();
 		$this->_hydrate = $this->_query->hydrate();
-		$this->_entityClass = $query->repository()->entityClass();
+		$this->_entityClass = $repository->entityClass();
 		$this->_useBuffering = $query->bufferResults();
+		$this->_sourceInfo = [
+			'alias' => $repository->alias(),
+			'className' => get_class($repository)
+		];
 
 		if ($statement) {
 			$this->count();
@@ -397,10 +409,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			$results = $instance->transformRow($results);
 		}
 
-		$options['source'] = [
-			'alias' => $defaultAlias,
-			'className' => $defaultClass
-		];
+		$options['source'] = $this->_sourceInfo;
 		$results = $results[$defaultAlias];
 		if ($this->_hydrate && !($results instanceof Entity)) {
 			$results = new $this->_entityClass($results, $options);

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1170,6 +1170,10 @@ class Table implements RepositoryInterface, EventListener {
 				$event = new Event('Model.afterSave', $this, compact('entity', 'options'));
 				$this->getEventManager()->dispatch($event);
 				$entity->isNew(false);
+				$entity->source([
+					'alias' => $this->alias(),
+					'className' => get_class($this)
+				]);
 				$success = true;
 			}
 		}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1170,10 +1170,7 @@ class Table implements RepositoryInterface, EventListener {
 				$event = new Event('Model.afterSave', $this, compact('entity', 'options'));
 				$this->getEventManager()->dispatch($event);
 				$entity->isNew(false);
-				$entity->source([
-					'alias' => $this->alias(),
-					'className' => get_class($this)
-				]);
+				$entity->source($this->alias());
 				$success = true;
 			}
 		}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -120,7 +120,13 @@ class EntityContext implements ContextInterface {
 			if (is_array($entity) || $entity instanceof Traversable) {
 				$entity = (new Collection($entity))->first();
 			}
-			if ($entity instanceof Entity && get_class($entity) !== 'Cake\ORM\Entity') {
+			$isEntity = $entity instanceof Entity;
+
+			if ($isEntity) {
+				$source = $entity->source();
+				$table = isset($source['alias']) ? $source['alias'] : null;
+			}
+			if (!$table && $isEntity && get_class($entity) !== 'Cake\ORM\Entity') {
 				list($ns, $entityClass) = namespaceSplit(get_class($entity));
 				$table = Inflector::pluralize($entityClass);
 			}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -120,7 +120,7 @@ class EntityContext implements ContextInterface {
 			if (is_array($entity) || $entity instanceof Traversable) {
 				$entity = (new Collection($entity))->first();
 			}
-			if ($entity instanceof Entity) {
+			if ($entity instanceof Entity && get_class($entity) !== 'Cake\ORM\Entity') {
 				list($ns, $entityClass) = namespaceSplit(get_class($entity));
 				$table = Inflector::pluralize($entityClass);
 			}

--- a/src/View/Form/EntityContext.php
+++ b/src/View/Form/EntityContext.php
@@ -123,8 +123,7 @@ class EntityContext implements ContextInterface {
 			$isEntity = $entity instanceof Entity;
 
 			if ($isEntity) {
-				$source = $entity->source();
-				$table = isset($source['alias']) ? $source['alias'] : null;
+				$table = $entity->source();
 			}
 			if (!$table && $isEntity && get_class($entity) !== 'Cake\ORM\Entity') {
 				list($ns, $entityClass) = namespaceSplit(get_class($entity));

--- a/tests/Fixture/CommentFixture.php
+++ b/tests/Fixture/CommentFixture.php
@@ -33,10 +33,10 @@ class CommentFixture extends TestFixture {
 		'id' => ['type' => 'integer'],
 		'article_id' => ['type' => 'integer', 'null' => false],
 		'user_id' => ['type' => 'integer', 'null' => false],
-		'comment' => 'text',
+		'comment' => ['type' => 'text'],
 		'published' => ['type' => 'string', 'length' => 1, 'default' => 'N'],
-		'created' => 'datetime',
-		'updated' => 'datetime',
+		'created' => ['type' => 'datetime'],
+		'updated' => ['type' => 'datetime'],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
 	);
 

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1010,19 +1010,23 @@ class BelongsToManyTest extends TestCase {
 
 		$joint->expects($this->at(0))
 			->method('save')
-			->with(
-				new Entity(['article_id' => 1, 'tag_id' => 2], ['markNew' => true]),
-				$saveOptions
-			)
-			->will($this->returnValue($entity));
+			->will($this->returnCallback(function($e, $opts) use ($entity) {
+				$expected = ['article_id' => 1, 'tag_id' => 2];
+				$this->assertEquals($expected, $e->toArray());
+				$this->assertEquals(['foo' => 'bar'], $opts);
+				$this->assertTrue($e->isNew());
+				return $entity;
+			}));
 
 		$joint->expects($this->at(1))
 			->method('save')
-			->with(
-				new Entity(['article_id' => 1, 'tag_id' => 3], ['markNew' => true]),
-				$saveOptions
-			)
-			->will($this->returnValue($entity));
+			->will($this->returnCallback(function($e, $opts) use ($entity) {
+				$expected = ['article_id' => 1, 'tag_id' => 3];
+				$this->assertEquals($expected, $e->toArray());
+				$this->assertEquals(['foo' => 'bar'], $opts);
+				$this->assertTrue($e->isNew());
+				return $entity;
+			}));
 
 		$this->assertTrue($assoc->link($entity, $tags, $saveOptions));
 		$this->assertSame($entity->test, $tags);

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1005,16 +1005,39 @@ class EntityTest extends TestCase {
 		$entity = new Entity(['foo' => 'bar'], ['markClean' => true]);
 		$entity->accessible('name', true);
 		$entity->virtualProperties(['baz']);
+		$entity->dirty('foo', true);
 		$entity->errors('foo', ['An error']);
+		$entity->source([
+			'alias' => 'foos',
+			'className' => 'Something'
+		]);
 		$result = $entity->__debugInfo();
 		$expected = [
-			'new' => true,
-			'accessible' => ['name'],
+			'new' => null,
+			'accessible' => ['name' => true],
 			'properties' => ['foo' => 'bar'],
 			'dirty' => ['foo' => true],
 			'virtual' => ['baz'],
-			'errors' => ['foo' => ['An error']]
+			'errors' => ['foo' => ['An error']],
+			'repository' => [
+				'alias' => 'foos',
+				'className' => 'Something'
+			]
 		];
+		$this->assertSame($expected, $result);
+	}
+
+/**
+ * Tests the source method
+ *
+ * @return void
+ */
+	public function testSource() {
+		$entity = new Entity;
+		$this->assertEquals([], $entity->source());
+		$source = ['alias' => 'foo', 'className' => 'bar'];
+		$entity->source($source);
+		$this->assertEquals($source, $entity->source());
 	}
 
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1007,10 +1007,7 @@ class EntityTest extends TestCase {
 		$entity->virtualProperties(['baz']);
 		$entity->dirty('foo', true);
 		$entity->errors('foo', ['An error']);
-		$entity->source([
-			'alias' => 'foos',
-			'className' => 'Something'
-		]);
+		$entity->source('foos');
 		$result = $entity->__debugInfo();
 		$expected = [
 			'new' => null,
@@ -1019,10 +1016,7 @@ class EntityTest extends TestCase {
 			'dirty' => ['foo' => true],
 			'virtual' => ['baz'],
 			'errors' => ['foo' => ['An error']],
-			'repository' => [
-				'alias' => 'foos',
-				'className' => 'Something'
-			]
+			'repository' => 'foos'
 		];
 		$this->assertSame($expected, $result);
 	}
@@ -1034,10 +1028,9 @@ class EntityTest extends TestCase {
  */
 	public function testSource() {
 		$entity = new Entity;
-		$this->assertEquals([], $entity->source());
-		$source = ['alias' => 'foo', 'className' => 'bar'];
-		$entity->source($source);
-		$this->assertEquals($source, $entity->source());
+		$this->assertNull($entity->source());
+		$entity->source('foos');
+		$this->assertEquals('foos', $entity->source());
 	}
 
 }

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -110,8 +110,7 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data, $result->toArray());
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
 		$this->assertNull($result->isNew(), 'Should be detached');
-		$source = ['alias' => 'Articles', 'className' => get_class($this->articles)];
-		$this->assertEquals($source, $result->source());
+		$this->assertEquals('Articles', $result->source());
 	}
 
 /**

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -110,6 +110,8 @@ class MarshallerTest extends TestCase {
 		$this->assertEquals($data, $result->toArray());
 		$this->assertTrue($result->dirty(), 'Should be a dirty entity.');
 		$this->assertNull($result->isNew(), 'Should be detached');
+		$source = ['alias' => 'Articles', 'className' => get_class($this->articles)];
+		$this->assertEquals($source, $result->source());
 	}
 
 /**

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -134,10 +134,7 @@ class ResultSetTest extends TestCase {
 		foreach ($results as $i => $row) {
 			$expected = new \Cake\ORM\Entity($this->fixtureData[$i]);
 			$expected->isNew(false);
-			$expected->source([
-				'alias' => $this->table->alias(),
-				'className' => get_class($this->table)
-			]);
+			$expected->source($this->table->alias());
 			$expected->clean();
 			$this->assertEquals($expected, $row, "Row $i does not match");
 		}
@@ -225,10 +222,7 @@ class ResultSetTest extends TestCase {
 		$options = [
 			'markNew' => false,
 			'markClean' => true,
-			'source' => [
-				'alias' => $this->table->alias(),
-				'className' => get_class($this->table)
-			]
+			'source' => $this->table->alias()
 		];
 		$expected = [
 			1 => [

--- a/tests/TestCase/ORM/ResultSetTest.php
+++ b/tests/TestCase/ORM/ResultSetTest.php
@@ -133,6 +133,11 @@ class ResultSetTest extends TestCase {
 		// Use a loop to test Iterator implementation
 		foreach ($results as $i => $row) {
 			$expected = new \Cake\ORM\Entity($this->fixtureData[$i]);
+			$expected->isNew(false);
+			$expected->source([
+				'alias' => $this->table->alias(),
+				'className' => get_class($this->table)
+			]);
 			$expected->clean();
 			$this->assertEquals($expected, $row, "Row $i does not match");
 		}
@@ -217,7 +222,14 @@ class ResultSetTest extends TestCase {
 	public function testGroupBy() {
 		$query = $this->table->find('all');
 		$results = $query->all()->groupBy('author_id')->toArray();
-		$options = ['markNew' => false, 'markClean' => true];
+		$options = [
+			'markNew' => false,
+			'markClean' => true,
+			'source' => [
+				'alias' => $this->table->alias(),
+				'className' => get_class($this->table)
+			]
+		];
 		$expected = [
 			1 => [
 				new Entity($this->fixtureData[0], $options),

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2692,9 +2692,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$article = $table->find('all')->where(['id' => 1])->contain(['tags'])->first();
 		$tags = $article->tags;
 		$this->assertNotEmpty($tags);
-		$tags[] = new \TestApp\Model\Entity\Tag([
-			'name' => 'Something New'
-		]);
+		$tags[] = new \TestApp\Model\Entity\Tag(['name' => 'Something New']);
 		$article->tags = $tags;
 		$this->assertSame($article, $table->save($article));
 		$tags = $article->tags;
@@ -2817,6 +2815,12 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 		$tagsTable = TableRegistry::get('tags');
+		$source = [
+			'source' => [
+				'alias' => 'tags',
+				'className' => 'TestApp\Model\Table\TagsTable'
+			]
+		];
 		$options = ['markNew' => false];
 
 		$article = new \Cake\ORM\Entity([
@@ -2825,10 +2829,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$newTag = new \TestApp\Model\Entity\Tag([
 			'name' => 'Foo'
-		]);
+		], $source);
 		$tags[] = new \TestApp\Model\Entity\Tag([
 			'id' => 3
-		], $options);
+		], $options + $source);
 		$tags[] = $newTag;
 
 		$tagsTable->save($newTag);

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2815,12 +2815,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$table = TableRegistry::get('articles');
 		$table->belongsToMany('tags');
 		$tagsTable = TableRegistry::get('tags');
-		$source = [
-			'source' => [
-				'alias' => 'tags',
-				'className' => 'TestApp\Model\Table\TagsTable'
-			]
-		];
+		$source = ['source' => 'tags'];
 		$options = ['markNew' => false];
 
 		$article = new \Cake\ORM\Entity([

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -92,7 +92,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testIsCreateSingle() {
-		$row = new Entity();
+		$row = new Article();
 		$context = new EntityContext($this->request, [
 			'entity' => $row,
 		]);
@@ -128,6 +128,18 @@ class EntityContextTest extends TestCase {
 		$row = new \StdClass();
 		$context = new EntityContext($this->request, [
 			'entity' => $row,
+		]);
+	}
+
+/**
+ * Tests that passing a plain entity will give an error as it cannot be matched
+ *
+ * @expectedException \RuntimeException
+ * @expectedExceptionMessage Unable to find table class for current entity
+ */
+	public function testDefaultEntityError() {
+		$context = new EntityContext($this->request, [
+			'entity' => new \Cake\ORM\Entity,
 		]);
 	}
 
@@ -200,14 +212,14 @@ class EntityContextTest extends TestCase {
  * @return array
  */
 	public static function collectionProvider() {
-		$one = new Entity([
+		$one = new Article([
 			'title' => 'First post',
 			'body' => 'Stuff',
 			'user' => new Entity(['username' => 'mark'])
 		]);
 		$one->errors('title', 'Required field');
 
-		$two = new Entity([
+		$two = new Article([
 			'title' => 'Second post',
 			'body' => 'Some text',
 			'user' => new Entity(['username' => 'jose'])
@@ -359,7 +371,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValBasic() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'body' => 'Something new'
 		]);
@@ -387,7 +399,7 @@ class EntityContextTest extends TestCase {
 			'title' => 'New title',
 			'notInEntity' => 'yes',
 		];
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'body' => 'Something new'
 		]);
@@ -406,7 +418,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociated() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'Test entity',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -444,14 +456,14 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedHasMany() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
 				'fname' => 'Mark',
 				'articles' => [
-					new Entity(['title' => 'First post']),
-					new Entity(['title' => 'Second post']),
+					new Article(['title' => 'First post']),
+					new Article(['title' => 'Second post']),
 				]
 			]),
 		]);
@@ -473,7 +485,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedDefaultIds() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -499,7 +511,7 @@ class EntityContextTest extends TestCase {
  * @return void
  */
 	public function testValAssociatedCustomIds() {
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'First post',
 			'user' => new Entity([
 				'username' => 'mark',
@@ -558,7 +570,7 @@ class EntityContextTest extends TestCase {
 			'rule' => 'numeric',
 		]);
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'comments' => [
 				new Entity(['comment' => 'First comment']),
@@ -585,7 +597,7 @@ class EntityContextTest extends TestCase {
 	public function testIsRequiredAssociatedValidator() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'comments' => [
 				new Entity(['comment' => 'First comment']),
@@ -615,7 +627,7 @@ class EntityContextTest extends TestCase {
 	public function testIsRequiredAssociatedBelongsTo() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -640,7 +652,7 @@ class EntityContextTest extends TestCase {
 	public function testType() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'body' => 'Some content',
 		]);
@@ -663,7 +675,7 @@ class EntityContextTest extends TestCase {
 	public function testTypeAssociated() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -685,7 +697,7 @@ class EntityContextTest extends TestCase {
 	public function testAttributes() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -718,7 +730,7 @@ class EntityContextTest extends TestCase {
 	public function testHasError() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -744,7 +756,7 @@ class EntityContextTest extends TestCase {
 	public function testHasErrorAssociated() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);
@@ -769,7 +781,7 @@ class EntityContextTest extends TestCase {
 	public function testError() {
 		$this->_setupTables();
 
-		$row = new Entity([
+		$row = new Article([
 			'title' => 'My title',
 			'user' => new Entity(['username' => 'Mark']),
 		]);

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -144,6 +144,21 @@ class EntityContextTest extends TestCase {
 	}
 
 /**
+ * Tests that the table can be derived from the entity source if it is present
+ *
+ * @return void
+ */
+	public function testTableFromEntitySource() {
+		$entity = new Entity;
+		$entity->source(['alias' => 'Articles']);
+		$context = new EntityContext($this->request, [
+			'entity' => $entity,
+		]);
+		$expected = ['id', 'author_id', 'title', 'body', 'published'];
+		$this->assertEquals($expected, $context->fieldNames());
+	}
+
+/**
  * Test operations with no entity.
  *
  * @return void

--- a/tests/TestCase/View/Form/EntityContextTest.php
+++ b/tests/TestCase/View/Form/EntityContextTest.php
@@ -150,7 +150,7 @@ class EntityContextTest extends TestCase {
  */
 	public function testTableFromEntitySource() {
 		$entity = new Entity;
-		$entity->source(['alias' => 'Articles']);
+		$entity->source('Articles');
 		$context = new EntityContext($this->request, [
 			'entity' => $entity,
 		]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1691,7 +1691,7 @@ class FormHelperTest extends TestCase {
 		$nested = new Entity(['foo' => 'bar']);
 		$nested->errors('foo', ['not a valid bar']);
 		$entity = new Entity(['nested' => $nested]);
-		$this->Form->create($entity);
+		$this->Form->create($entity, ['context' => ['table' => 'Articles']]);
 
 		$result = $this->Form->error('nested.foo');
 		$this->assertEquals('<div class="error-message">not a valid bar</div>', $result);
@@ -1709,7 +1709,7 @@ class FormHelperTest extends TestCase {
 		$nested = new Entity(['foo' => $inner]);
 		$entity = new Entity(['nested' => $nested]);
 		$inner->errors('bar', ['not a valid one']);
-		$this->Form->create($entity);
+		$this->Form->create($entity, ['context' => ['table' => 'Articles']]);
 		$result = $this->Form->error('nested.foo.bar');
 		$this->assertEquals('<div class="error-message">not a valid one</div>', $result);
 	}

--- a/tests/test_app/TestApp/Model/Table/ArticlesTable.php
+++ b/tests/test_app/TestApp/Model/Table/ArticlesTable.php
@@ -22,7 +22,7 @@ class ArticlesTable extends Table {
 	public function initialize(array $config) {
 		$this->belongsTo('authors');
 		$this->belongsToMany('tags');
-		$this->hasMany('articlesTags');
+		$this->hasMany('ArticlesTags');
 	}
 
 }

--- a/tests/test_app/TestApp/Model/Table/TagsTable.php
+++ b/tests/test_app/TestApp/Model/Table/TagsTable.php
@@ -22,7 +22,7 @@ class TagsTable extends Table {
 	public function initialize(array $config) {
 		$this->belongsTo('authors');
 		$this->belongsToMany('articles');
-		$this->hasMany('articlesTags', ['propertyName' => 'extraInfo']);
+		$this->hasMany('ArticlesTags', ['propertyName' => 'extraInfo']);
 	}
 
 }


### PR DESCRIPTION
With this set of changes the Marshaller and table will mark the entities thy create or save with information about the repository they are bound to. This makes it possible to use plain entities in the form helper as long as you create them using the marshaller.

``` php
$entity = $this->Articles->newEntity([]);
debug($entity->source()); // outputs ['alias' => 'Articles', 'className' => 'Cake\ORM\Table'];
....
$this->Form->create($entity); // Works!
```
