### PR TITLE
3.0 accessible entity

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -95,7 +95,7 @@ trait EntityTrait {
  *
  * @var array
  */
-	protected $_accessible = [];
+	protected $_accessible = ['*' => true];
 
 /**
  * Magic getter to access properties that has be set in this entity
@@ -644,7 +644,11 @@ trait EntityTrait {
  */
 	public function accessible($property, $set = null) {
 		if ($set === null) {
-			return !empty($this->_accessible[$property]) || !empty($this->_accessible['*']);
+			$value = isset($this->_accessible[$property]) ?
+				$this->_accessible[$property] :
+				null;
+
+			return ($value === null && !empty($this->_accessible['*'])) || $value;
 		}
 
 		if ($property === '*') {

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -860,6 +860,7 @@ class EntityTest extends TestCase {
  */
 	public function testAccessible() {
 		$entity = new Entity;
+		$entity->accessible('*', false);
 		$this->assertFalse($entity->accessible('foo'));
 		$this->assertFalse($entity->accessible('bar'));
 

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -937,6 +937,7 @@ class EntityTest extends TestCase {
 	public function testSetWithAccessible() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);
 		$options = ['guard' => true];
+		$entity->accessible('*', false);
 		$entity->accessible('foo', true);
 		$entity->set('bar', 3, $options);
 		$entity->set('foo', 4, $options);
@@ -956,6 +957,7 @@ class EntityTest extends TestCase {
 	public function testSetWithAccessibleWithArray() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);
 		$options = ['guard' => true];
+		$entity->accessible('*', false);
 		$entity->accessible('foo', true);
 		$entity->set(['bar' => 3, 'foo' => 4], $options);
 		$this->assertEquals(2, $entity->get('bar'));
@@ -974,6 +976,7 @@ class EntityTest extends TestCase {
  */
 	public function testSetWithAccessibleSingleProperty() {
 		$entity = new Entity(['foo' => 1, 'bar' => 2]);
+		$entity->accessible('*', false);
 		$entity->accessible('title', true);
 
 		$entity->set(['title' => 'test', 'body' => 'Nope']);

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -525,6 +525,7 @@ class MarshallerTest extends TestCase {
 			'title' => 'Foo',
 			'body' => 'My Content'
 		]);
+		$entity->accessible('*', false);
 		$entity->accessible('author_id', true);
 		$entity->isNew(false);
 		$result = $marshall->merge($entity, $data, []);


### PR DESCRIPTION
Making all properties mass-assignable by default on a plain entity. Bake should make the list stricter
