### PR TITLE
Check `validate` option before validating

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1125,7 +1125,7 @@ class Table implements RepositoryInterface, EventListener {
 		$associated = $options['associated'];
 		$options['associated'] = [];
 
-		if (!$this->validate($entity, $options)) {
+		if ($options['validate'] && !$this->validate($entity, $options)) {
 			return false;
 		}
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -2780,15 +2780,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			->with($entity->author->supervisor, ['name' => 'Marc'])
 			->will($this->returnValue($entity->author->supervisor));
 
-		$options = new \ArrayObject([
-			'validate' => false,
-			'atomic' => false,
-			'associated' => []
-		]);
-		$supervisors->expects($this->once())
-			->method('validate')
-			->with($entity->author->supervisor, $options)
-			->will($this->returnValue(true));
+		$supervisors->expects($this->never())->method('validate');
 
 		$tags->expects($this->never())->method('_insert');
 


### PR DESCRIPTION
Ran into an issue while trying out 3.0 today. My code:

```
public function register(User &$user) {
    if ($this->validate($user)) {
        $user->password = Security::hash($user->password);
    }
    return $this->save($user, ['validate' => false]);
}
```

The `save()` call would validate data again even though I passed `'validate' => false` and it would fail on password match rule because it is hashed now.

Added a check for the `validate` option.
