### PR TITLE
CakeTime: fixed wrong daysAsSql behavior

### DIFF
--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -439,10 +439,10 @@ class CakeTime {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::daysAsSql
  */
 	public static function daysAsSql($begin, $end, $fieldName, $timezone = null) {
-		$begin = self::fromString($begin, $timezone);
-		$end = self::fromString($end, $timezone);
-		$begin = date('Y-m-d', $begin) . ' 00:00:00';
-		$end = date('Y-m-d', $end) . ' 23:59:59';
+		$begin = self::fromString($begin . ' 00:00:00', $timezone);
+		$end = self::fromString($end . ' 23:59:59', $timezone);
+		$begin = date('Y-m-d H:i:s', $begin);
+		$end = date('Y-m-d H:i:s', $end);
 
 		return "($fieldName >= '$begin') AND ($fieldName <= '$end')";
 	}


### PR DESCRIPTION
When using the daysAsSql behavior, I would expect, that the input begin and end date are seen as days for the sql statement and NOT the generated begin and end dates.

**Example:**

User selects a date-range in the UI via local datepicker (html5 datetime input). Now (s)he would expect to receive all records for the given day (let's think of 2014-03-17 to 2014-03-18 as selected range).

**Assumptions:**
- All internal values are stored based on Europe/Vienna timezone.
- User's timezone is America/Sao_Paulo (-4h compared to Europe/Vienna)

**Code-change described in words:**
- The old implementation would return 2014-03-16 00:00:00 to 2014-03-17 23:59:59. 
- The new implementation returns, for example, 2014-03-16 20:00:00 to 2014-03-17 19:59:59.

The new implementation now returns all records for 2014-03-17 to 2014-03-18 (for the given timezone of the user).
