### PR TITLE
Make debug status boolean

### DIFF
--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -60,7 +60,7 @@ class BakeShell extends Shell {
  */
 	public function startup() {
 		parent::startup();
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Cache::disable();
 
 		$task = Inflector::classify($this->command);

--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -54,7 +54,7 @@ class BakeTask extends Shell {
  * @return void
  */
 	public function startup() {
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Cache::disable();
 		parent::startup();
 	}

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -273,7 +273,7 @@ class AuthComponent extends Component {
 		$this->response = $controller->response;
 		$this->_methods = $controller->methods;
 
-		if (Configure::read('debug') > 0) {
+		if (Configure::read('debug')) {
 			Debugger::checkSecurityKeys();
 		}
 	}

--- a/src/Template/Element/sql_dump.ctp
+++ b/src/Template/Element/sql_dump.ctp
@@ -15,7 +15,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!class_exists('ConnectionManager') || Configure::read('debug') < 2) {
+if (!class_exists('ConnectionManager')) {
 	return false;
 }
 $noLogs = !isset($sqlLogs);

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -304,7 +304,7 @@ class Helper extends Object implements EventListener {
  */
 	public function assetTimestamp($path) {
 		$stamp = Configure::read('Asset.timestamp');
-		$timestampEnabled = $stamp === 'force' || ($stamp === true && Configure::read('debug') > 0);
+		$timestampEnabled = $stamp === 'force' || ($stamp === true && Configure::read('debug'));
 		if ($timestampEnabled && strpos($path, '?') === false) {
 			$filepath = preg_replace(
 				'/^' . preg_quote($this->request->webroot, '/') . '/',

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -549,7 +549,7 @@ class View extends Object {
 		include $filename;
 
 		$type = $response->mapType($response->type());
-		if (Configure::read('debug') > 0 && $type === 'html') {
+		if (Configure::read('debug') && $type === 'html') {
 			echo "<!-- Cached Render Time: " . round(microtime(true) - $timeStart, 4) . "s -->";
 		}
 		$out = ob_get_clean();

--- a/src/basics.php
+++ b/src/basics.php
@@ -75,7 +75,7 @@ if (!function_exists('debug')) {
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#debug
  */
 	function debug($var, $showHtml = null, $showFrom = true) {
-		if (Configure::read('debug') > 0) {
+		if (Configure::read('debug')) {
 			$file = '';
 			$line = '';
 			$lineInfo = '';
@@ -264,7 +264,7 @@ if (!function_exists('pr')) {
  * @link http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#pr
  */
 	function pr($var) {
-		if (Configure::read('debug') > 0) {
+		if (Configure::read('debug')) {
 			$template = php_sapi_name() !== 'cli' ? '<pre>%s</pre>' : "\n%s\n";
 			printf($template, print_r($var, true));
 		}

--- a/tests/TestCase/Cache/Engine/FileEngineTest.php
+++ b/tests/TestCase/Cache/Engine/FileEngineTest.php
@@ -401,7 +401,7 @@ class FileEngineTest extends TestCase {
  */
 	public function testPathDoesNotExist() {
 		$this->skipIf(is_dir(TMP . 'tests' . DS . 'autocreate'), 'Cannot run if test directory exists.');
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 
 		Cache::drop('file_test');
 		Cache::config('file_test', array(
@@ -424,7 +424,7 @@ class FileEngineTest extends TestCase {
  */
 	public function testPathDoesNotExistDebugOff() {
 		$this->skipIf(is_dir(TMP . 'tests/autocreate'), 'Cannot run if test directory exists.');
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		Cache::drop('file_groups');
 		Cache::config('file_groups', array(

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -380,7 +380,7 @@ class ControllerTest extends TestCase {
 			'_serialize' => ['test']
 		]);
 		$debug = Configure::read('debug');
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$result = $Controller->render('index');
 		$this->assertEquals('{"test":"value"}', $result->body());
 		Configure::write('debug', $debug);

--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -57,7 +57,7 @@ class PagesControllerTest extends TestCase {
  * @return void
  */
 	public function testMissingView() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$Pages = new PagesController(new Request(), new Response());
 		$Pages->display('non_existing_page');
 	}
@@ -70,7 +70,7 @@ class PagesControllerTest extends TestCase {
  * @return void
  */
 	public function testMissingViewInDebug() {
-		Configure::write('debug', 1);
+		Configure::write('debug', true);
 		$Pages = new PagesController(new Request(), new Response());
 		$Pages->display('non_existing_page');
 	}

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -140,11 +140,11 @@ class ConfigureTest extends TestCase {
  * @return void
  */
 	public function testDebugSettingDisplayErrors() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$result = ini_get('display_errors');
 		$this->assertEquals(0, $result);
 
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		$result = ini_get('display_errors');
 		$this->assertEquals(1, $result);
 	}

--- a/tests/TestCase/Error/ErrorHandlerTest.php
+++ b/tests/TestCase/Error/ErrorHandlerTest.php
@@ -46,7 +46,7 @@ class ErrorHandlerTest extends TestCase {
 		$request = new Request();
 		$request->base = '';
 		Router::setRequestInfo($request);
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 
 		$this->_logger = $this->getMock('Cake\Log\LogInterface');
 		Log::config('error_test', [
@@ -141,7 +141,7 @@ class ErrorHandlerTest extends TestCase {
  * @return void
  */
 	public function testHandleErrorDebugOff() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$errorHandler = new ErrorHandler();
 		$errorHandler->register();
 		$this->_restoreError = true;
@@ -159,7 +159,7 @@ class ErrorHandlerTest extends TestCase {
  * @return void
  */
 	public function testHandleErrorLoggingTrace() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$errorHandler = new ErrorHandler(['trace' => true]);
 		$errorHandler->register();
 		$this->_restoreError = true;
@@ -274,7 +274,7 @@ class ErrorHandlerTest extends TestCase {
 	public function testHandleFatalErrorPage() {
 		$line = __LINE__;
 		$errorHandler = new ErrorHandler();
-		Configure::write('debug', 1);
+		Configure::write('debug', true);
 		ob_start();
 		ob_start();
 		$errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, $line);
@@ -285,7 +285,7 @@ class ErrorHandlerTest extends TestCase {
 
 		ob_start();
 		ob_start();
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$errorHandler->handleFatalError(E_ERROR, 'Something wrong', __FILE__, $line);
 		$result = ob_get_clean();
 		$this->assertNotContains('Something wrong', $result, 'message must not appear.');

--- a/tests/TestCase/Error/ExceptionRendererTest.php
+++ b/tests/TestCase/Error/ExceptionRendererTest.php
@@ -138,7 +138,7 @@ class ExceptionRendererTest extends TestCase {
 		$request = new Request();
 		$request->base = '';
 		Router::setRequestInfo($request);
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 	}
 
 /**
@@ -170,7 +170,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testSubclassMethodsNotBeingConvertedToError() {
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 
 		$exception = new MissingWidgetThingException('Widget not found');
 		$ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
@@ -188,7 +188,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testSubclassMethodsNotBeingConvertedDebug0() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$exception = new MissingWidgetThingException('Widget not found');
 		$ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
 
@@ -207,7 +207,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testSubclassConvertingFrameworkErrors() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$exception = new Error\MissingControllerException('PostsController');
 		$ExceptionRenderer = $this->_mockResponse(new MyCustomExceptionRenderer($exception));
@@ -241,7 +241,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testErrorMethodCoercion() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$exception = new Error\MissingActionException('Page not found');
 		$ExceptionRenderer = new ExceptionRenderer($exception);
 
@@ -311,7 +311,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testUnknownExceptionInProduction() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$exception = new \OutOfBoundsException('foul ball.');
 		$ExceptionRenderer = new ExceptionRenderer($exception);
@@ -378,7 +378,7 @@ class ExceptionRendererTest extends TestCase {
  * @return void
  */
 	public function testerror400OnlyChangingCakeException() {
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$exception = new Error\NotFoundException('Custom message');
 		$ExceptionRenderer = $this->_mockResponse(new ExceptionRenderer($exception));

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -695,7 +695,7 @@ class SessionTest extends TestCase {
  * @return void
  */
 	public function testSessionTimeout() {
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('Session.defaults', 'cake');
 		Configure::write('Session.autoRegenerate', false);
 

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -888,7 +888,7 @@ class DispatcherTest extends TestCase {
 		Cache::enable();
 		Configure::write('Cache.disable', false);
 		Configure::write('Cache.check', true);
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 
 		Router::reload();
 		Router::connect('/', array('controller' => 'test_cached_pages', 'action' => 'index'));

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -54,7 +54,7 @@ class DebuggerTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('log', false);
 	}
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -415,7 +415,7 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->image('cake.icon.png');
 		$this->assertTags($result, array('img' => array('src' => 'preg:/\/img\/cake\.icon\.png\?\d+/', 'alt' => '')));
 
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		Configure::write('Asset.timestamp', 'force');
 
 		$result = $this->Html->image('cake.icon.png');
@@ -441,7 +441,7 @@ class HtmlHelperTest extends TestCase {
 		new File($testfile, true);
 
 		Configure::write('Asset.timestamp', true);
-		Configure::write('debug', 1);
+		Configure::write('debug', true);
 
 		$this->Html->request->webroot = '/';
 		$this->Html->theme = 'test_theme';
@@ -672,7 +672,7 @@ class HtmlHelperTest extends TestCase {
  * @return void
  */
 	public function testCssTimestamping() {
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('Asset.timestamp', true);
 
 		$expected = array(
@@ -683,7 +683,7 @@ class HtmlHelperTest extends TestCase {
 		$expected['link']['href'] = 'preg:/.*css\/cake\.generic\.css\?[0-9]+/';
 		$this->assertTags($result, $expected);
 
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$result = $this->Html->css('cake.generic');
 		$expected['link']['href'] = 'preg:/.*css\/cake\.generic\.css/';
@@ -714,7 +714,7 @@ class HtmlHelperTest extends TestCase {
 	public function testPluginCssTimestamping() {
 		Plugin::load('TestPlugin');
 
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('Asset.timestamp', true);
 
 		$expected = array(
@@ -725,7 +725,7 @@ class HtmlHelperTest extends TestCase {
 		$expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css\?[0-9]+/';
 		$this->assertTags($result, $expected);
 
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$result = $this->Html->css('TestPlugin.test_plugin_asset');
 		$expected['link']['href'] = 'preg:/.*test_plugin\/css\/test_plugin_asset\.css/';
@@ -758,7 +758,7 @@ class HtmlHelperTest extends TestCase {
 	public function testScriptTimestamping() {
 		$this->skipIf(!is_writable(WWW_ROOT . 'js'), 'webroot/js is not Writable, timestamp testing has been skipped.');
 
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('Asset.timestamp', true);
 
 		touch(WWW_ROOT . 'js/__cake_js_test.js');
@@ -767,7 +767,7 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->script('__cake_js_test', array('once' => false));
 		$this->assertRegExp('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
 
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		Configure::write('Asset.timestamp', 'force');
 		$result = $this->Html->script('__cake_js_test', array('once' => false));
 		$this->assertRegExp('/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
@@ -787,7 +787,7 @@ class HtmlHelperTest extends TestCase {
 		$pluginJsPath = $pluginPath . 'webroot/js';
 		$this->skipIf(!is_writable($pluginJsPath), $pluginJsPath . ' is not Writable, timestamp testing has been skipped.');
 
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		Configure::write('Asset.timestamp', true);
 
 		touch($pluginJsPath . DS . '__cake_js_test.js');
@@ -796,7 +796,7 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->script('TestPlugin.__cake_js_test', array('once' => false));
 		$this->assertRegExp('/test_plugin\/js\/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');
 
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		Configure::write('Asset.timestamp', 'force');
 		$result = $this->Html->script('TestPlugin.__cake_js_test', array('once' => false));
 		$this->assertRegExp('/test_plugin\/js\/__cake_js_test.js\?' . $timestamp . '[0-9]{2}"/', $result, 'Timestamp value not found %s');

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -264,7 +264,7 @@ class HelperTest extends TestCase {
 		$this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
 		Configure::write('Asset.timestamp', true);
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 
 		$result = $this->Helper->assetTimestamp('/%3Cb%3E/cake.generic.css');
 		$this->assertEquals('/%3Cb%3E/cake.generic.css', $result);
@@ -273,12 +273,12 @@ class HelperTest extends TestCase {
 		$this->assertEquals(Configure::read('App.cssBaseUrl') . 'cake.generic.css', $result);
 
 		Configure::write('Asset.timestamp', true);
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 		$result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
 		$this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 
 		Configure::write('Asset.timestamp', 'force');
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 		$result = $this->Helper->assetTimestamp(Configure::read('App.cssBaseUrl') . 'cake.generic.css');
 		$this->assertRegExp('/' . preg_quote(Configure::read('App.cssBaseUrl') . 'cake.generic.css?', '/') . '[0-9]+/', $result);
 

--- a/tests/TestCase/View/JsonViewTest.php
+++ b/tests/TestCase/View/JsonViewTest.php
@@ -32,7 +32,7 @@ class JsonViewTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 	}
 
 /**

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -275,7 +275,7 @@ class ViewTest extends TestCase {
 		App::objects('Plugin', null, false);
 
 		Plugin::load(array('TestPlugin', 'TestPlugin', 'PluginJs'));
-		Configure::write('debug', 2);
+		Configure::write('debug', true);
 	}
 
 /**

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -33,7 +33,7 @@ class XmlViewTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		Configure::write('debug', 0);
+		Configure::write('debug', false);
 	}
 
 /**

--- a/tests/init.php
+++ b/tests/init.php
@@ -65,7 +65,7 @@ require CAKE . 'bootstrap.php';
 date_default_timezone_set('UTC');
 mb_internal_encoding('UTF-8');
 
-Configure::write('debug', 2);
+Configure::write('debug', true);
 Configure::write('App', [
 	'namespace' => 'App',
 	'encoding' => 'UTF-8',

--- a/tests/test_app/TestApp/Template/Error/error400.ctp
+++ b/tests/test_app/TestApp/Template/Error/error400.ctp
@@ -25,7 +25,7 @@ use Cake\Core\Configure;
 	); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0):
+if (Configure::read('debug')):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/tests/test_app/TestApp/Template/Error/error500.ctp
+++ b/tests/test_app/TestApp/Template/Error/error500.ctp
@@ -22,7 +22,7 @@ use Cake\Core\Configure;
 	<?= __d('cake', 'An Internal Error Has Occurred.'); ?>
 </p>
 <?php
-if (Configure::read('debug') > 0):
+if (Configure::read('debug')):
 	echo $this->element('exception_stack_trace');
 endif;
 ?>

--- a/tests/test_app/TestApp/Template/Pages/home.ctp
+++ b/tests/test_app/TestApp/Template/Pages/home.ctp
@@ -7,7 +7,7 @@ use Cake\Error;
 use Cake\Utility\Debugger;
 use Cake\Validation\Validation;
 
-if (Configure::read('debug') == 0):
+if (!Configure::read('debug')):
 	throw new Error\NotFoundException();
 endif;
 ?>


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/3042

> There is actually no reason anymore to have debug levels in cakephp as it basically works now as an on/off thing. We should update the places where it is treated as a number and reflect the change in the app template
