### PR TITLE
Themed CakeEmail should load view helpers with the theme set

### DIFF
--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1702,6 +1702,11 @@ class Email {
 		$View = new $viewClass(null);
 		$View->viewVars = $this->_viewVars;
 		$View->helpers = $this->_helpers;
+
+		if ($this->_theme) {
+			$View->theme = $this->_theme;
+		}
+
 		$View->loadHelpers();
 
 		list($templatePlugin, $template) = pluginSplit($this->_template);
@@ -1711,9 +1716,7 @@ class Email {
 		} elseif ($layoutPlugin) {
 			$View->plugin = $layoutPlugin;
 		}
-		if ($this->_theme) {
-			$View->theme = $this->_theme;
-		}
+
 		// Convert null to false, as View needs false to disable
 		// the layout.
 		if ($layout === null) {

--- a/tests/TestCase/Network/Email/EmailTest.php
+++ b/tests/TestCase/Network/Email/EmailTest.php
@@ -1389,6 +1389,7 @@ class EmailTest extends TestCase {
 		$result = $this->CakeEmail->send();
 
 		$this->assertContains('In TestTheme', $result['message']);
+		$this->assertContains('/theme/TestTheme/img/test.jpg', $result['message']);
 		$this->assertContains('Message-ID: ', $result['headers']);
 		$this->assertContains('To: ', $result['headers']);
 	}

--- a/tests/test_app/TestApp/Template/Themed/TestTheme/Email/text/themed.ctp
+++ b/tests/test_app/TestApp/Template/Themed/TestTheme/Email/text/themed.ctp
@@ -1,1 +1,2 @@
 In TestTheme
+<?php echo $this->Html->image('test.jpg') ?>


### PR DESCRIPTION
Otherwise the theme is not set in helpers, and functions related to Helper::webroot() won't be aware of the defined theme
