### PR TITLE
Themed CakeEmail should load view helpers with the theme set

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1623,6 +1623,11 @@ class CakeEmail {
 		$View = new $viewClass(null);
 		$View->viewVars = $this->_viewVars;
 		$View->helpers = $this->_helpers;
+
+		if ($this->_theme) {
+			$View->theme = $this->_theme;
+		}
+
 		$View->loadHelpers();
 
 		list($templatePlugin, $template) = pluginSplit($this->_template);
@@ -1632,9 +1637,7 @@ class CakeEmail {
 		} elseif ($layoutPlugin) {
 			$View->plugin = $layoutPlugin;
 		}
-		if ($this->_theme) {
-			$View->theme = $this->_theme;
-		}
+
 		// Convert null to false, as View needs false to disable
 		// the layout.
 		if ($layout === null) {

--- a/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
+++ b/lib/Cake/Test/Case/Network/Email/CakeEmailTest.php
@@ -1337,6 +1337,7 @@ class CakeEmailTest extends CakeTestCase {
 		$this->assertContains('In TestTheme', $result['message']);
 		$this->assertContains('Message-ID: ', $result['headers']);
 		$this->assertContains('To: ', $result['headers']);
+		$this->assertContains('/theme/TestTheme/img/test.jpg', $result['message']);
 	}
 
 /**

--- a/lib/Cake/Test/test_app/View/Themed/TestTheme/Emails/text/themed.ctp
+++ b/lib/Cake/Test/test_app/View/Themed/TestTheme/Emails/text/themed.ctp
@@ -1,1 +1,2 @@
 In TestTheme
+<?php echo $this->Html->image('test.jpg') ?>


### PR DESCRIPTION
Otherwise the theme is not set in helpers, and functions related to Helper::webroot() won't be aware of the defined theme
