### PR TITLE
Fix global callback issue in ValidationRule

### DIFF
--- a/src/Validation/ValidationRule.php
+++ b/src/Validation/ValidationRule.php
@@ -112,7 +112,7 @@ class ValidationRule {
 			return true;
 		}
 
-		if (is_callable($this->_rule)) {
+		if (!is_string($this->_rule) && is_callable($this->_rule)) {
 			$callable = $this->_rule;
 			$isCallable = true;
 		} else {


### PR DESCRIPTION
Adding a rule as `'date'` would try to call php's `date()` method instead of `Validation::date()`
