### PR TITLE
fix: 0 rows affected treated as an error

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1288,7 +1288,7 @@ class Table implements RepositoryInterface, EventListener {
 			->execute();
 
 		$success = false;
-		if ($statement->rowCount() > 0) {
+		if ($statement->errorCode() === '00000') {
 			$success = $entity;
 		}
 		$statement->closeCursor();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1103,6 +1103,25 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test that a `0 rows affected` response after update is treated as successful.
+ *
+ * @group save
+ * @return void
+ */
+	public function testUpdateZeroRowsAffected() {
+		$table = TableRegistry::get('users');
+		$entity = $table->get(1);
+		$fakeNewValues = [
+			'username' => $entity->username,
+			'password' => $entity->password
+		];
+		$entity->accessible('*', true);
+		$entity->set($fakeNewValues);
+		$save = $table->save($entity);
+		$this->assertNotEquals(false, $save);
+	}
+
+/**
  * Test that saving a new empty entity does nothing.
  *
  * @group save
@@ -2716,7 +2735,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testSaveDeepAssociationOptions() {
 		$articles = $this->getMock(
 			'\Cake\ORM\Table',
-			['_insert'],
+			['_tes'],
 			[['table' => 'articles', 'connection' => $this->connection]]
 		);
 		$authors = $this->getMock(

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1103,25 +1103,6 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test that a `0 rows affected` response after update is treated as successful.
- *
- * @group save
- * @return void
- */
-	public function testUpdateZeroRowsAffected() {
-		$table = TableRegistry::get('users');
-		$entity = $table->get(1);
-		$fakeNewValues = [
-			'username' => $entity->username,
-			'password' => $entity->password
-		];
-		$entity->accessible('*', true);
-		$entity->set($fakeNewValues);
-		$save = $table->save($entity);
-		$this->assertNotEquals(false, $save);
-	}
-
-/**
  * Test that saving a new empty entity does nothing.
  *
  * @group save
@@ -2735,7 +2716,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testSaveDeepAssociationOptions() {
 		$articles = $this->getMock(
 			'\Cake\ORM\Table',
-			['_tes'],
+			['_insert'],
 			[['table' => 'articles', 'connection' => $this->connection]]
 		);
 		$authors = $this->getMock(


### PR DESCRIPTION
Updating dirty entities fails when dirty properties are "chaged" to same values.
Rely on SQLSTATE code instead of counting affected rows.

Reproduce this issue:

```
$article->accessible('*', true);
$article->set($sameValuesFromFormSubmit); // gets marked as dirty
$this->Articles->save($article); // return false [0 rows affected]
```
