### PR TITLE
Underp!

### DIFF
--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -75,9 +75,10 @@ class TaskRegistry extends ObjectRegistry {
  *
  * @param string $class The classname to create.
  * @param string $alias The alias of the task.
+ * @param array $settings An array of settings to use for the task.
  * @return Component The constructed task class.
  */
-	protected function _create($class, $alias) {
+	protected function _create($class, $alias, $settings) {
 		return new $class(
 			$this->_Shell->stdout,
 			$this->_Shell->stderr,


### PR DESCRIPTION
This reverts commit e912c9cc0f7749f1cceba60e5ef8ad0ab3550fd2.

The parameter is present only because that's the signature of the parent
method
