### PR TITLE
3.0 testcase cleanup

### DIFF
--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -124,6 +124,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTest(PHPUnit_Framework_Test $test) {
+		$this->_fixtureManager->load($test);
 	}
 
 /**
@@ -134,6 +135,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTest(PHPUnit_Framework_Test $test, $time) {
+		$this->_fixtureManager->unload($test);
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -300,9 +300,6 @@ class FixtureManager {
  * @return void
  */
 	public function shutDown() {
-		if (session_id()) {
-			session_write_close();
-		}
 		foreach ($this->_loaded as $fixture) {
 			if (!empty($fixture->created)) {
 				foreach ($fixture->created as $ds) {

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -70,43 +70,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	protected $_pathRestore = array();
 
 /**
- * Runs the test case and collects the results in a TestResult object.
- * If no TestResult object is passed a new one will be created.
- * This method is run for each test method in this class
- *
- * @param \PHPUnit_Framework_TestResult $result
- * @return \PHPUnit_Framework_TestResult
- */
-	public function run(\PHPUnit_Framework_TestResult $result = null) {
-		if (!empty($this->fixtureManager)) {
-			$this->fixtureManager->load($this);
-		}
-		$result = parent::run($result);
-		if (!empty($this->fixtureManager)) {
-			$this->fixtureManager->unload($this);
-		}
-		return $result;
-	}
-
-/**
- * Called when a test case method is about to start (to be overridden when needed.)
- *
- * @param string $method Test method about to get executed.
- * @return void
- */
-	public function startTest($method) {
-	}
-
-/**
- * Called when a test case method has been executed (to be overridden when needed.)
- *
- * @param string $method Test method about that was executed.
- * @return void
- */
-	public function endTest($method) {
-	}
-
-/**
  * Overrides SimpleTestCase::skipIf to provide a boolean return value
  *
  * @param boolean $shouldSkip
@@ -163,30 +126,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	public static function date($format = 'Y-m-d H:i:s') {
 		return TestSuiteDispatcher::date($format);
 	}
-
-// @codingStandardsIgnoreStart PHPUnit overrides don't match CakePHP
-
-/**
- * Announces the start of a test.
- *
- * @return void
- */
-	protected function assertPreConditions() {
-		parent::assertPreConditions();
-		$this->startTest($this->getName());
-	}
-
-/**
- * Announces the end of a test.
- *
- * @return void
- */
-	protected function assertPostConditions() {
-		parent::assertPostConditions();
-		$this->endTest($this->getName());
-	}
-
-// @codingStandardsIgnoreEnd
 
 /**
  * Chooses which fixtures to load for a given test

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -144,24 +144,6 @@ class TestCaseTest extends TestCase {
 	}
 
 /**
- * testLoadFixtures
- *
- * @return void
- */
-	public function testLoadFixtures() {
-		$test = new FixturizedTestCase('testFixturePresent');
-		$manager = $this->getMock('Cake\TestSuite\Fixture\FixtureManager');
-		$manager->fixturize($test);
-		$test->fixtureManager = $manager;
-		$manager->expects($this->once())->method('load');
-		$manager->expects($this->once())->method('unload');
-		$result = $test->run();
-		$this->assertEquals(0, $result->errorCount());
-		$this->assertTrue($result->wasSuccessful());
-		$this->assertEquals(0, $result->failureCount());
-	}
-
-/**
  * testLoadFixturesOnDemand
  *
  * @return void


### PR DESCRIPTION
Now that we use phpunit directly both in the core and userland, we can
completely remove the fixture handling code out of the TestCase class.
Also removed some methods that were there for compatibility with SimpleTest
