### PR TITLE
Preventing invalid property names from being get/set into Entity

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -208,6 +208,9 @@ trait EntityTrait {
 		}
 
 		$options += ['setter' => true, 'guard' => $guard];
+		if (!is_array($property)) {
+			throw new \InvalidArgumentException('Cannot set an empty property');
+		}
 
 		foreach ($property as $p => $value) {
 			if ($options['guard'] === true && !$this->accessible($p)) {
@@ -235,10 +238,15 @@ trait EntityTrait {
  *
  * @param string $property the name of the property to retrieve
  * @return mixed
+ * @throws \InvalidArgumentException if an empty property name is passed
  */
 	public function &get($property) {
-		$method = 'get' . Inflector::camelize($property);
+		if (!strlen((string)$property)) {
+			throw new \InvalidArgumentException('Cannot get an empty property');
+		}
+
 		$value = null;
+		$method = 'get' . Inflector::camelize($property);
 
 		if (isset($this->_properties[$property])) {
 			$value =& $this->_properties[$property];

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -199,7 +199,8 @@ trait EntityTrait {
  * @return \Cake\Datasource\EntityInterface this object
  */
 	public function set($property, $value = null, $options = []) {
-		if (is_string($property)) {
+		$isString = is_string($property);
+		if ($isString && $property !== '') {
 			$guard = false;
 			$property = [$property => $value];
 		} else {
@@ -207,10 +208,10 @@ trait EntityTrait {
 			$options = (array)$value;
 		}
 
-		$options += ['setter' => true, 'guard' => $guard];
 		if (!is_array($property)) {
 			throw new \InvalidArgumentException('Cannot set an empty property');
 		}
+		$options += ['setter' => true, 'guard' => $guard];
 
 		foreach ($property as $p => $value) {
 			if ($options['guard'] === true && !$this->accessible($p)) {

--- a/src/ORM/Entity.php
+++ b/src/ORM/Entity.php
@@ -54,10 +54,13 @@ class Entity implements EntityInterface {
 			'source' => null
 		];
 		$this->_className = get_class($this);
-		$this->set($properties, [
-			'setter' => $options['useSetters'],
-			'guard' => $options['guard']
-		]);
+
+		if (!empty($properties)) {
+			$this->set($properties, [
+				'setter' => $options['useSetters'],
+				'guard' => $options['guard']
+			]);
+		}
 
 		if ($options['markClean']) {
 			$this->clean();

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1066,7 +1066,7 @@ class EntityTest extends TestCase {
  */
 	public function testSetEmptyPropertyName($property) {
 		$entity = new Entity();
-		$entity->set($property, 'foo');
+		$entity->set($property, 'bar');
 	}
 
 }

--- a/tests/TestCase/ORM/EntityTest.php
+++ b/tests/TestCase/ORM/EntityTest.php
@@ -1037,4 +1037,36 @@ class EntityTest extends TestCase {
 		$this->assertEquals('foos', $entity->source());
 	}
 
+/**
+ * Provides empty values
+ *
+ * @return void
+ */
+	public function emptyNamesProvider() {
+		return [[''], [null], [false]];
+	}
+/**
+ * Tests that trying to get an empty propery name throws exception
+ *
+ * @dataProvider emptyNamesProvider
+ * @expectedException \InvalidArgumentException
+ * @return void
+ */
+	public function testEmptyProperties($property) {
+		$entity = new Entity();
+		$entity->get($property);
+	}
+
+/**
+ * Tests that setitng an empty property name does nothing
+ *
+ * @expectedException \InvalidArgumentException
+ * @dataProvider emptyNamesProvider
+ * @return void
+ */
+	public function testSetEmptyPropertyName($property) {
+		$entity = new Entity();
+		$entity->set($property, 'foo');
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/cakephp/cakephp/issues/3071
