### PR TITLE
Update in_array() check to avoid fatal error

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1561,7 +1561,7 @@ class DboSource extends DataSource {
 					if (!empty($assocData['order'])) {
 						$queryData['order'][] = $assocData['order'];
 					}
-					if (!in_array($join, $queryData['joins'])) {
+					if (!in_array($join, $queryData['joins'], true)) {
 						$queryData['joins'][] = $join;
 					}
 					return true;


### PR DESCRIPTION
Enabling the $strict parameter to true avoids PHP's default behavior when search for an array in an array, which throws a fatal error if circular references exist - http://php.net/in_array#refsect1-function.in-array-parameters
