### PR TITLE
Insert manual joins *after* generated joins.

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1067,6 +1067,9 @@ class DboSource extends DataSource {
 			}
 		}
 
+		$originalJoins = $queryData['joins'];
+		$queryData['joins'] = array();
+
 		// Generate hasOne and belongsTo associations inside $queryData
 		$linkedModels = array();
 		foreach ($associations as $type) {
@@ -1091,6 +1094,10 @@ class DboSource extends DataSource {
 					$linkedModels[$type . '/' . $assoc] = true;
 				}
 			}
+		}
+
+		if (!empty($originalJoins)) {
+			$queryData['joins'] = array_merge($queryData['joins'], $originalJoins);
 		}
 
 		// Build SQL statement with the primary model, plus hasOne and belongsTo associations

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -1288,9 +1288,12 @@ class MysqlTest extends CakeTestCase {
 			->method('getDataSource')
 			->will($this->returnValue($test));
 
-		$search = "LEFT JOIN `cake_test_db`.`test_model8` AS `TestModel8` ON " .
+		$model8Table = $test->fullTableName($this->Model->TestModel8);
+		$usersTable = $test->fullTableName('users');
+
+		$search = "LEFT JOIN $model8Table AS `TestModel8` ON " .
 			"(`TestModel8`.`name` != 'larry' AND `TestModel9`.`test_model8_id` = `TestModel8`.`id`) " .
-			"LEFT JOIN `cake_test_db`.`users` AS `User` ON (`TestModel9`.`id` = `User`.`test_id`)";
+			"LEFT JOIN $usersTable AS `User` ON (`TestModel9`.`id` = `User`.`test_id`)";
 
 		$test->expects($this->at(0))->method('execute')
 			->with($this->stringContains($search));


### PR DESCRIPTION
Re-order query joins to make manually added joins be performed after generated joins. This removes the need to workaround the current join order, or redefine all association joins when you want to add an
additional join on a leaf table.

Refs #2179
Refs #2346
