### PR TITLE
moveUp|Down should return false on failure instead of throw

### DIFF
--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -117,10 +117,11 @@ class TreeBehavior extends Behavior {
  * @throws \InvalidArgumentException When the 'for' key is not passed in $options
  */
 	public function findChildren($query, $options) {
-		extract($this->config());
-		extract($options);
+		$config = $this->config();
+		$options += ['for' => null, 'direct' => false];
+		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
+		list($for, $direct) = [$options['for'], $options['direct']];
 		$primaryKey = $this->_table->primaryKey();
-		$direct = !isset($direct) ? false : $direct;
 
 		if (empty($for)) {
 			throw new \InvalidArgumentException("The 'for' key is required for find('children')");
@@ -157,11 +158,11 @@ class TreeBehavior extends Behavior {
  *
  * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number How many places to move the node, or true to move to first position
- * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return boolean true on success, false on failure
  */
 	public function moveUp($id, $number = 1) {
-		extract($this->config());
+		$config = $this->config();
+		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
 		$primaryKey = $this->_table->primaryKey();
 
 		if (!$number) {
@@ -174,7 +175,7 @@ class TreeBehavior extends Behavior {
 			->first();
 
 		if (!$node) {
-			throw new \Cake\ORM\Error\RecordNotFoundException("Node \"{$id}\" was not found in the tree.");
+			return false;
 		}
 
 		if ($node->{$parent}) {
@@ -217,11 +218,11 @@ class TreeBehavior extends Behavior {
  *
  * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number How many places to move the node or true to move to last position
- * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return boolean true on success, false on failure
  */
 	public function moveDown($id, $number = 1) {
-		extract($this->config());
+		$config = $this->config();
+		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
 		$primaryKey = $this->_table->primaryKey();
 
 		if (!$number) {
@@ -234,7 +235,7 @@ class TreeBehavior extends Behavior {
 			->first();
 
 		if (!$node) {
-			throw new \Cake\ORM\Error\RecordNotFoundException("Node \"{$id}\" was not found in the tree.");
+			return false;
 		}
 
 		if ($node->{$parent}) {

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -158,6 +158,7 @@ class TreeBehavior extends Behavior {
  *
  * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number How many places to move the node, or true to move to first position
+ * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return boolean true on success, false on failure
  */
 	public function moveUp($id, $number = 1) {
@@ -175,7 +176,7 @@ class TreeBehavior extends Behavior {
 			->first();
 
 		if (!$node) {
-			return false;
+			throw new \Cake\ORM\Error\RecordNotFoundException("Node \"{$id}\" was not found in the tree.");
 		}
 
 		if ($node->{$parent}) {
@@ -218,6 +219,7 @@ class TreeBehavior extends Behavior {
  *
  * @param integer|string $id The ID of the record to move
  * @param integer|boolean $number How many places to move the node or true to move to last position
+ * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return boolean true on success, false on failure
  */
 	public function moveDown($id, $number = 1) {
@@ -235,7 +237,7 @@ class TreeBehavior extends Behavior {
 			->first();
 
 		if (!$node) {
-			return false;
+			throw new \Cake\ORM\Error\RecordNotFoundException("Node \"{$id}\" was not found in the tree.");
 		}
 
 		if ($node->{$parent}) {

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -172,9 +172,6 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertFalse($this->table->moveUp(1, 0));
 		$this->assertFalse($this->table->moveUp(1, -10));
 
-		// move unexisting node
-		$this->assertFalse($table->moveUp(500, 1));
-
 		// move inner node
 		$result = $table->moveUp(3, 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
@@ -195,6 +192,18 @@ class TreeBehaviorTest extends TestCase {
 	}
 
 /**
+ * Tests that moveUp() will throw an exception if the node was not found
+ *
+ * @expectedException \Cake\ORM\Error\RecordNotFoundException
+ * @return void
+ */
+	public function testMoveUpException() {
+		$table = TableRegistry::get('MenuLinkTrees');
+		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
+		$table->moveUp(500, 1);
+	}
+
+/**
  * Tests the moveDown() method
  *
  * @return void
@@ -211,14 +220,10 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertFalse($this->table->moveUp(8, -10));
 
 		// move inner node
-		$nodeIds = [];
 		$result = $table->moveDown(2, 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
 		$this->assertTrue($result);
-
-		// move unexisting node
-		$this->assertFalse($table->moveDown(500, 1));
 
 		// move leaf
 		$this->assertFalse( $table->moveDown(5, 1));
@@ -231,6 +236,18 @@ class TreeBehaviorTest extends TestCase {
 			->order(['lft' => 'ASC'])
 			->all();
 		$this->assertEquals([6, 8, 1], $nodes->extract('id')->toArray());
+	}
+
+/**
+ * Tests that moveDown() will throw an exception if the node was not found
+ *
+ * @expectedException \Cake\ORM\Error\RecordNotFoundException
+ * @return void
+ */
+	public function testMoveDownException() {
+		$table = TableRegistry::get('MenuLinkTrees');
+		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
+		$table->moveDown(500, 1);
 	}
 
 /**

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -172,8 +172,10 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(false, $this->table->moveUp(1, 0));
 		$this->assertEquals(false, $this->table->moveUp(1, -10));
 
+		// move unexisting node
+		$this->assertEquals(false, $table->moveUp(500, 1));
+
 		// move inner node
-		$nodeIds = [];
 		$result = $table->moveUp(3, 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
@@ -186,22 +188,10 @@ class TreeBehaviorTest extends TestCase {
 		$table->moveUp(8, true);
 		$nodes = $table->find()
 			->select(['id'])
-			->where(['parent_id' => 0, 'menu' => 'main-menu'])
+			->where(['parent_id IS' => null, 'menu' => 'main-menu'])
 			->order(['lft' => 'ASC'])
 			->all();
 		$this->assertEquals([8, 1, 6], $nodes->extract('id')->toArray());
-	}
-
-/**
- * Tests that moveUp() will throw an exception if the node was not found
- *
- * @expectedException \Cake\ORM\Error\RecordNotFoundException
- * @return void
- */
-	public function testMoveUpException() {
-		$table = TableRegistry::get('MenuLinkTrees');
-		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-		$table->moveUp(500, 1);
 	}
 
 /**
@@ -227,6 +217,9 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
 		$this->assertEquals(true, $result);
 
+		// move unexisting node
+		$this->assertEquals(false, $table->moveDown(500, 1));
+
 		// move leaf
 		$this->assertEquals(false, $table->moveDown(5, 1));
 
@@ -234,22 +227,10 @@ class TreeBehaviorTest extends TestCase {
 		$table->moveDown(1, true);
 		$nodes = $table->find()
 			->select(['id'])
-			->where(['parent_id' => 0, 'menu' => 'main-menu'])
+			->where(['parent_id IS' => null, 'menu' => 'main-menu'])
 			->order(['lft' => 'ASC'])
 			->all();
 		$this->assertEquals([6, 8, 1], $nodes->extract('id')->toArray());
-	}
-
-/**
- * Tests that moveDown() will throw an exception if the node was not found
- *
- * @expectedException \Cake\ORM\Error\RecordNotFoundException
- * @return void
- */
-	public function testMoveDownException() {
-		$table = TableRegistry::get('MenuLinkTrees');
-		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
-		$table->moveDown(500, 1);
 	}
 
 /**

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -166,23 +166,23 @@ class TreeBehaviorTest extends TestCase {
 		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
 
 		// top level, wont move
-		$this->assertEquals(false, $this->table->moveUp(1, 10));
+		$this->assertFalse($this->table->moveUp(1, 10));
 
 		// edge cases
-		$this->assertEquals(false, $this->table->moveUp(1, 0));
-		$this->assertEquals(false, $this->table->moveUp(1, -10));
+		$this->assertFalse($this->table->moveUp(1, 0));
+		$this->assertFalse($this->table->moveUp(1, -10));
 
 		// move unexisting node
-		$this->assertEquals(false, $table->moveUp(500, 1));
+		$this->assertFalse($table->moveUp(500, 1));
 
 		// move inner node
 		$result = $table->moveUp(3, 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
-		$this->assertEquals(true, $result);
+		$this->assertTrue($result);
 
 		// move leaf
-		$this->assertEquals(false, $table->moveUp(5, 1));
+		$this->assertFalse($table->moveUp(5, 1));
 
 		// move to first position
 		$table->moveUp(8, true);
@@ -204,24 +204,24 @@ class TreeBehaviorTest extends TestCase {
 		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
 
 		// latest node, wont move
-		$this->assertEquals(false, $this->table->moveDown(8, 10));
+		$this->assertFalse($this->table->moveDown(8, 10));
 
 		// edge cases
-		$this->assertEquals(false, $this->table->moveDown(8, 0));
-		$this->assertEquals(false, $this->table->moveUp(8, -10));
+		$this->assertFalse($this->table->moveDown(8, 0));
+		$this->assertFalse($this->table->moveUp(8, -10));
 
 		// move inner node
 		$nodeIds = [];
 		$result = $table->moveDown(2, 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
-		$this->assertEquals(true, $result);
+		$this->assertTrue($result);
 
 		// move unexisting node
-		$this->assertEquals(false, $table->moveDown(500, 1));
+		$this->assertFalse($table->moveDown(500, 1));
 
 		// move leaf
-		$this->assertEquals(false, $table->moveDown(5, 1));
+		$this->assertFalse( $table->moveDown(5, 1));
 
 		// move to last position
 		$table->moveDown(1, true);


### PR DESCRIPTION
- Refactoring, remove usage of extract()
- Test cases updated
