### PR TITLE
add an instance config trait

### DIFF
--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -150,6 +150,7 @@ trait InstanceConfigTrait {
 /**
  * Delete a single config key
  *
+ * @throws Cake\Error\Exception if attempting to clobber existing config
  * @param string $key
  * @return void
  */

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -19,7 +19,7 @@ use Cake\Error;
 /**
  * A trait for reading and writing instance config
  *
- * Implementing objects are expected to declare a `$_config` property.
+ * Implementing objects are expected to declare a `$_defaultConfig` property.
  */
 trait InstanceConfigTrait {
 

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -67,7 +67,7 @@ trait InstanceConfigTrait {
 			$this->_config = $this->_defaultConfig;
 		}
 
-		if ($value !== null || is_array($key)) {
+		if (is_array($key) || func_num_args() === 2) {
 			return $this->_configWrite($key, $value);
 		}
 
@@ -120,14 +120,19 @@ trait InstanceConfigTrait {
 			return;
 		}
 
+		if ($value === null) {
+			return $this->_configDelete($key);
+		}
+
 		if (strpos($key, '.') === false) {
 			$this->_config[$key] = $value;
 			return;
 		}
 
 		$update =& $this->_config;
+		$stack = explode('.', $key);
 
-		foreach (explode('.', $key) as $k) {
+		foreach ($stack as $k) {
 			if (!is_array($update)) {
 				throw new Error\Exception(sprintf('Cannot set %s value', $key));
 			}
@@ -140,6 +145,40 @@ trait InstanceConfigTrait {
 		}
 
 		$update = $value;
+	}
+
+/**
+ * Delete a single config key
+ *
+ * @param string $key
+ * @return void
+ */
+	protected function _configDelete($key) {
+		if (strpos($key, '.') === false) {
+			unset($this->_config[$key]);
+			return;
+		}
+
+		$update =& $this->_config;
+		$stack = explode('.', $key);
+		$length = count($stack);
+
+		foreach ($stack as $i => $k) {
+			if (!is_array($update)) {
+				throw new Error\Exception(sprintf('Cannot unset %s value', $key));
+			}
+
+			if (!isset($update[$k])) {
+				break;
+			}
+
+			if ($i === $length - 2) {
+				unset($update[$k]);
+				break;
+			}
+
+			$update =& $update[$k];
+		}
 	}
 
 }

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Core;
+
+use Cake\Error;
+
+/**
+ * A trait for reading and writing instance config
+ *
+ * Implementing objects are expected to declare a `$_config` property.
+ */
+trait InstanceConfigTrait {
+
+/**
+ * Runtime config
+ *
+ * @var array
+ */
+	protected $_config = [];
+
+/**
+ * ### Usage
+ *
+ * Reading the whole config:
+ *
+ * `$this->config();`
+ *
+ * Reading a specific value:
+ *
+ * `$this->config('key');`
+ *
+ * Reading a nested value:
+ *
+ * `$this->config('some.nested.key');`
+ *
+ * Setting a specific value:
+ *
+ * `$this->config('key', $value);`
+ *
+ * Setting a nested value:
+ *
+ * `$this->config('some.nested.key', $value);`
+ *
+ * Updating multiple config settings at the same time:
+ *
+ * `$this->config(['one' => 'value', 'another' => 'value']);`
+ *
+ * @param string|array|null $key the key to get/set, or a complete array of configs
+ * @param mixed|null $value the value to set
+ * @return mixed|null null for write, or whatever is in the config on read
+ * @throws \Cake\Error\Exception When trying to set a key that is invalid
+ */
+	public function config($key = null, $value = null) {
+		if ($this->_config === [] && $this->_defaultConfig) {
+			$this->_config = $this->_defaultConfig;
+		}
+
+		if ($value !== null || is_array($key)) {
+			return $this->_configWrite($key, $value);
+		}
+
+		return $this->_configRead($key);
+	}
+
+/**
+ * Read a config variable
+ *
+ * @param string|null $key
+ * @return mixed
+ */
+	protected function _configRead($key) {
+		if ($key === null) {
+			return $this->_config;
+		}
+
+		if (strpos($key, '.') === false) {
+			return isset($this->_config[$key]) ? $this->_config[$key] : null;
+		}
+
+		$return = $this->_config;
+
+		foreach(explode('.', $key) as $k) {
+			if (!is_array($return) || !isset($return[$k])) {
+				$return = null;
+				break;
+			}
+
+			$return = $return[$k];
+
+		}
+
+		return $return;
+	}
+
+/**
+ * Write a config variable
+ *
+ * @throws Error\Exception if attempting to clobber existing config
+ * @param string|array $key
+ * @param mixed|null $value
+ * @return void
+ */
+	protected function _configWrite($key, $value = null) {
+		if (is_array($key)) {
+			foreach($key as $k => $val) {
+				$this->_configWrite($k, $val);
+			}
+			return;
+		}
+
+		if (strpos($key, '.') === false) {
+			$this->_config[$key] = $value;
+			return;
+		}
+
+		$update =& $this->_config;
+
+		foreach(explode('.', $key) as $k) {
+			if (!is_array($update)) {
+				throw new Error\Exception(sprintf('Cannot set %s value', $key));
+			}
+
+			if (!isset($update[$k])) {
+				$update[$k] = [];
+			}
+
+			$update =& $update[$k];
+		}
+
+		$update = $value;
+	}
+
+}

--- a/src/Core/InstanceConfigTrait.php
+++ b/src/Core/InstanceConfigTrait.php
@@ -91,7 +91,7 @@ trait InstanceConfigTrait {
 
 		$return = $this->_config;
 
-		foreach(explode('.', $key) as $k) {
+		foreach (explode('.', $key) as $k) {
 			if (!is_array($return) || !isset($return[$k])) {
 				$return = null;
 				break;
@@ -107,14 +107,14 @@ trait InstanceConfigTrait {
 /**
  * Write a config variable
  *
- * @throws Error\Exception if attempting to clobber existing config
+ * @throws Cake\Error\Exception if attempting to clobber existing config
  * @param string|array $key
  * @param mixed|null $value
  * @return void
  */
 	protected function _configWrite($key, $value = null) {
 		if (is_array($key)) {
-			foreach($key as $k => $val) {
+			foreach ($key as $k => $val) {
 				$this->_configWrite($k, $val);
 			}
 			return;
@@ -127,7 +127,7 @@ trait InstanceConfigTrait {
 
 		$update =& $this->_config;
 
-		foreach(explode('.', $key) as $k) {
+		foreach (explode('.', $key) as $k) {
 			if (!is_array($update)) {
 				throw new Error\Exception(sprintf('Cannot set %s value', $key));
 			}

--- a/tests/TestCase/Core/InstanceConfigTrait.php
+++ b/tests/TestCase/Core/InstanceConfigTrait.php
@@ -59,6 +59,7 @@ class ReadOnlyTestInstanceConfig {
 /**
  * Example of how to prevent modifying config at run time
  *
+ * @throws \Exception
  * @param mixed $key
  * @param mixed $value
  * @return void
@@ -66,6 +67,7 @@ class ReadOnlyTestInstanceConfig {
 	protected function _configWrite($key, $value = null) {
 		throw new \Exception('This Instance is readonly');
 	}
+
 }
 
 /**

--- a/tests/TestCase/Core/InstanceConfigTrait.php
+++ b/tests/TestCase/Core/InstanceConfigTrait.php
@@ -18,7 +18,7 @@ use Cake\Core\InstanceConfigTrait;
 use Cake\TestSuite\TestCase;
 
 /**
- * TestObject class
+ * TestInstanceConfig
  */
 class TestInstanceConfig {
 
@@ -29,12 +29,43 @@ class TestInstanceConfig {
  *
  * Some default config
  *
- * @var mixed
+ * @var array
  */
 	protected $_defaultConfig = [
 		'some' => 'string',
 		'a' => ['nested' => 'value']
 	];
+}
+
+/**
+ * ReadOnlyTestInstanceConfig
+ */
+class ReadOnlyTestInstanceConfig {
+
+	use InstanceConfigTrait;
+
+/**
+ * _defaultConfig
+ *
+ * Some default config
+ *
+ * @var array
+ */
+	protected $_defaultConfig = [
+		'some' => 'string',
+		'a' => ['nested' => 'value']
+	];
+
+/**
+ * Example of how to prevent modifying config at run time
+ *
+ * @param mixed $key
+ * @param mixed $value
+ * @return void
+ */
+	protected function _configWrite($key, $value = null) {
+		throw new \Exception('This Instance is readonly');
+	}
 }
 
 /**
@@ -228,6 +259,28 @@ class InstanceConfigTraitTest extends TestCase {
  */
 	public function testSetClobber() {
 		$this->object->config(['a.nested.value' => 'not possible']);
+	}
+
+/**
+ * testReadOnlyConfig
+ *
+ * @expectedException \Exception
+ * @expectedExceptionMessage This Instance is readonly
+ * @return void
+ */
+	public function testReadOnlyConfig() {
+		$object = new ReadOnlyTestInstanceConfig();
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'value']
+			],
+			$object->config(),
+			'default config should be returned'
+		);
+
+		$object->config('throw.me', 'an exception');
 	}
 
 }

--- a/tests/TestCase/Core/InstanceConfigTrait.php
+++ b/tests/TestCase/Core/InstanceConfigTrait.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Test\TestCase\Core;
+
+use Cake\Core\InstanceConfigTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * TestObject class
+ */
+class TestInstanceConfig {
+
+	use InstanceConfigTrait;
+
+/**
+ * _defaultConfig
+ *
+ * Some default config
+ *
+ * @var mixed
+ */
+	protected $_defaultConfig = [
+		'some' => 'string',
+		'a' => ['nested' => 'value']
+	];
+}
+
+/**
+ * InstanceConfigTraitTest
+ *
+ */
+class InstanceConfigTraitTest extends TestCase {
+
+/**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->object = new TestInstanceConfig();
+	}
+
+/**
+ * testDefaultsAreSet
+ *
+ * @return void
+ */
+	public function testDefaultsAreSet() {
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'value']
+			],
+			$this->object->config(),
+			'runtime config should match the defaults if not overriden'
+		);
+	}
+
+/**
+ * testGetSimple
+ *
+ * @return void
+ */
+	public function testGetSimple() {
+		$this->assertSame(
+			'string',
+			$this->object->config('some'),
+			'should return the key value only'
+		);
+
+		$this->assertSame(
+			['nested' => 'value'],
+			$this->object->config('a'),
+			'should return the key value only'
+		);
+	}
+
+/**
+ * testGetDot
+ *
+ * @return void
+ */
+	public function testGetDot() {
+		$this->assertSame(
+			'value',
+			$this->object->config('a.nested'),
+			'should return the nested value only'
+		);
+	}
+
+/**
+ * testSetSimple
+ *
+ * @return void
+ */
+	public function testSetSimple() {
+		$this->object->config('foo', 'bar');
+		$this->assertSame(
+			'bar',
+			$this->object->config('foo'),
+			'should return the same value just set'
+		);
+
+		$this->object->config('some', 'zum');
+		$this->assertSame(
+			'zum',
+			$this->object->config('some'),
+			'should return the overritten value'
+		);
+
+		$this->assertSame(
+			[
+				'some' => 'zum',
+				'a' => ['nested' => 'value'],
+				'foo' => 'bar',
+			],
+			$this->object->config(),
+			'updates should be merged with existing config'
+		);
+	}
+
+/**
+ * testSetNested
+ *
+ * @return void
+ */
+	public function testSetNested() {
+		$this->object->config('new.foo', 'bar');
+		$this->assertSame(
+			'bar',
+			$this->object->config('new.foo'),
+			'should return the same value just set'
+		);
+
+		$this->object->config('a.nested', 'zum');
+		$this->assertSame(
+			'zum',
+			$this->object->config('a.nested'),
+			'should return the overritten value'
+		);
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'zum'],
+				'new' => ['foo' => 'bar']
+			],
+			$this->object->config(),
+			'updates should be merged with existing config'
+		);
+	}
+
+/**
+ * testSetNested
+ *
+ * @return void
+ */
+	public function testSetArray() {
+		$this->object->config(['foo' => 'bar']);
+		$this->assertSame(
+			'bar',
+			$this->object->config('foo'),
+			'should return the same value just set'
+		);
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'value'],
+				'foo' => 'bar',
+			],
+			$this->object->config(),
+			'updates should be merged with existing config'
+		);
+
+		$this->object->config(['new.foo' => 'bar']);
+		$this->assertSame(
+			'bar',
+			$this->object->config('new.foo'),
+			'should return the same value just set'
+		);
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'value'],
+				'foo' => 'bar',
+				'new' => ['foo' => 'bar']
+			],
+			$this->object->config(),
+			'updates should be merged with existing config'
+		);
+
+		$this->object->config(['multiple' => 'different', 'a.values.to' => 'set']);
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+				'a' => ['nested' => 'value', 'values' => ['to' => 'set']],
+				'foo' => 'bar',
+				'new' => ['foo' => 'bar'],
+				'multiple' => 'different'
+			],
+			$this->object->config(),
+			'updates should be merged with existing config'
+		);
+	}
+
+/**
+ * testSetClobber
+ *
+ * @expectedException \Exception
+ * @expectedExceptionMessage Cannot set a.nested.value
+ * @return void
+ */
+	public function testSetClobber() {
+		$this->object->config(['a.nested.value' => 'not possible']);
+	}
+
+}

--- a/tests/TestCase/Core/InstanceConfigTrait.php
+++ b/tests/TestCase/Core/InstanceConfigTrait.php
@@ -310,7 +310,6 @@ class InstanceConfigTraitTest extends TestCase {
 			$this->object->config(),
 			'deleted keys should not be present'
 		);
-
 	}
 
 /**
@@ -338,6 +337,17 @@ class InstanceConfigTraitTest extends TestCase {
 			$this->object->config(),
 			'deleted keys should not be present'
 		);
+	}
+
+/**
+ * testSetClobber
+ *
+ * @expectedException \Exception
+ * @expectedExceptionMessage Cannot unset a.nested.value.whoops
+ * @return void
+ */
+	public function testDeleteClobber() {
+		$this->object->config('a.nested.value.whoops', null);
 	}
 
 }

--- a/tests/TestCase/Core/InstanceConfigTrait.php
+++ b/tests/TestCase/Core/InstanceConfigTrait.php
@@ -285,4 +285,59 @@ class InstanceConfigTraitTest extends TestCase {
 		$object->config('throw.me', 'an exception');
 	}
 
+/**
+ * testDeleteSimple
+ *
+ * @return void
+ */
+	public function testDeleteSimple() {
+		$this->object->config('foo', null);
+		$this->assertNull(
+			$this->object->config('foo'),
+			'setting a new key to null should have no effect'
+		);
+
+		$this->object->config('some', null);
+		$this->assertNull(
+			$this->object->config('some'),
+			'should delete the existing value'
+		);
+
+		$this->assertSame(
+			[
+				'a' => ['nested' => 'value'],
+			],
+			$this->object->config(),
+			'deleted keys should not be present'
+		);
+
+	}
+
+/**
+ * testDeleteNested
+ *
+ * @return void
+ */
+	public function testDeleteNested() {
+		$this->object->config('new.foo', null);
+		$this->assertNull(
+			$this->object->config('new.foo'),
+			'setting a new key to null should have no effect'
+		);
+
+		$this->object->config('a.nested', null);
+		$this->assertNull(
+			$this->object->config('a.nested'),
+			'should delete the existing value'
+		);
+
+		$this->assertSame(
+			[
+				'some' => 'string',
+			],
+			$this->object->config(),
+			'deleted keys should not be present'
+		);
+	}
+
 }


### PR DESCRIPTION
#3112 Can make use of this to prevent continuously re-implementing a config function/mechanism.

There are still a lot of other settings->config changes to make which will also use/need this.

Ref: #2298
