### PR TITLE
Update controller task to use magic get.

### DIFF
--- a/src/Console/Templates/default/actions/controller_actions.ctp
+++ b/src/Console/Templates/default/actions/controller_actions.ctp
@@ -69,7 +69,7 @@ foreach ($modelObj->associations()->type('BelongsTo') as $assoc) {
 		foreach ($modelObj->associations()->type($assoc) as $association):
 			$otherName = $association->target()->alias();
 			$otherPlural = $this->_pluralName($otherName);
-			echo "\t\t\${$otherPlural} = \$this->{$currentModelName}->association('{$otherName}')->find('list');\n";
+			echo "\t\t\${$otherPlural} = \$this->{$currentModelName}->{$otherName}->find('list');\n";
 			$compact[] = "'{$otherPlural}'";
 		endforeach;
 	endforeach;
@@ -101,7 +101,7 @@ foreach ($modelObj->associations()->type('BelongsTo') as $assoc) {
 			foreach ($modelObj->associations()->type($assoc) as $association):
 				$otherName = $association->target()->alias();
 				$otherPlural = $this->_pluralName($otherName);
-				echo "\t\t\${$otherPlural} = \$this->{$currentModelName}->association('{$otherName}')->find('list');\n";
+				echo "\t\t\${$otherPlural} = \$this->{$currentModelName}->{$otherName}->find('list');\n";
 				$compact[] = "'{$otherPlural}'";
 			endforeach;
 		endforeach;

--- a/tests/bake_compare/Controller/Actions.ctp
+++ b/tests/bake_compare/Controller/Actions.ctp
@@ -40,8 +40,8 @@
 				$this->Session->setFlash(__('The bake article could not be saved. Please, try again.'));
 			}
 		}
-		$bakeUsers = $this->BakeArticles->association('BakeUsers')->find('list');
-		$bakeTags = $this->BakeArticles->association('BakeTags')->find('list');
+		$bakeUsers = $this->BakeArticles->BakeUsers->find('list');
+		$bakeTags = $this->BakeArticles->BakeTags->find('list');
 		$this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
 	}
 
@@ -63,8 +63,8 @@
 				$this->Session->setFlash(__('The bake article could not be saved. Please, try again.'));
 			}
 		}
-		$bakeUsers = $this->BakeArticles->association('BakeUsers')->find('list');
-		$bakeTags = $this->BakeArticles->association('BakeTags')->find('list');
+		$bakeUsers = $this->BakeArticles->BakeUsers->find('list');
+		$bakeTags = $this->BakeArticles->BakeTags->find('list');
 		$this->set(compact('bakeArticle', 'bakeUsers', 'bakeTags'));
 	}
 


### PR DESCRIPTION
Now that association objects can be accessed using `__get()` bake can have shorter syntax in the generated actions.
