### PR TITLE
correct doc blocks

### DIFF
--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -390,18 +390,18 @@ trait EntityTrait {
  * Implements isset($entity);
  *
  * @param mixed $offset
- * @return void
+ * @return boolean Success
  */
 	public function offsetExists($offset) {
 		return $this->has($offset);
 	}
+
 /**
  * Implements $entity[$offset];
  *
  * @param mixed $offset
- * @return void
+ * @return mixed
  */
-
 	public function &offsetGet($offset) {
 		return $this->get($offset);
 	}
@@ -413,7 +413,6 @@ trait EntityTrait {
  * @param mixed $value
  * @return void
  */
-
 	public function offsetSet($offset, $value) {
 		$this->set($offset, $value);
 	}


### PR DESCRIPTION
Minor doc block corrections

Side-question:
Do we really need

```
public function jsonSerialize() {
    return $this->toArray();
}
```

As it is just a wrapper for toArray() which seems simple enough?
