### PR TITLE
Depcrecate Request  parameter to Controller::invokeAction()

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -375,14 +375,17 @@ class Controller extends Object implements EventListener {
  * exists and isn't private.
  *
  * @return mixed The resulting response.
+ * @throws \Cake\Error\Exception When request is not set.
  * @throws \Cake\Error\PrivateActionException When actions are not public or prefixed by _
  * @throws \Cake\Error\MissingActionException When actions are not defined.
  */
 	public function invokeAction() {
 		try {
 			$request = $this->request;
+			if (!isset($request)) {
+				throw new Error\Exception('No Request object configured. Cannot invoke action');
+			}
 			$method = new \ReflectionMethod($this, $request->params['action']);
-
 			if ($this->_isPrivateAction($method, $request)) {
 				throw new Error\PrivateActionException(array(
 					'controller' => $this->name . "Controller",

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -374,13 +374,13 @@ class Controller extends Object implements EventListener {
  * Dispatches the controller action. Checks that the action
  * exists and isn't private.
  *
- * @param \Cake\Network\Request $request
  * @return mixed The resulting response.
  * @throws \Cake\Error\PrivateActionException When actions are not public or prefixed by _
  * @throws \Cake\Error\MissingActionException When actions are not defined.
  */
-	public function invokeAction(Request $request) {
+	public function invokeAction() {
 		try {
+			$request = $this->request;
 			$method = new \ReflectionMethod($this, $request->params['action']);
 
 			if ($this->_isPrivateAction($method, $request)) {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -163,7 +163,7 @@ class Dispatcher implements EventListener {
 			));
 		}
 
-		$response = $this->_invoke($controller, $request, $response);
+		$response = $this->_invoke($controller, $response);
 		if (isset($request->params['return'])) {
 			return $response->body();
 		}
@@ -179,16 +179,15 @@ class Dispatcher implements EventListener {
  * Otherwise the return value of the controller action are returned.
  *
  * @param Controller $controller Controller to invoke
- * @param \Cake\Network\Request $request The request object to invoke the controller for.
  * @param \Cake\Network\Response $response The response object to receive the output
  * @return \Cake\Network\Response the resulting response object
  */
-	protected function _invoke(Controller $controller, Request $request, Response $response) {
+	protected function _invoke(Controller $controller, Response $response) {
 		$controller->constructClasses();
 		$controller->startupProcess();
 
 		$render = true;
-		$result = $controller->invokeAction($request);
+		$result = $controller->invokeAction();
 		if ($result instanceof Response) {
 			$render = false;
 			$response = $result;

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -730,7 +730,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -746,7 +746,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -762,7 +762,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -778,7 +778,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -794,7 +794,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -814,7 +814,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$Controller->invokeAction($url);
+		$Controller->invokeAction();
 	}
 
 /**
@@ -832,7 +832,7 @@ class ControllerTest extends TestCase {
 		$response = $this->getMock('Cake\Network\Response');
 
 		$Controller = new TestController($url, $response);
-		$result = $Controller->invokeAction($url);
+		$result = $Controller->invokeAction();
 		$this->assertEquals('I am from the controller.', $result);
 	}
 

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -58,13 +58,12 @@ class TestDispatcher extends Dispatcher {
  * invoke method
  *
  * @param \Cake\Controller\Controller $controller
- * @param \Cake\Network\Request $request
  * @param \Cake\Network\Response $response
  * @return void
  */
-	protected function _invoke(Controller $controller, Request $request, Response $response) {
+	protected function _invoke(Controller $controller, Response $response) {
 		$this->controller = $controller;
-		return parent::_invoke($controller, $request, $response);
+		return parent::_invoke($controller, $response);
 	}
 
 /**


### PR DESCRIPTION
Minor tidy up. Controller::__construct() takes a Request object and sets itself up accordingly. invokeAction() is potentially slipping a whole Request object in the backdoor. If that is desired Controller::setRequest() should be used since setting up the Controller for a new request is somewhat non-trivial. Its just disconcerting and another unknown having this potential way of setting the request. Its uneeded so should be removed.

Note this change has no actual affect on the Request object the Controller ends up with in the default flow of events.
