### PR TITLE
Use objects for type maps and pass them to QueryExpressions (to be able to use default mapping from schema)

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -431,7 +431,7 @@ class QueryExpression implements ExpressionInterface, Countable {
 				$this->_conditions[] = $c;
 				continue;
 			}
-			
+
 			if ($numericKey && is_array($c) || in_array(strtolower($k), $operators)) {
 				$this->_conditions[] = new self($c, $typeMap, $numericKey ? 'AND' : $k);
 				continue;

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -16,6 +16,7 @@ namespace Cake\Database\Expression;
 
 use Cake\Database\ExpressionInterface;
 use Cake\Database\Query;
+use Cake\Database\TypeMapTrait;
 use Cake\Database\ValueBinder;
 use Cake\Error;
 use \Countable;
@@ -27,6 +28,8 @@ use \Countable;
  * values correctly into the statement.
  */
 class ValuesExpression implements ExpressionInterface {
+
+	use TypeMapTrait;
 
 /**
  * Array of values to insert.
@@ -43,13 +46,6 @@ class ValuesExpression implements ExpressionInterface {
 	protected $_columns = [];
 
 /**
- * List of column types.
- *
- * @var array
- */
-	protected $_types = [];
-
-/**
  * The Query object to use as a values expression
  *
  * @var \Cake\Database\Query
@@ -60,11 +56,11 @@ class ValuesExpression implements ExpressionInterface {
  * Constructor
  *
  * @param array $columns The list of columns that are going to be part of the values.
- * @param array $types A dictionary of column -> type names
+ * @param TypeMap $types A dictionary of column -> type names
  */
-	public function __construct(array $columns, array $types = []) {
+	public function __construct(array $columns, $typeMap) {
 		$this->_columns = $columns;
-		$this->_types = $types;
+		$this->typeMap($typeMap);
 	}
 
 /**
@@ -152,7 +148,7 @@ class ValuesExpression implements ExpressionInterface {
 		foreach ($this->_values as $row) {
 			$row = array_merge($defaults, $row);
 			foreach ($row as $column => $value) {
-				$type = isset($this->_types[$column]) ? $this->_types[$column] : null;
+				$type = $this->typeMap()->type($column);
 				$generator->bind($i++, $value, $type);
 			}
 		}

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -14,18 +14,32 @@
  */
 namespace Cake\Database;
 
+/**
+ * Implements default and single-use mappings for columns to their associated types
+ */
 class TypeMap {
 
 /**
+ * Associative array with the default fields and their types this query might contain
+ * used to avoid repetition when calling multiple times functions inside this class that
+ * may require a custom type for a specific field.
+ *
  * @var array
  */
 	protected $_defaults;
 
 /**
+ * Associative array with the fields and their types that override defaults this query might contain
+ * used to avoid repetition when calling multiple times functions inside this class that
+ * may require a custom type for a specific field.
+ *
  * @var array
  */
 	protected $_types = [];
+
 /**
+ * Creates an instance with the given defaults
+ *
  * @param array $defaults
  */
 	public function __construct(array $defaults = []) {
@@ -33,22 +47,45 @@ class TypeMap {
 	}
 
 /**
- * Set/Get defaults
+ * Configures a map of default fields and their associated types to be
+ * used as the default list of types for every function in this class
+ * with a $types param. Useful to avoid repetition when calling the same
+ * functions using the same fields and types.
  *
- * @var this|array
+ * If called with no arguments it will return the currently configured types.
+ *
+ * ## Example
+ *
+ * {{{
+ *	$query->defaults(['created' => 'datetime', 'is_visible' => 'boolean']);
+ * }}}
+ *
+ * @param array $defaults associative array where keys are field names and values
+ * are the correspondent type.
+ * @return this|array
  */
 	public function defaults(array $defaults = null) {
 		if ($defaults === null) {
-				return $this->_defaults;
+			return $this->_defaults;
 		}
 		$this->_defaults = $defaults;
 		return $this;
 	}
 
 /**
- * Set/Get types
+ * Configures a map of fields and their associated types for single-use.
  *
- * @var this|array
+ * If called with no arguments it will return the currently configured types.
+ *
+ * ## Example
+ *
+ * {{{
+ *	$query->types(['created' => 'time']);
+ * }}}
+ *
+ * @param array $defaults associative array where keys are field names and values
+ * are the correspondent type.
+ * @return this|array
  */
 	public function types(array $types = null) {
 		if ($types === null) {
@@ -59,9 +96,11 @@ class TypeMap {
 	}
 
 /**
- * Get column type
+ * Returns the type of the given column. If there is no single use type is configured,
+ * the column type will be looked for inside the default mapping. If neither exist,
+ * null will be returned.
  *
- * @var string
+ * @var null|string
  */
 	public function type($column) {
 		if (isset($this->_types[$column])) {

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Database;
+
+class TypeMap {
+
+/**
+ * @var array
+ */
+	protected $_defaults;
+
+/**
+ * @var array
+ */
+	protected $_types = [];
+/**
+ * @param array $defaults
+ */
+	public function __construct(array $defaults = []) {
+			$this->defaults($defaults);
+	}
+
+/**
+ * Set/Get defaults
+ *
+ * @var this|array
+ */
+	public function defaults(array $defaults = null) {
+		if ($defaults === null) {
+				return $this->_defaults;
+		}
+		$this->_defaults = $defaults;
+		return $this;
+	}
+
+/**
+ * Set/Get types
+ *
+ * @var this|array
+ */
+	public function types(array $types = null) {
+		if ($types === null) {
+			return $this->_types;
+		}
+		$this->_types = $types;
+		return $this;
+	}
+
+/**
+ * Get column type
+ *
+ * @var string
+ */
+	public function type($column) {
+		if (isset($this->_types[$column])) {
+			return $this->_types[$column];
+		}
+		if (isset($this->_defaults[$column])) {
+			return $this->_defaults[$column];
+		}
+		return null;
+	}
+
+}

--- a/src/Database/TypeMap.php
+++ b/src/Database/TypeMap.php
@@ -29,7 +29,7 @@ class TypeMap {
  * @param array $defaults
  */
 	public function __construct(array $defaults = []) {
-			$this->defaults($defaults);
+		$this->defaults($defaults);
 	}
 
 /**

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * PHP Version 5.4
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -28,20 +26,22 @@ trait TypeMapTrait {
 /**
  * Setter/Getter for type map
  *
+ * @param array|TypeMap $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
  * @return this|TypeMap
  */
 	public function typeMap($typeMap = null) {
+		$this->_typeMap = ($this->_typeMap) ?: new TypeMap();
 		if ($typeMap === null) {
-			$this->_typeMap = ($this->_typeMap) ?: new TypeMap();
 			return $this->_typeMap;
 		}
-		$this->_typeMap = $typeMap;
+		$this->_typeMap = is_array($typeMap) ? (new TypeMap)->types($typeMap) : $typeMap;
 		return $this;
 	}
 
 /**
  * Allows setting default types when chaining query
  *
+ * @param array $types
  * @return this|array
  */
 	public function defaultTypes(array $types = null) {

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -16,6 +16,9 @@ namespace Cake\Database;
 
 use Cake\Database\TypeMap;
 
+/*
+ * Represents a class that holds a TypeMap object
+ */
 trait TypeMapTrait {
 
 /**
@@ -24,7 +27,8 @@ trait TypeMapTrait {
 	protected $_typeMap;
 
 /**
- * Setter/Getter for type map
+ * Creates a new TypeMap if $typeMap is an array, otherwise returns the existing type map
+ * or exchanges it for the given one.
  *
  * @param array|TypeMap $typeMap Creates a TypeMap if array, otherwise sets the given TypeMap
  * @return this|TypeMap
@@ -34,7 +38,7 @@ trait TypeMapTrait {
 		if ($typeMap === null) {
 			return $this->_typeMap;
 		}
-		$this->_typeMap = is_array($typeMap) ? (new TypeMap)->types($typeMap) : $typeMap;
+		$this->_typeMap = is_array($typeMap) ? new TypeMap($typeMap) : $typeMap;
 		return $this;
 	}
 

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHP Version 5.4
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\Database;
+
+use Cake\Database\TypeMap;
+
+trait TypeMapTrait {
+
+/**
+ * @var \Cake\Database\TypeMap
+ */
+	protected $_typeMap;
+
+/**
+ * Setter/Getter for type map
+ *
+ * @return this|TypeMap
+ */
+	public function typeMap($typeMap = null) {
+		if ($typeMap === null) {
+			$this->_typeMap = ($this->_typeMap) ?: new TypeMap();
+			return $this->_typeMap;
+		}
+		$this->_typeMap = $typeMap;
+		return $this;
+	}
+
+/**
+ * Allows setting default types when chaining query
+ *
+ * @return this|array
+ */
+	public function defaultTypes(array $types = null) {
+		if ($types === null) {
+			return $this->typeMap()->defaults();
+		}
+		$this->typeMap()->defaults($types);
+		return $this;
+	}
+
+}

--- a/src/Database/TypeMapTrait.php
+++ b/src/Database/TypeMapTrait.php
@@ -34,7 +34,9 @@ trait TypeMapTrait {
  * @return this|TypeMap
  */
 	public function typeMap($typeMap = null) {
-		$this->_typeMap = ($this->_typeMap) ?: new TypeMap();
+		if (!$this->_typeMap) {
+			$this->_typeMap = new TypeMap();
+		}
 		if ($typeMap === null) {
 			return $this->_typeMap;
 		}

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -102,7 +102,7 @@ class Query extends DatabaseQuery {
  * @param \Cake\ORM\Table $table
  */
 	public function __construct($connection, $table) {
-		$this->connection($connection);
+		parent::__construct($connection);
 		$this->repository($table);
 
 		if ($this->_repository) {
@@ -128,7 +128,7 @@ class Query extends DatabaseQuery {
 		foreach ($schema->columns() as $f) {
 			$fields[$f] = $fields[$alias . '.' . $f] = $schema->columnType($f);
 		}
-		$this->defaultTypes($this->defaultTypes() + $fields);
+		$this->defaultTypes($fields);
 
 		return $this;
 	}

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
@@ -222,11 +223,17 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
+		$typeMap = new TypeMap([
+			'Tags.id' => 'integer',
+			'id' => 'integer',
+			'Tags.name' => 'string',
+			'name' => 'string',
+		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], ['Tags.name' => 'string']),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -235,12 +242,19 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
+		$typeMap = new TypeMap([
+			'ArticlesTags.article_id' => 'integer',
+			'article_id' => 'integer',
+			'ArticlesTags.tag_id' => 'integer',
+			'tag_id' => 'integer',
+		]);
+
 		$query->expects($this->at(2))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -269,11 +283,17 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
+		$typeMap = new TypeMap([
+			'Tags.id' => 'integer',
+			'id' => 'integer',
+			'Tags.name' => 'string',
+			'name' => 'string',
+		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], ['Tags.name' => 'string']),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -282,12 +302,19 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
+		$typeMap = new TypeMap([
+			'ArticlesTags.article_id' => 'integer',
+			'article_id' => 'integer',
+			'ArticlesTags.tag_id' => 'integer',
+			'tag_id' => 'integer',
+		]);
+
 		$query->expects($this->at(1))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -310,12 +337,18 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
+		$typeMap = new TypeMap([
+			'Tags.id' => 'integer',
+			'id' => 'integer',
+			'Tags.name' => 'string',
+			'name' => 'string',
+		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Tags.name' => 'cake',
-				], ['Tags.name' => 'string']),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -324,12 +357,19 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
+		$typeMap = new TypeMap([
+			'ArticlesTags.article_id' => 'integer',
+			'article_id' => 'integer',
+			'ArticlesTags.tag_id' => 'integer',
+			'tag_id' => 'integer',
+		]);
+
 		$query->expects($this->at(2))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -367,11 +407,17 @@ class BelongsToManyTest extends TestCase {
 		$this->article->primaryKey(['id', 'site_id']);
 		$this->tag->primaryKey(['id', 'my_site_id']);
 		$association = new BelongsToMany('Tags', $config);
+		$typeMap = new TypeMap([
+			'Tags.id' => 'integer',
+			'id' => 'integer',
+			'Tags.name' => 'string',
+			'name' => 'string',
+		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], ['Tags.name' => 'string']),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -382,12 +428,19 @@ class BelongsToManyTest extends TestCase {
 		$fieldC = new IdentifierExpression('ArticlesTags.tag_id');
 		$fieldD = new IdentifierExpression('ArticlesTags.tag_site_id');
 
+		$typeMap = new TypeMap([
+			'ArticlesTags.article_id' => 'integer',
+			'article_id' => 'integer',
+			'ArticlesTags.tag_id' => 'integer',
+			'tag_id' => 'integer',
+		]);
+
 		$query->expects($this->at(1))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $fieldA, 'Articles.site_id' => $fieldB],
 					['Tags.id' => $fieldC, 'Tags.my_site_id' => $fieldD]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -16,10 +16,10 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Association\BelongsToMany;
 use Cake\ORM\Entity;
@@ -71,6 +71,18 @@ class BelongsToManyTest extends TestCase {
 					'primary' => ['type' => 'primary', 'columns' => ['article_id', 'tag_id']]
 				]
 			]
+		]);
+		$this->tagsTypeMap = new TypeMap([
+			'Tags.id' => 'integer',
+			'id' => 'integer',
+			'Tags.name' => 'string',
+			'name' => 'string',
+		]);
+		$this->articlesTagsTypeMap = new TypeMap([
+			'ArticlesTags.article_id' => 'integer',
+			'article_id' => 'integer',
+			'ArticlesTags.tag_id' => 'integer',
+			'tag_id' => 'integer',
 		]);
 	}
 
@@ -223,17 +235,11 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
-		$typeMap = new TypeMap([
-			'Tags.id' => 'integer',
-			'id' => 'integer',
-			'Tags.name' => 'string',
-			'name' => 'string',
-		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], $typeMap),
+				], $this->tagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -242,19 +248,12 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
-		$typeMap = new TypeMap([
-			'ArticlesTags.article_id' => 'integer',
-			'article_id' => 'integer',
-			'ArticlesTags.tag_id' => 'integer',
-			'tag_id' => 'integer',
-		]);
-
 		$query->expects($this->at(2))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				], $typeMap),
+				], $this->articlesTagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -283,17 +282,11 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
-		$typeMap = new TypeMap([
-			'Tags.id' => 'integer',
-			'id' => 'integer',
-			'Tags.name' => 'string',
-			'name' => 'string',
-		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], $typeMap),
+				], $this->tagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -302,19 +295,12 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
-		$typeMap = new TypeMap([
-			'ArticlesTags.article_id' => 'integer',
-			'article_id' => 'integer',
-			'ArticlesTags.tag_id' => 'integer',
-			'tag_id' => 'integer',
-		]);
-
 		$query->expects($this->at(1))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				], $typeMap),
+				], $this->articlesTagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -337,18 +323,12 @@ class BelongsToManyTest extends TestCase {
 			'conditions' => ['Tags.name' => 'cake']
 		];
 		$association = new BelongsToMany('Tags', $config);
-		$typeMap = new TypeMap([
-			'Tags.id' => 'integer',
-			'id' => 'integer',
-			'Tags.name' => 'string',
-			'name' => 'string',
-		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Tags.name' => 'cake',
-				], $typeMap),
+				], $this->tagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -357,19 +337,12 @@ class BelongsToManyTest extends TestCase {
 		$field1 = new IdentifierExpression('ArticlesTags.article_id');
 		$field2 = new IdentifierExpression('ArticlesTags.tag_id');
 
-		$typeMap = new TypeMap([
-			'ArticlesTags.article_id' => 'integer',
-			'article_id' => 'integer',
-			'ArticlesTags.tag_id' => 'integer',
-			'tag_id' => 'integer',
-		]);
-
 		$query->expects($this->at(2))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $field1],
 					['Tags.id' => $field2]
-				], $typeMap),
+				], $this->articlesTagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]
@@ -407,17 +380,11 @@ class BelongsToManyTest extends TestCase {
 		$this->article->primaryKey(['id', 'site_id']);
 		$this->tag->primaryKey(['id', 'my_site_id']);
 		$association = new BelongsToMany('Tags', $config);
-		$typeMap = new TypeMap([
-			'Tags.id' => 'integer',
-			'id' => 'integer',
-			'Tags.name' => 'string',
-			'name' => 'string',
-		]);
 		$query->expects($this->at(0))->method('join')->with([
 			'Tags' => [
 				'conditions' => new QueryExpression([
 					'Tags.name' => 'cake'
-				], $typeMap),
+				], $this->tagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'tags'
 			]
@@ -428,19 +395,12 @@ class BelongsToManyTest extends TestCase {
 		$fieldC = new IdentifierExpression('ArticlesTags.tag_id');
 		$fieldD = new IdentifierExpression('ArticlesTags.tag_site_id');
 
-		$typeMap = new TypeMap([
-			'ArticlesTags.article_id' => 'integer',
-			'article_id' => 'integer',
-			'ArticlesTags.tag_id' => 'integer',
-			'tag_id' => 'integer',
-		]);
-
 		$query->expects($this->at(1))->method('join')->with([
 			'ArticlesTags' => [
 				'conditions' => new QueryExpression([
 					['Articles.id' => $fieldA, 'Articles.site_id' => $fieldB],
 					['Tags.id' => $fieldC, 'Tags.my_site_id' => $fieldD]
-				], $typeMap),
+				], $this->articlesTagsTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles_tags'
 			]

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\BelongsTo;
@@ -94,12 +95,18 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], ['Companies.id' => 'integer']),
+				], $typeMap),
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]
@@ -124,11 +131,17 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Companies.is_active' => true]
 		];
 		$association = new BelongsTo('Companies', $config);
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => false
-				]),
+				], $typeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -159,12 +172,18 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], ['Companies.id' => 'integer']),
+				], $typeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -188,13 +207,19 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], ['Companies.id' => 'integer']),
+				], $typeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -226,12 +251,18 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], ['Companies.id' => 'integer']),
+				], $typeMap),
 				'table' => 'companies',
 				'type' => 'INNER'
 			]
@@ -308,12 +339,18 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsTo('Companies', $config);
 		$field1 = new IdentifierExpression('Clients.company_id');
 		$field2 = new IdentifierExpression('Clients.company_tenant_id');
+		$typeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field1, 'Companies.tenant_id' => $field2]
-				], ['Companies.id' => 'integer']),
+				], $typeMap),
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -16,9 +16,9 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\TypeMap;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -56,6 +56,12 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 					'primary' => ['type' => 'primary', 'columns' => ['id']]
 				]
 			]
+		]);
+		$this->companiesTypeMap = new TypeMap([
+			'Companies.id' => 'integer',
+			'id' => 'integer',
+			'Companies.company_name' => 'string',
+			'company_name' => 'string',
 		]);
 	}
 
@@ -95,18 +101,12 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]
@@ -131,17 +131,11 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Companies.is_active' => true]
 		];
 		$association = new BelongsTo('Companies', $config);
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => false
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -172,18 +166,12 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -207,19 +195,13 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'type' => 'LEFT',
 				'table' => 'companies',
 			]
@@ -251,18 +233,12 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new BelongsTo('Companies', $config);
 		$field = new IdentifierExpression('Clients.company_id');
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field]
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'table' => 'companies',
 				'type' => 'INNER'
 			]
@@ -339,18 +315,12 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		$association = new BelongsTo('Companies', $config);
 		$field1 = new IdentifierExpression('Clients.company_id');
 		$field2 = new IdentifierExpression('Clients.company_tenant_id');
-		$typeMap = new TypeMap([
-			'Companies.id' => 'integer',
-			'id' => 'integer',
-			'Companies.company_name' => 'string',
-			'company_name' => 'string',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Companies' => [
 				'conditions' => new QueryExpression([
 					'Companies.is_active' => true,
 					['Companies.id' => $field1, 'Companies.tenant_id' => $field2]
-				], $typeMap),
+				], $this->companiesTypeMap),
 				'table' => 'companies',
 				'type' => 'LEFT'
 			]

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
@@ -478,12 +479,20 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -509,11 +518,19 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Articles.is_active' => true]
 		];
 		$association = new HasMany('Articles', $config);
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => false
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -544,12 +561,20 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -576,12 +601,20 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$field1 = new IdentifierExpression('Articles.author_id');
 		$field2 = new IdentifierExpression('Articles.author_site_id');
 		$association = new HasMany('Articles', $config);
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field1, 'Authors.site_id' => $field2]
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -628,13 +661,21 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Articles.is_active' => true,
 					['Authors.id' => $field],
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -16,10 +16,10 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Database\Expression\TupleComparison;
+use Cake\Database\TypeMap;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -60,6 +60,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'_constraints' => [
 				'primary' => ['type' => 'primary', 'columns' => ['id']]
 			]
+		]);
+		$this->articlesTypeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
 		]);
 	}
 
@@ -479,20 +487,12 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				], $typeMap),
+				], $this->articlesTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -518,19 +518,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Articles.is_active' => true]
 		];
 		$association = new HasMany('Articles', $config);
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => false
-				], $typeMap),
+				], $this->articlesTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -561,20 +553,12 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field]
-				], $typeMap),
+				], $this->articlesTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -601,20 +585,12 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$field1 = new IdentifierExpression('Articles.author_id');
 		$field2 = new IdentifierExpression('Articles.author_site_id');
 		$association = new HasMany('Articles', $config);
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'Articles.is_active' => true,
 					['Authors.id' => $field1, 'Authors.site_id' => $field2]
-				], $typeMap),
+				], $this->articlesTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]
@@ -661,21 +637,13 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$field = new IdentifierExpression('Articles.author_id');
 		$association = new HasMany('Articles', $config);
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Articles' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Articles.is_active' => true,
 					['Authors.id' => $field],
-				], $typeMap),
+				], $this->articlesTypeMap),
 				'type' => 'INNER',
 				'table' => 'articles'
 			]

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -16,9 +16,9 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\TypeMap;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Entity;
 use Cake\ORM\Query;
@@ -56,6 +56,14 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 					'primary' => ['type' => 'primary', 'columns' => ['id']]
 				]
 			]
+		]);
+		$this->profilesTypeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
 		]);
 	}
 
@@ -95,20 +103,12 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
-		$typeMap = new TypeMap([
-			'Profiles.id' => 'integer',
-			'id' => 'integer',
-			'Profiles.first_name' => 'string',
-			'first_name' => 'string',
-			'Profiles.user_id' => 'integer',
-			'user_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				], $typeMap),
+				], $this->profilesTypeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -135,19 +135,11 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Profiles.is_active' => true]
 		];
 		$association = new HasOne('Profiles', $config);
-		$typeMap = new TypeMap([
-			'Profiles.id' => 'integer',
-			'id' => 'integer',
-			'Profiles.first_name' => 'string',
-			'first_name' => 'string',
-			'Profiles.user_id' => 'integer',
-			'user_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => false
-				], $typeMap),
+				], $this->profilesTypeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -178,20 +170,12 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
-		$typeMap = new TypeMap([
-			'Profiles.id' => 'integer',
-			'id' => 'integer',
-			'Profiles.first_name' => 'string',
-			'first_name' => 'string',
-			'Profiles.user_id' => 'integer',
-			'user_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				], $typeMap),
+				], $this->profilesTypeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -215,21 +199,13 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
-		$typeMap = new TypeMap([
-			'Profiles.id' => 'integer',
-			'id' => 'integer',
-			'Profiles.first_name' => 'string',
-			'first_name' => 'string',
-			'Profiles.user_id' => 'integer',
-			'user_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				], $typeMap),
+				], $this->profilesTypeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -263,20 +239,12 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association = new HasOne('Profiles', $config);
 		$field1 = new IdentifierExpression('Profiles.user_id');
 		$field2 = new IdentifierExpression('Profiles.user_site_id');
-		$typeMap = new TypeMap([
-			'Profiles.id' => 'integer',
-			'id' => 'integer',
-			'Profiles.first_name' => 'string',
-			'first_name' => 'string',
-			'Profiles.user_id' => 'integer',
-			'user_id' => 'integer',
-		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field1, 'Users.site_id' => $field2],
-				], $typeMap),
+				], $this->profilesTypeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -16,6 +16,7 @@
  */
 namespace Cake\Test\TestCase\ORM\Association;
 
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\ORM\Association\HasOne;
@@ -94,12 +95,20 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
+		$typeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -126,11 +135,19 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'conditions' => ['Profiles.is_active' => true]
 		];
 		$association = new HasOne('Profiles', $config);
+		$typeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => false
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -161,12 +178,20 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
+		$typeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -190,13 +215,21 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasOne('Profiles', $config);
 		$field = new IdentifierExpression('Profiles.user_id');
+		$typeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'a' => 1,
 					'Profiles.is_active' => true,
 					['Users.id' => $field],
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]
@@ -230,12 +263,20 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		$association = new HasOne('Profiles', $config);
 		$field1 = new IdentifierExpression('Profiles.user_id');
 		$field2 = new IdentifierExpression('Profiles.user_site_id');
+		$typeMap = new TypeMap([
+			'Profiles.id' => 'integer',
+			'id' => 'integer',
+			'Profiles.first_name' => 'string',
+			'first_name' => 'string',
+			'Profiles.user_id' => 'integer',
+			'user_id' => 'integer',
+		]);
 		$query->expects($this->once())->method('join')->with([
 			'Profiles' => [
 				'conditions' => new QueryExpression([
 					'Profiles.is_active' => true,
 					['Users.id' => $field1, 'Users.site_id' => $field2],
-				]),
+				], $typeMap),
 				'type' => 'INNER',
 				'table' => 'profiles'
 			]

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -14,9 +14,9 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\EagerLoader;
 use Cake\ORM\Query;
@@ -77,6 +77,43 @@ class EagerLoaderTest extends TestCase {
 		$orders->hasOne('stuff');
 		$stuff->belongsTo('stuffTypes');
 		$companies->belongsTo('categories');
+
+		$this->clientsTypeMap = new TypeMap([
+			'clients.id' => 'integer',
+			'id' => 'integer',
+			'clients.name' => 'string',
+			'name' => 'string',
+			'clients.phone' => 'string',
+			'phone' => 'string',
+		]);
+		$this->ordersTypeMap = new TypeMap([
+			'orders.id' => 'integer',
+			'id' => 'integer',
+			'orders.total' => 'string',
+			'total' => 'string',
+			'orders.placed' => 'datetime',
+			'placed' => 'datetime',
+		]);
+		$this->orderTypesTypeMap = new TypeMap([
+			'orderTypes.id' => 'integer',
+			'id' => 'integer',
+		]);
+		$this->stuffTypeMap = new TypeMap([
+			'stuff.id' => 'integer',
+			'id' => 'integer',
+		]);
+		$this->stuffTypesTypeMap = new TypeMap([
+			'stuffTypes.id' => 'integer',
+			'id' => 'integer',
+		]);
+		$this->companiesTypeMap = new TypeMap([
+			'companies.id' => 'integer',
+			'id' => 'integer',
+		]);
+		$this->categoriesTypeMap = new TypeMap([
+			'categories.id' => 'integer',
+			'id' => 'integer',
+		]);
 	}
 
 /**
@@ -110,16 +147,7 @@ class EagerLoaderTest extends TestCase {
 
 		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
 
-		$typeMap = new TypeMap([
-			'clients.id' => 'integer',
-			'id' => 'integer',
-			'clients.name' => 'string',
-			'name' => 'string',
-			'clients.phone' => 'string',
-			'phone' => 'string',
-		]);
-
-		$query->typeMap($typeMap);
+		$query->typeMap($this->clientsTypeMap);
 
 		$query->expects($this->at(0))->method('join')
 			->with(['clients' => [
@@ -127,18 +155,9 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['clients.id' => new IdentifierExpression('foo.client_id')],
-				], $query->typeMap())
+				], $this->clientsTypeMap)
 			]])
 			->will($this->returnValue($query));
-
-		$typeMap = new TypeMap([
-			'orders.id' => 'integer',
-			'id' => 'integer',
-			'orders.total' => 'string',
-			'total' => 'string',
-			'orders.placed' => 'datetime',
-			'placed' => 'datetime',
-		]);
 
 		$query->expects($this->at(1))->method('join')
 			->with(['orders' => [
@@ -146,14 +165,9 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'INNER',
 				'conditions' => new QueryExpression([
 					['clients.id' => new IdentifierExpression('orders.client_id')]
-				], $typeMap)
+				], $this->ordersTypeMap)
 			]])
 			->will($this->returnValue($query));
-
-		$typeMap = new TypeMap([
-			'orderTypes.id' => 'integer',
-			'id' => 'integer',
-		]);
 
 		$query->expects($this->at(2))->method('join')
 			->with(['orderTypes' => [
@@ -161,14 +175,9 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['orderTypes.id' => new IdentifierExpression('orders.order_type_id')]
-				], $typeMap)
+				], $this->orderTypesTypeMap)
 			]])
 			->will($this->returnValue($query));
-
-		$typeMap = new TypeMap([
-			'stuff.id' => 'integer',
-			'id' => 'integer',
-		]);
 
 		$query->expects($this->at(3))->method('join')
 			->with(['stuff' => [
@@ -176,14 +185,9 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'INNER',
 				'conditions' => new QueryExpression([
 					['orders.id' => new IdentifierExpression('stuff.order_id')]
-				], $typeMap)
+				], $this->stuffTypeMap)
 			]])
 			->will($this->returnValue($query));
-
-		$typeMap = new TypeMap([
-			'stuffTypes.id' => 'integer',
-			'id' => 'integer',
-		]);
 
 		$query->expects($this->at(4))->method('join')
 			->with(['stuffTypes' => [
@@ -191,14 +195,9 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['stuffTypes.id' => new IdentifierExpression('stuff.stuff_type_id')]
-				], $typeMap)
+				], $this->stuffTypesTypeMap)
 			]])
 			->will($this->returnValue($query));
-
-		$typeMap = new TypeMap([
-			'companies.id' => 'integer',
-			'id' => 'integer',
-		]);
 
 		$query->expects($this->at(5))->method('join')
 			->with(['companies' => [
@@ -206,21 +205,17 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['companies.id' => new IdentifierExpression('clients.organization_id')]
-				], $typeMap)
+				], $this->companiesTypeMap)
 			]])
 			->will($this->returnValue($query));
 
-		$typeMap = new TypeMap([
-			'categories.id' => 'integer',
-			'id' => 'integer',
-		]);
 		$query->expects($this->at(6))->method('join')
 			->with(['categories' => [
 				'table' => 'categories',
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['categories.id' => new IdentifierExpression('companies.category_id')]
-				], $typeMap)
+				], $this->categoriesTypeMap)
 			]])
 			->will($this->returnValue($query));
 

--- a/tests/TestCase/ORM/EagerLoaderTest.php
+++ b/tests/TestCase/ORM/EagerLoaderTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\ORM;
 
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
@@ -109,15 +110,35 @@ class EagerLoaderTest extends TestCase {
 
 		$query = $this->getMock('\Cake\ORM\Query', ['join'], [$this->connection, $this->table]);
 
+		$typeMap = new TypeMap([
+			'clients.id' => 'integer',
+			'id' => 'integer',
+			'clients.name' => 'string',
+			'name' => 'string',
+			'clients.phone' => 'string',
+			'phone' => 'string',
+		]);
+
+		$query->typeMap($typeMap);
+
 		$query->expects($this->at(0))->method('join')
 			->with(['clients' => [
 				'table' => 'clients',
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
-					['clients.id' => new IdentifierExpression('foo.client_id')]
-				], ['clients.id' => 'integer'])
+					['clients.id' => new IdentifierExpression('foo.client_id')],
+				], $query->typeMap())
 			]])
 			->will($this->returnValue($query));
+
+		$typeMap = new TypeMap([
+			'orders.id' => 'integer',
+			'id' => 'integer',
+			'orders.total' => 'string',
+			'total' => 'string',
+			'orders.placed' => 'datetime',
+			'placed' => 'datetime',
+		]);
 
 		$query->expects($this->at(1))->method('join')
 			->with(['orders' => [
@@ -125,9 +146,14 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'INNER',
 				'conditions' => new QueryExpression([
 					['clients.id' => new IdentifierExpression('orders.client_id')]
-				])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
+
+		$typeMap = new TypeMap([
+			'orderTypes.id' => 'integer',
+			'id' => 'integer',
+		]);
 
 		$query->expects($this->at(2))->method('join')
 			->with(['orderTypes' => [
@@ -135,9 +161,14 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['orderTypes.id' => new IdentifierExpression('orders.order_type_id')]
-				], ['orderTypes.id' => 'integer'])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
+
+		$typeMap = new TypeMap([
+			'stuff.id' => 'integer',
+			'id' => 'integer',
+		]);
 
 		$query->expects($this->at(3))->method('join')
 			->with(['stuff' => [
@@ -145,9 +176,14 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'INNER',
 				'conditions' => new QueryExpression([
 					['orders.id' => new IdentifierExpression('stuff.order_id')]
-				])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
+
+		$typeMap = new TypeMap([
+			'stuffTypes.id' => 'integer',
+			'id' => 'integer',
+		]);
 
 		$query->expects($this->at(4))->method('join')
 			->with(['stuffTypes' => [
@@ -155,9 +191,14 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['stuffTypes.id' => new IdentifierExpression('stuff.stuff_type_id')]
-				], ['stuffTypes.id' => 'integer'])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
+
+		$typeMap = new TypeMap([
+			'companies.id' => 'integer',
+			'id' => 'integer',
+		]);
 
 		$query->expects($this->at(5))->method('join')
 			->with(['companies' => [
@@ -165,17 +206,21 @@ class EagerLoaderTest extends TestCase {
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['companies.id' => new IdentifierExpression('clients.organization_id')]
-				], ['companies.id' => 'integer'])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
 
+		$typeMap = new TypeMap([
+			'categories.id' => 'integer',
+			'id' => 'integer',
+		]);
 		$query->expects($this->at(6))->method('join')
 			->with(['categories' => [
 				'table' => 'categories',
 				'type' => 'LEFT',
 				'conditions' => new QueryExpression([
 					['categories.id' => new IdentifierExpression('companies.category_id')]
-				], ['categories.id' => 'integer'])
+				], $typeMap)
 			]])
 			->will($this->returnValue($query));
 

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\ORM;
 use Cake\Database\Expression\IdentifierExpression;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Query;
 use Cake\ORM\ResultSet;
@@ -764,13 +765,16 @@ class QueryTest extends TestCase {
 
 		$this->assertEquals(['field_a', 'field_b'], $query->clause('select'));
 
+		$typeMap = new TypeMap(['foo.id' => 'integer', 'id' => 'integer']);
 		$expected = new QueryExpression($options['conditions']);
+		$expected->typeMap($typeMap);
 		$result = $query->clause('where');
 		$this->assertEquals($expected, $result);
 
 		$this->assertEquals(1, $query->clause('limit'));
 
 		$expected = new QueryExpression(['a > b']);
+		$expected->typeMap($typeMap);
 		$result = $query->clause('join');
 		$this->assertEquals([
 			'table_a' => ['alias' => 'table_a', 'type' => 'INNER', 'conditions' => $expected]
@@ -783,6 +787,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals(['field_a'], $query->clause('group'));
 
 		$expected = new QueryExpression($options['having']);
+		$expected->typeMap($typeMap);
 		$this->assertEquals($expected, $query->clause('having'));
 
 		$expected = ['table_a' => ['table_b' => []]];

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -86,6 +86,8 @@ class QueryTest extends TestCase {
 		$orders->hasOne('stuff');
 		$stuff->belongsTo('stuffTypes');
 		$companies->belongsTo('categories');
+
+		$this->fooTypeMap = new TypeMap(['foo.id' => 'integer', 'id' => 'integer']);
 	}
 
 /**
@@ -765,16 +767,14 @@ class QueryTest extends TestCase {
 
 		$this->assertEquals(['field_a', 'field_b'], $query->clause('select'));
 
-		$typeMap = new TypeMap(['foo.id' => 'integer', 'id' => 'integer']);
-		$expected = new QueryExpression($options['conditions']);
-		$expected->typeMap($typeMap);
+		$expected = new QueryExpression($options['conditions'], $this->fooTypeMap);
 		$result = $query->clause('where');
 		$this->assertEquals($expected, $result);
 
 		$this->assertEquals(1, $query->clause('limit'));
 
 		$expected = new QueryExpression(['a > b']);
-		$expected->typeMap($typeMap);
+		$expected->typeMap($this->fooTypeMap);
 		$result = $query->clause('join');
 		$this->assertEquals([
 			'table_a' => ['alias' => 'table_a', 'type' => 'INNER', 'conditions' => $expected]
@@ -787,7 +787,7 @@ class QueryTest extends TestCase {
 		$this->assertEquals(['field_a'], $query->clause('group'));
 
 		$expected = new QueryExpression($options['having']);
-		$expected->typeMap($typeMap);
+		$expected->typeMap($this->fooTypeMap);
 		$this->assertEquals($expected, $query->clause('having'));
 
 		$expected = ['table_a' => ['table_b' => []]];

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -15,9 +15,9 @@
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Core\Configure;
-use Cake\Database\TypeMap;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
+use Cake\Database\TypeMap;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -53,6 +53,31 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		parent::setUp();
 		$this->connection = ConnectionManager::get('test');
 		Configure::write('App.namespace', 'TestApp');
+
+		$this->usersTypeMap = new TypeMap([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
+		$this->articlesTypeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+			'Articles.body' => 'text',
+			'body' => 'text',
+			'Articles.published' => 'string',
+			'published' => 'string',
+		]);
 	}
 
 	public function tearDown() {
@@ -2038,19 +2063,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$result = $table->findByUsername('garrett');
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
-		$typeMap = new TypeMap([
-			'Users.id' => 'integer',
-			'id' => 'integer',
-			'Users.username' => 'string',
-			'username' => 'string',
-			'Users.password' => 'string',
-			'password' => 'string',
-			'Users.created' => 'timestamp',
-			'created' => 'timestamp',
-			'Users.updated' => 'timestamp',
-			'updated' => 'timestamp',
-		]);
-		$expected = new QueryExpression(['username' => 'garrett'], $typeMap);
+
+		$expected = new QueryExpression(['username' => 'garrett'], $this->usersTypeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2104,19 +2118,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$result = $table->findByUsernameAndId('garrett', 4);
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 
-		$typeMap = new TypeMap([
-			'Users.id' => 'integer',
-			'id' => 'integer',
-			'Users.username' => 'string',
-			'username' => 'string',
-			'Users.password' => 'string',
-			'password' => 'string',
-			'Users.created' => 'timestamp',
-			'created' => 'timestamp',
-			'Users.updated' => 'timestamp',
-			'updated' => 'timestamp',
-		]);
-		$expected = new QueryExpression(['username' => 'garrett', 'id' => 4], $typeMap);
+		$expected = new QueryExpression(['username' => 'garrett', 'id' => 4], $this->usersTypeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2131,19 +2133,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$result = $table->findByUsernameOrId('garrett', 4);
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 
-		$typeMap = new TypeMap([
-			'Users.id' => 'integer',
-			'id' => 'integer',
-			'Users.username' => 'string',
-			'username' => 'string',
-			'Users.password' => 'string',
-			'password' => 'string',
-			'Users.created' => 'timestamp',
-			'created' => 'timestamp',
-			'Users.updated' => 'timestamp',
-			'updated' => 'timestamp',
-		]);
-		$expected = new QueryExpression([], $typeMap);
+		$expected = new QueryExpression([], $this->usersTypeMap);
 		$expected->add([
 			'OR' => [
 				'username' => 'garrett',
@@ -2165,19 +2155,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 		$this->assertNull($result->clause('limit'));
 
-		$typeMap = new TypeMap([
-			'Articles.id' => 'integer',
-			'id' => 'integer',
-			'Articles.author_id' => 'integer',
-			'author_id' => 'integer',
-			'Articles.title' => 'string',
-			'title' => 'string',
-			'Articles.body' => 'text',
-			'body' => 'text',
-			'Articles.published' => 'string',
-			'published' => 'string',
-		]);
-		$expected = new QueryExpression(['author_id' => 1], $typeMap);
+		$expected = new QueryExpression(['author_id' => 1], $this->articlesTypeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2193,20 +2171,9 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 		$this->assertNull($result->clause('limit'));
 		$expected = new QueryExpression(
-			['author_id' => 1, 'published' => 'Y']
+			['author_id' => 1, 'published' => 'Y'],
+			$this->usersTypeMap
 		);
-		$expected->typeMap()->defaults([
-			'Users.id' => 'integer',
-			'id' => 'integer',
-			'Users.username' => 'string',
-			'username' => 'string',
-			'Users.password' => 'string',
-			'password' => 'string',
-			'Users.created' => 'timestamp',
-			'created' => 'timestamp',
-			'Users.updated' => 'timestamp',
-			'updated' => 'timestamp',
-		]);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -15,6 +15,7 @@
 namespace Cake\Test\TestCase\ORM;
 
 use Cake\Core\Configure;
+use Cake\Database\TypeMap;
 use Cake\Database\Expression\OrderByExpression;
 use Cake\Database\Expression\QueryExpression;
 use Cake\Datasource\ConnectionManager;
@@ -2037,7 +2038,19 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$result = $table->findByUsername('garrett');
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
-		$expected = new QueryExpression(['username' => 'garrett'], ['username' => 'string']);
+		$typeMap = new TypeMap([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
+		$expected = new QueryExpression(['username' => 'garrett'], $typeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2090,11 +2103,20 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$result = $table->findByUsernameAndId('garrett', 4);
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
-		$expected = new QueryExpression(
-			['username' => 'garrett', 'id' => 4],
-			['username' => 'string', 'id' => 'integer'],
-			'AND'
-		);
+
+		$typeMap = new TypeMap([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
+		$expected = new QueryExpression(['username' => 'garrett', 'id' => 4], $typeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2108,13 +2130,25 @@ class TableTest extends \Cake\TestSuite\TestCase {
 
 		$result = $table->findByUsernameOrId('garrett', 4);
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
-		$expected = new QueryExpression();
+
+		$typeMap = new TypeMap([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
+		$expected = new QueryExpression([], $typeMap);
 		$expected->add([
 			'OR' => [
 				'username' => 'garrett',
 				'id' => 4
-			]],
-			['username' => 'string', 'id' => 'integer']
+			]]
 		);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
@@ -2130,11 +2164,20 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$result = $table->findAllByAuthorId(1);
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 		$this->assertNull($result->clause('limit'));
-		$expected = new QueryExpression(
-			['author_id' => 1],
-			['author_id' => 'integer'],
-			'AND'
-		);
+
+		$typeMap = new TypeMap([
+			'Articles.id' => 'integer',
+			'id' => 'integer',
+			'Articles.author_id' => 'integer',
+			'author_id' => 'integer',
+			'Articles.title' => 'string',
+			'title' => 'string',
+			'Articles.body' => 'text',
+			'body' => 'text',
+			'Articles.published' => 'string',
+			'published' => 'string',
+		]);
+		$expected = new QueryExpression(['author_id' => 1], $typeMap);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2152,6 +2195,18 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$expected = new QueryExpression(
 			['author_id' => 1, 'published' => 'Y']
 		);
+		$expected->typeMap()->defaults([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
 		$this->assertEquals($expected, $result->clause('where'));
 	}
 
@@ -2167,6 +2222,18 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$this->assertInstanceOf('Cake\ORM\Query', $result);
 		$this->assertNull($result->clause('limit'));
 		$expected = new QueryExpression();
+		$expected->typeMap()->defaults([
+			'Users.id' => 'integer',
+			'id' => 'integer',
+			'Users.username' => 'string',
+			'username' => 'string',
+			'Users.password' => 'string',
+			'password' => 'string',
+			'Users.created' => 'timestamp',
+			'created' => 'timestamp',
+			'Users.updated' => 'timestamp',
+			'updated' => 'timestamp',
+		]);
 		$expected->add(
 			['or' => ['author_id' => 1, 'published' => 'Y']]
 		);


### PR DESCRIPTION
See discussion from #3118
