### PR TITLE
Cache library should support memcached getMulti - my proposal

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -277,9 +277,7 @@ class Cache {
 	}
 
 /**
- * Write data for key into cache. Will automatically use the currently
- * active cache configuration. To set the currently active configuration use
- * Cache::config()
+ * Write data for key into cache.
  *
  * ### Usage:
  *
@@ -314,23 +312,13 @@ class Cache {
 		$success = self::$_engines[$config]->write($settings['prefix'] . $key, $value, $settings['duration']);
 		self::set(null, $config);
 		if ($success === false && $value !== '') {
-			trigger_error(
-				__d('cake_dev',
-					"%s cache was unable to write '%s' to %s cache",
-					$config,
-					$key,
-					self::$_engines[$config]->settings['engine']
-				),
-				E_USER_WARNING
-			);
+			throw new CacheException(__d('cake_dev', '%s cache was unable to write \'%s\' to %s cache', $config. $key, self::$_engines[$config]->settings['engine']));
 		}
 		return $success;
 	}
 
 /**
- * Write data for many keys into cache. Will automatically use the currently
- * active cache configuration. To set the currently active configuration use
- * Cache::config()
+ * Write data for many keys into cache.
  *
  * ### Usage:
  *
@@ -360,14 +348,7 @@ class Cache {
 		if (method_exists(self::$_engines[$config],'writeMany')) {
 			$result = self::$_engines[$config]->writeMany($data, $settings['duration']);
 			if ($result === false) {
-				trigger_error(
-					__d('cake_dev',
-						"%s cache was unable to write to %s cache",
-						$config,
-						self::$_engines[$config]->settings['engine']
-					),
-					E_USER_WARNING
-				);
+				throw new CacheException(__d('cake_dev', '%s cache was unable to write to %s cache', $config. self::$_engines[$config]->settings['engine']));
 			}
 			self::set(null, $config);
 		}else{

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -312,7 +312,7 @@ class Cache {
 		$success = self::$_engines[$config]->write($settings['prefix'] . $key, $value, $settings['duration']);
 		self::set(null, $config);
 		if ($success === false && $value !== '') {
-			throw new CacheException(__d('cake_dev', '%s cache was unable to write \'%s\' to %s cache', $config. $key, self::$_engines[$config]->settings['engine']));
+			throw new CacheException(__d('cake_dev', '%s cache was unable to write \'%s\' to %s cache', $config, $key, self::$_engines[$config]->settings['engine']));
 		}
 		return $success;
 	}

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -371,17 +371,17 @@ class Cache {
  *
  * Reading multiple keys from the active cache configuration.
  *
- * `Cache::read(array('my_data_1', 'my_data_2)));`
+ * `Cache::readMany(array('my_data_1', 'my_data_2)));`
  *
  * Reading from a specific cache configuration.
  *
- * `Cache::read(array('my_data_1', 'my_data_2), 'long_term');`
+ * `Cache::readMany(array('my_data_1', 'my_data_2), 'long_term');`
  *
  * @param array $keys an array of keys to fetch from the cache
  * @param string $config optional name of the configuration to use. Defaults to 'default'
  * @return array An array containing, for each of the given $keys, the cached data or false if cached data could not be retreived
  */
-	public static function readMulti($keys, $config = 'default') {
+	public static function readMany($keys, $config = 'default') {
 		$settings = self::settings($config);
 		if (empty($settings)) {
 			return false;
@@ -389,7 +389,7 @@ class Cache {
 		if (!self::isInitialized($config)) {
 			return false;
 		}
-		if (method_exists(self::$_engines[$config],'readMulti')) {
+		if (method_exists(self::$_engines[$config],'readMany')) {
 			$falsekeys = array();
 			$readKeys = array();
 			foreach ($keys as $key) {
@@ -401,9 +401,8 @@ class Cache {
 					$readKeys[$key] = $settings['prefix'] . $engineKey;
 				}
 			}
-			return array_merge($falsekeys, self::$_engines[$config]->readMulti($readKeys));
+			return array_merge($falsekeys, self::$_engines[$config]->readMany($readKeys));
 		} else {
-			// revert to normal Cache::read for each key
 			$return = array();
 			foreach ($keys as $key) {
 				$return[$key] = self::read($key, $config);

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -357,7 +357,6 @@ class Cache {
 		}
 		
 		$return = array();
-		
 		if (method_exists(self::$_engines[$config],'writeMany')) {
 			$result = self::$_engines[$config]->writeMany($data, $settings['duration']);
 			if ($result === false) {
@@ -380,9 +379,7 @@ class Cache {
 	}
 
 /**
- * Read a key from the cache. Will automatically use the currently
- * active cache configuration. To set the currently active configuration use
- * Cache::config()
+ * Read a key from the cache.
  *
  * ### Usage:
  *
@@ -415,9 +412,7 @@ class Cache {
 	}
 
 /**
- * Read multiple keys from the cache. Will automatically use the currently
- * active cache configuration. To set the currently active configuration use
- * Cache::config()
+ * Read multiple keys from the cache.
  *
  * ### Usage:
  *
@@ -441,7 +436,7 @@ class Cache {
 		if (!self::isInitialized($config)) {
 			return false;
 		}
-		
+
 		$return = array();
 		if (method_exists(self::$_engines[$config],'readMany')) {
 			$return = self::$_engines[$config]->readMany($keys);
@@ -546,7 +541,7 @@ class Cache {
 	}
 
 /**
- * Delete a key from the cache.
+ * Delete many keys from the cache.
  *
  * ### Usage:
  *
@@ -573,10 +568,8 @@ class Cache {
 		}
 
 		$return = array();
-		
 		if (method_exists(self::$_engines[$config],'deleteMany')) {
 			$return = self::$_engines[$config]->deleteMany($keys);
-			
 		} else {
 			foreach ($keys as $key) {
 				$return[$key] = self::read($key, $config);

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -384,7 +384,6 @@ class Cache {
 			} else {
 				$result = array();
 			}
-			self::set(null, $config);
 			$return = array_merge($return, $result);
 		}else{
 			foreach ($data as $key => $value) {

--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -553,7 +553,7 @@ class Cache {
 			$return = self::$_engines[$config]->deleteMany($keys);
 		} else {
 			foreach ($keys as $key) {
-				$return[$key] = self::read($key, $config);
+				$return[$key] = self::delete($key, $config);
 			}
 		}
 		return $return;


### PR DESCRIPTION
Note: The pull request contains a readMany method which I have tested, but I propose the readMany, writeMany and deleteMany methods which work in a similar fashion.

The main purpose for this proposal is that Memcached supports Memcached:getMulti (http://www.php.net/manual/en/memcached.getmulti.php), setMulti and deleteMulti and the benefit of simultaneous actions is reduced latency times as each action is typically associated with a TCP request.

There is currently no good way of taking advantage of the speed benefits of simultaneous actions which I propose we work on. Updating the Cache library to support multiple read, writes and deletes is the first step to then allow cache engines to optionally implement them and take advantage of their respective engines - I believe WinCache also supports multiple actions in one request.

Any implementation needs to be backwards compatible so that existing engines work fine without changes even if Cache::readMany, Cache::writeMany or Cache::deleteMany are used in the application - and we can do this by having smart methods in the Cache class. I've written the code here so that Cache::readMany will work exactly the same for any engine, regardless of whether they implement simultaneous actions or not. Cache::readMany may actually be more convenient than Cache::read in some cases (i.e. when one uses a foreach loop for Cache::read).

Next steps: Also implement Cache::writeMany, Cache::deleteMany and modify MemcachedEngine (and others) to implement MemcachedEngine::readMany, MemcachedEngine::writeMany and MemcachedEngine::deleteMany to use Memcached::getMulti, Memcached::setMulti and Memcached::deleteMulti respectively.
