### PR TITLE
3.0 - Made Response instance the only valid return type for controller action.

### DIFF
--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -58,12 +58,11 @@ class TestDispatcher extends Dispatcher {
  * invoke method
  *
  * @param \Cake\Controller\Controller $controller
- * @param \Cake\Network\Response $response
- * @return void
+ * @return \Cake\Network\Response $response
  */
-	protected function _invoke(Controller $controller, Response $response) {
+	protected function _invoke(Controller $controller) {
 		$this->controller = $controller;
-		return parent::_invoke($controller, $response);
+		return parent::_invoke($controller);
 	}
 
 /**

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -186,7 +186,7 @@ class RequestActionTraitTest extends TestCase {
  */
 	public function testRequestActionParamParseAndPass() {
 		$result = $this->object->requestAction('/request_action/params_pass');
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals('request_action/params_pass', $result['url']);
 		$this->assertEquals('request_action', $result['params']['controller']);
 		$this->assertEquals('params_pass', $result['params']['action']);
@@ -204,14 +204,14 @@ class RequestActionTraitTest extends TestCase {
 			'item' => 'value'
 		);
 		$result = $this->object->requestAction(array('controller' => 'request_action', 'action' => 'post_pass'));
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEmpty($result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'post_pass'),
 			array('post' => $_POST)
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$expected = $_POST;
 		$this->assertEquals($expected, $result);
 	}
@@ -230,7 +230,7 @@ class RequestActionTraitTest extends TestCase {
 			['controller' => 'request_action', 'action' => 'query_pass'],
 			['query' => $query]
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals($query, $result);
 
 		$result = $this->object->requestAction([
@@ -238,13 +238,13 @@ class RequestActionTraitTest extends TestCase {
 			'action' => 'query_pass',
 			'?' => $query
 		]);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals($query, $result);
 
 		$result = $this->object->requestAction(
 			'/request_action/query_pass?page=3&sort=body'
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$expected = ['page' => 3, 'sort' => 'body'];
 		$this->assertEquals($expected, $result);
 	}
@@ -262,14 +262,14 @@ class RequestActionTraitTest extends TestCase {
 			array('controller' => 'request_action', 'action' => 'post_pass'),
 			array('post' => $data)
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals($data, $result);
 
 		$result = $this->object->requestAction(
 			'/request_action/post_pass',
 			array('post' => $data)
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals($data, $result);
 	}
 
@@ -282,14 +282,14 @@ class RequestActionTraitTest extends TestCase {
 		$result = $this->object->requestAction(
 			'/request_action/params_pass?get=value&limit=5'
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals('value', $result['query']['get']);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'params_pass'),
 			array('query' => array('get' => 'value', 'limit' => 5))
 		);
-		$result = unserialize($result);
+		$result = json_decode($result, true);
 		$this->assertEquals('value', $result['query']['get']);
 	}
 

--- a/tests/TestCase/Routing/RequestActionTraitTest.php
+++ b/tests/TestCase/Routing/RequestActionTraitTest.php
@@ -75,7 +75,7 @@ class RequestActionTraitTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->object->requestAction('/request_action/paginate_request_action');
-		$this->assertTrue($result);
+		$this->assertNull($result);
 
 		$result = $this->object->requestAction('/request_action/normal_request_action');
 		$expected = 'Hello World';
@@ -158,13 +158,13 @@ class RequestActionTraitTest extends TestCase {
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'paginate_request_action')
 		);
-		$this->assertTrue($result);
+		$this->assertNull($result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'paginate_request_action'),
 			array('pass' => array(5))
 		);
-		$this->assertTrue($result);
+		$this->assertNull($result);
 	}
 
 /**
@@ -186,10 +186,11 @@ class RequestActionTraitTest extends TestCase {
  */
 	public function testRequestActionParamParseAndPass() {
 		$result = $this->object->requestAction('/request_action/params_pass');
-		$this->assertEquals('request_action/params_pass', $result->url);
-		$this->assertEquals('request_action', $result['controller']);
-		$this->assertEquals('params_pass', $result['action']);
-		$this->assertEquals(null, $result['plugin']);
+		$result = unserialize($result);
+		$this->assertEquals('request_action/params_pass', $result['url']);
+		$this->assertEquals('request_action', $result['params']['controller']);
+		$this->assertEquals('params_pass', $result['params']['action']);
+		$this->assertNull($result['params']['plugin']);
 	}
 
 /**
@@ -203,13 +204,14 @@ class RequestActionTraitTest extends TestCase {
 			'item' => 'value'
 		);
 		$result = $this->object->requestAction(array('controller' => 'request_action', 'action' => 'post_pass'));
-		$expected = null;
+		$result = unserialize($result);
 		$this->assertEmpty($result);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'post_pass'),
 			array('post' => $_POST)
 		);
+		$result = unserialize($result);
 		$expected = $_POST;
 		$this->assertEquals($expected, $result);
 	}
@@ -228,6 +230,7 @@ class RequestActionTraitTest extends TestCase {
 			['controller' => 'request_action', 'action' => 'query_pass'],
 			['query' => $query]
 		);
+		$result = unserialize($result);
 		$this->assertEquals($query, $result);
 
 		$result = $this->object->requestAction([
@@ -235,11 +238,13 @@ class RequestActionTraitTest extends TestCase {
 			'action' => 'query_pass',
 			'?' => $query
 		]);
+		$result = unserialize($result);
 		$this->assertEquals($query, $result);
 
 		$result = $this->object->requestAction(
 			'/request_action/query_pass?page=3&sort=body'
 		);
+		$result = unserialize($result);
 		$expected = ['page' => 3, 'sort' => 'body'];
 		$this->assertEquals($expected, $result);
 	}
@@ -257,12 +262,14 @@ class RequestActionTraitTest extends TestCase {
 			array('controller' => 'request_action', 'action' => 'post_pass'),
 			array('post' => $data)
 		);
+		$result = unserialize($result);
 		$this->assertEquals($data, $result);
 
 		$result = $this->object->requestAction(
 			'/request_action/post_pass',
 			array('post' => $data)
 		);
+		$result = unserialize($result);
 		$this->assertEquals($data, $result);
 	}
 
@@ -275,13 +282,15 @@ class RequestActionTraitTest extends TestCase {
 		$result = $this->object->requestAction(
 			'/request_action/params_pass?get=value&limit=5'
 		);
-		$this->assertEquals('value', $result->query['get']);
+		$result = unserialize($result);
+		$this->assertEquals('value', $result['query']['get']);
 
 		$result = $this->object->requestAction(
 			array('controller' => 'request_action', 'action' => 'params_pass'),
 			array('query' => array('get' => 'value', 'limit' => 5))
 		);
-		$this->assertEquals('value', $result->query['get']);
+		$result = unserialize($result);
+		$this->assertEquals('value', $result['query']['get']);
 	}
 
 }

--- a/tests/test_app/Plugin/TestPlugin/Controller/TestsController.php
+++ b/tests/test_app/Plugin/TestPlugin/Controller/TestsController.php
@@ -34,7 +34,7 @@ class TestsController extends TestPluginAppController {
 	}
 
 	public function some_method() {
-		return 25;
+		$this->response->body(25);
 	}
 
 }

--- a/tests/test_app/TestApp/Controller/OrangeSessionTestController.php
+++ b/tests/test_app/TestApp/Controller/OrangeSessionTestController.php
@@ -35,9 +35,9 @@ class OrangeSessionTestController extends Controller {
 /**
  * session_id method
  *
- * @return string
+ * @return void
  */
 	public function session_id() {
-		return $this->Session->id();
+		$this->response->body($this->Session->id());
 	}
 }

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -87,7 +87,7 @@ class RequestActionController extends AppController {
  * @return array
  */
 	public function post_pass() {
-		$this->response->body(serialize($this->request->data));
+		$this->response->body(json_encode($this->request->data));
 	}
 
 /**
@@ -96,7 +96,7 @@ class RequestActionController extends AppController {
  * @return array
  */
 	public function query_pass() {
-		$this->response->body(serialize($this->request->query));
+		$this->response->body(json_encode($this->request->query));
 	}
 
 /**
@@ -105,7 +105,7 @@ class RequestActionController extends AppController {
  * @return void
  */
 	public function params_pass() {
-		$this->response->body(serialize([
+		$this->response->body(json_encode([
 			'params' => $this->request->params,
 			'query' => $this->request->query,
 			'url' => $this->request->url

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -33,10 +33,11 @@ class RequestActionController extends AppController {
 /**
  * test_request_action method
  *
- * @return string
+ * @return \Cake\Network\Response
  */
 	public function test_request_action() {
-		return 'This is a test';
+		$this->response->body('This is a test');
+		return $this->response;
 	}
 
 /**
@@ -44,39 +45,40 @@ class RequestActionController extends AppController {
  *
  * @param mixed $id
  * @param mixed $other
- * @access public
- * @return string
+ * @return \Cake\Network\Response
  */
 	public function another_ra_test($id, $other) {
-		return $id + $other;
+		$this->response->body($id + $other);
+		return $this->response;
 	}
 
 /**
  * normal_request_action method
  *
- * @return string
+ * @return \Cake\Network\Response
  */
 	public function normal_request_action() {
-		return 'Hello World';
+		$this->response->body('Hello World');
+		return $this->response;
 	}
 
 /**
- * returns $this->here
+ * returns $this->here as body
  *
- * @return string
+ * @return \Cake\Network\Response
  */
 	public function return_here() {
-		return $this->here;
+		$this->response->body($this->here);
+		return $this->response;
 	}
 
 /**
  * paginate_request_action method
  *
- * @return boolean
+ * @return void
  */
 	public function paginate_request_action() {
 		$data = $this->paginate();
-		return true;
 	}
 
 /**

--- a/tests/test_app/TestApp/Controller/RequestActionController.php
+++ b/tests/test_app/TestApp/Controller/RequestActionController.php
@@ -87,7 +87,7 @@ class RequestActionController extends AppController {
  * @return array
  */
 	public function post_pass() {
-		return $this->request->data;
+		$this->response->body(serialize($this->request->data));
 	}
 
 /**
@@ -96,16 +96,20 @@ class RequestActionController extends AppController {
  * @return array
  */
 	public function query_pass() {
-		return $this->request->query;
+		$this->response->body(serialize($this->request->query));
 	}
 
 /**
  * test param passing and parsing.
  *
- * @return array
+ * @return void
  */
 	public function params_pass() {
-		return $this->request;
+		$this->response->body(serialize([
+			'params' => $this->request->params,
+			'query' => $this->request->query,
+			'url' => $this->request->url
+		]));
 	}
 
 /**

--- a/tests/test_app/TestApp/Controller/SessionTestController.php
+++ b/tests/test_app/TestApp/Controller/SessionTestController.php
@@ -31,9 +31,9 @@ class SessionTestController extends Controller {
 /**
  * session_id method
  *
- * @return string
+ * @return void
  */
 	public function session_id() {
-		return $this->Session->id();
+		$this->response->body($this->Session->id());
 	}
 }

--- a/tests/test_app/TestApp/Controller/SomePostsController.php
+++ b/tests/test_app/TestApp/Controller/SomePostsController.php
@@ -57,7 +57,6 @@ class SomePostsController extends Controller {
  * @return void
  */
 	public function index() {
-		return true;
 	}
 
 /**
@@ -66,7 +65,6 @@ class SomePostsController extends Controller {
  * @return void
  */
 	public function change() {
-		return true;
 	}
 
 }

--- a/tests/test_app/TestApp/Controller/TestDispatchPagesController.php
+++ b/tests/test_app/TestApp/Controller/TestDispatchPagesController.php
@@ -34,7 +34,6 @@ class TestDispatchPagesController extends Controller {
  * @return void
  */
 	public function admin_index() {
-		return true;
 	}
 
 /**
@@ -43,7 +42,6 @@ class TestDispatchPagesController extends Controller {
  * @return void
  */
 	public function camelCased() {
-		return true;
 	}
 
 }

--- a/tests/test_app/TestApp/Controller/TestsAppsController.php
+++ b/tests/test_app/TestApp/Controller/TestsAppsController.php
@@ -36,7 +36,7 @@ class TestsAppsController extends AppController {
 	}
 
 	public function some_method() {
-		return 5;
+		$this->response->body(5);
 	}
 
 	public function set_action() {


### PR DESCRIPTION
Refs #3135

Lot of failing test cases to take care of. The obvious ones are due to cases where requestAction() returns an array. Should I just get rid of them as @AD7six suggested?
