### PR TITLE
3.0 unloading

### DIFF
--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -30,16 +30,9 @@ class ComponentRegistry extends ObjectRegistry {
 /**
  * The controller that this collection was initialized with.
  *
- * @var Controller
+ * @var \Cake\Controller\Controller
  */
 	protected $_Controller = null;
-
-/**
- * The event manager to bind components to.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager = null;
 
 /**
  * Constructor.
@@ -110,20 +103,6 @@ class ComponentRegistry extends ObjectRegistry {
 			$this->_eventManager->attach($instance);
 		}
 		return $instance;
-	}
-
-/**
- * Destroys all objects in the registry.
- *
- * Removes all attached listeners and destroys all stored instances.
- *
- * @return void
- */
-	public function reset() {
-		foreach ($this->_loaded as $component) {
-			$this->_eventManager->detach($component);
-		}
-		parent::reset();
 	}
 
 }

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -195,9 +195,9 @@ class Controller extends Object implements EventListener {
 /**
  * Instance of ComponentRegistry used to create Components
  *
- * @var ComponentRegistry
+ * @var \Cake\Controller\ComponentRegistry
  */
-	public $Components = null;
+	public $_components = null;
 
 /**
  * Array containing the names of components this controller uses. Component names
@@ -319,7 +319,29 @@ class Controller extends Object implements EventListener {
 		if ($response instanceof Response) {
 			$this->response = $response;
 		}
-		$this->Components = new ComponentRegistry($this);
+	}
+
+/**
+ * Get the component registry for this controller.
+ *
+ * @return \Cake\Controller\ComponentRegistry
+ */
+	public function components() {
+		if ($this->_components === null) {
+			$this->_components = new ComponentRegistry($this);
+		}
+		return $this->_components;
+	}
+
+/**
+ * Add a component to the controller's registry
+ *
+ * @param string $name The name of the component to load.
+ * @param array $config The config for the component.
+ * @return \Cake\Controller\Component
+ */
+	public function addComponent($name, $config = []) {
+		return $this->components()->load($name, $config);
 	}
 
 /**
@@ -486,10 +508,11 @@ class Controller extends Object implements EventListener {
 		if (empty($this->components)) {
 			return;
 		}
-		$components = $this->Components->normalizeArray($this->components);
+		$registry = $this->components();
+		$components = $registry->normalizeArray($this->components);
 		foreach ($components as $properties) {
 			list(, $class) = pluginSplit($properties['class']);
-			$this->{$class} = $this->Components->load($properties['class'], $properties['settings']);
+			$this->{$class} = $registry->load($properties['class'], $properties['settings']);
 		}
 	}
 
@@ -677,7 +700,7 @@ class Controller extends Object implements EventListener {
 			}
 		}
 
-		$this->Paginator = $this->Components->load('Paginator');
+		$this->Paginator = $this->addComponent('Paginator');
 		if (
 			!in_array('Paginator', $this->helpers) &&
 			!array_key_exists('Paginator', $this->helpers)

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -197,7 +197,7 @@ class Controller extends Object implements EventListener {
  *
  * @var \Cake\Controller\ComponentRegistry
  */
-	public $_components = null;
+	protected $_components = null;
 
 /**
  * Array containing the names of components this controller uses. Component names

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -334,14 +334,23 @@ class Controller extends Object implements EventListener {
 	}
 
 /**
- * Add a component to the controller's registry
+ * Add a component to the controller's registry.
+ *
+ * This method will also set the component to a property.
+ * For example:
+ *
+ * `$this->addComponent('DebugKit.Toolbar');`
+ *
+ * Will result in a `Toolbar` property being set.
  *
  * @param string $name The name of the component to load.
  * @param array $config The config for the component.
  * @return \Cake\Controller\Component
  */
 	public function addComponent($name, $config = []) {
-		return $this->components()->load($name, $config);
+		list(, $prop) = pluginSplit($name);
+		$this->{$prop} = $this->components()->load($name, $config);
+		return $this->{$prop};
 	}
 
 /**

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Error Handling Controller
- *
- * Controller used by ErrorHandler to render error views.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -24,7 +20,6 @@ use Cake\Routing\Router;
  * Error Handling Controller
  *
  * Controller used by ErrorHandler to render error views.
- *
  */
 class ErrorController extends Controller {
 
@@ -47,7 +42,7 @@ class ErrorController extends Controller {
 		if (count(Router::extensions()) &&
 			!isset($this->RequestHandler)
 		) {
-			$this->RequestHandler = $this->Components->load('RequestHandler');
+			$this->addComponent('RequestHandler');
 		}
 		$eventManager = $this->getEventManager();
 		if (isset($this->Auth)) {

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -38,6 +38,13 @@ abstract class ObjectRegistry {
 	protected $_loaded = [];
 
 /**
+ * The event manager to bind components to.
+ *
+ * @var \Cake\Event\EventManager
+ */
+	protected $_eventManager;
+
+/**
  * Loads/constructs a object instance.
  *
  * Will return the instance in the registry if it already exists.
@@ -170,24 +177,47 @@ abstract class ObjectRegistry {
 /**
  * Clear loaded instances in the registry.
  *
+ * If the registry subclass has an event manager, the objects will be detached from events as well.
+ *
  * @return void
  */
 	public function reset() {
-		$this->_loaded = [];
+		foreach (array_keys($this->_loaded) as $name) {
+			$this->unload($name);
+		}
 	}
 
 /**
  * set an object directly into the registry by name
  *
- * This is primarily to aide testing
+ * This is primarily to aid testing
  *
- * @param string $objectName
+ * @param string $objectName The name of the object to set in the registry.
  * @param object $object instance to store in the registry
  * @return void
  */
 	public function set($objectName, $object) {
 		list($plugin, $name) = pluginSplit($objectName);
 		$this->_loaded[$name] = $object;
+	}
+
+/**
+ * Remove an object from the registry.
+ *
+ * If this registry has an event manager, the object will be detached from any events as well.
+ *
+ * @param string $objectName The name of the object to remove from the registry.
+ * @return void
+ */
+	public function unload($objectName) {
+		if (empty($this->_loaded[$objectName])) {
+			return;
+		}
+		$object = $this->_loaded[$objectName];
+		if (isset($this->_eventManager)) {
+			$this->_eventManager->detach($object);
+		}
+		unset($this->_loaded[$objectName]);
 	}
 
 }

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -150,7 +150,7 @@ class Helper extends Object implements EventListener {
 			$this->settings = Hash::merge($this->settings, $settings);
 		}
 		if (!empty($this->helpers)) {
-			$this->_helperMap = $View->Helpers->normalizeArray($this->helpers);
+			$this->_helperMap = $View->helpers()->normalizeArray($this->helpers);
 		}
 	}
 
@@ -175,7 +175,7 @@ class Helper extends Object implements EventListener {
 	public function __get($name) {
 		if (isset($this->_helperMap[$name]) && !isset($this->{$name})) {
 			$settings = array_merge((array)$this->_helperMap[$name]['settings'], array('enabled' => false));
-			$this->{$name} = $this->_View->loadHelper($this->_helperMap[$name]['class'], $settings);
+			$this->{$name} = $this->_View->addHelper($this->_helperMap[$name]['class'], $settings);
 		}
 		if (isset($this->{$name})) {
 			return $this->{$name};

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -151,18 +151,4 @@ class HelperRegistry extends ObjectRegistry {
 		return $instance;
 	}
 
-/**
- * Destroys all objects in the registry.
- *
- * Removes all attached listeners and destroys all stored instances.
- *
- * @return void
- */
-	public function reset() {
-		foreach ($this->_loaded as $helper) {
-			$this->_eventManager->detach($helper);
-		}
-		parent::reset();
-	}
-
 }

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Methods for displaying presentation data in the view.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -67,9 +65,9 @@ class View extends Object {
 /**
  * Helpers collection
  *
- * @var HelperRegistry
+ * @var Cake\View\HelperRegistry
  */
-	public $Helpers;
+	public $_helpers;
 
 /**
  * ViewBlock instance.
@@ -337,7 +335,6 @@ class View extends Object {
 		} else {
 			$this->response = new Response();
 		}
-		$this->Helpers = new HelperRegistry($this);
 		$this->Blocks = new ViewBlock();
 		$this->loadHelpers();
 		parent::__construct();
@@ -774,9 +771,10 @@ class View extends Object {
  * @return mixed
  */
 	public function __get($name) {
-		if (isset($this->Helpers->{$name})) {
-			$this->{$name} = $this->Helpers->{$name};
-			return $this->Helpers->{$name};
+		$registry = $this->helpers();
+		if (isset($registry->{$name})) {
+			$this->{$name} = $registry->{$name};
+			return $registry->{$name};
 		}
 		return $this->{$name};
 	}
@@ -811,10 +809,11 @@ class View extends Object {
  * @return void
  */
 	public function loadHelpers() {
-		$helpers = $this->Helpers->normalizeArray($this->helpers);
+		$registry = $this->helpers();
+		$helpers = $registry->normalizeArray($this->helpers);
 		foreach ($helpers as $properties) {
 			list(, $class) = pluginSplit($properties['class']);
-			$this->{$class} = $this->Helpers->load($properties['class'], $properties['settings']);
+			$this->{$class} = $registry->load($properties['class'], $properties['settings']);
 		}
 	}
 
@@ -882,6 +881,17 @@ class View extends Object {
 	}
 
 /**
+ * Get the helper registry in use by this View class.
+ *
+ * @return \Cake\View\HelperRegistry
+ */
+	public function helpers() {
+		if ($this->_helpers === null) {
+			$this->_helpers = new HelperRegistry($this);
+		}
+		return $this->_helpers;
+	}
+/**
  * Loads a helper. Delegates to the `HelperRegistry::load()` to load the helper
  *
  * @param string $helperName Name of the helper to load.
@@ -889,8 +899,8 @@ class View extends Object {
  * @return Helper a constructed helper object.
  * @see HelperRegistry::load()
  */
-	public function loadHelper($helperName, $settings = array()) {
-		return $this->Helpers->load($helperName, $settings);
+	public function addHelper($helperName, $settings = []) {
+		return $this->helpers()->load($helperName, $settings);
 	}
 
 /**

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -67,7 +67,7 @@ class View extends Object {
  *
  * @var Cake\View\HelperRegistry
  */
-	public $_helpers;
+	protected $_helpers;
 
 /**
  * ViewBlock instance.

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * AuthComponentTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -79,7 +77,7 @@ class AuthComponentTest extends TestCase {
 		$this->Controller = new AuthTestController($request, $this->getMock('Cake\Network\Response'));
 		$this->Controller->constructClasses();
 
-		$this->Auth = new TestAuthComponent($this->Controller->Components);
+		$this->Auth = new TestAuthComponent($this->Controller->components());
 		$this->Auth->request = $request;
 		$this->Auth->response = $this->getMock('Cake\Network\Response');
 		AuthComponent::$sessionKey = 'Auth.User';
@@ -752,7 +750,7 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->Session = $this->getMock(
 			'Cake\Controller\Component\SessionComponent',
 			array('setFlash'),
-			array($Controller->Components)
+			array($Controller->components())
 		);
 
 		$Controller->expects($this->once())
@@ -790,7 +788,7 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->Session = $this->getMock(
 			'Cake\Controller\Component\SessionComponent',
 			array('setFlash'),
-			array($Controller->Components)
+			array($Controller->components())
 		);
 
 		$Controller->expects($this->once())

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -68,7 +68,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$response = new Response();
 		$this->Controller = new RequestHandlerTestController($request, $response);
 		$this->Controller->constructClasses();
-		$this->RequestHandler = new RequestHandlerComponent($this->Controller->Components);
+		$this->RequestHandler = new RequestHandlerComponent($this->Controller->components());
 		$this->_extensions = Router::extensions();
 	}
 
@@ -499,7 +499,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
 			array('_header'),
-			array(&$this->Controller->Components)
+			array($this->Controller->components())
 		);
 		$this->RequestHandler->response = $this->getMock('Cake\Network\Response', array('type', 'download'));
 		$this->RequestHandler->request = $this->getMock('Cake\Network\Request', ['parseAccept']);
@@ -699,7 +699,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
 			array('_stop'),
-			array(&$this->Controller->Components)
+			array($this->Controller->components())
 		);
 		$this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
 		$this->Controller->response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
@@ -732,7 +732,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->Controller->RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
 			array('_stop'),
-			array(&$this->Controller->Components)
+			array($this->Controller->components())
 		);
 		$this->Controller->request = $this->getMock('Cake\Network\Request', ['is']);
 		$this->Controller->response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
@@ -774,7 +774,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$RequestHandler = $this->getMock(
 			'Cake\Controller\Component\RequestHandlerComponent',
 			array('_stop'),
-			array(&$this->Controller->Components)
+			array($this->Controller->components())
 		);
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('_sendHeader'));
 		$RequestHandler->request = new Request('posts/index');
@@ -806,7 +806,11 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testCheckNotModifiedByEtagStar() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = '*';
 		$event = new Event('Controller.beforeRender', $this->Controller);
-		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
+		$RequestHandler = $this->getMock(
+			'Cake\Controller\Component\RequestHandlerComponent',
+			array('_stop'),
+			array($this->Controller->components())
+		);
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something');
 		$RequestHandler->response->expects($this->once())->method('notModified');
@@ -821,7 +825,11 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testCheckNotModifiedByEtagExact() {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
 		$event = new Event('Controller.beforeRender');
-		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
+		$RequestHandler = $this->getMock(
+			'Cake\Controller\Component\RequestHandlerComponent',
+			array('_stop'),
+			array($this->Controller->components())
+		);
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->expects($this->once())->method('notModified');
@@ -837,7 +845,11 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_IF_NONE_MATCH'] = 'W/"something", "other"';
 		$_SERVER['HTTP_IF_MODIFIED_SINCE'] = '2012-01-01 00:00:00';
 		$event = new Event('Controller.beforeRender', $this->Controller);
-		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
+		$RequestHandler = $this->getMock(
+			'Cake\Controller\Component\RequestHandlerComponent',
+			array('_stop'),
+			array($this->Controller->components())
+		);
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->etag('something', true);
 		$RequestHandler->response->modified('2012-01-01 00:00:00');
@@ -852,7 +864,11 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testCheckNotModifiedNoInfo() {
 		$event = new Event('Controller.beforeRender', $this->Controller);
-		$RequestHandler = $this->getMock('Cake\Controller\Component\RequestHandlerComponent', array('_stop'), array(&$this->Controller->Components));
+		$RequestHandler = $this->getMock(
+			'Cake\Controller\Component\RequestHandlerComponent',
+			array('_stop'),
+			array($this->Controller->components())
+		);
 		$RequestHandler->response = $this->getMock('Cake\Network\Response', array('notModified'));
 		$RequestHandler->response->expects($this->never())->method('notModified');
 		$this->assertNull($RequestHandler->beforeRender($event, '', $RequestHandler->response));

--- a/tests/TestCase/Controller/Component/SecurityComponentTest.php
+++ b/tests/TestCase/Controller/Component/SecurityComponentTest.php
@@ -174,7 +174,7 @@ class SecurityComponentTest extends TestCase {
 		]);
 		$Controller = new \TestApp\Controller\SomePagesController($request);
 		$event = new Event('Controller.startup', $Controller, $this->Controller);
-		$Security = new SecurityComponent($Controller->Components);
+		$Security = new SecurityComponent($Controller->components());
 		$Security->blackHoleCallback = '_fail';
 		$Security->startup($event);
 		$Security->blackHole($Controller, 'csrf');
@@ -207,7 +207,7 @@ class SecurityComponentTest extends TestCase {
 			'requireSecure' => array('update_account'),
 			'validatePost' => false,
 		);
-		$Security = new SecurityComponent($this->Controller->Components, $settings);
+		$Security = new SecurityComponent($this->Controller->components(), $settings);
 		$this->assertEquals($Security->validatePost, $settings['validatePost']);
 	}
 

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -178,4 +178,19 @@ class ComponentRegistryTest extends TestCase {
 		$this->assertNotSame($instance, $this->Components->load('Auth'));
 	}
 
+/**
+ * Test unloading.
+ *
+ * @return void
+ */
+	public function testUnload() {
+		$eventManager = $this->Components->getController()->getEventManager();
+
+		$result = $this->Components->load('Auth');
+		$this->Components->unload('Auth');
+
+		$this->assertFalse(isset($this->Components->Auth), 'Should be gone');
+		$this->assertCount(0, $eventManager->listeners('Controller.startup'));
+	}
+
 }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -855,4 +855,37 @@ class ControllerTest extends TestCase {
 		$this->assertEquals('Pages', $Controller->viewPath);
 	}
 
+/**
+ * Test the components() method.
+ *
+ * @return void
+ */
+	public function testComponents() {
+		$request = new Request('/');
+		$response = $this->getMock('Cake\Network\Response');
+
+		$controller = new TestController($request, $response);
+		$this->assertInstanceOf('Cake\Controller\ComponentRegistry', $controller->components());
+
+		$result = $controller->components();
+		$this->assertSame($result, $controller->components());
+	}
+
+/**
+ * Test adding a component
+ *
+ * @return void
+ */
+	public function testAddComponent() {
+		$request = new Request('/');
+		$response = $this->getMock('Cake\Network\Response');
+
+		$controller = new TestController($request, $response);
+		$result = $controller->addComponent('Paginator');
+		$this->assertInstanceOf('Cake\Controller\Component\PaginatorComponent', $result);
+
+		$registry = $controller->components();
+		$this->assertTrue(isset($registry->Paginator));
+	}
+
 }

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -883,6 +883,7 @@ class ControllerTest extends TestCase {
 		$controller = new TestController($request, $response);
 		$result = $controller->addComponent('Paginator');
 		$this->assertInstanceOf('Cake\Controller\Component\PaginatorComponent', $result);
+		$this->assertSame($result, $controller->Paginator);
 
 		$registry = $controller->components();
 		$this->assertTrue(isset($registry->Paginator));

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -317,7 +317,7 @@ class DebuggerTest extends TestCase {
 		$result = Debugger::exportVar($View);
 		$expected = <<<TEXT
 object(Cake\View\View) {
-	Helpers => object(Cake\View\HelperRegistry) {}
+	_helpers => object(Cake\View\HelperRegistry) {}
 	Blocks => object(Cake\View\ViewBlock) {}
 	plugin => null
 	name => ''

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -317,7 +317,6 @@ class DebuggerTest extends TestCase {
 		$result = Debugger::exportVar($View);
 		$expected = <<<TEXT
 object(Cake\View\View) {
-	_helpers => object(Cake\View\HelperRegistry) {}
 	Blocks => object(Cake\View\ViewBlock) {}
 	plugin => null
 	name => ''
@@ -346,6 +345,7 @@ object(Cake\View\View) {
 	Form => object(Cake\View\Helper\FormHelper) {}
 	int => (int) 2
 	float => (float) 1.333
+	[protected] _helpers => object(Cake\View\HelperRegistry) {}
 	[protected] _ext => '.ctp'
 	[protected] _passedVars => [
 		(int) 0 => 'viewVars',

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -200,4 +200,22 @@ class HelperRegistryTest extends TestCase {
 
 		$this->assertNotSame($instance, $this->Helpers->load('Paginator'));
 	}
+
+/**
+ * Test unloading.
+ *
+ * @return void
+ */
+	public function testUnload() {
+		$instance = $this->Helpers->load('Paginator');
+		$this->assertSame(
+			$instance,
+			$this->Helpers->Paginator,
+			'Instance in registry should be the same as previously loaded'
+		);
+		$this->assertCount(1, $this->Events->listeners('View.beforeRender'));
+
+		$this->assertNull($this->Helpers->unload('Paginator'), 'No return expected');
+		$this->assertCount(0, $this->Events->listeners('View.beforeRender'));
+	}
 }

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ViewTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -787,9 +785,9 @@ class ViewTest extends TestCase {
  *
  * @return void
  */
-	public function testMagicGet() {
+	public function testMagicGetAndAddHelper() {
 		$View = new View($this->PostsController);
-		$View->loadHelper('Html');
+		$View->addHelper('Html');
 		$this->assertInstanceOf('Cake\View\Helper\HtmlHelper', $View->Html);
 	}
 
@@ -920,7 +918,7 @@ class ViewTest extends TestCase {
 		);
 		$View = new View($this->PostsController);
 		$View->render('index');
-		$this->assertEquals('Valuation', $View->Helpers->TestBeforeAfter->property);
+		$this->assertEquals('Valuation', $View->helpers()->TestBeforeAfter->property);
 	}
 
 /**
@@ -956,7 +954,7 @@ class ViewTest extends TestCase {
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
 
-		$attached = $View->Helpers->loaded();
+		$attached = $View->helpers()->loaded();
 		$this->assertEquals(array('Session', 'Html', 'Form', 'Number'), $attached);
 
 		$this->PostsController->helpers = array('Html', 'Form', 'Number', 'TestPlugin.PluggedHelper');
@@ -965,7 +963,7 @@ class ViewTest extends TestCase {
 		$result = $View->render('index', false);
 		$this->assertEquals('posts index', $result);
 
-		$attached = $View->Helpers->loaded();
+		$attached = $View->helpers()->loaded();
 		$expected = array('Html', 'Form', 'Number', 'PluggedHelper');
 		$this->assertEquals($expected, $attached, 'Attached helpers are wrong.');
 	}
@@ -1572,4 +1570,17 @@ TEXT;
 		$result = $this->View->get('title', $default);
 		$this->assertEquals($expected, $result);
 	}
+
+/**
+ * Test the helpers() method.
+ *
+ * @return void
+ */
+	public function testHelpers() {
+		$this->assertInstanceOf('Cake\View\HelperRegistry', $this->View->helpers());
+
+		$result = $this->View->helpers();
+		$this->assertSame($result, $this->View->helpers());
+	}
+
 }

--- a/tests/TestCase/View/XmlViewTest.php
+++ b/tests/TestCase/View/XmlViewTest.php
@@ -190,7 +190,7 @@ class XmlViewTest extends TestCase {
 		$expected = Xml::build($expected)->asXML();
 		$this->assertSame($expected, $output);
 		$this->assertSame('application/xml', $Response->type());
-		$this->assertInstanceOf('Cake\View\HelperRegistry', $View->Helpers);
+		$this->assertInstanceOf('Cake\View\HelperRegistry', $View->helpers());
 	}
 
 }

--- a/tests/test_app/TestApp/Template/Layout/default.ctp
+++ b/tests/test_app/TestApp/Template/Layout/default.ctp
@@ -1,5 +1,5 @@
 <?php
-$this->loadHelper('Html');
+$this->addHelper('Html');
 
 $cakeDescription = 'CakePHP: the rapid development php framework';
 ?>


### PR DESCRIPTION
Implements #3083. I've added a few new methods to make Components and Helpers consistent with the Table class. I've also added `unload()` to the base class and made it generally useful.

I feel most of these changes can be backported to 2.x, and once we've settled on method names and arguments I'll open another pull request to backport these changes and mark the existing methods as deprecated. Perhaps as part of 2.6?
