### PR TITLE
3.0 Separate default templates and runtime templates.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -76,7 +76,7 @@ class FormHelper extends Helper {
 		],
 		'widgets' => [],
 		'registry' => null,
-		'templates' => [
+		'defaultTemplates' => [
 			'button' => '<button{{attrs}}>{{text}}</button>',
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
 			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
@@ -168,9 +168,8 @@ class FormHelper extends Helper {
  * @param \Cake\View\View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, $config = []) {
 		parent::__construct($View, $config);
-
 		$config = $this->config();
 
 		$this->widgetRegistry($config['registry'], $config['widgets']);
@@ -2238,7 +2237,7 @@ class FormHelper extends Helper {
  * @return void
  */
 	public function resetTemplates() {
-		$this->templates($this->_defaultConfig['templates']);
+		$this->templates($this->_defaultConfig['defaultTemplates']);
 	}
 
 /**

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -49,7 +49,7 @@ class PaginatorHelper extends Helper {
  */
 	protected $_defaultConfig = [
 		'options' => [],
-		'templates' => [
+		'defaultTemplates' => [
 			'nextActive' => '<li class="next"><a rel="next" href="{{url}}">{{text}}</a></li>',
 			'nextDisabled' => '<li class="next disabled"><span>{{text}}</span></li>',
 			'prevActive' => '<li class="prev"><a rel="prev" href="{{url}}">{{text}}</a></li>',

--- a/src/View/Helper/SessionHelper.php
+++ b/src/View/Helper/SessionHelper.php
@@ -36,7 +36,7 @@ class SessionHelper extends Helper {
  * @var array
  */
 	protected $_defaultConfig = [
-		'templates' => [
+		'defaultTemplates' => [
 			'flash' => '<div id="{{key}}-message" class="{{class}}">{{message}}</div>'
 		]
 	];

--- a/src/View/Helper/StringTemplateTrait.php
+++ b/src/View/Helper/StringTemplateTrait.php
@@ -66,8 +66,10 @@ trait StringTemplateTrait {
 			$class = $this->config('templateClass') ?: '\Cake\View\StringTemplate';
 			$this->_templater = new $class;
 
-			$templates = $this->config('templates');
+			$defaults = $this->config('defaultTemplates');
+			$this->_templater->add($defaults);
 
+			$templates = $this->config('templates');
 			if ($templates) {
 				if (is_string($templates)) {
 					$this->_templater->load($templates);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -143,7 +143,6 @@ class FormHelperTest extends TestCase {
 		$this->View = new View(null);
 
 		$this->Form = new FormHelper($this->View);
-		$this->Form->Html = new HtmlHelper($this->View);
 		$this->Form->request = new Request('articles/add');
 		$this->Form->request->here = '/articles/add';
 		$this->Form->request['controller'] = 'articles';
@@ -187,8 +186,21 @@ class FormHelperTest extends TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		unset($this->Form->Html, $this->Form, $this->Controller, $this->View);
+		unset($this->Form, $this->Controller, $this->View);
 		TableRegistry::clear();
+	}
+
+/**
+ * Test construct() with the templates option.
+ *
+ * @return void
+ */
+	public function testConstructTemplatesFile() {
+		$helper = new FormHelper($this->View, [
+			'templates' => 'htmlhelper_tags.php'
+		]);
+		$result = $helper->input('name');
+		$this->assertContains('<input', $result);
 	}
 
 /**


### PR DESCRIPTION
This makes for fewer workarounds with managing templates vs. having duplicate conditions for handling string/array templates.

Fixes #3142
