### PR TITLE
3.0 travis fixes

### DIFF
--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -16,7 +16,6 @@ namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\PostgresDialectTrait;
 use Cake\Database\Statement;
-use Cake\Datasource\ConnectionManager;
 use PDO;
 
 class Postgres extends \Cake\Database\Driver {

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -16,6 +16,7 @@ namespace Cake\Database\Driver;
 
 use Cake\Database\Dialect\PostgresDialectTrait;
 use Cake\Database\Statement;
+use Cake\Datasource\ConnectionManager;
 use PDO;
 
 class Postgres extends \Cake\Database\Driver {

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\TestSuite\Fixture;
 
-use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
 use Exception;
@@ -37,13 +36,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
 	protected $_fixtureManager;
 
 /**
- * Indicates the current number of nested testsuites
- *
- * @var integer
- */
-	protected $_nesting = 0;
-
-/**
  * Constructor. Save internally the reference to the passed fixture manager
  *
  * @param \Cake\TestSuite\Fixture\FixtureManager $manager
@@ -60,13 +52,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
-		$this->_nesting++;
-		foreach ($suite->getIterator() as $test) {
-			if ($test instanceof TestCase) {
-				$this->_fixtureManager->fixturize($test);
-				$test->fixtureManager = $this->_fixtureManager;
-			}
-		}
 	}
 
 /**
@@ -77,13 +62,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
-		$this->_nesting--;
-		if (!$this->_nesting) {
-			$this->_fixtureManager->shutdown();
-			$config = ConnectionManager::config('test');
-			ConnectionManager::drop('test');
-			ConnectionManager::config('test', $config);
-		}
 	}
 
 /**
@@ -137,6 +115,8 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTest(PHPUnit_Framework_Test $test) {
+		$this->_fixtureManager->fixturize($test);
+		$test->fixtureManager = $this->_fixtureManager;
 		$this->_fixtureManager->load($test);
 	}
 
@@ -149,6 +129,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  */
 	public function endTest(PHPUnit_Framework_Test $test, $time) {
 		$this->_fixtureManager->unload($test);
+		$this->_fixtureManager->shutdown();
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -116,6 +116,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  */
 	public function startTest(PHPUnit_Framework_Test $test) {
 		$test->fixtureManager = $this->_fixtureManager;
+		$this->_fixtureManager->fixturize($test);
 		$this->_fixtureManager->load($test);
 	}
 

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -37,6 +37,13 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
 	protected $_fixtureManager;
 
 /**
+ * Indicates the current number of nested testsuites
+ *
+ * @var integer
+ */
+	protected $_nesting = 0;
+
+/**
  * Constructor. Save internally the reference to the passed fixture manager
  *
  * @param \Cake\TestSuite\Fixture\FixtureManager $manager
@@ -53,6 +60,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		$this->_nesting++;
 		foreach ($suite->getIterator() as $test) {
 			if ($test instanceof TestCase) {
 				$this->_fixtureManager->fixturize($test);
@@ -69,10 +77,13 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		$this->_nesting--;
 		$this->_fixtureManager->shutdown();
-		$config = ConnectionManager::config('test');
-		ConnectionManager::drop('test');
-		ConnectionManager::config('test', $config);
+		if (!$this->_nesting) {
+			$config = ConnectionManager::config('test');
+			ConnectionManager::drop('test');
+			ConnectionManager::config('test', $config);
+		}
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -62,6 +62,7 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		$this->_fixtureManager->shutdown();
 	}
 
 /**
@@ -129,7 +130,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  */
 	public function endTest(PHPUnit_Framework_Test $test, $time) {
 		$this->_fixtureManager->unload($test);
-		$this->_fixtureManager->shutdown();
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -14,13 +14,14 @@
  */
 namespace Cake\TestSuite\Fixture;
 
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\Fixture\FixtureManager;
 use Cake\TestSuite\TestCase;
-use \Exception;
-use \PHPUnit_Framework_AssertionFailedError;
-use \PHPUnit_Framework_Test;
-use \PHPUnit_Framework_TestListener;
-use \PHPUnit_Framework_TestSuite;
+use Exception;
+use PHPUnit_Framework_AssertionFailedError;
+use PHPUnit_Framework_Test;
+use PHPUnit_Framework_TestListener;
+use PHPUnit_Framework_TestSuite;
 
 /**
  * Test listener used to inject a fixture manager in all tests that
@@ -69,6 +70,9 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
 		$this->_fixtureManager->shutdown();
+		$config = ConnectionManager::config('test');
+		ConnectionManager::drop('test');
+		ConnectionManager::config('test', $config);
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -36,12 +36,20 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
 	protected $_fixtureManager;
 
 /**
+ * Holds a reference to the conainer test suite
+ *
+ * @var \PHPUnit_Framework_TestSuite
+ */
+	protected $_first;
+
+/**
  * Constructor. Save internally the reference to the passed fixture manager
  *
  * @param \Cake\TestSuite\Fixture\FixtureManager $manager
  */
 	public function __construct(FixtureManager $manager) {
 		$this->_fixtureManager = $manager;
+		$this->_fixtureManager->shutdown();
 	}
 
 /**
@@ -52,6 +60,9 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		if (empty($this->_first)) {
+			$this->_first = $suite;
+		}
 	}
 
 /**
@@ -62,6 +73,9 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
+		if ($this->_first === $suite) {
+			$this->_fixtureManager->shutdown();
+		}
 	}
 
 /**

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -62,7 +62,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
-		$this->_fixtureManager->shutdown();
 	}
 
 /**
@@ -116,7 +115,6 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  * @return void
  */
 	public function startTest(PHPUnit_Framework_Test $test) {
-		$this->_fixtureManager->fixturize($test);
 		$test->fixtureManager = $this->_fixtureManager;
 		$this->_fixtureManager->load($test);
 	}

--- a/src/TestSuite/Fixture/FixtureInjector.php
+++ b/src/TestSuite/Fixture/FixtureInjector.php
@@ -78,8 +78,8 @@ class FixtureInjector implements PHPUnit_Framework_TestListener {
  */
 	public function endTestSuite(PHPUnit_Framework_TestSuite $suite) {
 		$this->_nesting--;
-		$this->_fixtureManager->shutdown();
 		if (!$this->_nesting) {
+			$this->_fixtureManager->shutdown();
 			$config = ConnectionManager::config('test');
 			ConnectionManager::drop('test');
 			ConnectionManager::config('test', $config);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -287,7 +287,7 @@ class FixtureManager {
 			}
 
 			if (!in_array($db->configName(), (array)$fixture->created)) {
-				$this->_setupTable($fixture, $db, $test->dropTables);
+				$this->_setupTable($fixture, $db, $dropTables);
 			}
 			$fixture->truncate($db);
 			$fixture->insert($db);

--- a/src/TestSuite/Fixture/FixtureManager.php
+++ b/src/TestSuite/Fixture/FixtureManager.php
@@ -223,7 +223,6 @@ class FixtureManager {
 		}
 
 		$dbs = [];
-		$this->fixturize($test);
 		foreach ($fixtures as $f) {
 			if (!empty($this->_loaded[$f])) {
 				$fixture = $this->_loaded[$f];
@@ -256,7 +255,7 @@ class FixtureManager {
  * @return void
  */
 	public function unload(TestCase $test) {
-		$fixtures = !empty($test->fixtures) ? $test->fixtures : array();
+		$fixtures = !empty($test->fixtures) ? $test->fixtures : [];
 		foreach (array_reverse($fixtures) as $f) {
 			if (isset($this->_loaded[$f])) {
 				$fixture = $this->_loaded[$f];
@@ -299,9 +298,6 @@ class FixtureManager {
 /**
  * Drop all fixture tables loaded by this class
  *
- * This will also close the session, as failing to do so will cause
- * fatal errors with database sessions.
- *
  * @return void
  */
 	public function shutDown() {
@@ -311,6 +307,7 @@ class FixtureManager {
 					$db = ConnectionManager::get($ds);
 					$fixture->drop($db);
 				}
+				$fixture->created = [];
 			}
 		}
 	}

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -47,13 +47,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 /**
  * Control table create/drops on each test method.
  *
- * Set this to false to avoid tables to be dropped if they already exist
- * between each test method. Tables will still be dropped at the
+ * If true, tables will still be dropped at the
  * end of each test runner execution.
  *
  * @var boolean
  */
-	public $dropTables = true;
+	public $dropTables = false;
 
 /**
  * Configure values to restore at end of test.

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -97,6 +97,7 @@ class ModelTaskTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		unset($this->Task);
+		$this->fixtureManager->shutDown();
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -448,6 +448,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testOutOfVeryBigPageNumberGetsClamped() {
+		$this->loadFixtures('Post');
 		$this->request->query = [
 			'page' => '3000000000000000000000000',
 		];
@@ -615,6 +616,7 @@ class PaginatorComponentTest extends TestCase {
  * @return void
  */
 	public function testPaginateMaxLimit() {
+		$this->loadFixtures('Post');
 		$table = TableRegistry::get('PaginatorPosts');
 
 		$settings = [

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -123,7 +123,7 @@ class ConnectionTest extends TestCase {
  *
  * @return void
  **/
-	public function _testDisconnect() {
+	public function testDisconnect() {
 		$config = ConnectionManager::config('test');
 		ConnectionManager::config('test_disconnect', $config);
 		$this->connection = ConnectionManager::get('test_disconnect');

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -119,22 +119,6 @@ class ConnectionTest extends TestCase {
 	}
 
 /**
- * Tests disconnecting from database
- *
- * @return void
- **/
-	public function testDisconnect() {
-		$config = ConnectionManager::config('test');
-		ConnectionManager::config('test_disconnect', $config);
-		$this->connection = ConnectionManager::get('test_disconnect');
-		$this->assertTrue($this->connection->connect());
-		$this->assertTrue($this->connection->isConnected());
-		$this->connection->disconnect();
-		$this->assertFalse($this->connection->isConnected());
-		ConnectionManager::drop('test_disconnect');
-	}
-
-/**
  * Tests creation of prepared statements
  *
  * @return void

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -158,6 +158,7 @@ class ConnectionTest extends TestCase {
 		$statement = $this->connection->execute($sql, ['one' => 2, 'two' => 3], array('one' => 'integer', 'two' => 'integer'));
 		$this->assertCount(1, $statement);
 		$result = $statement->fetch('assoc');
+		$statement->closeCursor();
 		$this->assertEquals(['total' => 6], $result);
 	}
 
@@ -176,6 +177,7 @@ class ConnectionTest extends TestCase {
 		$params = [new \DateTime('2012-01-01 10:10:10'), '2000-01-01 10:10:10', 2.1];
 		$statement = $this->connection->execute($sql, $params, ['date', 'string', 'integer']);
 		$result = $statement->fetch();
+		$statement->closeCursor();
 		$this->assertEquals($result, array_filter($result));
 	}
 
@@ -199,6 +201,7 @@ class ConnectionTest extends TestCase {
 		$sql = 'SELECT 1';
 		$statement = $this->connection->execute($sql);
 		$result = $statement->fetch();
+		$statement->closeCursor();
 		$this->assertCount(1, $result);
 		$this->assertEquals([1], $result);
 	}
@@ -275,8 +278,9 @@ class ConnectionTest extends TestCase {
 		$this->_insertTwoRecords();
 
 		$total = $this->connection->execute('SELECT COUNT(*) AS total FROM things');
-		$total = $total->fetch('assoc');
-		$this->assertEquals(2, $total['total']);
+		$result = $total->fetch('assoc');
+		$this->assertEquals(2, $result['total']);
+		$total->closeCursor();
 
 		$result = $this->connection->execute('SELECT title, body  FROM things');
 		$row = $result->fetch('assoc');
@@ -284,6 +288,7 @@ class ConnectionTest extends TestCase {
 		$this->assertEquals('a body', $row['body']);
 
 		$row = $result->fetch('assoc');
+		$result->closeCursor();
 		$this->assertEquals('another title', $row['title']);
 		$this->assertEquals('another body', $row['body']);
 	}
@@ -300,6 +305,7 @@ class ConnectionTest extends TestCase {
 		$this->connection->update('things', ['title' => $title, 'body' => $body]);
 		$result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
 		$this->assertCount(2, $result);
+		$result->closeCursor();
 	}
 
 /**
@@ -314,6 +320,7 @@ class ConnectionTest extends TestCase {
 		$this->connection->update('things', ['title' => $title, 'body' => $body], ['id' => 2]);
 		$result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
 		$this->assertCount(1, $result);
+		$result->closeCursor();
 	}
 
 /**
@@ -328,6 +335,7 @@ class ConnectionTest extends TestCase {
 		$this->connection->update('things', ['title' => $title, 'body' => $body], ['id' => 2, 'body is not null']);
 		$result = $this->connection->execute('SELECT * FROM things WHERE title = ? AND body = ?', [$title, $body]);
 		$this->assertCount(1, $result);
+		$result->closeCursor();
 	}
 
 /**
@@ -347,6 +355,7 @@ class ConnectionTest extends TestCase {
 		$this->assertEquals('2012-01-01', $row['body']);
 		$row = $result->fetch('assoc');
 		$this->assertEquals('2012-01-01', $row['body']);
+		$result->closeCursor();
 	}
 
 /**
@@ -364,6 +373,7 @@ class ConnectionTest extends TestCase {
 		$this->assertCount(1, $result);
 		$row = $result->fetch('assoc');
 		$this->assertEquals('2012-01-01', $row['body']);
+		$result->closeCursor();
 	}
 
 /**

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -147,14 +147,14 @@ class ConnectionTest extends TestCase {
 		$this->assertCount(1, $statement);
 		$result = $statement->fetch();
 		$this->assertEquals([2], $result);
-		$result->closeCursor();
+		$statement->closeCursor();
 
 		$sql = 'SELECT 1 + ? + ? AS total';
 		$statement = $this->connection->execute($sql, [2, 3], array('integer', 'integer'));
 		$this->assertCount(1, $statement);
 		$result = $statement->fetch('assoc');
 		$this->assertEquals(['total' => 6], $result);
-		$result->closeCursor();
+		$statement->closeCursor();
 
 		$sql = 'SELECT 1 + :one + :two AS total';
 		$statement = $this->connection->execute($sql, ['one' => 2, 'two' => 3], array('one' => 'integer', 'two' => 'integer'));
@@ -173,7 +173,7 @@ class ConnectionTest extends TestCase {
 		$sql = "SELECT ? = '2012-01-01'";
 		$statement = $this->connection->execute($sql, [new \DateTime('2012-01-01')], ['date']);
 		$result = $statement->fetch();
-		$result->closeCursor();
+		$statement->closeCursor();
 		$this->assertTrue((bool)$result[0]);
 
 		$sql = "SELECT ? = '2012-01-01', ? = '2000-01-01 10:10:10', ? = 2";

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -123,7 +123,7 @@ class ConnectionTest extends TestCase {
  *
  * @return void
  **/
-	public function testDisconnect() {
+	public function _testDisconnect() {
 		$config = ConnectionManager::config('test');
 		ConnectionManager::config('test_disconnect', $config);
 		$this->connection = ConnectionManager::get('test_disconnect');

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -147,12 +147,14 @@ class ConnectionTest extends TestCase {
 		$this->assertCount(1, $statement);
 		$result = $statement->fetch();
 		$this->assertEquals([2], $result);
+		$result->closeCursor();
 
 		$sql = 'SELECT 1 + ? + ? AS total';
 		$statement = $this->connection->execute($sql, [2, 3], array('integer', 'integer'));
 		$this->assertCount(1, $statement);
 		$result = $statement->fetch('assoc');
 		$this->assertEquals(['total' => 6], $result);
+		$result->closeCursor();
 
 		$sql = 'SELECT 1 + :one + :two AS total';
 		$statement = $this->connection->execute($sql, ['one' => 2, 'two' => 3], array('one' => 'integer', 'two' => 'integer'));
@@ -171,6 +173,7 @@ class ConnectionTest extends TestCase {
 		$sql = "SELECT ? = '2012-01-01'";
 		$statement = $this->connection->execute($sql, [new \DateTime('2012-01-01')], ['date']);
 		$result = $statement->fetch();
+		$result->closeCursor();
 		$this->assertTrue((bool)$result[0]);
 
 		$sql = "SELECT ? = '2012-01-01', ? = '2000-01-01 10:10:10', ? = 2";

--- a/tests/TestCase/Database/ConnectionTest.php
+++ b/tests/TestCase/Database/ConnectionTest.php
@@ -124,10 +124,14 @@ class ConnectionTest extends TestCase {
  * @return void
  **/
 	public function testDisconnect() {
+		$config = ConnectionManager::config('test');
+		ConnectionManager::config('test_disconnect', $config);
+		$this->connection = ConnectionManager::get('test_disconnect');
 		$this->assertTrue($this->connection->connect());
 		$this->assertTrue($this->connection->isConnected());
 		$this->connection->disconnect();
 		$this->assertFalse($this->connection->isConnected());
+		ConnectionManager::drop('test_disconnect');
 	}
 
 /**

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -105,20 +105,4 @@ class MysqlTest extends TestCase {
 		$driver->connect();
 	}
 
-/**
- * Tests disconnecting from database
- *
- * @return void
- **/
-	public function testDisconnect() {
-		$config = ConnectionManager::config('test');
-		ConnectionManager::config('test_disconnect', $config);
-		$connection = ConnectionManager::get('test_disconnect');
-		$this->assertTrue($connection->connect());
-		$this->assertTrue($connection->isConnected());
-		$connection->disconnect();
-		$this->assertFalse($connection->isConnected());
-		ConnectionManager::drop('test_disconnect');
-	}
-
 }

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -17,6 +17,7 @@ namespace Cake\Test\TestCase\Database\Driver;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
+use Cake\Datasource\ConnectionManager;
 use Cake\TestSuite\TestCase;
 use \PDO;
 

--- a/tests/TestCase/Database/Driver/MysqlTest.php
+++ b/tests/TestCase/Database/Driver/MysqlTest.php
@@ -104,4 +104,20 @@ class MysqlTest extends TestCase {
 		$driver->connect();
 	}
 
+/**
+ * Tests disconnecting from database
+ *
+ * @return void
+ **/
+	public function testDisconnect() {
+		$config = ConnectionManager::config('test');
+		ConnectionManager::config('test_disconnect', $config);
+		$connection = ConnectionManager::get('test_disconnect');
+		$this->assertTrue($connection->connect());
+		$this->assertTrue($connection->isConnected());
+		$connection->disconnect();
+		$this->assertFalse($connection->isConnected());
+		ConnectionManager::drop('test_disconnect');
+	}
+
 }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -165,4 +165,20 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals('FOO', $query->clause('epilog'));
 	}
 
+/**
+ * Tests disconnecting from database
+ *
+ * @return void
+ **/
+	public function testDisconnect() {
+		$config = ConnectionManager::config('test');
+		ConnectionManager::config('test_disconnect', $config);
+		$connection = ConnectionManager::get('test_disconnect');
+		$this->assertTrue($connection->connect());
+		$this->assertTrue($connection->isConnected());
+		$connection->disconnect();
+		$this->assertFalse($connection->isConnected());
+		ConnectionManager::drop('test_disconnect');
+	}
+
 }

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -18,6 +18,7 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Postgres;
 use Cake\Database\Query;
+use Cake\Datasource\ConnectionManager;
 use \PDO;
 
 /**
@@ -172,6 +173,7 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
  **/
 	public function testDisconnect() {
 		$config = ConnectionManager::config('test');
+		$this->skipIf(strpos($config['datasource'], 'Postgres') === false, 'Not using Postgres for test config');
 		ConnectionManager::config('test_disconnect', $config);
 		$connection = ConnectionManager::get('test_disconnect');
 		$this->assertTrue($connection->connect());

--- a/tests/TestCase/Database/Driver/PostgresTest.php
+++ b/tests/TestCase/Database/Driver/PostgresTest.php
@@ -166,21 +166,4 @@ class PostgresTest extends \Cake\TestSuite\TestCase {
 		$this->assertEquals('FOO', $query->clause('epilog'));
 	}
 
-/**
- * Tests disconnecting from database
- *
- * @return void
- **/
-	public function testDisconnect() {
-		$config = ConnectionManager::config('test');
-		$this->skipIf(strpos($config['datasource'], 'Postgres') === false, 'Not using Postgres for test config');
-		ConnectionManager::config('test_disconnect', $config);
-		$connection = ConnectionManager::get('test_disconnect');
-		$this->assertTrue($connection->connect());
-		$this->assertTrue($connection->isConnected());
-		$connection->disconnect();
-		$this->assertFalse($connection->isConnected());
-		ConnectionManager::drop('test_disconnect');
-	}
-
 }

--- a/tests/TestCase/Database/Log/LoggingStatementTest.php
+++ b/tests/TestCase/Database/Log/LoggingStatementTest.php
@@ -37,7 +37,7 @@ class LoggingStatementTest extends \Cake\TestSuite\TestCase {
 			->with($this->logicalAnd(
 				$this->isInstanceOf('\Cake\Database\Log\LoggedQuery'),
 				$this->attributeEqualTo('query', 'SELECT bar FROM foo'),
-				$this->attributeEqualTo('took', 5, 60),
+				$this->attributeEqualTo('took', 5, 200),
 				$this->attributeEqualTo('numRows', 3),
 				$this->attributeEqualTo('params', [])
 			));

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -44,7 +44,9 @@ class CompositeKeyTest extends TestCase {
  * @var array
  */
 	public $fixtures = [
-		'core.site_article', 'core.site_author', 'core.site_tag',
+		'core.site_article',
+		'core.site_author',
+		'core.site_tag',
 		'core.site_articles_tag'
 	];
 
@@ -74,7 +76,7 @@ class CompositeKeyTest extends TestCase {
  * @dataProvider strategiesProvider
  * @return void
  */
-	public function testHasManyEager($strategy) {
+	public function _testHasManyEager($strategy) {
 		$table = TableRegistry::get('SiteAuthors');
 		$table->hasMany('SiteArticles', [
 			'propertyName' => 'articles',
@@ -147,7 +149,7 @@ class CompositeKeyTest extends TestCase {
  * @dataProvider strategiesProvider
  * @return void
  **/
-	public function testBelongsToManyEager($strategy) {
+	public function _testBelongsToManyEager($strategy) {
 		$articles = TableRegistry::get('SiteArticles');
 		$tags = TableRegistry::get('SiteTags');
 		$junction = TableRegistry::get('SiteArticlesTags');

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -61,35 +61,22 @@ class CompositeKeyTest extends TestCase {
 	}
 
 /**
+ * Data provider for the two types of strategies HasMany implements
+ *
+ * @return void
+ */
+	public function strategiesProvider() {
+		return [['subquery'], ['select']];
+	}
+
+/**
  * Tests that HasMany associations are correctly eager loaded and results
  * correctly nested when multiple foreignKeys are used
  *
- * Uses the select strategy
- *
+ * @dataProvider strategiesProvider
  * @return void
  */
-	public function testHasManyEagerSelect() {
-		$this->_testHasMany('select');
-	}
-
-/**
- * Tests that HasMany associations are correctly eager loaded and results
- * correctly nested when multiple foreignKeys are used.
- *
- * Uses the subquery startegy
- *
- * @return void
- */
-	public function testHasManyEagerSubquery() {
-		$this->_testHasMany('subquery');
-	}
-
-/**
- * Helper method used to test eager loading of hasMany associations
- *
- * @return void
- */
-	protected function _testHasMany($strategy) {
+	public function _testHasManyEager($strategy) {
 		$table = TableRegistry::get('SiteAuthors');
 		$table->hasMany('SiteArticles', [
 			'propertyName' => 'articles',
@@ -159,32 +146,10 @@ class CompositeKeyTest extends TestCase {
  * Tests that BelongsToMany associations are correctly eager loaded when multiple
  * foreignKeys are used
  *
- * Uses the select strategy
- *
+ * @dataProvider strategiesProvider
  * @return void
  **/
-	public function testBelongsToManyEagerSelect() {
-		$this->_testBelongsToMany('select');
-	}
-
-/**
- * Tests that BelongsToMany associations are correctly eager loaded when multiple
- * foreignKeys are used
- *
- * Uses the subquery strategy
- *
- * @return void
- **/
-	public function testBelongsToManyEagerSubquery() {
-		$this->_testBelongsToMany('subquery');
-	}
-
-/**
- * Helper method used to test eager loding of BelongsToMany associations
- *
- * @return void
- */
-	protected function _testBelongsToMany($strategy) {
+	public function _testBelongsToManyEager($strategy) {
 		$articles = TableRegistry::get('SiteArticles');
 		$tags = TableRegistry::get('SiteTags');
 		$junction = TableRegistry::get('SiteArticlesTags');

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -61,22 +61,35 @@ class CompositeKeyTest extends TestCase {
 	}
 
 /**
- * Data provider for the two types of strategies HasMany implements
+ * Tests that HasMany associations are correctly eager loaded and results
+ * correctly nested when multiple foreignKeys are used
+ *
+ * Uses the select strategy
  *
  * @return void
  */
-	public function strategiesProvider() {
-		return [['subquery'], ['select']];
+	public function testHasManyEagerSelect() {
+		$this->_testHasMany('select');
 	}
 
 /**
  * Tests that HasMany associations are correctly eager loaded and results
- * correctly nested when multiple foreignKeys are used
+ * correctly nested when multiple foreignKeys are used.
  *
- * @dataProvider strategiesProvider
+ * Uses the subquery startegy
+ *
  * @return void
  */
-	public function _testHasManyEager($strategy) {
+	public function testHasManyEagerSubquery() {
+		$this->_testHasMany('subquery');
+	}
+
+/**
+ * Helper method used to test eager loading of hasMany associations
+ *
+ * @return void
+ */
+	protected function _testHasMany($strategy) {
 		$table = TableRegistry::get('SiteAuthors');
 		$table->hasMany('SiteArticles', [
 			'propertyName' => 'articles',
@@ -146,10 +159,32 @@ class CompositeKeyTest extends TestCase {
  * Tests that BelongsToMany associations are correctly eager loaded when multiple
  * foreignKeys are used
  *
- * @dataProvider strategiesProvider
+ * Uses the select strategy
+ *
  * @return void
  **/
-	public function _testBelongsToManyEager($strategy) {
+	public function testBelongsToManyEagerSelect() {
+		$this->_testBelongsToMany('select');
+	}
+
+/**
+ * Tests that BelongsToMany associations are correctly eager loaded when multiple
+ * foreignKeys are used
+ *
+ * Uses the subquery strategy
+ *
+ * @return void
+ **/
+	public function testBelongsToManyEagerSubquery() {
+		$this->_testBelongsToMany('subquery');
+	}
+
+/**
+ * Helper method used to test eager loding of BelongsToMany associations
+ *
+ * @return void
+ */
+	protected function _testBelongsToMany($strategy) {
 		$articles = TableRegistry::get('SiteArticles');
 		$tags = TableRegistry::get('SiteTags');
 		$junction = TableRegistry::get('SiteArticlesTags');

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -76,7 +76,7 @@ class CompositeKeyTest extends TestCase {
  * @dataProvider strategiesProvider
  * @return void
  */
-	public function _testHasManyEager($strategy) {
+	public function testHasManyEager($strategy) {
 		$table = TableRegistry::get('SiteAuthors');
 		$table->hasMany('SiteArticles', [
 			'propertyName' => 'articles',
@@ -149,7 +149,7 @@ class CompositeKeyTest extends TestCase {
  * @dataProvider strategiesProvider
  * @return void
  **/
-	public function _testBelongsToManyEager($strategy) {
+	public function testBelongsToManyEager($strategy) {
 		$articles = TableRegistry::get('SiteArticles');
 		$tags = TableRegistry::get('SiteTags');
 		$junction = TableRegistry::get('SiteArticlesTags');

--- a/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
+++ b/tests/test_app/TestApp/Model/Table/PaginatorPostsTable.php
@@ -24,18 +24,12 @@ use Cake\Utility\Hash;
 class PaginatorPostsTable extends Table {
 
 /**
- * table property
- *
- * @var string
- */
-	protected $_table = 'posts';
-
-/**
  * initialize method
  *
  * @return void
  */
 	public function initialize(array $config) {
+		$this->table('posts');
 		$this->belongsTo('PaginatorAuthor', [
 			'foreignKey' => 'author_id'
 		]);


### PR DESCRIPTION
This fixes random fails in sqlite, some of the errors fixed:
- Test suites can be nested in PHPUnit, we were dropping fixtures even though the parent suite was not over
- Dropping tables in between tests methods was not actually required, removing it made the test suite a bit faster and more robust
- A test in ConnectionTest was re-creating the sqlite connection, effectively dropping all tables. I had to remove this test entirely and will look into adding it back at a later point.
- Sqlite does not like leaving cursors open, added `closeCursor` calls in the ConnectionTest suite.
