### PR TITLE
Make `cake acl delete <acl-object>` delete all matching records.

### DIFF
--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -156,7 +156,7 @@ class AclShell extends AppShell {
 			$identifier = array('alias' => $identifier);
 		}
 
-		if ($this->Acl->{$class}->find('all', ['conditions' => $identifier])) {
+		if ($this->Acl->{$class}->find('all', array('conditions' => $identifier))) {
 			if (!$this->Acl->{$class}->deleteAll($identifier)) {
 				$this->error(__d('cake_console', 'Node Not Deleted. ') . __d('cake_console', 'There was an error deleting the %s.', $class) . "\n");
 			}

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -152,11 +152,11 @@ class AclShell extends AppShell {
 		extract($this->_dataVars());
 
 		$identifier = $this->parseIdentifier($this->args[1]);
-		if(is_string($identifier)) {
-			$identifier = ['alias' => $identifier];
+		if (is_string($identifier)) {
+			$identifier = array('alias' => $identifier);
 		}
 
-		if($this->Acl->{$class}->find('all')) {
+		if ($this->Acl->{$class}->find('all', ['conditions' => $identifier])) {
 			if (!$this->Acl->{$class}->deleteAll($identifier)) {
 				$this->error(__d('cake_console', 'Node Not Deleted. ') . __d('cake_console', 'There was an error deleting the %s.', $class) . "\n");
 			}

--- a/lib/Cake/Console/Command/AclShell.php
+++ b/lib/Cake/Console/Command/AclShell.php
@@ -143,7 +143,8 @@ class AclShell extends AppShell {
 	}
 
 /**
- * Delete an ARO/ACO node.
+ * Delete an ARO/ACO node. Note there may be (as a result of poor configuration)
+ * multiple records with the same logical identifier. All are deleted.
  *
  * @return void
  */
@@ -151,12 +152,18 @@ class AclShell extends AppShell {
 		extract($this->_dataVars());
 
 		$identifier = $this->parseIdentifier($this->args[1]);
-		$nodeId = $this->_getNodeId($class, $identifier);
-
-		if (!$this->Acl->{$class}->delete($nodeId)) {
-			$this->error(__d('cake_console', 'Node Not Deleted') . __d('cake_console', 'There was an error deleting the %s. Check that the node exists.', $class) . "\n");
+		if(is_string($identifier)) {
+			$identifier = ['alias' => $identifier];
 		}
-		$this->out(__d('cake_console', '<success>%s deleted.</success>', $class), 2);
+
+		if($this->Acl->{$class}->find('all')) {
+			if (!$this->Acl->{$class}->deleteAll($identifier)) {
+				$this->error(__d('cake_console', 'Node Not Deleted. ') . __d('cake_console', 'There was an error deleting the %s.', $class) . "\n");
+			}
+			$this->out(__d('cake_console', '<success>%s deleted.</success>', $class), 2);
+		} else {
+			$this->error(__d('cake_console', 'Node Not Deleted. ') . __d('cake_console', 'There was an error deleting the %s. Node does not exist.', $class) . "\n");
+		}
 	}
 
 /**


### PR DESCRIPTION
You can create multi records in acos or aros table that are logically the same. Calling `cake create (aco|aro) "" <spec>` multiple times will do this, and there is no default restriction on the acl nodes  (although you can and probably should place unique constraints on them..). Anyway you can easily end up with multiple ACL nodes that are logically the same in default setup. It makes more sense for `cake acl delete` to delete them all rather than one arbitrary one.

Use case that drove me to want to change this was a deployment script that  did `cake acl create "" admin`. Somehow 2 aro node for admin where in there. With this change I can do `cake acl delete "admin"; cake acl create "" admin` and be sure there is only one admin entry for example. You could also try and force uniqueness on `create` but this is still useful for edge case of deleting nodes that may have got in another way - very edge but its still the right behavior.

On reflection I will apply unique constraints but this change may be more useful to others in general.
