### PR TITLE
Avoid ordering when counting.

### DIFF
--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -463,6 +463,7 @@ class Query extends DatabaseQuery {
 	public function count() {
 		$query = clone $this;
 		$query->limit(null);
+		$query->order([], true);
 		$query->offset(null);
 		$query->mapReduce(null, null, true);
 		$query->formatResults(null, true);


### PR DESCRIPTION
This not only optimizes the query, but also avoid errors caused when
ordering by fields set in the WHERE clause, because count() overrides
them by default.
