### PR TITLE
Allow Association to define foreign keys and properties DRY

### DIFF
--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -45,8 +45,7 @@ class BelongsTo extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_generateKey($this->target()->alias());
 			}
 			return $this->_foreignKey;
 		}
@@ -80,7 +79,11 @@ class BelongsTo extends Association {
 		}
 		if ($name === null && !$this->_propertyName) {
 			list($plugin, $name) = pluginSplit($this->_name);
-			$this->_propertyName = Inflector::underscore(Inflector::singularize($name));
+			$name = Inflector::underscore(Inflector::singularize($name));
+			if ($this->_camelBacked) {
+				$name = lcfirst(Inflector::camelize($name));
+			}
+			$this->_propertyName = $name;
 		}
 		return $this->_propertyName;
 	}

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -131,8 +131,7 @@ class BelongsToMany extends Association {
 	public function targetForeignKey($key = null) {
 		if ($key === null) {
 			if ($this->_targetForeignKey === null) {
-				$key = Inflector::singularize($this->target()->alias());
-				$this->_targetForeignKey = Inflector::underscore($key) . '_id';
+				$this->_targetForeignKey = $this->_generateKey($this->target()->alias());
 			}
 			return $this->_targetForeignKey;
 		}

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -53,8 +53,7 @@ trait ExternalAssociationTrait {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_generateKey($this->source()->alias());
 			}
 			return $this->_foreignKey;
 		}

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -55,8 +55,7 @@ class HasOne extends Association {
 	public function foreignKey($key = null) {
 		if ($key === null) {
 			if ($this->_foreignKey === null) {
-				$key = Inflector::singularize($this->source()->alias());
-				$this->_foreignKey = Inflector::underscore($key) . '_id';
+				$this->_foreignKey = $this->_generateKey($this->source()->alias());
 			}
 			return $this->_foreignKey;
 		}
@@ -77,7 +76,11 @@ class HasOne extends Association {
 		}
 		if ($name === null && !$this->_propertyName) {
 			list($plugin, $name) = pluginSplit($this->_name);
-			$this->_propertyName = Inflector::underscore(Inflector::singularize($name));
+			$name = Inflector::underscore(Inflector::singularize($name));
+			if ($this->_camelBacked) {
+				$name = lcfirst(Inflector::camelize($name));
+			}
+			$this->_propertyName = $name;
 		}
 		return $this->_propertyName;
 	}


### PR DESCRIPTION
Allow Association objects to define in a more DRY approach how the foreign_key_id/foreignKeyId fields and all field properties are generated.
Especially regarding the use of camelBacked vs under_scored.
### Basis

If one would want to use camelBacked for table fields including foreign key fields, it is currently difficult to achieve.
One could use the Entitiy::set/get to map those underscored fields into camelBacked properties of the Entity classes. But it would be consistent if the ORM would be able to resolve this internally and both code and DB use the same type of field naming scheme.

So $UserEntity->someForeignKey maps to "someForeignKey" of the "users" table then.

Since the whole framework uses camelBacked options/settings keys it would also make DB driven settings and merging them with Configure settings way easier and uniform (as of right now Inflection would be needed).
### Implementation

This PR uses a generic _generateKey() method to reduce the redundancy in the code as well as allowing the _camelBack property to define what scheme should be used as default one.
### Outview

This might need more adjustments in the other parts of the ORM, framework to be a fully working "camelBack" standard instead of the former "under_scored" one.

If this approach sounds sane, I can also add some tests.
