### PR TITLE
Correct logic to determine timezone setting

### DIFF
--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -489,6 +489,7 @@ class CakeTimeTest extends CakeTestCase {
 		$time = time();
 		date_default_timezone_set('Europe/Paris');
 		$result = $this->Time->toServer($time, 'America/New_York');
+		date_default_timezone_set('America/New_York');
 		$this->assertEquals(date('Y-m-d H:i:s', $time), $result);
 
 		date_default_timezone_set('Europe/Paris');

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -612,13 +612,13 @@ class CakeTime {
 	}
 
 /**
- * Returns a formatted date in server's timezone.
+ * Returns a formatted date in a specified timezone, or by default the server's timezone.
  *
- * If a DateTime object is given or the dateString has a timezone
+ * If a DateTime object is given with a timezone or the dateString has a timezone
  * segment, the timezone parameter will be ignored.
  *
  * If no timezone parameter is given and no DateTime object, the passed $dateString will be
- * considered to be in the UTC timezone.
+ * considered to be in the server's timezone.
  *
  * @param integer|string|DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|DateTimeZone $timezone Timezone string or DateTimeZone object
@@ -628,25 +628,24 @@ class CakeTime {
  */
 	public static function toServer($dateString, $timezone = null, $format = 'Y-m-d H:i:s') {
 		if ($timezone === null) {
-			$timezone = new DateTimeZone('UTC');
+			$timezone = new DateTimeZone(date_default_timezone_get());
 		} elseif (is_string($timezone)) {
 			$timezone = new DateTimeZone($timezone);
 		} elseif (!($timezone instanceof DateTimeZone)) {
 			return false;
 		}
-
 		if ($dateString instanceof DateTime) {
 			$date = $dateString;
+			if (!$date->getTimezone()) {
+				$date->setTimezone($timezone);
+			}
 		} elseif (is_int($dateString) || is_numeric($dateString)) {
 			$dateString = (int)$dateString;
-
 			$date = new DateTime('@' . $dateString);
 			$date->setTimezone($timezone);
 		} else {
 			$date = new DateTime($dateString, $timezone);
 		}
-
-		$date->setTimezone(new DateTimeZone(date_default_timezone_get()));
 		return $date->format($format);
 	}
 


### PR DESCRIPTION
Updated the method to correctly reflect the intended functionality, and removed the explicit 'UTC' timezone setting which was always overwritten by date_default_timezone_get(), which makes more sense
