### PR TITLE
Use $limit instead.

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -195,7 +195,7 @@ class PaginatorComponent extends Component {
 			'pageCount' => $pageCount,
 			'sort' => key($order),
 			'direction' => current($order),
-			'limit' => $defaults['limit'] != $options['limit'] ? $options['limit'] : null,
+			'limit' => $defaults['limit'] != $limit ? $limit : null,
 			'sortDefault' => $sortDefault,
 			'directionDefault' => $directionDefault
 		);


### PR DESCRIPTION
I don't know why is that test there, maybe because the helper needs to be `null` if the default is used, but maybe that line can just read:

```
'limit' => $limit,
```

as in `2.x`.
