### PR TITLE
Removing parentheses from generated Query when converting to string

### DIFF
--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -79,8 +79,7 @@ trait PDODriverTrait {
  */
 	public function prepare($query) {
 		$this->connect();
-		$sql = $query instanceof Query ? $query->sql() : $query;
-		$statement = $this->_connection->prepare($sql);
+		$statement = $this->_connection->prepare((string)$query);
 		return new PDOStatement($statement, $this);
 	}
 

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -88,8 +88,7 @@ class Sqlite extends \Cake\Database\Driver {
  */
 	public function prepare($query) {
 		$this->connect();
-		$sql = $query instanceof Query ? $query->sql() : $query;
-		$statement = $this->_connection->prepare($sql);
+		$statement = $this->_connection->prepare((string)$query);
 		return new SqliteStatement(new PDOStatement($statement, $this), $this);
 	}
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1822,7 +1822,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * @return string
  */
 	public function __toString() {
-		return sprintf('(%s)', $this->sql());
+		return $this->sql();
 	}
 
 /**

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -2397,6 +2397,20 @@ class QueryTest extends TestCase {
 	}
 
 /**
+ * Tests converting a query to a string
+ *
+ * @return void
+ */
+	public function testToString() {
+		$query = new Query($this->connection);
+		$query
+			->select(['title'])
+			->from('articles');
+		$result = (string)$query;
+		$this->assertQuotedQuery('SELECT <title> FROM <articles>', $result, true);
+	}
+
+/**
  * Tests __debugInfo
  *
  * @return void


### PR DESCRIPTION
As discussed in https://github.com/cakephp/cakephp/pull/2689/files#r9021184
