### PR TITLE
Fixing CS on QueryTest for having two blank lines.

### DIFF
--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -808,7 +808,6 @@ class QueryTest extends TestCase {
 		$this->assertEquals(10, $query->clause('offset'));
 	}
 
-
 /**
  * ApplyOptions should ignore null values.
  *


### PR DESCRIPTION
```
FILE: /home/travis/build/cakephp/cakephp/tests/TestCase/ORM/QueryTest.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 809 | ERROR | Expected 1 blank lines after function; 2 found
--------------------------------------------------------------------------------
```
