### PR TITLE
begin decoupling the two paginate methods

### DIFF
--- a/src/Controller/Component/PaginatorComponent.php
+++ b/src/Controller/Component/PaginatorComponent.php
@@ -169,7 +169,6 @@ class PaginatorComponent extends Component {
 		$count = $numResults ? $query->count() : 0;
 
 		$defaults = $this->getDefaults($alias, $settings);
-		unset($defaults[0]);
 
 		$page = $options['page'];
 		$limit = $options['limit'];
@@ -247,18 +246,13 @@ class PaginatorComponent extends Component {
  * @return array An array of pagination defaults for a model, or the general settings.
  */
 	public function getDefaults($alias, $defaults) {
-		if (isset($defaults[$alias])) {
-			$defaults = $defaults[$alias];
-		}
 		if (isset($defaults['limit']) &&
 			(empty($defaults['maxLimit']) || $defaults['limit'] > $defaults['maxLimit'])
 		) {
 			$defaults['maxLimit'] = $defaults['limit'];
 		}
-		return array_merge(
-			array('page' => 1, 'limit' => 20, 'maxLimit' => 100),
-			$defaults
-		);
+
+		return $defaults + $this->_config;
 	}
 
 /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -699,9 +699,7 @@ class Controller extends Object implements EventListener {
 	public function paginate($object = null) {
 		if (is_object($object)) {
 			$table = $object;
-		}
-
-		if (is_string($object) || $object === null) {
+		} elseif (is_string($object) || $object === null) {
 			$try = [$object, $this->modelClass];
 			foreach ($try as $tableName) {
 				if (empty($tableName)) {
@@ -712,14 +710,22 @@ class Controller extends Object implements EventListener {
 			}
 		}
 
-		$this->Paginator = $this->addComponent('Paginator');
+		$alias = $table->alias();
+		$paginate = $this->paginate;
+		if (isset($paginate[$alias])) {
+			$paginate = $paginate[$alias];
+		}
+
+		if (!isset($this->Paginator)) {
+			$this->addComponent('Paginator');
+		}
 		if (
 			!in_array('Paginator', $this->helpers) &&
 			!array_key_exists('Paginator', $this->helpers)
 		) {
 			$this->helpers[] = 'Paginator';
 		}
-		return $this->Paginator->paginate($table, $this->paginate);
+		return $this->Paginator->paginate($table, $paginate);
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/PaginatorComponentTest.php
+++ b/tests/TestCase/Controller/Component/PaginatorComponentTest.php
@@ -114,12 +114,10 @@ class PaginatorComponentTest extends TestCase {
 	public function testPaginateExtraParams() {
 		$this->request->query = array('page' => '-1');
 		$settings = array(
-			'PaginatorPosts' => array(
-				'contain' => array('PaginatorAuthor'),
-				'maxLimit' => 10,
-				'group' => 'PaginatorPosts.published',
-				'order' => array('PaginatorPosts.id' => 'ASC')
-			),
+			'contain' => array('PaginatorAuthor'),
+			'maxLimit' => 10,
+			'group' => 'PaginatorPosts.published',
+			'order' => array('PaginatorPosts.id' => 'ASC')
 		);
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery();
@@ -147,11 +145,9 @@ class PaginatorComponentTest extends TestCase {
  */
 	public function testPaginateCustomFinder() {
 		$settings = array(
-			'PaginatorPosts' => array(
-				'findType' => 'popular',
-				'fields' => array('id', 'title'),
-				'maxLimit' => 10,
-			)
+			'findType' => 'popular',
+			'fields' => array('id', 'title'),
+			'maxLimit' => 10,
 		);
 
 		$table = $this->_getMockPosts(['findPopular']);
@@ -233,20 +229,11 @@ class PaginatorComponentTest extends TestCase {
 	public function testMergeOptionsModelSpecific() {
 		$settings = array(
 			'page' => 1,
-			'limit' => 20,
-			'maxLimit' => 100,
-			'Posts' => array(
-				'page' => 1,
-				'limit' => 10,
-				'maxLimit' => 50,
-			)
+			'limit' => 10,
+			'maxLimit' => 50,
 		);
 		$result = $this->Paginator->mergeOptions('Silly', $settings);
 		$this->assertEquals($settings, $result);
-
-		$result = $this->Paginator->mergeOptions('Posts', $settings);
-		$expected = array('page' => 1, 'limit' => 10, 'maxLimit' => 50);
-		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -358,14 +345,43 @@ class PaginatorComponentTest extends TestCase {
 		);
 		$result = $this->Paginator->mergeOptions('Post', $settings);
 		$expected = array('page' => 1, 'limit' => 200, 'maxLimit' => 200, 'paramType' => 'named');
+		$this->assertEquals(
+			$expected,
+			$result,
+			'Configuring a higher limit than maxLimit should bump the maxLimit value'
+		);
+	}
+
+/**
+ * testMergeOptionsUsesConfig
+ *
+ * @return void
+ */
+	public function testMergeOptionsUsesConfig() {
+		$this->Paginator->config('limit', 12);
+
+		$result = $this->Paginator->mergeOptions('Post', []);
+		$expected = array(
+			'page' => 1,
+			'limit' => 12,
+			'maxLimit' => 100,
+		);
 		$this->assertEquals($expected, $result);
 
-		$settings = array(
-			'maxLimit' => 10,
-			'paramType' => 'named',
+		$result = $this->Paginator->mergeOptions('Post', ['limit' => 34]);
+		$expected = array(
+			'page' => 1,
+			'limit' => 34,
+			'maxLimit' => 34
 		);
-		$result = $this->Paginator->mergeOptions('Post', $settings);
-		$expected = array('page' => 1, 'limit' => 20, 'maxLimit' => 10, 'paramType' => 'named');
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Paginator->mergeOptions('Post', ['limit' => 123]);
+		$expected = array(
+			'page' => 1,
+			'limit' => 123,
+			'maxLimit' => 123
+		);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -750,12 +766,10 @@ class PaginatorComponentTest extends TestCase {
 	public function testPaginateQuery() {
 		$this->request->query = array('page' => '-1');
 		$settings = array(
-			'PaginatorPosts' => array(
-				'contain' => array('PaginatorAuthor'),
-				'maxLimit' => 10,
-				'group' => 'PaginatorPosts.published',
-				'order' => array('PaginatorPosts.id' => 'ASC')
-			)
+			'contain' => array('PaginatorAuthor'),
+			'maxLimit' => 10,
+			'group' => 'PaginatorPosts.published',
+			'order' => array('PaginatorPosts.id' => 'ASC')
 		);
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery($table);
@@ -781,13 +795,11 @@ class PaginatorComponentTest extends TestCase {
 	public function testPaginateQueryWithLimit() {
 		$this->request->query = array('page' => '-1');
 		$settings = array(
-			'PaginatorPosts' => array(
-				'contain' => array('PaginatorAuthor'),
-				'maxLimit' => 10,
-				'limit' => 5,
-				'group' => 'PaginatorPosts.published',
-				'order' => array('PaginatorPosts.id' => 'ASC')
-			)
+			'contain' => array('PaginatorAuthor'),
+			'maxLimit' => 10,
+			'limit' => 5,
+			'group' => 'PaginatorPosts.published',
+			'order' => array('PaginatorPosts.id' => 'ASC')
 		);
 		$table = $this->_getMockPosts(['find']);
 		$query = $this->_getMockFindQuery($table);

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -718,6 +718,37 @@ class ControllerTest extends TestCase {
 	}
 
 /**
+ * testPaginateNestedConfig
+ *
+ * @return void
+ */
+	public function testPaginateNestedConfig() {
+		$request = new Request('controller_posts/index');
+		$request->params['pass'] = array();
+		$response = $this->getMock('Cake\Network\Response', ['httpCodes']);
+
+		$Controller = new Controller($request, $response);
+		$Controller->paginate = [
+			'limit' => 123,
+			'Posts' => [
+				'limit' => 456
+			],
+			'Authors' => [
+				'limit' => 789
+			]
+		];
+
+		$Controller->Posts = TableRegistry::get('Posts');
+		$Controller->Paginator = $this->getMock('Cake\Component\PaginatorComponent', ['paginate']);
+		$Controller->Paginator
+			->expects($this->at(0))
+			->method('paginate')
+			->with($Controller->Posts, ['limit' => 456]);
+
+		$Controller->paginate('Posts');
+	}
+
+/**
  * testMissingAction method
  *
  * @expectedException \Cake\Error\MissingActionException


### PR DESCRIPTION
The config of the paginator component should be used/honored. Right now
this has no effect:

```
$Paginator->config('limit', 123);
$result = $Paginator->paginate('Name');
```

The only way, currently, to preconfigure the paginator component is to
modify the `Controller::$paginate` property and call `Controller::paginate()`.

So - move the paginate-property juggling to the controller, and make the component read it's own config as the last-line defaults.

It's surely confusing that to configure`X::x()` you must modify `Y::$y` and call `Y::y()` - I'm more interested/concerned with the confusion this can case with testing and debugging than usage.
