### PR TITLE
3.0 test action

### DIFF
--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -201,7 +201,7 @@ abstract class ControllerTestCase extends TestCase {
  *   REST webservices.
  * - `query` The query string parameters to set.
  * - `cookies` The cookie data to use for the request.
- * - `method` POST or GET. Defaults to POST.
+ * - `method` POST or GET. Defaults to GET.
  * - `return` Specify the return type you want. Choose from:
  *     - `vars` Get the set view variables.
  *     - `view` Get the rendered view, without a layout.
@@ -220,7 +220,7 @@ abstract class ControllerTestCase extends TestCase {
 			'query' => array(),
 			'data' => array(),
 			'cookies' => array(),
-			'method' => 'POST',
+			'method' => 'GET',
 			'return' => 'result'
 		), $options);
 

--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -326,6 +326,7 @@ class ControllerTestCaseTest extends TestCase {
 			)
 		);
 		$this->Case->testAction('/tests_apps_posts/post_var', array(
+			'method' => 'post',
 			'data' => $data
 		));
 		$this->assertEquals($this->Case->controller->viewVars['data'], $data);
@@ -419,6 +420,7 @@ class ControllerTestCaseTest extends TestCase {
 
 		$data = array('var' => 'set');
 		$result = $this->Case->testAction('/tests_apps_posts/post_var', array(
+			'method' => 'post',
 			'data' => $data,
 			'return' => 'vars'
 		));


### PR DESCRIPTION
GET as default method makes way more sense for testAction()
Also quite a few unnecessary POSTs can be prevented this way, as they (silently) happen without knowledge due to the default value here.

I will update the migration guide afterwards.
