### PR TITLE
Get all the connected routes list.

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -226,6 +226,15 @@ class RouteCollection implements \Countable {
 	}
 
 /**
+ * Get the list of connected routes.
+ *
+ * @return array.
+ */
+	public function routes() {
+		return $this->_routes;
+	}
+
+/**
  * Part of the countable interface.
  *
  * @return integer The number of connected routes.

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -226,11 +226,11 @@ class RouteCollection implements \Countable {
 	}
 
 /**
- * Get the list of connected routes.
+ * Get the list of all connected routes.
  *
  * @return array.
  */
-	public function routes() {
+	public function all() {
 		return $this->_routes;
 	}
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -333,6 +333,25 @@ class RouterTest extends TestCase {
 	}
 
 /**
+ * Test that RouterCollection::routes() gets the list of connected routes.
+ *
+ * @return void
+ */
+	public function testRouteCollectionRoutes() {
+		$collection = new RouteCollection();
+		Router::setRouteCollection($collection);
+		Router::mapResources('Posts');
+
+		$routes = $collection->routes();
+
+		$this->assertEquals(count($routes), 6);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $routes[0]);
+		$this->assertEquals($collection->get(0), $routes[0]);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $routes[5]);
+		$this->assertEquals($collection->get(5), $routes[5]);
+	}
+
+/**
  * Test mapResources with a plugin and prefix.
  *
  * @return void

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -333,7 +333,7 @@ class RouterTest extends TestCase {
 	}
 
 /**
- * Test that RouterCollection::routes() gets the list of connected routes.
+ * Test that RouterCollection::all() gets the list of all connected routes.
  *
  * @return void
  */
@@ -342,7 +342,7 @@ class RouterTest extends TestCase {
 		Router::setRouteCollection($collection);
 		Router::mapResources('Posts');
 
-		$routes = $collection->routes();
+		$routes = $collection->all();
 
 		$this->assertEquals(count($routes), 6);
 		$this->assertInstanceOf('Cake\Routing\Route\Route', $routes[0]);


### PR DESCRIPTION
Expose a function for `RouteCollection` to get all connected routes.

We have `RouteCollection::get()` but you must know the route name/index beforehand all the time.
