### PR TITLE
Adds phpunit required version to TestShell "not found" error message.

### DIFF
--- a/lib/Cake/Console/Command/TestShell.php
+++ b/lib/Cake/Console/Command/TestShell.php
@@ -171,7 +171,7 @@ class TestShell extends Shell {
 		$this->_dispatcher = new CakeTestSuiteDispatcher();
 		$success = $this->_dispatcher->loadTestFramework();
 		if (!$success) {
-			throw new Exception(__d('cake_dev', 'Please install PHPUnit framework <info>(http://www.phpunit.de)</info>'));
+			throw new Exception(__d('cake_dev', 'Please install PHPUnit framework v3.7 <info>(http://www.phpunit.de)</info>'));
 		}
 	}
 

--- a/lib/Cake/Test/Case/Utility/FileTest.php
+++ b/lib/Cake/Test/Case/Utility/FileTest.php
@@ -532,7 +532,7 @@ class FileTest extends CakeTestCase {
 		$path = CAKE . 'Test' . DS . 'test_app' . DS . 'webroot' . DS . 'img' . DS . 'cake.power.gif';
 		$file = new File($path);
 		$expected = 'image/gif';
-		if (function_exists('mime_content_type') && false === mime_content_type($file->pwd())) {
+		if (function_exists('mime_content_type') && mime_content_type($file->pwd()) === false) {
 			$expected = false;
 		}
 		$this->assertEquals($expected, $file->mime());


### PR DESCRIPTION
Ref: #3185

Just a thought: Is there any benefit in modifying the error message in the 2.x branch to specify the required version given that no attempt is going to be made to make Cake compatible with 4? If it avoids even one extra "useless" ticket like mine, it seems like it might be worth it.
