### PR TITLE
3.0 - Implemented the select and subquery strategy for BelongsTo

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -591,7 +591,7 @@ abstract class Association {
  * Query. This callable will be responsible for injecting the fields that are
  * related to each specific passed row.
  *
- * Options array accept the following keys:
+ * Options array accepts the following keys:
  *
  * - query: Query object setup to find the source table records
  * - keys: List of primary key values from the source table

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -578,7 +578,29 @@ abstract class Association {
 
 /**
  * Eager loads a list of records in the target table that are related to another
- * set of records in the source table.
+ * set of records in the source table. Source records can specified in two ways:
+ * first one is by passing a Query object setup to find on the source table and
+ * the other way is by explicitly passing an array of primary key values from
+ * the source table.
+ *
+ * The required way of passing related source records is controlled by "strategy"
+ * By default the subquery strategy is used, which requires a query on the source
+ * When using the select strategy, the list of primary keys will be used.
+ *
+ * Returns a closure that should be run for each record returned in an specific
+ * Query. This callable will be responsible for injecting the fields that are
+ * related to each specific passed row.
+ *
+ * Options array accept the following keys:
+ *
+ * - query: Query object setup to find the source table records
+ * - keys: List of primary key values from the source table
+ * - foreignKey: The name of the field used to relate both tables
+ * - conditions: List of conditions to be passed to the query where() method
+ * - sort: The direction in which the records should be returned
+ * - fields: List of fields to select from the target table
+ * - contain: List of related tables to eager load associated to the target table
+ * - strategy: The name of strategy to use for finding target table records
  *
  * @param array $options
  * @return \Closure

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -80,13 +80,6 @@ abstract class Association {
 	protected $_name;
 
 /**
- * Whether this association can be expressed directly in a query join
- *
- * @var boolean
- */
-	protected $_canBeJoined = false;
-
-/**
  * The class name of the target table object
  *
  * @var string
@@ -302,7 +295,8 @@ abstract class Association {
  * @return boolean
  */
 	public function canBeJoined($options = []) {
-		return $this->_canBeJoined;
+		$strategy = isset($options['strategy']) ? $options['strategy'] : $this->strategy();
+		return $strategy == $this::STRATEGY_JOIN;
 	}
 
 /**

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -577,6 +577,15 @@ abstract class Association {
 	}
 
 /**
+ * Eager loads a list of records in the target table that are related to another
+ * set of records in the source table.
+ *
+ * @param array $options
+ * @return \Closure
+ */
+	public abstract function eagerLoader(array $options);
+
+/**
  * Returns a single or multiple condition(s) to be appended to the generated join
  * clause for getting the results on the target table. If false is returned then
  * it will not attach any new conditions to the join clause

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -91,6 +91,16 @@ class BelongsTo extends Association {
 	}
 
 /**
+ * Eager loads a list of records in the target table that are related to another
+ * set of records in the source table.
+ *
+ * @param array $options
+ * @return \Closure
+ */
+	public function eagerLoader(array $options) {
+	}
+
+/**
  * Takes an entity from the source table and looks if there is a field
  * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -91,16 +91,6 @@ class BelongsTo extends Association {
 	}
 
 /**
- * Eager loads a list of records in the target table that are related to another
- * set of records in the source table.
- *
- * @param array $options
- * @return \Closure
- */
-	public function eagerLoader(array $options) {
-	}
-
-/**
  * Takes an entity from the source table and looks if there is a field
  * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
@@ -161,6 +151,13 @@ class BelongsTo extends Association {
 		}
 
 		return $conditions;
+	}
+
+/**
+ * {@inheritdoc}
+ *
+ */
+	public function eagerLoader(array $options) {
 	}
 
 }

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -29,13 +29,6 @@ use Cake\Utility\Inflector;
 class BelongsTo extends Association {
 
 /**
- * Whether this association can be expressed directly in a query join
- *
- * @var boolean
- */
-	protected $_canBeJoined = true;
-
-/**
  * Sets the name of the field representing the foreign key to the target table.
  * If no parameters are passed current field is returned
  *

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -280,33 +280,8 @@ class BelongsToMany extends Association {
 	}
 
 /**
- * Eager loads a list of records in the target table that are related to another
- * set of records in the source table. Source records can specified in two ways:
- * first one is by passing a Query object setup to find on the source table and
- * the other way is by explicitly passing an array of primary key values from
- * the source table.
+ * {@inheritdoc}
  *
- * The required way of passing related source records is controlled by "strategy"
- * By default the subquery strategy is used, which requires a query on the source
- * When using the select strategy, the list of primary keys will be used.
- *
- * Returns a closure that should be run for each record returned in an specific
- * Query. This callable will be responsible for injecting the fields that are
- * related to each specific passed row.
- *
- * Options array accept the following keys:
- *
- * - query: Query object setup to find the source table records
- * - keys: List of primary key values from the source table
- * - foreignKey: The name of the field used to relate both tables
- * - conditions: List of conditions to be passed to the query where() method
- * - sort: The direction in which the records should be returned
- * - fields: List of fields to select from the target table
- * - contain: List of related tables to eager load associated to the target table
- * - strategy: The name of strategy to use for finding target table records
- *
- * @param array $options
- * @return \Closure
  */
 	public function eagerLoader(array $options) {
 		$options += [

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -131,65 +131,6 @@ trait ExternalAssociationTrait {
 	}
 
 /**
- * Returns a callable to be used for each row in a query result set
- * for injecting the eager loaded rows
- *
- * @param \Cake\ORM\Query $fetchQuery the Query used to fetch results
- * @param array $resultMap an array with the foreignKey as keys and
- * the corresponding target table results as value.
- * @return \Closure
- */
-	protected function _resultInjector($fetchQuery, $resultMap) {
-		$source = $this->source();
-		$sAlias = $source->alias();
-		$tAlias = $this->target()->alias();
-
-		$sourceKeys = [];
-		foreach ((array)$source->primaryKey() as $key) {
-			$sourceKeys[] = key($fetchQuery->aliasField($key, $sAlias));
-		}
-
-		$nestKey = $tAlias . '___collection_';
-
-		if (count($sourceKeys) > 1) {
-			return $this->_multiKeysInjector($resultMap, $sourceKeys, $nestKey);
-		}
-
-		$sourceKey = $sourceKeys[0];
-		return function($row) use ($resultMap, $sourceKey, $nestKey) {
-			if (isset($resultMap[$row[$sourceKey]])) {
-				$row[$nestKey] = $resultMap[$row[$sourceKey]];
-			}
-			return $row;
-		};
-	}
-
-/**
- * Returns a callable to be used for each row in a query result set
- * for injecting the eager loaded rows when the matching needs to
- * be done with multiple foreign keys
- *
- * @param array $resultMap a keyed arrays containing the target table
- * @param array $sourceKeys an array with aliased keys to match
- * @param string $nestKey the key under which results should be nested
- * @return \Closure
- */
-	protected function _multiKeysInjector($resultMap, $sourceKeys, $nestKey) {
-		return function($row) use ($resultMap, $sourceKeys, $nestKey) {
-			$values = [];
-			foreach ($sourceKeys as $key) {
-				$values[] = $row[$key];
-			}
-
-			$key = implode(';', $values);
-			if (isset($resultMap[$key])) {
-				$row[$nestKey] = $resultMap[$key];
-			}
-			return $row;
-		};
-	}
-
-/**
  * Parse extra options passed in the constructor.
  *
  * @param array $opts original list of options passed in constructor

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -25,7 +25,9 @@ use Cake\Utility\Inflector;
  */
 trait ExternalAssociationTrait {
 
-	use SelectableAssociationTrait;
+	use SelectableAssociationTrait {
+		_defaultOptions as private _selectableOptions;
+	}
 
 /**
  * Order in which target records should be returned
@@ -98,6 +100,44 @@ trait ExternalAssociationTrait {
 
 		$row[$sourceAlias][$this->property()] = $values;
 		return $row;
+	}
+
+/**
+ * Returns the default options to use for the eagerLoader
+ *
+ * @return array
+ */
+	protected function _defaultOptions() {
+		return $this->_selectableOptions() + [
+			'sort' => $this->sort()
+		];
+	}
+
+/**
+ * {@inheritdoc}
+ *
+ */
+	protected function _buildResultMap($fetchQuery, $options) {
+		$resultMap = [];
+		$key = (array)$options['foreignKey'];
+
+		foreach ($fetchQuery->all() as $result) {
+			$values = [];
+			foreach ($key as $k) {
+				$values[] = $result[$k];
+			}
+			$resultMap[implode(';', $values)][] = $result;
+		}
+		return $resultMap;
+	}
+
+/**
+ * Returns the key under which the eagerLoader will put this association results
+ *
+ * @return void
+ */
+	protected function _nestingKey() {
+		return $this->_name . '___collection_';
 	}
 
 /**

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -111,15 +111,6 @@ trait ExternalAssociationTrait {
 	}
 
 /**
- * Eager loads a list of records in the target table that are related to another
- * set of records in the source table.
- *
- * @param array $options
- * @return \Closure
- */
-	public abstract function eagerLoader(array $options);
-
-/**
  * Returns a single or multiple conditions to be appended to the generated join
  * clause for getting the results on the target table.
  *

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -47,33 +47,8 @@ class HasMany extends Association {
 	protected $_strategy = parent::STRATEGY_SELECT;
 
 /**
- * Eager loads a list of records in the target table that are related to another
- * set of records in the source table. Source records can specified in two ways:
- * first one is by passing a Query object setup to find on the source table and
- * the other way is by explicitly passing an array of primary key values from
- * the source table.
+ * {@inheritdoc}
  *
- * The required way of passing related source records is controlled by "strategy"
- * By default the subquery strategy is used, which requires a query on the source
- * When using the select strategy, the list of primary keys will be used.
- *
- * Returns a closure that should be run for each record returned in an specific
- * Query. This callable will be responsible for injecting the fields that are
- * related to each specific passed row.
- *
- * Options array accept the following keys:
- *
- * - query: Query object setup to find the source table records
- * - keys: List of primary key values from the source table
- * - foreignKey: The name of the field used to relate both tables
- * - conditions: List of conditions to be passed to the query where() method
- * - sort: The direction in which the records should be returned
- * - fields: List of fields to select from the target table
- * - contain: List of related tables to eager load associated to the target table
- * - strategy: The name of strategy to use for finding target table records
- *
- * @param array $options
- * @return \Closure
  */
 	public function eagerLoader(array $options) {
 		$options += [

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -47,43 +47,6 @@ class HasMany extends Association {
 	protected $_strategy = parent::STRATEGY_SELECT;
 
 /**
- * {@inheritdoc}
- *
- */
-	public function eagerLoader(array $options) {
-		$options += [
-			'foreignKey' => $this->foreignKey(),
-			'conditions' => [],
-			'sort' => $this->sort(),
-			'strategy' => $this->strategy()
-		];
-
-		$queryBuilder = false;
-		if (!empty($options['queryBuilder'])) {
-			$queryBuilder = $options['queryBuilder'];
-			unset($options['queryBuilder']);
-		}
-
-		$fetchQuery = $this->_buildQuery($options);
-		if ($queryBuilder) {
-			$fetchQuery = $queryBuilder($fetchQuery);
-		}
-
-		$resultMap = [];
-		$key = (array)$options['foreignKey'];
-
-		foreach ($fetchQuery->all() as $result) {
-			$values = [];
-			foreach ($key as $k) {
-				$values[] = $result[$k];
-			}
-			$resultMap[implode(';', $values)][] = $result;
-		}
-
-		return $this->_resultInjector($fetchQuery, $resultMap);
-	}
-
-/**
  * Returns whether or not the passed table is the owning side for this
  * association. This means that rows in the 'target' table would miss important
  * or required information if the row in 'source' did not exist.

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -118,6 +118,25 @@ class HasMany extends Association {
 	}
 
 /**
+ * {@inheritdoc}
+ *
+ */
+	protected function _linkField($options) {
+		$links = [];
+		$name = $this->name();
+
+		foreach ((array)$options['foreignKey'] as $key) {
+			$links[] = sprintf('%s.%s', $name, $key);
+		}
+
+		if (count($links) === 1) {
+			return $links[0];
+		}
+
+		return $links;
+	}
+
+/**
  * Get the relationship type.
  *
  * @return string

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -88,16 +88,6 @@ class HasOne extends Association {
 	}
 
 /**
- * Eager loads a list of records in the target table that are related to another
- * set of records in the source table.
- *
- * @param array $options
- * @return \Closure
- */
-	public function eagerLoader(array $options) {
-	}
-
-/**
  * Takes an entity from the source table and looks if there is a field
  * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied
@@ -158,6 +148,13 @@ class HasOne extends Association {
 		}
 
 		return $conditions;
+	}
+
+/**
+ * {@inheritdoc}
+ *
+ */
+	public function eagerLoader(array $options) {
 	}
 
 }

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -88,6 +88,16 @@ class HasOne extends Association {
 	}
 
 /**
+ * Eager loads a list of records in the target table that are related to another
+ * set of records in the source table.
+ *
+ * @param array $options
+ * @return \Closure
+ */
+	public function eagerLoader(array $options) {
+	}
+
+/**
  * Takes an entity from the source table and looks if there is a field
  * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -32,13 +32,6 @@ class HasOne extends Association {
 	use DependentDeleteTrait;
 
 /**
- * Whether this association can be expressed directly in a query join
- *
- * @var boolean
- */
-	protected $_canBeJoined = true;
-
-/**
  * The type of join to be used when adding the association to a query
  *
  * @var string

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+namespace Cake\ORM\Association;
+
+use Cake\Database\Expression\TupleComparison;
+
+/**
+ * Represents a type of association that that can be fetched using another query
+ */
+trait SelectableAssociationTrait {
+
+/**
+ * Returns true if the eager loading process will require a set of parent table's
+ * primary keys in order to use them as a filter in the finder query.
+ *
+ * @param array $options
+ * @return boolean true if a list of keys will be required
+ */
+	public function requiresKeys($options = []) {
+		$strategy = isset($options['strategy']) ? $options['strategy'] : $this->strategy();
+		return $strategy === parent::STRATEGY_SELECT;
+	}
+
+/**
+ * Auxiliary function to construct a new Query object to return all the records
+ * in the target table that are associated to those specified in $options from
+ * the source table
+ *
+ * @param array $options options accepted by eagerLoader()
+ * @return \Cake\ORM\Query
+ * @throws \InvalidArgumentException When a key is required for associations but not selected.
+ */
+	protected function _buildQuery($options) {
+		$target = $this->target();
+		$alias = $target->alias();
+		$key = $this->_linkField($options);
+
+		$filter = $options['keys'];
+		if ($options['strategy'] === parent::STRATEGY_SUBQUERY) {
+			$filter = $this->_buildSubquery($options['query'], $key);
+		}
+
+		$fetchQuery = $this
+			->find('all')
+			->where($options['conditions'])
+			->eagerLoaded(true)
+			->hydrate($options['query']->hydrate());
+		$fetchQuery = $this->_addFilteringCondition($fetchQuery, $key, $filter);
+
+		if (!empty($options['fields'])) {
+			$fields = $fetchQuery->aliasFields($options['fields'], $alias);
+			if (!in_array($key, $fields)) {
+				throw new \InvalidArgumentException(
+					sprintf('You are required to select the "%s" field', $key)
+				);
+			}
+			$fetchQuery->select($fields);
+		}
+
+		if (!empty($options['sort'])) {
+			$fetchQuery->order($options['sort']);
+		}
+
+		if (!empty($options['contain'])) {
+			$fetchQuery->contain($options['contain']);
+		}
+
+		if (!empty($options['queryBuilder'])) {
+			$options['queryBuilder']($fetchQuery);
+		}
+
+		return $fetchQuery;
+	}
+
+/**
+ * Appends any conditions required to load the relevant set of records in the
+ * target table query given a filter key and some filtering values.
+ *
+ * @param \Cake\ORM\Query taget table's query
+ * @param string $key the fields that should be used for filtering
+ * @param mixed $filter the value that should be used to match for $key
+ * @return \Cake\ORM\Query
+ */
+	protected function _addFilteringCondition($query, $key, $filter) {
+		if (is_array($key)) {
+			$types = [];
+			$defaults = $query->defaultTypes();
+			foreach ($key as $k) {
+				if (isset($defaults[$k])) {
+					$types[] = $defaults[$k];
+				}
+			}
+			return $query->andWhere(new TupleComparison($key, $filter, $types, 'IN'));
+		}
+
+		return $query->andWhere([$key . ' IN' => $filter]);
+	}
+
+/**
+ * Generates a string used as a table field that contains the values upon
+ * which the filter should be applied
+ *
+ * @param array $options
+ * @return string
+ */
+	protected function _linkField($options) {
+		$links = [];
+		$name = $this->name();
+
+		foreach ((array)$options['foreignKey'] as $key) {
+			$links[] = sprintf('%s.%s', $name, $key);
+		}
+
+		if (count($links) === 1) {
+			return $links[0];
+		}
+
+		return $links;
+	}
+
+/**
+ * Builds a query to be used as a condition for filtering records in in the
+ * target table, it is constructed by cloning the original query that was used
+ * to load records in the source table.
+ *
+ * @param \Cake\ORM\Query $query the original query used to load source records
+ * @param string $foreignKey the field to be selected in the query
+ * @return \Cake\ORM\Query
+ */
+	protected function _buildSubquery($query, $foreignKey) {
+		$filterQuery = clone $query;
+		$filterQuery->limit(null);
+		$filterQuery->contain([], true);
+		$joins = $filterQuery->join();
+		foreach ($joins as $i => $join) {
+			if (strtolower($join['type']) !== 'inner') {
+				unset($joins[$i]);
+			}
+		}
+		$filterQuery->join($joins, [], true);
+		$fields = $query->aliasFields((array)$query->repository()->primaryKey());
+		return $filterQuery->select($fields, true);
+	}
+
+}

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -86,10 +86,6 @@ trait SelectableAssociationTrait {
 			$filter = $this->_buildSubquery($options['query']);
 		}
 
-		if (is_array($filter) && count(current($filter)) > 1) {
-			$filter = $this->_extractFilteringColumns($filter);
-		}
-
 		$fetchQuery = $this
 			->find('all')
 			->where($options['conditions'])
@@ -120,39 +116,6 @@ trait SelectableAssociationTrait {
 		}
 
 		return $fetchQuery;
-	}
-
-/**
- * Returns an array containing only the values from the foreignKey for the
- * target table that can be used for a matching query. The values are
- * taken from another array containing all the primary key columns and
- * theirs values from another query.
- *
- * @param array $keys the primary key values extracted from a source query
- * @return array
- */
-	protected function _extractFilteringColumns($keys) {
-		$primary = (array)$this->source()->primaryKey();
-		$foreignKeys = (array)$this->foreignKey();
-
-		if (count($primary) === count($foreignKeys)) {
-			return $keys;
-		}
-
-		$positions = array_keys(array_intersect($primary, $foreignKeys));
-		$single = count($foreignKeys) === 1;
-		return array_map(function($keys) use ($positions, $single) {
-			if ($single) {
-				return $keys[$positions[0]];
-			}
-
-			$result = [];
-			foreach ($positions as $p) {
-				$result[] = $keys[$p];
-			}
-
-			return $result;
-		}, $keys);
 	}
 
 /**

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -206,8 +206,17 @@ trait SelectableAssociationTrait {
 				unset($joins[$i]);
 			}
 		}
+
+		$primary = (array)$query->repository()->primaryKey();
+		$foreignKey = (array)$this->foreignKey();
+		$keys = $primary;
+
+		if (count($primary) !== count($foreignKey)) {
+			$keys = $foreignKey;
+		}
+
 		$filterQuery->join($joins, [], true);
-		$fields = $query->aliasFields((array)$query->repository()->primaryKey());
+		$fields = $query->aliasFields($keys);
 		return $filterQuery->select($fields, true);
 	}
 

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -122,7 +122,7 @@ trait SelectableAssociationTrait {
  * Appends any conditions required to load the relevant set of records in the
  * target table query given a filter key and some filtering values.
  *
- * @param \Cake\ORM\Query taget table's query
+ * @param \Cake\ORM\Query $query Target table's query
  * @param string $key the fields that should be used for filtering
  * @param mixed $filter the value that should be used to match for $key
  * @return \Cake\ORM\Query
@@ -152,7 +152,7 @@ trait SelectableAssociationTrait {
 	protected abstract function _linkField($options);
 
 /**
- * Builds a query to be used as a condition for filtering records in in the
+ * Builds a query to be used as a condition for filtering records in the
  * target table, it is constructed by cloning the original query that was used
  * to load records in the source table.
  *
@@ -242,9 +242,9 @@ trait SelectableAssociationTrait {
  * for injecting the eager loaded rows when the matching needs to
  * be done with multiple foreign keys
  *
- * @param array $resultMap a keyed arrays containing the target table
- * @param array $sourceKeys an array with aliased keys to match
- * @param string $nestKey the key under which results should be nested
+ * @param array $resultMap A keyed arrays containing the target table
+ * @param array $sourceKeys An array with aliased keys to match
+ * @param string $nestKey The key under which results should be nested
  * @return \Closure
  */
 	protected function _multiKeysInjector($resultMap, $sourceKeys, $nestKey) {

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -147,7 +147,7 @@ trait SelectableAssociationTrait {
  * which the filter should be applied
  *
  * @param array $options
- * @return string
+ * @return string|array
  */
 	protected abstract function _linkField($options);
 
@@ -170,12 +170,10 @@ trait SelectableAssociationTrait {
 			}
 		}
 
-		$primary = (array)$query->repository()->primaryKey();
-		$foreignKey = (array)$this->foreignKey();
-		$keys = $primary;
+		$keys = (array)$query->repository()->primaryKey();
 
 		if ($this->type() === $this::ONE_TO_ONE) {
-			$keys = $foreignKey;
+			$keys = (array)$this->foreignKey();
 		}
 
 		$filterQuery->join($joins, [], true);

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -174,7 +174,7 @@ trait SelectableAssociationTrait {
 		$foreignKey = (array)$this->foreignKey();
 		$keys = $primary;
 
-		if (count($primary) !== count($foreignKey)) {
+		if ($this->type() === $this::ONE_TO_ONE) {
 			$keys = $foreignKey;
 		}
 

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -395,15 +395,21 @@ class EagerLoader {
 	protected function _collectKeys($external, $query, $statement) {
 		$collectKeys = [];
 		foreach ($external as $meta) {
-			$source = $meta['instance']->source();
-			if ($meta['instance']->requiresKeys($meta['config'])) {
-				$alias = $source->alias();
-				$pkFields = [];
-				foreach ((array)$source->primaryKey() as $key) {
-					$pkFields[] = key($query->aliasField($key, $alias));
-				}
-				$collectKeys[$alias] = [$alias, $pkFields, count($pkFields) === 1];
+			if (!$meta['instance']->requiresKeys($meta['config'])) {
+				continue;
 			}
+
+			$source = $meta['instance']->source();
+			$keys = $meta['instance']->type() === $meta['instance']::ONE_TO_ONE ?
+				(array)$meta['instance']->foreignKey() :
+				(array)$source->primaryKey();
+
+			$alias = $source->alias();
+			$pkFields = [];
+			foreach ($keys as $key) {
+				$pkFields[] = key($query->aliasField($key, $alias));
+			}
+			$collectKeys[$alias] = [$alias, $pkFields, count($pkFields) === 1];
 		}
 
 		if (empty($collectKeys)) {

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -50,7 +50,10 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
 		];
 		$this->association = $this->getMock(
 			'\Cake\ORM\Association',
-			['_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide', 'save'],
+			[
+				'_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
+				'save', 'eagerLoader'
+			],
 			['Foo', $config]
 		);
 	}

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -117,7 +117,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testCanBeJoined() {
-		$this->assertFalse($this->association->canBeJoined());
+		$this->assertTrue($this->association->canBeJoined());
 	}
 
 /**

--- a/tests/TestCase/ORM/CompositeKeysTest.php
+++ b/tests/TestCase/ORM/CompositeKeysTest.php
@@ -252,7 +252,7 @@ class CompositeKeyTest extends TestCase {
 		]);
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
-			->where(['id IN' => [1, 2]])
+			->where(['SiteArticles.id IN' => [1, 2]])
 			->contain('SiteAuthors')
 			->hydrate(false)
 			->toArray();

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -98,14 +98,24 @@ class QueryTest extends TestCase {
 	}
 
 /**
- * Tests that results are grouped correctly when using contain()
- * and results are not hydrated
+ * Provides strategies for associations that can be joined
  *
  * @return void
  */
-	public function testContainResultFetchingOneLevel() {
+	public function internalStategiesProvider() {
+		return [['join'], ['select'], ['subquery']];
+	}
+
+/**
+ * Tests that results are grouped correctly when using contain()
+ * and results are not hydrated
+ *
+ * @dataProvider internalStategiesProvider
+ * @return void
+ */
+	public function testContainResultFetchingOneLevel($strategy) {
 		$table = TableRegistry::get('articles', ['table' => 'articles']);
-		$table->belongsTo('authors');
+		$table->belongsTo('authors', ['strategy' => $strategy]);
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1910,7 +1910,11 @@ class QueryTest extends TestCase {
 		$table->belongsTo('Articles', ['strategy' => $strategy]);
 		$table->belongsTo('Tags', ['strategy' => $strategy]);
 		TableRegistry::get('Tags')->belongsToMany('Articles');
-		$results = $table->find()->contain(['Articles', 'Tags.Articles'])->hydrate(false)->toArray();
+		$results = $table
+			->find()
+			->contain(['Articles', 'Tags.Articles'])
+			->hydrate(false)
+			->toArray();
 		$this->assertNotEmpty($results[0]['tag']['articles']);
 		$this->assertNotEmpty($results[0]['article']);
 		$this->assertNotEmpty($results[1]['tag']['articles']);

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1148,12 +1148,13 @@ class QueryTest extends TestCase {
 /**
  * Tests that belongsTo relations are correctly hydrated
  *
+ * @dataProvider internalStategiesProvider
  * @return void
  */
-	public function testHydrateBelongsTo() {
+	public function testHydrateBelongsTo($strategy) {
 		$table = TableRegistry::get('articles');
 		TableRegistry::get('authors');
-		$table->belongsTo('authors');
+		$table->belongsTo('authors', ['strategy' => $strategy]);
 
 		$query = new Query($this->connection, $table);
 		$results = $query->select()
@@ -1171,16 +1172,17 @@ class QueryTest extends TestCase {
 /**
  * Tests that deeply nested associations are also hydrated correctly
  *
+ * @dataProvider internalStategiesProvider
  * @return void
  */
-	public function testHydrateDeep() {
+	public function testHydrateDeep($strategy) {
 		$table = TableRegistry::get('authors');
 		$article = TableRegistry::get('articles');
 		$table->hasMany('articles', [
 			'propertyName' => 'articles',
 			'sort' => ['articles.id' => 'asc']
 		]);
-		$article->belongsTo('authors');
+		$article->belongsTo('authors', ['strategy' => $strategy]);
 		$query = new Query($this->connection, $table);
 
 		$results = $query->select()
@@ -1900,12 +1902,13 @@ class QueryTest extends TestCase {
  * Tests that it is possible to use the same association aliases in the association
  * chain for contain
  *
+ * @dataProvider internalStategiesProvider
  * @return void
  */
-	public function testRepeatedAssociationAliases() {
+	public function testRepeatedAssociationAliases($strategy) {
 		$table = TableRegistry::get('ArticlesTags');
-		$table->belongsTo('Articles');
-		$table->belongsTo('Tags');
+		$table->belongsTo('Articles', ['strategy' => $strategy]);
+		$table->belongsTo('Tags', ['strategy' => $strategy]);
 		TableRegistry::get('Tags')->belongsToMany('Articles');
 		$results = $table->find()->contain(['Articles', 'Tags.Articles'])->hydrate(false)->toArray();
 		$this->assertNotEmpty($results[0]['tag']['articles']);


### PR DESCRIPTION
Refactored the associations code into another trait as some of it was quite similar. Reused parts of the code to implement the select and subquery strategies for BelongsTo. This means that this association type can now be loaded by using separate queries, opening the possibility of eager loading records in external databases.
