### PR TITLE
3.0 - Fix a few schema reflection issues

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -80,7 +80,7 @@ class MysqlSchema extends BaseSchema {
 		if (strpos($col, 'bigint') !== false || $col === 'bigint') {
 			return ['type' => 'biginteger', 'length' => $length, 'unsigned' => $unsigned];
 		}
-		if (strpos($col, 'int') !== false) {
+		if (in_array($col, ['int', 'integer', 'tinyint', 'smallint', 'mediumint'])) {
 			return ['type' => 'integer', 'length' => $length, 'unsigned' => $unsigned];
 		}
 		if ($col === 'char' && $length === 36) {

--- a/src/Database/Schema/PostgresSchema.php
+++ b/src/Database/Schema/PostgresSchema.php
@@ -81,7 +81,7 @@ class PostgresSchema extends BaseSchema {
 			return ['type' => $col, 'length' => null];
 		}
 		if (strpos($col, 'timestamp') !== false) {
-			return ['type' => 'datetime', 'length' => null];
+			return ['type' => 'timestamp', 'length' => null];
 		}
 		if ($col === 'serial' || $col === 'integer') {
 			return ['type' => 'integer', 'length' => 10];

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -68,6 +68,10 @@ class MysqlSchemaTest extends TestCase {
 				['type' => 'integer', 'length' => 11, 'unsigned' => false]
 			],
 			[
+				'MEDIUMINT(11)',
+				['type' => 'integer', 'length' => 11, 'unsigned' => false]
+			],
+			[
 				'INTEGER(11) UNSIGNED',
 				['type' => 'integer', 'length' => 11, 'unsigned' => true]
 			],

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -228,9 +228,8 @@ SQL;
 		$result = $schema->listTables();
 
 		$this->assertInternalType('array', $result);
-		$this->assertCount(2, $result);
-		$this->assertEquals('schema_articles', $result[0]);
-		$this->assertEquals('schema_authors', $result[1]);
+		$this->assertContains('schema_articles', $result);
+		$this->assertContains('schema_authors', $result);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -33,7 +33,7 @@ class MysqlSchemaTest extends TestCase {
  */
 	protected function _needsConnection() {
 		$config = ConnectionManager::config('test');
-		$this->skipIf(strpos($config['className'], 'Mysql') === false, 'Not using Mysql for test config');
+		$this->skipIf(strpos($config['driver'], 'Mysql') === false, 'Not using Mysql for test config');
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -33,7 +33,7 @@ class PostgresSchemaTest extends TestCase {
  */
 	protected function _needsConnection() {
 		$config = ConnectionManager::config('test');
-		$this->skipIf(strpos($config['className'], 'Postgres') === false, 'Not using Postgres for test config');
+		$this->skipIf(strpos($config['driver'], 'Postgres') === false, 'Not using Postgres for test config');
 	}
 
 /**
@@ -87,11 +87,11 @@ SQL;
 			// Timestamp
 			[
 				'TIMESTAMP',
-				['type' => 'datetime', 'length' => null]
+				['type' => 'timestamp', 'length' => null]
 			],
 			[
 				'TIMESTAMP WITHOUT TIME ZONE',
-				['type' => 'datetime', 'length' => null]
+				['type' => 'timestamp', 'length' => null]
 			],
 			// Date & time
 			[
@@ -307,7 +307,7 @@ SQL;
 				'autoIncrement' => null,
 			],
 			'created' => [
-				'type' => 'datetime',
+				'type' => 'timestamp',
 				'null' => true,
 				'default' => null,
 				'length' => null,

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -234,9 +234,8 @@ SQL;
 		$schema = new SchemaCollection($connection);
 		$result = $schema->listTables();
 		$this->assertInternalType('array', $result);
-		$this->assertCount(2, $result);
-		$this->assertEquals('schema_articles', $result[0]);
-		$this->assertEquals('schema_authors', $result[1]);
+		$this->assertContains('schema_articles', $result);
+		$this->assertContains('schema_authors', $result);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -33,7 +33,7 @@ class SqliteSchemaTest extends TestCase {
  */
 	protected function _needsConnection() {
 		$config = ConnectionManager::config('test');
-		$this->skipIf(strpos($config['className'], 'Sqlite') === false, 'Not using Sqlite for test config');
+		$this->skipIf(strpos($config['driver'], 'Sqlite') === false, 'Not using Sqlite for test config');
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -193,8 +193,15 @@ class SqliteSchemaTest extends TestCase {
  */
 	protected function _createTables($connection) {
 		$this->_needsConnection();
-		$connection->execute('DROP TABLE IF EXISTS schema_articles');
-		$connection->execute('DROP TABLE IF EXISTS schema_authors');
+
+		$schema = new SchemaCollection($connection);
+		$result = $schema->listTables();
+		if (
+			in_array('schema_articles', $result) &&
+			in_array('schema_authors', $result)
+		) {
+			return;
+		}
 
 		$table = <<<SQL
 CREATE TABLE schema_authors (
@@ -235,10 +242,8 @@ SQL;
 		$result = $schema->listTables();
 
 		$this->assertInternalType('array', $result);
-		$this->assertCount(3, $result);
-		$this->assertEquals('schema_articles', $result[0]);
-		$this->assertEquals('schema_authors', $result[1]);
-		$this->assertEquals('sqlite_sequence', $result[2]);
+		$this->assertContains('schema_articles', $result);
+		$this->assertContains('schema_authors', $result);
 	}
 
 /**


### PR DESCRIPTION
Fix a few schema reflection issues. 
- The point type confusion in #2953 is now fixed. 
- I've also fixed the mismatching types that were causing failures in #3133. 
- Lastly there were tests being skipped that shouldn't have been. SQLite required a few additional workarounds.
