### PR TITLE
3.0 shell cleanup

### DIFF
--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -20,7 +20,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Model\Model;
-use Cake\Utility\Inflector;
+use Cake\Utility\ConventionsTrait;
 
 /**
  * Command-line code generation utility to automate programmer chores.
@@ -32,6 +32,8 @@ use Cake\Utility\Inflector;
  * @link          http://book.cakephp.org/3.0/en/console-and-shells/code-generation-with-bake.html
  */
 class BakeShell extends Shell {
+
+	use ConventionsTrait;
 
 /**
  * Contains tasks to load and instantiate
@@ -57,7 +59,7 @@ class BakeShell extends Shell {
 		Configure::write('debug', true);
 		Cache::disable();
 
-		$task = Inflector::classify($this->command);
+		$task = $this->_camelize($this->command);
 		if (isset($this->{$task}) && !in_array($task, ['Project'])) {
 			if (isset($this->params['connection'])) {
 				$this->{$task}->connection = $this->params['connection'];
@@ -87,9 +89,10 @@ class BakeShell extends Shell {
 		$this->out(__d('cake_console', 'model'));
 		$this->out(__d('cake_console', 'view'));
 		$this->out(__d('cake_console', 'controller'));
-		$this->out(__d('cake_console', 'project'));
 		$this->out(__d('cake_console', 'fixture'));
+		$this->out(__d('cake_console', 'project'));
 		$this->out(__d('cake_console', 'test'));
+		$this->out(__d('cake_console', 'view'));
 		$this->out('');
 		$this->out(__d('cake_console', 'Using <info>Console/cake bake [name]</info> you can invoke a specific bake task.'));
 	}

--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Base class for Bake Tasks.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -19,12 +17,15 @@ namespace Cake\Console\Command\Task;
 use Cake\Cache\Cache;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
+use Cake\Utility\ConventionsTrait;
 
 /**
  * Base class for Bake Tasks.
  *
  */
 class BakeTask extends Shell {
+
+	use ConventionsTrait;
 
 /**
  * The default path to bake files into.

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -17,15 +17,17 @@ namespace Cake\Console\Command\Task;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Utility\ConventionsTrait;
 use Cake\Utility\File;
 use Cake\Utility\Folder;
-use Cake\Utility\Inflector;
 
 /**
  * The Plugin Task handles creating an empty plugin, ready to be used
  *
  */
 class PluginTask extends Shell {
+
+	use ConventionsTrait;
 
 /**
  * path to plugins directory
@@ -65,7 +67,7 @@ class PluginTask extends Shell {
  */
 	public function execute() {
 		if (isset($this->args[0])) {
-			$plugin = Inflector::camelize($this->args[0]);
+			$plugin = $this->_camelize($this->args[0]);
 			$pluginPath = $this->_pluginPath($plugin);
 			if (is_dir($pluginPath)) {
 				$this->out(__d('cake_console', 'Plugin: %s already exists, no action taken', $plugin));

--- a/src/Console/Command/Task/TemplateTask.php
+++ b/src/Console/Command/Task/TemplateTask.php
@@ -18,6 +18,7 @@ namespace Cake\Console\Command\Task;
 
 use Cake\Console\Shell;
 use Cake\Core\App;
+use Cake\Utility\ConventionsTrait;
 use Cake\Utility\Folder;
 use Cake\Utility\ViewVarsTrait;
 
@@ -28,6 +29,7 @@ use Cake\Utility\ViewVarsTrait;
  */
 class TemplateTask extends Shell {
 
+	use ConventionsTrait;
 	use ViewVarsTrait;
 
 /**

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -23,7 +23,7 @@ use Cake\Core\Plugin;
 use Cake\Error;
 use Cake\Log\Engine\ConsoleLog;
 use Cake\Log\Log;
-use Cake\Utility\ClassRegistry;
+use Cake\Utility\ConventionsTrait;
 use Cake\Utility\File;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
@@ -668,31 +668,6 @@ class Shell extends Object {
 
 		$this->err(__d('cake_console', '<error>Could not write to `%s`</error>.', $path), 2);
 		return false;
-	}
-
-/**
- * Action to create a Unit Test
- *
- * @return boolean Success
- */
-	protected function _checkUnitTest() {
-		if (class_exists('PHPUnit_Framework_TestCase')) {
-			return true;
-			//@codingStandardsIgnoreStart
-		} elseif (@include 'PHPUnit/Autoload.php') {
-			//@codingStandardsIgnoreEnd
-			return true;
-		}
-
-		$prompt = __d('cake_console', 'PHPUnit is not installed. Do you want to bake unit test files anyway?');
-		$unitTest = $this->in($prompt, ['y', 'n'], 'y');
-		$result = strtolower($unitTest) === 'y' || strtolower($unitTest) === 'yes';
-
-		if ($result) {
-			$this->out();
-			$this->out(__d('cake_console', 'You can download PHPUnit from %s', 'http://phpunit.de'));
-		}
-		return $result;
 	}
 
 /**

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -684,110 +684,6 @@ class Shell extends Object {
 	}
 
 /**
- * Creates the proper controller path for the specified controller class name
- *
- * @param string $name Controller class name
- * @return string Path to controller
- */
-	protected function _controllerPath($name) {
-		return Inflector::underscore($name);
-	}
-
-/**
- * Creates the proper controller plural name for the specified controller class name
- *
- * @param string $name Controller class name
- * @return string Controller plural name
- */
-	protected function _controllerName($name) {
-		return Inflector::pluralize(Inflector::camelize($name));
-	}
-
-/**
- * Creates the proper model camelized name (plural) for the specified name
- *
- * @param string $name Name
- * @return string Camelized and plural model name
- */
-	protected function _modelName($name) {
-		return Inflector::pluralize(Inflector::camelize($name));
-	}
-
-/**
- * Creates the proper underscored model key for associations
- *
- * @param string $name Model class name
- * @return string Singular model key
- */
-	protected function _modelKey($name) {
-		return Inflector::underscore(Inflector::singularize($name)) . '_id';
-	}
-
-/**
- * Creates the proper model name from a foreign key
- *
- * @param string $key Foreign key
- * @return string Model name
- */
-	protected function _modelNameFromKey($key) {
-		$key = str_replace('_id', '', $key);
-		return $this->_modelName($key);
-	}
-
-/**
- * creates the singular name for use in views.
- *
- * @param string $name
- * @return string $name
- */
-	protected function _singularName($name) {
-		return Inflector::variable(Inflector::singularize($name));
-	}
-
-/**
- * Creates the plural name for views
- *
- * @param string $name Name to use
- * @return string Plural name for views
- */
-	protected function _pluralName($name) {
-		return Inflector::variable(Inflector::pluralize($name));
-	}
-
-/**
- * Creates the singular human name used in views
- *
- * @param string $name Controller name
- * @return string Singular human name
- */
-	protected function _singularHumanName($name) {
-		return Inflector::humanize(Inflector::underscore(Inflector::singularize($name)));
-	}
-
-/**
- * Creates the plural human name used in views
- *
- * @param string $name Controller name
- * @return string Plural human name
- */
-	protected function _pluralHumanName($name) {
-		return Inflector::humanize(Inflector::underscore($name));
-	}
-
-/**
- * Find the correct path for a plugin. Scans $pluginPaths for the plugin you want.
- *
- * @param string $pluginName Name of the plugin you want ie. DebugKit
- * @return string $path path to the correct plugin.
- */
-	protected function _pluginPath($pluginName) {
-		if (Plugin::loaded($pluginName)) {
-			return Plugin::path($pluginName);
-		}
-		return current(App::path('Plugin')) . $pluginName . DS;
-	}
-
-/**
  * Used to enable or disable logging stream output to stdout and stderr
  * If you don't wish to see in your stdout or stderr everything that is logged
  * through Cake Log, call this function with first param as false
@@ -812,4 +708,5 @@ class Shell extends Object {
 		Log::config('stdout', ['engine' => $stdout]);
 		Log::config('stderr', ['engine' => $stderr]);
 	}
+
 }

--- a/src/Utility/ConventionsTrait.php
+++ b/src/Utility/ConventionsTrait.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Utility;
+
+use Cake\Core\App;
+use Cake\Core\Plugin;
+use Cake\Utility\Inflector;
+
+/**
+ * Provides methods that allow other classes access to conventions based inflections.
+ */
+trait ConventionsTrait {
+
+/**
+ * Creates the proper controller path for the specified controller class name
+ *
+ * @param string $name Controller class name
+ * @return string Path to controller
+ */
+	protected function _controllerPath($name) {
+		return Inflector::underscore($name);
+	}
+
+/**
+ * Creates the proper controller plural name for the specified controller class name
+ *
+ * @param string $name Controller class name
+ * @return string Controller plural name
+ */
+	protected function _controllerName($name) {
+		return Inflector::pluralize(Inflector::camelize($name));
+	}
+
+/**
+ * Creates the proper model camelized name (plural) for the specified name
+ *
+ * @param string $name Name
+ * @return string Camelized and plural model name
+ */
+	protected function _modelName($name) {
+		return Inflector::pluralize(Inflector::camelize($name));
+	}
+
+/**
+ * Creates the proper underscored model key for associations
+ *
+ * @param string $name Model class name
+ * @return string Singular model key
+ */
+	protected function _modelKey($name) {
+		return Inflector::underscore(Inflector::singularize($name)) . '_id';
+	}
+
+/**
+ * Creates the proper model name from a foreign key
+ *
+ * @param string $key Foreign key
+ * @return string Model name
+ */
+	protected function _modelNameFromKey($key) {
+		$key = str_replace('_id', '', $key);
+		return $this->_modelName($key);
+	}
+
+/**
+ * creates the singular name for use in views.
+ *
+ * @param string $name
+ * @return string $name
+ */
+	protected function _singularName($name) {
+		return Inflector::variable(Inflector::singularize($name));
+	}
+
+/**
+ * Creates the plural name for views
+ *
+ * @param string $name Name to use
+ * @return string Plural name for views
+ */
+	protected function _pluralName($name) {
+		return Inflector::variable(Inflector::pluralize($name));
+	}
+
+/**
+ * Creates the singular human name used in views
+ *
+ * @param string $name Controller name
+ * @return string Singular human name
+ */
+	protected function _singularHumanName($name) {
+		return Inflector::humanize(Inflector::underscore(Inflector::singularize($name)));
+	}
+
+/**
+ * Creates a camelized version of $name
+ *
+ * @param string $name name
+ * @return string Camelized name
+ */
+	protected function _camelize($name) {
+		return Inflector::camelize($name);
+	}
+
+/**
+ * Creates the plural human name used in views
+ *
+ * @param string $name Controller name
+ * @return string Plural human name
+ */
+	protected function _pluralHumanName($name) {
+		return Inflector::humanize(Inflector::underscore($name));
+	}
+
+/**
+ * Find the correct path for a plugin. Scans $pluginPaths for the plugin you want.
+ *
+ * @param string $pluginName Name of the plugin you want ie. DebugKit
+ * @return string $path path to the correct plugin.
+ */
+	protected function _pluginPath($pluginName) {
+		if (Plugin::loaded($pluginName)) {
+			return Plugin::path($pluginName);
+		}
+		return current(App::path('Plugin')) . $pluginName . DS;
+	}
+
+}

--- a/src/Utility/Debugger.php
+++ b/src/Utility/Debugger.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Framework debugging and PHP error-handling class
- *
- * Provides enhanced logging, stack traces, and rendering debug views
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -54,7 +54,7 @@ class BakeShellTest extends TestCase {
  */
 	public function tearDown() {
 		parent::tearDown();
-		unset($this->Dispatch, $this->Shell);
+		unset($this->Shell);
 	}
 
 /**
@@ -94,6 +94,21 @@ class BakeShellTest extends TestCase {
 		$this->Shell->all();
 
 		$this->assertEquals('Comments', $this->Shell->View->args[0]);
+	}
+
+/**
+ * Test the main function.
+ *
+ * @return void
+ */
+	public function testMain() {
+		$this->Shell->expects($this->at(0))
+			->method('out')
+			->with($this->stringContains('The following commands'));
+		$this->Shell->expects($this->at(3))
+			->method('out')
+			->with('controller');
+		$this->Shell->main();
 	}
 
 }

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -107,7 +107,7 @@ class BakeShellTest extends TestCase {
 			->with($this->stringContains('The following commands'));
 		$this->Shell->expects($this->at(3))
 			->method('out')
-			->with('controller');
+			->with('behavior');
 		$this->Shell->main();
 	}
 


### PR DESCRIPTION
Extract a trait from the shell class. I've always found having the conventions/inflection methods included in `Shell` as a bit silly. Having a separate trait opens up the possibility of re-using these methods in other parts of the framework.
