### PR TITLE
untangle url methods

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -401,7 +401,7 @@ class PaginatorHelper extends Helper {
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
  */
-	public function generateUrl($options = array(), $model = null, $full = false) {
+	public function generateUrl(array $options = array(), $model = null, $full = false) {
 		$paging = $this->params($model);
 		$paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 		$url = [

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -239,7 +239,7 @@ class PaginatorHelper extends Helper {
 			$options['url'],
 			['page' => $paging['page'] + $options['step']]
 		);
-		$url = $this->url($url, $options['model']);
+		$url = $this->generateUrl($url, $options['model']);
 		return $this->templater()->format($template, [
 			'url' => $url,
 			'text' => $text,
@@ -387,7 +387,7 @@ class PaginatorHelper extends Helper {
 		);
 		$vars = [
 			'text' => $options['escape'] ? h($title) : $title,
-			'url' => $this->url($url, $options['model']),
+			'url' => $this->generateUrl($url, $options['model']),
 		];
 		return $this->templater()->format($template, $vars);
 	}
@@ -397,10 +397,11 @@ class PaginatorHelper extends Helper {
  *
  * @param array $options Pagination/URL options array
  * @param string $model Which model to paginate on
+ * @param boolean $full If true, the full base URL will be prepended to the result
  * @return mixed By default, returns a full pagination URL string for use in non-standard contexts (i.e. JavaScript)
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::url
  */
-	public function url($options = array(), $model = null) {
+	public function generateUrl($options = array(), $model = null, $full = false) {
 		$paging = $this->params($model);
 		$paging += ['page' => null, 'sort' => null, 'direction' => null, 'limit' => null];
 		$url = [
@@ -425,7 +426,7 @@ class PaginatorHelper extends Helper {
 		) {
 			$url['sort'] = $url['direction'] = null;
 		}
-		return parent::url($url);
+		return $this->url($url, $full);
 	}
 
 /**
@@ -632,21 +633,21 @@ class PaginatorHelper extends Helper {
 			for ($i = $start; $i < $params['page']; $i++) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $i], $options['model']),
+					'url' => $this->generateUrl(['page' => $i], $options['model']),
 				];
 				$out .= $this->templater()->format('number', $vars);
 			}
 
 			$out .= $this->templater()->format('current', [
 				'text' => $params['page'],
-				'url' => $this->url(['page' => $params['page']], $options['model']),
+				'url' => $this->generateUrl(['page' => $params['page']], $options['model']),
 			]);
 
 			$start = $params['page'] + 1;
 			for ($i = $start; $i < $end; $i++) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $i], $options['model']),
+					'url' => $this->generateUrl(['page' => $i], $options['model']),
 				];
 				$out .= $this->templater()->format('number', $vars);
 			}
@@ -654,7 +655,7 @@ class PaginatorHelper extends Helper {
 			if ($end != $params['page']) {
 				$vars = [
 					'text' => $i,
-					'url' => $this->url(['page' => $end], $options['model']),
+					'url' => $this->generateUrl(['page' => $end], $options['model']),
 				];
 				$out .= $this->templater()->format('number', $vars);
 			}
@@ -676,12 +677,12 @@ class PaginatorHelper extends Helper {
 				if ($i == $params['page']) {
 					$out .= $this->templater()->format('current', [
 						'text' => $params['page'],
-						'url' => $this->url(['page' => $params['page']], $options['model']),
+						'url' => $this->generateUrl(['page' => $params['page']], $options['model']),
 					]);
 				} else {
 					$vars = [
 						'text' => $i,
-						'url' => $this->url(['page' => $i], $options['model']),
+						'url' => $this->generateUrl(['page' => $i], $options['model']),
 					];
 					$out .= $this->templater()->format('number', $vars);
 				}
@@ -733,14 +734,14 @@ class PaginatorHelper extends Helper {
 		if (is_int($first) && $params['page'] >= $first) {
 			for ($i = 1; $i <= $first; $i++) {
 				$out .= $this->templater()->format('number', [
-					'url' => $this->url(['page' => $i], $options['model']),
+					'url' => $this->generateUrl(['page' => $i], $options['model']),
 					'text' => $i
 				]);
 			}
 		} elseif ($params['page'] > 1 && is_string($first)) {
 			$first = $options['escape'] ? h($first) : $first;
 			$out .= $this->templater()->format('first', [
-				'url' => $this->url(['page' => 1], $options['model']),
+				'url' => $this->generateUrl(['page' => 1], $options['model']),
 				'text' => $first
 			]);
 		}
@@ -786,14 +787,14 @@ class PaginatorHelper extends Helper {
 		if (is_int($last) && $params['page'] <= $lower) {
 			for ($i = $lower; $i <= $params['pageCount']; $i++) {
 				$out .= $this->templater()->format('number', [
-					'url' => $this->url(['page' => $i], $options['model']),
+					'url' => $this->generateUrl(['page' => $i], $options['model']),
 					'text' => $i
 				]);
 			}
 		} elseif ($params['page'] < $params['pageCount'] && is_string($last)) {
 			$last = $options['escape'] ? h($last) : $last;
 			$out .= $this->templater()->format('last', [
-				'url' => $this->url(['page' => $params['pageCount']], $options['model']),
+				'url' => $this->generateUrl(['page' => $params['pageCount']], $options['model']),
 				'text' => $last
 			]);
 		}

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -591,20 +591,20 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->url();
+		$result = $this->Paginator->generateUrl();
 		$this->assertEquals('/index', $result);
 
 		$this->Paginator->request->params['paging']['Article']['page'] = 2;
-		$result = $this->Paginator->url();
+		$result = $this->Paginator->generateUrl();
 		$this->assertEquals('/index?page=2', $result);
 
 		$options = array('sort' => 'Article', 'direction' => 'desc');
-		$result = $this->Paginator->url($options);
+		$result = $this->Paginator->generateUrl($options);
 		$this->assertEquals('/index?page=2&amp;sort=Article&amp;direction=desc', $result);
 
 		$this->Paginator->request->params['paging']['Article']['page'] = 3;
 		$options = array('sort' => 'Article.name', 'direction' => 'desc');
-		$result = $this->Paginator->url($options);
+		$result = $this->Paginator->generateUrl($options);
 		$this->assertEquals('/index?page=3&amp;sort=Article.name&amp;direction=desc', $result);
 	}
 
@@ -628,7 +628,7 @@ class PaginatorHelperTest extends TestCase {
 		$this->Paginator->request->params['paging']['Article']['prevPage'] = true;
 		$options = array('prefix' => 'members');
 
-		$result = $this->Paginator->url($options);
+		$result = $this->Paginator->generateUrl($options);
 		$expected = '/members/posts/index?page=2';
 		$this->assertEquals($expected, $result);
 
@@ -661,12 +661,12 @@ class PaginatorHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$options = array('prefix' => 'members', 'controller' => 'posts', 'sort' => 'name', 'direction' => 'desc');
-		$result = $this->Paginator->url($options);
+		$result = $this->Paginator->generateUrl($options);
 		$expected = '/members/posts/index?page=2&amp;sort=name&amp;direction=desc';
 		$this->assertEquals($expected, $result);
 
 		$options = array('controller' => 'posts', 'sort' => 'Article.name', 'direction' => 'desc');
-		$result = $this->Paginator->url($options);
+		$result = $this->Paginator->generateUrl($options);
 		$expected = '/posts/index?page=2&amp;sort=Article.name&amp;direction=desc';
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
When trying to add a type hint I found that the two method signatures are so completely different that sharing the same method name should be avoided.

```
Declaration of Cake\View\Helper\PaginatorHelper::url() should be compatible with
Cake\View\Helper::url($url = NULL, $full = false)
```

The signature of PaginatorHelper::url() was:

```
public function url(array $options = array(), $model = null)
```

Those are obviously two different things.

This also now allows to set $full true/false for url generation.
