### PR TITLE
Fix generating opaque from realm options for DigestAuthenticate component

### DIFF
--- a/src/Controller/Component/Auth/DigestAuthenticate.php
+++ b/src/Controller/Component/Auth/DigestAuthenticate.php
@@ -201,11 +201,13 @@ class DigestAuthenticate extends BasicAuthenticate {
  * @return string Headers for logging in.
  */
 	public function loginHeaders(Request $request) {
+		$realm = $this->_config['realm'] ?: $request->env('SERVER_NAME');
+
 		$options = array(
-			'realm' => $this->_config['realm'] ?: $request->env('SERVER_NAME'),
+			'realm' => $realm,
 			'qop' => $this->_config['qop'],
 			'nonce' => $this->_config['nonce'] ?: uniqid(''),
-			'opaque' => $this->_config['opaque'] ?: md5($options['realm'])
+			'opaque' => $this->_config['opaque'] ?: md5($realm)
 		);
 
 		$opts = array();

--- a/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/tests/TestCase/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -206,6 +206,24 @@ DIGEST;
 	}
 
 /**
+ * testLoginHeaders method
+ *
+ * @return void
+ */
+	public function testLoginHeaders() {
+		$request = new Request([
+			'environment' => ['SERVER_NAME' => 'localhost']
+		]);
+		$this->auth = new DigestAuthenticate($this->Collection, array(
+			'realm' => 'localhost',
+			'nonce' => '123'
+		));
+		$expected = 'WWW-Authenticate: Digest realm="localhost",qop="auth",nonce="123",opaque="421aa90e079fa326b6494f812ad13e79"';
+		$result = $this->auth->loginHeaders($request);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testParseDigestAuthData method
  *
  * @return void


### PR DESCRIPTION
Generation of opaque value from realm for Digest authentication was broken. Added test case for testing DigestAuthenticate component's loginHeaders function.
