### PR TITLE
Fix failing tests around DS on different OS

### DIFF
--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -523,6 +523,20 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 /**
+ * Compatibility function to test paths.
+ *
+ * @param string $expected
+ * @param string $result
+ * @param string $message the text to display if the assertion is not correct
+ * @return void
+ */
+	protected static function assertPathEquals($expected, $result, $message = '') {
+		$expected = str_replace(DS, '/', $expected);
+		$result = str_replace(DS, '/', $result);
+		static::assertEquals($expected, $result, $message);
+	}
+
+/**
  * Compatibility function for skipping.
  *
  * @param boolean $condition Condition to trigger skipping

--- a/tests/TestCase/Core/AppTest.php
+++ b/tests/TestCase/Core/AppTest.php
@@ -121,7 +121,7 @@ class AppTest extends TestCase {
 		Plugin::load('TestPlugin');
 
 		$result = App::path('Controller', 'TestPlugin');
-		$this->assertEquals($basepath . 'TestPlugin' . DS . 'Controller' . DS, $result[0]);
+		$this->assertPathEquals($basepath . 'TestPlugin' . DS . 'Controller' . DS, $result[0]);
 	}
 
 /**
@@ -243,11 +243,11 @@ class AppTest extends TestCase {
 
 		$path = App::pluginPath('TestPlugin');
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
-		$this->assertEquals($expected, $path);
+		$this->assertPathEquals($expected, $path);
 
 		$path = App::pluginPath('TestPluginTwo');
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS;
-		$this->assertEquals($expected, $path);
+		$this->assertPathEquals($expected, $path);
 	}
 
 /**
@@ -258,11 +258,11 @@ class AppTest extends TestCase {
 	public function testThemePath() {
 		$path = App::themePath('test_theme');
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEquals($expected, $path);
+		$this->assertPathEquals($expected, $path);
 
 		$path = App::themePath('TestTheme');
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Themed' . DS . 'TestTheme' . DS;
-		$this->assertEquals($expected, $path);
+		$this->assertPathEquals($expected, $path);
 	}
 
 }

--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -221,10 +221,10 @@ class PluginTest extends TestCase {
 	public function testPath() {
 		Plugin::load(array('TestPlugin', 'TestPluginTwo'));
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS;
-		$this->assertEquals(Plugin::path('TestPlugin'), $expected);
+		$this->assertPathEquals(Plugin::path('TestPlugin'), $expected);
 
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPluginTwo' . DS;
-		$this->assertEquals(Plugin::path('TestPluginTwo'), $expected);
+		$this->assertPathEquals(Plugin::path('TestPluginTwo'), $expected);
 	}
 
 /**

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -647,7 +647,7 @@ object(Cake\Test\TestCase\Utility\DebuggableThing) {
 	'inner' => object(Cake\Test\TestCase\Utility\DebuggableThing) {
 
 		[maximum depth reached]
-	
+
 	}
 
 }

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -647,7 +647,7 @@ object(Cake\Test\TestCase\Utility\DebuggableThing) {
 	'inner' => object(Cake\Test\TestCase\Utility\DebuggableThing) {
 
 		[maximum depth reached]
-
+	
 	}
 
 }

--- a/tests/TestCase/Utility/FolderTest.php
+++ b/tests/TestCase/Utility/FolderTest.php
@@ -657,14 +657,14 @@ class FolderTest extends TestCase {
 		$Folder = new Folder(CAKE);
 		$result = $Folder->findRecursive('(config|paths)\.php');
 		$expected = array(
-			CAKE . 'Config'. DS . 'config.php'
+			CAKE . 'Config' . DS . 'config.php'
 		);
 		$this->assertSame(array(), array_diff($expected, $result));
 		$this->assertSame(array(), array_diff($expected, $result));
 
 		$result = $Folder->findRecursive('(config|woot)\.php', true);
 		$expected = array(
-			CAKE . 'Config'. DS . 'config.php'
+			CAKE . 'Config' . DS . 'config.php'
 		);
 		$this->assertSame($expected, $result);
 
@@ -690,15 +690,15 @@ class FolderTest extends TestCase {
 
 		$result = $Folder->findRecursive('(paths|my)\.php');
 		$expected = array(
-			$path . 'testme'. DS . 'my.php',
-			$path . 'testme'. DS . 'paths.php'
+			$path . 'testme' . DS . 'my.php',
+			$path . 'testme' . DS . 'paths.php'
 		);
 		$this->assertSame(sort($expected), sort($result));
 
 		$result = $Folder->findRecursive('(paths|my)\.php', true);
 		$expected = array(
-			$path . 'testme'. DS . 'my.php',
-			$path . 'testme'. DS . 'paths.php'
+			$path . 'testme' . DS . 'my.php',
+			$path . 'testme' . DS . 'paths.php'
 		);
 		$this->assertSame($expected, $result);
 	}
@@ -787,7 +787,7 @@ class FolderTest extends TestCase {
  * @return void
  */
 	public function testDelete() {
-		$path = TMP . 'tests'. DS . 'folder_delete_test';
+		$path = TMP . 'tests' . DS . 'folder_delete_test';
 		mkdir($path, 0777, true);
 		touch($path . DS . 'file_1');
 		mkdir($path . DS . 'level_1_1');

--- a/tests/TestCase/Utility/FolderTest.php
+++ b/tests/TestCase/Utility/FolderTest.php
@@ -407,7 +407,7 @@ class FolderTest extends TestCase {
 				CAKE . 'Config',
 			),
 			array(
-				CAKE . 'Config/config.php',
+				CAKE . 'Config' . DS . 'config.php',
 			)
 		);
 
@@ -657,18 +657,18 @@ class FolderTest extends TestCase {
 		$Folder = new Folder(CAKE);
 		$result = $Folder->findRecursive('(config|paths)\.php');
 		$expected = array(
-			CAKE . 'Config/config.php'
+			CAKE . 'Config'. DS . 'config.php'
 		);
 		$this->assertSame(array(), array_diff($expected, $result));
 		$this->assertSame(array(), array_diff($expected, $result));
 
 		$result = $Folder->findRecursive('(config|woot)\.php', true);
 		$expected = array(
-			CAKE . 'Config/config.php'
+			CAKE . 'Config'. DS . 'config.php'
 		);
 		$this->assertSame($expected, $result);
 
-		$path = TMP . 'tests/';
+		$path = TMP . 'tests' . DS;
 		$Folder = new Folder($path, true);
 		$Folder->create($path . 'sessions');
 		$Folder->create($path . 'testme');
@@ -690,15 +690,15 @@ class FolderTest extends TestCase {
 
 		$result = $Folder->findRecursive('(paths|my)\.php');
 		$expected = array(
-			$path . 'testme/my.php',
-			$path . 'testme/paths.php'
+			$path . 'testme'. DS . 'my.php',
+			$path . 'testme'. DS . 'paths.php'
 		);
 		$this->assertSame(sort($expected), sort($result));
 
 		$result = $Folder->findRecursive('(paths|my)\.php', true);
 		$expected = array(
-			$path . 'testme/my.php',
-			$path . 'testme/paths.php'
+			$path . 'testme'. DS . 'my.php',
+			$path . 'testme'. DS . 'paths.php'
 		);
 		$this->assertSame($expected, $result);
 	}
@@ -738,7 +738,7 @@ class FolderTest extends TestCase {
  * @return void
  */
 	public function testReset() {
-		$path = TMP . 'tests/folder_delete_test';
+		$path = TMP . 'tests' . DS . 'folder_delete_test';
 		mkdir($path, 0777, true);
 		$folder = $path . DS . 'sub';
 		mkdir($folder);
@@ -787,7 +787,7 @@ class FolderTest extends TestCase {
  * @return void
  */
 	public function testDelete() {
-		$path = TMP . 'tests/folder_delete_test';
+		$path = TMP . 'tests'. DS . 'folder_delete_test';
 		mkdir($path, 0777, true);
 		touch($path . DS . 'file_1');
 		mkdir($path . DS . 'level_1_1');

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -308,25 +308,25 @@ class ViewTest extends TestCase {
 		$ThemeView->theme = 'TestTheme';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
 		$result = $ThemeView->getViewFileName('home');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $ThemeView->getViewFileName('/Posts/index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Themed' . DS . 'TestTheme' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$ThemeView->layoutPath = 'rss';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'rss' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$ThemeView->layoutPath = 'Email' . DS . 'html';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'Email' . DS . 'html' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -368,15 +368,15 @@ class ViewTest extends TestCase {
 
 		$expected = $themePath . 'Plugin' . DS . 'TestPlugin' . DS . 'Tests' . DS . 'index.ctp';
 		$result = $ThemeView->getViewFileName('index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = $themePath . 'Plugin' . DS . 'TestPlugin' . DS . 'Layout' . DS . 'plugin_default.ctp';
 		$result = $ThemeView->getLayoutFileName('plugin_default');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = $themePath . 'Layout' . DS . 'default.ctp';
 		$result = $ThemeView->getLayoutFileName('default');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -403,7 +403,7 @@ class ViewTest extends TestCase {
 			TEST_APP . 'TestApp' . DS . 'Template' . DS,
 			CAKE . 'Template' . DS,
 		);
-		$this->assertEquals($expected, $paths);
+		$this->assertPathEquals($expected, $paths);
 	}
 
 /**
@@ -422,11 +422,11 @@ class ViewTest extends TestCase {
 		$pluginPath = Plugin::path('TestPlugin');
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Tests' . DS . 'index.ctp';
 		$result = $View->getViewFileName('index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = $pluginPath . 'Template' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -445,29 +445,29 @@ class ViewTest extends TestCase {
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
 		$result = $View->getViewFileName('home');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('/Posts/index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'page.home.ctp';
 		$result = $View->getViewFileName('page.home');
-		$this->assertEquals($expected, $result, 'Should not ruin files with dots.');
+		$this->assertPathEquals($expected, $result, 'Should not ruin files with dots.');
 
 		Plugin::load('TestPlugin');
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Pages' . DS . 'home.ctp';
 		$result = $View->getViewFileName('TestPlugin.home');
-		$this->assertEquals($expected, $result, 'Plugin is missing the view, cascade to app.');
+		$this->assertPathEquals($expected, $result, 'Plugin is missing the view, cascade to app.');
 
 		$View->viewPath = 'Tests';
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Tests' . DS . 'index.ctp';
 		$result = $View->getViewFileName('TestPlugin.index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -485,17 +485,17 @@ class ViewTest extends TestCase {
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$View->layoutPath = 'rss';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'rss' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$View->layoutPath = 'Email' . DS . 'html';
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Layout' . DS . 'Email' . DS . 'html' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName();
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -514,12 +514,12 @@ class ViewTest extends TestCase {
 
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName('TestPlugin.default');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 
 		$View->plugin = 'TestPlugin';
 		$expected = TEST_APP . 'Plugin' . DS . 'TestPlugin' . DS . 'Template' . DS . 'Layout' . DS . 'default.ctp';
 		$result = $View->getLayoutFileName('default');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -1033,7 +1033,7 @@ class ViewTest extends TestCase {
 
 		$result = $View->getViewFileName('sub_dir/sub_element');
 		$expected = $pluginPath . 'Template' . DS . 'Element' . DS . 'sub_dir' . DS . 'sub_element.ctp';
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**
@@ -1078,7 +1078,7 @@ class ViewTest extends TestCase {
 
 		$expected = TEST_APP . 'TestApp' . DS . 'Template' . DS . 'Posts' . DS . 'index.ctp';
 		$result = $View->getViewFileName('../Posts/index');
-		$this->assertEquals($expected, $result);
+		$this->assertPathEquals($expected, $result);
 	}
 
 /**


### PR DESCRIPTION
Currently all those tests file on windows due to at least one DS in there that has the wrong direction 
`\` vs `/`.
Since both slashes work, though, it is just cosmetics and only make the tests fail.
This PR resolves it by adding assertPathEquals() which unifies the path DS prior to comparing them.

The alternative would be either fixing it in the app (more str_replace necessary) or in the tests (more replace overhead there cloaking the actual test functionality).
