### PR TITLE
improve mysql default settings

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -155,7 +155,9 @@ class Mysql extends DboSource {
 		$flags = $config['flags'] + array(
 			PDO::ATTR_PERSISTENT => $config['persistent'],
 			PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
-			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
+			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+			PDO::ATTR_STRINGIFY_FETCHES => false,
+			PDO::ATTR_EMULATE_PREPARES => false
 		);
 
 		if (!empty($config['encoding'])) {


### PR DESCRIPTION
I think it's smart to set these PDO settings as default. This way you get the correct value types out of your database. I added two images with a var_dump() ouput after settings these options and before.

Before:
![before](https://cloud.githubusercontent.com/assets/5982785/2604576/d3be7eb8-bb3b-11e3-8e2d-9ef6cbf6cb45.png)

After:
![after](https://cloud.githubusercontent.com/assets/5982785/2604581/e1277b2c-bb3b-11e3-9fa6-3e644d421cda.png)

Take also note of the php documentation. It should be possible to use these settings with php 5.1 or greater.
