### PR TITLE
3.0 duplicate aliases

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -447,15 +447,18 @@ abstract class Association {
  * source results.
  *
  * @param array $row
+ * @param string $nestKey The array key under which the results for this association
+ * should be found
  * @param boolean $joined Whether or not the row is a result of a direct join
  * with this association
  * @return array
  */
-	public function transformRow($row, $joined) {
+	public function transformRow($row, $nestKey, $joined) {
 		$sourceAlias = $this->source()->alias();
-		$targetAlias = $this->target()->alias();
+		$nestKey = $nestKey ?: $this->_name;
 		if (isset($row[$sourceAlias])) {
-			$row[$sourceAlias][$this->property()] = $row[$targetAlias];
+			$row[$sourceAlias][$this->property()] = $row[$nestKey];
+			unset($row[$nestKey]);
 		}
 		return $row;
 	}

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -645,6 +645,7 @@ abstract class Association {
  * - fields: List of fields to select from the target table
  * - contain: List of related tables to eager load associated to the target table
  * - strategy: The name of strategy to use for finding target table records
+ * - nestKey: The array key under which results will be found when transforming the row
  *
  * @param array $options
  * @return \Closure

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -460,13 +460,6 @@ abstract class Association {
 	}
 
 /**
- * Get the relationship type.
- *
- * @return string Constant of either ONE_TO_ONE, MANY_TO_ONE, ONE_TO_MANY or MANY_TO_MANY.
- */
-	public abstract function type();
-
-/**
  * Proxies the finding operation to the target table's find method
  * and modifies the query accordingly based of this association
  * configuration
@@ -615,6 +608,13 @@ abstract class Association {
 
 		return $conditions;
 	}
+
+/**
+ * Get the relationship type.
+ *
+ * @return string Constant of either ONE_TO_ONE, MANY_TO_ONE, ONE_TO_MANY or MANY_TO_MANY.
+ */
+	public abstract function type();
 
 /**
  * Eager loads a list of records in the target table that are related to another

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\ORM;
 
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\ResultSetDecorator;
 use Cake\Event\Event;
 use Cake\ORM\Entity;

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -169,8 +169,13 @@ class BelongsTo extends Association {
 		$primaryKey = (array)$this->_targetTable->primaryKey();
 
 		if (count($foreignKey) !== count($primaryKey)) {
-			$msg = 'Cannot match provided foreignKey, got %d columns expected %d';
-			throw new \RuntimeException(sprintf($msg, count($foreignKey), count($primaryKey)));
+			$msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
+			throw new \RuntimeException(sprintf(
+				$msg,
+				$this->_name,
+				implode(', ', $foreignKey),
+				implode(', ', $primaryKey)
+			));
 		}
 
 		foreach ($foreignKey as $k => $f) {

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -103,23 +103,6 @@ class BelongsTo extends Association {
 	}
 
 /**
- * {@inheritdoc}
- *
- */
-	public function transformRow($row, $joined) {
-		if ($this->strategy() === $this::STRATEGY_JOIN) {
-			return parent::transformRow($row, $joined);
-		}
-
-		$sourceAlias = $this->source()->alias();
-		$nestKey = $this->_nestingKey();
-		if (isset($row[$nestKey])) {
-			$row[$sourceAlias][$this->property()] = $row[$nestKey];
-		}
-		return $row;
-	}
-
-/**
  * Takes an entity from the source table and looks if there is a field
  * matching the property name for this association. The found entity will be
  * saved on the target table for this association by passing supplied

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -32,7 +32,6 @@ class BelongsToMany extends Association {
 	use ExternalAssociationTrait {
 		_options as _externalOptions;
 		_addFilteringCondition as _addExternalConditions;
-		transformRow as protected _transformRow;
 	}
 
 /**
@@ -236,21 +235,17 @@ class BelongsToMany extends Association {
 	}
 
 /**
- * Correctly nests a result row associated values into the correct array keys inside the
- * source results.
+ * {@inheritdoc}
  *
- * @param array $row
- * @param boolean $joined Whether or not the row is a result of a direct join
- * with this association
- * @return array
  */
-	public function transformRow($row, $joined) {
+	public function transformRow($row, $nestKey, $joined) {
 		$alias = $this->junction()->alias();
 		if ($joined) {
 			$row[$this->target()->alias()][$this->_junctionProperty] = $row[$alias];
 			unset($row[$alias]);
 		}
-		return $this->_transformRow($row, $joined);
+
+		return parent::transformRow($row, $nestKey, $joined);
 	}
 
 /**

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -50,13 +50,6 @@ class BelongsToMany extends Association {
 	const SAVE_REPLACE = 'replace';
 
 /**
- * Whether this association can be expressed directly in a query join
- *
- * @var boolean
- */
-	protected $_canBeJoined = false;
-
-/**
  * The type of join to be used when adding the association to a query
  *
  * @var string

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -78,30 +78,6 @@ trait ExternalAssociationTrait {
 	}
 
 /**
- * Correctly nests a result row associated values into the correct array keys inside the
- * source results.
- *
- * @param array $row
- * @param boolean $joined Whether or not the row is a result of a direct join
- * with this association
- * @return array
- */
-	public function transformRow($row, $joined) {
-		$sourceAlias = $this->source()->alias();
-		$targetAlias = $this->target()->alias();
-
-		$collectionAlias = $this->_name . '___collection_';
-		if (isset($row[$collectionAlias])) {
-			$values = $row[$collectionAlias];
-		} else {
-			$values = $row[$this->_name];
-		}
-
-		$row[$sourceAlias][$this->property()] = $values;
-		return $row;
-	}
-
-/**
  * Returns the default options to use for the eagerLoader
  *
  * @return array
@@ -129,16 +105,6 @@ trait ExternalAssociationTrait {
 		}
 		return $resultMap;
 	}
-
-/**
- * Returns the key under which the eagerLoader will put this association results
- *
- * @return void
- */
-	protected function _nestingKey() {
-		return $this->_name . '___collection_';
-	}
-
 
 /**
  * Parse extra options passed in the constructor.

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -157,8 +157,13 @@ trait ExternalAssociationTrait {
 		$primaryKey = (array)$this->_sourceTable->primaryKey();
 
 		if (count($foreignKey) !== count($primaryKey)) {
-			$msg = 'Cannot match provided foreignKey, got %d columns expected %d';
-			throw new \RuntimeException(sprintf($msg, count($foreignKey), count($primaryKey)));
+			$msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
+			throw new \RuntimeException(sprintf(
+				$msg,
+				$this->_name,
+				implode(', ', $foreignKey),
+				implode(', ', $primaryKey)
+			));
 		}
 
 		foreach ($foreignKey as $k => $f) {

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\ORM\Association;
 
-use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Association\SelectableAssociationTrait;
 use Cake\ORM\Query;
 use Cake\Utility\Inflector;

--- a/src/ORM/Association/ExternalAssociationTrait.php
+++ b/src/ORM/Association/ExternalAssociationTrait.php
@@ -140,40 +140,6 @@ trait ExternalAssociationTrait {
 		return $this->_name . '___collection_';
 	}
 
-/**
- * Returns a single or multiple conditions to be appended to the generated join
- * clause for getting the results on the target table.
- *
- * @param array $options list of options passed to attachTo method
- * @return array
- * @throws \RuntimeException if the number of columns in the foreignKey do not
- * match the number of columns in the source table primaryKey
- */
-	protected function _joinCondition(array $options) {
-		$conditions = [];
-		$tAlias = $this->target()->alias();
-		$sAlias = $this->source()->alias();
-		$foreignKey = (array)$options['foreignKey'];
-		$primaryKey = (array)$this->_sourceTable->primaryKey();
-
-		if (count($foreignKey) !== count($primaryKey)) {
-			$msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
-			throw new \RuntimeException(sprintf(
-				$msg,
-				$this->_name,
-				implode(', ', $foreignKey),
-				implode(', ', $primaryKey)
-			));
-		}
-
-		foreach ($foreignKey as $k => $f) {
-			$field = sprintf('%s.%s', $sAlias, $primaryKey[$k]);
-			$value = new IdentifierExpression(sprintf('%s.%s', $tAlias, $f));
-			$conditions[$field] = $value;
-		}
-
-		return $conditions;
-	}
 
 /**
  * Parse extra options passed in the constructor.

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -14,7 +14,6 @@
  */
 namespace Cake\ORM\Association;
 
-use Cake\Database\Expression\IdentifierExpression;
 use Cake\ORM\Association;
 use Cake\ORM\Association\DependentDeleteTrait;
 use Cake\ORM\Association\SelectableAssociationTrait;

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -148,8 +148,13 @@ class HasOne extends Association {
 		$primaryKey = (array)$this->_sourceTable->primaryKey();
 
 		if (count($foreignKey) !== count($primaryKey)) {
-			$msg = 'Cannot match provided foreignKey, got %d columns expected %d';
-			throw new \RuntimeException(sprintf($msg, count($foreignKey), count($primaryKey)));
+			$msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
+			throw new \RuntimeException(sprintf(
+				$msg,
+				$this->_name,
+				implode(', ', $foreignKey),
+				implode(', ', $primaryKey)
+			));
 		}
 
 		foreach ($foreignKey as $k => $f) {

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -132,41 +132,6 @@ class HasOne extends Association {
 	}
 
 /**
- * Returns a single or multiple conditions to be appended to the generated join
- * clause for getting the results on the target table.
- *
- * @param array $options list of options passed to attachTo method
- * @return array
- * @throws \RuntimeException if the number of columns in the foreignKey do not
- * match the number of columns in the source table primaryKey
- */
-	protected function _joinCondition(array $options) {
-		$conditions = [];
-		$tAlias = $this->target()->alias();
-		$sAlias = $this->_sourceTable->alias();
-		$foreignKey = (array)$options['foreignKey'];
-		$primaryKey = (array)$this->_sourceTable->primaryKey();
-
-		if (count($foreignKey) !== count($primaryKey)) {
-			$msg = 'Cannot match provided foreignKey for "%s", got "(%s)" but expected foreign key for "(%s)"';
-			throw new \RuntimeException(sprintf(
-				$msg,
-				$this->_name,
-				implode(', ', $foreignKey),
-				implode(', ', $primaryKey)
-			));
-		}
-
-		foreach ($foreignKey as $k => $f) {
-			$field = sprintf('%s.%s', $sAlias, $primaryKey[$k]);
-			$value = new IdentifierExpression(sprintf('%s.%s', $tAlias, $f));
-			$conditions[$field] = $value;
-		}
-
-		return $conditions;
-	}
-
-/**
  * {@inheritdoc}
  *
  */

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -79,7 +79,6 @@ trait SelectableAssociationTrait {
 		$target = $this->target();
 		$alias = $target->alias();
 		$key = $this->_linkField($options);
-
 		$filter = $options['keys'];
 
 		if ($options['strategy'] === $this::STRATEGY_SUBQUERY) {

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -50,7 +50,7 @@ trait SelectableAssociationTrait {
 			$fetchQuery = $queryBuilder($fetchQuery);
 		}
 		$resultMap = $this->_buildResultMap($fetchQuery, $options);
-		return $this->_resultInjector($fetchQuery, $resultMap);
+		return $this->_resultInjector($fetchQuery, $resultMap, $options);
 	}
 
 /**
@@ -62,7 +62,8 @@ trait SelectableAssociationTrait {
 		return [
 			'foreignKey' => $this->foreignKey(),
 			'conditions' => [],
-			'strategy' => $this->strategy()
+			'strategy' => $this->strategy(),
+			'nestKey' => $this->_name
 		];
 	}
 
@@ -199,7 +200,7 @@ trait SelectableAssociationTrait {
  * the corresponding target table results as value.
  * @return \Closure
  */
-	protected function _resultInjector($fetchQuery, $resultMap) {
+	protected function _resultInjector($fetchQuery, $resultMap, $options) {
 		$source = $this->source();
 		$sAlias = $source->alias();
 		$keys = $this->type() === $this::MANY_TO_ONE ?
@@ -211,7 +212,7 @@ trait SelectableAssociationTrait {
 			$sourceKeys[] = key($fetchQuery->aliasField($key, $sAlias));
 		}
 
-		$nestKey = $this->_nestingKey();
+		$nestKey = $options['nestKey'];
 		if (count($sourceKeys) > 1) {
 			return $this->_multiKeysInjector($resultMap, $sourceKeys, $nestKey);
 		}
@@ -223,15 +224,6 @@ trait SelectableAssociationTrait {
 			}
 			return $row;
 		};
-	}
-
-/**
- * Returns the key under which the eagerLoader will put this association results
- *
- * @return string
- */
-	protected function _nestingKey() {
-		return $this->property();
 	}
 
 /**

--- a/src/ORM/Association/SelectableAssociationTrait.php
+++ b/src/ORM/Association/SelectableAssociationTrait.php
@@ -198,6 +198,7 @@ trait SelectableAssociationTrait {
  * @param \Cake\ORM\Query $fetchQuery the Query used to fetch results
  * @param array $resultMap an array with the foreignKey as keys and
  * the corresponding target table results as value.
+ * @param array $options The options passed to the eagerLoader method
  * @return \Closure
  */
 	protected function _resultInjector($fetchQuery, $resultMap, $options) {

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -327,7 +327,8 @@ class EagerLoader {
 		];
 
 		$config['canBeJoined'] = $instance->canBeJoined($config['config']);
-		if ($config['canBeJoined'] && !empty($this->_aliasList[$alias])) {
+		$canChange = $config['canBeJoined'] && empty($config['config']['matching']);
+		if ($canChange && !empty($this->_aliasList[$alias])) {
 			$config['canBeJoined'] = false;
 			$config['config']['strategy'] = $instance::STRATEGY_SELECT;
 		}

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -68,6 +68,13 @@ class EagerLoader {
 	protected $_loadExternal = [];
 
 /**
+ * Contains a list of the association names that are to be eagerly loaded
+ *
+ * @var array
+ */
+	protected $_aliasList = [];
+
+/**
  * Sets the list of associations that should be eagerly loaded along for a
  * specific table using when a query is provided. The list of associated tables
  * passed to this method must have been previously set as associations using the
@@ -318,7 +325,14 @@ class EagerLoader {
 			'aliasPath' => trim($paths['aliasPath'], '.'),
 			'propertyPath' => trim($paths['propertyPath'], '.'),
 		];
+
 		$config['canBeJoined'] = $instance->canBeJoined($config['config']);
+		if ($config['canBeJoined'] && !empty($this->_aliasList[$alias])) {
+			$config['canBeJoined'] = false;
+			$config['config']['strategy'] = $instance::STRATEGY_SELECT;
+		}
+
+		$this->_aliasList[$alias][] = $paths['aliasPath'];
 
 		foreach ($extra as $t => $assoc) {
 			$config['associations'][$t] = $this->_normalizeContain($table, $t, $assoc, $paths);

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -389,7 +389,12 @@ class EagerLoader {
 
 			$keys = isset($collected[$alias]) ? $collected[$alias] : null;
 			$f = $meta['instance']->eagerLoader(
-				$meta['config'] + ['query' => $query, 'contain' => $contain, 'keys' => $keys]
+				$meta['config'] + [
+					'query' => $query,
+					'contain' => $contain,
+					'keys' => $keys,
+					'nestKey' => $meta['aliasPath']
+				]
 			);
 			$statement = new CallbackStatement($statement, $driver, $f);
 		}

--- a/src/ORM/EagerLoader.php
+++ b/src/ORM/EagerLoader.php
@@ -106,6 +106,7 @@ class EagerLoader {
 		$associations = (array)$associations;
 		$associations = $this->_reformatContain($associations, $this->_containments);
 		$this->_normalized = $this->_loadExternal = null;
+		$this->_aliasList = [];
 		return $this->_containments = $associations;
 	}
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -310,9 +310,9 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 					'instance' => $meta['instance'],
 					'canBeJoined' => $meta['canBeJoined'],
 					'entityClass' => $meta['instance']->target()->entityClass(),
-					'nestKey' => $meta['aliasPath']
+					'nestKey' => $meta['canBeJoined'] ? $assoc : $meta['aliasPath']
 				];
-				if (!empty($meta['associations'])) {
+				if ($meta['canBeJoined'] && !empty($meta['associations'])) {
 					$visitor($meta['associations']);
 				}
 			}

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -310,7 +310,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 					'instance' => $meta['instance'],
 					'canBeJoined' => $meta['canBeJoined'],
 					'entityClass' => $meta['instance']->target()->entityClass(),
-					'nestKey' => $meta['canBeJoined'] ? $assoc : $meta['aliasPath']
+					'nestKey' => $meta['aliasPath']
 				];
 				if (!empty($meta['associations'])) {
 					$visitor($meta['associations']);
@@ -384,7 +384,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 			'markNew' => false,
 			'guard' => false
 		];
-			
+
 		foreach (array_reverse($this->_associationMap) as $assoc) {
 			$alias = $assoc['nestKey'];
 			if (!isset($results[$alias])) {

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -439,14 +439,14 @@ class BelongsToManyTest extends TestCase {
 		$callable = $association->eagerLoader(compact('keys', 'query'));
 		$row = ['Articles__id' => 1, 'title' => 'article 1'];
 		$result = $callable($row);
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			['id' => 1, 'name' => 'foo', '_joinData' => ['article_id' => 1]]
 		];
 		$this->assertEquals($row, $result);
 
 		$row = ['Articles__id' => 2, 'title' => 'article 2'];
 		$result = $callable($row);
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			['id' => 2, 'name' => 'bar', '_joinData' => ['article_id' => 2]]
 		];
 		$this->assertEquals($row, $result);
@@ -682,14 +682,14 @@ class BelongsToManyTest extends TestCase {
 			'keys' => []
 		]);
 
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			['id' => 1, 'name' => 'foo', '_joinData' => ['article_id' => 1]]
 		];
 		$row['Articles__id'] = 1;
 		$result = $callable($row);
 		$this->assertEquals($row, $result);
 
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			['id' => 2, 'name' => 'bar', '_joinData' => ['article_id' => 2]]
 		];
 		$row['Articles__id'] = 2;
@@ -834,7 +834,7 @@ class BelongsToManyTest extends TestCase {
 		$callable = $association->eagerLoader(compact('keys', 'query'));
 		$row = ['Articles__id' => 1, 'title' => 'article 1', 'Articles__site_id' => 1];
 		$result = $callable($row);
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			[
 				'id' => 1,
 				'name' => 'foo',
@@ -846,7 +846,7 @@ class BelongsToManyTest extends TestCase {
 
 		$row = ['Articles__id' => 2, 'title' => 'article 2', 'Articles__site_id' => 2];
 		$result = $callable($row);
-		$row['Tags___collection_'] = [
+		$row['Tags'] = [
 			[
 				'id' => 2,
 				'name' => 'bar',

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -328,7 +328,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * key will work if the foreign key is passed
  *
  * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot match provided foreignKey, got 1 columns expected 2
+ * @expectedExceptionMessage Cannot match provided foreignKey for "Companies", got "(company_id)" but expected foreign key for "(id, tenant_id)"
  * @return void
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -132,14 +132,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$callable = $association->eagerLoader(compact('keys', 'query'));
 		$row = ['Authors__id' => 1, 'username' => 'author 1'];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 			];
 		$this->assertEquals($row, $result);
 
 		$row = ['Authors__id' => 2, 'username' => 'author 2'];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2]
 			];
 		$this->assertEquals($row, $result);
@@ -347,14 +347,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		]);
 		$row = ['Authors__id' => 1, 'username' => 'author 1'];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1]
 		];
 		$this->assertEquals($row, $result);
 
 		$row = ['Authors__id' => 2, 'username' => 'author 2'];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2]
 		];
 		$this->assertEquals($row, $result);
@@ -447,14 +447,14 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$callable = $association->eagerLoader(compact('keys', 'query'));
 		$row = ['Authors__id' => 2, 'Authors__site_id' => 10, 'username' => 'author 1'];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 1, 'title' => 'article 1', 'author_id' => 2, 'site_id' => 10]
 		];
 		$this->assertEquals($row, $result);
 
 		$row = ['Authors__id' => 1, 'username' => 'author 2', 'Authors__site_id' => 20];
 		$result = $callable($row);
-		$row['Articles___collection_'] = [
+		$row['Articles'] = [
 			['id' => 2, 'title' => 'article 2', 'author_id' => 1, 'site_id' => 20]
 		];
 		$this->assertEquals($row, $result);
@@ -593,7 +593,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * key will work if the foreign key is passed
  *
  * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot match provided foreignKey, got 1 columns expected 2
+ * @expectedExceptionMessage Cannot match provided foreignKey for "Articles", got "(author_id)" but expected foreign key for "(id, site_id)
  * @return void
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -247,7 +247,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * key will work if the foreign key is passed
  *
  * @expectedException \RuntimeException
- * @expectedExceptionMessage Cannot match provided foreignKey, got 1 columns expected 2
+ * @expectedExceptionMessage Cannot match provided foreignKey for "Profiles", got "(user_id)" but expected foreign key for "(id, site_id)"
  * @return void
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -30,7 +30,7 @@ class QueryRegressionTest extends TestCase {
  *
  * @var array
  */
-	public $fixtures = ['core.user', 'core.article', 'core.tag', 'core.articles_tag'];
+	public $fixtures = ['core.user', 'core.article', 'core.tag', 'core.articles_tag', 'core.author'];
 
 /**
  * Tear down
@@ -64,6 +64,16 @@ class QueryRegressionTest extends TestCase {
 		$table->belongsToMany('ArticlesTags');
 		$results = $table->find()->where(['id >' => 100])->contain('ArticlesTags')->toArray();
 		$this->assertEmpty($results);
+	}
+
+	public function testDuplicateAttachableAliases() {
+		$table = TableRegistry::get('Articles');
+		$table->belongsTo('Authors');
+		$table->hasOne('ArticlesTags');
+		$table->Authors->target()->hasOne('Tags', ['foreignKey' => 'id']);
+		$table->ArticlesTags->target()->belongsTo('Tags', ['foreignKey' => 'tag_id']);
+
+		$results = $table->find()->contain(['Authors.Tags', 'ArticlesTags.Tags']);
 	}
 
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -67,13 +67,20 @@ class QueryRegressionTest extends TestCase {
 	}
 
 	public function testDuplicateAttachableAliases() {
+		TableRegistry::get('Stuff', ['table' => 'tags']);
+		TableRegistry::get('Things', ['table' => 'articles_tags']);
+
 		$table = TableRegistry::get('Articles');
 		$table->belongsTo('Authors');
-		$table->hasOne('ArticlesTags');
-		$table->Authors->target()->hasOne('Tags', ['foreignKey' => 'id']);
-		$table->ArticlesTags->target()->belongsTo('Tags', ['foreignKey' => 'tag_id']);
+		$table->hasOne('Things');
+		
+		$table->Authors->target()->hasOne('Stuff', ['foreignKey' => 'id']);
+		$table->Things->target()->belongsTo('Stuff', ['foreignKey' => 'tag_id']);
 
-		$results = $table->find()->contain(['Authors.Tags', 'ArticlesTags.Tags']);
+		$results = $table->find()
+			->contain(['Authors.Stuff', 'Things.Stuff'])
+			->hydrate(false)
+			->toArray();
 	}
 
 }

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -72,10 +72,16 @@ class QueryRegressionTest extends TestCase {
 
 		$table = TableRegistry::get('Articles');
 		$table->belongsTo('Authors');
-		$table->hasOne('Things');
+		$table->hasOne('Things', ['propertyName' => 'articles_tag']);
 		
-		$table->Authors->target()->hasOne('Stuff', ['foreignKey' => 'id']);
-		$table->Things->target()->belongsTo('Stuff', ['foreignKey' => 'tag_id']);
+		$table->Authors->target()->hasOne('Stuff', [
+			'foreignKey' => 'id',
+			'propertyName' => 'favorite_tag'
+		]);
+		$table->Things->target()->belongsTo('Stuff', [
+			'foreignKey' => 'tag_id',
+			'propertyName' => 'foo']
+		);
 
 		$results = $table->find()
 			->contain(['Authors.Stuff', 'Things.Stuff'])

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -66,6 +66,14 @@ class QueryRegressionTest extends TestCase {
 		$this->assertEmpty($results);
 	}
 
+/**
+ * Tests that duplicate aliases in contain() can be used, even when they would
+ * naturally be attached to the query instead of eagerly loaded. What should
+ * happen here is that One of the duplicates will be changed to be loaded using
+ * an extra query, but yielding the same results
+ *
+ * @return void
+ */
 	public function testDuplicateAttachableAliases() {
 		TableRegistry::get('Stuff', ['table' => 'tags']);
 		TableRegistry::get('Things', ['table' => 'articles_tags']);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -81,7 +81,6 @@ class QueryRegressionTest extends TestCase {
 		$table = TableRegistry::get('Articles');
 		$table->belongsTo('Authors');
 		$table->hasOne('Things', ['propertyName' => 'articles_tag']);
-		
 		$table->Authors->target()->hasOne('Stuff', [
 			'foreignKey' => 'id',
 			'propertyName' => 'favorite_tag'

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -85,8 +85,16 @@ class QueryRegressionTest extends TestCase {
 
 		$results = $table->find()
 			->contain(['Authors.Stuff', 'Things.Stuff'])
-			->hydrate(false)
 			->toArray();
+
+		$this->assertEquals(1, $results[0]->articles_tag->foo->id);
+		$this->assertEquals(1, $results[0]->author->favorite_tag->id);
+		$this->assertEquals(2, $results[1]->articles_tag->foo->id);
+		$this->assertEquals(1, $results[0]->author->favorite_tag->id);
+		$this->assertEquals(1, $results[2]->articles_tag->foo->id);
+		$this->assertEquals(3, $results[2]->author->favorite_tag->id);
+		$this->assertEquals(3, $results[3]->articles_tag->foo->id);
+		$this->assertEquals(3, $results[3]->author->favorite_tag->id);
 	}
 
 }

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1923,4 +1923,23 @@ class QueryTest extends TestCase {
 		$this->assertNotEmpty($results[2]['article']);
 	}
 
+/**
+ * Tests that it is not allowed to use matching on an association
+ * that is already added to containments.
+ *
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Cannot use "matching" on "Authors" as there is another association with the same alias
+ * @return void
+ */
+	public function testConflitingAliases() {
+		$table = TableRegistry::get('ArticlesTags');
+		$table->belongsTo('Articles')->target()->belongsTo('Authors');
+		$table->belongsTo('Tags');
+		$table->Tags->target()->hasOne('Authors');
+		$table->find()
+			->contain(['Articles.Authors'])
+			->matching('Tags.Authors')
+			->all();
+	}
+
 }


### PR DESCRIPTION
With this change, when containing multiple tables with the same alias, duplicates will be forced to use a separate query. This is to prevent alias collision in the query and when hydrating the results.

Fixes https://github.com/cakephp/cakephp/issues/3113
