### PR TITLE
Correct plugin controller name to extend from in template

### DIFF
--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -145,8 +145,10 @@ class ControllerTask extends BakeTask {
 		}
 
 		$namespace = Configure::read('App.namespace');
+        	$plugin = null;
 		if ($this->plugin) {
-			$namespace = $this->plugin;
+            		$plugin = Inflector::camelize($this->plugin);
+			$namespace = $plugin;
 		}
 
 		$data = compact(
@@ -154,7 +156,8 @@ class ControllerTask extends BakeTask {
 			'actions',
 			'helpers',
 			'components',
-			'namespace'
+			'namespace',
+			'plugin'
 		);
 		$data['name'] = $controllerName;
 

--- a/src/Console/Templates/default/classes/controller.ctp
+++ b/src/Console/Templates/default/classes/controller.ctp
@@ -21,7 +21,7 @@ use Cake\Utility\Inflector;
 echo "<?php\n"; ?>
 namespace <?= $namespace ?>\Controller<?= $prefix ?>;
 
-use <?= $namespace ?>\Controller\AppController;
+use <?= $namespace ?>\Controller\<?= $plugin; ?>AppController;
 
 /**
  * <?= $name; ?> Controller
@@ -36,7 +36,7 @@ if (!empty($components)) {
 }
 ?>
  */
-class <?= $name; ?>Controller extends AppController {
+class <?= $name; ?>Controller extends <?= $plugin; >AppController {
 
 <?php
 


### PR DESCRIPTION
Currently the controller task and corresponding template extends and use is set to derive from AppController rather then {plugin name}AppController.  I am assuming that since the plugin task correctly creates this {plugin name}AppController when it bakes that we should extend from that file in CakePHP 3.
