### PR TITLE
WIP - 3.0 method signature

### DIFF
--- a/src/Core/Object.php
+++ b/src/Core/Object.php
@@ -53,7 +53,7 @@ class Object {
  * @param array $params Parameter list to use when calling $method
  * @return mixed Returns the result of the method call
  */
-	public function dispatchMethod($method, $params = []) {
+	public function dispatchMethod($method, array $params = []) {
 		switch (count($params)) {
 			case 0:
 				return $this->{$method}();

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -215,13 +215,13 @@ abstract class ControllerTestCase extends TestCase {
 	protected function _testAction($url = '', $options = array()) {
 		$this->vars = $this->result = $this->view = $this->contents = $this->headers = null;
 
-		$options = array_merge(array(
+		$options += array(
 			'query' => array(),
 			'data' => array(),
 			'cookies' => array(),
 			'method' => 'GET',
 			'return' => 'result'
-		), $options);
+		);
 
 		$method = strtoupper($options['method']);
 		$_SERVER['REQUEST_METHOD'] = $method;
@@ -308,7 +308,7 @@ abstract class ControllerTestCase extends TestCase {
  * @throws \Cake\Error\MissingControllerException When controllers could not be created.
  * @throws \Cake\Error\MissingComponentException When components could not be created.
  */
-	public function generate($controller, $mocks = array()) {
+	public function generate($controller, array $mocks = array()) {
 		$classname = App::classname($controller, 'Controller', 'Controller');
 		if (!$classname) {
 			list($plugin, $controller) = pluginSplit($controller);
@@ -322,7 +322,7 @@ abstract class ControllerTestCase extends TestCase {
 			'methods' => array('_stop'),
 			'models' => array(),
 			'components' => array()
-		), (array)$mocks);
+		), $mocks);
 		list(, $controllerName) = namespaceSplit($classname);
 		$name = substr($controllerName, 0, -10);
 

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -566,12 +566,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
  * Mock a model, maintain fixtures and table association
  *
  * @param string $alias
- * @param mixed $methods
+ * @param array $methods
  * @param array $options
  * @throws \Cake\ORM\Error\MissingTableClassException
  * @return Model
  */
-	public function getMockForModel($alias, $methods = array(), $options = array()) {
+	public function getMockForModel($alias, array $methods = array(), array $options = array()) {
 		if (empty($options['className'])) {
 			$class = Inflector::camelize($alias);
 			$className = App::classname($class, 'Model/Table', 'Table');

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -146,7 +146,7 @@ class Helper extends Object implements EventListener {
  * @param View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, array $config = array()) {
 		$this->_View = $View;
 		$this->request = $View->request;
 
@@ -249,7 +249,7 @@ class Helper extends Object implements EventListener {
  *   `plugin` False value will prevent parsing path as a plugin
  * @return string Generated URL
  */
-	public function assetUrl($path, $options = array()) {
+	public function assetUrl($path, array $options = array()) {
 		if (is_array($path)) {
 			return $this->url($path, !empty($options['fullBase']));
 		}
@@ -368,7 +368,7 @@ class Helper extends Object implements EventListener {
  * @param string $key the key to use for class.
  * @return array Array of options with $key set.
  */
-	public function addClass($options = array(), $class = null, $key = 'class') {
+	public function addClass(array $options = array(), $class = null, $key = 'class') {
 		if (isset($options[$key]) && trim($options[$key])) {
 			$options[$key] .= ' ' . $class;
 		} else {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -886,7 +886,7 @@ class FormHelper extends Helper {
 	protected function _getInput($fieldName, $options) {
 		switch ($options['type']) {
 			case 'select':
-				$opts = $options['options'];
+				$opts = (array)$options['options'];
 				unset($options['options']);
 				return $this->select($fieldName, $opts, $options);
 			case 'url':

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -168,7 +168,7 @@ class FormHelper extends Helper {
  * @param \Cake\View\View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper.
  */
-	public function __construct(View $View, $config = []) {
+	public function __construct(View $View, array $config = []) {
 		parent::__construct($View, $config);
 		$config = $this->_config;
 
@@ -440,14 +440,14 @@ class FormHelper extends Helper {
  * the hidden input tags generated for the Security Component. This is
  * especially useful to set HTML5 attributes like 'form'.
  *
- * @param array|null $fields If set specifies the list of fields to use when
+ * @param array $fields If set specifies the list of fields to use when
  *    generating the hash, else $this->fields is being used.
  * @param array $secureAttributes will be passed as html attributes into the hidden
  *    input elements generated for the Security Component.
  * @return string A hidden input field with a security hash
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::secure
  */
-	public function secure($fields = array(), $secureAttributes = array()) {
+	public function secure(array $fields = array(), array $secureAttributes = array()) {
 		if (!isset($this->request['_Token']) || empty($this->request['_Token'])) {
 			return;
 		}
@@ -571,7 +571,7 @@ class FormHelper extends Helper {
  * @return string Formatted errors or ''.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::error
  */
-	public function error($field, $text = null, $options = []) {
+	public function error($field, $text = null, array $options = []) {
 		$options += ['escape' => true];
 
 		$context = $this->_getContext();
@@ -734,7 +734,7 @@ class FormHelper extends Helper {
  * and fieldset rendering.
  * `$this->Form->inputs('My legend');` Would generate an input set with a custom legend.
  *
- * @param array $fields An array of customizations for the fields that will be
+ * @param mixed $fields An array of customizations for the fields that will be
  *   generated. This array allows you to set custom types, labels, or other options.
  * @param array $blacklist A list of fields to not create inputs for.
  * @param array $options Options array. Valid keys are:
@@ -744,7 +744,7 @@ class FormHelper extends Helper {
  * @return string Completed form inputs.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
-	public function inputs($fields = null, $blacklist = null, $options = array()) {
+	public function inputs($fields = null, array $blacklist = [], array $options = []) {
 		$fieldset = $legend = true;
 		$context = $this->_getContext();
 
@@ -788,7 +788,7 @@ class FormHelper extends Helper {
 			}
 			$entity = explode('.', $name);
 			$blacklisted = (
-				is_array($blacklist) &&
+				!empty($blacklist) &&
 				(in_array($name, $blacklist) || in_array(end($entity), $blacklist))
 			);
 			if ($blacklisted) {
@@ -828,13 +828,13 @@ class FormHelper extends Helper {
  * @return string Completed form widget.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#creating-form-elements
  */
-	public function input($fieldName, $options = []) {
+	public function input($fieldName, array $options = []) {
 		$options += [
 			'type' => null,
 			'label' => null,
 			'error' => null,
-			'options' => null,
 			'required' => null,
+			'options' => null,
 			'templates' => []
 		];
 		$options = $this->_parseOptions($fieldName, $options);
@@ -1132,7 +1132,7 @@ class FormHelper extends Helper {
  * @return string An HTML text input element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
-	public function checkbox($fieldName, $options = []) {
+	public function checkbox($fieldName, array $options = []) {
 		$options += array('hiddenField' => true, 'value' => 1);
 
 		// Work around value=>val translations.
@@ -1177,7 +1177,7 @@ class FormHelper extends Helper {
  * @return string Completed radio widget set.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
-	public function radio($fieldName, $options = [], $attributes = []) {
+	public function radio($fieldName, array $options = [], array $attributes = []) {
 		$attributes = $this->_initInputField($fieldName, $attributes);
 
 		$hiddenField = isset($attributes['hiddenField']) ? $attributes['hiddenField'] : true;
@@ -1246,7 +1246,7 @@ class FormHelper extends Helper {
  * @return string A generated HTML text input element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::textarea
  */
-	public function textarea($fieldName, $options = array()) {
+	public function textarea($fieldName, array $options = array()) {
 		$options = $this->_initInputField($fieldName, $options);
 		return $this->widget('textarea', $options);
 	}
@@ -1259,7 +1259,7 @@ class FormHelper extends Helper {
  * @return string A generated hidden input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::hidden
  */
-	public function hidden($fieldName, $options = array()) {
+	public function hidden($fieldName, array $options = array()) {
 		$options += array('required' => false, 'secure' => true);
 
 		$secure = $options['secure'];
@@ -1285,7 +1285,7 @@ class FormHelper extends Helper {
  * @return string A generated file input.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::file
  */
-	public function file($fieldName, $options = array()) {
+	public function file($fieldName, array $options = array()) {
 		$options += array('secure' => true);
 		$secure = $options['secure'];
 		$options['secure'] = static::SECURE_SKIP;
@@ -1318,7 +1318,7 @@ class FormHelper extends Helper {
  * @return string A HTML button tag.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::button
  */
-	public function button($title, $options = array()) {
+	public function button($title, array $options = array()) {
 		$options += array('type' => 'submit', 'escape' => false, 'secure' => false);
 		if (isset($options['name'])) {
 			$this->_secure($options['secure'], $this->_secureFieldName($options));
@@ -1346,7 +1346,7 @@ class FormHelper extends Helper {
  * @return string A HTML button tag.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postButton
  */
-	public function postButton($title, $url, $options = array()) {
+	public function postButton($title, $url, array $options = array()) {
 		$out = $this->create(false, array('url' => $url));
 		if (isset($options['data']) && is_array($options['data'])) {
 			foreach (Hash::flatten($options['data']) as $key => $value) {
@@ -1383,7 +1383,7 @@ class FormHelper extends Helper {
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postLink
  */
-	public function postLink($title, $url = null, $options = array(), $confirmMessage = false) {
+	public function postLink($title, $url = null, array $options = array(), $confirmMessage = false) {
 		$options += array('block' => null);
 
 		$requestMethod = 'POST';
@@ -1465,7 +1465,7 @@ class FormHelper extends Helper {
  * @return string A HTML submit button
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::submit
  */
-	public function submit($caption = null, $options = []) {
+	public function submit($caption = null, array $options = []) {
 		if (!is_string($caption) && empty($caption)) {
 			$caption = __d('cake', 'Submit');
 		}
@@ -1573,7 +1573,7 @@ class FormHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  * @see \Cake\View\Helper\FormHelper::multiCheckbox() for creating multiple checkboxes.
  */
-	public function select($fieldName, $options = [], $attributes = []) {
+	public function select($fieldName, array $options = [], array $attributes = []) {
 		$attributes += [
 			'disabled' => null,
 			'escape' => true,
@@ -1638,7 +1638,7 @@ class FormHelper extends Helper {
  * @return string Formatted SELECT element
  * @see \Cake\View\Helper\FormHelper::select() for supported option formats.
  */
-	public function multiCheckbox($fieldName, $options, $attributes = []) {
+	public function multiCheckbox($fieldName, array $options, array $attributes = []) {
 		$attributes += [
 			'disabled' => null,
 			'escape' => true,
@@ -1696,7 +1696,7 @@ class FormHelper extends Helper {
  * @return string A generated day select box.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::day
  */
-	public function day($fieldName = null, $options = []) {
+	public function day($fieldName = null, array $options = []) {
 		$options = $this->_singleDatetime($options, 'day');
 
 		if (isset($options['val']) && $options['val'] > 0 && $options['val'] <= 31) {
@@ -1727,7 +1727,7 @@ class FormHelper extends Helper {
  * @return string Completed year select input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::year
  */
-	public function year($fieldName, $options = []) {
+	public function year($fieldName, array $options = []) {
 		$options = $this->_singleDatetime($options, 'year');
 
 		$len = isset($options['val']) ? strlen($options['val']) : 0;
@@ -1758,7 +1758,7 @@ class FormHelper extends Helper {
  * @return string A generated month select dropdown.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::month
  */
-	public function month($fieldName, $options = array()) {
+	public function month($fieldName, array $options = array()) {
 		$options = $this->_singleDatetime($options, 'month');
 
 		if (isset($options['val']) && $options['val'] > 0 && $options['val'] <= 12) {
@@ -1786,7 +1786,7 @@ class FormHelper extends Helper {
  * @return string Completed hour select input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::hour
  */
-	public function hour($fieldName, $options = []) {
+	public function hour($fieldName, array $options = []) {
 		$options += ['format' => 12];
 		$options = $this->_singleDatetime($options, 'hour');
 
@@ -1819,7 +1819,7 @@ class FormHelper extends Helper {
  * @return string Completed minute select input.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::minute
  */
-	public function minute($fieldName, $options = []) {
+	public function minute($fieldName, array $options = []) {
 		$options = $this->_singleDatetime($options, 'minute');
 
 		if (isset($options['val']) && $options['val'] > 0 && $options['val'] <= 60) {
@@ -1845,7 +1845,7 @@ class FormHelper extends Helper {
  * @return string Completed meridian select input
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::meridian
  */
-	public function meridian($fieldName, $options = array()) {
+	public function meridian($fieldName, array $options = array()) {
 		$options = $this->_singleDatetime($options, 'meridian');
 
 		if (isset($options['val'])) {
@@ -1893,7 +1893,7 @@ class FormHelper extends Helper {
  * @return string Generated set of select boxes for the date and time formats chosen.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::dateTime
  */
-	public function dateTime($fieldName, $options = array()) {
+	public function dateTime($fieldName, array $options = array()) {
 		$options += [
 			'empty' => true,
 			'value' => null,
@@ -1992,7 +1992,7 @@ class FormHelper extends Helper {
  * @return string Generated set of select boxes for time formats chosen.
  * @see Cake\View\Helper\FormHelper::dateTime() for templating options.
  */
-	public function time($fieldName, $options = []) {
+	public function time($fieldName, array $options = []) {
 		$options += [
 			'empty' => true,
 			'value' => null,
@@ -2020,7 +2020,7 @@ class FormHelper extends Helper {
  * @return string Generated set of select boxes for time formats chosen.
  * @see Cake\View\Helper\FormHelper::dateTime() for templating options.
  */
-	public function date($fieldName, $options = []) {
+	public function date($fieldName, array $options = []) {
 		$options += [
 			'empty' => true,
 			'value' => null,

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -132,7 +132,7 @@ class HtmlHelper extends Helper {
  * @param View $View The View this helper is being attached to.
  * @param array $config Configuration settings for the helper.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);
 		$this->response = $this->_View->response ?: new Response();
 	}
@@ -147,7 +147,7 @@ class HtmlHelper extends Helper {
  * @see HtmlHelper::link() for details on $options that can be used.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
-	public function addCrumb($name, $link = null, $options = null) {
+	public function addCrumb($name, $link = null, array $options = array()) {
 		$this->_crumbs[] = array($name, $link, $options);
 	}
 
@@ -203,7 +203,7 @@ class HtmlHelper extends Helper {
  * @return string A completed `<link />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::meta
  */
-	public function meta($type, $url = null, $options = array()) {
+	public function meta($type, $url = null, array $options = array()) {
 		$options += array('block' => null);
 
 		if (!is_array($type)) {
@@ -305,7 +305,7 @@ class HtmlHelper extends Helper {
  * @return string An `<a />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::link
  */
-	public function link($title, $url = null, $options = array(), $confirmMessage = false) {
+	public function link($title, $url = null, array $options = array(), $confirmMessage = false) {
 		$escapeTitle = true;
 		if ($url !== null) {
 			$url = $this->url($url);
@@ -387,19 +387,7 @@ class HtmlHelper extends Helper {
  * @return string CSS <link /> or <style /> tag, depending on the type of link.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::css
  */
-	public function css($path, $options = array()) {
-		if (!is_array($options)) {
-			$rel = $options;
-			$options = array();
-			if ($rel) {
-				$options['rel'] = $rel;
-			}
-			if (func_num_args() > 2) {
-				$options = func_get_arg(2) + $options;
-			}
-			unset($rel);
-		}
-
+	public function css($path, array $options = array()) {
 		$options += array('block' => null, 'rel' => 'stylesheet');
 
 		if (is_array($path)) {
@@ -478,7 +466,7 @@ class HtmlHelper extends Helper {
  *   or if $once is true and the file has been included before.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::script
  */
-	public function script($url, $options = array()) {
+	public function script($url, array $options = array()) {
 		$options = array_merge(array('block' => null, 'once' => true), $options);
 
 		if (is_array($url)) {
@@ -529,7 +517,7 @@ class HtmlHelper extends Helper {
  * @return mixed string or null depending on the value of `$options['block']`
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::scriptBlock
  */
-	public function scriptBlock($script, $options = array()) {
+	public function scriptBlock($script, array $options = array()) {
 		$options += array('safe' => true, 'block' => null);
 		if ($options['safe']) {
 			$script = "\n" . '//<![CDATA[' . "\n" . $script . "\n" . '//]]>' . "\n";
@@ -565,7 +553,7 @@ class HtmlHelper extends Helper {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::scriptStart
  */
-	public function scriptStart($options = array()) {
+	public function scriptStart(array $options = array()) {
 		$options += array('safe' => true, 'block' => null);
 		$this->_scriptBlockOptions = $options;
 		ob_start();
@@ -600,19 +588,16 @@ class HtmlHelper extends Helper {
  * }}}
  *
  * @param array $data Style data array, keys will be used as property names, values as property values.
- * @param boolean $oneline Whether or not the style block should be displayed on one line.
+ * @param boolean $oneLine Whether or not the style block should be displayed on one line.
  * @return string CSS styling data
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::style
  */
-	public function style($data, $oneline = true) {
-		if (!is_array($data)) {
-			return $data;
-		}
+	public function style(array $data, $oneLine = true) {
 		$out = array();
 		foreach ($data as $key => $value) {
 			$out[] = $key . ':' . $value . ';';
 		}
-		if ($oneline) {
+		if ($oneLine) {
 			return implode(' ', $out);
 		}
 		return implode("\n", $out);
@@ -669,9 +654,9 @@ class HtmlHelper extends Helper {
  * @return string breadcrumbs html list
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#creating-breadcrumb-trails-with-htmlhelper
  */
-	public function getCrumbList($options = array(), $startText = false) {
+	public function getCrumbList(array $options = array(), $startText = false) {
 		$defaults = array('firstClass' => 'first', 'lastClass' => 'last', 'separator' => '', 'escape' => true);
-		$options = array_merge($defaults, (array)$options);
+		$options = array_merge($defaults, $options);
 		$firstClass = $options['firstClass'];
 		$lastClass = $options['lastClass'];
 		$separator = $options['separator'];
@@ -763,7 +748,7 @@ class HtmlHelper extends Helper {
  * @return string completed img tag
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::image
  */
-	public function image($path, $options = array()) {
+	public function image($path, array $options = array()) {
 		$path = $this->assetUrl($path, $options + array('pathPrefix' => Configure::read('App.imageBaseUrl')));
 		$options = array_diff_key($options, array('fullBase' => null, 'pathPrefix' => null));
 
@@ -802,7 +787,7 @@ class HtmlHelper extends Helper {
  * @return string Completed table headers
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::tableHeaders
  */
-	public function tableHeaders($names, $trOptions = null, $thOptions = null) {
+	public function tableHeaders(array $names, array $trOptions = null, array $thOptions = null) {
 		$out = array();
 		foreach ($names as $arg) {
 			if (!is_array($arg)) {
@@ -897,7 +882,7 @@ class HtmlHelper extends Helper {
  * @return string The formatted tag element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::tag
  */
-	public function tag($name, $text = null, $options = array()) {
+	public function tag($name, $text = null, array $options = array()) {
 		if (empty($name)) {
 			return $text;
 		}
@@ -931,7 +916,7 @@ class HtmlHelper extends Helper {
  * @return string The formatted DIV element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::div
  */
-	public function div($class = null, $text = null, $options = array()) {
+	public function div($class = null, $text = null, array $options = array()) {
 		if (!empty($class)) {
 			$options['class'] = $class;
 		}
@@ -951,7 +936,7 @@ class HtmlHelper extends Helper {
  * @return string The formatted P element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::para
  */
-	public function para($class, $text, $options = array()) {
+	public function para($class, $text, array $options = array()) {
 		if (isset($options['escape'])) {
 			$text = h($text);
 		}
@@ -1020,7 +1005,7 @@ class HtmlHelper extends Helper {
  * @param array $options Array of HTML attributes, and special options above.
  * @return string Generated media element
  */
-	public function media($path, $options = array()) {
+	public function media($path, array $options = array()) {
 		$options += array(
 			'tag' => null,
 			'pathPrefix' => 'files/',
@@ -1092,13 +1077,13 @@ class HtmlHelper extends Helper {
  * Build a nested list (UL/OL) out of an associative array.
  *
  * @param array $list Set of elements to list
- * @param array $options Additional HTML attributes of the list (ol/ul) tag or if ul/ol use that as tag
+ * @param string|array $options Additional HTML attributes of the list (ol/ul) tag or if ul/ol use that as tag
  * @param array $itemOptions Additional HTML attributes of the list item (LI) tag
  * @param string $tag Type of list tag to use (ol/ul)
  * @return string The nested list
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::nestedList
  */
-	public function nestedList($list, $options = array(), $itemOptions = array(), $tag = 'ul') {
+	public function nestedList($list, $options = array(), array $itemOptions = array(), $tag = 'ul') {
 		if (is_string($options)) {
 			$tag = $options;
 			$options = array();
@@ -1120,7 +1105,7 @@ class HtmlHelper extends Helper {
  * @return string The nested list element
  * @see HtmlHelper::nestedList()
  */
-	protected function _nestedListItem($items, $options, $itemOptions, $tag) {
+	protected function _nestedListItem($items, $options, array $itemOptions, $tag) {
 		$out = '';
 
 		$index = 1;

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -58,7 +58,7 @@ class NumberHelper extends Helper {
  * @param array $config Configuration settings for the helper
  * @throws \Cake\Error\Exception When the engine class could not be found.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);
 
 		$config = $this->_config;
@@ -124,7 +124,7 @@ class NumberHelper extends Helper {
  * @return string Percentage string
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::toPercentage
  */
-	public function toPercentage($number, $precision = 2, $options = array()) {
+	public function toPercentage($number, $precision = 2, array $options = array()) {
 		return $this->_engine->toPercentage($number, $precision, $options);
 	}
 
@@ -134,7 +134,7 @@ class NumberHelper extends Helper {
  * @see \Cake\Utility\Number::format()
  *
  * @param float $number A floating point number
- * @param integer $options If integer then places, if string then before, if (,.-) then use it
+ * @param mixed $options If integer then places, if string then before, if (,.-) then use it
  *   or array with places and before keys
  * @return string formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
@@ -183,7 +183,7 @@ class NumberHelper extends Helper {
  * @return string Number formatted as a currency.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::currency
  */
-	public function currency($number, $currency = null, $options = array()) {
+	public function currency($number, $currency = null, array $options = array()) {
 		return $this->_engine->currency($number, $currency, $options);
 	}
 
@@ -208,7 +208,7 @@ class NumberHelper extends Helper {
  * @see NumberHelper::currency()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::addFormat
  */
-	public function addFormat($formatName, $options) {
+	public function addFormat($formatName, array $options) {
 		return $this->_engine->addFormat($formatName, $options);
 	}
 

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -124,7 +124,7 @@ class PaginatorHelper extends Helper {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::options
  */
-	public function options($options = array()) {
+	public function options(array $options = array()) {
 		if (!empty($options['paging'])) {
 			if (!isset($this->request->params['paging'])) {
 				$this->request->params['paging'] = array();
@@ -171,7 +171,7 @@ class PaginatorHelper extends Helper {
  *  null if the results are not currently sorted.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sortKey
  */
-	public function sortKey($model = null, $options = array()) {
+	public function sortKey($model = null, array $options = array()) {
 		if (empty($options)) {
 			$options = $this->params($model);
 		}
@@ -190,7 +190,7 @@ class PaginatorHelper extends Helper {
  *  null if the results are not currently sorted.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sortDir
  */
-	public function sortDir($model = null, $options = array()) {
+	public function sortDir($model = null, array $options = array()) {
 		$dir = null;
 
 		if (empty($options)) {
@@ -263,7 +263,7 @@ class PaginatorHelper extends Helper {
  * @return string A "previous" link or a disabled link.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::prev
  */
-	public function prev($title = '<< Previous', $options = []) {
+	public function prev($title = '<< Previous', array $options = []) {
 		$defaults = [
 			'url' => [],
 			'model' => $this->defaultModel(),
@@ -298,7 +298,7 @@ class PaginatorHelper extends Helper {
  * @return string A "next" link or $disabledTitle text if the link is disabled.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::next
  */
-	public function next($title = 'Next >>', $options = []) {
+	public function next($title = 'Next >>', array $options = []) {
 		$defaults = [
 			'url' => [],
 			'model' => $this->defaultModel(),
@@ -335,7 +335,7 @@ class PaginatorHelper extends Helper {
  *  key the returned link will sort by 'desc'.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sort
  */
-	public function sort($key, $title = null, $options = []) {
+	public function sort($key, $title = null, array $options = []) {
 		$options = array_merge(
 			['url' => array(), 'model' => null, 'escape' => true],
 			$options
@@ -508,7 +508,7 @@ class PaginatorHelper extends Helper {
  *    the following placeholders `{{page}}`, `{{pages}}`, `{{current}}`, `{{count}}`, `{{model}}`, `{{start}}`, `{{end}}` and any
  *    custom content you would like.
  *
- * @param array $options Options for the counter string. See #options for list of keys.
+ * @param string|array $options Options for the counter string. See #options for list of keys.
  * @return string Counter string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::counter
  */
@@ -581,17 +581,11 @@ class PaginatorHelper extends Helper {
  * and the number of pages exceed the modulus. For example if you have 25 pages, and use the first/last
  * options and a modulus of 8, ellipsis content will be inserted after the first and last link sets.
  *
- * @param array $options Options for the numbers, (before, after, model, modulus)
+ * @param array $options Options for the numbers.
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::numbers
  */
-	public function numbers($options = array()) {
-		if ($options === true) {
-			$options = array(
-				'first' => 'first', 'last' => 'last'
-			);
-		}
-
+	public function numbers(array $options = array()) {
 		$defaults = array(
 			'before' => null, 'after' => null, 'model' => $this->defaultModel(),
 			'modulus' => 8, 'first' => null, 'last' => null,
@@ -717,10 +711,10 @@ class PaginatorHelper extends Helper {
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::first
  */
-	public function first($first = '<< first', $options = []) {
+	public function first($first = '<< first', array $options = []) {
 		$options = array_merge(
 			['model' => $this->defaultModel(), 'escape' => true],
-			(array)$options
+			$options
 		);
 
 		$params = $this->params($options['model']);
@@ -769,10 +763,10 @@ class PaginatorHelper extends Helper {
  * @return string numbers string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last
  */
-	public function last($last = 'last >>', $options = array()) {
+	public function last($last = 'last >>', array $options = array()) {
 		$options = array_merge(
 			['model' => $this->defaultModel(), 'escape' => true],
-			(array)$options
+			$options
 		);
 
 		$params = $this->params($options['model']);

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -74,7 +74,7 @@ class TextHelper extends Helper {
  * @param array $config Settings array Settings array
  * @throws \Cake\Error\Exception when the engine class could not be found.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);
 
 		$config = $this->_config;
@@ -110,7 +110,7 @@ class TextHelper extends Helper {
  * @return string The text with links
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::autoLinkUrls
  */
-	public function autoLinkUrls($text, $options = array()) {
+	public function autoLinkUrls($text, array $options = array()) {
 		$this->_placeholders = array();
 		$options += array('escape' => true);
 
@@ -191,7 +191,7 @@ class TextHelper extends Helper {
  * @return string The text with links
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::autoLinkEmails
  */
-	public function autoLinkEmails($text, $options = array()) {
+	public function autoLinkEmails($text, array $options = array()) {
 		$options += array('escape' => true);
 		$this->_placeholders = array();
 
@@ -219,7 +219,7 @@ class TextHelper extends Helper {
  * @return string The text with links
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::autoLink
  */
-	public function autoLink($text, $options = array()) {
+	public function autoLink($text, array $options = array()) {
 		$text = $this->autoLinkUrls($text, $options);
 		return $this->autoLinkEmails($text, array_merge($options, array('escape' => false)));
 	}
@@ -236,7 +236,7 @@ class TextHelper extends Helper {
  * @return string The highlighted text
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::highlight
  */
-	public function highlight($text, $phrase, $options = array()) {
+	public function highlight($text, $phrase, array $options = array()) {
 		return $this->_engine->highlight($text, $phrase, $options);
 	}
 
@@ -295,7 +295,7 @@ class TextHelper extends Helper {
  * @return string Trimmed string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
  */
-	public function truncate($text, $length = 100, $options = array()) {
+	public function truncate($text, $length = 100, array $options = array()) {
 		return $this->_engine->truncate($text, $length, $options);
 	}
 

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -62,7 +62,7 @@ class TimeHelper extends Helper {
  * @param array $config Settings array
  * @throws \Cake\Error\Exception When the engine class could not be found.
  */
-	public function __construct(View $View, $config = array()) {
+	public function __construct(View $View, array $config = array()) {
 		parent::__construct($View, $config);
 
 		$config = $this->_config;
@@ -336,7 +336,7 @@ class TimeHelper extends Helper {
  * @return string Relative time string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
-	public function timeAgoInWords($dateTime, $options = array()) {
+	public function timeAgoInWords($dateTime, array $options = array()) {
 		$element = null;
 
 		if (!empty($options['element'])) {

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -410,7 +410,7 @@ class View extends Object {
  * - `ignoreMissing` - Used to allow missing elements. Set to true to not trigger notices.
  * @return string Rendered Element
  */
-	public function element($name, $data = array(), $options = array()) {
+	public function element($name, array $data = array(), array $options = array()) {
 		$file = $plugin = null;
 
 		if (!isset($options['callbacks'])) {
@@ -926,7 +926,7 @@ class View extends Object {
  * @return Helper a constructed helper object.
  * @see HelperRegistry::load()
  */
-	public function addHelper($helperName, $config = []) {
+	public function addHelper($helperName, array $config = []) {
 		return $this->helpers()->load($helperName, $config);
 	}
 
@@ -1126,7 +1126,7 @@ class View extends Object {
  * Checks if an element is cached and returns the cached data if present
  *
  * @param string $name Element name
- * @param string $data Data
+ * @param array $data Data
  * @param array $options Element options
  * @return string|null
  */

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2659,19 +2659,19 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs(null, null, array('legend' => 'Field of Dreams', 'fieldset' => true));
+		$result = $this->Form->inputs(null, array(), array('legend' => 'Field of Dreams', 'fieldset' => true));
 		$this->assertContains('<legend>Field of Dreams</legend>', $result);
 		$this->assertContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs('Field of Dreams', null, array('fieldset' => true));
+		$result = $this->Form->inputs('Field of Dreams', array(), array('fieldset' => true));
 		$this->assertContains('<legend>Field of Dreams</legend>', $result);
 		$this->assertContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => false));
+		$result = $this->Form->inputs(null, array(), array('fieldset' => false, 'legend' => false));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs(null, null, array('fieldset' => false, 'legend' => 'Hello'));
+		$result = $this->Form->inputs(null, array(), array('fieldset' => false, 'legend' => 'Hello'));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -492,9 +492,6 @@ class HtmlHelperTest extends TestCase {
  * @return void
  */
 	public function testStyle() {
-		$result = $this->Html->style('display: none;');
-		$this->assertEquals('display: none;', $result);
-
 		$result = $this->Html->style(array('display' => 'none', 'margin' => '10px'));
 		$expected = 'display:none; margin:10px;';
 		$this->assertRegExp('/^display\s*:\s*none\s*;\s*margin\s*:\s*10px\s*;?$/', $expected);
@@ -521,7 +518,7 @@ class HtmlHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		Plugin::load('TestPlugin');
-		$result = $this->Html->css('TestPlugin.style', null, array('plugin' => false));
+		$result = $this->Html->css('TestPlugin.style', array('plugin' => false));
 		$expected['link']['href'] = 'preg:/.*css\/TestPlugin\.style\.css/';
 		$this->assertTags($result, $expected);
 		Plugin::unload('TestPlugin');
@@ -582,40 +579,6 @@ class HtmlHelperTest extends TestCase {
 	}
 
 /**
- * Test css link BC usage
- *
- * @return void
- */
-	public function testCssLinkBC() {
-		Configure::write('Asset.filter.css', false);
-
-		Plugin::load('TestPlugin');
-		$result = $this->Html->css('TestPlugin.style', null, array('plugin' => false));
-		$expected = array(
-			'link' => array(
-				'rel' => 'stylesheet',
-				'href' => 'preg:/.*css\/TestPlugin\.style\.css/'
-			)
-		);
-		$this->assertTags($result, $expected);
-		Plugin::unload('TestPlugin');
-
-		$result = $this->Html->css('screen', 'import');
-		$expected = array(
-			'<style',
-			'preg:/@import url\(.*css\/screen\.css\);/',
-			'/style'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Html->css('css_in_head', null, array('block' => true));
-		$this->assertNull($result);
-
-		$result = $this->Html->css('more_css_in_head', null, array('block' => true));
-		$this->assertNull($result);
-	}
-
-/**
  * testCssWithFullBase method
  *
  * @return void
@@ -624,7 +587,7 @@ class HtmlHelperTest extends TestCase {
 		Configure::write('Asset.filter.css', false);
 		$here = $this->Html->url('/', true);
 
-		$result = $this->Html->css('screen', null, array('fullBase' => true));
+		$result = $this->Html->css('screen', array('fullBase' => true));
 		$expected = array(
 			'link' => array('rel' => 'stylesheet', 'href' => $here . 'css/screen.css')
 		);
@@ -1265,7 +1228,7 @@ class HtmlHelperTest extends TestCase {
  * Test the array form of $startText
  */
 	public function testGetCrumbFirstLink() {
-		$result = $this->Html->getCrumbList(null, 'Home');
+		$result = $this->Html->getCrumbList(array(), 'Home');
 		$this->assertTags(
 			$result,
 			array(
@@ -1882,7 +1845,7 @@ class HtmlHelperTest extends TestCase {
 		$this->Html->addCrumb('First', '#first');
 		$this->Html->addCrumb('Second', '#second');
 
-		$result = $this->Html->getCrumbList(null, 'Home');
+		$result = $this->Html->getCrumbList(array(), 'Home');
 		$this->assertTags(
 			$result,
 			array(
@@ -1900,7 +1863,7 @@ class HtmlHelperTest extends TestCase {
 			)
 		);
 
-		$result = $this->Html->getCrumbList(null, array('url' => '/home', 'text' => '<img src="/home.png" />', 'escape' => false));
+		$result = $this->Html->getCrumbList(array(), array('url' => '/home', 'text' => '<img src="/home.png" />', 'escape' => false));
 		$this->assertTags(
 			$result,
 			array(

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -79,16 +79,34 @@ class NumberHelperTest extends TestCase {
  */
 	public function testNumberHelperProxyMethodCalls() {
 		$methods = array(
-			'precision', 'toReadableSize', 'toPercentage', 'format',
-			'currency', 'addFormat',
+			'precision', 'toReadableSize', 'format',
 		);
 		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', $methods);
 		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
 		$Number->attach($CakeNumber);
+
 		foreach ($methods as $method) {
 			$CakeNumber->expects($this->at(0))->method($method);
 			$Number->{$method}('who', 'what', 'when', 'where', 'how');
 		}
+
+		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', array('toPercentage'));
+		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
+		$Number->attach($CakeNumber);
+		$CakeNumber->expects($this->at(0))->method('toPercentage');
+		$Number->toPercentage('who', 'what', array('when'));
+
+		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', array('currency'));
+		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
+		$Number->attach($CakeNumber);
+		$CakeNumber->expects($this->at(0))->method('currency');
+		$Number->currency('who', 'what', array('when'));
+
+		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', array('addFormat'));
+		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
+		$Number->attach($CakeNumber);
+		$CakeNumber->expects($this->at(0))->method('addFormat');
+		$Number->addFormat('who', array('when'));
 	}
 
 /**

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -1031,7 +1031,7 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Paginator->numbers(true);
+		$result = $this->Paginator->numbers(array('first' => 'first', 'last' => 'last'));
 		$expected = array(
 			array('li' => array('class' => 'first')), array('a' => array('href' => '/index')), 'first', '/a', '/li',
 			array('li' => array('class' => 'ellipsis')), '...', '/li',

--- a/tests/TestCase/View/Helper/TextHelperTest.php
+++ b/tests/TestCase/View/Helper/TextHelperTest.php
@@ -82,14 +82,25 @@ class TextHelperTest extends TestCase {
  */
 	public function testTextHelperProxyMethodCalls() {
 		$methods = array(
-			'highlight', 'stripLinks', 'truncate', 'excerpt', 'toList',
-			);
+			'stripLinks', 'excerpt', 'toList',
+		);
 		$String = $this->getMock(__NAMESPACE__ . '\StringMock', $methods);
 		$Text = new TextHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\StringMock'));
 		$Text->attach($String);
 		foreach ($methods as $method) {
 			$String->expects($this->at(0))->method($method);
 			$Text->{$method}('who', 'what', 'when', 'where', 'how');
+		}
+
+		$methods = array(
+			'highlight', 'truncate'
+		);
+		$String = $this->getMock(__NAMESPACE__ . '\StringMock', $methods);
+		$Text = new TextHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\StringMock'));
+		$Text->attach($String);
+		foreach ($methods as $method) {
+			$String->expects($this->at(0))->method($method);
+			$Text->{$method}('who', array('what'));
 		}
 	}
 


### PR DESCRIPTION
Harden method signatures for public methods, cleanup/simplify methods and correct doc blocks.

Quite a few times methods cast internally to array, while the method should only accept arrays in the first place (according to doc block).

Also quite a few methods accepted too many different types per argument, from string to boolean to array at the same time. This helps to avoid these dirty uses and removes undocumented juggling of array params.
