### PR TITLE
3.0 tree behavior pt. 2

### DIFF
--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -346,7 +346,7 @@ class TreeBehavior extends Behavior {
 
 		$node->set($config['parent'], null);
 
-		if ($right - $left < 2) {
+		if ($right - $left == 1) {
 			return $this->_table->save($node);
 		}
 

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -14,14 +14,10 @@
  */
 namespace Cake\Model\Behavior;
 
-use ArrayObject;
-use Cake\Collection\Collection;
-use Cake\Database\Expression\QueryExpression;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
-use Cake\ORM\TableRegistry;
 
 class TreeBehavior extends Behavior {
 
@@ -571,13 +567,11 @@ class TreeBehavior extends Behavior {
 		$config = $this->config();
 
 		foreach ([$config['left'], $config['right']] as $field) {
-			$exp = new QueryExpression();
+			$query = $this->_scope($this->_table->query());
+
 			$mark = $mark ? '*-1' : '';
 			$template = sprintf('%s = (%s %s %s)%s', $field, $field, $dir, $shift, $mark);
-			$exp->add($template);
-
-			$query = $this->_scope($this->_table->query());
-			$query->update()->set($exp);
+			$query->update()->set($query->newExpr()->add($template));
 			$query->where("{$field} {$conditions}");
 
 			$query->execute();

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -44,7 +44,8 @@ class TreeBehavior extends Behavior {
 			'childCount' => 'childCount',
 			'moveUp' => 'moveUp',
 			'moveDown' => 'moveDown',
-			'recover' => 'recover'
+			'recover' => 'recover',
+			'removeFromTree' => 'removeFromTree'
 		],
 		'parent' => 'parent_id',
 		'left' => 'lft',
@@ -326,6 +327,25 @@ class TreeBehavior extends Behavior {
 				"{$right} <" => $node->{$right},
 				"{$left} >" => $node->{$left}
 			]);
+	}
+
+	public function removeFromTree($node) {
+		$config = $this->config();
+		$left = $node->get($config['left']);
+		$right = $node->get($config['right']);
+		$parent = $node->get($config['parent']);
+
+		if ($right - $left > 1) {
+			$this->_table->updateAll(
+				[$config['parent'] => $parent],
+				[$config['parent'] => $id]
+			);
+			$this->_sync(1, '-', 'BETWEEN ' . ($left + 1) . ' AND ' . ($right - 1));
+			$this->_sync(2, '-', "> {$right}");
+		}
+
+		$node->set($config['parent'], null);
+		return $this->_table->save($node);
 	}
 
 /**

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -268,12 +268,12 @@ class TreeBehavior extends Behavior {
 /**
  * Get the number of children nodes.
  *
- * @param \Cake\ORM\Entity The entity to count children for
+ * @param \Cake\ORM\Entity $node The entity to count children for
  * @param boolean $direct whether to count all nodes in the subtree or just
  * direct children
  * @return integer Number of children nodes.
  */
-	public function childCount($node, $direct = false) {
+	public function childCount(Entity $node, $direct = false) {
 		$config = $this->config();
 		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
 
@@ -338,7 +338,7 @@ class TreeBehavior extends Behavior {
  * @return \Cake\ORM\Entity|false the node after being removed from the tree or
  * false on error
  */
-	public function removeFromTree($node) {
+	public function removeFromTree(Entity $node) {
 		$config = $this->config();
 		$left = $node->get($config['left']);
 		$right = $node->get($config['right']);
@@ -381,7 +381,7 @@ class TreeBehavior extends Behavior {
  * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return \Cake\ORM\Entity|boolean $node The node after being moved or false on failure
  */
-	public function moveUp($node, $number = 1) {
+	public function moveUp(Entity $node, $number = 1) {
 		$config = $this->config();
 		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
 
@@ -441,7 +441,7 @@ class TreeBehavior extends Behavior {
  * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @return \Cake\ORM\Entity|boolean the entity after being moved or false on failure
  */
-	public function moveDown($node, $number = 1) {
+	public function moveDown(Entity $node, $number = 1) {
 		$config = $this->config();
 		list($parent, $left, $right) = [$config['parent'], $config['left'], $config['right']];
 

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -560,32 +560,12 @@ class TreeBehavior extends Behavior {
  * @return integer
  */
 	protected function _getMax() {
-		return $this->_getMaxOrMin('max');
-	}
-
-/**
- * Returns the minimum index value in the table.
- *
- * @return integer
- */
-	protected function _getMin() {
-		return $this->_getMaxOrMin('min');
-	}
-
-/**
- * Get the maximum|minimum index value in the table.
- *
- * @param string $maxOrMin Either 'max' or 'min'
- * @return integer
- */
-	protected function _getMaxOrMin($maxOrMin = 'max') {
 		$config = $this->config();
-		$field = $maxOrMin === 'max' ? $config['right'] : $config['left'];
-		$direction = $maxOrMin === 'max' ? 'DESC' : 'ASC';
+		$field = $config['right'];
 
 		$edge = $this->_scope($this->_table->find())
 			->select([$field])
-			->order([$field => $direction])
+			->order([$field => 'DESC'])
 			->first();
 
 		if (empty($edge->{$field})) {

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -299,7 +299,6 @@ class TreeBehavior extends Behavior {
  *
  * @param array $options Array of options as described above
  * @return \Cake\ORM\Query
- * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  * @throws \InvalidArgumentException When the 'for' key is not passed in $options
  */
 	public function findChildren($query, $options) {
@@ -425,7 +424,7 @@ class TreeBehavior extends Behavior {
 			$node->set($left, $newLeft);
 			$node->set($right, $newLeft + ($nodeRight - $nodeLeft));
 		}
-		
+
 		$node->dirty($left, false);
 		$node->dirty($right, false);
 		return $node;
@@ -489,7 +488,7 @@ class TreeBehavior extends Behavior {
 			$node->set($left, $newLeft);
 			$node->set($right, $newLeft + ($nodeRight - $nodeLeft));
 		}
-		
+
 		$node->dirty($left, false);
 		$node->dirty($right, false);
 		return $node;
@@ -500,6 +499,7 @@ class TreeBehavior extends Behavior {
  *
  * @param mixed $id
  * @return Cake\ORM\Entity
+ * @throws \Cake\ORM\Error\RecordNotFoundException When node was not found
  */
 	protected function _getNode($id) {
 		$config = $this->config();

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -607,4 +607,30 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(range(1, 22), $numbers);
 	}
 
+/**
+ * Tests removing the root of a tree
+ *
+ * @return void
+ */
+	public function testRemoveRootFromTree() {
+		$table = TableRegistry::get('NumberTrees');
+		$table->addBehavior('Tree');
+		$entity = $table->get(1);
+		$this->assertSame($entity, $table->removeFromTree($entity));
+		$result = $table->find('threaded')->order('lft')->hydrate(false)->toArray();
+		$this->assertEquals(21, $entity->lft);
+		$this->assertEquals(22, $entity->rght);
+		$this->assertEquals(null, $entity->parent_id);
+		$result = $table->find()->order('lft')->hydrate(false);
+		$expected = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 1];
+		$this->assertEquals($expected, $result->extract('id')->toArray());
+		$numbers = [];
+		$result->each(function($v) use (&$numbers) {
+			$numbers[] = $v['lft'];
+			$numbers[] = $v['rght'];
+		});
+		sort($numbers);
+		$this->assertEquals(range(1, 22), $numbers);
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -168,23 +168,44 @@ class TreeBehaviorTest extends TestCase {
 		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
 
 		// top level, wont move
-		$this->assertFalse($this->table->moveUp($table->get(1), 10));
+		$node = $this->table->moveUp($table->get(1), 10);
+		$this->assertEquals(['lft' => 1, 'rght' => 10], $node->extract(['lft', 'rght']));
 
 		// edge cases
 		$this->assertFalse($this->table->moveUp($table->get(1), 0));
-		$this->assertFalse($this->table->moveUp($table->get(1), -10));
+		$node = $this->table->moveUp($table->get(1), -10);
+		$this->assertEquals(['lft' => 1, 'rght' => 10], $node->extract(['lft', 'rght']));
 
 		// move inner node
-		$result = $table->moveUp($table->get(3), 1);
+		$node = $table->moveUp($table->get(3), 1);
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
-		$this->assertTrue($result);
+		$this->assertEquals(['lft' => 2, 'rght' => 7], $node->extract(['lft', 'rght']));
+		return;
+	}
 
-		// move leaf
-		$this->assertFalse($table->moveUp($table->get(5), 1));
+/**
+ * Tests moving a node with no siblings
+ *
+ * @return void
+ */
+	public function testMoveLeaf() {
+		$table = TableRegistry::get('MenuLinkTrees');
+		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
+		$node = $table->moveUp($table->get(5), 1);
+		$this->assertEquals(['lft' => 6, 'rght' => 7], $node->extract(['lft', 'rght']));
+	}
 
-		// move to first position
-		$table->moveUp($table->get(8), true);
+/**
+ * Tests moving a node to the top
+ *
+ * @return void
+ */
+	public function testMoveTop() {
+		$table = TableRegistry::get('MenuLinkTrees');
+		$table->addBehavior('Tree', ['scope' => ['menu' => 'main-menu']]);
+		$node = $table->moveUp($table->get(8), true);
+		$this->assertEquals(['lft' => 1, 'rght' => 2], $node->extract(['lft', 'rght']));
 		$nodes = $table->find()
 			->select(['id'])
 			->where(function($exp) {

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -556,4 +556,29 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Tests that a leaf can be taken out of the tree and put in as a root
+ *
+ * @return void
+ */
+	public function testRemoveFromLeafFromTree() {
+		$table = TableRegistry::get('NumberTrees');
+		$table->addBehavior('Tree');
+		$entity = $table->get(10);
+		$this->assertSame($entity, $table->removeFromTree($entity));
+		$this->assertEquals(21, $entity->lft);
+		$this->assertEquals(22, $entity->rght);
+		$this->assertEquals(null, $entity->parent_id);
+		$result = $table->find()->order('lft')->hydrate(false);
+		$expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 10];
+		$this->assertEquals($expected, $result->extract('id')->toArray());
+		$numbers = [];
+		$result->each(function($v) use (&$numbers) {
+			$numbers[] = $v['lft'];
+			$numbers[] = $v['rght'];
+		});
+		sort($numbers);
+		$this->assertEquals(range(1, 22), $numbers);
+	}
+
 }

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -181,7 +181,6 @@ class TreeBehaviorTest extends TestCase {
 		$nodes = $table->find('children', ['for' => 1])->all();
 		$this->assertEquals([3, 4, 5, 2], $nodes->extract('id')->toArray());
 		$this->assertEquals(['lft' => 2, 'rght' => 7], $node->extract(['lft', 'rght']));
-		return;
 	}
 
 /**

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -405,14 +405,7 @@ class TreeBehaviorTest extends TestCase {
 
 		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [1, 6, 7, 8, 9, 10, 2, 3, 4, 5, 11];
-		$this->assertEquals($expected, $result->extract('id')->toArray());
-		$numbers = [];
-		$result->each(function($v) use (&$numbers) {
-			$numbers[] = $v['lft'];
-			$numbers[] = $v['rght'];
-		});
-		sort($numbers);
-		$this->assertEquals(range(1, 22), $numbers);
+		$this->assertTreeNumbers($expected, $table);
 	}
 
 /**
@@ -471,14 +464,7 @@ class TreeBehaviorTest extends TestCase {
 
 		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [1, 2, 3, 4, 6, 7, 8, 9, 10, 5, 11];
-		$this->assertEquals($expected, $result->extract('id')->toArray());
-		$numbers = [];
-		$result->each(function($v) use (&$numbers) {
-			$numbers[] = $v['lft'];
-			$numbers[] = $v['rght'];
-		});
-		sort($numbers);
-		$this->assertEquals(range(1, 22), $numbers);
+		$this->assertTreeNumbers($expected, $table);
 	}
 
 /**
@@ -497,14 +483,7 @@ class TreeBehaviorTest extends TestCase {
 
 		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [1, 6, 7, 8, 9, 10, 11, 2, 3, 4, 5];
-		$this->assertEquals($expected, $result->extract('id')->toArray());
-		$numbers = [];
-		$result->each(function($v) use (&$numbers) {
-			$numbers[] = $v['lft'];
-			$numbers[] = $v['rght'];
-		});
-		sort($numbers);
-		$this->assertEquals(range(1, 22), $numbers);
+		$this->assertTreeNumbers($expected, $table);
 	}
 
 /**
@@ -585,14 +564,7 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(null, $entity->parent_id);
 		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 10];
-		$this->assertEquals($expected, $result->extract('id')->toArray());
-		$numbers = [];
-		$result->each(function($v) use (&$numbers) {
-			$numbers[] = $v['lft'];
-			$numbers[] = $v['rght'];
-		});
-		sort($numbers);
-		$this->assertEquals(range(1, 22), $numbers);
+		$this->assertTreeNumbers($expected, $table);
 	}
 
 /**
@@ -611,14 +583,7 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(null, $entity->parent_id);
 		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 6];
-		$this->assertEquals($expected, $result->extract('id')->toArray());
-		$numbers = [];
-		$result->each(function($v) use (&$numbers) {
-			$numbers[] = $v['lft'];
-			$numbers[] = $v['rght'];
-		});
-		sort($numbers);
-		$this->assertEquals(range(1, 22), $numbers);
+		$this->assertTreeNumbers($expected, $table);
 	}
 
 /**
@@ -635,8 +600,20 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(21, $entity->lft);
 		$this->assertEquals(22, $entity->rght);
 		$this->assertEquals(null, $entity->parent_id);
-		$result = $table->find()->order('lft')->hydrate(false);
 		$expected = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 1];
+		$this->assertTreeNumbers($expected, $table);
+	}
+
+/**
+ * Custom assertion use to verify tha a tree is returned in the expected order
+ * and that it is still valid
+ *
+ * @param array $expected The list of ids in the order they are expected
+ * @param \Cake\ORM\Table the table instance to use for comparing
+ * @return void
+ */
+	public function assertTreeNumbers($expected, $table) {
+		$result = $table->find()->order('lft')->hydrate(false);
 		$this->assertEquals($expected, $result->extract('id')->toArray());
 		$numbers = [];
 		$result->each(function($v) use (&$numbers) {

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -581,4 +581,30 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals(range(1, 22), $numbers);
 	}
 
+/**
+ * Test removing a middle node from a tree
+ *
+ * @return void
+ */
+	public function testRemoveMiddleNodeFromTree() {
+		$table = TableRegistry::get('NumberTrees');
+		$table->addBehavior('Tree');
+		$entity = $table->get(6);
+		$this->assertSame($entity, $table->removeFromTree($entity));
+		$result = $table->find('threaded')->order('lft')->hydrate(false)->toArray();
+		$this->assertEquals(21, $entity->lft);
+		$this->assertEquals(22, $entity->rght);
+		$this->assertEquals(null, $entity->parent_id);
+		$result = $table->find()->order('lft')->hydrate(false);
+		$expected = [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 6];
+		$this->assertEquals($expected, $result->extract('id')->toArray());
+		$numbers = [];
+		$result->each(function($v) use (&$numbers) {
+			$numbers[] = $v['lft'];
+			$numbers[] = $v['rght'];
+		});
+		sort($numbers);
+		$this->assertEquals(range(1, 22), $numbers);
+	}
+
 }


### PR DESCRIPTION
This implements removeFromTree, changes all methods in the tree behavior that were accepting `id` to only accept entities and changes `moveUp` and `moveDown` to be non-recursives
