### PR TITLE
2.5 validation method chaining

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -325,7 +325,12 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
 	}
 
 /**
- * Sets or replace a validation rule
+ * Sets or replace a validation rule.
+ *
+ * This is a wrapper for ArrayAccess. Use setRule() directly for
+ * chainable access.
+ *
+ * @see http://www.php.net/manual/en/arrayobject.offsetset.php
  *
  * @param string $index name of the rule
  * @param CakeValidationRule|array rule to add to $index


### PR DESCRIPTION
Following the other recent changes in the API of 2.5, this also makes a method allowing to be chained.
Especially since this is just a wrapper for setRule().

Doctype of setRule() is:

```
@return CakeValidationSet this instance
```

PS: I wonder why this method is needed besides setRule() as it seems both do exactly the same?

Alternatively, a note could be added to state that setRule() is the main method and this only a wrapper for compatibility with ArrayAccess etc.
