### PR TITLE
3.0 bake auto-discover

### DIFF
--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -249,7 +249,7 @@ class BakeShell extends Shell {
 			'help' => __d('cake_console', 'Theme to use when baking code.')
 		]);
 
-		foreach ($this->tasks as $task) {
+		foreach ($this->_taskMap as $task => $config) {
 			$taskParser = $this->{$task}->getOptionParser();
 			$parser->addSubcommand(Inflector::underscore($task), [
 				'help' => $taskParser->description(),

--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -22,6 +22,7 @@ use Cake\Core\Plugin;
 use Cake\Datasource\ConnectionManager;
 use Cake\Model\Model;
 use Cake\Utility\ConventionsTrait;
+use Cake\Utility\Inflector;
 
 /**
  * Command-line code generation utility to automate programmer chores.
@@ -30,24 +31,11 @@ use Cake\Utility\ConventionsTrait;
  * application development by writing fully functional skeleton controllers,
  * models, and views. Going further, Bake can also write Unit Tests for you.
  *
- * @link          http://book.cakephp.org/3.0/en/console-and-shells/code-generation-with-bake.html
+ * @link http://book.cakephp.org/3.0/en/console-and-shells/code-generation-with-bake.html
  */
 class BakeShell extends Shell {
 
 	use ConventionsTrait;
-
-/**
- * Contains tasks to load and instantiate
- *
- * @var array
- */
-	public $tasks = [
-		'Plugin', 'Project',
-		'Model', 'Behavior',
-		'Controller', 'Component',
-		'View', 'Helper',
-		'Fixture', 'Test'
-	];
 
 /**
  * The connection being used.
@@ -90,19 +78,13 @@ class BakeShell extends Shell {
 			return false;
 		}
 		$this->out(__d('cake_console', 'The following commands you can generate skeleton code your your application.'));
-		$this->out(__d('cake_console', 'Available bake commands:'));
 		$this->out('');
-		$this->out(__d('cake_console', 'model'));
-		$this->out(__d('cake_console', 'behavior'));
-		$this->out(__d('cake_console', 'view'));
-		$this->out(__d('cake_console', 'controller'));
-		$this->out(__d('cake_console', 'component'));
-		$this->out(__d('cake_console', 'project'));
-		$this->out(__d('cake_console', 'plugin'));
-		$this->out(__d('cake_console', 'fixture'));
-		$this->out(__d('cake_console', 'project'));
-		$this->out(__d('cake_console', 'test'));
-		$this->out(__d('cake_console', 'view'));
+		$this->out(__d('cake_console', '<info>Available bake commands:</info>'));
+		$this->out('');
+		foreach ($this->tasks as $task) {
+			list($p, $name) = pluginSplit($task);
+			$this->out(Inflector::underscore($name));
+		}
 		$this->out('');
 		$this->out(__d('cake_console', 'Using <info>Console/cake bake [name]</info> you can invoke a specific bake task.'));
 	}
@@ -258,36 +240,6 @@ class BakeShell extends Shell {
 			' You can customize the generation process by telling Bake where different parts of your application are using command line arguments.'
 		))->addSubcommand('all', [
 			'help' => __d('cake_console', 'Bake a complete MVC. optional <name> of a Model'),
-		])->addSubcommand('project', [
-			'help' => __d('cake_console', 'Bake a new app folder in the path supplied or in current directory if no path is specified'),
-			'parser' => $this->Project->getOptionParser()
-		])->addSubcommand('plugin', [
-			'help' => __d('cake_console', 'Bake a new plugin folder in the path supplied or in current directory if no path is specified.'),
-			'parser' => $this->Plugin->getOptionParser()
-		])->addSubcommand('behavior', [
-			'help' => __d('cake_console', 'Bake a behavior.'),
-			'parser' => $this->Behavior->getOptionParser()
-		])->addSubcommand('model', [
-			'help' => __d('cake_console', 'Bake a model.'),
-			'parser' => $this->Model->getOptionParser()
-		])->addSubcommand('view', [
-			'help' => __d('cake_console', 'Bake views for controllers.'),
-			'parser' => $this->View->getOptionParser()
-		])->addSubcommand('controller', [
-			'help' => __d('cake_console', 'Bake a controller.'),
-			'parser' => $this->Controller->getOptionParser()
-		])->addSubcommand('component', [
-			'help' => __d('cake_console', 'Bake a component.'),
-			'parser' => $this->Controller->getOptionParser()
-		])->addSubcommand('fixture', [
-			'help' => __d('cake_console', 'Bake a fixture.'),
-			'parser' => $this->Fixture->getOptionParser()
-		])->addSubcommand('helper', [
-			'help' => __d('cake_console', 'Bake a helper.'),
-			'parser' => $this->Helper->getOptionParser()
-		])->addSubcommand('test', [
-			'help' => __d('cake_console', 'Bake a unit test.'),
-			'parser' => $this->Test->getOptionParser()
 		])->addOption('connection', [
 			'help' => __d('cake_console', 'Database connection to use in conjunction with `bake all`.'),
 			'short' => 'c',
@@ -296,6 +248,14 @@ class BakeShell extends Shell {
 			'short' => 't',
 			'help' => __d('cake_console', 'Theme to use when baking code.')
 		]);
+
+		foreach ($this->tasks as $task) {
+			$taskParser = $this->{$task}->getOptionParser();
+			$parser->addSubcommand(Inflector::underscore($task), [
+				'help' => $taskParser->description(),
+				'parser' => $taskParser
+			]);
+		}
 
 		return $parser;
 	}

--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -149,6 +149,24 @@ class BakeShell extends Shell {
 		if (!is_dir($path)) {
 			return $tasks;
 		}
+		$candidates = $this->_findClassFiles($path, $namespace);
+		$classes = $this->_findTaskClasses($candidates);
+		foreach ($classes as $class) {
+			list($ns, $name) = namespaceSplit($class);
+			$name = substr($name, 0, -4);
+			$fullName = ($prefix ? $prefix . '.' : '') . $name;
+			$tasks[$name] = $fullName;
+		}
+		return $tasks;
+	}
+
+/**
+ * Find task classes in a given path.
+ *
+ * @param string $path The path to scan.
+ * @return array An array of files that may contain bake tasks.
+ */
+	protected function _findClassFiles($path, $namespace) {
 		$iterator = new \DirectoryIterator($path);
 		$candidates = [];
 		foreach ($iterator as $item) {
@@ -158,8 +176,18 @@ class BakeShell extends Shell {
 			$name = $item->getBasename('.php');
 			$candidates[] = $namespace . '\Console\Command\Task\\' . $name;
 		}
+		return $candidates;
+	}
+
+/**
+ * Find bake tasks in a given set of files.
+ *
+ * @param array $files The array of files.
+ * @return array An array of matching classes.
+ */
+	protected function _findTaskClasses($files) {
 		$classes = [];
-		foreach ($candidates as $classname) {
+		foreach ($files as $classname) {
 			if (!class_exists($classname)) {
 				continue;
 			}
@@ -172,13 +200,7 @@ class BakeShell extends Shell {
 			}
 			$classes[] = $classname;
 		}
-		foreach ($classes as $class) {
-			list($ns, $name) = namespaceSplit($class);
-			$name = substr($name, 0, -4);
-			$fullName = ($prefix ? $prefix . '.' : '') . $name;
-			$tasks[$name] = $fullName;
-		}
-		return $tasks;
+		return $classes;
 	}
 
 /**

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -257,7 +257,7 @@ class ControllerTask extends BakeTask {
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
 		$parser->description(
-			__d('cake_console', 'Bake a controller for a model. Using options you can bake public, admin or both.')
+			__d('cake_console', 'Bake a controller skeleton.')
 		)->addArgument('name', [
 			'help' => __d('cake_console', 'Name of the controller to bake. Can use Plugin.name to bake controllers into plugins.')
 		])->addOption('plugin', [

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -651,7 +651,7 @@ class ModelTask extends BakeTask {
 		$parser = parent::getOptionParser();
 
 		$parser->description(
-			__d('cake_console', 'Bake models.')
+			__d('cake_console', 'Bake table and entity classes.')
 		)->addArgument('name', [
 			'help' => __d('cake_console', 'Name of the model to bake. Can use Plugin.name to bake plugin models.')
 		])->addSubcommand('all', [

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Console\Command\Task;
 
-use Cake\Console\Shell;
+use Cake\Console\Command\Task\BakeTask;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Utility\ConventionsTrait;
@@ -25,16 +25,7 @@ use Cake\Utility\Folder;
  * The Plugin Task handles creating an empty plugin, ready to be used
  *
  */
-class PluginTask extends Shell {
-
-	use ConventionsTrait;
-
-/**
- * path to plugins directory
- *
- * @var array
- */
-	public $path = null;
+class PluginTask extends BakeTask {
 
 /**
  * Path to the bootstrap file. Changed in tests.

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -15,6 +15,7 @@
 namespace Cake\Console\Command\Task;
 
 use Cake\Console\Command\Task\BakeTask;
+use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Utility\ConventionsTrait;
@@ -57,31 +58,18 @@ class PluginTask extends BakeTask {
  * @return void
  */
 	public function execute() {
-		if (isset($this->args[0])) {
-			$plugin = $this->_camelize($this->args[0]);
-			$pluginPath = $this->_pluginPath($plugin);
-			if (is_dir($pluginPath)) {
-				$this->out(__d('cake_console', 'Plugin: %s already exists, no action taken', $plugin));
-				$this->out(__d('cake_console', 'Path: %s', $pluginPath));
-				return false;
-			}
-			$this->_interactive($plugin);
-		} else {
-			return $this->_interactive();
+		if (empty($this->args[0])) {
+			$this->err('<error>You must provide a plugin name in CamelCase format.</error>');
+			$this->err('To make an "Example" plugin, run <info>Console/cake bake plugin Example</info>.');
+			return false;
 		}
-	}
-
-/**
- * Interactive interface
- *
- * @param string $plugin
- * @return void
- */
-	protected function _interactive($plugin = null) {
-		while ($plugin === null) {
-			$plugin = $this->in(__d('cake_console', 'Enter the name of the plugin in CamelCase format'));
+		$plugin = $this->_camelize($this->args[0]);
+		$pluginPath = $this->_pluginPath($plugin);
+		if (is_dir($pluginPath)) {
+			$this->out(__d('cake_console', 'Plugin: %s already exists, no action taken', $plugin));
+			$this->out(__d('cake_console', 'Path: %s', $pluginPath));
+			return false;
 		}
-
 		if (!$this->bake($plugin)) {
 			$this->error(__d('cake_console', "An error occurred trying to bake: %s in %s", $plugin, $this->path . $plugin));
 		}

--- a/src/Console/Command/Task/ProjectTask.php
+++ b/src/Console/Command/Task/ProjectTask.php
@@ -14,7 +14,7 @@
  */
 namespace Cake\Console\Command\Task;
 
-use Cake\Console\Shell;
+use Cake\Console\Command\Task\BakeTask;
 use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Utility\File;
@@ -26,7 +26,7 @@ use Cake\Utility\String;
  * Task class for creating new project apps and plugins
  *
  */
-class ProjectTask extends Shell {
+class ProjectTask extends BakeTask {
 
 /**
  * App path (used in testing).

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -429,9 +429,7 @@ class ViewTask extends BakeTask {
 			'help' => __d('cake_console', 'The routing prefix to generate views for.'),
 		])->addSubcommand('all', [
 			'help' => __d('cake_console', 'Bake all CRUD action views for all controllers. Requires models and controllers to exist.')
-		])->epilog(
-			__d('cake_console', 'Omitting all arguments and options will enter into an interactive mode.')
-		);
+		]);
 
 		return $parser;
 	}

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -115,6 +115,21 @@ class BakeShellTest extends TestCase {
 	}
 
 /**
+ * Test that the generated option parser reflects all tasks.
+ *
+ * @return void
+ */
+	public function testGetOptionParser() {
+		$this->Shell->loadTasks();
+		$parser = $this->Shell->getOptionParser();
+		$commands = $parser->subcommands();
+		$this->assertArrayHasKey('fixture', $commands);
+		$this->assertArrayHasKey('view', $commands);
+		$this->assertArrayHasKey('controller', $commands);
+		$this->assertArrayHasKey('model', $commands);
+	}
+
+/**
  * Test loading tasks from core directories.
  *
  * @return void

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -18,6 +18,7 @@ use Cake\Console\Command\BakeShellShell;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 
 class BakeShellTest extends TestCase {
@@ -112,11 +113,11 @@ class BakeShellTest extends TestCase {
 	}
 
 /**
- * Test loading tasks from core and app directories.
+ * Test loading tasks from core directories.
  *
  * @return void
  */
-	public function testLoadTasks() {
+	public function testLoadTasksCoreAndApp() {
 		$this->Shell->loadTasks();
 		$expected = [
 			'Behavior',
@@ -128,7 +129,8 @@ class BakeShellTest extends TestCase {
 			'Plugin',
 			'Project',
 			'Test',
-			'View'
+			'View',
+			'Zerg',
 		];
 		$this->assertEquals($expected, $this->Shell->tasks);
 	}
@@ -139,6 +141,10 @@ class BakeShellTest extends TestCase {
  * @return void
  */
 	public function testLoadTasksPlugin() {
+		Plugin::load('TestPlugin');
+		$this->Shell->loadTasks();
+		$this->assertContains('TestPlugin.Widget', $this->Shell->tasks);
+		$this->assertContains('TestPlugin.Zerg', $this->Shell->tasks);
 	}
 
 }

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -111,4 +111,34 @@ class BakeShellTest extends TestCase {
 		$this->Shell->main();
 	}
 
+/**
+ * Test loading tasks from core and app directories.
+ *
+ * @return void
+ */
+	public function testLoadTasks() {
+		$this->Shell->loadTasks();
+		$expected = [
+			'Behavior',
+			'Component',
+			'Controller',
+			'Fixture',
+			'Helper',
+			'Model',
+			'Plugin',
+			'Project',
+			'Test',
+			'View'
+		];
+		$this->assertEquals($expected, $this->Shell->tasks);
+	}
+
+/**
+ * Test loading tasks from plugins
+ *
+ * @return void
+ */
+	public function testLoadTasksPlugin() {
+	}
+
 }

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -106,9 +106,11 @@ class BakeShellTest extends TestCase {
 		$this->Shell->expects($this->at(0))
 			->method('out')
 			->with($this->stringContains('The following commands'));
-		$this->Shell->expects($this->at(3))
+		$this->Shell->expects($this->at(4))
 			->method('out')
-			->with('model');
+			->with('behavior');
+
+		$this->Shell->loadTasks();
 		$this->Shell->main();
 	}
 

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -106,9 +106,9 @@ class BakeShellTest extends TestCase {
 		$this->Shell->expects($this->at(0))
 			->method('out')
 			->with($this->stringContains('The following commands'));
-		$this->Shell->expects($this->at(4))
-			->method('out')
-			->with('behavior');
+
+		$this->Shell->expects($this->exactly(17))
+			->method('out');
 
 		$this->Shell->loadTasks();
 		$this->Shell->main();
@@ -149,6 +149,8 @@ class BakeShellTest extends TestCase {
 			'View',
 			'Zerg',
 		];
+		sort($this->Shell->tasks);
+		sort($expected);
 		$this->assertEquals($expected, $this->Shell->tasks);
 	}
 

--- a/tests/TestCase/Console/Command/CompletionShellTest.php
+++ b/tests/TestCase/Console/Command/CompletionShellTest.php
@@ -164,7 +164,7 @@ class CompletionShellTest extends TestCase {
 		$this->Shell->runCommand('subCommands', array('subCommands', 'CORE.bake'));
 		$output = $this->Shell->stdout->output;
 
-		$expected = "behavior component controller fixture helper model plugin project test view\n";
+		$expected = "behavior component controller fixture helper model plugin project test view widget zerg\n";
 		$this->assertEquals($expected, $output);
 	}
 
@@ -229,7 +229,7 @@ class CompletionShellTest extends TestCase {
 		$this->Shell->runCommand('subCommands', array('subCommands', 'bake'));
 		$output = $this->Shell->stdout->output;
 
-		$expected = "behavior component controller fixture helper model plugin project test view\n";
+		$expected = "behavior component controller fixture helper model plugin project test view widget zerg\n";
 		$this->assertEquals($expected, $output);
 	}
 

--- a/tests/TestCase/Console/Command/Task/PluginTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/PluginTaskTest.php
@@ -114,27 +114,15 @@ class PluginTaskTest extends TestCase {
  * @return void
  */
 	public function testExecuteWithNoArgs() {
-		$this->Task->expects($this->at(0))
-			->method('in')
-			->will($this->returnValue('TestPlugin'));
-
-		$this->Task->expects($this->at(1))
-			->method('in')
-			->will($this->returnValue('y'));
-
 		$path = $this->Task->path . 'TestPlugin';
 		$file = $path . DS . 'Controller' . DS . 'TestPluginAppController.php';
 
-		$this->Task->expects($this->at(2))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+		$this->Task->expects($this->at(0))
+			->method('err')
+			->with($this->stringContains('You must'));
 
-		$file = $path . DS . 'phpunit.xml';
-		$this->Task->expects($this->at(3))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
-
-		$file = $path . DS . 'Test' . DS . 'bootstrap.php';
-		$this->Task->expects($this->at(4))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+		$this->Task->expects($this->never())
+			->method('createFile');
 
 		$this->Task->args = array();
 		$this->Task->execute();

--- a/tests/test_app/Plugin/TestPlugin/Console/Command/Task/WidgetTask.php
+++ b/tests/test_app/Plugin/TestPlugin/Console/Command/Task/WidgetTask.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Console\Command\Task;
+
+use Cake\Console\Command\Task\BakeTask;
+
+/**
+ * Test stub for BakeShell.
+ */
+class WidgetTask extends BakeTask {
+
+}

--- a/tests/test_app/Plugin/TestPlugin/Console/Command/Task/ZergTask.php
+++ b/tests/test_app/Plugin/TestPlugin/Console/Command/Task/ZergTask.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestPlugin\Console\Command\Task;
+
+use Cake\Console\Command\Task\BakeTask;
+
+/**
+ * Test stub for BakeShell.
+ */
+class ZergTask extends BakeTask {
+
+}

--- a/tests/test_app/TestApp/Console/Command/Task/ZergTask.php
+++ b/tests/test_app/TestApp/Console/Command/Task/ZergTask.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace TestApp\Console\Command\Task;
+
+use Cake\Console\Command\Task\BakeTask;
+
+/**
+ * Test stub for BakeShell.
+ */
+class ZergTask extends BakeTask {
+
+}


### PR DESCRIPTION
Implements the features described in #3219. This allows bake to auto-discover app/plugin tasks that extend `BakeTask`. This process should work for plugins that use non-conventional directory layouts, as `Plugin::pluginPath()` should manage the path tricks. This includes changes from #3254 which can be split out if required.
