### PR TITLE
microptimize options and default merge and other string key array merges

### DIFF
--- a/lib/Cake/Cache/Cache.php
+++ b/lib/Cake/Cache/Cache.php
@@ -130,7 +130,7 @@ class Cache {
 		}
 
 		if (!empty($settings)) {
-			self::$_config[$name] = array_merge($current, $settings);
+			self::$_config[$name] = $settings + $current;
 		}
 
 		if (empty(self::$_config[$name]['engine'])) {
@@ -253,7 +253,7 @@ class Cache {
 				if (is_string($settings) && $value !== null) {
 					$settings = array($settings => $value);
 				}
-				$settings = array_merge(self::$_config[$config], $settings);
+				$settings += self::$_config[$config];
 				if (isset($settings['duration']) && !is_numeric($settings['duration'])) {
 					$settings['duration'] = strtotime($settings['duration']) - time();
 				}

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -203,7 +203,7 @@ class DbConfigTask extends AppShell {
  * @return boolean True if user says it looks good, false otherwise
  */
 	protected function _verify($config) {
-		$config = array_merge($this->_defaultConfig, $config);
+		$config += $this->_defaultConfig;
 		extract($config);
 		$this->out();
 		$this->hr();

--- a/lib/Cake/Console/Command/Task/DbConfigTask.php
+++ b/lib/Cake/Console/Command/Task/DbConfigTask.php
@@ -264,7 +264,7 @@ class DbConfigTask extends AppShell {
 			$temp = get_class_vars(get_class($db));
 
 			foreach ($temp as $configName => $info) {
-				$info = array_merge($this->_defaultConfig, $info);
+				$info += $this->_defaultConfig;
 
 				if (!isset($info['schema'])) {
 					$info['schema'] = null;
@@ -307,7 +307,7 @@ class DbConfigTask extends AppShell {
 		$out .= "class DATABASE_CONFIG {\n\n";
 
 		foreach ($configs as $config) {
-			$config = array_merge($this->_defaultConfig, $config);
+			$config += $this->_defaultConfig;
 			extract($config);
 
 			if (strpos($datasource, 'Database/') === false) {

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -199,7 +199,7 @@ class UpgradeShell extends AppShell {
 				$dir = $options;
 				$options = array();
 			}
-			$options = array_merge($defaultOptions, $options);
+			$options += $defaultOptions;
 			$this->_movePhpFiles($dir, $options);
 		}
 	}

--- a/lib/Cake/Console/ConsoleOptionParser.php
+++ b/lib/Cake/Console/ConsoleOptionParser.php
@@ -299,7 +299,7 @@ class ConsoleOptionParser {
 				'boolean' => false,
 				'choices' => array()
 			);
-			$options = array_merge($defaults, $options);
+			$options += $defaults;
 			$option = new ConsoleInputOption($options);
 		}
 		$this->_options[$name] = $option;
@@ -338,7 +338,7 @@ class ConsoleOptionParser {
 				'required' => false,
 				'choices' => array()
 			);
-			$options = array_merge($defaults, $params);
+			$options = $params + $defaults;
 			$index = $options['index'];
 			unset($options['index']);
 			$arg = new ConsoleInputArgument($options);
@@ -403,7 +403,7 @@ class ConsoleOptionParser {
 				'help' => '',
 				'parser' => null
 			);
-			$options = array_merge($defaults, $options);
+			$options += $defaults;
 			$command = new ConsoleInputSubcommand($options);
 		}
 		$this->_subcommands[$name] = $command;

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -311,7 +311,7 @@ class ShellDispatcher {
 			$params = str_replace('/', '\\', $params);
 		}
 
-		$this->params = array_merge($this->params, $params);
+		$this->params = $params + $this->params;
 	}
 
 /**

--- a/lib/Cake/Controller/Component.php
+++ b/lib/Cake/Controller/Component.php
@@ -92,7 +92,7 @@ class Component extends Object {
  */
 	public function __get($name) {
 		if (isset($this->_componentMap[$name]) && !isset($this->{$name})) {
-			$settings = array_merge((array)$this->_componentMap[$name]['settings'], array('enabled' => false));
+			$settings = array('enabled' => false) + (array)$this->_componentMap[$name]['settings'];
 			$this->{$name} = $this->_Collection->load($this->_componentMap[$name]['class'], $settings);
 		}
 		if (isset($this->{$name})) {

--- a/lib/Cake/Controller/Component/Acl/PhpAcl.php
+++ b/lib/Cake/Controller/Component/Acl/PhpAcl.php
@@ -81,7 +81,7 @@ class PhpAcl extends Object implements AclInterface {
  */
 	public function initialize(Component $Component) {
 		if (!empty($Component->settings['adapter'])) {
-			$this->options = array_merge($this->options, $Component->settings['adapter']);
+			$this->options = $Component->settings['adapter'] + $this->options;
 		}
 
 		App::uses('PhpReader', 'Configure');
@@ -546,7 +546,7 @@ class PhpAro {
  * @return void
  */
 	public function addAlias(array $alias) {
-		$this->aliases = array_merge($this->aliases, $alias);
+		$this->aliases = $alias + $this->aliases;
 	}
 
 /**

--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -603,7 +603,7 @@ class RequestHandlerComponent extends Component {
 		if (Configure::read('App.encoding') !== null) {
 			$defaults['charset'] = Configure::read('App.encoding');
 		}
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		if ($type === 'ajax') {
 			$controller->layout = $this->ajaxLayout;

--- a/lib/Cake/Core/Object.php
+++ b/lib/Cake/Core/Object.php
@@ -84,7 +84,7 @@ class Object {
 		if ($arrayUrl && !isset($extra['data'])) {
 			$extra['data'] = array();
 		}
-		$extra = array_merge(array('autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1), $extra);
+		$extra += array('autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1);
 		$data = isset($extra['data']) ? $extra['data'] : null;
 		unset($extra['data']);
 
@@ -95,7 +95,7 @@ class Object {
 			$request = new CakeRequest($url);
 		} elseif (is_array($url)) {
 			$params = $url + array('pass' => array(), 'named' => array(), 'base' => false);
-			$params = array_merge($params, $extra);
+			$params = $extra + $params;
 			$request = new CakeRequest(Router::reverse($params));
 		}
 		if (isset($data)) {

--- a/lib/Cake/Model/Behavior/TreeBehavior.php
+++ b/lib/Cake/Model/Behavior/TreeBehavior.php
@@ -67,7 +67,7 @@ class TreeBehavior extends ModelBehavior {
 			$config['type'] = $config[0];
 			unset($config[0]);
 		}
-		$settings = array_merge($this->_defaults, $config);
+		$settings = $config + $this->_defaults;
 
 		if (in_array($settings['scope'], $Model->getAssociated('belongsTo'))) {
 			$data = $Model->getAssociated($settings['scope']);
@@ -743,7 +743,7 @@ class TreeBehavior extends ModelBehavior {
  * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/tree.html#TreeBehavior::reorder
  */
 	public function reorder(Model $Model, $options = array()) {
-		$options = array_merge(array('id' => null, 'field' => $Model->displayField, 'order' => 'ASC', 'verify' => true), $options);
+		$options += array('id' => null, 'field' => $Model->displayField, 'order' => 'ASC', 'verify' => true);
 		extract($options);
 		if ($verify && !$this->verify($Model)) {
 			return false;

--- a/lib/Cake/Model/Datasource/Database/Sqlite.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlite.php
@@ -395,7 +395,7 @@ class Sqlite extends DboSource {
  */
 	public function buildColumn($column) {
 		$name = $type = null;
-		$column = array_merge(array('null' => true), $column);
+		$column += array('null' => true);
 		extract($column);
 
 		if (empty($name) || empty($type)) {

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1663,7 +1663,7 @@ class Model extends Object implements CakeEventListener {
 
 		$options = array('validate' => $validate, 'fieldList' => array($name));
 		if (is_array($validate)) {
-			$options = array_merge(array('validate' => false, 'fieldList' => array($name)), $validate);
+			$options = $validate + array('validate' => false, 'fieldList' => array($name));
 		}
 
 		return $this->save(array($this->alias => array($this->primaryKey => $id, $name => $value)), $options);
@@ -1697,9 +1697,9 @@ class Model extends Object implements CakeEventListener {
 		$fields = array();
 
 		if (!is_array($validate)) {
-			$options = array_merge($defaults, compact('validate', 'fieldList'));
+			$options = compact('validate', 'fieldList') + $defaults;
 		} else {
-			$options = array_merge($defaults, $validate);
+			$options = $validate + $defaults;
 		}
 
 		if (!empty($options['fieldList'])) {
@@ -2164,7 +2164,7 @@ class Model extends Object implements CakeEventListener {
  * @link http://book.cakephp.org/2.0/en/models/saving-your-data.html#model-saveall-array-data-null-array-options-array
  */
 	public function saveAll($data = array(), $options = array()) {
-		$options = array_merge(array('validate' => 'first'), $options);
+		$options += array('validate' => 'first');
 		if (Hash::numeric(array_keys($data))) {
 			if ($options['validate'] === 'only') {
 				return $this->validateMany($data, $options);
@@ -2206,7 +2206,7 @@ class Model extends Object implements CakeEventListener {
 			$data = $this->data;
 		}
 
-		$options = array_merge(array('validate' => 'first', 'atomic' => true, 'deep' => false), $options);
+		$options += array('validate' => 'first', 'atomic' => true, 'deep' => false);
 		$this->validationErrors = $validationErrors = array();
 
 		if (empty($data) && $options['validate'] !== false) {
@@ -2328,7 +2328,7 @@ class Model extends Object implements CakeEventListener {
 			$data = $this->data;
 		}
 
-		$options = array_merge(array('validate' => 'first', 'atomic' => true, 'deep' => false), $options);
+		$options += array('validate' => 'first', 'atomic' => true, 'deep' => false);
 		$this->validationErrors = $validationErrors = array();
 
 		if (empty($data) && $options['validate'] !== false) {
@@ -2369,9 +2369,9 @@ class Model extends Object implements CakeEventListener {
 			$saved = false;
 			if ($validates) {
 				if ($options['deep']) {
-					$saved = $Model->saveAssociated($values, array_merge($options, array('atomic' => false)));
+					$saved = $Model->saveAssociated($values, array('atomic' => false) + $options);
 				} else {
-					$saved = $Model->save($values, array_merge($options, array('atomic' => false)));
+					$saved = $Model->save($values, array('atomic' => false) + $options);
 				}
 				$validates = ($saved === true || (is_array($saved) && !in_array(false, $saved, true)));
 			}
@@ -2425,7 +2425,7 @@ class Model extends Object implements CakeEventListener {
 					if ($validates) {
 						$options = $Model->_addToWhiteList($key, $options);
 						if ($options['deep']) {
-							$saved = $Model->saveAssociated($values, array_merge($options, array('atomic' => false)));
+							$saved = $Model->saveAssociated($values, array('atomic' => false) + $options);
 						} else {
 							$saved = $Model->save($values, $options);
 						}
@@ -2448,7 +2448,7 @@ class Model extends Object implements CakeEventListener {
 					}
 
 					$options = $Model->_addToWhiteList($key, $options);
-					$_return = $Model->saveMany($values, array_merge($options, array('atomic' => false)));
+					$_return = $Model->saveMany($values, array('atomic' => false) + $options);
 					if (in_array(false, $_return, true)) {
 						$validationErrors[$association] = $Model->validationErrors;
 						$validates = false;

--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -127,7 +127,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  */
 	public function validateAssociated(&$data, $options = array()) {
 		$model = $this->getModel();
-		$options = array_merge(array('atomic' => true, 'deep' => false), $options);
+		$options += array('atomic' => true, 'deep' => false);
 		$model->validationErrors = $validationErrors = $return = array();
 		$model->create(null);
 		$return[$model->alias] = true;
@@ -204,7 +204,7 @@ class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
  */
 	public function validateMany(&$data, $options = array()) {
 		$model = $this->getModel();
-		$options = array_merge(array('atomic' => true, 'deep' => false), $options);
+		$options += array('atomic' => true, 'deep' => false);
 		$model->validationErrors = $validationErrors = $return = array();
 		foreach ($data as $key => &$record) {
 			if ($options['deep']) {

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1135,7 +1135,7 @@ class CakeEmail {
 				if (!is_array($this->_config['log'])) {
 					$this->_config['log'] = array('level' => $this->_config['log']);
 				}
-				$config = array_merge($config, $this->_config['log']);
+				$config = $this->_config['log'] + $config;
 			}
 			CakeLog::write(
 				$config['level'],
@@ -1199,7 +1199,7 @@ class CakeEmail {
 			}
 			$config = $configs->{$config};
 		}
-		$this->_config = array_merge($this->_config, $config);
+		$this->_config = $config + $this->_config;
 		if (!empty($config['charset'])) {
 			$this->charset = $config['charset'];
 		}

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -893,7 +893,7 @@ class HttpSocket extends CakeSocket {
 		}
 
 		$request['uri'] = $this->_parseUri($request['uri']);
-		$request = array_merge(array('method' => 'GET'), $request);
+		$request += array('method' => 'GET');
 		if (!empty($this->_proxy['host'])) {
 			$request['uri'] = $this->_buildUri($request['uri'], '%scheme://%host:%port/%path?%query');
 		} else {

--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -480,10 +480,10 @@ class Router {
 		}
 
 		if ($named === true || $named === false) {
-			$options = array_merge(array('default' => $named, 'reset' => true, 'greedy' => $named), $options);
+			$options += array('default' => $named, 'reset' => true, 'greedy' => $named);
 			$named = array();
 		} else {
-			$options = array_merge(array('default' => false, 'reset' => false, 'greedy' => true), $options);
+			$options += array('default' => false, 'reset' => false, 'greedy' => true);
 		}
 
 		if ($options['reset'] || self::$_namedConfig['rules'] === false) {
@@ -532,11 +532,11 @@ class Router {
  */
 	public static function mapResources($controller, $options = array()) {
 		$hasPrefix = isset($options['prefix']);
-		$options = array_merge(array(
+		$options += array(
 			'connectOptions' => array(),
 			'prefix' => '/',
 			'id' => self::ID . '|' . self::UUID
-		), $options);
+		);
 
 		$prefix = $options['prefix'];
 		$connectOptions = $options['connectOptions'];

--- a/lib/Cake/Test/Case/Model/models.php
+++ b/lib/Cake/Test/Case/Model/models.php
@@ -172,7 +172,7 @@ class TestValidate extends CakeTestModel {
  * @return void
  */
 	public function validateNumber($value, $options) {
-		$options = array_merge(array('min' => 0, 'max' => 100), $options);
+		$options += array('min' => 0, 'max' => 100);
 		$valid = ($value['number'] >= $options['min'] && $value['number'] <= $options['max']);
 		return $valid;
 	}
@@ -1511,8 +1511,8 @@ class SomethingElse extends CakeTestModel {
 
 /**
  * afterFind callBack
- * 
- * @param array $results 
+ *
+ * @param array $results
  * @param bool $primary
  * @return array
  */
@@ -1550,8 +1550,8 @@ class JoinThing extends CakeTestModel {
 
 /**
  * afterFind callBack
- * 
- * @param array $results 
+ *
+ * @param array $results
  * @param bool $primary
  * @return array
  */

--- a/lib/Cake/TestSuite/ControllerTestCase.php
+++ b/lib/Cake/TestSuite/ControllerTestCase.php
@@ -215,11 +215,11 @@ abstract class ControllerTestCase extends CakeTestCase {
 	protected function _testAction($url = '', $options = array()) {
 		$this->vars = $this->result = $this->view = $this->contents = $this->headers = null;
 
-		$options = array_merge(array(
+		$options += array(
 			'data' => array(),
 			'method' => 'POST',
 			'return' => 'result'
-		), $options);
+		);
 
 		$restore = array('get' => $_GET, 'post' => $_POST);
 

--- a/lib/Cake/Utility/CakeNumber.php
+++ b/lib/Cake/Utility/CakeNumber.php
@@ -323,18 +323,18 @@ class CakeNumber {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::currency
  */
 	public static function currency($value, $currency = null, $options = array()) {
-		$default = self::$_currencyDefaults;
+		$defaults = self::$_currencyDefaults;
 		if ($currency === null) {
 			$currency = self::defaultCurrency();
 		}
 
 		if (isset(self::$_currencies[$currency])) {
-			$default = self::$_currencies[$currency];
+			$defaults = self::$_currencies[$currency];
 		} elseif (is_string($currency)) {
 			$options['before'] = $currency;
 		}
 
-		$options = array_merge($default, $options);
+		$options += $defaults;
 
 		if (isset($options['before']) && $options['before'] !== '') {
 			$options['wholeSymbol'] = $options['before'];

--- a/lib/Cake/Utility/ClassRegistry.php
+++ b/lib/Cake/Utility/ClassRegistry.php
@@ -119,7 +119,7 @@ class ClassRegistry {
 
 			if (is_array($settings)) {
 				$pluginPath = null;
-				$settings = array_merge($defaults, $settings);
+				$settings += $defaults;
 				$class = $settings['class'];
 
 				list($plugin, $class) = pluginSplit($class);

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -645,7 +645,7 @@ class Folder {
 			$to = $options;
 			$options = array();
 		}
-		$options = array_merge(array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme' => Folder::MERGE), $options);
+		$options += array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array(), 'scheme' => Folder::MERGE);
 
 		$fromDir = $options['from'];
 		$toDir = $options['to'];
@@ -695,13 +695,13 @@ class Folder {
 							chmod($to, $mode);
 							umask($old);
 							$this->_messages[] = __d('cake_dev', '%s created', $to);
-							$options = array_merge($options, array('to' => $to, 'from' => $from));
+							$options = array('to' => $to, 'from' => $from) + $options;
 							$this->copy($options);
 						} else {
 							$this->_errors[] = __d('cake_dev', '%s not created', $to);
 						}
 					} elseif (is_dir($from) && $options['scheme'] == Folder::MERGE) {
-						$options = array_merge($options, array('to' => $to, 'from' => $from));
+						$options = array('to' => $to, 'from' => $from) + $options;
 						$this->copy($options);
 					}
 				}
@@ -738,10 +738,7 @@ class Folder {
 			$to = $options;
 			$options = (array)$options;
 		}
-		$options = array_merge(
-			array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array()),
-			$options
-		);
+		$options += array('to' => $to, 'from' => $this->path, 'mode' => $this->mode, 'skip' => array());
 
 		if ($this->copy($options)) {
 			if ($this->delete($options['from'])) {

--- a/lib/Cake/Utility/ObjectCollection.php
+++ b/lib/Cake/Utility/ObjectCollection.php
@@ -113,14 +113,11 @@ abstract class ObjectCollection {
 			$parts = explode('.', $event->name());
 			$callback = array_pop($parts);
 		}
-		$options = array_merge(
-			array(
-				'break' => false,
-				'breakOn' => false,
-				'collectReturn' => false,
-				'modParams' => false
-			),
-			$options
+		$options += array(
+			'break' => false,
+			'breakOn' => false,
+			'collectReturn' => false,
+			'modParams' => false
 		);
 		$collected = array();
 		$list = array_keys($this->_enabled);

--- a/lib/Cake/Utility/Sanitize.php
+++ b/lib/Cake/Utility/Sanitize.php
@@ -104,14 +104,14 @@ class Sanitize {
 				$defaultCharset = 'UTF-8';
 			}
 		}
-		$default = array(
+		$defaults = array(
 			'remove' => false,
 			'charset' => $defaultCharset,
 			'quotes' => ENT_QUOTES,
 			'double' => true
 		);
 
-		$options = array_merge($default, $options);
+		$options += $defaults;
 
 		if ($options['remove']) {
 			$string = strip_tags($string);
@@ -224,7 +224,7 @@ class Sanitize {
 			$options = array('connection' => $options);
 		}
 
-		$options = array_merge(array(
+		$options += array(
 			'connection' => 'default',
 			'odd_spaces' => true,
 			'remove_html' => false,
@@ -234,7 +234,7 @@ class Sanitize {
 			'unicode' => true,
 			'escape' => true,
 			'backslash' => true
-		), $options);
+		);
 
 		if (is_array($data)) {
 			foreach ($data as $key => $val) {

--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -327,7 +327,7 @@ class Set {
 			return $data;
 		}
 		$contexts = $data;
-		$options = array_merge(array('flatten' => true), $options);
+		$options += array('flatten' => true);
 		if (!isset($contexts[0])) {
 			$current = current($data);
 			if ((is_array($current) && count($data) < 1) || !is_array($current) || !Set::numeric(array_keys($data))) {
@@ -1010,7 +1010,7 @@ class Set {
  */
 	public static function apply($path, $data, $callback, $options = array()) {
 		$defaults = array('type' => 'pass');
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 		$extracted = Set::extract($path, $data);
 
 		if ($options['type'] === 'map') {

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -416,12 +416,12 @@ class String {
 			return $text;
 		}
 
-		$default = array(
+		$defaults = array(
 			'format' => '<span class="highlight">\1</span>',
 			'html' => false,
 			'regex' => "|%s|iu"
 		);
-		$options = array_merge($default, $options);
+		$options += $defaults;
 		extract($options);
 
 		if (is_array($phrase)) {
@@ -477,10 +477,10 @@ class String {
  * @return string Trimmed string.
  */
 	public static function tail($text, $length = 100, $options = array()) {
-		$default = array(
+		$defaults = array(
 			'ellipsis' => '...', 'exact' => true
 		);
-		$options = array_merge($default, $options);
+		$options += $defaults;
 		extract($options);
 
 		if (!function_exists('mb_strlen')) {
@@ -519,15 +519,15 @@ class String {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
  */
 	public static function truncate($text, $length = 100, $options = array()) {
-		$default = array(
+		$defaults = array(
 			'ellipsis' => '...', 'exact' => true, 'html' => false
 		);
 		if (isset($options['ending'])) {
-			$default['ellipsis'] = $options['ending'];
+			$defaults['ellipsis'] = $options['ending'];
 		} elseif (!empty($options['html']) && Configure::read('App.encoding') === 'UTF-8') {
-			$default['ellipsis'] = "\xe2\x80\xa6";
+			$defaults['ellipsis'] = "\xe2\x80\xa6";
 		}
-		$options = array_merge($default, $options);
+		$options += $defaults;
 		extract($options);
 
 		if (!function_exists('mb_strlen')) {

--- a/lib/Cake/Utility/Validation.php
+++ b/lib/Cake/Utility/Validation.php
@@ -575,7 +575,7 @@ class Validation {
  */
 	public static function multiple($check, $options = array(), $caseInsensitive = false) {
 		$defaults = array('in' => null, 'max' => null, 'min' => null);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		$check = array_filter((array)$check);
 		if (empty($check)) {
@@ -890,7 +890,7 @@ class Validation {
 			'deep' => false,
 			'type' => null
 		);
-		$params = array_merge($defaults, $params);
+		$params += $defaults;
 		if ($params['country'] !== null) {
 			$params['country'] = mb_strtolower($params['country']);
 		}

--- a/lib/Cake/Utility/Xml.php
+++ b/lib/Cake/Utility/Xml.php
@@ -92,7 +92,7 @@ class Xml {
 			'return' => 'simplexml',
 			'loadEntities' => false,
 		);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		if (is_array($input) || is_object($input)) {
 			return self::fromArray((array)$input, $options);
@@ -208,7 +208,7 @@ class Xml {
 			'return' => 'simplexml',
 			'pretty' => false
 		);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		$dom = new DOMDocument($options['version'], $options['encoding']);
 		if ($options['pretty']) {

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -201,7 +201,7 @@ class Helper extends Object {
  */
 	public function __get($name) {
 		if (isset($this->_helperMap[$name]) && !isset($this->{$name})) {
-			$settings = array_merge((array)$this->_helperMap[$name]['settings'], array('enabled' => false));
+			$settings = array('enabled' => false) + (array)$this->_helperMap[$name]['settings'];
 			$this->{$name} = $this->_View->loadHelper($this->_helperMap[$name]['class'], $settings);
 		}
 		if (isset($this->{$name})) {

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -133,7 +133,7 @@ class CacheHelper extends AppHelper {
 			$options = $cacheAction;
 			if (isset($cacheAction[$index])) {
 				if (is_array($cacheAction[$index])) {
-					$options = array_merge(array('duration' => 0, 'callbacks' => false), $cacheAction[$index]);
+					$options = $cacheAction[$index] + array('duration' => 0, 'callbacks' => false);
 				} else {
 					$cacheTime = $cacheAction[$index];
 				}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -360,14 +360,14 @@ class FormHelper extends AppHelper {
 			}
 		}
 
-		$options = array_merge(array(
+		$options += array(
 			'type' => ($created && empty($options['action'])) ? 'put' : 'post',
 			'action' => null,
 			'url' => null,
 			'default' => true,
 			'encoding' => strtolower(Configure::read('App.encoding')),
-			'inputDefaults' => array()),
-		$options);
+			'inputDefaults' => array()
+		);
 		$this->inputDefaults($options['inputDefaults']);
 		unset($options['inputDefaults']);
 
@@ -621,9 +621,9 @@ class FormHelper extends AppHelper {
  *
  * @param boolean $lock Whether this field should be part of the validation
  *     or excluded as part of the unlockedFields.
- * @param string $field Reference to field to be secured. Should be dot separated to indicate nesting.
+ * @param string|array $field Reference to field to be secured. Should be dot separated to indicate nesting.
  * @param mixed $value Field value, if value should not be tampered with.
- * @return mixed|null Not used yet
+ * @return void
  */
 	protected function _secure($lock, $field = null, $value = null) {
 		if (!$field) {
@@ -685,7 +685,7 @@ class FormHelper extends AppHelper {
  */
 	public function error($field, $text = null, $options = array()) {
 		$defaults = array('wrap' => true, 'class' => 'error-message', 'escape' => true);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 		$this->setEntity($field);
 
 		$error = $this->tagIsInvalid();

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -273,7 +273,7 @@ class HtmlHelper extends AppHelper {
 			}
 		}
 
-		$options = array_merge($type, $options);
+		$options += $type;
 		$out = null;
 
 		if (isset($options['link'])) {
@@ -522,7 +522,7 @@ class HtmlHelper extends AppHelper {
 			list($inline, $options) = array($options, array());
 			$options['inline'] = $inline;
 		}
-		$options = array_merge(array('block' => null, 'inline' => true, 'once' => true), $options);
+		$options += array('block' => null, 'inline' => true, 'once' => true);
 		if (!$options['inline'] && empty($options['block'])) {
 			$options['block'] = __FUNCTION__;
 		}
@@ -715,7 +715,7 @@ class HtmlHelper extends AppHelper {
  */
 	public function getCrumbList($options = array(), $startText = false) {
 		$defaults = array('firstClass' => 'first', 'lastClass' => 'last', 'separator' => '', 'escape' => true);
-		$options = array_merge($defaults, (array)$options);
+		$options = (array)$options + $defaults;
 		$firstClass = $options['firstClass'];
 		$lastClass = $options['lastClass'];
 		$separator = $options['separator'];
@@ -1231,13 +1231,13 @@ class HtmlHelper extends AppHelper {
 		$readerObj = new $readerClass($path);
 		$configs = $readerObj->read($file);
 		if (isset($configs['tags']) && is_array($configs['tags'])) {
-			$this->_tags = array_merge($this->_tags, $configs['tags']);
+			$this->_tags = $configs['tags'] + $this->_tags;
 		}
 		if (isset($configs['minimizedAttributes']) && is_array($configs['minimizedAttributes'])) {
-			$this->_minimizedAttributes = array_merge($this->_minimizedAttributes, $configs['minimizedAttributes']);
+			$this->_minimizedAttributes = $configs['minimizedAttributes'] + $this->_minimizedAttributes;
 		}
 		if (isset($configs['docTypes']) && is_array($configs['docTypes'])) {
-			$this->_docTypes = array_merge($this->_docTypes, $configs['docTypes']);
+			$this->_docTypes = $configs['docTypes'] + $this->_docTypes;
 		}
 		if (isset($configs['attributeFormat'])) {
 			$this->_attributeFormat = $configs['attributeFormat'];

--- a/lib/Cake/View/Helper/JqueryEngineHelper.php
+++ b/lib/Cake/View/Helper/JqueryEngineHelper.php
@@ -171,7 +171,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
  */
 	public function event($type, $callback, $options = array()) {
 		$defaults = array('wrap' => true, 'stop' => true);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		$function = 'function (event) {%s}';
 		if ($options['wrap'] && $options['stop']) {
@@ -345,7 +345,7 @@ class JqueryEngineHelper extends JsBaseEngineHelper {
  * @see JsBaseEngineHelper::serializeForm() for option list.
  */
 	public function serializeForm($options = array()) {
-		$options = array_merge(array('isForm' => false, 'inline' => false), $options);
+		$options += array('isForm' => false, 'inline' => false);
 		$selector = $this->selection;
 		if (!$options['isForm']) {
 			$selector = $this->selection . '.closest("form")';

--- a/lib/Cake/View/Helper/JsBaseEngineHelper.php
+++ b/lib/Cake/View/Helper/JsBaseEngineHelper.php
@@ -128,7 +128,7 @@ abstract class JsBaseEngineHelper extends AppHelper {
 		$defaultOptions = array(
 			'prefix' => '', 'postfix' => '',
 		);
-		$options = array_merge($defaultOptions, $options);
+		$options += $defaultOptions;
 
 		return $options['prefix'] . json_encode($data) . $options['postfix'];
 	}

--- a/lib/Cake/View/Helper/JsHelper.php
+++ b/lib/Cake/View/Helper/JsHelper.php
@@ -194,7 +194,7 @@ class JsHelper extends AppHelper {
 			'onDomReady' => $domReady, 'inline' => true,
 			'cache' => false, 'clear' => true, 'safe' => true
 		);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 		$script = implode("\n", $this->getBuffer($options['clear']));
 
 		if (empty($script)) {

--- a/lib/Cake/View/Helper/MootoolsEngineHelper.php
+++ b/lib/Cake/View/Helper/MootoolsEngineHelper.php
@@ -150,7 +150,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
  */
 	public function event($type, $callback, $options = array()) {
 		$defaults = array('wrap' => true, 'stop' => true);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		$function = 'function (event) {%s}';
 		if ($options['wrap'] && $options['stop']) {
@@ -361,7 +361,7 @@ class MootoolsEngineHelper extends JsBaseEngineHelper {
  * @see JsBaseEngineHelper::serializeForm()
  */
 	public function serializeForm($options = array()) {
-		$options = array_merge(array('isForm' => false, 'inline' => false), $options);
+		$options += array('isForm' => false, 'inline' => false);
 		$selection = $this->selection;
 		if (!$options['isForm']) {
 			$selection = '$(' . $this->selection . '.form)';

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -281,7 +281,7 @@ class PaginatorHelper extends AppHelper {
 		$defaults = array(
 			'rel' => 'prev'
 		);
-		$options = array_merge($defaults, (array)$options);
+		$options = (array)$options + $defaults;
 		return $this->_pagingLink('Prev', $title, $options, $disabledTitle, $disabledOptions);
 	}
 
@@ -307,7 +307,7 @@ class PaginatorHelper extends AppHelper {
 		$defaults = array(
 			'rel' => 'next'
 		);
-		$options = array_merge($defaults, (array)$options);
+		$options = (array)$options + $defaults;
 		return $this->_pagingLink('Next', $title, $options, $disabledTitle, $disabledOptions);
 	}
 
@@ -331,7 +331,7 @@ class PaginatorHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::sort
  */
 	public function sort($key, $title = null, $options = array()) {
-		$options = array_merge(array('url' => array(), 'model' => null), $options);
+		$options += array('url' => array(), 'model' => null);
 		$url = $options['url'];
 		unset($options['url']);
 
@@ -397,12 +397,12 @@ class PaginatorHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::link
  */
 	public function link($title, $url = array(), $options = array()) {
-		$options = array_merge(array('model' => null, 'escape' => true), $options);
+		$options += array('model' => null, 'escape' => true);
 		$model = $options['model'];
 		unset($options['model']);
 
 		if (!empty($this->options)) {
-			$options = array_merge($this->options, $options);
+			$options += $this->options;
 		}
 		if (isset($options['url'])) {
 			$url = array_merge((array)$options['url'], (array)$url);
@@ -489,7 +489,7 @@ class PaginatorHelper extends AppHelper {
 			'url' => array(), 'step' => 1, 'escape' => true, 'model' => null,
 			'tag' => 'span', 'class' => strtolower($which), 'disabledTag' => null
 		);
-		$options = array_merge($_defaults, (array)$options);
+		$options = (array)$options + $_defaults;
 		$paging = $this->params($options['model']);
 		if (empty($disabledOptions)) {
 			$disabledOptions = $options;
@@ -499,7 +499,7 @@ class PaginatorHelper extends AppHelper {
 			if (!empty($disabledTitle) && $disabledTitle !== true) {
 				$title = $disabledTitle;
 			}
-			$options = array_merge($_defaults, (array)$disabledOptions);
+			$options = (array)$disabledOptions + $_defaults;
 		} elseif (!$this->{$check}($options['model'])) {
 			return null;
 		}
@@ -631,13 +631,11 @@ class PaginatorHelper extends AppHelper {
 			$options = array('format' => $options);
 		}
 
-		$options = array_merge(
-			array(
-				'model' => $this->defaultModel(),
-				'format' => 'pages',
-				'separator' => __d('cake', ' of ')
-			),
-		$options);
+		$options += array(
+			'model' => $this->defaultModel(),
+			'format' => 'pages',
+			'separator' => __d('cake', ' of ')
+		);
 
 		$paging = $this->params($options['model']);
 		if (!$paging['pageCount']) {
@@ -855,16 +853,14 @@ class PaginatorHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::first
  */
 	public function first($first = '<< first', $options = array()) {
-		$options = array_merge(
-			array(
-				'tag' => 'span',
-				'after' => null,
-				'model' => $this->defaultModel(),
-				'separator' => ' | ',
-				'ellipsis' => '...',
-				'class' => null
-			),
-		(array)$options);
+		$options = (array)$options + array(
+			'tag' => 'span',
+			'after' => null,
+			'model' => $this->defaultModel(),
+			'separator' => ' | ',
+			'ellipsis' => '...',
+			'class' => null
+		);
 
 		$params = array_merge(array('page' => 1), (array)$this->params($options['model']));
 		unset($options['model']);
@@ -920,16 +916,14 @@ class PaginatorHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/paginator.html#PaginatorHelper::last
  */
 	public function last($last = 'last >>', $options = array()) {
-		$options = array_merge(
-			array(
-				'tag' => 'span',
-				'before' => null,
-				'model' => $this->defaultModel(),
-				'separator' => ' | ',
-				'ellipsis' => '...',
-				'class' => null
-			),
-		(array)$options);
+		$options = (array)$options + array(
+			'tag' => 'span',
+			'before' => null,
+			'model' => $this->defaultModel(),
+			'separator' => ' | ',
+			'ellipsis' => '...',
+			'class' => null
+		);
 
 		$params = array_merge(array('page' => 1), (array)$this->params($options['model']));
 		unset($options['model']);

--- a/lib/Cake/View/Helper/PrototypeEngineHelper.php
+++ b/lib/Cake/View/Helper/PrototypeEngineHelper.php
@@ -146,7 +146,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
  */
 	public function event($type, $callback, $options = array()) {
 		$defaults = array('wrap' => true, 'stop' => true);
-		$options = array_merge($defaults, $options);
+		$options += $defaults;
 
 		$function = 'function (event) {%s}';
 		if ($options['wrap'] && $options['stop']) {
@@ -354,7 +354,7 @@ class PrototypeEngineHelper extends JsBaseEngineHelper {
  * @see JsBaseEngineHelper::serializeForm()
  */
 	public function serializeForm($options = array()) {
-		$options = array_merge(array('isForm' => false, 'inline' => false), $options);
+		$options += array('isForm' => false, 'inline' => false);
 		$selection = $this->selection;
 		if (!$options['isForm']) {
 			$selection = '$(' . $this->selection . '.form)';

--- a/lib/Cake/View/Helper/TimeHelper.php
+++ b/lib/Cake/View/Helper/TimeHelper.php
@@ -408,7 +408,7 @@ class TimeHelper extends AppHelper {
 			);
 
 			if (is_array($options['element'])) {
-				$element = array_merge($element, $options['element']);
+				$element = $options['element'] + $element;
 			} else {
 				$element['tag'] = $options['element'];
 			}


### PR DESCRIPTION
This unifies the way string-key-based options are merged across the core.
Those should be merged using `+` as already done everywhere else.
Additionally is 4-5x faster than array_merge, as well.

`+` operator can be used with options where
- options are a flat array of string based keys
- the resulting order doesn't matter

So I ignored some occurrences in PaginatorHelper - as well as in some other places - to not have to touch/modify any test cases and to keep it 100% BC.
