### PR TITLE
Without any params this method does not make sense

### DIFF
--- a/lib/Cake/Utility/Set.php
+++ b/lib/Cake/Utility/Set.php
@@ -735,7 +735,7 @@ class Set {
  * @return integer The number of dimensions in $array
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/set.html#Set::countDim
  */
-	public static function countDim($array = null, $all = false, $count = 0) {
+	public static function countDim($array, $all = false, $count = 0) {
 		if ($all) {
 			$depth = array($count);
 			if (is_array($array) && reset($array) !== false) {


### PR DESCRIPTION
`Set::countDim()` with no arguments passed (especially for the first param) is useless and a no op.
Thus the first param is not allowed to default to null.

Scrutinizer threw a warning here. That's how I detected it.
