### PR TITLE
2.5 load all

### DIFF
--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -121,11 +121,11 @@ class CakePlugin {
 	public static function loadAll($options = array()) {
 		$plugins = App::objects('plugins');
 		foreach ($plugins as $p) {
-			$opts = isset($options[$p]) ? $options[$p] : array();
+			$opts = isset($options[$p]) ? (array)$options[$p] : array();
 			if (isset($options[0])) {
 				$opts += $options[0];
 			}
-			self::load($p, (array)$opts);
+			self::load($p, $opts);
 		}
 	}
 

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -121,9 +121,9 @@ class CakePlugin {
 	public static function loadAll($options = array()) {
 		$plugins = App::objects('plugins');
 		foreach ($plugins as $p) {
-			$opts = isset($options[$p]) ? $options[$p] : null;
-			if ($opts === null && isset($options[0])) {
-				$opts = $options[0];
+			$opts = isset($options[$p]) ? $options[$p] : array();
+			if (isset($options[0])) {
+				$opts += $options[0];
 			}
 			self::load($p, (array)$opts);
 		}

--- a/lib/Cake/Core/CakePlugin.php
+++ b/lib/Cake/Core/CakePlugin.php
@@ -108,12 +108,12 @@ class CakePlugin {
  * {{{
  * 	CakePlugin::loadAll(array(
  *		array('bootstrap' => true),
- * 		'DebugKit' => array('routes' => true),
+ * 		'DebugKit' => array('routes' => true, 'bootstrap' => false),
  * 	))
  * }}}
  *
- * The above example will load the bootstrap file for all plugins, but for DebugKit it will only load the routes file
- * and will not look for any bootstrap script.
+ * The above example will load the bootstrap file for all plugins, but for DebugKit it will only load
+ * the routes file and will not look for any bootstrap script.
  *
  * @param array $options
  * @return void

--- a/lib/Cake/Test/Case/Core/CakePluginTest.php
+++ b/lib/Cake/Test/Case/Core/CakePluginTest.php
@@ -253,13 +253,31 @@ class CakePluginTest extends CakeTestCase {
 	}
 
 /**
- * Tests that CakePlugin::loadAll() will load all plugins in the configured folder wit defaults
- * and overrides for a plugin
+ * Tests that CakePlugin::loadAll() will load all plugins in the configured folder with defaults
+ * and merges in global defaults.
  *
  * @return void
  */
 	public function testLoadAllWithDefaultsAndOverride() {
 		CakePlugin::loadAll(array(array('bootstrap' => true), 'TestPlugin' => array('routes' => true)));
+		CakePlugin::routes();
+
+		$expected = array('PluginJs', 'TestPlugin', 'TestPluginTwo');
+		$this->assertEquals($expected, CakePlugin::loaded());
+		$this->assertEquals('loaded js plugin bootstrap', Configure::read('CakePluginTest.js_plugin.bootstrap'));
+		$this->assertEquals('loaded plugin routes', Configure::read('CakePluginTest.test_plugin.routes'));
+		$this->assertEquals('loaded plugin bootstrap', Configure::read('CakePluginTest.test_plugin.bootstrap'));
+		$this->assertEquals('loaded plugin two bootstrap', Configure::read('CakePluginTest.test_plugin_two.bootstrap'));
+	}
+
+/**
+ * Tests that CakePlugin::loadAll() will load all plugins in the configured folder with defaults
+ * and overrides for a plugin
+ *
+ * @return void
+ */
+	public function testLoadAllWithDefaultsAndOverrideComplex() {
+		CakePlugin::loadAll(array(array('bootstrap' => true), 'TestPlugin' => array('routes' => true, 'bootstrap' => false)));
 		CakePlugin::routes();
 
 		$expected = array('PluginJs', 'TestPlugin', 'TestPluginTwo');


### PR DESCRIPTION
This is how the loadAll method should intuitively work.
If global defaults are set, they should be respected as long as they are not specifically overwritten by a specific plugin config.

For me it is not sound that having global `bootstrap => true` suddenly doesnt work anymore just because for a plugin I add `routes => true`, as well.

``` php
CakePlugin::loadAll(array(
        array('bootstrap' => true), // For all plugins
        'Pdf' => array('routes' => true)
));
```

Would not load the bootstrap for Pdf now.

This would be needed, which seems overhead to me:

``` php
CakePlugin::loadAll(array(
        array('bootstrap' => true), // For all plugins
        'Pdf' => array('routes' => true, 'bootstrap' => true) // Even though we said we want bootstrap for all plugins
));
```

This is the intuitive way when we don't want the global config for a specific plugin:

``` php
CakePlugin::loadAll(array(
        array('bootstrap' => true), // For all plugins
        'Pdf' => array('routes' => true, 'bootstrap' => false)
));
```
