### PR TITLE
3.0 Remove validation i18n

### DIFF
--- a/src/Console/Command/Task/ExtractTask.php
+++ b/src/Console/Command/Task/ExtractTask.php
@@ -94,13 +94,6 @@ class ExtractTask extends Shell {
 	protected $_exclude = [];
 
 /**
- * Holds whether this call should extract model validation messages
- *
- * @var boolean
- */
-	protected $_extractValidation = true;
-
-/**
  * Holds the validation string domain to use for validation messages when extracting
  *
  * @var boolean
@@ -183,9 +176,6 @@ class ExtractTask extends Shell {
 			$this->_exclude = array_merge($this->_exclude, App::path('Plugin'));
 		}
 
-		if (!empty($this->params['ignore-model-validation']) || (!$this->_isExtractingApp() && empty($plugin))) {
-			$this->_extractValidation = false;
-		}
 		if (!empty($this->params['validation-domain'])) {
 			$this->_validationDomain = $this->params['validation-domain'];
 		}
@@ -288,12 +278,10 @@ class ExtractTask extends Shell {
 		$this->out(__d('cake_console', 'Output Directory: ') . $this->_output);
 		$this->hr();
 		$this->_extractTokens();
-		$this->_extractValidationMessages();
 		$this->_buildFiles();
 		$this->_writeFiles();
 		$this->_paths = $this->_files = $this->_storage = [];
 		$this->_translations = $this->_tokens = [];
-		$this->_extractValidation = true;
 		$this->out();
 		$this->out(__d('cake_console', 'Done.'));
 	}
@@ -433,107 +421,6 @@ class ExtractTask extends Shell {
 				}
 			}
 			$count++;
-		}
-	}
-
-/**
- * Looks for models in the application and extracts the validation messages
- * to be added to the translation map
- *
- * @return void
- */
-	protected function _extractValidationMessages() {
-		if (!$this->_extractValidation) {
-			return;
-		}
-
-		$plugins = [null];
-		if (empty($this->params['exclude-plugins'])) {
-			$plugins = array_merge($plugins, App::objects('Plugin', null, false));
-		}
-		foreach ($plugins as $plugin) {
-			$this->_extractPluginValidationMessages($plugin);
-		}
-	}
-
-/**
- * Extract validation messages from application or plugin models
- *
- * @param string $plugin Plugin name or `null` to process application models
- * @return void
- */
-	protected function _extractPluginValidationMessages($plugin = null) {
-		if (!empty($plugin)) {
-			if (!Plugin::loaded($plugin)) {
-				return;
-			}
-			$plugin = $plugin . '.';
-		}
-		$models = App::objects($plugin . 'Model', null, false);
-
-		foreach ($models as $model) {
-			$modelClass = App::classname($plugin . $model, 'Model');
-			$reflection = new \ReflectionClass($modelClass);
-			if (!$reflection->isSubClassOf('Cake\Model\Model')) {
-				continue;
-			}
-			$properties = $reflection->getDefaultProperties();
-			$validate = $properties['validate'];
-			if (empty($validate)) {
-				continue;
-			}
-
-			$file = $reflection->getFileName();
-			$domain = $this->_validationDomain;
-			if (!empty($properties['validationDomain'])) {
-				$domain = $properties['validationDomain'];
-			}
-			foreach ($validate as $field => $rules) {
-				$this->_processValidationRules($field, $rules, $file, $domain);
-			}
-		}
-	}
-
-/**
- * Process a validation rule for a field and looks for a message to be added
- * to the translation map
- *
- * @param string $field the name of the field that is being processed
- * @param array $rules the set of validation rules for the field
- * @param string $file the file name where this validation rule was found
- * @param string $domain default domain to bind the validations to
- * @param string $category the translation category
- * @return void
- */
-	protected function _processValidationRules($field, $rules, $file, $domain, $category = 'LC_MESSAGES') {
-		if (!is_array($rules)) {
-			return;
-		}
-
-		$dims = Hash::dimensions($rules);
-		if ($dims === 1 || ($dims === 2 && isset($rules['message']))) {
-			$rules = [$rules];
-		}
-
-		foreach ($rules as $rule => $validateProp) {
-			$msgid = null;
-			if (isset($validateProp['message'])) {
-				if (is_array($validateProp['message'])) {
-					$msgid = $validateProp['message'][0];
-				} else {
-					$msgid = $validateProp['message'];
-				}
-			} elseif (is_string($rule)) {
-				$msgid = $rule;
-			}
-			if ($msgid) {
-				$msgid = $this->_formatString(sprintf("'%s'", $msgid));
-				$details = [
-					'file' => $file,
-					'line' => 'validation for field ' . $field
-				];
-				$this->_addTranslation($category, $domain, $msgid, $details);
-			}
 		}
 	}
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -43,13 +43,6 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 	protected $_providers = [];
 
 /**
- * The translation domain to use when setting the error messages
- *
- * @var string
- */
-	protected $_validationDomain = 'default';
-
-/**
  * Contains the validation messages associated with checking the presence
  * for each corresponding field.
  *
@@ -84,7 +77,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 
 			if (!$keyPresent && !$this->_checkPresence($field, $newRecord)) {
 				$errors[$name][] = isset($this->_presenceMessages[$name])
-					? __d($this->_validationDomain, $this->_presenceMessages[$name])
+					? $this->_presenceMessages[$name]
 					: $requiredMessage;
 				continue;
 			}
@@ -98,7 +91,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 
 			if (!$canBeEmpty && $isEmpty) {
 				$errors[$name][] = isset($this->_allowEmptyMessages[$name])
-					? __d($this->_validationDomain, $this->_allowEmptyMessages[$name])
+					? $this->_allowEmptyMessages[$name]
 					: $emptyMessage;
 				continue;
 			}
@@ -167,17 +160,6 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 			return null;
 		}
 		$this->_providers[$name] = $object;
-		return $this;
-	}
-
-/**
- * Sets the I18n domain for validation messages. This method is chainable.
- *
- * @param string $validationDomain The validation domain to be used.
- * @return \Cake\Validation\Validation
- */
-	public function setValidationDomain($validationDomain) {
-		$this->_validationDomain = $validationDomain;
 		return $this;
 	}
 
@@ -442,7 +424,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
 
 			$errors[$name] = __d('cake', 'The provided value is invalid');
 			if (is_string($result)) {
-				$errors[$name] = __d($this->_validationDomain, $result);
+				$errors[$name] = $result;
 			}
 
 			if ($rule->isLast()) {

--- a/tests/TestCase/Console/Command/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ExtractTaskTest.php
@@ -209,10 +209,10 @@ class ExtractTaskTest extends TestCase {
 		$this->out = $this->getMock('Cake\Console\ConsoleOutput', array(), array(), '', false);
 		$this->in = $this->getMock('Cake\Console\ConsoleInput', array(), array(), '', false);
 		$this->Task = $this->getMock('Cake\Console\Command\Task\ExtractTask',
-			array('_isExtractingApp', '_extractValidationMessages', 'in', 'out', 'err', 'clear', '_stop'),
+			array('_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'),
 			array($this->out, $this->out, $this->in)
 		);
-		$this->Task->expects($this->exactly(2))
+		$this->Task->expects($this->exactly(1))
 			->method('_isExtractingApp')
 			->will($this->returnValue(true));
 
@@ -243,106 +243,11 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['plugin'] = 'TestPlugin';
 
-		$this->markTestIncomplete('Extracting validation messages from plugin models is not working.');
 		$this->Task->execute();
 		$result = file_get_contents($this->path . DS . 'default.pot');
 		$this->assertNotRegExp('#Pages#', $result);
 		$this->assertRegExp('/translate\.ctp:\d+/', $result);
 		$this->assertContains('This is a translatable string', $result);
-		$this->assertContains('I can haz plugin model validation message', $result);
-	}
-
-/**
- * Tests that the task will inspect application models and extract the validation messages from them
- *
- * @return void
- */
-	public function testExtractModelValidation() {
-		$this->markTestIncomplete('Extracting validation messages is not working right now.');
-		Configure::write('App.namespace', 'TestApp');
-		Plugin::load('TestPlugin');
-
-		$this->out = $this->getMock('Cake\Console\ConsoleOutput', array(), array(), '', false);
-		$this->in = $this->getMock('Cake\Console\ConsoleInput', array(), array(), '', false);
-		$this->Task = $this->getMock('Cake\Console\Command\Task\ExtractTask',
-			array('_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'),
-			array($this->out, $this->out, $this->in)
-		);
-		$this->Task->expects($this->exactly(2))
-			->method('_isExtractingApp')
-			->will($this->returnValue(true));
-
-		$this->Task->params['paths'] = TEST_APP . 'TestApp/';
-		$this->Task->params['output'] = $this->path . DS;
-		$this->Task->params['extract-core'] = 'no';
-		$this->Task->params['exclude-plugins'] = true;
-		$this->Task->params['ignore-model-validation'] = false;
-
-		$this->Task->execute();
-		$result = file_get_contents($this->path . DS . 'default.pot');
-
-		$pattern = preg_quote('#Model/PersisterOne.php:validation for field title#', '\\');
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = preg_quote('#Model/PersisterOne.php:validation for field body#', '\\');
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post title is required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "You may enter up to %s chars \(minimum is %s chars\)"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post body is required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post body is super required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$this->assertContains('msgid "double \\"quoted\\" validation"', $result, 'Strings with quotes not handled correctly');
-		$this->assertContains("msgid \"single 'quoted' validation\"", $result, 'Strings with quotes not handled correctly');
-	}
-
-/**
- *  Test that the extract shell can obtain validation messages from models inside a specific plugin
- *
- * @return void
- */
-	public function testExtractModelValidationInPlugin() {
-		$this->markTestIncomplete('Extracting validation messages is not working right now.');
-		Configure::write('App.namespace', 'TestApp');
-		Plugin::load('TestPlugin');
-		$this->out = $this->getMock('Cake\Console\ConsoleOutput', array(), array(), '', false);
-		$this->in = $this->getMock('Cake\Console\ConsoleInput', array(), array(), '', false);
-		$this->Task = $this->getMock('Cake\Console\Command\Task\ExtractTask',
-			array('_isExtractingApp', 'in', 'out', 'err', 'clear', '_stop'),
-			array($this->out, $this->out, $this->in)
-		);
-
-		$this->Task->params['output'] = $this->path . DS;
-		$this->Task->params['ignore-model-validation'] = false;
-		$this->Task->params['plugin'] = 'TestPlugin';
-
-		$this->Task->execute();
-		$result = file_get_contents($this->path . DS . 'test_plugin.pot');
-
-		$pattern = preg_quote('#Model/TestPluginPost.php:validation for field title#', '\\');
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = preg_quote('#Model/TestPluginPost.php:validation for field body#', '\\');
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post title is required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post body is required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#msgid "Post body is super required"#';
-		$this->assertRegExp($pattern, $result);
-
-		$pattern = '#Plugin/TestPlugin/Model/TestPluginPost.php:validation for field title#';
-		$this->assertNotRegExp($pattern, $result);
 	}
 
 /**


### PR DESCRIPTION
The validator classes currently have i18n logic sprinkled in them. I don't feel this is necessary anymore, as validators are declared inside methods now. With validators being defined in methods, we don't have the same problems we had in 2.x.

People wanting translated validation messages can simply use the `__*()` family of functions when providing their validation messages now.
