### PR TITLE
3.0 mixed

### DIFF
--- a/src/Collection/CollectionTrait.php
+++ b/src/Collection/CollectionTrait.php
@@ -181,7 +181,7 @@ trait CollectionTrait {
  * Returns true if $value is present in this collection. Comparisons are made
  * both by value and type.
  *
- * @param mixed $value the value to check for
+ * @param mixed $value The value to check for
  * @return boolean true if $value is present in this collection
  */
 	public function contains($value) {

--- a/src/Collection/Iterator/MapReduce.php
+++ b/src/Collection/Iterator/MapReduce.php
@@ -133,7 +133,7 @@ class MapReduce implements IteratorAggregate {
  * Appends a new record to the bucket labelled with $key, usually as a result
  * of mapping a single record from the original data.
  *
- * @param mixed $value the record itself to store in the bucket
+ * @param mixed $value The record itself to store in the bucket
  * @param string $bucket the name of the bucket where to put the record
  * @return void
  */

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -50,7 +50,7 @@ class Comparison extends QueryExpression {
  * Constructor
  *
  * @param string $field the field name to compare to a value
- * @param mixed $value the value to be used in comparison
+ * @param mixed $value The value to be used in comparison
  * @param string $type the type name used to cast the value
  * @param string $conjunction the operator used for comparing field and value
  */

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -127,7 +127,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field = value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * If it is suffixed with "[]" and the value is an array then multiple placeholders
  * will be created, one per each value in the array.
@@ -141,7 +141,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field != value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * If it is suffixed with "[]" and the value is an array then multiple placeholders
  * will be created, one per each value in the array.
@@ -155,7 +155,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field > value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -167,7 +167,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field < value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -179,7 +179,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field >= value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -191,7 +191,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field <= value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -223,7 +223,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field LIKE value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */
@@ -235,7 +235,7 @@ class QueryExpression implements ExpressionInterface, Countable {
  * Adds a new condition to the expression object in the form "field NOT LIKE value".
  *
  * @param string $field database field to be compared against value
- * @param mixed $value the value to be bound to $field for comparison
+ * @param mixed $value The value to be bound to $field for comparison
  * @param string $type the type name for $value as configured using the Type map.
  * @return QueryExpression
  */

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -63,7 +63,7 @@ class LoggingStatement extends StatementDecorator {
  * in the logger function.
  *
  * @param string|integer $column name or param position to be bound
- * @param mixed $value the value to bind to variable in query
+ * @param mixed $value The value to bind to variable in query
  * @param string|integer $type PDO type or name of configured Type class
  * @return void
  */

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -1645,7 +1645,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param string|integer $param placeholder to be replaced with quoted version
  * of $value
- * @param mixed $value the value to be bound
+ * @param mixed $value The value to be bound
  * @param string|integer $type the mapped type name, used for casting when sending
  * to database
  * @return Query

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -53,7 +53,7 @@ class PDOStatement extends StatementDecorator {
  *	`$statement->bindValue(5, new \DateTime(), 'date');`
  *
  * @param string|integer $column name or param position to be bound
- * @param mixed $value the value to bind to variable in query
+ * @param mixed $value The value to bind to variable in query
  * @param string|integer $type PDO type or name of configured Type class
  * @return void
  */

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -81,7 +81,7 @@ class PDOStatement extends StatementDecorator {
  * }}}
  *
  * @param string $type 'num' for positional columns, assoc for named columns
- * @return mixed|boolean result array containing columns and values or false if no results
+ * @return mixed Result array containing columns and values or false if no results
  * are left
  */
 	public function fetch($type = 'num') {

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -84,7 +84,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
  * }}
  *
  * @param string|integer $column name or param position to be bound
- * @param mixed $value the value to bind to variable in query
+ * @param mixed $value The value to bind to variable in query
  * @param string $type name of configured Type class
  * @return void
  */

--- a/src/Database/Statement/StatementDecorator.php
+++ b/src/Database/Statement/StatementDecorator.php
@@ -166,7 +166,7 @@ class StatementDecorator implements StatementInterface, \Countable, \IteratorAgg
  * }}}
  *
  * @param string $type 'num' for positional columns, assoc for named columns
- * @return mixed|boolean result array containing columns and values or false if no results
+ * @return mixed Result array containing columns and values or false if no results
  * are left
  */
 	public function fetch($type = 'num') {

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -104,7 +104,7 @@ interface StatementInterface {
  * }}}
  *
  * @param string $type 'num' for positional columns, assoc for named columns
- * @return mixed|boolean result array containing columns and values or false if no results
+ * @return mixed Result array containing columns and values or false if no results
  * are left
  */
 	public function fetch($type = 'num');

--- a/src/Database/StatementInterface.php
+++ b/src/Database/StatementInterface.php
@@ -34,7 +34,7 @@ interface StatementInterface {
  *	`$statement->bindValue(5, new \DateTime(), 'date');`
  *
  * @param string|integer $column name or param position to be bound
- * @param mixed $value the value to bind to variable in query
+ * @param mixed $value The value to bind to variable in query
  * @param string $type name of configured Type class
  * @return void
  */

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -40,7 +40,7 @@ class ValueBinder {
  *
  * @param string|integer $param placeholder to be replaced with quoted version
  * of $value
- * @param mixed $value the value to be bound
+ * @param mixed $value The value to be bound
  * @param string|integer $type the mapped type name, used for casting when sending
  * to database
  * @return void

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -29,7 +29,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable {
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
- * @param mixed|array $value the value to set to the property or an array if the
+ * @param mixed $value the value to set to the property or an array if the
  * first argument is also an array, in which case will be treated as $options
  * @param array $options options to be used for setting the property. Allowed option
  * keys are `setter` and `guard`

--- a/src/Datasource/EntityInterface.php
+++ b/src/Datasource/EntityInterface.php
@@ -29,7 +29,7 @@ interface EntityInterface extends ArrayAccess, JsonSerializable {
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
- * @param mixed $value the value to set to the property or an array if the
+ * @param mixed $value The value to set to the property or an array if the
  * first argument is also an array, in which case will be treated as $options
  * @param array $options options to be used for setting the property. Allowed option
  * keys are `setter` and `guard`

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -118,7 +118,7 @@ trait EntityTrait {
  * Magic setter to add or edit a property in this entity
  *
  * @param string $property the name of the property to set
- * @param mixed $value the value to set to the property
+ * @param mixed $value The value to set to the property
  * @return void
  */
 	public function __set($property, $value) {
@@ -192,7 +192,7 @@ trait EntityTrait {
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
- * @param mixed $value the value to set to the property or an array if the
+ * @param mixed $value The value to set to the property or an array if the
  * first argument is also an array, in which case will be treated as $options
  * @param array $options options to be used for setting the property. Allowed option
  * keys are `setter` and `guard`

--- a/src/Datasource/EntityTrait.php
+++ b/src/Datasource/EntityTrait.php
@@ -192,7 +192,7 @@ trait EntityTrait {
  *
  * @param string|array $property the name of property to set or a list of
  * properties with their respective values
- * @param mixed|array $value the value to set to the property or an array if the
+ * @param mixed $value the value to set to the property or an array if the
  * first argument is also an array, in which case will be treated as $options
  * @param array $options options to be used for setting the property. Allowed option
  * keys are `setter` and `guard`

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -342,7 +342,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 /**
  * Correctly nests results keys including those coming from associations
  *
- * @param mixed $row array containing columns and values or false if there is no results
+ * @param mixed $row Array containing columns and values or false if there is no results
  * @return array Results
  */
 	protected function _groupResult($row) {

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -173,7 +173,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	}
 
 /**
- * Rewind a ResultSet.
+ * Rewinds a ResultSet.
  *
  * Part of Iterator interface.
  *
@@ -222,7 +222,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	}
 
 /**
- * Serialize a resultset.
+ * Serializes a resultset.
  *
  * Part of Serializable interface.
  *
@@ -236,7 +236,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	}
 
 /**
- * Unserialize a resultset.
+ * Unserializes a resultset.
  *
  * Part of Serializable interface.
  *
@@ -340,10 +340,10 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
 	}
 
 /**
- * Correctly nest results keys including those coming from associations
+ * Correctly nests results keys including those coming from associations
  *
- * @param mixed|boolean $row array containing columns and values or false if there is no results
- * @return array
+ * @param mixed $row array containing columns and values or false if there is no results
+ * @return array Results
  */
 	protected function _groupResult($row) {
 		$defaultAlias = $this->_defaultTable->alias();

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -1248,7 +1248,7 @@ class Table implements RepositoryInterface, EventListener {
  * for id generation.
  *
  * @param array $primary The primary key columns to get a new ID for.
- * @return null|mixed Either null or the new primary key value.
+ * @return mixed Either null or the new primary key value.
  */
 	protected function _newId($primary) {
 		if (!$primary || count((array)$primary) > 1) {

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -425,7 +425,7 @@ class Validator implements \ArrayAccess, \IteratorAggregate, \Countable {
  * from executing them
  *
  * @param ValidationSet $rules the list of rules for a field
- * @param mixed $value the value to be checked
+ * @param mixed $value The value to be checked
  * @param array $data the full data passed to the validator
  * @param boolean $newRecord whether is it a new record or an existing one
  * @return array


### PR DESCRIPTION
Doesn't "mixed" already include all types?
The `|` only makes sense for specific types IMO, like `array|boolean`.
