### PR TITLE
3.0 form inputs

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -712,7 +712,7 @@ class FormHelper extends Helper {
 	}
 
 /**
- * Generate a set of inputs for `$fields`. If $fields is null the fields of current model
+ * Generate a set of inputs for `$fields`. If $fields is empty the fields of current model
  * will be used.
  *
  * You can customize individual inputs through `$fields`.
@@ -725,16 +725,12 @@ class FormHelper extends Helper {
  * You can exclude fields using the `$blacklist` parameter:
  *
  * {{{
- * $this->Form->inputs(null, ['title']);
+ * $this->Form->inputs([], ['title']);
  * }}}
  *
  * In the above example, no field would be generated for the title field.
  *
- * In addition to controller fields output, `$fields` can be used to control legend
- * and fieldset rendering.
- * `$this->Form->inputs('My legend');` Would generate an input set with a custom legend.
- *
- * @param mixed $fields An array of customizations for the fields that will be
+ * @param array $fields An array of customizations for the fields that will be
  *   generated. This array allows you to set custom types, labels, or other options.
  * @param array $blacklist A list of fields to not create inputs for.
  * @param array $options Options array. Valid keys are:
@@ -744,19 +740,11 @@ class FormHelper extends Helper {
  * @return string Completed form inputs.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
-	public function inputs($fields = null, array $blacklist = [], array $options = []) {
+	public function inputs(array $fields = [], array $blacklist = [], array $options = []) {
 		$fieldset = $legend = true;
 		$context = $this->_getContext();
 
 		$modelFields = $context->fieldNames();
-
-		if (is_string($fields)) {
-			$legend = $fields;
-			$fields = [];
-		} elseif (is_bool($fields)) {
-			$fieldset = $legend = $fields;
-			$fields = [];
-		}
 
 		$fields = array_merge(
 			Hash::normalize($modelFields),

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -748,7 +748,7 @@ class FormHelper extends Helper {
 
 		$fields = array_merge(
 			Hash::normalize($modelFields),
-			Hash::normalize((array)$fields)
+			Hash::normalize($fields)
 		);
 
 		if (isset($options['legend'])) {

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2649,7 +2649,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputsLegendFieldset() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs('The Legend');
+		$result = $this->Form->inputs([], [], array('legend' => 'The Legend'));
 		$expected = array(
 			'<fieldset',
 			'<legend',
@@ -2659,19 +2659,15 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs(null, array(), array('legend' => 'Field of Dreams', 'fieldset' => true));
+		$result = $this->Form->inputs([], [], array('fieldset' => true, 'legend' => 'Field of Dreams'));
 		$this->assertContains('<legend>Field of Dreams</legend>', $result);
 		$this->assertContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs('Field of Dreams', array(), array('fieldset' => true));
-		$this->assertContains('<legend>Field of Dreams</legend>', $result);
-		$this->assertContains('<fieldset>', $result);
-
-		$result = $this->Form->inputs(null, array(), array('fieldset' => false, 'legend' => false));
+		$result = $this->Form->inputs([], [], array('fieldset' => false, 'legend' => false));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs(null, array(), array('fieldset' => false, 'legend' => 'Hello'));
+		$result = $this->Form->inputs([], [], array('fieldset' => false, 'legend' => 'Hello'));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
@@ -2734,7 +2730,7 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs('Hello');
+		$result = $this->Form->inputs([], [], ['legend' => 'Hello']);
 		$expected = array(
 			'fieldset' => array(),
 			'legend' => array(),


### PR DESCRIPTION
I propose to remove the semi-documented param weirdness around FormHelper::inputs() and simplify it to just an array for the first argument.

No mixture of bools/strings/arrays anymore, just array :)
