### PR TITLE
Simplify Number::format()

### DIFF
--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -199,7 +199,7 @@ class Number {
  *
  * @param float $value A floating point number.
  * @param array $options An array with options.
- * @return string formatted number
+ * @return string Formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
  */
 	public static function format($value, array $options = []) {

--- a/src/Utility/Number.php
+++ b/src/Utility/Number.php
@@ -188,39 +188,25 @@ class Number {
 /**
  * Formats a number into a currency format.
  *
- * @param float $value A floating point number
- * @param integer $options If integer then places, if string then before, if (,.-) then use it
- *   or array with places and before keys
+ * Options:
+ *
+ * - `places` - Number of decimal places to use. ie. 2
+ * - `before` - The string to place before whole numbers. ie. '['
+ * - `after` - The string to place after decimal numbers. ie. ']'
+ * - `thousands` - Thousands separator ie. ','
+ * - `decimals` - Decimal separator symbol ie. '.'
+ * - `escape` - Set to false to prevent escaping
+ *
+ * @param float $value A floating point number.
+ * @param array $options An array with options.
  * @return string formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
  */
-	public static function format($value, $options = false) {
-		$places = 0;
-		if (is_int($options)) {
-			$places = $options;
-		}
-
-		$separators = array(',', '.', '-', ':');
-
-		$before = $after = null;
-		if (is_string($options) && !in_array($options, $separators)) {
-			$before = $options;
-		}
-		$thousands = ',';
-		if (!is_array($options) && in_array($options, $separators)) {
-			$thousands = $options;
-		}
-		$decimals = '.';
-		if (!is_array($options) && in_array($options, $separators)) {
-			$decimals = $options;
-		}
-
-		$escape = true;
-		if (is_array($options)) {
-			$defaults = array('before' => '$', 'places' => 2, 'thousands' => ',', 'decimals' => '.');
-			$options += $defaults;
-			extract($options);
-		}
+	public static function format($value, array $options = []) {
+		$defaults = array('before' => '', 'after' => '', 'places' => 2,
+			'thousands' => ',', 'decimals' => '.', 'escape' => true);
+		$options += $defaults;
+		extract($options);
 
 		$out = $before . number_format($value, $places, $decimals, $thousands) . $after;
 

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -133,13 +133,12 @@ class NumberHelper extends Helper {
  *
  * @see \Cake\Utility\Number::format()
  *
- * @param float $number A floating point number
- * @param mixed $options If integer then places, if string then before, if (,.-) then use it
- *   or array with places and before keys
- * @return string formatted number
+ * @param float $number A floating point number.
+ * @param array $options Array of options.
+ * @return string Formatted number
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/number.html#NumberHelper::format
  */
-	public function format($number, $options = false) {
+	public function format($number, array $options = []) {
 		return $this->_engine->format($number, $options);
 	}
 

--- a/tests/TestCase/Utility/NumberTest.php
+++ b/tests/TestCase/Utility/NumberTest.php
@@ -53,34 +53,38 @@ class NumberTest extends TestCase {
 	public function testFormat() {
 		$value = '100100100';
 
-		$result = $this->Number->format($value, '#');
-		$expected = '#100,100,100';
+		$result = $this->Number->format($value);
+		$expected = '100,100,100.00';
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Number->format($value, 3);
+		$result = $this->Number->format($value, array('before' => '#'));
+		$expected = '#100,100,100.00';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Number->format($value, array('places' => 3));
 		$expected = '100,100,100.000';
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Number->format($value);
-		$expected = '100,100,100';
+		$result = $this->Number->format($value, array('thousands' => '-'));
+		$expected = '100-100-100.00';
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Number->format($value, '-');
-		$expected = '100-100-100';
+		$result = $this->Number->format($value, array('decimals' => ',', 'thousands' => '.'));
+		$expected = '100.100.100,00';
 		$this->assertEquals($expected, $result);
 
 		$value = 0.00001;
-		$result = $this->Number->format($value, array('places' => 1));
+		$result = $this->Number->format($value, array('places' => 1, 'before' => '$'));
 		$expected = '$0.0';
 		$this->assertEquals($expected, $result);
 
 		$value = -0.00001;
-		$result = $this->Number->format($value, array('places' => 1));
+		$result = $this->Number->format($value, array('places' => 1, 'before' => '$'));
 		$expected = '$-0.0';
 		$this->assertEquals($expected, $result);
 
 		$value = 1.23;
-		$options = array('decimals' => ',', 'thousands' => '.', 'before' => '', 'after' => ' €');
+		$options = array('decimals' => ',', 'thousands' => '.', 'after' => ' €');
 		$result = $this->Number->format($value, $options);
 		$expected = '1,23 €';
 		$this->assertEquals($expected, $result);
@@ -142,7 +146,6 @@ class NumberTest extends TestCase {
 			'decimals' => '&amp;',
 			'places' => 3,
 			'escape' => false,
-			'before' => '',
 		));
 		$expected = '5&nbsp;199&nbsp;100&amp;001';
 		$this->assertEquals($expected, $result);
@@ -153,7 +156,7 @@ class NumberTest extends TestCase {
 			'decimals' => '.a',
 			'escape' => false,
 		));
-		$expected = '$1,,000.a45';
+		$expected = '1,,000.a45';
 		$this->assertEquals($expected, $result);
 
 		$value = 519919827593784.00;
@@ -172,7 +175,6 @@ class NumberTest extends TestCase {
 		$result = Number::format($value, array(
 			'thousands' => '- |-| /-\ >< () |2 -',
 			'decimals' => '- £€€† -',
-			'before' => ''
 		));
 		$expected = '13- |-| /-\ &gt;&lt; () |2 -371- |-| /-\ &gt;&lt; () |2 -337- £€€† -13';
 		$this->assertEquals($expected, $result);

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -79,7 +79,7 @@ class NumberHelperTest extends TestCase {
  */
 	public function testNumberHelperProxyMethodCalls() {
 		$methods = array(
-			'precision', 'toReadableSize', 'format',
+			'precision', 'toReadableSize',
 		);
 		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', $methods);
 		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
@@ -101,6 +101,12 @@ class NumberHelperTest extends TestCase {
 		$Number->attach($CakeNumber);
 		$CakeNumber->expects($this->at(0))->method('currency');
 		$Number->currency('who', 'what', array('when'));
+
+		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', array('format'));
+		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));
+		$Number->attach($CakeNumber);
+		$CakeNumber->expects($this->at(0))->method('format');
+		$Number->format('who', array('when'));
 
 		$CakeNumber = $this->getMock(__NAMESPACE__ . '\NumberMock', array('addFormat'));
 		$Number = new NumberHelperTestObject($this->View, array('engine' => __NAMESPACE__ . '\NumberMock'));


### PR DESCRIPTION
``` php
public static function format($value, array $options = []) {}
```

This eases the way for a more consistent functionality and format replacement in 3.0 which will sure soon be on the agenda.
