### PR TITLE
Simplify Time::timeAgoInWords()

### DIFF
--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -608,7 +608,6 @@ class Time {
  * - `end` => The end of relative time telling
  * - `relativeString` => The printf compatible string when outputting relative time
  * - `absoluteString` => The printf compatible string when outputting absolute time
- * - `userOffset` => Users offset from GMT (in hours) *Deprecated* use timezone intead.
  * - `timezone` => The user timezone the timestamp should be formatted in.
  *
  * Relative dates look something like this:
@@ -638,8 +637,6 @@ class Time {
 
 		if (isset($options['timezone'])) {
 			$timezone = $options['timezone'];
-		} elseif (isset($options['userOffset'])) {
-			$timezone = $options['userOffset'];
 		}
 
 		if (isset($options['accuracy'])) {

--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -623,12 +623,12 @@ class Time {
  *
  * NOTE: If the difference is one week or more, the lowest level of accuracy is day
  *
- * @param integer|string|\DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object
- * @param string|array $options Default format if timestamp is used in $dateString
+ * @param integer|string|\DateTime $dateTime Datetime UNIX timestamp, strtotime() valid string or DateTime object.
+ * @param array $options Array of options.
  * @return string Relative time string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#TimeHelper::timeAgoInWords
  */
-	public static function timeAgoInWords($dateTime, $options = array()) {
+	public static function timeAgoInWords($dateTime, array $options = []) {
 		$timezone = null;
 		$format = static::$wordFormat;
 		$end = static::$wordEnd;
@@ -636,41 +636,38 @@ class Time {
 		$absoluteString = __d('cake', 'on %s');
 		$accuracy = static::$wordAccuracy;
 
-		if (is_array($options)) {
-			if (isset($options['timezone'])) {
-				$timezone = $options['timezone'];
-			} elseif (isset($options['userOffset'])) {
-				$timezone = $options['userOffset'];
-			}
 
-			if (isset($options['accuracy'])) {
-				if (is_array($options['accuracy'])) {
-					$accuracy = array_merge($accuracy, $options['accuracy']);
-				} else {
-					foreach ($accuracy as $key => $level) {
-						$accuracy[$key] = $options['accuracy'];
-					}
+		if (isset($options['timezone'])) {
+			$timezone = $options['timezone'];
+		} elseif (isset($options['userOffset'])) {
+			$timezone = $options['userOffset'];
+		}
+
+		if (isset($options['accuracy'])) {
+			if (is_array($options['accuracy'])) {
+				$accuracy = array_merge($accuracy, $options['accuracy']);
+			} else {
+				foreach ($accuracy as $key => $level) {
+					$accuracy[$key] = $options['accuracy'];
 				}
 			}
-
-			if (isset($options['format'])) {
-				$format = $options['format'];
-			}
-			if (isset($options['end'])) {
-				$end = $options['end'];
-			}
-			if (isset($options['relativeString'])) {
-				$relativeString = $options['relativeString'];
-				unset($options['relativeString']);
-			}
-			if (isset($options['absoluteString'])) {
-				$absoluteString = $options['absoluteString'];
-				unset($options['absoluteString']);
-			}
-			unset($options['end'], $options['format']);
-		} else {
-			$format = $options;
 		}
+
+		if (isset($options['format'])) {
+			$format = $options['format'];
+		}
+		if (isset($options['end'])) {
+			$end = $options['end'];
+		}
+		if (isset($options['relativeString'])) {
+			$relativeString = $options['relativeString'];
+			unset($options['relativeString']);
+		}
+		if (isset($options['absoluteString'])) {
+			$absoluteString = $options['absoluteString'];
+			unset($options['absoluteString']);
+		}
+		unset($options['end'], $options['format']);
 
 		$now = static::fromString(time(), $timezone);
 		$inSeconds = static::fromString($dateTime, $timezone);

--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -636,7 +636,6 @@ class Time {
 		$absoluteString = __d('cake', 'on %s');
 		$accuracy = static::$wordAccuracy;
 
-
 		if (isset($options['timezone'])) {
 			$timezone = $options['timezone'];
 		} elseif (isset($options['userOffset'])) {

--- a/tests/TestCase/Utility/TimeTest.php
+++ b/tests/TestCase/Utility/TimeTest.php
@@ -270,15 +270,15 @@ class TimeTest extends TestCase {
  * @return void
  */
 	public function testTimeAgoInWordsWithFormat() {
-		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
+		$result = $this->Time->timeAgoInWords('2007-9-25', array('format' => 'Y-m-d'));
 		$this->assertEquals('on 2007-09-25', $result);
 
-		$result = $this->Time->timeAgoInWords('2007-9-25', 'Y-m-d');
+		$result = $this->Time->timeAgoInWords('2007-9-25', array('format' => 'Y-m-d'));
 		$this->assertEquals('on 2007-09-25', $result);
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('+2 weeks +2 days'),
-			'Y-m-d'
+			 array('format' =>'Y-m-d')
 		);
 		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
 
@@ -321,7 +321,7 @@ class TimeTest extends TestCase {
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('-2 weeks -2 days'),
-			'Y-m-d'
+			 array('format' =>'Y-m-d')
 		);
 		$this->assertEquals('2 weeks, 2 days ago', $result);
 

--- a/tests/TestCase/Utility/TimeTest.php
+++ b/tests/TestCase/Utility/TimeTest.php
@@ -278,7 +278,7 @@ class TimeTest extends TestCase {
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('+2 weeks +2 days'),
-			 array('format' =>'Y-m-d')
+			array('format' => 'Y-m-d')
 		);
 		$this->assertRegExp('/^2 weeks, [1|2] day(s)?$/', $result);
 
@@ -321,7 +321,7 @@ class TimeTest extends TestCase {
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('-2 weeks -2 days'),
-			 array('format' =>'Y-m-d')
+			array('format' => 'Y-m-d')
 		);
 		$this->assertEquals('2 weeks, 2 days ago', $result);
 


### PR DESCRIPTION
Simplier and concise API.

This also unifies the method signature with the view Helper which already is
`public function timeAgoInWords($dateTime, array $options = array()) {}`
