### PR TITLE
3.0 meta

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -198,42 +198,41 @@ class HtmlHelper extends Helper {
  *   custom block name.
  *
  * @param string $type The title of the external resource
- * @param string|array $url The address of the external resource or string for content attribute
+ * @param string|array $content The address of the external resource or string for content attribute
  * @param array $options Other attributes for the generated tag. If the type attribute is html,
  *    rss, atom, or icon, the mime-type is returned.
  * @return string A completed `<link />` element.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::meta
  */
-	public function meta($type, $url = null, array $options = array()) {
+	public function meta($type, $content = null, array $options = array()) {
 		$options += array('block' => null);
 
-		if (!is_array($type)) {
-			$types = array(
-				'rss' => array('type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $url),
-				'atom' => array('type' => 'application/atom+xml', 'title' => $type, 'link' => $url),
-				'icon' => array('type' => 'image/x-icon', 'rel' => 'icon', 'link' => $url),
-				'keywords' => array('name' => 'keywords', 'content' => $url),
-				'description' => array('name' => 'description', 'content' => $url),
-			);
+		$types = array(
+			'rss' => array('type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => $type, 'link' => $content),
+			'atom' => array('type' => 'application/atom+xml', 'title' => $type, 'link' => $content),
+			'icon' => array('type' => 'image/x-icon', 'rel' => 'icon', 'link' => $content),
+			'keywords' => array('name' => 'keywords', 'content' => $content),
+			'description' => array('name' => 'description', 'content' => $content),
+			'robots' => array('name' => 'robots', 'content' => $content),
+		);
 
-			if ($type === 'icon' && $url === null) {
-				$types['icon']['link'] = 'favicon.ico';
-			}
+		if ($type === 'icon' && $content === null) {
+			$types['icon']['link'] = 'favicon.ico';
+		}
 
-			if (isset($types[$type])) {
-				$type = $types[$type];
-			} elseif (!isset($options['type']) && $url !== null) {
-				if (is_array($url) && isset($url['ext'])) {
-					$type = $types[$url['ext']];
-				} else {
-					$type = $types['rss'];
-				}
-			} elseif (isset($options['type']) && isset($types[$options['type']])) {
-				$type = $types[$options['type']];
-				unset($options['type']);
+		if (isset($types[$type])) {
+			$type = $types[$type];
+		} elseif (!isset($options['type']) && $content !== null) {
+			if (is_array($content) && isset($content['ext'])) {
+				$type = $types[$content['ext']];
 			} else {
-				$type = array();
+				$type = $types['rss'];
 			}
+		} elseif (isset($options['type']) && isset($types[$options['type']])) {
+			$type = $types[$options['type']];
+			unset($options['type']);
+		} else {
+			$type = array();
 		}
 
 		$options += $type;

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1504,21 +1504,14 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->meta('atom', array('controller' => 'posts', 'ext' => 'xml'), array('link' => '/articles.rss'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/articles\.rss/', 'type' => 'application/atom+xml', 'title' => 'atom')));
 
-		$result = $this->Html->meta(array('link' => 'favicon.ico', 'rel' => 'icon'));
-		$expected = array(
-			'link' => array('href' => 'preg:/.*favicon\.ico/', 'rel' => 'icon'),
-			array('link' => array('href' => 'preg:/.*favicon\.ico/', 'rel' => 'shortcut icon'))
-		);
-		$this->assertTags($result, $expected);
-
 		$result = $this->Html->meta('keywords', 'these, are, some, meta, keywords');
 		$this->assertTags($result, array('meta' => array('name' => 'keywords', 'content' => 'these, are, some, meta, keywords')));
 
 		$result = $this->Html->meta('description', 'this is the meta description');
 		$this->assertTags($result, array('meta' => array('name' => 'description', 'content' => 'this is the meta description')));
 
-		$result = $this->Html->meta(array('name' => 'ROBOTS', 'content' => 'ALL'));
-		$this->assertTags($result, array('meta' => array('name' => 'ROBOTS', 'content' => 'ALL')));
+		$result = $this->Html->meta('robots', 'ALL');
+		$this->assertTags($result, array('meta' => array('name' => 'robots', 'content' => 'ALL')));
 	}
 
 /**
@@ -1576,13 +1569,13 @@ class HtmlHelperTest extends TestCase {
 	public function testMetaWithBlocks() {
 		$this->View->expects($this->at(0))
 			->method('append')
-			->with('meta', $this->stringContains('ROBOTS'));
+			->with('meta', $this->stringContains('robots'));
 
 		$this->View->expects($this->at(1))
 			->method('append')
 			->with('metaTags', $this->stringContains('favicon.ico'));
 
-		$result = $this->Html->meta(array('name' => 'ROBOTS', 'content' => 'ALL'), null, array('block' => true));
+		$result = $this->Html->meta('robots', 'ALL', array('block' => true));
 		$this->assertNull($result);
 
 		$result = $this->Html->meta('icon', 'favicon.ico', array('block' => 'metaTags'));


### PR DESCRIPTION
`@param string $type The title of the external resource`

Remove undocumented part where `$type` could also be of type array and some additional joggling was done - which all could be passed as `$options` already.
