### PR TITLE
3.0 bake task cleanup

### DIFF
--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -86,7 +86,7 @@ class BakeShell extends Shell {
 			$this->out(Inflector::underscore($name));
 		}
 		$this->out('');
-		$this->out(__d('cake_console', 'Using <info>Console/cake bake [name]</info> you can invoke a specific bake task.'));
+		$this->out(__d('cake_console', 'By using <info>Console/cake bake [name]</info> you can invoke a specific bake task.'));
 	}
 
 /**

--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -95,4 +95,30 @@ class BakeTask extends Shell {
 		}
 	}
 
+/**
+ * Get the option parser for this task.
+ *
+ * This base class method sets up some commonly used options.
+ *
+ * @return \Cake\Console\ConsoleOptionParser
+ */
+	public function getOptionParser() {
+		$parser = parent::getOptionParser();
+		$parser->addOption('plugin', [
+			'short' => 'p',
+			'help' => __d('cake_console', 'Plugin to bake into.')
+		])->addOption('force', [
+			'short' => 'f',
+			'boolean' => true,
+			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
+		])->addOption('connection', [
+			'short' => 'c',
+			'help' => __d('cake_console', 'The datasource connection to get data from.')
+		])->addOption('theme', [
+			'short' => 't',
+			'help' => __d('cake_console', 'Theme to use when baking code.')
+		]);
+		return $parser;
+	}
+
 }

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -260,15 +260,6 @@ class ControllerTask extends BakeTask {
 			__d('cake_console', 'Bake a controller skeleton.')
 		)->addArgument('name', [
 			'help' => __d('cake_console', 'Name of the controller to bake. Can use Plugin.name to bake controllers into plugins.')
-		])->addOption('plugin', [
-			'short' => 'p',
-			'help' => __d('cake_console', 'Plugin to bake the controller into.')
-		])->addOption('connection', [
-			'short' => 'c',
-			'help' => __d('cake_console', 'The connection the controller\'s model is on.')
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
 		])->addOption('components', [
 			'help' => __d('cake_console', 'The comma separated list of components to use.')
 		])->addOption('helpers', [
@@ -281,10 +272,6 @@ class ControllerTask extends BakeTask {
 		])->addOption('no-actions', [
 			'boolean' => true,
 			'help' => __d('cake_console', 'Do not generate basic CRUD action methods.')
-		])->addOption('force', [
-			'short' => 'f',
-			'boolean' => true,
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addSubcommand('all', [
 			'help' => __d('cake_console', 'Bake all controllers with CRUD methods.')
 		]);

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -58,26 +58,12 @@ class FixtureTask extends BakeTask {
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
 
-		$parser->description(
+		$parser = $parser->description(
 			__d('cake_console', 'Generate fixtures for use with the test suite. You can use `bake fixture all` to bake all fixtures.')
 		)->addArgument('name', [
 			'help' => __d('cake_console', 'Name of the fixture to bake. Can use Plugin.name to bake plugin fixtures.')
-		])->addOption('connection', [
-			'help' => __d('cake_console', 'Which database configuration to use for baking.'),
-			'short' => 'c',
-			'default' => 'default'
 		])->addOption('table', [
 			'help' => __d('cake_console', 'The table name if it does not follow conventions.'),
-		])->addOption('plugin', [
-			'help' => __d('cake_console', 'CamelCased name of the plugin to bake fixtures for.'),
-			'short' => 'p',
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		])->addOption('force', [
-			'short' => 'f',
-			'boolean' => true,
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addOption('count', [
 			'help' => __d('cake_console', 'When using generated data, the number of records to include in the fixture(s).'),
 			'short' => 'n',

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -656,19 +656,6 @@ class ModelTask extends BakeTask {
 			'help' => __d('cake_console', 'Name of the model to bake. Can use Plugin.name to bake plugin models.')
 		])->addSubcommand('all', [
 			'help' => __d('cake_console', 'Bake all model files with associations and validation.')
-		])->addOption('plugin', [
-			'short' => 'p',
-			'help' => __d('cake_console', 'Plugin to bake the model into.')
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		])->addOption('connection', [
-			'short' => 'c',
-			'help' => __d('cake_console', 'The connection the model table is on.')
-		])->addOption('force', [
-			'short' => 'f',
-			'boolean' => true,
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addOption('table', [
 			'help' => __d('cake_console', 'The table name to use if you have non-conventional table names.')
 		])->addOption('no-entity', [

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -129,12 +129,12 @@ class PluginTask extends BakeTask {
 				return false;
 			}
 
-			$controllerFileName = $plugin . 'AppController.php';
+			$controllerFileName = 'AppController.php';
 
 			$out = "<?php\n\n";
 			$out .= "namespace {$plugin}\\Controller;\n\n";
-			$out .= "use App\\Controller\\AppController;\n\n";
-			$out .= "class {$plugin}AppController extends AppController {\n\n";
+			$out .= "use App\\Controller\\AppController; as BaseController\n\n";
+			$out .= "class AppController extends BaseController {\n\n";
 			$out .= "}\n";
 			$this->createFile($this->path . $plugin . DS . 'Controller' . DS . $controllerFileName, $out);
 

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -18,7 +18,6 @@ use Cake\Console\Command\Task\BakeTask;
 use Cake\Console\Shell;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Utility\ConventionsTrait;
 use Cake\Utility\File;
 use Cake\Utility\Folder;
 
@@ -244,7 +243,7 @@ class PluginTask extends BakeTask {
 			'Can create plugins in any of your bootstrapped plugin paths.'
 		))->addArgument('name', [
 			'help' => __d('cake_console', 'CamelCased name of the plugin to create.')
-		]);
+		])->removeOption('plugin');
 
 		return $parser;
 	}

--- a/src/Console/Command/Task/ProjectTask.php
+++ b/src/Console/Command/Task/ProjectTask.php
@@ -227,7 +227,7 @@ class ProjectTask extends BakeTask {
 			])->addOption('composer', [
 				'default' => ROOT . '/composer.phar',
 				'help' => __d('cake_console', 'The path to the composer executable.')
-			]);
+			])->removeOption('plugin');
 	}
 
 }

--- a/src/Console/Command/Task/SimpleBakeTask.php
+++ b/src/Console/Command/Task/SimpleBakeTask.php
@@ -125,19 +125,9 @@ abstract class SimpleBakeTask extends BakeTask {
 				$name,
 				$name
 			)
-		])->addOption('plugin', [
-			'short' => 'p',
-			'help' => __d('cake_console', 'Plugin to bake the %s into.', $name)
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
 		])->addOption('no-test', [
 			'boolean' => true,
 			'help' => __d('cake_console', 'Do not generate a test skeleton.')
-		])->addOption('force', [
-			'short' => 'f',
-			'boolean' => true,
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		]);
 
 		return $parser;

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -512,16 +512,6 @@ class TestTask extends BakeTask {
 			]
 		])->addArgument('name', [
 			'help' => __d('cake_console', 'An existing class to bake tests for.')
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		])->addOption('plugin', [
-			'short' => 'p',
-			'help' => __d('cake_console', 'CamelCased name of the plugin to bake tests for.')
-		])->addOption('force', [
-			'short' => 'f',
-			'boolean' => true,
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addOption('fixtures', [
 			'help' => __d('cake_console', 'A comma separated list of fixture names you want to include.')
 		]);

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -410,19 +410,6 @@ class ViewTask extends BakeTask {
 			'help' => __d('cake_console', "Will bake a single action's file. core templates are (index, add, edit, view)")
 		])->addArgument('alias', [
 			'help' => __d('cake_console', 'Will bake the template in <action> but create the filename after <alias>.')
-		])->addOption('plugin', [
-			'short' => 'p',
-			'help' => __d('cake_console', 'Plugin to bake the view into.')
-		])->addOption('theme', [
-			'short' => 't',
-			'help' => __d('cake_console', 'Theme to use when baking code.')
-		])->addOption('connection', [
-			'short' => 'c',
-			'help' => __d('cake_console', 'The connection the connected model is on.')
-		])->addOption('force', [
-			'boolean' => true,
-			'short' => 'f',
-			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addOption('controller', [
 			'help' => __d('cake_console', 'The controller name if you have a controller that does not follow conventions.')
 		])->addOption('prefix', [

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -304,6 +304,17 @@ class ConsoleOptionParser {
 	}
 
 /**
+ * Remove an option from the option parser.
+ *
+ * @param string $name The option name to remove.
+ * @return ConsoleOptionParser $this
+ */
+	public function removeOption($name) {
+		unset($this->_options[$name]);
+		return $this;
+	}
+
+/**
  * Add a positional argument to the option parser.
  *
  * ### Params

--- a/tests/TestCase/Console/Command/Task/PluginTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/PluginTaskTest.php
@@ -75,9 +75,9 @@ class PluginTaskTest extends TestCase {
 
 		$path = $this->Task->path . 'BakeTestPlugin';
 
-		$file = $path . DS . 'Controller' . DS . 'BakeTestPluginAppController.php';
+		$file = $path . DS . 'Controller' . DS . 'AppController.php';
 		$this->Task->expects($this->at(1))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+			->with($file, $this->stringContains('namespace BakeTestPlugin\Controller;'));
 
 		$this->Task->bake('BakeTestPlugin');
 
@@ -141,9 +141,9 @@ class PluginTaskTest extends TestCase {
 			->will($this->returnValue('y'));
 
 		$path = $this->Task->path . 'BakeTestPlugin';
-		$file = $path . DS . 'Controller' . DS . 'BakeTestPluginAppController.php';
+		$file = $path . DS . 'Controller' . DS . 'AppController.php';
 		$this->Task->expects($this->at(1))->method('createFile')
-			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
+			->with($file, $this->stringContains('class AppController extends BaseController {'));
 
 		$file = $path . DS . 'phpunit.xml';
 		$this->Task->expects($this->at(2))->method('createFile')

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ConsoleOptionParserTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -69,6 +67,20 @@ class ConsoleOptionParserTest extends TestCase {
 		$parser = new ConsoleOptionParser('test', false);
 		$result = $parser->addOption('test');
 		$this->assertEquals($parser, $result, 'Did not return $this from addOption');
+	}
+
+/**
+ * test removing an option
+ *
+ * @return void
+ */
+	public function testRemoveOption() {
+		$parser = new ConsoleOptionParser('test', false);
+		$result = $parser->addOption('test')
+			->removeOption('test')
+			->removeOption('help');
+		$this->assertSame($parser, $result, 'Did not return $this from removeOption');
+		$this->assertEquals([], $result->options());
 	}
 
 /**


### PR DESCRIPTION
Clean up bake task and the various subclasses
- Remove duplication in the option setup.
- Fix plugin AppController generation. See #3229
