### PR TITLE
3.0 tree behavior the end

### DIFF
--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -130,6 +130,7 @@ class TreeBehavior extends Behavior {
  */
 	public function beforeDelete(Event $event, Entity $entity) {
 		$config = $this->config();
+		$this->_ensureFields($entity);
 		$left = $entity->get($config['left']);
 		$right = $entity->get($config['right']);
 		$diff = $right - $left + 1;

--- a/src/Model/Behavior/TreeBehavior.php
+++ b/src/Model/Behavior/TreeBehavior.php
@@ -29,7 +29,7 @@ use Cake\ORM\Table;
  * order will be cached.
  *
  * For more information on what is a nested set and a how it works refer to
- * http://www.sitepoint.com/hierarchical-data-database
+ * http://www.sitepoint.com/hierarchical-data-database-2/
  */
 class TreeBehavior extends Behavior {
 

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -700,7 +700,6 @@ class TreeBehaviorTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-
 /**
  * Test deleting a node with no tree columns
  *

--- a/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TreeBehaviorTest.php
@@ -107,6 +107,20 @@ class TreeBehaviorTest extends TestCase {
 	}
 
 /**
+ * Tests that childCount will provide the correct lft and rght values
+ *
+ * @return void
+ */
+	public function testChildCountNoTreeColumns() {
+		$table = $this->table;
+		$node = $table->get(6);
+		$node->unsetProperty('lft');
+		$node->unsetProperty('rght');
+		$count = $this->table->childCount($node, false);
+		$this->assertEquals(4, $count);
+	}
+
+/**
  * Tests the childCount() plus callable scoping
  *
  * @return void


### PR DESCRIPTION
The last change required to finish the TreeBehavior. This change is to make sure the left and right columns are present in the passed entities, where required.

I decided not to crate a trait for the entities as there was going to be rather useless.
