### PR TITLE
Revert the removal of a BC relevant part.

### DIFF
--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -137,7 +137,6 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$this->__config = $this->db->config;
 
 		$this->testDb = new DboTestSource();
 		$this->testDb->cacheSources = false;
@@ -869,7 +868,7 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testQueryAssociationUnneededQueries() {
 		$this->loadFixtures('Article', 'User', 'Comment', 'Attachment', 'Tag', 'ArticlesTag');
-		$Comment = new Comment;
+		$Comment = ClassRegistry::init('Comment');
 
 		$fullDebug = $this->db->fullDebug;
 		$this->db->fullDebug = true;
@@ -915,6 +914,40 @@ class DboSourceTest extends CakeTestCase {
 		$this->assertEquals(1, count($log['log']));
 
 		$this->db->fullDebug = $fullDebug;
+	}
+
+/**
+ * Tests that generation association queries without LinkModel still works.
+ * Mainly BC.
+ *
+ * @return void
+ */
+	public function testGenerateAssociationQuery() {
+		$this->loadFixtures('Article');
+		$Article = ClassRegistry::init('Article');
+
+		$queryData = array(
+			'conditions' => array(
+				'Article.id' => 1
+			),
+			'fields' => array(
+				'Article.id',
+				'Article.title',
+			),
+			'joins' => array(),
+			'limit' => 2,
+			'offset' => 2,
+			'order' => array('title'),
+			'page' => 2,
+			'group' => null,
+			'callbacks' => 1
+		);
+
+		$result = $this->db->generateAssociationQuery($Article, null, null, null, null, $queryData, false);
+		$this->assertContains('SELECT', $result);
+		$this->assertContains('FROM', $result);
+		$this->assertContains('WHERE', $result);
+		$this->assertContains('ORDER', $result);
 	}
 
 /**
@@ -1019,7 +1052,7 @@ class DboSourceTest extends CakeTestCase {
  */
 	public function testTransactionLogging() {
 		$conn = $this->getMock('MockPDO');
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 		$db->setConnection($conn);
 		$conn->expects($this->exactly(2))->method('beginTransaction')
 			->will($this->returnValue(true));
@@ -1132,7 +1165,7 @@ class DboSourceTest extends CakeTestCase {
 		$conn->expects($this->at(0))
 			->method('quote')
 			->will($this->returnValue('foo bar'));
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 		$db->setConnection($conn);
 		$subQuery = $db->buildStatement(
 			array(
@@ -1223,7 +1256,7 @@ class DboSourceTest extends CakeTestCase {
  * @return void
  */
 	public function testBuildJoinStatementWithTablePrefix($join, $expected) {
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 		$db->config['prefix'] = 'pre_';
 		$result = $db->buildJoinStatement($join);
 		$this->assertEquals($expected, $result);
@@ -1237,7 +1270,7 @@ class DboSourceTest extends CakeTestCase {
 	public function testConditionKeysToString() {
 		$Article = ClassRegistry::init('Article');
 		$conn = $this->getMock('MockPDO', array('quote'));
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 		$db->setConnection($conn);
 
 		$conn->expects($this->at(0))
@@ -1273,7 +1306,7 @@ class DboSourceTest extends CakeTestCase {
 			'extra' => 'something virtual'
 		);
 		$conn = $this->getMock('MockPDO', array('quote'));
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 		$db->setConnection($conn);
 
 		$conn->expects($this->at(0))
@@ -1304,7 +1337,7 @@ class DboSourceTest extends CakeTestCase {
  * @return void
  */
 	public function testLimit() {
-		$db = new DboTestSource;
+		$db = new DboTestSource();
 
 		$result = $db->limit('0');
 		$this->assertNull($result);


### PR DESCRIPTION
Revert the removal of a BC relevant part.
Fixes reported BC break in 2.5 mentioned in https://github.com/CakeDC/search/issues/119
and happened in https://github.com/cakephp/cakephp/pull/2289/files#r11487575

Completes https://github.com/cakephp/cakephp/pull/3015

Comparing the current 2.5 branch to the [2.4 master branch](https://github.com/cakephp/cakephp/blob/master/lib/Cake/Model/Datasource/DboSource.php#L1476) revealed the issue at hand.
