### PR TITLE
Hash::_matches boolean issue

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -192,7 +192,7 @@ class Hash {
 				return false;
 			}
 
-			$prop = isset($data[$attr]) ? $data[$attr] : null;
+			$prop = isset($data[$attr]) ? ( is_bool($data[$attr]) ? (($data[$attr]) ? 'true' : 'false') : $data[$attr] ) : null;
 
 			// Pattern matches and other operators.
 			if ($op === '=' && $val && $val[0] === '/') {


### PR DESCRIPTION
When using comparison with a boolean, as the filter is a string, we have to convert the data boolean to "boolean string" to avoid type-casting troubles.
## Example

``` php
$users = [
    [
        'id' => 2,
        'username' => 'johndoe',
        'active' => true
    ],
    [   'id' => 5,
        'username' => 'kevin',
        'active' => true
    ],
    [
        'id' => 9,
        'username' => 'samantha',
        'active' => false
    ],
];
$unactiveUsers = Hash::extract($users, '{n}[active=false]');
print_r($unactiveUsers);
```

This example returns the two unwanted active users because `"false"` is `true` but not `false` :)

I think this pull request will fix this issue by converting true/false boolean to string (to match with our filter).
