### PR TITLE
Hash::_matches boolean issue

### DIFF
--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -201,7 +201,13 @@ class Hash {
 				return false;
 			}
 
-			$prop = isset($data[$attr]) ? $data[$attr] : null;
+			$prop = null;
+			if (isset($data[$attr])) {
+				$prop = $data[$attr];
+			}
+			if ($prop === true || $prop === false) {
+				$prop = $prop ? 'true' : 'false';
+			}
 
 			// Pattern matches and other operators.
 			if ($op === '=' && $val && $val[0] === '/') {

--- a/tests/TestCase/Utility/HashTest.php
+++ b/tests/TestCase/Utility/HashTest.php
@@ -836,6 +836,39 @@ class HashTest extends TestCase {
 	}
 
 /**
+ * Test extracting based on attributes with boolean values.
+ *
+ * @return void
+ */
+	public function testExtractAttributeBoolean() {
+		$users = array(
+			array(
+				'id' => 2,
+				'username' => 'johndoe',
+				'active' => true
+			),
+			array(
+				'id' => 5,
+				'username' => 'kevin',
+				'active' => true
+			),
+			array(
+				'id' => 9,
+				'username' => 'samantha',
+				'active' => false
+			),
+		);
+		$result = Hash::extract($users, '{n}[active=false]');
+		$this->assertCount(1, $result);
+		$this->assertEquals($users[2], $result[0]);
+
+		$result = Hash::extract($users, '{n}[active=true]');
+		$this->assertCount(2, $result);
+		$this->assertEquals($users[0], $result[0]);
+		$this->assertEquals($users[1], $result[1]);
+	}
+
+/**
  * Test that attribute matchers don't cause errors on scalar data.
  *
  * @return void


### PR DESCRIPTION
As merged in #3288

When using comparison with a boolean, as the filter is a string, we have to convert the data boolean to "boolean string" to avoid type-casting troubles.
## Example

``` php
$users = [
    [
        'id' => 2,
        'username' => 'johndoe',
        'active' => true
    ],
    [   'id' => 5,
        'username' => 'kevin',
        'active' => true
    ],
    [
        'id' => 9,
        'username' => 'samantha',
        'active' => false
    ],
];
$unactiveUsers = Hash::extract($users, '{n}[active=false]');
print_r($unactiveUsers);
```

This example returns the two unwanted active users because `"false"` is `true` but not `false` :)

I think this pull request will fix this issue by converting true/false boolean to string (to match with our filter).
