### PR TITLE
Handle situation where PHP can';t figure out what version of SSL to use when creating a socket.

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -157,7 +157,7 @@ class CakeSocket {
 			$connectAs,
 			$context
 		);
-		if(empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://'){
+		if (empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://'){
 			$scheme = 'sslv3://';
 			$this->connection = stream_socket_client(
 					$scheme . $this->config['host'] . ':' . $this->config['port'],
@@ -180,7 +180,7 @@ class CakeSocket {
 		 		$context
 		 	);
 		 	$scheme = "sslv".$iLatestSSLVersion--.'://';
-		}while(empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
+		}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
 		
 		restore_error_handler();
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -149,7 +149,7 @@ class CakeSocket {
 		}
 
 		set_error_handler(array($this, '_connectionErrorHandler'));
-		$this->connection = stream_socket_client(
+		/*$this->connection = stream_socket_client(
 			$scheme . $this->config['host'] . ':' . $this->config['port'],
 			$errNum,
 			$errStr,
@@ -167,9 +167,9 @@ class CakeSocket {
 					$connectAs,
 					$context
 			);
-		}
+		}*/
 		//The above lines of duplicated code can be replaced with a single do while, and I've included it here in a commen if you want to use it instead, but I believe it hurts readability.
-		/*$iLatestSSLVersion = 3; //Maybe this could become a class constant?
+		$iLatestSSLVersion = 3; //Maybe this could become a class constant?
 		do{
 		 	$this->connection = stream_socket_client(
 		 		$scheme . $this->config['host'] . ':' . $this->config['port'],
@@ -180,7 +180,7 @@ class CakeSocket {
 		 		$context
 		 	);
 		 	$scheme = "sslv".$iLatestSSLVersion--.'://';
-		 	* 		}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
+		 	}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);		
 		
 		restore_error_handler();
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -149,7 +149,7 @@ class CakeSocket {
 		}
 
 		set_error_handler(array($this, '_connectionErrorHandler'));
-		/*$this->connection = stream_socket_client(
+		$this->connection = stream_socket_client(
 			$scheme . $this->config['host'] . ':' . $this->config['port'],
 			$errNum,
 			$errStr,
@@ -167,21 +167,23 @@ class CakeSocket {
 					$connectAs,
 					$context
 			);
-		}*/
-		//The above lines of duplicated code can be replaced with a single do while, and I've included it here in a commen if you want to use it instead, but I believe it hurts readability.
-		$iLatestSSLVersion = 3; //Maybe this could become a class constant?
-		do{
-		 	$this->connection = stream_socket_client(
-		 		$scheme . $this->config['host'] . ':' . $this->config['port'],
-		 		$errNum,
-		 		$errStr,
-		 		$this->config['timeout'],
-		 		$connectAs,
-		 		$context
-		 	);
-		 	$scheme = "sslv".$iLatestSSLVersion--.'://';
-		 	}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);		
-		
+		}
+		//The above lines of duplicated code can be replaced with a single do while.
+		// I've included it here in a comment if you want to use it instead, but I believe it hurts readability.
+		//Though it does have the distinct advantage of being  much more flexible to future SSL standards being created. 
+		/*$iLatestSSLVersion = 3; //Maybe this could become a class constant?
+		do {
+			$this->connection = stream_socket_client(
+				$scheme . $this->config['host'] . ':' . $this->config['port'],
+				$errNum,
+				$errStr,
+				$this->config['timeout'],
+				$connectAs,
+				$context
+			);
+			$scheme = "sslv" . $iLatestSSLVersion-- . '://';
+		} while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/
+
 		restore_error_handler();
 
 		if (!empty($errNum) || !empty($errStr)) {

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -157,7 +157,7 @@ class CakeSocket {
 			$connectAs,
 			$context
 		);
-		if (empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://'){
+		if (empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://') {
 			$scheme = 'sslv3://';
 			$this->connection = stream_socket_client(
 					$scheme . $this->config['host'] . ':' . $this->config['port'],

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -169,16 +169,18 @@ class CakeSocket {
 			);
 		}
 		//The above lines of duplicated code can be replaced with a single do while, and I've included it here in a commen if you want to use it instead, but I believe it hurts readability.
-		/*do{
-		 $this->connection = stream_socket_client(
+		/*$iLatestSSLVersion = 3; //Maybe this could become a class constant?
+		do{
+		 	$this->connection = stream_socket_client(
 		 		$scheme . $this->config['host'] . ':' . $this->config['port'],
 		 		$errNum,
 		 		$errStr,
 		 		$this->config['timeout'],
 		 		$connectAs,
 		 		$context
-		 );
-		}while(empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://' && $scheme = 'sslv3://');*/		
+		 	);
+		 	$scheme = "sslv".$iLatestSSLVersion--.'://';
+		}while(empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
 		
 		restore_error_handler();
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -170,7 +170,7 @@ class CakeSocket {
 		}
 		//The above lines of duplicated code can be replaced with a single do while.
 		// I've included it here in a comment if you want to use it instead, but I believe it hurts readability.
-		//Though it does have the distinct advantage of being  much more flexible to future SSL standards being created. 
+		//Though it does have the distinct advantage of being  much more flexible to future SSL standards being created.
 		/*$iLatestSSLVersion = 3; //Maybe this could become a class constant?
 		do {
 			$this->connection = stream_socket_client(

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -180,7 +180,7 @@ class CakeSocket {
 		 		$context
 		 	);
 		 	$scheme = "sslv".$iLatestSSLVersion--.'://';
-		}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
+		 	* 		}while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/		
 		
 		restore_error_handler();
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -182,7 +182,7 @@ class CakeSocket {
 				$context
 			);
 			$scheme = "sslv" . $iLatestSSLVersion-- . '://';
-		} while (empty($errNum) && empty($errStr) && !$this->connection && strpos($scheme, 'ssl') === 0);*/
+		} while (!$this->connection && empty($errNum) && empty($errStr) && ($iLatestSSLVersion - 1) && strpos($scheme, 'ssl') === 0);*/
 
 		restore_error_handler();
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -157,6 +157,29 @@ class CakeSocket {
 			$connectAs,
 			$context
 		);
+		if(empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://'){
+			$scheme = 'sslv3://';
+			$this->connection = stream_socket_client(
+					$scheme . $this->config['host'] . ':' . $this->config['port'],
+					$errNum,
+					$errStr,
+					$this->config['timeout'],
+					$connectAs,
+					$context
+			);
+		}
+		//The above lines of duplicated code can be replaced with a single do while, and I've included it here in a commen if you want to use it instead, but I believe it hurts readability.
+		/*do{
+		 $this->connection = stream_socket_client(
+		 		$scheme . $this->config['host'] . ':' . $this->config['port'],
+		 		$errNum,
+		 		$errStr,
+		 		$this->config['timeout'],
+		 		$connectAs,
+		 		$context
+		 );
+		}while(empty($errNum) && empty($errStr) && !$this->connection && $scheme === 'ssl://' && $scheme = 'sslv3://');*/		
+		
 		restore_error_handler();
 
 		if (!empty($errNum) || !empty($errStr)) {


### PR DESCRIPTION
According to the PHP documentation, PHP is suppose to be able to figure out which version of the SSL standard to use if you create a socket with "ssl://". I recently discovered that this doesn't always work and it fails to create the socket, even though the website being accessed is fully functional and accessible through other means, such as a web browser. 

Currently, HttpSocket uses the "ssl://" prefix, and when it runs into the aforementioned situation, it fails to return a result to the user and says there is a problem establishing the encrypted connection. This obviously would cause confusion, since the user is likely to then check the URL with a browser and see that it's working jut fine. Luckily this error is handleable, by simply specifying which version of SSL should be used. 

While I'm not sure if the root of this bug is a server configuration issue, PHP issue, etc. I do know that browsers handling it just fine, and I see no reason why Cake shouldn't handle it too. 

There are two proposed solutions in this pull request as you can see. The do while solution currently can't pass a Travis build because there is no guarantee that PHP has sslv2 support compiled in. I can submit another pull request for the Test Case to accommodate that situation if it's decided  to go with the do while.
