### PR TITLE
Updated AclComponent documentation

### DIFF
--- a/lib/Cake/Controller/Component/Acl/IniAcl.php
+++ b/lib/Cake/Controller/Component/Acl/IniAcl.php
@@ -43,7 +43,7 @@ class IniAcl extends Object implements AclInterface {
 /**
  * Initialize method
  *
- * @param AclBase $component
+ * @param Component $component
  * @return void
  */
 	public function initialize(Component $component) {

--- a/lib/Cake/Controller/Component/AclComponent.php
+++ b/lib/Cake/Controller/Component/AclComponent.php
@@ -21,8 +21,8 @@ App::uses('AclInterface', 'Controller/Component/Acl');
  * Access Control List factory class.
  *
  * Uses a strategy pattern to allow custom ACL implementations to be used with the same component interface.
- * You can define by changing `Configure::write('Acl.classname', 'DbAcl');` in your core.php. Concrete ACL
- * implementations should extend `AclBase` and implement the methods it defines.
+ * You can define by changing `Configure::write('Acl.classname', 'DbAcl');` in your core.php. The adapter
+ * you specify must implement `AclInterface`
  *
  * @package       Cake.Controller.Component
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/access-control-lists.html

--- a/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AclComponentTest.php
@@ -78,7 +78,7 @@ class AclComponentTest extends CakeTestCase {
 	}
 
 /**
- * test that adapter() whines when the class is not an AclBase
+ * test that adapter() whines when the class does not implement AclInterface
  *
  * @expectedException CakeException
  * @return void


### PR DESCRIPTION
The AclComponent documentation erroneously mentions an old class named `AclBase` that was converted to `AclInterface` [in this commit](https://github.com/cakephp/cakephp/commit/e111735905442a939fb351a4997adfc4124423e3)
#### Changes in this PR
- Updated `IniAcl::initialize` documentation to match the method signature.
- Updated the `AclComponent` class documentation to remove `AclBase` and add the `AclInterface` implementation requirement.
- Updated `AclComponentTest::testAdapterException` documentation to correctly indicate that a missing `AclInterface` implementation is what triggers the `CakeException`
