### PR TITLE
Fix CakeHtmlReporter output for HTML

### DIFF
--- a/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
+++ b/lib/Cake/TestSuite/Reporter/CakeHtmlReporter.php
@@ -264,7 +264,7 @@ class CakeHtmlReporter extends CakeBaseReporter {
 		echo "<div class='msg'><pre>" . $this->_htmlEntities($message->toString());
 
 		if ((is_string($actualMsg) && is_string($expectedMsg)) || (is_array($actualMsg) && is_array($expectedMsg))) {
-			echo "<br />" . PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg);
+			echo "<br />" . $this->_htmlEntities(PHPUnit_Util_Diff::diff($expectedMsg, $actualMsg));
 		}
 
 		echo "</pre></div>\n";


### PR DESCRIPTION
This improves the output of the Webtestrunner.
Currently, output for HTML in the diff would not show:

```
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '
-'
+'
```

With this patch it now is visible:

```
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<link href="http://example.com/some/url" rel="alternate" hreflang="de" />
-<link href="http://localhost/some/url" rel="alternate" hreflang="de-ch" />'
+<link href="http://example.com/some/url" rel="alternate" hreflang="de-ch" />'
```
