### PR TITLE
Don't 404 extensions that could be handled by routing.

### DIFF
--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -55,10 +55,17 @@ class AssetDispatcher extends DispatcherFilter {
 			return null;
 		}
 
+		$pathSegments = explode('.', $url);
+		$ext = array_pop($pathSegments);
+		$isFile = file_exists($assetFile);
+		if (in_array($ext, Router::extensions()) && !$isFile) {
+			return null;
+		}
+
 		$response = $event->data['response'];
 		$event->stopPropagation();
 
-		if (!file_exists($assetFile)) {
+		if (!$isFile) {
 			$response->statusCode(404);
 			$response->send();
 			return $response;
@@ -69,8 +76,6 @@ class AssetDispatcher extends DispatcherFilter {
 			return $response;
 		}
 
-		$pathSegments = explode('.', $url);
-		$ext = array_pop($pathSegments);
 		$this->_deliverAsset($response, $assetFile, $ext);
 		return $response;
 	}

--- a/lib/Cake/Routing/Filter/AssetDispatcher.php
+++ b/lib/Cake/Routing/Filter/AssetDispatcher.php
@@ -51,30 +51,19 @@ class AssetDispatcher extends DispatcherFilter {
 		}
 
 		$assetFile = $this->_getAssetFile($url);
-		if ($assetFile === null) {
+		if ($assetFile === null || !file_exists($assetFile)) {
 			return null;
 		}
-
-		$pathSegments = explode('.', $url);
-		$ext = array_pop($pathSegments);
-		$isFile = file_exists($assetFile);
-		if (in_array($ext, Router::extensions()) && !$isFile) {
-			return null;
-		}
-
 		$response = $event->data['response'];
 		$event->stopPropagation();
-
-		if (!$isFile) {
-			$response->statusCode(404);
-			$response->send();
-			return $response;
-		}
 
 		$response->modified(filemtime($assetFile));
 		if ($response->checkNotModified($event->data['request'])) {
 			return $response;
 		}
+
+		$pathSegments = explode('.', $url);
+		$ext = array_pop($pathSegments);
 
 		$this->_deliverAsset($response, $assetFile, $ext);
 		return $response;

--- a/lib/Cake/Test/Case/Routing/Filter/AssetDispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/Filter/AssetDispatcherTest.php
@@ -108,11 +108,6 @@ class AssetDispatcherTest extends CakeTestCase {
 		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
 		$this->assertNull($filter->beforeDispatch($event));
 		$this->assertFalse($event->isStopped(), 'Events for routed extensions should not be stopped');
-
-		$request = new CakeRequest('test_plugin/api/v1/forwarding.png');
-		$event = new CakeEvent('DispatcherTest', $this, compact('request', 'response'));
-		$this->assertSame($response, $filter->beforeDispatch($event));
-		$this->assertTrue($event->isStopped());
 	}
 
 /**
@@ -159,23 +154,6 @@ class AssetDispatcherTest extends CakeTestCase {
 
 		$this->assertSame($response, $filter->beforeDispatch($event));
 		$this->assertEquals($time->format('D, j M Y H:i:s') . ' GMT', $response->modified());
-	}
-
-/**
- * Test 404 status code is set on missing asset.
- *
- * @return void
- */
-	public function test404OnMissingFile() {
-		$filter = new AssetDispatcher();
-
-		$response = $this->getMock('CakeResponse', array('_sendHeader'));
-		$request = new CakeRequest('/theme/test_theme/img/nope.gif');
-		$event = new CakeEvent('Dispatcher.beforeRequest', $this, compact('request', 'response'));
-
-		$response = $filter->beforeDispatch($event);
-		$this->assertTrue($event->isStopped());
-		$this->assertEquals(404, $response->statusCode());
 	}
 
 /**


### PR DESCRIPTION
Fixes an error in #2750 where routed extensions would always return 404's for plugin requests. When a file extension could be handled by router, AssetDispatcher cannot 404 the request.

Refs #3305
