### PR TITLE
Use ISO standard for hour format.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -80,7 +80,7 @@ class FormHelper extends Helper {
 			'button' => '<button{{attrs}}>{{text}}</button>',
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
 			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
-			'dateWidget' => '{{month}}{{day}}{{year}}{{hour}}{{minute}}{{second}}{{meridian}}',
+			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
 			'error' => '<div class="error-message">{{content}}</div>',
 			'errorList' => '<ul>{{content}}</ul>',
 			'errorItem' => '<li>{{text}}</li>',
@@ -1763,7 +1763,7 @@ class FormHelper extends Helper {
  * - `empty` - If true, the empty select option is shown. If a string,
  *   that string is displayed as the empty element.
  * - `value` The selected value of the input.
- * - `format` Set to 12 or 24 to use 12 or 24 hour formatting. Defaults to 12.
+ * - `format` Set to 12 or 24 to use 12 or 24 hour formatting. Defaults to 24.
  *
  * @param string $fieldName Prefix name for the SELECT element
  * @param array $options List of HTML attributes
@@ -1771,7 +1771,7 @@ class FormHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::hour
  */
 	public function hour($fieldName, array $options = []) {
-		$options += ['format' => 12];
+		$options += ['format' => 24];
 		$options = $this->_singleDatetime($options, 'hour');
 
 		$options['timeFormat'] = $options['format'];
@@ -1887,7 +1887,7 @@ class FormHelper extends Helper {
 			'minYear' => null,
 			'maxYear' => null,
 			'orderYear' => 'desc',
-			'timeFormat' => 12,
+			'timeFormat' => 24,
 			'second' => false,
 		];
 		$options = $this->_initInputField($fieldName, $options);
@@ -1982,7 +1982,7 @@ class FormHelper extends Helper {
 			'value' => null,
 			'interval' => 1,
 			'round' => null,
-			'timeFormat' => 12,
+			'timeFormat' => 24,
 			'second' => false,
 		];
 		$options['year'] = $options['month'] = $options['day'] = false;

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -133,11 +133,12 @@ class DateTime implements WidgetInterface {
 
 		$selected = $this->_deconstructDate($data['val'], $data);
 
-		if (!isset($data['meridian']) &&
-			isset($data['hour']['format']) &&
-			$data['hour']['format'] == 12
-		) {
+		$timeFormat = isset($data['hour']['format']) ? $data['hour']['format'] : null;
+		if ($timeFormat === 12 && !isset($data['meridian'])) {
 			$data['meridian'] = [];
+		}
+		if ($timeFormat === 24) {
+			$data['meridian'] = false;
 		}
 
 		$templateOptions = [];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4024,6 +4024,26 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Ensure that timeFormat=24 has no merdian.
+ *
+ * @return void.
+ */
+	public function testTimeFormat24NoMeridian() {
+		$result = $this->Form->time('start_time', array(
+			'timeFormat' => 24,
+			'interval' => 5,
+			'value' => '2014-03-08 16:30:00'
+		));
+		$this->assertContains('<option value="16" selected="selected">16</option>', $result);
+		$this->assertContains('<option value="30" selected="selected">30</option>', $result);
+		$this->assertNotContains('meridian', $result);
+		$this->assertNotContains('pm', $result);
+		$this->assertNotContains('year', $result);
+		$this->assertNotContains('month', $result);
+		$this->assertNotContains('day', $result);
+	}
+
+/**
  * Test the date type.
  *
  * @return void
@@ -4054,6 +4074,13 @@ class FormHelperTest extends TestCase {
 		$result = $this->Form->dateTime('Contact.date', array('empty' => false));
 		$now = strtotime('now');
 		$expected = array(
+			array('select' => array('name' => 'Contact[date][year]')),
+			$yearsRegex,
+			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
+			date('Y', $now),
+			'/option',
+			'*/select',
+
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => date('m', $now), 'selected' => 'selected')),
@@ -4065,13 +4092,6 @@ class FormHelperTest extends TestCase {
 			$daysRegex,
 			array('option' => array('value' => date('d', $now), 'selected' => 'selected')),
 			date('j', $now),
-			'/option',
-			'*/select',
-
-			array('select' => array('name' => 'Contact[date][year]')),
-			$yearsRegex,
-			array('option' => array('value' => date('Y', $now), 'selected' => 'selected')),
-			date('Y', $now),
 			'/option',
 			'*/select',
 
@@ -4088,13 +4108,6 @@ class FormHelperTest extends TestCase {
 			date('i', $now),
 			'/option',
 			'*/select',
-
-			array('select' => array('name' => 'Contact[date][meridian]')),
-			$meridianRegex,
-			array('option' => array('value' => date('a', $now), 'selected' => 'selected')),
-			date('a', $now),
-			'/option',
-			'*/select'
 		);
 		$this->assertTags($result, $expected);
 	}
@@ -4109,9 +4122,16 @@ class FormHelperTest extends TestCase {
 		$now = strtotime('now');
 
 		$result = $this->Form->dateTime('Contact.date', array(
+			'timeFormat' => 12,
 			'empty' => true,
 		));
 		$expected = array(
+			array('select' => array('name' => 'Contact[date][year]')),
+			$yearsRegex,
+			array('option' => array('value' => '')),
+			'/option',
+			'*/select',
+
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('value' => '')),
@@ -4120,12 +4140,6 @@ class FormHelperTest extends TestCase {
 
 			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
-			array('option' => array('value' => '')),
-			'/option',
-			'*/select',
-
-			array('select' => array('name' => 'Contact[date][year]')),
-			$yearsRegex,
 			array('option' => array('value' => '')),
 			'/option',
 			'*/select',
@@ -4166,6 +4180,12 @@ class FormHelperTest extends TestCase {
 			'value' => ''
 		));
 		$expected = array(
+			array('select' => array('name' => 'Contact[date][year]')),
+			$yearsRegex,
+			array('option' => array('selected' => 'selected', 'value' => '')),
+			'/option',
+			'*/select',
+
 			array('select' => array('name' => 'Contact[date][month]')),
 			$monthsRegex,
 			array('option' => array('selected' => 'selected', 'value' => '')),
@@ -4174,12 +4194,6 @@ class FormHelperTest extends TestCase {
 
 			array('select' => array('name' => 'Contact[date][day]')),
 			$daysRegex,
-			array('option' => array('selected' => 'selected', 'value' => '')),
-			'/option',
-			'*/select',
-
-			array('select' => array('name' => 'Contact[date][year]')),
-			$yearsRegex,
 			array('option' => array('selected' => 'selected', 'value' => '')),
 			'/option',
 			'*/select',
@@ -4319,7 +4333,6 @@ class FormHelperTest extends TestCase {
 		$this->assertContains('Contact[1][updated][year]', $result);
 		$this->assertContains('Contact[1][updated][hour]', $result);
 		$this->assertContains('Contact[1][updated][minute]', $result);
-		$this->assertContains('Contact[1][updated][meridian]', $result);
 	}
 
 /**
@@ -4640,7 +4653,7 @@ class FormHelperTest extends TestCase {
 	public function testHour() {
 		extract($this->dateRegex);
 
-		$result = $this->Form->hour('Model.field', ['value' => '']);
+		$result = $this->Form->hour('Model.field', ['format' => 12, 'value' => '']);
 		$expected = array(
 			array('select' => array('name' => 'Model[field][hour]')),
 			array('option' => array('selected' => 'selected', 'value' => '')),
@@ -5451,7 +5464,6 @@ class FormHelperTest extends TestCase {
 		$this->assertContains('name="created[day]"', $result, 'day name attribute is wrong.');
 		$this->assertContains('name="created[hour]"', $result, 'hour name attribute is wrong.');
 		$this->assertContains('name="created[minute]"', $result, 'min name attribute is wrong.');
-		$this->assertContains('name="created[meridian]"', $result, 'meridian name attribute is wrong.');
 	}
 
 /**

--- a/tests/TestCase/View/Widget/DateTimeTest.php
+++ b/tests/TestCase/View/Widget/DateTimeTest.php
@@ -519,6 +519,7 @@ class DateTimeTest extends TestCase {
 			$result,
 			'contains 17 hours'
 		);
+		$this->assertNotContains('meridian', $result, '24hrs has no meridian');
 	}
 
 /**
@@ -534,11 +535,13 @@ class DateTimeTest extends TestCase {
 			'month' => false,
 			'day' => false,
 			'hour' => [
+				'format' => 24,
 				'data-foo' => 'test'
 			],
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
+			'meridian' => [],
 		]);
 		$this->assertContains('<select name="date[hour]" data-foo="test">', $result);
 		$this->assertContains('<option value="00">0</option>', $result);


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/2090

After already complying to ISO standards regarding localization CakePHP 3.0 should comply with the international standard for hour format as outlined in ISO 8601: 

> ISO 8601 uses the 24-hour clock system

This is now the right time to adjust it.
Related and dependent issues around DateTime as object etc. have already been resolved.
