### PR TITLE
fix misplaced semi-colon

### DIFF
--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -133,7 +133,7 @@ class PluginTask extends BakeTask {
 
 			$out = "<?php\n\n";
 			$out .= "namespace {$plugin}\\Controller;\n\n";
-			$out .= "use App\\Controller\\AppController; as BaseController\n\n";
+			$out .= "use App\\Controller\\AppController as BaseController;\n\n";
 			$out .= "class AppController extends BaseController {\n\n";
 			$out .= "}\n";
 			$this->createFile($this->path . $plugin . DS . 'Controller' . DS . $controllerFileName, $out);


### PR DESCRIPTION
Semi-colon when writing the "use as" statement moved to end of line.
