### PR TITLE
Add newline after actions in controller template

### DIFF
--- a/lib/Cake/Console/Templates/default/classes/controller.ctp
+++ b/lib/Cake/Console/Templates/default/classes/controller.ctp
@@ -74,7 +74,9 @@ class <?php echo $controllerName; ?>Controller extends <?php echo $plugin; ?>App
 		echo ");\n\n";
 	endif;
 
-	echo trim($actions) . "\n";
+	if (!empty($actions)) {
+		echo trim($actions) . "\n";
+	}
 
 endif; ?>
 }

--- a/lib/Cake/Console/Templates/default/classes/controller.ctp
+++ b/lib/Cake/Console/Templates/default/classes/controller.ctp
@@ -74,7 +74,7 @@ class <?php echo $controllerName; ?>Controller extends <?php echo $plugin; ?>App
 		echo ");\n\n";
 	endif;
 
-	echo trim($actions);
+	echo trim($actions) . "\n";
 
 endif; ?>
 }


### PR DESCRIPTION
This was removed in https://github.com/cakephp/cakephp/commit/703d9881e97df0b6996e5c689972b670fd88fe3a#diff-b9017fc7e3098fa599f85fda06cef776 , but results in the closing brace of `delete()` actions and the closing brace of the Controller class to be on the same line.
