### PR TITLE
Fix closing non resource

### DIFF
--- a/lib/Cake/Console/ConsoleOutput.php
+++ b/lib/Cake/Console/ConsoleOutput.php
@@ -295,7 +295,9 @@ class ConsoleOutput {
  * Clean up and close handles
  */
 	public function __destruct() {
-		fclose($this->_output);
+		if (is_resource($this->_output)) {
+			fclose($this->_output);
+		}
 	}
 
 }


### PR DESCRIPTION
I get a load of these errors when running tests in the shell, this check stops the errors from happening

```
Warning: 2 :: fclose() expects parameter 1 to be resource, integer given on line 298 of CORE\Cake\Console\ConsoleOutput.php
Trace:
fclose - [internal], line ??
ConsoleOutput::__destruct() - CORE\Cake\Console\ConsoleOutput.php, line 298
ToolbarComponent::_saveState() - APP\Plugin\DebugKit\Controller\Component\ToolbarComponent.php, line 307
ToolbarComponent::beforeRedirect() - APP\Plugin\DebugKit\Controller\Component\ToolbarComponent.php, line 307
ObjectCollection::trigger() - CORE\Cake\Utility\ObjectCollection.php, line 132
call_user_func - [internal], line ??
CakeEventManager::dispatch() - CORE\Cake\Event\CakeEventManager.php, line 247
Controller::redirect() - CORE\Cake\Controller\Controller.php, line 765
AuthComponent::_unauthenticated() - CORE\Cake\Controller\Component\AuthComponent.php, line 364
AuthComponent::startup() - CORE\Cake\Controller\Component\AuthComponent.php, line 304
ObjectCollection::trigger() - CORE\Cake\Utility\ObjectCollection.php, line 132
call_user_func - [internal], line ??
CakeEventManager::dispatch() - CORE\Cake\Event\CakeEventManager.php, line 247
Controller::startupProcess() - CORE\Cake\Controller\Controller.php, line 675
Dispatcher::_invoke() - CORE\Cake\Routing\Dispatcher.php, line 182
Dispatcher::dispatch() - CORE\Cake\Routing\Dispatcher.php, line 160
```
