### PR TITLE
Fix FormHelper + ORM\Query integration

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -870,11 +870,11 @@ class FormHelper extends Helper {
 	protected function _getInput($fieldName, $options) {
 		switch ($options['type']) {
 			case 'select':
-				$opts = (array)$options['options'];
+				$opts = $options['options'];
 				unset($options['options']);
 				return $this->select($fieldName, $opts, $options);
 			case 'radio':
-				$opts = (array)$options['options'];
+				$opts = $options['options'];
 				unset($options['options']);
 				return $this->radio($fieldName, $opts, $options);
 			case 'url':
@@ -1161,12 +1161,12 @@ class FormHelper extends Helper {
  *   the radio label will be 'empty'. Set this option to a string to control the label value.
  *
  * @param string $fieldName Name of a field, like this "Modelname.fieldname"
- * @param array $options Radio button options array.
+ * @param array|\Traversable $options Radio button options array.
  * @param array $attributes Array of HTML attributes, and special attributes above.
  * @return string Completed radio widget set.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  */
-	public function radio($fieldName, array $options = [], array $attributes = []) {
+	public function radio($fieldName, $options = [], array $attributes = []) {
 		$attributes = $this->_initInputField($fieldName, $attributes);
 
 		$hiddenField = isset($attributes['hiddenField']) ? $attributes['hiddenField'] : true;
@@ -1555,14 +1555,14 @@ class FormHelper extends Helper {
  * }}}
  *
  * @param string $fieldName Name attribute of the SELECT
- * @param array $options Array of the OPTION elements (as 'value'=>'Text' pairs) to be used in the
+ * @param array|\Traversable $options Array of the OPTION elements (as 'value'=>'Text' pairs) to be used in the
  *   SELECT element
  * @param array $attributes The HTML attributes of the select element.
  * @return string Formatted SELECT element
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#options-for-select-checkbox-and-radio-inputs
  * @see \Cake\View\Helper\FormHelper::multiCheckbox() for creating multiple checkboxes.
  */
-	public function select($fieldName, array $options = [], array $attributes = []) {
+	public function select($fieldName, $options = [], array $attributes = []) {
 		$attributes += [
 			'disabled' => null,
 			'escape' => true,

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -873,6 +873,10 @@ class FormHelper extends Helper {
 				$opts = (array)$options['options'];
 				unset($options['options']);
 				return $this->select($fieldName, $opts, $options);
+			case 'radio':
+				$opts = (array)$options['options'];
+				unset($options['options']);
+				return $this->radio($fieldName, $opts, $options);
 			case 'url':
 				$options = $this->_initInputField($fieldName, $options);
 				return $this->widget($options['type'], $options);
@@ -999,7 +1003,8 @@ class FormHelper extends Helper {
 		}
 
 		$typesWithOptions = ['text', 'number', 'radio', 'select'];
-		if ($allowOverride && in_array($options['type'], $typesWithOptions)) {
+		$magicOptions = (in_array($options['type'], ['radio', 'select']) || $allowOverride);
+		if ($magicOptions && in_array($options['type'], $typesWithOptions)) {
 			$options = $this->_optionsOptions($fieldName, $options);
 		}
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1621,13 +1621,13 @@ class FormHelper extends Helper {
  * Can be used in place of a select box with the multiple attribute.
  *
  * @param string $fieldName Name attribute of the SELECT
- * @param array $options Array of the OPTION elements (as 'value'=>'Text' pairs) to be used in the
+ * @param array $options|\Traversable Array of the OPTION elements (as 'value'=>'Text' pairs) to be used in the
  *   checkboxes element.
  * @param array $attributes The HTML attributes of the select element.
  * @return string Formatted SELECT element
  * @see \Cake\View\Helper\FormHelper::select() for supported option formats.
  */
-	public function multiCheckbox($fieldName, array $options, array $attributes = []) {
+	public function multiCheckbox($fieldName, $options, array $attributes = []) {
 		$attributes += [
 			'disabled' => null,
 			'escape' => true,

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -202,7 +202,7 @@ class Radio implements WidgetInterface {
  * @return string Generated label.
  */
 	protected function _renderLabel($radio, $label, $input, $escape) {
-		if (!$label) {
+		if ($label === false) {
 			return false;
 		}
 		$labelAttrs = is_array($label) ? $label : [];

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -3864,6 +3864,11 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Form->multiCheckbox(
+			'category',
+			new Collection(['1', '2']),
+			['name' => 'fish']
+		);
 		$result = $this->Form->multiCheckbox('category', ['1', '2'], [
 			'name' => 'fish',
 		]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\Test\TestCase\View\Helper;
 
+use Cake\Collection\Collection;
 use Cake\Controller\Controller;
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -3060,6 +3061,9 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Form->radio('Model.field', new Collection(['option A']));
+		$this->assertTags($result, $expected);
+
 		$result = $this->Form->radio('Model.field', array('option A', 'option B'));
 		$expected = array(
 			'input' => array('type' => 'hidden', 'name' => 'Model[field]', 'value' => ''),
@@ -3192,6 +3196,9 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Form->select('Model.field', new Collection(['value' => 'good', 'other' => 'bad']));
+		$this->assertTags($result, $expected);
+
 		$this->Form->request->data = array();
 		$result = $this->Form->select('Model.field', array('value' => 'good', 'other' => 'bad'));
 		$expected = array(
@@ -3201,39 +3208,6 @@ class FormHelperTest extends TestCase {
 			'/option',
 			array('option' => array('value' => 'other')),
 			'bad',
-			'/option',
-			'/select'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->select(
-			'Model.field', array('first' => 'first "html" <chars>', 'second' => 'value'),
-			array('empty' => false)
-		);
-		$expected = array(
-			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => 'first')),
-			'first &quot;html&quot; &lt;chars&gt;',
-			'/option',
-			array('option' => array('value' => 'second')),
-			'value',
-			'/option',
-			'/select'
-		);
-		$this->assertTags($result, $expected);
-
-		$result = $this->Form->select(
-			'Model.field',
-			array('first' => 'first "html" <chars>', 'second' => 'value'),
-			array('escape' => false, 'empty' => false)
-		);
-		$expected = array(
-			'select' => array('name' => 'Model[field]'),
-			array('option' => array('value' => 'first')),
-			'first "html" <chars>',
-			'/option',
-			array('option' => array('value' => 'second')),
-			'value',
 			'/option',
 			'/select'
 		);
@@ -3283,6 +3257,46 @@ class FormHelperTest extends TestCase {
 			'select' => array('name' => 'Model[field]'),
 			array('option' => array('value' => '0', 'selected' => 'selected')), 'No', '/option',
 			array('option' => array('value' => '1')), 'Yes', '/option',
+			'/select'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * Test that select() escapes HTML.
+ *
+ * @return void
+ */
+	public function testSelectEscapeHtml() {
+		$result = $this->Form->select(
+			'Model.field', array('first' => 'first "html" <chars>', 'second' => 'value'),
+			array('empty' => false)
+		);
+		$expected = array(
+			'select' => array('name' => 'Model[field]'),
+			array('option' => array('value' => 'first')),
+			'first &quot;html&quot; &lt;chars&gt;',
+			'/option',
+			array('option' => array('value' => 'second')),
+			'value',
+			'/option',
+			'/select'
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->select(
+			'Model.field',
+			array('first' => 'first "html" <chars>', 'second' => 'value'),
+			array('escape' => false, 'empty' => false)
+		);
+		$expected = array(
+			'select' => array('name' => 'Model[field]'),
+			array('option' => array('value' => 'first')),
+			'first "html" <chars>',
+			'/option',
+			array('option' => array('value' => 'second')),
+			'value',
+			'/option',
 			'/select'
 		);
 		$this->assertTags($result, $expected);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * FormHelperTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -2409,6 +2407,13 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Form->input('email', [
+			'type' => 'select',
+			'options' => new \ArrayObject(['First', 'Second']),
+			'empty' => true
+		]);
+		$this->assertTags($result, $expected);
+
 		$this->View->viewVars['users'] = array('value' => 'good', 'other' => 'bad');
 		$this->Form->request->data = array('Model' => array('user_id' => 'value'));
 
@@ -2480,10 +2485,10 @@ class FormHelperTest extends TestCase {
 
 		$this->Form->data = array();
 		$result = $this->Form->input('Publisher.id', array(
-				'label'		=> 'Publisher',
-				'type'		=> 'select',
-				'multiple'	=> 'checkbox',
-				'options'	=> array('Value 1' => 'Label 1', 'Value 2' => 'Label 2')
+				'label' => 'Publisher',
+				'type' => 'select',
+				'multiple' => 'checkbox',
+				'options' => array('Value 1' => 'Label 1', 'Value 2' => 'Label 2')
 		));
 		$expected = array(
 			array('div' => array('class' => 'input select')),
@@ -2637,7 +2642,7 @@ class FormHelperTest extends TestCase {
 	public function testInputMagicSelectChangeToRadio() {
 		$this->View->viewVars['users'] = array('value' => 'good', 'other' => 'bad');
 		$result = $this->Form->input('Model.user_id', array('type' => 'radio'));
-		$this->assertRegExp('/input type="radio"/', $result);
+		$this->assertContains('input type="radio"', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/RadioTest.php
+++ b/tests/TestCase/View/Widget/RadioTest.php
@@ -50,6 +50,7 @@ class RadioTest extends TestCase {
 		$radio = new Radio($this->templates, $label);
 		$data = [
 			'name' => 'Crayons[color]',
+			'label' => null,
 			'options' => ['r' => 'Red', 'b' => 'Black']
 		];
 		$result = $radio->render($data);


### PR DESCRIPTION
Some additional array casts squeaked by the test suite and broke ORM\Query objects working for $options in radio(), select(), and multiCheckbox().
