### PR TITLE
3.0 - Remove extra space fron entity template

### DIFF
--- a/src/Console/Templates/default/classes/entity.ctp
+++ b/src/Console/Templates/default/classes/entity.ctp
@@ -36,7 +36,6 @@ class <?= $name ?> extends Entity {
 	];
 
 <?php endif ?>
-
 <?php if (!empty($hidden)): ?>
 <?php
 $hidden = array_map(function($el) { return "'$el'"; }, $hidden);


### PR DESCRIPTION
Results in an extra new line when `$_hidden` isn't present.
