### PR TITLE
3.0 Pass positional shell arguments to Shell class

### DIFF
--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -190,7 +190,7 @@ class BakeShell extends Shell {
  *
  * @return void
  */
-	public function all() {
+	public function all($name = null) {
 		$this->out('Bake All');
 		$this->hr();
 
@@ -199,7 +199,7 @@ class BakeShell extends Shell {
 			$this->connection = $this->params['connection'];
 		}
 
-		if (empty($this->args)) {
+		if (empty($name)) {
 			$this->Model->connection = $this->connection;
 			$this->out(__d('cake_console', 'Possible model names based on your database'));
 			foreach ($this->Model->listAll() as $table) {
@@ -213,14 +213,12 @@ class BakeShell extends Shell {
 			$this->{$task}->connection = $this->connection;
 		}
 
-		$name = $this->args[0];
 		$name = $this->_modelName($name);
 
 		$this->Model->bake($name);
 		$this->Controller->bake($name);
 
-		$this->View->args = [$name];
-		$this->View->execute();
+		$this->View->execute($name);
 
 		$this->out(__d('cake_console', '<success>Bake All complete</success>'), 1, Shell::QUIET);
 		return true;

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -44,14 +44,14 @@ class ControllerTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
+	public function execute($name = null) {
 		parent::execute();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';
 		}
 
-		if (empty($this->args)) {
+		if (empty($name)) {
 			$this->out(__d('cake_console', 'Possible controllers based on your current database:'));
 			foreach ($this->listAll() as $table) {
 				$this->out('- ' . $this->_controllerName($table));
@@ -59,11 +59,11 @@ class ControllerTask extends BakeTask {
 			return true;
 		}
 
-		if (strtolower($this->args[0]) === 'all') {
+		if (strtolower($name) === 'all') {
 			return $this->all();
 		}
 
-		$controller = $this->_controllerName($this->args[0]);
+		$controller = $this->_controllerName($name);
 		$this->bake($controller);
 	}
 

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -90,13 +90,13 @@ class FixtureTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
+	public function execute($name = null) {
 		parent::execute();
 		if (!isset($this->connection)) {
 			$this->connection = 'default';
 		}
 
-		if (empty($this->args)) {
+		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a fixture to bake from the following:'));
 			foreach ($this->Model->listAll() as $table) {
 				$this->out('- ' . $this->_modelName($table));
@@ -104,14 +104,14 @@ class FixtureTask extends BakeTask {
 			return true;
 		}
 
-		if (strtolower($this->args[0]) === 'all') {
+		if (strtolower($name) === 'all') {
 			return $this->all();
 		}
 		$table = null;
 		if (isset($this->params['table'])) {
 			$table = $this->params['table'];
 		}
-		$model = $this->_modelName($this->args[0]);
+		$model = $this->_modelName($name);
 		$this->bake($model, $table);
 	}
 

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -75,14 +75,14 @@ class ModelTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
+	public function execute($name = null) {
 		parent::execute();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';
 		}
 
-		if (empty($this->args)) {
+		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a model to bake from the following:'));
 			foreach ($this->listAll() as $table) {
 				$this->out('- ' . $this->_modelName($table));
@@ -90,11 +90,11 @@ class ModelTask extends BakeTask {
 			return true;
 		}
 
-		if (strtolower($this->args[0]) === 'all') {
+		if (strtolower($name) === 'all') {
 			return $this->all();
 		}
 
-		$this->bake($this->_modelName($this->args[0]));
+		$this->bake($this->_modelName($name));
 	}
 
 /**

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -56,13 +56,13 @@ class PluginTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
-		if (empty($this->args[0])) {
+	public function execute($name = null) {
+		if (empty($name)) {
 			$this->err('<error>You must provide a plugin name in CamelCase format.</error>');
 			$this->err('To make an "Example" plugin, run <info>Console/cake bake plugin Example</info>.');
 			return false;
 		}
-		$plugin = $this->_camelize($this->args[0]);
+		$plugin = $this->_camelize($name);
 		$pluginPath = $this->_pluginPath($plugin);
 		if (is_dir($pluginPath)) {
 			$this->out(__d('cake_console', 'Plugin: %s already exists, no action taken', $plugin));

--- a/src/Console/Command/Task/SimpleBakeTask.php
+++ b/src/Console/Command/Task/SimpleBakeTask.php
@@ -72,9 +72,9 @@ abstract class SimpleBakeTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
+	public function execute($name = null) {
 		parent::execute();
-		$name = Inflector::classify($this->args[0]);
+		$name = Inflector::classify($name);
 		$this->bake($name);
 		$this->bakeTest($name);
 	}

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -79,18 +79,17 @@ class TestTask extends BakeTask {
  *
  * @return void
  */
-	public function execute() {
+	public function execute($type = null, $name = null) {
 		parent::execute();
-		if (empty($this->args)) {
+		if (empty($type) && empty($name)) {
 			return $this->outputTypeChoices();
 		}
 
-		$count = count($this->args);
-		if ($count === 1) {
-			return $this->outputClassChoices($this->args[0]);
+		if (empty($name)) {
+			return $this->outputClassChoices($type);
 		}
 
-		if ($this->bake($this->args[0], $this->args[1])) {
+		if ($this->bake($type, $name)) {
 			$this->out('<success>Done</success>');
 		}
 	}

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -98,14 +98,14 @@ class ViewTask extends BakeTask {
  *
  * @return mixed
  */
-	public function execute() {
+	public function execute($name = null, $template = null, $action = null) {
 		parent::execute();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';
 		}
 
-		if (empty($this->args)) {
+		if (empty($name)) {
 			$this->out(__d('cake_console', 'Possible tables to bake views for based on your current database:'));
 			$this->Model->connection = $this->connection;
 			foreach ($this->Model->listAll() as $table) {
@@ -114,8 +114,7 @@ class ViewTask extends BakeTask {
 			return true;
 		}
 
-		$action = null;
-		if (strtolower($this->args[0]) === 'all') {
+		if (strtolower($name) === 'all') {
 			return $this->all();
 		}
 
@@ -123,13 +122,10 @@ class ViewTask extends BakeTask {
 		if (!empty($this->params['controller'])) {
 			$controller = $this->params['controller'];
 		}
-		$this->controller($this->args[0], $controller);
+		$this->controller($name, $controller);
 
-		if (isset($this->args[1])) {
-			$this->template = $this->args[1];
-		}
-		if (isset($this->args[2])) {
-			$action = $this->args[2];
+		if (isset($template)) {
+			$this->template = $template;
 		}
 		if (!$action) {
 			$action = $this->template;
@@ -223,8 +219,7 @@ class ViewTask extends BakeTask {
 		$tables = $this->Model->listAll();
 
 		foreach ($tables as $table) {
-			$this->args[0] = $table;
-			$this->execute();
+			$this->execute($table);
 		}
 	}
 

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -374,10 +374,10 @@ class Shell extends Object {
 			return $this->{$command}->runCommand('execute', $argv);
 		}
 		if ($isMethod) {
-			return $this->{$command}();
+			return call_user_func_array([$this, $command], $this->args);
 		}
 		if ($isMain) {
-			return $this->main();
+			return call_user_func_array([$this, 'main'], $this->args);
 		}
 		$this->out($this->OptionParser->help($command));
 		return false;

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -78,7 +78,8 @@ class BakeShellTest extends TestCase {
 			->will($this->returnValue(true));
 
 		$this->Shell->View->expects($this->once())
-			->method('execute');
+			->method('execute')
+			->with('Comments');
 
 		$this->Shell->expects($this->at(0))
 			->method('out')
@@ -90,10 +91,7 @@ class BakeShellTest extends TestCase {
 
 		$this->Shell->connection = '';
 		$this->Shell->params = [];
-		$this->Shell->args = ['Comment'];
-		$this->Shell->all();
-
-		$this->assertEquals('Comments', $this->Shell->View->args[0]);
+		$this->Shell->all('Comment');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
@@ -302,7 +302,6 @@ class ControllerTaskTest extends TestCase {
 			$this->markTestSkipped('Additional tables detected.');
 		}
 		$this->Task->connection = 'test';
-		$this->Task->args = ['all'];
 		$this->Task->params = ['helpers' => 'Time,Text'];
 
 		$this->Task->Test->expects($this->atLeastOnce())
@@ -317,7 +316,7 @@ class ControllerTaskTest extends TestCase {
 			))
 			->will($this->returnValue(true));
 
-		$this->Task->execute();
+		$this->Task->execute('all');
 	}
 
 /**
@@ -339,13 +338,12 @@ class ControllerTaskTest extends TestCase {
  */
 	public function testExecuteWithControllerNameVariations($name) {
 		$this->Task->connection = 'test';
-		$this->Task->args = [$name];
 
 		$filename = APP . 'Controller/BakeArticlesController.php';
 		$this->Task->expects($this->once())
 			->method('createFile')
 			->with($filename, $this->stringContains('public function index()'));
-		$this->Task->execute();
+		$this->Task->execute($name);
 	}
 
 }

--- a/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
@@ -179,7 +179,6 @@ class FixtureTaskTest extends TestCase {
  */
 	public function testExecuteWithTableOption() {
 		$this->Task->connection = 'test';
-		$this->Task->args = array('article');
 		$this->Task->params = ['table' => 'comments'];
 		$filename = ROOT . '/Test/Fixture/ArticleFixture.php';
 
@@ -187,7 +186,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains("public \$table = 'comments';"));
 
-		$this->Task->execute();
+		$this->Task->execute('article');
 	}
 
 /**
@@ -197,14 +196,13 @@ class FixtureTaskTest extends TestCase {
  */
 	public function testExecuteWithNamedModel() {
 		$this->Task->connection = 'test';
-		$this->Task->args = array('article');
 		$filename = ROOT . '/Test/Fixture/ArticleFixture.php';
 
 		$this->Task->expects($this->at(0))
 			->method('createFile')
 			->with($filename, $this->stringContains('class ArticleFixture'));
 
-		$this->Task->execute();
+		$this->Task->execute('article');
 	}
 
 /**
@@ -214,7 +212,6 @@ class FixtureTaskTest extends TestCase {
  */
 	public function testExecuteIntoAll() {
 		$this->Task->connection = 'test';
-		$this->Task->args = array('all');
 		$this->Task->Model->expects($this->any())
 			->method('listAll')
 			->will($this->returnValue(array('articles', 'comments')));
@@ -229,7 +226,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class CommentFixture'));
 
-		$this->Task->execute();
+		$this->Task->execute('all');
 	}
 
 /**
@@ -239,7 +236,6 @@ class FixtureTaskTest extends TestCase {
  */
 	public function testAllWithCountAndRecordsFlags() {
 		$this->Task->connection = 'test';
-		$this->Task->args = ['all'];
 		$this->Task->params = ['count' => 10, 'records' => true];
 
 		$this->Task->Model->expects($this->any())->method('listAll')
@@ -266,7 +262,6 @@ class FixtureTaskTest extends TestCase {
  */
 	public function testAllWithSchemaImport() {
 		$this->Task->connection = 'test';
-		$this->Task->args = array('all');
 		$this->Task->params = array('schema' => true);
 
 		$this->Task->Model->expects($this->any())->method('listAll')

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -751,7 +751,6 @@ class ModelTaskTest extends TestCase {
  */
 	public function testExecuteWithNamedModel() {
 		$this->Task->connection = 'test';
-		$this->Task->args = ['BakeArticles'];
 
 		$tableFile = $this->_normalizePath(APP . 'Model/Table/BakeArticlesTable.php');
 		$this->Task->expects($this->at(0))
@@ -763,7 +762,7 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($entityFile, $this->stringContains('class BakeArticle extends Entity'));
 
-		$this->Task->execute();
+		$this->Task->execute('BakeArticles');
 	}
 
 /**
@@ -786,13 +785,12 @@ class ModelTaskTest extends TestCase {
 	public function testExecuteWithNamedModelVariations($name) {
 		$this->Task->connection = 'test';
 
-		$this->Task->args = array($name);
 		$filename = $this->_normalizePath(APP . 'Model/Table/BakeArticlesTable.php');
 
 		$this->Task->expects($this->at(0))
 			->method('createFile')
 			->with($filename, $this->stringContains('class BakeArticlesTable extends Table {'));
-		$this->Task->execute();
+		$this->Task->execute($name);
 	}
 
 /**
@@ -807,7 +805,6 @@ class ModelTaskTest extends TestCase {
 		}
 
 		$this->Task->connection = 'test';
-		$this->Task->args = ['all'];
 
 		$this->Task->Fixture->expects($this->exactly($count))
 			->method('bake');
@@ -864,7 +861,7 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class CategoryThread extends'));
 
-		$this->Task->execute();
+		$this->Task->execute('all');
 	}
 
 /**
@@ -879,7 +876,6 @@ class ModelTaskTest extends TestCase {
 		}
 
 		$this->Task->connection = 'test';
-		$this->Task->args = ['all'];
 		$this->Task->skipTables = ['bake_tags'];
 
 		$this->Task->Fixture->expects($this->exactly(7))
@@ -917,7 +913,7 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename);
 
-		$this->Task->execute();
+		$this->Task->execute('all');
 	}
 
 }

--- a/tests/TestCase/Console/Command/Task/PluginTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/PluginTaskTest.php
@@ -124,7 +124,6 @@ class PluginTaskTest extends TestCase {
 		$this->Task->expects($this->never())
 			->method('createFile');
 
-		$this->Task->args = array();
 		$this->Task->execute();
 
 		$Folder = new Folder($path);
@@ -153,8 +152,7 @@ class PluginTaskTest extends TestCase {
 		$this->Task->expects($this->at(3))->method('createFile')
 			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
 
-		$this->Task->args = array('BakeTestPlugin');
-		$this->Task->execute();
+		$this->Task->execute('BakeTestPlugin');
 
 		$Folder = new Folder($this->Task->path . 'BakeTestPlugin');
 		$Folder->delete();

--- a/tests/TestCase/Console/Command/Task/ProjectTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ProjectTaskTest.php
@@ -72,12 +72,11 @@ class ProjectTaskTest extends TestCase {
  */
 	public function testExecuteWithAbsolutePath() {
 		$this->markTestIncomplete('Need to figure this out');
-		$path = $this->Task->args[0] = TMP . 'BakeTestApp';
 		$this->Task->params['skel'] = CAKE . 'Console/Templates/skel';
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
-		$this->Task->execute();
+		$this->Task->execute(TMP . 'BakeTestApp');
 
-		$this->assertTrue(is_dir($this->Task->args[0]), 'No project dir');
+		$this->assertTrue(is_dir(TMP . 'BakeTestApp'), 'No project dir');
 		$File = new File($path . DS . 'Config/paths.php');
 		$contents = $File->read();
 		$this->assertRegExp('/define\(\'CAKE_CORE_INCLUDE_PATH\', .*?DS/', $contents);

--- a/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
@@ -67,7 +67,6 @@ class SimpleBakeTaskTest extends TestCase {
  * @return void
  */
 	public function testExecute() {
-		$this->Task->args = ['Example'];
 		$this->Task->expects($this->once())
 			->method('createFile')
 			->with(
@@ -78,7 +77,7 @@ class SimpleBakeTaskTest extends TestCase {
 			->method('bake')
 			->with('behavior', 'Example');
 
-		$this->Task->execute();
+		$this->Task->execute('Example');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/TestTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/TestTaskTest.php
@@ -123,8 +123,7 @@ class TestTaskTest extends TestCase {
 		$this->Task->expects($this->once())
 			->method('outputClassChoices');
 
-		$this->Task->args = ['Entity'];
-		$this->Task->execute();
+		$this->Task->execute('Entity');
 	}
 
 /**
@@ -133,13 +132,12 @@ class TestTaskTest extends TestCase {
  * @return void
  */
 	public function testExecuteWithTwoArgs() {
-		$this->Task->args = ['Table', 'TestTaskTag'];
 		$this->Task->expects($this->once())->method('createFile')
 			->with(
 				$this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'TestTaskTagTableTest.php'),
 				$this->stringContains('class TestTaskTagTableTest extends TestCase')
 			);
-		$this->Task->execute();
+		$this->Task->execute('Table', 'TestTaskTag');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/ViewTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ViewTaskTest.php
@@ -475,12 +475,11 @@ class ViewTaskTest extends TestCase {
  */
 	public function testExecuteIntoAll() {
 		$this->_setupTask(['in', 'err', 'createFile', 'all', '_stop']);
-		$this->Task->args[0] = 'all';
 
 		$this->Task->expects($this->once())
 			->method('all');
 
-		$this->Task->execute();
+		$this->Task->execute('all');
 	}
 
 /**
@@ -497,9 +496,14 @@ class ViewTaskTest extends TestCase {
 
 		$this->Task->expects($this->exactly(2))
 			->method('execute');
+		$this->Task->expects($this->at(0))
+			->method('execute')
+			->with('comments');
+		$this->Task->expects($this->at(1))
+			->method('execute')
+			->with('articles');
 
 		$this->Task->all();
-		$this->assertEquals('articles', $this->Task->args[0]);
 	}
 
 /**
@@ -509,14 +513,12 @@ class ViewTaskTest extends TestCase {
  */
 	public function testExecuteWithActionParam() {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
-		$this->Task->args[0] = 'ViewTaskComments';
-		$this->Task->args[1] = 'view';
 
 		$this->Task->expects($this->once())
 			->method('bake')
 			->with('view', true);
 
-		$this->Task->execute();
+		$this->Task->execute('ViewTaskComments', 'view');
 	}
 
 /**
@@ -527,7 +529,6 @@ class ViewTaskTest extends TestCase {
  */
 	public function testExecuteWithController() {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
-		$this->Task->args[0] = 'ViewTaskComments';
 
 		$this->Task->expects($this->exactly(4))
 			->method('bake');
@@ -548,7 +549,7 @@ class ViewTaskTest extends TestCase {
 			->method('bake')
 			->with('edit', $this->anything());
 
-		$this->Task->execute();
+		$this->Task->execute('ViewTaskComments');
 	}
 
 /**
@@ -566,7 +567,6 @@ class ViewTaskTest extends TestCase {
  * @return void
  */
 	public function testExecuteWithControllerFlag() {
-		$this->Task->args[0] = 'Posts';
 		$this->Task->params['controller'] = 'Blog';
 
 		$this->Task->expects($this->exactly(4))
@@ -580,7 +580,7 @@ class ViewTaskTest extends TestCase {
 					$this->anything()
 				);
 		}
-		$this->Task->execute();
+		$this->Task->execute('Posts');
 	}
 
 /**
@@ -589,7 +589,6 @@ class ViewTaskTest extends TestCase {
  * @return void
  */
 	public function testExecuteWithControllerAndAdminFlag() {
-		$this->Task->args[0] = 'Posts';
 		$this->Task->params['prefix'] = 'Admin';
 
 		$this->Task->expects($this->exactly(2))
@@ -603,7 +602,7 @@ class ViewTaskTest extends TestCase {
 					$this->anything()
 				);
 		}
-		$this->Task->execute();
+		$this->Task->execute('Posts');
 	}
 
 /**
@@ -615,13 +614,12 @@ class ViewTaskTest extends TestCase {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
 
 		$this->Task->connection = 'test';
-		$this->Task->args = ['ViewTaskComments', 'index', 'list'];
 		$this->Task->params = [];
 
 		$this->Task->expects($this->once())
 			->method('bake')
 			->with('list', true);
-		$this->Task->execute();
+		$this->Task->execute('ViewTaskComments', 'index', 'list');
 	}
 
 /**

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -523,10 +523,14 @@ class ShellTest extends TestCase {
  * @return void
  */
 	public function testRunCommandMain() {
-		$Mock = $this->getMock('Cake\Console\Shell', array('main', 'startup'), array(), '', false);
+		$io = $this->getMock('Cake\Console\ConsoleIo');
+		$Mock = $this->getMock('Cake\Console\Shell', ['main', 'startup'], [$io]);
 
-		$Mock->expects($this->once())->method('main')->will($this->returnValue(true));
-		$result = $Mock->runCommand(null, array());
+		$Mock->expects($this->once())->method('startup');
+		$Mock->expects($this->once())->method('main')
+			->with('cakes')
+			->will($this->returnValue(true));
+		$result = $Mock->runCommand(null, ['cakes', '--verbose']);
 		$this->assertTrue($result);
 	}
 
@@ -536,10 +540,14 @@ class ShellTest extends TestCase {
  * @return void
  */
 	public function testRunCommandWithMethod() {
-		$Mock = $this->getMock('Cake\Console\Shell', array('hit_me', 'startup'), array(), '', false);
+		$io = $this->getMock('Cake\Console\ConsoleIo');
+		$Mock = $this->getMock('Cake\Console\Shell', ['hit_me', 'startup'], [$io]);
 
-		$Mock->expects($this->once())->method('hit_me')->will($this->returnValue(true));
-		$result = $Mock->runCommand('hit_me', array());
+		$Mock->expects($this->once())->method('startup');
+		$Mock->expects($this->once())->method('hit_me')
+			->with('cakes')
+			->will($this->returnValue(true));
+		$result = $Mock->runCommand('hit_me', ['hit_me', 'cakes', '--verbose']);
 		$this->assertTrue($result);
 	}
 
@@ -606,11 +614,11 @@ class ShellTest extends TestCase {
  * @return void
  */
 	public function testRunCommandHittingTask() {
-		$Shell = $this->getMock('Cake\Console\Shell', array('hasTask', 'startup'), array(), '', false);
-		$task = $this->getMock('Cake\Console\Shell', array('execute', 'runCommand'), array(), '', false);
+		$Shell = $this->getMock('Cake\Console\Shell', ['hasTask', 'startup'], [], '', false);
+		$task = $this->getMock('Cake\Console\Shell', ['execute', 'runCommand'], [], '', false);
 		$task->expects($this->any())
 			->method('runCommand')
-			->with('execute', array('one', 'value'));
+			->with('execute', ['one', 'value']);
 
 		$Shell->expects($this->once())->method('startup');
 		$Shell->expects($this->any())
@@ -619,7 +627,7 @@ class ShellTest extends TestCase {
 
 		$Shell->RunCommand = $task;
 
-		$Shell->runCommand('run_command', array('run_command', 'one', 'value'));
+		$Shell->runCommand('run_command', ['run_command', 'one', 'value']);
 	}
 
 /**


### PR DESCRIPTION
Part of #3325. This makes shells get all positional arguments as method arguments just like controllers. I've updated the existing core shells to use this pattern as it saves more than a few lines of code.
