### PR TITLE
Don't use any groupTemplate or generic template for hidden fields

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -842,19 +842,21 @@ class FormHelper extends Helper {
 		}
 
 		$input = $this->_getInput($fieldName, $options);
-		$label = $this->_getLabel($fieldName, compact('input', 'label') + $options);
+		if ($options['type'] === 'hidden') {
+			$this->templates($originalTemplates);
+			return $input;
+		}
+
+		$label = $this->_getLabel($fieldName, compact('input', 'label', 'error') + $options);
 
 		$groupTemplate = $options['type'] === 'checkbox' ? 'checkboxFormGroup' : 'formGroup';
-		$result = $this->formatTemplate($groupTemplate, compact('input', 'label'));
-
-		if ($options['type'] !== 'hidden') {
-			$result = $this->formatTemplate($template, [
-				'content' => $result,
-				'error' => $error,
-				'required' => $options['required'] ? ' required' : '',
-				'type' => $options['type'],
-			]);
-		}
+		$result = $this->formatTemplate($groupTemplate, compact('input', 'label', 'error'));
+		$result = $this->formatTemplate($template, [
+			'content' => $result,
+			'error' => $error,
+			'required' => $options['required'] ? ' required' : '',
+			'type' => $options['type'],
+		]);
 
 		$this->templates($originalTemplates);
 		return $result;

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2196,6 +2196,30 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that input() does not create wrapping div and label tag for hidden fields
+ *
+ * @return void
+ */
+	public function testInputHidden() {
+		TableRegistry::get('ValidateUsers', [
+			'className' => __NAMESPACE__ . '\ValidateUsersTable'
+		]);
+		$this->Form->create([], ['context' => ['table' => 'ValidateUsers']]);
+
+		$result = $this->Form->input('ValidateUser.id');
+		$expected = array(
+			'input' => array('name', 'type' => 'hidden', 'id')
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('ValidateUser.custom', ['type' => 'hidden']);
+		$expected = array(
+			'input' => array('name', 'type' => 'hidden', 'id')
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
  * test form->input() with datetime
  *
  * @return void


### PR DESCRIPTION
They should just be returned as-is based on their own input template.

Say you have a form template config like this (Twitter Bootstrap compatible):

```
$config = [
    'formGroup' => '{{label}}<div class="col-sm-10">{{input}}{{error}}</div>',
];
```

Then the hidden field would also include the div in the output, even though nothing
is visible.

This will screw up the visible form quite a bit, since the div will still consume the space
horizontally, but vertically be just 0 (1?) px high.

Additionally this PR includes the `error` in both groupTemplate and label template for even more
flexibility

This is the code needed to reach quite a lot of Bootstrap compat based on this PR

```
$config = [
    'fieldset' => '{{content}}',

    'formGroup' => '{{label}}<div class="col-sm-10">{{input}}{{error}}</div>',

    'groupContainer' => '<div class="input {{type}}{{required}} form-group">{{content}}</div>',
    'groupContainerError' => '<div class="input {{type}}{{required}} form-group has-error">{{content}}</div>',

    'input' => '<input type="{{type}}" name="{{name}}" {{attrs}}>',
    'error' => '<div class="help-block error-message">{{content}}</div>',

    'checkboxFormGroup' => '{{label}}<div class="col-sm-10">{{input}}</div>',
];
```
