### PR TITLE
3.0 - Add Shelldispatcher::alias()

### DIFF
--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -35,6 +35,13 @@ class ShellDispatcher {
 	public $args = [];
 
 /**
+ * List of connected aliases.
+ *
+ * @var array
+ */
+	protected static $_aliases = [];
+
+/**
  * Constructor
  *
  * The execution of the script is stopped after dispatching the request with
@@ -50,6 +57,23 @@ class ShellDispatcher {
 		if ($bootstrap) {
 			$this->_initEnvironment();
 		}
+	}
+
+/**
+ * Add an alias for a shell command.
+ *
+ * Aliases allow you to call shells by alternate names. This is most
+ * useful when dealing with plugin shells that you want to have shorter
+ * names for.
+ *
+ * If you re-use an alias the last alias set will be the one available.
+ *
+ * @param string $short The new short name for the shell.
+ * @param string $original The original full name for the shell.
+ * @return void
+ */
+	public static function alias($short, $original) {
+		static::$_aliases[$short] = $original;
 	}
 
 /**
@@ -165,6 +189,9 @@ class ShellDispatcher {
  * @throws \Cake\Console\Error\MissingShellException when errors are encountered.
  */
 	protected function _getShell($shell) {
+		if (isset(static::$_aliases[$shell])) {
+			$shell = static::$_aliases[$shell];
+		}
 		list($plugin, $shell) = pluginSplit($shell);
 
 		$plugin = Inflector::camelize($plugin);

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -164,28 +164,8 @@ class ShellDispatcher {
 			$command = $this->args[0];
 		}
 
-		if ($Shell instanceof Shell) {
-			$Shell->initialize();
-			return $Shell->runCommand($command, $this->args);
-		}
-
-		$methods = array_diff(get_class_methods($Shell), get_class_methods('Cake\Console\Shell'));
-		$added = in_array($command, $methods);
-		$private = $command[0] === '_' && method_exists($Shell, $command);
-
-		if (!$private) {
-			if ($added) {
-				$this->shiftArgs();
-				$Shell->startup();
-				return $Shell->{$command}();
-			}
-			if (method_exists($Shell, 'main')) {
-				$Shell->startup();
-				return $Shell->main();
-			}
-		}
-
-		throw new Error\MissingShellMethodException(['shell' => $shell, 'method' => $command]);
+		$Shell->initialize();
+		return $Shell->runCommand($command, $this->args);
 	}
 
 /**

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -201,7 +201,8 @@ class ShellDispatcher {
  * @return string|boolean Either the classname or false.
  */
 	protected function _shellExists($shell) {
-		$class = Inflector::camelize($shell);
+		$class = array_map('Cake\Utility\Inflector::camelize', explode('.', $shell));
+		$class = implode('.', $class);
 		$class = App::classname($class, 'Console/Command', 'Shell');
 		if (class_exists($class)) {
 			return $class;

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -174,7 +174,7 @@ class ShellDispatcher {
  * All paths in the loaded shell paths are searched.
  *
  * @param string $shell Optionally the name of a plugin
- * @return mixed An object
+ * @return \Cake\Console\Shell A shell instance.
  * @throws \Cake\Console\Error\MissingShellException when errors are encountered.
  */
 	public function findShell($shell) {

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -112,6 +112,7 @@ class ShellDispatcherTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		Plugin::load('TestPlugin');
+		Configure::write('App.namespace', 'TestApp');
 	}
 
 /**
@@ -120,10 +121,6 @@ class ShellDispatcherTest extends TestCase {
  * @return void
  */
 	public function testGetShell() {
-		$this->skipIf(class_exists('SampleShell'), 'SampleShell Class already loaded.');
-		$this->skipIf(class_exists('ExampleShell'), 'ExampleShell Class already loaded.');
-
-		Configure::write('App.namespace', 'TestApp');
 		$Dispatcher = new TestShellDispatcher();
 
 		$result = $Dispatcher->getShell('sample');
@@ -138,6 +135,21 @@ class ShellDispatcherTest extends TestCase {
 		$Dispatcher = new TestShellDispatcher();
 		$result = $Dispatcher->getShell('TestPlugin.example');
 		$this->assertInstanceOf('TestPlugin\Console\Command\ExampleShell', $result);
+	}
+
+/**
+ * Test getting shells with aliases.
+ *
+ * @return void
+ */
+	public function testGetShellAliased() {
+		TestShellDispatcher::alias('short', 'test_plugin.example');
+
+		$dispatcher = new TestShellDispatcher();
+		$result = $dispatcher->getShell('short');
+		$this->assertInstanceOf('TestPlugin\Console\Command\ExampleShell', $result);
+		$this->assertEquals('TestPlugin', $result->plugin);
+		$this->assertEquals('Example', $result->name);
 	}
 
 /**


### PR DESCRIPTION
As part of #3325, this add `ShellDispatcher::alias()` which can be used by plugins or application bootstrap code to define shorter aliases for plugin/app shells. Aliases are only checked _after_ a matching shell could not be found.

I've also cleaned up the ShellDispatcher tests and removed the support for running shells that do not inherit from Shell. I think requiring inheritance from Shell is something we can do in 3.0.
