### PR TITLE
Use composer installed PHPUnit vs. whatever is on travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_script:
   - set +H
 
 script:
-  - sh -c "if [ '$PHPCS' != '1' ]; then phpunit --stderr; else phpcs -p --extensions=php --standard=CakePHP ./src ./tests; fi"
+  - sh -c "if [ '$PHPCS' != '1' ]; then vendor/bin/phpunit --stderr; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then phpcs -p --extensions=php --standard=CakePHP ./src ./tests; fi"
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "nesbot/Carbon": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.33"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Lock down to an older PHPUnit until we can get session code re-written. The latest PHPUnit 3.7.x breaks session support which we need for the time being.
