### PR TITLE
3.0 - Fix pagination in Sqlserver2008

### DIFF
--- a/src/Cache/Engine/WincacheEngine.php
+++ b/src/Cache/Engine/WincacheEngine.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Wincache storage engine for cache.
- *
- * Supports wincache 1.1.0 and higher.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -24,7 +20,6 @@ use Cake\Cache\CacheEngine;
  * Wincache storage engine for cache
  *
  * Supports wincache 1.1.0 and higher.
- *
  */
 class WincacheEngine extends CacheEngine {
 

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -16,8 +16,12 @@ namespace Cake\Database\Dialect;
 
 use Cake\Database\Dialect\TupleComparisonTranslatorTrait;
 use Cake\Database\Expression\FunctionExpression;
+use Cake\Database\Expression\OrderByExpression;
+use Cake\Database\Expression\UnaryExpression;
+use Cake\Database\Query;
 use Cake\Database\SqlDialectTrait;
 use Cake\Database\SqlserverCompiler;
+use PDO;
 
 /**
  * Contains functions that encapsulates the SQL dialect used by SQLServer,
@@ -60,7 +64,58 @@ trait SqlserverDialectTrait {
 			$query->order($query->newExpr()->add('SELECT NULL'));
 		}
 
+		if ($this->_version() < 11 && $offset) {
+			return $this->_pagingSubquery($query, $limit, $offset);
+		}
+
 		return $query;
+	}
+
+/**
+ * Get the version of SQLserver we are connected to.
+ *
+ * @return int
+ */
+	public function _version() {
+		return $this->_connection->getAttribute(PDO::ATTR_SERVER_VERSION);
+	}
+
+/**
+ * Generate a paging subquery for older versions of SQLserver.
+ *
+ * Prior to SQLServer 2012 there was no equivalent to LIMIT OFFSET, so a subquery must
+ * be used.
+ *
+ * @param \Cake\Database\Query $query The query to wrap in a subquery.
+ * @param int $limit The number of rows to fetch.
+ * @param int $offset The number of rows to offset.
+ * @return \Cake\Database\Query Modified query object.
+ */
+	protected function _pagingSubquery($query, $limit, $offset) {
+		$field = '_cake_paging_._cake_page_rownum_';
+
+		$order = $query->clause('order') ?: new OrderByExpression('NULL');
+		$query->select([
+				'_cake_page_rownum_' => new UnaryExpression($order, [], 'ROW_NUMBER() OVER')
+			])->limit(null)
+			->offset(null)
+			->order([], true);
+
+		$outer = new Query($query->connection());
+		$outer->select('*')
+			->from(['_cake_paging_' => $query]);
+		if ($offset) {
+			$outer->where(["$field >" => $offset]);
+		}
+		if ($limit) {
+			$outer->where(["$field <=" => (int)$offset + (int)$limit]);
+		}
+		return $outer->decorateResults(function ($row) {
+			if (isset($row['_cake_page_rownum_'])) {
+				unset($row['_cake_page_rownum_']);
+			}
+			return $row;
+		});
 	}
 
 /**

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -17,6 +17,9 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 
+/**
+ * An expression object that represents an expression with only a single operand.
+ */
 class UnaryExpression extends QueryExpression {
 
 /**

--- a/tests/Fixture/DatatypeFixture.php
+++ b/tests/Fixture/DatatypeFixture.php
@@ -41,7 +41,8 @@ class DatatypeFixture extends TestFixture {
  *
  * @var array
  */
-	public $records = array(
-		array('id' => 1, 'float_field' => 42.23, 'huge_int' => '1234567891234567891', 'bool' => 0),
-	);
+	public $records = [
+		['float_field' => 42.23, 'huge_int' => '1234567891234567891', 'bool' => 0],
+	];
+
 }

--- a/tests/TestCase/Cache/Engine/WincacheEngineTest.php
+++ b/tests/TestCase/Cache/Engine/WincacheEngineTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * WincacheEngineTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -34,6 +32,7 @@ class WincacheEngineTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->skipIf(!function_exists('wincache_ucache_set'), 'Wincache is not installed or configured properly.');
+		$this->skipIf(!ini_get('wincache.enablecli'), 'Wincache is not enabled on the CLI.');
 		Cache::enable();
 		$this->_configCache();
 	}

--- a/tests/TestCase/Database/Driver/SqlserverTest.php
+++ b/tests/TestCase/Database/Driver/SqlserverTest.php
@@ -200,11 +200,12 @@ class SqlserverTest extends \Cake\TestSuite\TestCase {
 		$query->select(['id', 'title'])
 			->from('articles')
 			->order(['id'])
+			->where(['title' => 'Something'])
 			->limit(10)
 			->offset(50);
 		$expected = 'SELECT * FROM (SELECT id, title, (ROW_NUMBER() OVER (ORDER BY id)) AS [_cake_page_rownum_] ' .
-			'FROM articles) AS _cake_paging_ ' .
-			'WHERE (_cake_paging_._cake_page_rownum_ > :c0 AND _cake_paging_._cake_page_rownum_ <= :c1)';
+			'FROM articles WHERE title = :c0) AS _cake_paging_ ' .
+			'WHERE (_cake_paging_._cake_page_rownum_ > :c1 AND _cake_paging_._cake_page_rownum_ <= :c2)';
 		$this->assertEquals($expected, $query->sql());
 	}
 

--- a/tests/TestCase/Database/QueryTest.php
+++ b/tests/TestCase/Database/QueryTest.php
@@ -1374,7 +1374,9 @@ class QueryTest extends TestCase {
 		$query = new Query($this->connection);
 		$result = $query->select('id')->from('comments')
 			->limit(1)
-			->offset(0)->execute();
+			->offset(0)
+			->order(['id' => 'ASC'])
+			->execute();
 		$this->assertCount(1, $result);
 		$this->assertEquals(['id' => 1], $result->fetch('assoc'));
 
@@ -1396,9 +1398,10 @@ class QueryTest extends TestCase {
 
 		$query = new Query($this->connection);
 		$result = $query->select('id')->from('articles')
-			->order(['id' => 'desc'])
+			->order(['id' => 'DESC'])
 			->limit(1)
-			->offset(0)->execute();
+			->offset(0)
+			->execute();
 		$this->assertCount(1, $result);
 		$this->assertEquals(['id' => 3], $result->fetch('assoc'));
 


### PR DESCRIPTION
This re-adds the subquery flavour of pagination required by SQLServer <= 2008. I've also updated the wincache tests so they don't fail when `wincache.enablecli` is off.

I wasn't able to run all the test cases due to errors elsewhere in the suite but the database and ORM package tests all pass.

![screen shot 2014-04-20 at 11 06 10 pm](https://cloud.githubusercontent.com/assets/24086/2760623/0357f5c6-c9bc-11e3-975f-5ea1e794e1dd.png)
