### PR TITLE
Fix file array parsing for flat file arrays.

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Request
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -386,7 +384,7 @@ class Request implements \ArrayAccess {
  * @return array merged post + file data.
  */
 	protected function _processFiles($post, $files) {
-		if (isset($files) && is_array($files)) {
+		if (is_array($files)) {
 			foreach ($files as $key => $data) {
 				if (!is_numeric($key)) {
 					$this->_processFileData($post, '', $data, $key);
@@ -417,7 +415,11 @@ class Request implements \ArrayAccess {
 			if (is_array($fields)) {
 				$this->_processFileData($post, $newPath, $fields, $field);
 			} else {
-				$newPath .= '.' . $field;
+				if (strpos($newPath, '.') === false) {
+					$newPath = $field . '.' . $key;
+				} else {
+					$newPath .= '.' . $field;
+				}
 				$post = Hash::insert($post, $newPath, $fields);
 			}
 		}

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -170,8 +170,12 @@ class Marshaller {
  * @return array An array of built entities.
  */
 	protected function _belongsToMany(Association $assoc, array $data, $include = []) {
-		if (isset($data['_ids']) && is_array($data['_ids'])) {
+		$hasIds = isset($data['_ids']);
+		if ($hasIds && is_array($data['_ids'])) {
 			return $this->_loadBelongsToMany($assoc, $data['_ids']);
+		}
+		if ($hasIds) {
+			return [];
 		}
 
 		$records = $this->many($data, $include);

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * CakeRequest Test case file.
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -490,25 +488,34 @@ class RequestTest extends TestCase {
 			)
 		);
 		$this->assertEquals($expected, $request->data);
+	}
 
-		$files = array(
-			'name' => array('birth_cert' => 'born on.txt'),
-			'type' => array('birth_cert' => 'application/octet-stream'),
-			'tmp_name' => array('birth_cert' => '/private/var/tmp/phpbsUWfH'),
-			'error' => array('birth_cert' => 0),
-			'size' => array('birth_cert' => 123)
-		);
+/**
+ * Test processing a file input with no .'s in it.
+ *
+ * @return void
+ */
+	public function testProcessFilesFlat() {
+		$files = [
+			'birth_cert' => [
+				'name' => 'born on.txt',
+				'type' => 'application/octet-stream',
+				'tmp_name' => '/private/var/tmp/phpbsUWfH',
+				'error' => 0,
+				'size' => 123,
+			]
+		];
 
 		$request = new Request(compact('files'));
-		$expected = array(
-			'birth_cert' => array(
+		$expected = [
+			'birth_cert' => [
 				'name' => 'born on.txt',
 				'type' => 'application/octet-stream',
 				'tmp_name' => '/private/var/tmp/phpbsUWfH',
 				'error' => 0,
 				'size' => 123
-			)
-		);
+			]
+		];
 		$this->assertEquals($expected, $request->data);
 	}
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -473,6 +473,16 @@ class MarshallerTest extends TestCase {
 		$data = [
 			'title' => 'Haz tags',
 			'body' => 'Some content here',
+			'tags' => ['_ids' => '']
+		];
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->one($data, ['Tags']);
+
+		$this->assertCount(0, $result->tags);
+
+		$data = [
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
 			'tags' => ['_ids' => [1, 2, 3]]
 		];
 		$marshall = new Marshaller($this->articles);


### PR DESCRIPTION
The file array parsing was not correct when handling flat file arrays. When dealing with flat arrays we don't need to munge data nearly as much.

Fixes #3364
