### PR TITLE
Improve return values of Paginator::params()

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -95,7 +95,7 @@ class PaginatorHelper extends Helper {
 			$model = $this->defaultModel();
 		}
 		if (!isset($this->request->params['paging']) || empty($this->request->params['paging'][$model])) {
-			return null;
+			return [];
 		}
 		return $this->request->params['paging'][$model];
 	}
@@ -465,6 +465,9 @@ class PaginatorHelper extends Helper {
 			$model = null;
 		}
 		$paging = $this->params($model);
+		if ($paging === []) {
+			return false;
+		}
 		return $page <= $paging['pageCount'];
 	}
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -150,6 +150,12 @@ class PaginatorHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
+		$result = $this->Paginator->sort('title', null, ['model' => 'Nope']);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Paginator->sort('title', null, ['model' => 'Article']);
+		$this->assertTags($result, $expected);
+
 		$result = $this->Paginator->sort('date');
 		$expected = array(
 			'a' => array('href' => '/accounts/index/param?sort=date&amp;direction=desc', 'class' => 'asc'),
@@ -1548,7 +1554,7 @@ class PaginatorHelperTest extends TestCase {
 			'pageCount' => 5,
 		);
 
-		$result = $this->Paginator->first('first', ['model' => 'Article:']);
+		$result = $this->Paginator->first('first', ['model' => 'Article']);
 		$this->assertEquals('', $result);
 
 		$result = $this->Paginator->first('first', ['model' => 'Client']);
@@ -1642,6 +1648,9 @@ class PaginatorHelperTest extends TestCase {
 		$result = $this->Paginator->params();
 		$this->assertArrayHasKey('page', $result);
 		$this->assertArrayHasKey('pageCount', $result);
+
+		$result = $this->Paginator->params('Nope');
+		$this->assertEquals([], $result);
 	}
 
 /**
@@ -1766,7 +1775,7 @@ class PaginatorHelperTest extends TestCase {
 			'pageCount' => 5,
 		);
 
-		$result = $this->Paginator->last('last', ['model' => 'Article:']);
+		$result = $this->Paginator->last('last', ['model' => 'Article']);
 		$this->assertEquals('', $result);
 
 		$result = $this->Paginator->last('last', ['model' => 'Client']);


### PR DESCRIPTION
Always returning an array fixes downstream fatal errors caused by merging an array onto null.

Fixes #3374
