### PR TITLE
3.0 - Strict subcommands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,5 @@
 			"Cake\\": "src",
 			"Cake\\Test\\": "tests"
 		}
-	},
-	"bin": [
-		"src/Console/cake"
-	]
+	}
 }

--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -194,7 +194,6 @@ class BakeShell extends Shell {
 		$this->out('Bake All');
 		$this->hr();
 
-		$this->connection = 'default';
 		if (!empty($this->params['connection'])) {
 			$this->connection = $this->params['connection'];
 		}
@@ -218,7 +217,7 @@ class BakeShell extends Shell {
 		$this->Model->bake($name);
 		$this->Controller->bake($name);
 
-		$this->View->execute($name);
+		$this->View->main($name);
 
 		$this->out(__d('cake_console', '<success>Bake All complete</success>'), 1, Shell::QUIET);
 		return true;

--- a/src/Console/Command/CompletionShell.php
+++ b/src/Console/Command/CompletionShell.php
@@ -75,7 +75,7 @@ class CompletionShell extends Shell {
  *
  * @return void
  */
-	public function subCommands() {
+	public function subcommands() {
 		if (!$this->args) {
 			return $this->_output();
 		}
@@ -86,7 +86,7 @@ class CompletionShell extends Shell {
 
 /**
  * Guess autocomplete from the whole argument string
- * 
+ *
  * @return void
  */
 	public function fuzzy() {
@@ -132,6 +132,8 @@ class CompletionShell extends Shell {
 					]
 				]
 			]
+		])->addSubcommand('fuzzy', [
+			'help' => __d('cake_console', 'Guess autocomplete')
 		])->epilog([
 			__d('cake_console', 'This command is not intended to be called manually'),
 		]);

--- a/src/Console/Command/CompletionShell.php
+++ b/src/Console/Command/CompletionShell.php
@@ -107,8 +107,6 @@ class CompletionShell extends Shell {
 			'help' => __d('cake_console', 'Output a list of available commands'),
 			'parser' => [
 				'description' => __d('cake_console', 'List all availables'),
-				'arguments' => [
-				]
 			]
 		])->addSubcommand('subcommands', [
 			'help' => __d('cake_console', 'Output a list of available subcommands'),
@@ -117,7 +115,7 @@ class CompletionShell extends Shell {
 				'arguments' => [
 					'command' => [
 						'help' => __d('cake_console', 'The command name'),
-						'required' => true,
+						'required' => false,
 					]
 				]
 			]

--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -80,7 +80,7 @@ class BakeTask extends Shell {
  *
  * @return void
  */
-	public function execute() {
+	public function main() {
 		foreach ($this->args as $i => $arg) {
 			if (strpos($arg, '.')) {
 				list($this->params['plugin'], $this->args[$i]) = pluginSplit($arg);

--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -113,6 +113,7 @@ class BakeTask extends Shell {
 			'help' => __d('cake_console', 'Force overwriting existing files without prompting.')
 		])->addOption('connection', [
 			'short' => 'c',
+			'default' => 'default',
 			'help' => __d('cake_console', 'The datasource connection to get data from.')
 		])->addOption('theme', [
 			'short' => 't',

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -44,8 +44,8 @@ class ControllerTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($name = null) {
-		parent::execute();
+	public function main($name = null) {
+		parent::main();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -47,20 +47,12 @@ class ControllerTask extends BakeTask {
 	public function main($name = null) {
 		parent::main();
 
-		if (!isset($this->connection)) {
-			$this->connection = 'default';
-		}
-
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Possible controllers based on your current database:'));
 			foreach ($this->listAll() as $table) {
 				$this->out('- ' . $this->_controllerName($table));
 			}
 			return true;
-		}
-
-		if (strtolower($name) === 'all') {
-			return $this->all();
 		}
 
 		$controller = $this->_controllerName($name);

--- a/src/Console/Command/Task/ExtractTask.php
+++ b/src/Console/Command/Task/ExtractTask.php
@@ -145,7 +145,7 @@ class ExtractTask extends Shell {
  *
  * @return void
  */
-	public function execute() {
+	public function main() {
 		if (!empty($this->params['exclude'])) {
 			$this->_exclude = explode(',', $this->params['exclude']);
 		}

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -92,9 +92,6 @@ class FixtureTask extends BakeTask {
  */
 	public function main($name = null) {
 		parent::main();
-		if (!isset($this->connection)) {
-			$this->connection = 'default';
-		}
 
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a fixture to bake from the following:'));
@@ -104,9 +101,6 @@ class FixtureTask extends BakeTask {
 			return true;
 		}
 
-		if (strtolower($name) === 'all') {
-			return $this->all();
-		}
 		$table = null;
 		if (isset($this->params['table'])) {
 			$table = $this->params['table'];

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -90,8 +90,8 @@ class FixtureTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($name = null) {
-		parent::execute();
+	public function main($name = null) {
+		parent::main();
 		if (!isset($this->connection)) {
 			$this->connection = 'default';
 		}

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -75,8 +75,8 @@ class ModelTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($name = null) {
-		parent::execute();
+	public function main($name = null) {
+		parent::main();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -78,20 +78,12 @@ class ModelTask extends BakeTask {
 	public function main($name = null) {
 		parent::main();
 
-		if (!isset($this->connection)) {
-			$this->connection = 'default';
-		}
-
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a model to bake from the following:'));
 			foreach ($this->listAll() as $table) {
 				$this->out('- ' . $this->_modelName($table));
 			}
 			return true;
-		}
-
-		if (strtolower($name) === 'all') {
-			return $this->all();
 		}
 
 		$this->bake($this->_modelName($name));

--- a/src/Console/Command/Task/PluginTask.php
+++ b/src/Console/Command/Task/PluginTask.php
@@ -56,7 +56,7 @@ class PluginTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($name = null) {
+	public function main($name = null) {
 		if (empty($name)) {
 			$this->err('<error>You must provide a plugin name in CamelCase format.</error>');
 			$this->err('To make an "Example" plugin, run <info>Console/cake bake plugin Example</info>.');

--- a/src/Console/Command/Task/ProjectTask.php
+++ b/src/Console/Command/Task/ProjectTask.php
@@ -41,7 +41,7 @@ class ProjectTask extends BakeTask {
  *
  * @return mixed
  */
-	public function execute() {
+	public function main() {
 		$project = null;
 		if (isset($this->args[0])) {
 			$project = $this->args[0];

--- a/src/Console/Command/Task/SimpleBakeTask.php
+++ b/src/Console/Command/Task/SimpleBakeTask.php
@@ -72,8 +72,8 @@ abstract class SimpleBakeTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($name = null) {
-		parent::execute();
+	public function main($name = null) {
+		parent::main();
 		if (empty($name)) {
 			return $this->error('You must provide a name to bake a ' . $this->name());
 		}

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -81,8 +81,8 @@ class TestTask extends BakeTask {
  *
  * @return void
  */
-	public function execute($type = null, $name = null) {
-		parent::execute();
+	public function main($type = null, $name = null) {
+		parent::main();
 		if (empty($type) && empty($name)) {
 			return $this->outputTypeChoices();
 		}

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -98,8 +98,8 @@ class ViewTask extends BakeTask {
  *
  * @return mixed
  */
-	public function execute($name = null, $template = null, $action = null) {
-		parent::execute();
+	public function main($name = null, $template = null, $action = null) {
+		parent::main();
 
 		if (!isset($this->connection)) {
 			$this->connection = 'default';

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -101,10 +101,6 @@ class ViewTask extends BakeTask {
 	public function main($name = null, $template = null, $action = null) {
 		parent::main();
 
-		if (!isset($this->connection)) {
-			$this->connection = 'default';
-		}
-
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Possible tables to bake views for based on your current database:'));
 			$this->Model->connection = $this->connection;
@@ -112,10 +108,6 @@ class ViewTask extends BakeTask {
 				$this->out('- ' . $this->_controllerName($table));
 			}
 			return true;
-		}
-
-		if (strtolower($name) === 'all') {
-			return $this->all();
 		}
 
 		$controller = null;
@@ -219,7 +211,7 @@ class ViewTask extends BakeTask {
 		$tables = $this->Model->listAll();
 
 		foreach ($tables as $table) {
-			$this->execute($table);
+			$this->main($table);
 		}
 	}
 

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * ConsoleOptionParser file
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -463,9 +463,12 @@ class ConsoleOptionParser {
  * @return Array [$params, $args]
  * @throws \Cake\Console\Error\ConsoleException When an invalid parameter is encountered.
  */
-	public function parse($argv, $command = null) {
-		if (isset($this->_subcommands[$command]) && $this->_subcommands[$command]->parser()) {
+	public function parse($argv) {
+		$command = isset($argv[0]) ? $argv[0] : null;
+		if (isset($this->_subcommands[$command])) {
 			array_shift($argv);
+		}
+		if (isset($this->_subcommands[$command]) && $this->_subcommands[$command]->parser()) {
 			return $this->_subcommands[$command]->parser()->parse($argv);
 		}
 		$params = $args = [];

--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -465,6 +465,7 @@ class ConsoleOptionParser {
  */
 	public function parse($argv, $command = null) {
 		if (isset($this->_subcommands[$command]) && $this->_subcommands[$command]->parser()) {
+			array_shift($argv);
 			return $this->_subcommands[$command]->parser()->parse($argv);
 		}
 		$params = $args = [];

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -332,8 +332,6 @@ class Shell {
  * you must define all the subcommands your shell needs, whether they be methods on this class
  * or methods on tasks.
  *
- * @param string $command The command name to run on this shell. If this argument is empty,
- *   and the shell has a `main()` method, that will be called instead.
  * @param array $argv Array of arguments to run the shell with. This array should be missing the shell name.
  * @param boolean $autoMethod Set to true to allow any public method to be called even if it
  *   was not defined as a subcommand. This is used by ShellDispatcher to make building simple shells easy.

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -335,10 +335,12 @@ class Shell {
  * @param string $command The command name to run on this shell. If this argument is empty,
  *   and the shell has a `main()` method, that will be called instead.
  * @param array $argv Array of arguments to run the shell with. This array should be missing the shell name.
+ * @param boolean $autoMethod Set to true to allow any public method to be called even if it
+ *   was not defined as a subcommand. This is used by ShellDispatcher to make building simple shells easy.
  * @return void
  * @link http://book.cakephp.org/2.0/en/console-and-shells.html#Shell::runCommand
  */
-	public function runCommand($argv) {
+	public function runCommand($argv, $autoMethod = false) {
 		$command = isset($argv[0]) ? $argv[0] : null;
 		$this->OptionParser = $this->getOptionParser();
 		try {
@@ -367,7 +369,7 @@ class Shell {
 		$subcommands = $this->OptionParser->subcommands();
 		$isMethod = $this->hasMethod($command);
 
-		if ($isMethod && count($subcommands) === 0) {
+		if ($isMethod && $autoMethod && count($subcommands) === 0) {
 			array_shift($this->args);
 			$this->startup();
 			return call_user_func_array([$this, $command], $this->args);
@@ -382,7 +384,7 @@ class Shell {
 			$this->startup();
 			$command = Inflector::camelize($command);
 			array_shift($argv);
-			return $this->{$command}->runCommand($argv);
+			return $this->{$command}->runCommand($argv, false);
 		}
 
 		if ($this->hasMethod('main')) {

--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -381,7 +381,7 @@ class Shell {
 		if ($this->hasTask($command) && isset($subcommands[$command])) {
 			$this->startup();
 			$command = Inflector::camelize($command);
-			$argv[0] = 'execute';
+			array_shift($argv);
 			return $this->{$command}->runCommand($argv);
 		}
 

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -159,13 +159,8 @@ class ShellDispatcher {
 
 		$Shell = $this->findShell($shell);
 
-		$command = null;
-		if (isset($this->args[0])) {
-			$command = $this->args[0];
-		}
-
 		$Shell->initialize();
-		return $Shell->runCommand($command, $this->args);
+		return $Shell->runCommand($this->args);
 	}
 
 /**

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -160,7 +160,7 @@ class ShellDispatcher {
 		$Shell = $this->findShell($shell);
 
 		$Shell->initialize();
-		return $Shell->runCommand($this->args);
+		return $Shell->runCommand($this->args, true);
 	}
 
 /**

--- a/tests/TestCase/Console/Command/BakeShellTest.php
+++ b/tests/TestCase/Console/Command/BakeShellTest.php
@@ -78,7 +78,7 @@ class BakeShellTest extends TestCase {
 			->will($this->returnValue(true));
 
 		$this->Shell->View->expects($this->once())
-			->method('execute')
+			->method('main')
 			->with('Comments');
 
 		$this->Shell->expects($this->at(0))

--- a/tests/TestCase/Console/Command/CompletionShellTest.php
+++ b/tests/TestCase/Console/Command/CompletionShellTest.php
@@ -83,7 +83,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testStartup() {
-		$this->Shell->runCommand('main', array());
+		$this->Shell->runCommand(['main']);
 		$output = $this->out->output;
 
 		$needle = 'Welcome to CakePHP';
@@ -96,7 +96,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testMain() {
-		$this->Shell->runCommand('main', array());
+		$this->Shell->runCommand(['main']);
 		$output = $this->out->output;
 
 		$expected = "/This command is not intended to be called manually/";
@@ -109,7 +109,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testCommands() {
-		$this->Shell->runCommand('commands', array());
+		$this->Shell->runCommand(['commands']);
 		$output = $this->out->output;
 
 		$expected = "TestPlugin.example TestPluginTwo.example TestPluginTwo.welcome bake i18n server test sample\n";
@@ -122,7 +122,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testOptionsNoArguments() {
-		$this->Shell->runCommand('options', array());
+		$this->Shell->runCommand(['options']);
 		$output = $this->out->output;
 
 		$expected = "--help -h --verbose -v --quiet -q\n";
@@ -135,7 +135,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testOptionsNonExistingCommand() {
-		$this->Shell->runCommand('options', array('options', 'foo'));
+		$this->Shell->runCommand(['options', 'foo']);
 		$output = $this->out->output;
 
 		$expected = "--help -h --verbose -v --quiet -q\n";
@@ -148,7 +148,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testOptions() {
-		$this->Shell->runCommand('options', array('options', 'bake'));
+		$this->Shell->runCommand(['options', 'bake']);
 		$output = $this->out->output;
 
 		$expected = "--help -h --verbose -v --quiet -q --connection -c --theme -t\n";
@@ -161,7 +161,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsCorePlugin() {
-		$this->Shell->runCommand('subcommands', array('subcommands', 'CORE.bake'));
+		$this->Shell->runCommand(['subcommands', 'CORE.bake']);
 		$output = $this->out->output;
 
 		$expected = "behavior component controller fixture helper model plugin project shell test view widget zerg\n";
@@ -174,7 +174,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsAppPlugin() {
-		$this->Shell->runCommand('subcommands', array('subcommands', 'app.sample'));
+		$this->Shell->runCommand(['subcommands', 'app.sample']);
 		$output = $this->out->output;
 
 		$expected = '';
@@ -187,7 +187,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsPlugin() {
-		$this->Shell->runCommand('subcommands', array('subcommands', 'TestPluginTwo.welcome'));
+		$this->Shell->runCommand(['subcommands', 'TestPluginTwo.welcome']);
 		$output = $this->out->output;
 
 		$expected = "say_hello\n";
@@ -200,7 +200,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsNoArguments() {
-		$this->Shell->runCommand('subcommands', array());
+		$this->Shell->runCommand(['subcommands']);
 		$output = $this->out->output;
 
 		$expected = '';
@@ -213,7 +213,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsNonExistingCommand() {
-		$this->Shell->runCommand('subcommands', array('subcommands', 'foo'));
+		$this->Shell->runCommand(['subcommands', 'foo']);
 		$output = $this->out->output;
 
 		$expected = '';
@@ -226,7 +226,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommands() {
-		$this->Shell->runCommand('subcommands', array('subcommands', 'bake'));
+		$this->Shell->runCommand(['subcommands', 'bake']);
 		$output = $this->out->output;
 
 		$expected = "behavior component controller fixture helper model plugin project shell test view widget zerg\n";
@@ -239,7 +239,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testFuzzy() {
-		$this->Shell->runCommand('fuzzy', array());
+		$this->Shell->runCommand(['fuzzy']);
 		$output = $this->out->output;
 
 		$expected = '';

--- a/tests/TestCase/Console/Command/CompletionShellTest.php
+++ b/tests/TestCase/Console/Command/CompletionShellTest.php
@@ -161,7 +161,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsCorePlugin() {
-		$this->Shell->runCommand('subCommands', array('subCommands', 'CORE.bake'));
+		$this->Shell->runCommand('subcommands', array('subcommands', 'CORE.bake'));
 		$output = $this->out->output;
 
 		$expected = "behavior component controller fixture helper model plugin project shell test view widget zerg\n";
@@ -174,7 +174,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsAppPlugin() {
-		$this->Shell->runCommand('subCommands', array('subCommands', 'app.sample'));
+		$this->Shell->runCommand('subcommands', array('subcommands', 'app.sample'));
 		$output = $this->out->output;
 
 		$expected = '';
@@ -187,7 +187,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsPlugin() {
-		$this->Shell->runCommand('subCommands', array('subCommands', 'TestPluginTwo.welcome'));
+		$this->Shell->runCommand('subcommands', array('subcommands', 'TestPluginTwo.welcome'));
 		$output = $this->out->output;
 
 		$expected = "say_hello\n";
@@ -200,7 +200,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsNoArguments() {
-		$this->Shell->runCommand('subCommands', array());
+		$this->Shell->runCommand('subcommands', array());
 		$output = $this->out->output;
 
 		$expected = '';
@@ -213,7 +213,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommandsNonExistingCommand() {
-		$this->Shell->runCommand('subCommands', array('subCommands', 'foo'));
+		$this->Shell->runCommand('subcommands', array('subcommands', 'foo'));
 		$output = $this->out->output;
 
 		$expected = '';
@@ -226,7 +226,7 @@ class CompletionShellTest extends TestCase {
  * @return void
  */
 	public function testSubCommands() {
-		$this->Shell->runCommand('subCommands', array('subCommands', 'bake'));
+		$this->Shell->runCommand('subcommands', array('subcommands', 'bake'));
 		$output = $this->out->output;
 
 		$expected = "behavior component controller fixture helper model plugin project shell test view widget zerg\n";

--- a/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
@@ -280,7 +280,7 @@ class ControllerTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteNoArgs() {
+	public function testMainNoArgs() {
 		$this->Task->expects($this->never())
 			->method('createFile');
 
@@ -288,7 +288,7 @@ class ControllerTaskTest extends TestCase {
 			->method('out')
 			->with($this->stringContains('Possible controllers based on your current database'));
 
-		$this->Task->execute();
+		$this->Task->main();
 	}
 
 /**
@@ -296,7 +296,7 @@ class ControllerTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteIntoAll() {
+	public function testMainIntoAll() {
 		$count = count($this->Task->listAll());
 		if ($count != count($this->fixtures)) {
 			$this->markTestSkipped('Additional tables detected.');
@@ -316,11 +316,11 @@ class ControllerTaskTest extends TestCase {
 			))
 			->will($this->returnValue(true));
 
-		$this->Task->execute('all');
+		$this->Task->all();
 	}
 
 /**
- * data provider for testExecuteWithControllerNameVariations
+ * data provider for testMainWithControllerNameVariations
  *
  * @return void
  */
@@ -336,14 +336,14 @@ class ControllerTaskTest extends TestCase {
  * @dataProvider nameVariations
  * @return void
  */
-	public function testExecuteWithControllerNameVariations($name) {
+	public function testMainWithControllerNameVariations($name) {
 		$this->Task->connection = 'test';
 
 		$filename = $this->_normalizePath(APP . 'Controller/BakeArticlesController.php');
 		$this->Task->expects($this->once())
 			->method('createFile')
 			->with($filename, $this->stringContains('public function index()'));
-		$this->Task->execute($name);
+		$this->Task->main($name);
 	}
 
 }

--- a/tests/TestCase/Console/Command/Task/ExtractTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ExtractTaskTest.php
@@ -75,7 +75,7 @@ class ExtractTaskTest extends TestCase {
 			->will($this->returnValue('y'));
 		$this->Task->expects($this->never())->method('_stop');
 
-		$this->Task->execute();
+		$this->Task->main();
 		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
@@ -135,7 +135,7 @@ class ExtractTaskTest extends TestCase {
 			->will($this->returnValue('y'));
 		$this->Task->expects($this->never())->method('_stop');
 
-		$this->Task->execute();
+		$this->Task->main();
 		$this->assertTrue(file_exists($this->path . DS . 'LC_TIME' . DS . 'default.pot'));
 
 		$result = file_get_contents($this->path . DS . 'default.pot');
@@ -159,7 +159,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->expects($this->any())->method('in')
 			->will($this->returnValue('y'));
 
-		$this->Task->execute();
+		$this->Task->main();
 		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
@@ -186,7 +186,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->params['extract-core'] = 'no';
 		$this->Task->expects($this->never())->method('err');
 		$this->Task->expects($this->never())->method('_stop');
-		$this->Task->execute();
+		$this->Task->main();
 
 		$result = file_get_contents($this->path . DS . 'default.pot');
 
@@ -213,7 +213,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['exclude-plugins'] = true;
 
-		$this->Task->execute();
+		$this->Task->main();
 		$result = file_get_contents($this->path . DS . 'default.pot');
 		$this->assertNotRegExp('#TestPlugin#', $result);
 	}
@@ -234,7 +234,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['plugin'] = 'TestPlugin';
 
-		$this->Task->execute();
+		$this->Task->main();
 		$result = file_get_contents($this->path . DS . 'default.pot');
 		$this->assertNotRegExp('#Pages#', $result);
 		$this->assertRegExp('/translate\.ctp:\d+/', $result);
@@ -259,7 +259,7 @@ class ExtractTaskTest extends TestCase {
 		$this->assertTrue(file_exists($this->path . DS . 'default.pot'));
 		$original = file_get_contents($this->path . DS . 'default.pot');
 
-		$this->Task->execute();
+		$this->Task->main();
 		$result = file_get_contents($this->path . DS . 'default.pot');
 		$this->assertNotEquals($original, $result);
 	}
@@ -277,7 +277,7 @@ class ExtractTaskTest extends TestCase {
 		$this->Task->params['output'] = $this->path . DS;
 		$this->Task->params['extract-core'] = 'yes';
 
-		$this->Task->execute();
+		$this->Task->main();
 		$this->assertTrue(file_exists($this->path . DS . 'cake.pot'));
 		$result = file_get_contents($this->path . DS . 'cake.pot');
 

--- a/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
@@ -177,7 +177,7 @@ class FixtureTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithTableOption() {
+	public function testMainWithTableOption() {
 		$this->Task->connection = 'test';
 		$this->Task->params = ['table' => 'comments'];
 		$filename = $this->_normalizePath(ROOT . '/Test/Fixture/ArticleFixture.php');
@@ -186,7 +186,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains("public \$table = 'comments';"));
 
-		$this->Task->execute('article');
+		$this->Task->main('article');
 	}
 
 /**
@@ -194,7 +194,7 @@ class FixtureTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithNamedModel() {
+	public function testMainWithNamedModel() {
 		$this->Task->connection = 'test';
 		$filename = $this->_normalizePath(ROOT . '/Test/Fixture/ArticleFixture.php');
 
@@ -202,7 +202,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class ArticleFixture'));
 
-		$this->Task->execute('article');
+		$this->Task->main('article');
 	}
 
 /**
@@ -210,7 +210,7 @@ class FixtureTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteIntoAll() {
+	public function testMainIntoAll() {
 		$this->Task->connection = 'test';
 		$this->Task->Model->expects($this->any())
 			->method('listAll')
@@ -226,7 +226,7 @@ class FixtureTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class CommentFixture'));
 
-		$this->Task->execute('all');
+		$this->Task->all();
 	}
 
 /**
@@ -284,7 +284,7 @@ class FixtureTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteNoArgs() {
+	public function testMainNoArgs() {
 		$this->Task->connection = 'test';
 
 		$this->Task->Model->expects($this->any())
@@ -295,7 +295,7 @@ class FixtureTaskTest extends TestCase {
 		$this->Task->expects($this->never())
 			->method('createFile');
 
-		$this->Task->execute();
+		$this->Task->main();
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -732,7 +732,7 @@ class ModelTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteNoArgs() {
+	public function testMainNoArgs() {
 		$this->_useMockedOut();
 		$this->Task->connection = 'test';
 		$this->Task->path = '/my/path/';
@@ -741,7 +741,7 @@ class ModelTaskTest extends TestCase {
 			->method('out')
 			->with($this->stringContains('Choose a model to bake from the following:'));
 
-		$this->Task->execute();
+		$this->Task->main();
 	}
 
 /**
@@ -749,7 +749,7 @@ class ModelTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithNamedModel() {
+	public function testMainWithNamedModel() {
 		$this->Task->connection = 'test';
 
 		$tableFile = $this->_normalizePath(APP . 'Model/Table/BakeArticlesTable.php');
@@ -762,11 +762,11 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($entityFile, $this->stringContains('class BakeArticle extends Entity'));
 
-		$this->Task->execute('BakeArticles');
+		$this->Task->main('BakeArticles');
 	}
 
 /**
- * data provider for testExecuteWithNamedModelVariations
+ * data provider for testMainWithNamedModelVariations
  *
  * @return void
  */
@@ -782,7 +782,7 @@ class ModelTaskTest extends TestCase {
  * @dataProvider nameVariations
  * @return void
  */
-	public function testExecuteWithNamedModelVariations($name) {
+	public function testMainWithNamedModelVariations($name) {
 		$this->Task->connection = 'test';
 
 		$filename = $this->_normalizePath(APP . 'Model/Table/BakeArticlesTable.php');
@@ -790,7 +790,7 @@ class ModelTaskTest extends TestCase {
 		$this->Task->expects($this->at(0))
 			->method('createFile')
 			->with($filename, $this->stringContains('class BakeArticlesTable extends Table {'));
-		$this->Task->execute($name);
+		$this->Task->main($name);
 	}
 
 /**
@@ -798,7 +798,7 @@ class ModelTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteIntoAll() {
+	public function testMainIntoAll() {
 		$count = count($this->Task->listAll());
 		if ($count != count($this->fixtures)) {
 			$this->markTestSkipped('Additional tables detected.');
@@ -861,7 +861,7 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('class CategoryThread extends'));
 
-		$this->Task->execute('all');
+		$this->Task->all();
 	}
 
 /**
@@ -913,7 +913,7 @@ class ModelTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename);
 
-		$this->Task->execute('all');
+		$this->Task->all();
 	}
 
 }

--- a/tests/TestCase/Console/Command/Task/PluginTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/PluginTaskTest.php
@@ -124,7 +124,7 @@ class PluginTaskTest extends TestCase {
 		$this->Task->expects($this->never())
 			->method('createFile');
 
-		$this->Task->execute();
+		$this->Task->main();
 
 		$Folder = new Folder($path);
 		$Folder->delete();
@@ -152,7 +152,7 @@ class PluginTaskTest extends TestCase {
 		$this->Task->expects($this->at(3))->method('createFile')
 			->with($file, new \PHPUnit_Framework_Constraint_IsAnything());
 
-		$this->Task->execute('BakeTestPlugin');
+		$this->Task->main('BakeTestPlugin');
 
 		$Folder = new Folder($this->Task->path . 'BakeTestPlugin');
 		$Folder->delete();

--- a/tests/TestCase/Console/Command/Task/ProjectTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ProjectTaskTest.php
@@ -74,7 +74,7 @@ class ProjectTaskTest extends TestCase {
 		$this->markTestIncomplete('Need to figure this out');
 		$this->Task->params['skel'] = CAKE . 'Console/Templates/skel';
 		$this->Task->expects($this->at(0))->method('in')->will($this->returnValue('y'));
-		$this->Task->execute(TMP . 'BakeTestApp');
+		$this->Task->main(TMP . 'BakeTestApp');
 
 		$this->assertTrue(is_dir(TMP . 'BakeTestApp'), 'No project dir');
 		$File = new File($path . DS . 'Config/paths.php');

--- a/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
@@ -77,7 +77,7 @@ class SimpleBakeTaskTest extends TestCase {
 			->method('bake')
 			->with('behavior', 'Example');
 
-		$this->Task->execute('Example');
+		$this->Task->main('Example');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/TestTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/TestTaskTest.php
@@ -84,7 +84,7 @@ class TestTaskTest extends TestCase {
 		$this->Task->expects($this->once())
 			->method('outputTypeChoices');
 
-		$this->Task->execute();
+		$this->Task->main();
 	}
 
 /**
@@ -123,7 +123,7 @@ class TestTaskTest extends TestCase {
 		$this->Task->expects($this->once())
 			->method('outputClassChoices');
 
-		$this->Task->execute('Entity');
+		$this->Task->main('Entity');
 	}
 
 /**
@@ -137,7 +137,7 @@ class TestTaskTest extends TestCase {
 				$this->stringContains('TestCase' . DS . 'Model' . DS . 'Table' . DS . 'TestTaskTagTableTest.php'),
 				$this->stringContains('class TestTaskTagTableTest extends TestCase')
 			);
-		$this->Task->execute('Table', 'TestTaskTag');
+		$this->Task->main('Table', 'TestTaskTag');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/ViewTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ViewTaskTest.php
@@ -455,7 +455,7 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteNoArgs() {
+	public function testMainNoArgs() {
 		$this->_setupTask(['in', 'err', 'bake', 'createFile', '_stop']);
 
 		$this->Task->Model->expects($this->once())
@@ -465,21 +465,7 @@ class ViewTaskTest extends TestCase {
 		$this->Task->expects($this->never())
 			->method('bake');
 
-		$this->Task->execute();
-	}
-
-/**
- * Test all()
- *
- * @return void
- */
-	public function testExecuteIntoAll() {
-		$this->_setupTask(['in', 'err', 'createFile', 'all', '_stop']);
-
-		$this->Task->expects($this->once())
-			->method('all');
-
-		$this->Task->execute('all');
+		$this->Task->main();
 	}
 
 /**
@@ -487,20 +473,20 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testAllCallsExecute() {
-		$this->_setupTask(['in', 'err', 'createFile', 'execute', '_stop']);
+	public function testAllCallsMain() {
+		$this->_setupTask(['in', 'err', 'createFile', 'main', '_stop']);
 
 		$this->Task->Model->expects($this->once())
 			->method('listAll')
 			->will($this->returnValue(['comments', 'articles']));
 
 		$this->Task->expects($this->exactly(2))
-			->method('execute');
+			->method('main');
 		$this->Task->expects($this->at(0))
-			->method('execute')
+			->method('main')
 			->with('comments');
 		$this->Task->expects($this->at(1))
-			->method('execute')
+			->method('main')
 			->with('articles');
 
 		$this->Task->all();
@@ -511,14 +497,14 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithActionParam() {
+	public function testMainWithActionParam() {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
 
 		$this->Task->expects($this->once())
 			->method('bake')
 			->with('view', true);
 
-		$this->Task->execute('ViewTaskComments', 'view');
+		$this->Task->main('ViewTaskComments', 'view');
 	}
 
 /**
@@ -527,7 +513,7 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithController() {
+	public function testMainWithController() {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
 
 		$this->Task->expects($this->exactly(4))
@@ -549,7 +535,7 @@ class ViewTaskTest extends TestCase {
 			->method('bake')
 			->with('edit', $this->anything());
 
-		$this->Task->execute('ViewTaskComments');
+		$this->Task->main('ViewTaskComments');
 	}
 
 /**
@@ -566,7 +552,7 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithControllerFlag() {
+	public function testMainWithControllerFlag() {
 		$this->Task->params['controller'] = 'Blog';
 
 		$this->Task->expects($this->exactly(4))
@@ -580,7 +566,7 @@ class ViewTaskTest extends TestCase {
 					$this->anything()
 				);
 		}
-		$this->Task->execute('Posts');
+		$this->Task->main('Posts');
 	}
 
 /**
@@ -588,7 +574,7 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithControllerAndAdminFlag() {
+	public function testMainWithControllerAndAdminFlag() {
 		$this->Task->params['prefix'] = 'Admin';
 
 		$this->Task->expects($this->exactly(2))
@@ -602,7 +588,7 @@ class ViewTaskTest extends TestCase {
 					$this->anything()
 				);
 		}
-		$this->Task->execute('Posts');
+		$this->Task->main('Posts');
 	}
 
 /**
@@ -610,7 +596,7 @@ class ViewTaskTest extends TestCase {
  *
  * @return void
  */
-	public function testExecuteWithAlternateTemplates() {
+	public function testMainWithAlternateTemplates() {
 		$this->_setupTask(['in', 'err', 'createFile', 'bake', '_stop']);
 
 		$this->Task->connection = 'test';
@@ -619,7 +605,7 @@ class ViewTaskTest extends TestCase {
 		$this->Task->expects($this->once())
 			->method('bake')
 			->with('list', true);
-		$this->Task->execute('ViewTaskComments', 'index', 'list');
+		$this->Task->main('ViewTaskComments', 'index', 'list');
 	}
 
 /**

--- a/tests/TestCase/Console/ConsoleOptionParserTest.php
+++ b/tests/TestCase/Console/ConsoleOptionParserTest.php
@@ -633,7 +633,7 @@ TEXT;
 				)
 			));
 
-		$result = $parser->parse(array('--secondary', '--fourth', '4', 'c'), 'sub');
+		$result = $parser->parse(array('sub', '--secondary', '--fourth', '4', 'c'));
 		$expected = array(array(
 			'secondary' => true,
 			'fourth' => '4',

--- a/tests/TestCase/Console/ShellDispatcherTest.php
+++ b/tests/TestCase/Console/ShellDispatcherTest.php
@@ -130,7 +130,7 @@ class ShellDispatcherTest extends TestCase {
 
 		$Shell->expects($this->once())->method('initialize');
 		$Shell->expects($this->once())->method('runCommand')
-			->with(null, array())
+			->with([])
 			->will($this->returnValue(true));
 
 		$dispatcher->expects($this->any())
@@ -155,7 +155,7 @@ class ShellDispatcherTest extends TestCase {
 
 		$Shell->expects($this->once())->method('initialize');
 		$Shell->expects($this->once())->method('runCommand')
-			->with('initdb', array('initdb'))
+			->with(['initdb'])
 			->will($this->returnValue(true));
 
 		$dispatcher->expects($this->any())

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -715,10 +715,10 @@ class ShellTest extends TestCase {
 		$parser->addSubcommand('slice');
 
 		$shell = $this->getMock('Cake\Console\Shell', ['hasTask', 'startup', 'getOptionParser'], [], '', false);
-		$task = $this->getMock('Cake\Console\Shell', ['execute', 'runCommand'], [], '', false);
-		$task->expects($this->any())
+		$task = $this->getMock('Cake\Console\Shell', ['main', 'runCommand'], [], '', false);
+		$task->expects($this->once())
 			->method('runCommand')
-			->with(['execute', 'one']);
+			->with(['one']);
 
 		$shell->expects($this->once())->method('getOptionParser')
 			->will($this->returnValue($parser));

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -548,8 +548,27 @@ class ShellTest extends TestCase {
 		$shell->expects($this->once())->method('hit_me')
 			->with('cakes')
 			->will($this->returnValue(true));
-		$result = $shell->runCommand(['hit_me', 'cakes', '--verbose']);
+		$result = $shell->runCommand(['hit_me', 'cakes', '--verbose'], true);
 		$this->assertTrue($result);
+	}
+
+/**
+ * Test that runCommand() doesn't call public methods when the second arg is false.
+ *
+ * @return void
+ */
+	public function testRunCommandAutoMethodOff() {
+		$io = $this->getMock('Cake\Console\ConsoleIo');
+		$shell = $this->getMock('Cake\Console\Shell', ['hit_me', 'startup'], [$io]);
+
+		$shell->expects($this->never())->method('startup');
+		$shell->expects($this->never())->method('hit_me');
+
+		$result = $shell->runCommand(['hit_me', 'baseball'], false);
+		$this->assertFalse($result);
+
+		$result = $shell->runCommand(['hit_me', 'baseball']);
+		$this->assertFalse($result, 'Default value of runCommand() should be false');
 	}
 
 /**
@@ -718,7 +737,7 @@ class ShellTest extends TestCase {
 		$task = $this->getMock('Cake\Console\Shell', ['main', 'runCommand'], [], '', false);
 		$task->expects($this->once())
 			->method('runCommand')
-			->with(['one']);
+			->with(['one'], false);
 
 		$shell->expects($this->once())->method('getOptionParser')
 			->will($this->returnValue($parser));

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -531,7 +531,7 @@ class ShellTest extends TestCase {
 		$shell->expects($this->once())->method('main')
 			->with('cakes')
 			->will($this->returnValue(true));
-		$result = $shell->runCommand('cakes', ['cakes', '--verbose']);
+		$result = $shell->runCommand(['cakes', '--verbose']);
 		$this->assertTrue($result);
 	}
 
@@ -548,7 +548,7 @@ class ShellTest extends TestCase {
 		$shell->expects($this->once())->method('hit_me')
 			->with('cakes')
 			->will($this->returnValue(true));
-		$result = $shell->runCommand('hit_me', ['hit_me', 'cakes', '--verbose']);
+		$result = $shell->runCommand(['hit_me', 'cakes', '--verbose']);
 		$this->assertTrue($result);
 	}
 
@@ -574,7 +574,7 @@ class ShellTest extends TestCase {
 		$shell->expects($this->never())->method('startup');
 		$shell->expects($this->never())->method('roll');
 
-		$result = $shell->runCommand('roll', ['roll', 'cakes', '--verbose']);
+		$result = $shell->runCommand(['roll', 'cakes', '--verbose']);
 		$this->assertFalse($result);
 	}
 
@@ -599,7 +599,7 @@ class ShellTest extends TestCase {
 			->method('slice')
 			->with('cakes');
 
-		$shell->runCommand('slice', ['slice', 'cakes', '--verbose']);
+		$shell->runCommand(['slice', 'cakes', '--verbose']);
 	}
 
 /**
@@ -623,7 +623,7 @@ class ShellTest extends TestCase {
 		$parser->expects($this->once())
 			->method('help');
 
-		$shell->runCommand('slice', ['slice', 'cakes', '--verbose']);
+		$shell->runCommand(['slice', 'cakes', '--verbose']);
 	}
 
 /**
@@ -641,7 +641,7 @@ class ShellTest extends TestCase {
 		$shell->expects($this->never())->method('hr');
 		$shell->expects($this->once())->method('out');
 
-		$shell->runCommand('hr', array());
+		$shell->runCommand(['hr']);
 	}
 
 /**
@@ -658,7 +658,7 @@ class ShellTest extends TestCase {
 			->will($this->returnValue($parser));
 		$shell->expects($this->once())->method('out');
 
-		$result = $shell->runCommand('idontexist', array());
+		$result = $shell->runCommand(['idontexist']);
 		$this->assertFalse($result);
 	}
 
@@ -679,7 +679,7 @@ class ShellTest extends TestCase {
 			->will($this->returnValue($Parser));
 		$Shell->expects($this->once())->method('out');
 
-		$Shell->runCommand(null, array('--help'));
+		$Shell->runCommand(['--help']);
 	}
 
 /**
@@ -701,7 +701,7 @@ class ShellTest extends TestCase {
 		$shell->expects($this->once())->method('out');
 		$shell->RunCommand = $task;
 
-		$result = $shell->runCommand('run_command', ['run_command', 'one']);
+		$result = $shell->runCommand(['run_command', 'one']);
 		$this->assertFalse($result);
 	}
 
@@ -718,7 +718,7 @@ class ShellTest extends TestCase {
 		$task = $this->getMock('Cake\Console\Shell', ['execute', 'runCommand'], [], '', false);
 		$task->expects($this->any())
 			->method('runCommand')
-			->with('execute', ['one']);
+			->with(['execute', 'one']);
 
 		$shell->expects($this->once())->method('getOptionParser')
 			->will($this->returnValue($parser));
@@ -729,7 +729,7 @@ class ShellTest extends TestCase {
 			->will($this->returnValue(true));
 
 		$shell->Slice = $task;
-		$shell->runCommand('slice', ['slice', 'one']);
+		$shell->runCommand(['slice', 'one']);
 	}
 
 /**
@@ -799,7 +799,7 @@ TEXT;
 			->with(false);
 
 		$this->Shell = $this->getMock(__NAMESPACE__ . '\ShellTestShell', array('_useLogger'), array($io));
-		$this->Shell->runCommand('foo', array('--quiet'));
+		$this->Shell->runCommand(['foo', '--quiet']);
 	}
 
 }


### PR DESCRIPTION
This set of changes implements stricter subcommand handling. After these changes, subcommands work in  the following way:
- If a shell has no subcommands in its option parser, and it is the top level shell, all public methods can be called. This lets us keep a nice RAD way to build simple shells that don't need additional parsing features.
- For Shells that define subcommands, only those subcommands will be callable.
- Tasks must be exposed via subcommands. Any subcommands on tasks must also be exposed by nested parsers.

One nice benefit of these changes is that subcommands and tasks can be nested as deeply as it is required.

This set of changes also renames Task::execute() to be main(). This makes one convention fewer that people need to remember, and makes shells and tasks more interchangeable.
