### PR TITLE
Updating the TimestapBehavior so it uses the new Time lib

### DIFF
--- a/src/Model/Behavior/TimestampBehavior.php
+++ b/src/Model/Behavior/TimestampBehavior.php
@@ -18,6 +18,7 @@ use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
+use Cake\Utility\Time;
 
 class TimestampBehavior extends Behavior {
 
@@ -131,16 +132,16 @@ class TimestampBehavior extends Behavior {
  *
  * @param \DateTime $ts
  * @param bool $refreshTimestamp
- * @return \DateTime
+ * @return \Cake\Utility\Time
  */
 	public function timestamp(\DateTime $ts = null, $refreshTimestamp = false) {
 		if ($ts) {
 			if ($this->_config['refreshTimestamp']) {
 				$this->_config['refreshTimestamp'] = false;
 			}
-			$this->_ts = $ts;
+			$this->_ts = new Time($ts);
 		} elseif ($this->_ts === null || $refreshTimestamp) {
-			$this->_ts = new \DateTime();
+			$this->_ts = new Time();
 		}
 
 		return $this->_ts;

--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -105,7 +105,7 @@ class Time extends Carbon implements JsonSerializable {
  */
 	public function __construct($time = null, $tz = null) {
 		if ($time instanceof \DateTime) {
-			list($time, $tz) = [$dt->format('Y-m-d H:i:s'), $dt->getTimeZone()];
+			list($time, $tz) = [$time->format('Y-m-d H:i:s'), $time->getTimeZone()];
 		}
 
 		if (is_numeric($time)) {

--- a/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
@@ -92,7 +92,8 @@ class TimestampBehaviorTest extends TestCase {
 
 		$return = $this->Behavior->handleEvent($event, $entity);
 		$this->assertTrue($return, 'Handle Event is expected to always return true');
-		$this->assertSame($ts, $entity->created, 'Created timestamp is expected to be the mocked value');
+		$this->assertInstanceOf('Cake\Utility\Time', $entity->created);
+		$this->assertSame($ts->format('c'), $entity->created->format('c'), 'Created timestamp is not the same');
 	}
 
 /**
@@ -152,7 +153,8 @@ class TimestampBehaviorTest extends TestCase {
 
 		$return = $this->Behavior->handleEvent($event, $entity);
 		$this->assertTrue($return, 'Handle Event is expected to always return true');
-		$this->assertSame($ts, $entity->modified, 'Modified timestamp is expected to be the mocked value');
+		$this->assertInstanceOf('Cake\Utility\Time', $entity->modified);
+		$this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is not the same');
 	}
 
 /**
@@ -174,7 +176,8 @@ class TimestampBehaviorTest extends TestCase {
 
 		$return = $this->Behavior->handleEvent($event, $entity);
 		$this->assertTrue($return, 'Handle Event is expected to always return true');
-		$this->assertSame($ts, $entity->modified, 'Modified timestamp is expected to be updated');
+		$this->assertInstanceOf('Cake\Utility\Time', $entity->modified);
+		$this->assertSame($ts->format('c'), $entity->modified->format('c'), 'Modified timestamp is expected to be updated');
 	}
 
 /**
@@ -269,9 +272,9 @@ class TimestampBehaviorTest extends TestCase {
 		$this->Behavior->timestamp($ts);
 		$return = $this->Behavior->timestamp();
 
-		$this->assertSame(
-			$ts,
-			$return,
+		$this->assertEquals(
+			$ts->format('c'),
+			$return->format('c'),
 			'Should return the same value as initially set'
 		);
 	}

--- a/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/TimestampBehaviorTest.php
@@ -19,6 +19,7 @@ use Cake\Model\Behavior\TimestampBehavior;
 use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Time;
 
 /**
  * Behavior test case
@@ -213,10 +214,8 @@ class TimestampBehaviorTest extends TestCase {
 			'Should return a timestamp object'
 		);
 
-		$now = time();
-		$ts = $return->getTimestamp();
-
-		$this->assertLessThan(3, abs($now - $ts), "Timestamp is expected to within 3 seconds of the current timestamp");
+		$now = Time::now();
+		$this->assertEquals($now, $return);
 
 		return $this->Behavior;
 	}
@@ -374,12 +373,8 @@ class TimestampBehaviorTest extends TestCase {
 
 		$row = $table->find('all')->where(['id' => $entity->id])->first();
 
-		$now = time();
-
-		$storedValue = $row->created->getTimestamp();
-		$this->assertLessThan(3, abs($storedValue - $now), "The stored created timestamp is expected to within 3 seconds of the current timestamp");
-
-		$storedValue = $row->updated->getTimestamp();
-		$this->assertLessThan(3, abs($storedValue - $now), "The stored updated timestamp is expected to within 3 seconds of the current timestamp");
+		$now = Time::now();
+		$this->assertEquals($now, $row->created);
+		$this->assertEquals($now, $row->updated);
 	}
 }


### PR DESCRIPTION
After reading https://github.com/cakephp/cakephp/issues/3388, I realized that the Timestamp behavior was not using the Time lib, thus it would have been impossible to mock "now" in the tests.
