### PR TITLE
Don't use a low port number for ServerShell.

### DIFF
--- a/src/Console/Command/ServerShell.php
+++ b/src/Console/Command/ServerShell.php
@@ -36,7 +36,7 @@ class ServerShell extends Shell {
  *
  * @var int
  */
-	const DEFAULT_PORT = 80;
+	const DEFAULT_PORT = 8765;
 
 /**
  * server host


### PR DESCRIPTION
Using port 80 requires sudo on many installations. Far too many applications use 8080, or 8000 so use something different.
