### PR TITLE
2.5-ExceptionRenderer support optional view class for rendering

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -71,12 +71,14 @@
  * - `skipLog` - array - list of exceptions to skip for logging. Exceptions that
  *   extend one of the listed exceptions will also be skipped for logging.
  *   Example: `'skipLog' => array('NotFoundException', 'UnauthorizedException')`
+ * - `viewClass` - string - The name of the View class.
  *
  * @see ErrorHandler for more information on exception handling and configuration.
  */
 	Configure::write('Exception', array(
 		'handler' => 'ErrorHandler::handleException',
 		'renderer' => 'ExceptionRenderer',
+		'viewClass' => 'View',
 		'log' => true
 	));
 

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -321,7 +321,9 @@ class ExceptionRenderer {
 			$viewClass = $viewClass . 'View';
 			App::uses($viewClass, $plugin . 'View');
 		}
-
+		if (!class_exists($viewClass)) {
+			$viewClass = 'View';
+		}
 		return new $viewClass($controller);
 	}
 }

--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -303,10 +303,25 @@ class ExceptionRenderer {
 		$this->controller->layout = 'error';
 		$this->controller->helpers = array('Form', 'Html', 'Session');
 
-		$view = new View($this->controller);
+		$view = $this->_getViewObject($this->controller);
 		$this->controller->response->body($view->render($template, 'error'));
 		$this->controller->response->type('html');
 		$this->controller->response->send();
 	}
 
+/**
+ * Constructs the view class instance based on the Exception config
+ *
+ * @return View
+ */
+	protected function _getViewObject(Controller $controller) {
+		$viewClass = Configure::read('Exception.viewClass');
+		if ($viewClass !== 'View') {
+			list($plugin, $viewClass) = pluginSplit($viewClass, true);
+			$viewClass = $viewClass . 'View';
+			App::uses($viewClass, $plugin . 'View');
+		}
+
+		return new $viewClass($controller);
+	}
 }

--- a/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
+++ b/lib/Cake/Test/Case/Error/ExceptionRendererTest.php
@@ -20,6 +20,16 @@ App::uses('ExceptionRenderer', 'Error');
 App::uses('Controller', 'Controller');
 App::uses('Component', 'Controller');
 App::uses('Router', 'Routing');
+App::uses('View', 'View');
+
+/**
+ * TestView class
+ *
+ * @package       Cake.Test.Case.Error
+ */
+class TestView extends View {
+
+}
 
 /**
  * Short description for class.
@@ -117,6 +127,15 @@ class MyCustomExceptionRenderer extends ExceptionRenderer {
  */
 	public function missingWidgetThing() {
 		echo 'widget thing is missing';
+	}
+
+/**
+ * name of view class is used for render.
+ *
+ * @return void
+ */
+	public function getViewObjectName() {
+		return get_class($this->_getViewObject($this->controller));
 	}
 
 }
@@ -810,4 +829,22 @@ class ExceptionRendererTest extends CakeTestCase {
 		$this->assertContains(h('SELECT * from poo_query < 5 and :seven'), $result);
 		$this->assertContains("'seven' => (int) 7", $result);
 	}
+
+/**
+ * Test View class
+ *
+ * @return void
+ */
+	public function testViewClassRender() {
+		$exception = new NotFoundException('Not there, sorry');
+
+		Configure::write('Exception.viewClass', 'View');
+		$ExceptionRenderer = new MyCustomExceptionRenderer($exception);
+		$this->assertEquals('View', $ExceptionRenderer->getViewObjectName());
+
+		Configure::write('Exception.viewClass', 'Test');
+		$ExceptionRenderer = new MyCustomExceptionRenderer($exception);
+		$this->assertEquals('TestView', $ExceptionRenderer->getViewObjectName());
+	}
+
 }


### PR DESCRIPTION
This is a proposal for when use  a custom View class for rendering.
if adding some function in custom view class and use this functions in layouts or view of errors, The rendering will not cause problems
