### PR TITLE
3.0 - Make view cells work with themes

### DIFF
--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -40,13 +40,12 @@ abstract class Cell {
 	public $View;
 
 /**
- * Name of the action that was invoked.
- *
- * Action name will be inflected to get the template name when rendering.
+ * Name of the template that will be rendered.
+ * This property is inflected from the action name that was invoked.
  *
  * @var string
  */
-	public $action;
+	public $template;
 
 /**
  * Automatically set to the name of a plugin.
@@ -137,13 +136,16 @@ abstract class Cell {
 /**
  * Render the cell.
  *
- * @param string $action Custom template name to render. If not provided (null), the last
+ * @param string $template Custom template name to render. If not provided (null), the last
  * value will be used. This value is automatically set by `CellTrait::cell()`.
  * @return void
  */
-	public function render($action = null) {
-		if ($action !== null) {
-			$this->action = $action;
+	public function render($template = null) {
+		if ($template !== null) {
+			$template = Inflector::underscore($template);
+		}
+		if (empty($template)) {
+			$template = $this->template;
 		}
 
 		$this->View = $this->createView();
@@ -153,7 +155,7 @@ abstract class Cell {
 		$className = array_pop($className);
 		$this->View->subDir = 'Cell' . DS . substr($className, 0, strpos($className, 'Cell'));
 
-		return $this->View->render(Inflector::underscore($this->action));
+		return $this->View->render($template);
 	}
 
 /**
@@ -175,7 +177,7 @@ abstract class Cell {
 	public function __debugInfo() {
 		return [
 			'plugin' => $this->plugin,
-			'action' => $this->action,
+			'template' => $this->template,
 			'viewClass' => $this->viewClass,
 			'request' => $this->request,
 			'response' => $this->response,

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -79,6 +79,13 @@ abstract class Cell {
 	public $viewClass = 'Cake\View\View';
 
 /**
+ * The theme name that will be used to render.
+ *
+ * @var string
+ */
+	public $theme;
+
+/**
  * Instance of the Cake\Event\EventManager this cell is using
  * to dispatch inner events.
  *
@@ -93,7 +100,7 @@ abstract class Cell {
  * @see \Cake\View\View
  */
 	protected $_validViewOptions = [
-		'viewVars', 'helpers', 'viewPath', 'plugin',
+		'viewVars', 'helpers', 'viewPath', 'plugin', 'theme'
 	];
 
 /**

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -73,6 +73,7 @@ trait CellTrait {
 		$cellInstance = new $className($this->request, $this->response, $this->getEventManager(), $options);
 		$cellInstance->action = Inflector::underscore($action);
 		$cellInstance->plugin = !empty($plugin) ? $plugin : null;
+		$cellInstance->theme = !empty($this->theme) ? $this->theme : null;
 		$length = count($data);
 
 		if ($length) {

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -71,7 +71,7 @@ trait CellTrait {
 		}
 
 		$cellInstance = new $className($this->request, $this->response, $this->getEventManager(), $options);
-		$cellInstance->action = Inflector::underscore($action);
+		$cellInstance->template = Inflector::underscore($action);
 		$cellInstance->plugin = !empty($plugin) ? $plugin : null;
 		$cellInstance->theme = !empty($this->theme) ? $this->theme : null;
 		$length = count($data);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -757,27 +757,6 @@ class View {
 	}
 
 /**
- * Adds a script block or other element to be inserted in $scripts_for_layout in
- * the `<head />` of a document layout
- *
- * @param string $name Either the key name for the script, or the script content. Name can be used to
- *   update/replace a script element.
- * @param string $content The content of the script being added, optional.
- * @return void
- * @deprecated Will be removed in 3.0. Superseded by blocks functionality.
- * @see View::start()
- */
-	public function addScript($name, $content = null) {
-		if (empty($content)) {
-			if (!in_array($name, array_values($this->_scripts))) {
-				$this->_scripts[] = $name;
-			}
-		} else {
-			$this->_scripts[$name] = $content;
-		}
-	}
-
-/**
  * Generates a unique, non-random DOM ID for an object, based on the object type and the target URL.
  *
  * @param string $object Type of object, i.e. 'form' or 'link'

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -64,12 +64,10 @@ class CellTest extends TestCase {
 		$cell = $this->View->cell('Articles::teaserList');
 		$render = "{$cell}";
 
-		$this->assertTrue(
-			strpos($render, '<h2>Lorem ipsum</h2>') !== false &&
-			strpos($render, '<h2>Usectetur adipiscing eli</h2>') !== false &&
-			strpos($render, '<h2>Topis semper blandit eu non</h2>') !== false &&
-			strpos($render, '<h2>Suspendisse gravida neque</h2>') !== false
-		);
+		$this->assertContains('<h2>Lorem ipsum</h2>', $render);
+		$this->assertContains('<h2>Usectetur adipiscing eli</h2>', $render);
+		$this->assertContains('<h2>Topis semper blandit eu non</h2>', $render);
+		$this->assertContains('<h2>Suspendisse gravida neque</h2>', $render);
 	}
 
 /**
@@ -80,7 +78,7 @@ class CellTest extends TestCase {
 	public function testCellWithArguments() {
 		$cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
 		$render = "{$cell}";
-		$this->assertTrue(strpos($render, 'dummy message') !== false);
+		$this->assertContains('dummy message', $render);
 	}
 
 /**
@@ -90,10 +88,10 @@ class CellTest extends TestCase {
  */
 	public function testDefaultCellAction() {
 		$appCell = $this->View->cell('Articles');
-		$this->assertTrue(strpos("{$appCell}", 'dummy') !== false);
+		$this->assertContains('dummy', "{$appCell}");
 
 		$pluginCell = $this->View->cell('TestPlugin.Dummy');
-		$this->assertTrue(strpos("{$pluginCell}", 'dummy') !== false);
+		$this->assertContains('dummy', "{$pluginCell}");
 	}
 
 /**
@@ -103,10 +101,10 @@ class CellTest extends TestCase {
  */
 	public function testCellManualRender() {
 		$cell = $this->View->cell('Articles::doEcho', ['msg1' => 'dummy', 'msg2' => ' message']);
-		$this->assertTrue(strpos($cell->render(), 'dummy message') !== false);
+		$this->assertContains('dummy message', $cell->render());
 
 		$cell->teaserList();
-		$this->assertTrue(strpos($cell->render('teaser_list'), '<h2>Lorem ipsum</h2>') !== false);
+		$this->assertContains('<h2>Lorem ipsum</h2>', $cell->render('teaser_list'));
 	}
 
 /**
@@ -116,7 +114,7 @@ class CellTest extends TestCase {
  */
 	public function testPluginCell() {
 		$cell = $this->View->cell('TestPlugin.Dummy::echoThis', ['msg' => 'hello world!']);
-		$this->assertTrue(strpos("{$cell}", 'hello world!') !== false);
+		$this->assertContains('hello world!', "{$cell}");
 	}
 
 /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -64,6 +64,7 @@ class CellTest extends TestCase {
 		$cell = $this->View->cell('Articles::teaserList');
 		$render = "{$cell}";
 
+		$this->assertEquals('teaser_list', $cell->template);
 		$this->assertContains('<h2>Lorem ipsum</h2>', $render);
 		$this->assertContains('<h2>Usectetur adipiscing eli</h2>', $render);
 		$this->assertContains('<h2>Topis semper blandit eu non</h2>', $render);
@@ -88,10 +89,13 @@ class CellTest extends TestCase {
  */
 	public function testDefaultCellAction() {
 		$appCell = $this->View->cell('Articles');
+
+		$this->assertEquals('display', $appCell->template);
 		$this->assertContains('dummy', "{$appCell}");
 
 		$pluginCell = $this->View->cell('TestPlugin.Dummy');
 		$this->assertContains('dummy', "{$pluginCell}");
+		$this->assertEquals('display', $pluginCell->template);
 	}
 
 /**

--- a/tests/TestCase/View/CellTest.php
+++ b/tests/TestCase/View/CellTest.php
@@ -108,6 +108,20 @@ class CellTest extends TestCase {
 	}
 
 /**
+ * Test rendering a cell with a theme.
+ *
+ * @return void
+ */
+	public function testCellRenderThemed() {
+		$this->View->theme = 'TestTheme';
+		$cell = $this->View->cell('Articles', ['msg' => 'hello world!']);
+
+		$this->assertEquals($this->View->theme, $cell->theme);
+		$this->assertContains('Themed cell content.', $cell->render());
+		$this->assertEquals($cell->View->theme, $cell->theme);
+	}
+
+/**
  * Tests that using plugin's cells works.
  *
  * @return void

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -598,21 +598,6 @@ class ViewTest extends TestCase {
 	}
 
 /**
- * Test addInlineScripts method
- *
- * @return void
- */
-	public function testAddInlineScripts() {
-		$View = new TestView();
-		$View->addScript('prototype.js');
-		$View->addScript('prototype.js');
-		$this->assertEquals(array('prototype.js'), $View->scripts());
-
-		$View->addScript('mainEvent', 'Event.observe(window, "load", function() { doSomething(); }, true);');
-		$this->assertEquals(array('prototype.js', 'mainEvent' => 'Event.observe(window, "load", function() { doSomething(); }, true);'), $View->scripts());
-	}
-
-/**
  * Test elementExists method
  *
  * @return void

--- a/tests/test_app/TestApp/Template/Themed/TestTheme/Cell/Articles/display.ctp
+++ b/tests/test_app/TestApp/Template/Themed/TestTheme/Cell/Articles/display.ctp
@@ -1,0 +1,1 @@
+Themed cell content.


### PR DESCRIPTION
When writing the docs and playing around with view cells I noticed that they did not integrate well with themes. This solves that and corrects a few non-idiomatic test cases. I also removed `View::addScript()` as it is deprecated and I stumbled across it.
