### PR TITLE
Add missing ConsoleIo method.

### DIFF
--- a/src/Console/ConsoleIo.php
+++ b/src/Console/ConsoleIo.php
@@ -240,9 +240,24 @@ class ConsoleIo {
  *
  * @param int $mode
  * @return void
+ * @see \Cake\Console\ConsoleOutput::outputAs()
  */
 	public function outputAs($mode) {
 		$this->_out->outputAs($mode);
+	}
+
+/**
+ * Add a new output style or get defined styles.
+ *
+ * @param string $style The style to get or create.
+ * @param array $definition The array definition of the style to change or create a style
+ *   or false to remove a style.
+ * @return mixed If you are getting styles, the style or null will be returned. If you are creating/modifying
+ *   styles true will be returned.
+ * @see \Cake\Console\ConsoleOutput::styles()
+ */
+	public function styles($style = null, $definition = null) {
+		$this->_out->styles($style, $definition);
 	}
 
 /**

--- a/src/Console/ConsoleOutput.php
+++ b/src/Console/ConsoleOutput.php
@@ -241,15 +241,15 @@ class ConsoleOutput {
  *
  * ### Get a style definition
  *
- * `$this->output->styles('error');`
+ * `$output->styles('error');`
  *
  * ### Get all the style definitions
  *
- * `$this->output->styles();`
+ * `$output->styles();`
  *
  * ### Create or modify an existing style
  *
- * `$this->output->styles('annoy', ['text' => 'purple', 'background' => 'yellow', 'blink' => true]);`
+ * `$output->styles('annoy', ['text' => 'purple', 'background' => 'yellow', 'blink' => true]);`
  *
  * ### Remove a style
  *

--- a/tests/TestCase/Console/ConsoleIoTest.php
+++ b/tests/TestCase/Console/ConsoleIoTest.php
@@ -327,4 +327,16 @@ class ConsoleIoTest extends TestCase {
 		$this->assertFalse(Log::engine('stderr'));
 	}
 
+/**
+ * Ensure that styles() just proxies to stdout.
+ *
+ * @return void
+ */
+	public function testStyles() {
+		$this->out->expects($this->once())
+			->method('styles')
+			->with('name', 'props');
+		$this->io->styles('name', 'props');
+	}
+
 }


### PR DESCRIPTION
When updating the documentation, I noticed that styles() was missing on ConsoleIo. This corrects that issue.
