### PR TITLE
Removed Router::parseExtensions().

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -128,7 +128,7 @@ class Route {
  * @param array $extensions The extensions to set.
  * @return void
  */
-	public function setExtensions(array $extensions) {
+	public function parseExtensions(array $extensions) {
 		$this->_extensions = $extensions;
 	}
 

--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -265,9 +265,9 @@ class RouteCollection implements \Countable {
  * @param array $extensions The extensions for routes to use.
  * @return void
  */
-	public function setExtensions(array $extensions) {
+	public function parseExtensions(array $extensions) {
 		foreach ($this->_routes as $route) {
-			$route->setExtensions($extensions);
+			$route->parseExtensions($extensions);
 		}
 	}
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -302,7 +302,7 @@ class Router {
  *   reverse routing lookups. If undefined a name will be generated for each
  *   connected route.
  * - `_ext` is an array of filename extensions that will be parsed out of the url if present.
- *   See {@link Route::setExtensions()}.
+ *   See {@link Route::parseExtensions()}.
  *
  * You can also add additional conditions for matching routes to the $defaults array.
  * The following conditions can be used:
@@ -961,7 +961,7 @@ class Router {
  *   current extensions
  * @return array
  */
-	public static function setExtensions($extensions = null, $merge = true) {
+	public static function parseExtensions($extensions = null, $merge = true) {
 		if ($extensions === null) {
 			return static::$_validExtensions;
 		}
@@ -969,15 +969,14 @@ class Router {
 		if ($merge) {
 			$extensions = array_merge(static::$_validExtensions, $extensions);
 		}
-		static::$_routes->setExtensions($extensions);
+		static::$_routes->parseExtensions($extensions);
 		return static::$_validExtensions = $extensions;
 	}
 
 /**
  * Get the list of extensions that can be parsed by Router.
  *
- * To initially set extensions use `Router::parseExtensions()`
- * To add more see `setExtensions()`
+ * To add / update extensions use `Router::parseExtensions()`
  *
  * @return array Array of extensions Router is configured to parse.
  */

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -944,39 +944,28 @@ class Router {
 	}
 
 /**
- * Instructs the router to parse out file extensions from the URL. For example,
- * http://example.com/posts.rss would yield an file extension of "rss".
- * The file extension itself is made available in the controller as
- * `$this->params['_ext']`, and is used by the RequestHandler component to
- * automatically switch to alternate layouts and templates, and load helpers
- * corresponding to the given content, i.e. RssHelper. Switching layouts and helpers
- * requires that the chosen extension has a defined mime type in `Cake\Network\Response`
+ * Set/add valid extensions. Instructs the router to parse out file extensions
+ * from the URL. For example, http://example.com/posts.rss would yield an file
+ * extension of "rss". The file extension itself is made available in the
+ * controller as `$this->params['_ext']`, and is used by the RequestHandler
+ * component to automatically switch to alternate layouts and templates, and
+ * load helpers corresponding to the given content, i.e. RssHelper. Switching
+ * layouts and helpers requires that the chosen extension has a defined mime type
+ * in `Cake\Network\Response`.
  *
- * A list of valid extension can be passed to this method, i.e. Router::parseExtensions('rss', 'xml');
- * If no parameters are given, anything after the first . (dot) after the last / in the URL will be
- * parsed, excluding querystring parameters (i.e. ?q=...).
+ * An array of valid extension can be passed to this method. If called without
+ * any parameters it will return current list of set extensions.
  *
- * @return void
- * @see RequestHandler::startup()
- */
-	public static function parseExtensions() {
-		if (func_num_args() > 0) {
-			static::setExtensions(func_get_args(), false);
-		}
-	}
-
-/**
- * Set/add valid extensions.
- * To have the extensions parsed you still need to call `Router::parseExtensions()`
- *
- * @param array $extensions List of extensions to be added as valid extension
- * @param bool $merge Default true will merge extensions. Set to false to override current extensions
+ * @param array|string $extensions List of extensions to be added as valid extension
+ * @param bool $merge Default true will merge extensions. Set to false to override
+ *   current extensions
  * @return array
  */
-	public static function setExtensions($extensions, $merge = true) {
-		if (!is_array($extensions)) {
+	public static function setExtensions($extensions = null, $merge = true) {
+		if ($extensions === null) {
 			return static::$_validExtensions;
 		}
+		$extensions = (array)$extensions;
 		if ($merge) {
 			$extensions = array_merge(static::$_validExtensions, $extensions);
 		}

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -83,7 +83,7 @@ class RequestHandlerComponentTest extends TestCase {
 		if (!headers_sent()) {
 			header('Content-type: text/html'); //reset content type.
 		}
-		call_user_func_array('Cake\Routing\Router::setExtensions', [$this->_extensions, false]);
+		call_user_func_array('Cake\Routing\Router::parseExtensions', [$this->_extensions, false]);
 	}
 
 /**
@@ -122,7 +122,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testInitializeContentTypeSettingExt() {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
-		Router::setExtensions('json', false);
+		Router::parseExtensions('json', false);
 
 		$this->assertNull($this->RequestHandler->ext);
 
@@ -139,7 +139,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions('json', false);
+		Router::parseExtensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -154,7 +154,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/plain, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions('csv', false);
+		Router::parseExtensions('csv', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -170,7 +170,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions(['rss', 'json'], false);
+		Router::parseExtensions(['rss', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -185,7 +185,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions('json', false);
+		Router::parseExtensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -203,13 +203,13 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, application/xml, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions(['xml', 'json'], false);
+		Router::parseExtensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('xml', $this->RequestHandler->ext);
 
 		$this->RequestHandler->ext = null;
-		Router::setExtensions(array('json', 'xml'), false);
+		Router::parseExtensions(array('json', 'xml'), false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -224,7 +224,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions(['xml', 'json'], false);
+		Router::parseExtensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -239,7 +239,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::setExtensions(['html', 'xml'], false);
+		Router::parseExtensions(['html', 'xml'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -252,7 +252,7 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInititalizeFirefoxHeaderNotXml() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8';
-		Router::setExtensions(['xml', 'json'], false);
+		Router::parseExtensions(['xml', 'json'], false);
 
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -268,7 +268,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		$extensions = Router::extensions();
-		Router::setExtensions('xml', false);
+		Router::parseExtensions('xml', false);
 
 		$this->Controller->request = $this->getMock('Cake\Network\Request', ['accepts']);
 		$this->Controller->request->expects($this->any())
@@ -278,7 +278,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 
-		call_user_func_array(array('Cake\Routing\Router', 'setExtensions'), [$extensions, false]);
+		call_user_func_array(array('Cake\Routing\Router', 'parseExtensions'), [$extensions, false]);
 	}
 
 /**
@@ -353,7 +353,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom JsonView class is loaded and correct.
  */
 	public function testJsonViewLoaded() {
-		Router::setExtensions(['json', 'xml', 'ajax'], false);
+		Router::parseExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'json';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -368,7 +368,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom XmlView class is loaded and correct.
  */
 	public function testXmlViewLoaded() {
-		Router::setExtensions(['json', 'xml', 'ajax'], false);
+		Router::parseExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'xml';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -383,7 +383,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom AjaxView class is loaded and correct.
  */
 	public function testAjaxViewLoaded() {
-		Router::setExtensions(['json', 'xml', 'ajax'], false);
+		Router::parseExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'ajax';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -397,7 +397,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test configured extension but no view class set.
  */
 	public function testNoViewClassExtension() {
-		Router::setExtensions(['json', 'xml', 'ajax', 'csv'], false);
+		Router::parseExtensions(['json', 'xml', 'ajax', 'csv'], false);
 		$this->Controller->request->params['_ext'] = 'csv';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -83,7 +83,7 @@ class RequestHandlerComponentTest extends TestCase {
 		if (!headers_sent()) {
 			header('Content-type: text/html'); //reset content type.
 		}
-		call_user_func_array('Cake\Routing\Router::parseExtensions', $this->_extensions);
+		call_user_func_array('Cake\Routing\Router::setExtensions', [$this->_extensions, false]);
 	}
 
 /**
@@ -122,7 +122,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testInitializeContentTypeSettingExt() {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$_SERVER['HTTP_ACCEPT'] = 'application/json';
-		Router::parseExtensions('json');
+		Router::setExtensions('json', false);
 
 		$this->assertNull($this->RequestHandler->ext);
 
@@ -139,7 +139,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('json');
+		Router::setExtensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -154,7 +154,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/plain, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('csv');
+		Router::setExtensions('csv', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -170,7 +170,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('rss', 'json');
+		Router::setExtensions(['rss', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -185,7 +185,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, text/html, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('json');
+		Router::setExtensions('json', false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -203,7 +203,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/json, application/javascript, application/xml, */*; q=0.01';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('xml', 'json');
+		Router::setExtensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('xml', $this->RequestHandler->ext);
@@ -224,7 +224,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'text/csv;q=1.0, application/json;q=0.8, application/xml;q=0.7';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('xml', 'json');
+		Router::setExtensions(['xml', 'json'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertEquals('json', $this->RequestHandler->ext);
@@ -239,7 +239,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$_SERVER['HTTP_ACCEPT'] = 'application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5';
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
-		Router::parseExtensions('html', 'xml');
+		Router::setExtensions(['html', 'xml'], false);
 
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
@@ -252,7 +252,7 @@ class RequestHandlerComponentTest extends TestCase {
  */
 	public function testInititalizeFirefoxHeaderNotXml() {
 		$_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;image/png,image/jpeg,image/*;q=0.9,*/*;q=0.8';
-		Router::parseExtensions('xml', 'json');
+		Router::setExtensions(['xml', 'json'], false);
 
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -268,7 +268,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->assertNull($this->RequestHandler->ext);
 		$extensions = Router::extensions();
-		Router::parseExtensions('xml');
+		Router::setExtensions('xml', false);
 
 		$this->Controller->request = $this->getMock('Cake\Network\Request', ['accepts']);
 		$this->Controller->request->expects($this->any())
@@ -278,7 +278,7 @@ class RequestHandlerComponentTest extends TestCase {
 		$this->RequestHandler->initialize($event);
 		$this->assertNull($this->RequestHandler->ext);
 
-		call_user_func_array(array('Cake\Routing\Router', 'parseExtensions'), $extensions);
+		call_user_func_array(array('Cake\Routing\Router', 'setExtensions'), [$extensions, false]);
 	}
 
 /**
@@ -353,7 +353,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom JsonView class is loaded and correct.
  */
 	public function testJsonViewLoaded() {
-		Router::parseExtensions('json', 'xml', 'ajax');
+		Router::setExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'json';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -368,7 +368,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom XmlView class is loaded and correct.
  */
 	public function testXmlViewLoaded() {
-		Router::parseExtensions('json', 'xml', 'ajax');
+		Router::setExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'xml';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -383,7 +383,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test custom AjaxView class is loaded and correct.
  */
 	public function testAjaxViewLoaded() {
-		Router::parseExtensions('json', 'xml', 'ajax');
+		Router::setExtensions(['json', 'xml', 'ajax'], false);
 		$this->Controller->request->params['_ext'] = 'ajax';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);
@@ -397,7 +397,7 @@ class RequestHandlerComponentTest extends TestCase {
  * test configured extension but no view class set.
  */
 	public function testNoViewClassExtension() {
-		Router::parseExtensions('json', 'xml', 'ajax', 'csv');
+		Router::setExtensions(['json', 'xml', 'ajax', 'csv'], false);
 		$this->Controller->request->params['_ext'] = 'csv';
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->RequestHandler->initialize($event);

--- a/tests/TestCase/Routing/Route/RouteTest.php
+++ b/tests/TestCase/Routing/Route/RouteTest.php
@@ -105,7 +105,7 @@ class RouteTest extends TestCase {
 		$result = $route->parse('/posts/index.pdf');
 		$this->assertFalse(isset($result['_ext']));
 
-		$route->setExtensions(array('pdf', 'json', 'xml'));
+		$route->parseExtensions(array('pdf', 'json', 'xml'));
 		$result = $route->parse('/posts/index.pdf');
 		$this->assertEquals('pdf', $result['_ext']);
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -292,7 +292,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals(['posts'], $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
-		Router::parseExtensions('json', 'xml');
+		Router::setExtensions(['json', 'xml'], false);
 
 		$expected = array(
 			'plugin' => null,
@@ -839,7 +839,7 @@ class RouterTest extends TestCase {
 		Router::connect('/reset/*', array('admin' => true, 'controller' => 'users', 'action' => 'reset'));
 		Router::connect('/tests', array('controller' => 'tests', 'action' => 'index'));
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parseExtensions('rss');
+		Router::setExtensions('rss', false);
 
 		$request = new Request();
 		$request->addParams(array(
@@ -1630,7 +1630,7 @@ class RouterTest extends TestCase {
  */
 	public function testParseExtensions() {
 		Router::extensions();
-		Router::parseExtensions('rss');
+		Router::setExtensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 	}
 
@@ -1641,7 +1641,7 @@ class RouterTest extends TestCase {
  */
 	public function testSetExtensions() {
 		Router::extensions();
-		Router::setExtensions(array('rss'));
+		Router::setExtensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 
 		require CAKE . 'Config/routes.php';
@@ -1670,7 +1670,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testExtensionParsing() {
-		Router::parseExtensions('rss');
+		Router::setExtensions('rss', false);
 		require CAKE . 'Config/routes.php';
 
 		$result = Router::parse('/posts.rss');
@@ -1698,7 +1698,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::parseExtensions('rss', 'xml');
+		Router::setExtensions(['rss', 'xml'], false);
 		require CAKE . 'Config/routes.php';
 
 		$result = Router::parse('/posts.xml');
@@ -1740,7 +1740,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::parseExtensions('rss');
+		Router::setExtensions('rss', false);
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', '_ext' => 'rss'));
 		$result = Router::parse('/controller/action');
 		$expected = array(
@@ -2069,7 +2069,7 @@ class RouterTest extends TestCase {
 	public function testParsingWithTrailingPeriodAndParseExtensions() {
 		Router::reload();
 		Router::connect('/:controller/:action/*');
-		Router::parseExtensions('json');
+		Router::setExtensions('json', false);
 
 		$result = Router::parse('/posts/view/something.');
 		$this->assertEquals('something.', $result['pass'][0], 'Period was chopped off %s');
@@ -2486,7 +2486,7 @@ class RouterTest extends TestCase {
  */
 	public function testReverseWithExtension() {
 		Router::connect('/:controller/:action/*');
-		Router::parseExtensions('json');
+		Router::setExtensions('json', false);
 
 		$request = new Request('/posts/view/1.json');
 		$request->addParams(array(

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -292,7 +292,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals(['posts'], $resources);
 
 		$_SERVER['REQUEST_METHOD'] = 'GET';
-		Router::setExtensions(['json', 'xml'], false);
+		Router::parseExtensions(['json', 'xml'], false);
 
 		$expected = array(
 			'plugin' => null,
@@ -839,7 +839,7 @@ class RouterTest extends TestCase {
 		Router::connect('/reset/*', array('admin' => true, 'controller' => 'users', 'action' => 'reset'));
 		Router::connect('/tests', array('controller' => 'tests', 'action' => 'index'));
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::setExtensions('rss', false);
+		Router::parseExtensions('rss', false);
 
 		$request = new Request();
 		$request->addParams(array(
@@ -1630,7 +1630,7 @@ class RouterTest extends TestCase {
  */
 	public function testParseExtensions() {
 		Router::extensions();
-		Router::setExtensions('rss', false);
+		Router::parseExtensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 	}
 
@@ -1641,7 +1641,7 @@ class RouterTest extends TestCase {
  */
 	public function testSetExtensions() {
 		Router::extensions();
-		Router::setExtensions('rss', false);
+		Router::parseExtensions('rss', false);
 		$this->assertContains('rss', Router::extensions());
 
 		require CAKE . 'Config/routes.php';
@@ -1652,7 +1652,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts.xml');
 		$this->assertFalse(isset($result['_ext']));
 
-		Router::setExtensions(array('xml'));
+		Router::parseExtensions(array('xml'));
 		$result = Router::extensions();
 		$this->assertContains('rss', $result);
 		$this->assertContains('xml', $result);
@@ -1660,7 +1660,7 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts.xml');
 		$this->assertEquals('xml', $result['_ext']);
 
-		$result = Router::setExtensions(array('pdf'), false);
+		$result = Router::parseExtensions(array('pdf'), false);
 		$this->assertEquals(array('pdf'), $result);
 	}
 
@@ -1670,7 +1670,7 @@ class RouterTest extends TestCase {
  * @return void
  */
 	public function testExtensionParsing() {
-		Router::setExtensions('rss', false);
+		Router::parseExtensions('rss', false);
 		require CAKE . 'Config/routes.php';
 
 		$result = Router::parse('/posts.rss');
@@ -1698,7 +1698,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::setExtensions(['rss', 'xml'], false);
+		Router::parseExtensions(['rss', 'xml'], false);
 		require CAKE . 'Config/routes.php';
 
 		$result = Router::parse('/posts.xml');
@@ -1740,7 +1740,7 @@ class RouterTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		Router::reload();
-		Router::setExtensions('rss', false);
+		Router::parseExtensions('rss', false);
 		Router::connect('/controller/action', array('controller' => 'controller', 'action' => 'action', '_ext' => 'rss'));
 		$result = Router::parse('/controller/action');
 		$expected = array(
@@ -2069,7 +2069,7 @@ class RouterTest extends TestCase {
 	public function testParsingWithTrailingPeriodAndParseExtensions() {
 		Router::reload();
 		Router::connect('/:controller/:action/*');
-		Router::setExtensions('json', false);
+		Router::parseExtensions('json', false);
 
 		$result = Router::parse('/posts/view/something.');
 		$this->assertEquals('something.', $result['pass'][0], 'Period was chopped off %s');
@@ -2486,7 +2486,7 @@ class RouterTest extends TestCase {
  */
 	public function testReverseWithExtension() {
 		Router::connect('/:controller/:action/*');
-		Router::setExtensions('json', false);
+		Router::parseExtensions('json', false);
 
 		$request = new Request('/posts/view/1.json');
 		$request->addParams(array(

--- a/tests/test_app/TestApp/Config/routes.php
+++ b/tests/test_app/TestApp/Config/routes.php
@@ -22,7 +22,7 @@ use Cake\Routing\Router;
 
 // Configure::write('Routing.prefixes', array());
 
-Router::setExtensions('json');
+Router::parseExtensions('json');
 Router::connect('/some_alias', array('controller' => 'tests_apps', 'action' => 'some_method'));
 
 Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);

--- a/tests/test_app/TestApp/Config/routes.php
+++ b/tests/test_app/TestApp/Config/routes.php
@@ -22,7 +22,7 @@ use Cake\Routing\Router;
 
 // Configure::write('Routing.prefixes', array());
 
-Router::parseExtensions('json');
+Router::setExtensions('json');
 Router::connect('/some_alias', array('controller' => 'tests_apps', 'action' => 'some_method'));
 
 Router::connect('/', ['controller' => 'pages', 'action' => 'display', 'home']);


### PR DESCRIPTION
Just use Router::setExtensions() instead. setExtensions() now also takes
a single extension as string for first param.
