### PR TITLE
Fix for #3410

### DIFF
--- a/src/Database/Type/DateTimeType.php
+++ b/src/Database/Type/DateTimeType.php
@@ -56,7 +56,7 @@ class DateTimeType extends \Cake\Database\Type {
  * @return string
  */
 	public function toDatabase($value, Driver $driver) {
-		if (is_string($value)) {
+		if ($value === null || is_string($value)) {
 			return $value;
 		}
 		return $value->format($this->_format);

--- a/tests/TestCase/ORM/QueryRegressionTest.php
+++ b/tests/TestCase/ORM/QueryRegressionTest.php
@@ -107,4 +107,16 @@ class QueryRegressionTest extends TestCase {
 		$this->assertEquals(3, $results[3]->author->favorite_tag->id);
 	}
 
+/**
+ * Test for https://github.com/cakephp/cakephp/issues/3410
+ *
+ * @return void
+ */
+	public function testNullableTimeColumn() {
+		$table = TableRegistry::get('users');
+		$entity = $table->newEntity(['username' => 'derp', 'created' => null]);
+		$this->assertSame($entity, $table->save($entity));
+		$this->assertNull($entity->created);
+	}
+
 }


### PR DESCRIPTION
Avoids fatal error when trying to save null datetime value
