### PR TITLE
Backporting overwrite() from 3.0 to 2.6.

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -168,6 +168,14 @@ class Shell extends Object {
 	public $stdin;
 
 /**
+ * The number of bytes last written to the output stream
+ * used when overwriting the previous message.
+ *
+ * @var int
+ */
+	protected $_lastWritten = 0;
+
+/**
  *  Constructs this Shell instance.
  *
  * @param ConsoleOutput $stdout A ConsoleOutput object for stdout.
@@ -609,9 +617,42 @@ class Shell extends Object {
 			$currentLevel = Shell::QUIET;
 		}
 		if ($level <= $currentLevel) {
-			return $this->stdout->write($message, $newlines);
+			$this->_lastWritten = $this->stdout->write($message, $newlines);
+			return $this->_lastWritten;
 		}
 		return true;
+	}
+
+/**
+ * Overwrite some already output text.
+ *
+ * Useful for building progress bars, or when you want to replace
+ * text already output to the screen with new text.
+ *
+ * **Warning** You cannot overwrite text that contains newlines.
+ *
+ * @param array|string $message The message to output.
+ * @param int $newlines Number of newlines to append.
+ * @param int $size The number of bytes to overwrite. Defaults to the
+ *    length of the last message output.
+ * @return int|bool Returns the number of bytes returned from writing to stdout.
+ */
+	public function overwrite($message, $newlines = 1, $size = null) {
+		$size = $size ? $size : $this->_lastWritten;
+
+		// Output backspaces.
+		$this->out(str_repeat("\x08", $size), 0);
+
+		$newBytes = $this->out($message, 0);
+
+		// Fill any remaining bytes with spaces.
+		$fill = $size - $newBytes;
+		if ($fill > 0) {
+			$this->out(str_repeat(' ', $fill), 0);
+		}
+		if ($newlines) {
+			$this->out($this->nl($newlines), 0);
+		}
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -369,6 +369,36 @@ class ShellTest extends CakeTestCase {
 	}
 
 /**
+ * Test overwriting.
+ *
+ * @return void
+ */
+	public function testOverwrite() {
+		$number = strlen('Some text I want to overwrite');
+
+		$this->Shell->stdout->expects($this->at(0))
+			->method('write')
+			->with('Some <info>text</info> I want to overwrite', 0)
+			->will($this->returnValue($number));
+
+		$this->Shell->stdout->expects($this->at(1))
+			->method('write')
+			->with(str_repeat("\x08", $number), 0);
+
+		$this->Shell->stdout->expects($this->at(2))
+			->method('write')
+			->with('Less text', 0)
+			->will($this->returnValue(9));
+
+		$this->Shell->stdout->expects($this->at(3))
+			->method('write')
+			->with(str_repeat(' ', $number - 9), 0);
+
+		$this->Shell->out('Some <info>text</info> I want to overwrite', 0);
+		$this->Shell->overwrite('Less text');
+	}
+
+/**
  * testErr method
  *
  * @return void


### PR DESCRIPTION
Backport https://github.com/cakephp/cakephp/issues/3183 to 2.6
Gonna love it :)

Note: CS Tests in travis break due to not yet merged hotfix https://github.com/cakephp/cakephp/commit/1d1a2f859c7dd0434e29524a48a573f3e0afe889
