### PR TITLE
Removed incorrect usage of @deprecated phpDoc

### DIFF
--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -381,13 +381,12 @@ class View extends Object {
  *   If an array, the following keys can be used:
  *   - `config` - Used to store the cached element in a custom cache configuration.
  *   - `key` - Used to define the key used in the Cache::write(). It will be prefixed with `element_`
- * - `plugin` - Load an element from a specific plugin. This option is deprecated, see below.
+ * - `plugin` - (deprecated!) Load an element from a specific plugin. This option is deprecated, and
+ *              will be removed in CakePHP 3.0. Use `Plugin.element_name` instead.
  * - `callbacks` - Set to true to fire beforeRender and afterRender helper callbacks for this element.
  *   Defaults to false.
  * - `ignoreMissing` - Used to allow missing elements. Set to true to not trigger notices.
  * @return string Rendered Element
- * @deprecated The `$options['plugin']` is deprecated and will be removed in CakePHP 3.0. Use
- *   `Plugin.element_name` instead.
  */
 	public function element($name, $data = array(), $options = array()) {
 		$file = $plugin = null;


### PR DESCRIPTION
@deprecated is flagging the function element as deprecated in all IDE's that support phpDOC tags. There is no phpDoc tag to deprecate a function parameter.
