### PR TITLE
3.0 Simplify API - Use array syntax instead of var args.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -477,53 +477,45 @@ class AuthComponent extends Component {
  * Takes a list of actions in the current controller for which authentication is not required, or
  * no parameters to allow all actions.
  *
- * You can use allow with either an array, or var args.
+ * You can use allow with either an array or a simple string.
  *
- * `$this->Auth->allow(array('edit', 'add'));` or
- * `$this->Auth->allow('edit', 'add');` or
+ * `$this->Auth->allow('view');`
+ * `$this->Auth->allow(['edit', 'add']);`
  * `$this->Auth->allow();` to allow all actions
  *
- * @param string|array $action,... Controller action name or array of actions
+ * @param string|array $actions Controller action name or array of actions
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#making-actions-public
  */
-	public function allow($action = null) {
-		$args = func_get_args();
-		if (empty($args) || $action === null) {
+	public function allow($actions = null) {
+		if ($actions === null) {
 			$this->allowedActions = $this->_methods;
 			return;
 		}
-		if (isset($args[0]) && is_array($args[0])) {
-			$args = $args[0];
-		}
-		$this->allowedActions = array_merge($this->allowedActions, $args);
+		$this->allowedActions = array_merge($this->allowedActions, (array)$actions);
 	}
 
 /**
  * Removes items from the list of allowed/no authentication required actions.
  *
- * You can use deny with either an array, or var args.
+ * You can use deny with either an array or a simple string.
  *
- * `$this->Auth->deny(array('edit', 'add'));` or
- * `$this->Auth->deny('edit', 'add');` or
+ * `$this->Auth->deny('view');`
+ * `$this->Auth->deny(['edit', 'add']);`
  * `$this->Auth->deny();` to remove all items from the allowed list
  *
- * @param string|array $action,... Controller action name or array of actions
+ * @param string|array $actions Controller action name or array of actions
  * @return void
  * @see AuthComponent::allow()
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#making-actions-require-authorization
  */
-	public function deny($action = null) {
-		$args = func_get_args();
-		if (empty($args) || $action === null) {
+	public function deny($actions = null) {
+		if ($actions === null) {
 			$this->allowedActions = array();
 			return;
 		}
-		if (isset($args[0]) && is_array($args[0])) {
-			$args = $args[0];
-		}
-		foreach ($args as $arg) {
-			$i = array_search($arg, $this->allowedActions);
+		foreach ((array)$actions as $action) {
+			$i = array_search($action, $this->allowedActions);
 			if (is_int($i)) {
 				unset($this->allowedActions[$i]);
 			}

--- a/src/Controller/Component/SecurityComponent.php
+++ b/src/Controller/Component/SecurityComponent.php
@@ -132,12 +132,12 @@ class SecurityComponent extends Component {
 /**
  * Sets the actions that require a request that is SSL-secured, or empty for all actions
  *
+ * @param string|array $actions
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#SecurityComponent::requireSecure
  */
-	public function requireSecure() {
-		$args = func_get_args();
-		$this->_requireMethod('Secure', $args);
+	public function requireSecure($actions) {
+		$this->_requireMethod('Secure', (array)$actions);
 	}
 
 /**
@@ -147,12 +147,12 @@ class SecurityComponent extends Component {
  * set in SecurityComponent::$allowedControllers and
  * SecurityComponent::$allowedActions.
  *
+ * @param string|array $actions
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#SecurityComponent::requireAuth
  */
-	public function requireAuth() {
-		$args = func_get_args();
-		$this->_requireMethod('Auth', $args);
+	public function requireAuth($actions) {
+		$this->_requireMethod('Auth', (array)$actions);
 	}
 
 /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -1022,9 +1022,9 @@ class Request implements \ArrayAccess {
  *
  * Example:
  *
- * $this->request->allowMethod('post', 'delete');
+ * $this->request->allowMethod('post');
  * or
- * $this->request->allowMethod(array('post', 'delete'));
+ * $this->request->allowMethod(['post', 'delete']);
  *
  * If the request would be GET, response header "Allow: POST, DELETE" will be set
  * and a 405 error will be returned.
@@ -1034,9 +1034,7 @@ class Request implements \ArrayAccess {
  * @throws \Cake\Error\MethodNotAllowedException
  */
 	public function allowMethod($methods) {
-		if (!is_array($methods)) {
-			$methods = func_get_args();
-		}
+		$methods = (array)$methods;
 		foreach ($methods as $method) {
 			if ($this->is($method)) {
 				return true;

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -379,7 +379,7 @@ class AuthComponentTest extends TestCase {
 		$this->Controller->Auth->initialize($event);
 
 		$this->Controller->Auth->allow();
-		$this->Controller->Auth->deny('add', 'camelCase');
+		$this->Controller->Auth->deny(['add', 'camelCase']);
 
 		$this->Controller->request['action'] = 'delete';
 		$this->assertNull($this->Controller->Auth->startup($event));
@@ -439,7 +439,7 @@ class AuthComponentTest extends TestCase {
 		$event = new Event('Controller.startup', $this->Controller);
 		$this->Controller->Auth->initialize($event);
 		$this->Controller->Auth->allow();
-		$this->Controller->Auth->deny('add', 'camelCase');
+		$this->Controller->Auth->deny(['add', 'camelCase']);
 
 		$url = '/auth_test/camelCase';
 		$this->Controller->request->addParams(Router::parse($url));
@@ -501,7 +501,7 @@ class AuthComponentTest extends TestCase {
 		$this->Controller->request->query['url'] = Router::normalize($url);
 		$event = new Event('Controller.initialize', $this->Controller);
 		$this->Controller->Auth->initialize($event);
-		$this->Controller->Auth->allow('action_name', 'anotherAction');
+		$this->Controller->Auth->allow(['action_name', 'anotherAction']);
 		$this->assertEquals(array('action_name', 'anotherAction'), $this->Controller->Auth->allowedActions);
 	}
 

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -2222,10 +2222,10 @@ XML;
 			'REQUEST_METHOD' => 'PUT'
 		]]);
 
-		$this->assertTrue($request->allowMethod(array('put')));
+		$this->assertTrue($request->allowMethod('put'));
 
 		$request->env('REQUEST_METHOD', 'DELETE');
-		$this->assertTrue($request->allowMethod('post', 'delete'));
+		$this->assertTrue($request->allowMethod(['post', 'delete']));
 	}
 
 /**
@@ -2240,7 +2240,7 @@ XML;
 		]);
 
 		try {
-			$request->allowMethod('POST', 'DELETE');
+			$request->allowMethod(['POST', 'DELETE']);
 			$this->fail('An expected exception has not been raised.');
 		} catch (Error\MethodNotAllowedException $e) {
 			$this->assertEquals(array('Allow' => 'POST, DELETE'), $e->responseHeader());


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/3422
