### PR TITLE
remove constructor return value.

### DIFF
--- a/lib/Cake/Error/ExceptionRenderer.php
+++ b/lib/Cake/Error/ExceptionRenderer.php
@@ -92,7 +92,8 @@ class ExceptionRenderer {
 		$this->controller = $this->_getController($exception);
 
 		if (method_exists($this->controller, 'appError')) {
-			return $this->controller->appError($exception);
+			$this->controller->appError($exception);
+			return;
 		}
 		$method = $template = Inflector::variable(str_replace('Exception', '', get_class($exception)));
 		$code = $exception->getCode();


### PR DESCRIPTION
Not sure why this was here, but constructors shouldn't return a value. Nothing in the docs says that a controller's implementation of appError should return a value either. So I figure this was a mistake.
