### PR TITLE
Hotfix - For TextHelper

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -79,7 +79,7 @@ class TextHelperTest extends CakeTestCase {
  */
 	public function testTextHelperProxyMethodCalls() {
 		$methods = array(
-			'highlight', 'stripLinks', 'truncate', 'excerpt', 'toList',
+			'highlight', 'stripLinks', 'truncate', 'tail', 'excerpt', 'toList',
 			);
 		$String = $this->getMock('StringMock', $methods);
 		$Text = new TextHelperTestObject($this->View, array('engine' => 'StringMock'));

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -267,6 +267,30 @@ class TextHelper extends AppHelper {
 	}
 
 /**
+ * Truncates text.
+ *
+ * Cuts a string to the length of $length and replaces the last characters
+ * with the ellipsis if the text is longer than length.
+ *
+ * ### Options:
+ *
+ * - `ellipsis` Will be used as Ending and appended to the trimmed string (`ending` is deprecated)
+ * - `exact` If false, $text will not be cut mid-word
+ * - `html` If true, HTML tags would be handled correctly
+ *
+ * @see String::truncate()
+ *
+ * @param string $text String to truncate.
+ * @param integer $length Length of returned string, including ellipsis.
+ * @param array $options An array of html attributes and options.
+ * @return string Trimmed string.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
+ */
+	public function truncate($text, $length = 100, $options = array()) {
+		return $this->_engine->truncate($text, $length, $options);
+	}
+
+/**
  * Truncates text starting from the end.
  *
  * Cuts a string to the length of $length and replaces the first characters
@@ -283,10 +307,10 @@ class TextHelper extends AppHelper {
  * @param integer $length Length of returned string, including ellipsis.
  * @param array $options An array of html attributes and options.
  * @return string Trimmed string.
- * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::truncate
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::tail
  */
-	public function truncate($text, $length = 100, $options = array()) {
-		return $this->_engine->truncate($text, $length, $options);
+	public function tail($text, $length = 100, $options = array()) {
+		return $this->_engine->tail($text, $length, $options);
 	}
 
 /**

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -301,7 +301,7 @@ class TextHelper extends AppHelper {
  * - `ellipsis` Will be used as Beginning and prepended to the trimmed string
  * - `exact` If false, $text will not be cut mid-word
  *
- * @see String::truncate()
+ * @see String::tail()
  *
  * @param string $text String to truncate.
  * @param integer $length Length of returned string, including ellipsis.


### PR DESCRIPTION
which seems to have gone wrong (messed up the file) in a merge. 
tail() is missing completely and the docs for truncate() are the ones for tail(). 
This fixes it.

Also added missing test case to avoid this regression.
