### PR TITLE
RFC: merge blacklist and fields for Form::inputs

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -734,17 +734,16 @@ class FormHelper extends Helper {
  * ]);
  * }}}
  *
- * You can exclude fields using the `$blacklist` parameter:
+ * You can exclude fields by specifying them as false:
  *
  * {{{
- * $this->Form->inputs([], ['title']);
+ * $this->Form->inputs(['title' => false]);
  * }}}
  *
  * In the above example, no field would be generated for the title field.
  *
  * @param array $fields An array of customizations for the fields that will be
  *   generated. This array allows you to set custom types, labels, or other options.
- * @param array $blacklist A list of fields to not create inputs for.
  * @param array $options Options array. Valid keys are:
  * - `fieldset` Set to false to disable the fieldset.
  * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
@@ -752,7 +751,7 @@ class FormHelper extends Helper {
  * @return string Completed form inputs.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
-	public function inputs(array $fields = [], array $blacklist = [], array $options = []) {
+	public function inputs(array $fields = [], array $options = []) {
 		$fieldset = $legend = true;
 		$context = $this->_getContext();
 
@@ -782,18 +781,15 @@ class FormHelper extends Helper {
 
 		$out = null;
 		foreach ($fields as $name => $options) {
+			if ($options === false) {
+				continue;
+			}
+
 			if (is_numeric($name) && !is_array($options)) {
 				$name = $options;
 				$options = [];
 			}
 			$entity = explode('.', $name);
-			$blacklisted = (
-				!empty($blacklist) &&
-				(in_array($name, $blacklist) || in_array(end($entity), $blacklist))
-			);
-			if ($blacklisted) {
-				continue;
-			}
 			$out .= $this->input($name, (array)$options);
 		}
 

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2679,7 +2679,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputsLegendFieldset() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([], [], array('legend' => 'The Legend'));
+		$result = $this->Form->inputs([], array('legend' => 'The Legend'));
 		$expected = array(
 			'<fieldset',
 			'<legend',
@@ -2689,15 +2689,15 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs([], [], array('fieldset' => true, 'legend' => 'Field of Dreams'));
+		$result = $this->Form->inputs([], array('fieldset' => true, 'legend' => 'Field of Dreams'));
 		$this->assertContains('<legend>Field of Dreams</legend>', $result);
 		$this->assertContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs([], [], array('fieldset' => false, 'legend' => false));
+		$result = $this->Form->inputs([], array('fieldset' => false, 'legend' => false));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs([], [], array('fieldset' => false, 'legend' => 'Hello'));
+		$result = $this->Form->inputs([], array('fieldset' => false, 'legend' => 'Hello'));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
@@ -2760,7 +2760,7 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([], [], ['legend' => 'Hello']);
+		$result = $this->Form->inputs([], ['legend' => 'Hello']);
 		$expected = array(
 			'fieldset' => array(),
 			'legend' => array(),
@@ -2792,7 +2792,6 @@ class FormHelperTest extends TestCase {
 		);
 		$result = $this->Form->inputs(
 			array('foo' => array('type' => 'text')),
-			array(),
 			array('legend' => false)
 		);
 		$this->assertTags($result, $expected);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2798,6 +2798,52 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * testFormInputsBlacklist
+ *
+ * @return void
+ */
+	public function testFormInputsBlacklist() {
+		$this->Form->create($this->article);
+		$result = $this->Form->inputs([
+			'id' => false
+		]);
+		$expected = array(
+			'<fieldset',
+			'<legend', 'New Article', '/legend',
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			'/fieldset',
+		);
+		$this->assertTags($result, $expected);
+
+		$this->Form->create($this->article);
+		$result = $this->Form->inputs([
+			'id' => []
+		]);
+		$expected = array(
+			'<fieldset',
+			'<legend', 'New Article', '/legend',
+			'input' => array('type' => 'hidden', 'name' => 'id', 'id' => 'id'),
+			array('div' => array('class' => 'input select required')),
+			'*/div',
+			array('div' => array('class' => 'input text required')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			array('div' => array('class' => 'input text')),
+			'*/div',
+			'/fieldset',
+		);
+		$this->assertTags($result, $expected, 'A falsey value (array) should not remove the input');
+	}
+
+/**
  * testSelectAsCheckbox method
  *
  * test multi-select widget with checkbox formatting.


### PR DESCRIPTION
Rather than have an explicit blacklist to not render a field just specify it as false.

Thoughts?
