### PR TITLE
RFC: Simplify/split up FormHelper::inputs

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -770,11 +770,10 @@ class FormHelper extends Helper {
  * You can customize individual inputs through `$fields`.
  * {{{
  * $this->Form->inputs([
- *   'name' => ['label' => 'custom label']
+ *   'name' => ['label' => 'custom label'],
+ *   'email'
  * ]);
  * }}}
- *
- * In the above example, no field would be generated for the title field.
  *
  * @param array $fields An array of customizations for the fields that will be
  *   generated. This array allows you to set custom types, labels, or other options.

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -729,7 +729,7 @@ class FormHelper extends Helper {
  *
  * You can customize individual inputs through `$fields`.
  * {{{
- * $this->Form->inputs([
+ * $this->Form->allInputs([
  *   'name' => ['label' => 'custom label']
  * ]);
  * }}}
@@ -737,7 +737,7 @@ class FormHelper extends Helper {
  * You can exclude fields by specifying them as false:
  *
  * {{{
- * $this->Form->inputs(['title' => false]);
+ * $this->Form->allInputs(['title' => false]);
  * }}}
  *
  * In the above example, no field would be generated for the title field.
@@ -751,8 +751,7 @@ class FormHelper extends Helper {
  * @return string Completed form inputs.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
  */
-	public function inputs(array $fields = [], array $options = []) {
-		$fieldset = $legend = true;
+	public function allInputs(array $fields = [], array $options = []) {
 		$context = $this->_getContext();
 
 		$modelFields = $context->fieldNames();
@@ -761,6 +760,61 @@ class FormHelper extends Helper {
 			Hash::normalize($modelFields),
 			Hash::normalize($fields)
 		);
+
+		return $this->inputs($fields, $options);
+	}
+
+/**
+ * Generate a set of inputs for `$fields`
+ *
+ * You can customize individual inputs through `$fields`.
+ * {{{
+ * $this->Form->inputs([
+ *   'name' => ['label' => 'custom label']
+ * ]);
+ * }}}
+ *
+ * In the above example, no field would be generated for the title field.
+ *
+ * @param array $fields An array of customizations for the fields that will be
+ *   generated. This array allows you to set custom types, labels, or other options.
+ * @param array $options Options array. Valid keys are:
+ * - `fieldset` Set to false to disable the fieldset.
+ * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
+ *    to customize the legend text.
+ * @return string Completed form inputs.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
+ */
+	public function inputs(array $fields, array $options = []) {
+		$fields = Hash::normalize($fields);
+
+		$out = '';
+		foreach ($fields as $name => $opts) {
+			if ($opts === false) {
+				continue;
+			}
+
+			$out .= $this->input($name, (array)$opts);
+		}
+
+		return $this->fieldset($out, $options);
+	}
+
+/**
+ * Wrap a set of inputs in a fieldset
+ *
+ * @param string $fields the form inputs to wrap in a fieldset
+ * @param array $options Options array. Valid keys are:
+ * - `fieldset` Set to false to disable the fieldset.
+ * - `legend` Set to false to disable the legend for the generated input set. Or supply a string
+ *    to customize the legend text.
+ * @return string Completed form inputs.
+ * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::inputs
+ */
+	public function fieldset($fields = '', array $options = []) {
+		$fieldset = $legend = true;
+		$context = $this->_getContext();
+		$out = $fields;
 
 		if (isset($options['legend'])) {
 			$legend = $options['legend'];
@@ -777,20 +831,6 @@ class FormHelper extends Helper {
 			}
 			$modelName = Inflector::humanize(Inflector::singularize($this->request->params['controller']));
 			$legend = sprintf($actionName, $modelName);
-		}
-
-		$out = null;
-		foreach ($fields as $name => $options) {
-			if ($options === false) {
-				continue;
-			}
-
-			if (is_numeric($name) && !is_array($options)) {
-				$name = $options;
-				$options = [];
-			}
-			$entity = explode('.', $name);
-			$out .= $this->input($name, (array)$options);
 		}
 
 		if ($fieldset) {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -775,8 +775,8 @@ class FormHelper extends Helper {
  * ]);
  * }}}
  *
- * @param array $fields An array of customizations for the fields that will be
- *   generated. This array allows you to set custom types, labels, or other options.
+ * @param array $fields An array of the fields to generate. This array allows you to set custom
+ *   types, labels, or other options.
  * @param array $options Options array. Valid keys are:
  * - `fieldset` Set to false to disable the fieldset.
  * - `legend` Set to false to disable the legend for the generated input set. Or supply a string

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -2679,7 +2679,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputsLegendFieldset() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([], array('legend' => 'The Legend'));
+		$result = $this->Form->allInputs([], array('legend' => 'The Legend'));
 		$expected = array(
 			'<fieldset',
 			'<legend',
@@ -2689,15 +2689,15 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs([], array('fieldset' => true, 'legend' => 'Field of Dreams'));
+		$result = $this->Form->allInputs([], array('fieldset' => true, 'legend' => 'Field of Dreams'));
 		$this->assertContains('<legend>Field of Dreams</legend>', $result);
 		$this->assertContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs([], array('fieldset' => false, 'legend' => false));
+		$result = $this->Form->allInputs([], array('fieldset' => false, 'legend' => false));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
-		$result = $this->Form->inputs([], array('fieldset' => false, 'legend' => 'Hello'));
+		$result = $this->Form->allInputs([], array('fieldset' => false, 'legend' => 'Hello'));
 		$this->assertNotContains('<legend>', $result);
 		$this->assertNotContains('<fieldset>', $result);
 
@@ -2705,7 +2705,7 @@ class FormHelperTest extends TestCase {
 		$this->Form->request->params['prefix'] = 'admin';
 		$this->Form->request->params['action'] = 'admin_edit';
 		$this->Form->request->params['controller'] = 'articles';
-		$result = $this->Form->inputs();
+		$result = $this->Form->allInputs();
 		$expected = [
 			'<fieldset',
 			'<legend',
@@ -2723,7 +2723,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputs() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs();
+		$result = $this->Form->allInputs();
 		$expected = array(
 			'<fieldset',
 			'<legend', 'New Article', '/legend',
@@ -2740,7 +2740,7 @@ class FormHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Form->inputs([
+		$result = $this->Form->allInputs([
 			'published' => ['type' => 'boolean']
 		]);
 		$expected = array(
@@ -2760,7 +2760,7 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([], ['legend' => 'Hello']);
+		$result = $this->Form->allInputs([], ['legend' => 'Hello']);
 		$expected = array(
 			'fieldset' => array(),
 			'legend' => array(),
@@ -2790,7 +2790,7 @@ class FormHelperTest extends TestCase {
 			'*/div',
 			'/fieldset'
 		);
-		$result = $this->Form->inputs(
+		$result = $this->Form->allInputs(
 			array('foo' => array('type' => 'text')),
 			array('legend' => false)
 		);
@@ -2804,7 +2804,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testFormInputsBlacklist() {
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([
+		$result = $this->Form->allInputs([
 			'id' => false
 		]);
 		$expected = array(
@@ -2823,7 +2823,7 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$this->Form->create($this->article);
-		$result = $this->Form->inputs([
+		$result = $this->Form->allInputs([
 			'id' => []
 		]);
 		$expected = array(


### PR DESCRIPTION
FormHelper inputs is a problematic function.

For example in 2.x:
- You can't customize one field without declaring all fields.
- You can't say "give me all fields except this-one"

In 3.x currently:
- You can't change the field order.
- You can only blacklist fields, you can't say "only give me these 2 fields"

In both versions the function wraps the output in a fieldset - which means it's "some work" to not use inputs and still get the same output.

These changes separate functionality into different methods so that users can pick and choose what they want to do/use.

Thoughts?
