### PR TITLE
Add unix socket support to Redis cache engine

### DIFF
--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -80,7 +80,7 @@ class RedisEngine extends CacheEngine {
 		$return = false;
 		try {
 			$this->_Redis = new Redis();
-			if(!empty($this->settings['unix_socket'])) {
+			if (!empty($this->settings['unix_socket'])) {
 				$return = $this->_Redis->connect($this->settings['unix_socket']);
 			} elseif (empty($this->settings['persistent'])) {
 				$return = $this->_Redis->connect($this->settings['server'], $this->settings['port'], $this->settings['timeout']);

--- a/lib/Cake/Cache/Engine/RedisEngine.php
+++ b/lib/Cake/Cache/Engine/RedisEngine.php
@@ -37,6 +37,7 @@ class RedisEngine extends CacheEngine {
  *  - port = integer port number to the Redis server (default: 6379)
  *  - timeout = float timeout in seconds (default: 0)
  *  - persistent = boolean Connects to the Redis server with a persistent connection (default: true)
+ *  - unix_socket = path to the unix socket file (default: false)
  *
  * @var array
  */
@@ -62,7 +63,8 @@ class RedisEngine extends CacheEngine {
 			'port' => 6379,
 			'password' => false,
 			'timeout' => 0,
-			'persistent' => true
+			'persistent' => true,
+			'unix_socket' => false
 			), $settings)
 		);
 
@@ -78,7 +80,9 @@ class RedisEngine extends CacheEngine {
 		$return = false;
 		try {
 			$this->_Redis = new Redis();
-			if (empty($this->settings['persistent'])) {
+			if(!empty($this->settings['unix_socket'])) {
+				$return = $this->_Redis->connect($this->settings['unix_socket']);
+			} elseif (empty($this->settings['persistent'])) {
 				$return = $this->_Redis->connect($this->settings['server'], $this->settings['port'], $this->settings['timeout']);
 			} else {
 				$return = $this->_Redis->pconnect($this->settings['server'], $this->settings['port'], $this->settings['timeout']);


### PR DESCRIPTION
- adds support for unix sockets 
  example:
  'unix_socket' => '/home/user/.redis/sock'
