### PR TITLE
Fixes issue with Sql Server driver when loading fixtures

### DIFF
--- a/lib/Cake/Model/Datasource/Database/Sqlserver.php
+++ b/lib/Cake/Model/Datasource/Database/Sqlserver.php
@@ -208,7 +208,7 @@ class Sqlserver extends DboSource {
 		}
 
 		$fields = array();
-		$schema = $model->schemaName;
+		$schema = is_object($model) ? $model->schemaName : false;
 
 		$cols = $this->_execute(
 			"SELECT


### PR DESCRIPTION
Sqlserver::describe is expecting a model object (Unlike other drivers which work with either a object or string). While this does work under normal conditions, it causes a "Trying to get property of non-object" notice when using fixtures. The same problem also causes the testLimitOffsetHack test to fail.

This change does a simple test to ensure that the $model variable is an object before trying to access a property of it. All SqlServer tests are now passing.
