### PR TITLE
Allowing same Authenticate object to be setup with different settings

### DIFF
--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -775,6 +775,10 @@ class AuthComponent extends Component {
 			unset($config[AuthComponent::ALL]);
 		}
 		foreach ($config as $class => $settings) {
+			if (!empty($settings['className'])) {
+				$class = $settings['className'];
+				unset($settings['className']);
+			}
 			list($plugin, $class) = pluginSplit($class, true);
 			$className = $class . 'Authenticate';
 			App::uses($className, $plugin . 'Controller/Component/Auth');

--- a/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/AuthComponentTest.php
@@ -591,6 +591,27 @@ class AuthComponentTest extends CakeTestCase {
 	}
 
 /**
+ * test defining the same Authenticate object but with different password hashers
+ *
+ * @return void
+ */
+	public function testSameAuthenticateWithDifferentHashers() {
+		$this->Controller->Auth->authenticate = array(
+			'FormSimple' => array('className' => 'Form', 'passwordHasher' => 'Simple'),
+			'FormBlowfish' => array('className' => 'Form', 'passwordHasher' => 'Blowfish'),
+		);
+
+		$objects = $this->Controller->Auth->constructAuthenticate();
+		$this->assertEquals(2, count($objects));
+
+		$this->assertInstanceOf('FormAuthenticate', $objects[0]);
+		$this->assertInstanceOf('FormAuthenticate', $objects[1]);
+
+		$this->assertInstanceOf('SimplePasswordHasher', $objects[0]->passwordHasher());
+		$this->assertInstanceOf('BlowfishPasswordHasher', $objects[1]->passwordHasher());
+	}
+
+/**
  * Tests that deny always takes precedence over allow
  *
  * @return void


### PR DESCRIPTION
Useful when you are migrating users from one type of hashing to another, or have users stored in different sources, etc.

I targeted 2.4 because it is where `PasswordHasher` was introduced, and it actually broke a 2.3 application I had.
Let me know if this is good for 2.4 or should be on 2.5.
