### PR TITLE
avoiding unnecessary merging in load()

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -250,9 +250,21 @@ class Configure {
 					$values[$key] = Hash::merge($c, $values[$key]);
 				}
 			}
+			static::write($values);
 		}
 
-		return static::write($values);
+		else {
+			static::$_values = $values;
+			if (isset($values['debug']) && function_exists('ini_set')) {
+				if ($values['debug']) {
+					ini_set('display_errors', 1);
+				} else {
+					ini_set('display_errors', 0);
+				}
+			}
+		}
+
+		return true;
 	}
 
 /**

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -81,13 +81,8 @@ class Configure {
 			static::$_values = Hash::insert(static::$_values, $name, $value);
 		}
 
-		if (isset($config['debug']) && function_exists('ini_set')) {
-			if (static::$_values['debug']) {
-				ini_set('display_errors', 1);
-			} else {
-				ini_set('display_errors', 0);
-			}
-		}
+		static::_setDisplayErrors();
+
 		return true;
 	}
 
@@ -253,13 +248,7 @@ class Configure {
 			static::write($values);
 		} else {
 			static::$_values = $values;
-			if (isset($values['debug']) && function_exists('ini_set')) {
-				if ($values['debug']) {
-					ini_set('display_errors', 1);
-				} else {
-					ini_set('display_errors', 0);
-				}
-			}
+			static::_setDisplayErrors();
 		}
 
 		return true;
@@ -378,6 +367,21 @@ class Configure {
 	public static function clear() {
 		static::$_values = [];
 		return true;
+	}
+
+/**
+ * Sets display_errors according to 'debug' setting.
+ *
+ * @return void
+ */
+	protected static function _setDisplayErrors() {
+		if (isset(static::$_values['debug']) && function_exists('ini_set')) {
+			if (static::$_values['debug']) {
+				ini_set('display_errors', 1);
+			} else {
+				ini_set('display_errors', 0);
+			}
+		}
 	}
 
 }

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -251,9 +251,7 @@ class Configure {
 				}
 			}
 			static::write($values);
-		}
-
-		else {
+		} else {
 			static::$_values = $values;
 			if (isset($values['debug']) && function_exists('ini_set')) {
 				if ($values['debug']) {


### PR DESCRIPTION
When using only one Configure::load (in order to avoid expensive Hash::merge), values are still being inserted one by one using Hash::insert (via static::write).

This modification speeds up my bootstrap.php significantly, load() needs now in average 0.2ms instead of 2ms (which is about 30-50% of bootstrap cumulative time).

What are your thoughts?
