### PR TITLE
3.0 range

### DIFF
--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -731,7 +731,7 @@ class Validation {
 			return false;
 		}
 		if (isset($lower) && isset($upper)) {
-			return ($check > $lower && $check < $upper);
+			return ($check >= $lower && $check <= $upper);
 		}
 		return is_finite($check);
 	}

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -475,7 +475,7 @@ class Validation {
 	}
 
 /**
- * Check that value is exactly $comparedTo.
+ * Checks that value is exactly $comparedTo.
  *
  * @param mixed $check Value to check
  * @param mixed $comparedTo Value to compare
@@ -486,7 +486,7 @@ class Validation {
 	}
 
 /**
- * Check that value has a valid file extension.
+ * Checks that value has a valid file extension.
  *
  * @param string|array $check Value to check
  * @param array $extensions file extensions to allow. By default extensions are 'gif', 'jpeg', 'png', 'jpg'
@@ -564,7 +564,7 @@ class Validation {
 	}
 
 /**
- * Validate a multiple select. Comparison is case sensitive by default.
+ * Validates a multiple select. Comparison is case sensitive by default.
  *
  * Valid Options
  *
@@ -632,7 +632,7 @@ class Validation {
 	}
 
 /**
- * Check that a value is a valid phone number.
+ * Checks that a value is a valid phone number.
  *
  * @param string|array $check Value to check (string or array)
  * @param string $regex Regular expression to use
@@ -717,9 +717,11 @@ class Validation {
 	}
 
 /**
- * Validate that a number is in specified range.
- * if $lower and $upper are not set, will return true if
- * $check is a legal finite on this platform
+ * Validates that a number is in specified range.
+ *
+ * If $lower and $upper are set the range is inclusive.
+ * If they are not set, will return true if $check is a
+ * legal finite on this platform.
  *
  * @param string $check Value to check
  * @param int|float $lower Lower limit

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -719,7 +719,7 @@ class Validation {
 /**
  * Validates that a number is in specified range.
  *
- * If $lower and $upper are set the range is inclusive.
+ * If $lower and $upper are set, the range is inclusive.
  * If they are not set, will return true if $check is a
  * legal finite on this platform.
  *

--- a/tests/TestCase/Validation/ValidationTest.php
+++ b/tests/TestCase/Validation/ValidationTest.php
@@ -2011,6 +2011,10 @@ class ValidationTest extends TestCase {
 		$this->assertTrue(Validation::range(5));
 		$this->assertTrue(Validation::range(-5, -10, 1));
 		$this->assertFalse(Validation::range('word'));
+		$this->assertTrue(Validation::range(5.1));
+		$this->assertTrue(Validation::range(2.1, 2.1, 3.2));
+		$this->assertTrue(Validation::range(3.2, 2.1, 3.2));
+		$this->assertFalse(Validation::range(2.099, 2.1, 3.2));
 	}
 
 /**


### PR DESCRIPTION
Resolves https://github.com/cakephp/cakephp/issues/3304

I decided to go with the solution formed at the end of the discussion - "switch range() to inclusive for 3.0".
This is probably better than to add another validation rule to overcome the deficiencies of the current implementation.

One can use a custom (own) validation rule rangeExclusive() for exclusive ranges from there on if needed.
But that sounds like a really rare use case to me.

I will update the migration guide / docs afterwards.
