### PR TITLE
3.0 class name

### DIFF
--- a/src/Cache/CacheRegistry.php
+++ b/src/Cache/CacheRegistry.php
@@ -37,7 +37,7 @@ class CacheRegistry extends ObjectRegistry {
 		if (is_object($class)) {
 			return $class;
 		}
-		return App::classname($class, 'Cache/Engine', 'Engine');
+		return App::className($class, 'Cache/Engine', 'Engine');
 	}
 
 /**

--- a/src/Console/Command/BakeShell.php
+++ b/src/Console/Command/BakeShell.php
@@ -169,18 +169,18 @@ class BakeShell extends Shell {
  */
 	protected function _findTaskClasses($files) {
 		$classes = [];
-		foreach ($files as $classname) {
-			if (!class_exists($classname)) {
+		foreach ($files as $className) {
+			if (!class_exists($className)) {
 				continue;
 			}
-			$reflect = new \ReflectionClass($classname);
+			$reflect = new \ReflectionClass($className);
 			if (!$reflect->isInstantiable()) {
 				continue;
 			}
 			if (!$reflect->isSubclassOf('Cake\Console\Command\Task\BakeTask')) {
 				continue;
 			}
-			$classes[] = $classname;
+			$classes[] = $className;
 		}
 		return $classes;
 	}

--- a/src/Console/Command/Task/CommandTask.php
+++ b/src/Console/Command/Task/CommandTask.php
@@ -151,7 +151,7 @@ class CommandTask extends Shell {
 
 		$name = Inflector::camelize($name);
 		$pluginDot = Inflector::camelize($pluginDot);
-		$class = App::classname($pluginDot . $name, 'Console/Command', 'Shell');
+		$class = App::className($pluginDot . $name, 'Console/Command', 'Shell');
 		if (!$class) {
 			return false;
 		}

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -253,7 +253,7 @@ class TestTask extends BakeTask {
  *
  * @param string $type The Type of object you are generating tests for eg. controller.
  * @param string $class the Classname of the class the test is being generated for.
- * @return string Real classname
+ * @return string Real class name
  */
 	public function getRealClassName($type, $class) {
 		$namespace = Configure::read('App.namespace');

--- a/src/Console/Command/Task/TestTask.php
+++ b/src/Console/Command/Task/TestTask.php
@@ -269,7 +269,7 @@ class TestTask extends BakeTask {
 	}
 
 /**
- * Map the types that TestTask uses to concrete types that App::classname can use.
+ * Map the types that TestTask uses to concrete types that App::className can use.
  *
  * @param string $type The type of thing having a test generated.
  * @return string

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -198,7 +198,7 @@ class ShellDispatcher {
 	protected function _shellExists($shell) {
 		$class = array_map('Cake\Utility\Inflector::camelize', explode('.', $shell));
 		$class = implode('.', $class);
-		$class = App::classname($class, 'Console/Command', 'Shell');
+		$class = App::className($class, 'Console/Command', 'Shell');
 		if (class_exists($class)) {
 			return $class;
 		}

--- a/src/Console/ShellDispatcher.php
+++ b/src/Console/ShellDispatcher.php
@@ -173,14 +173,14 @@ class ShellDispatcher {
  * @throws \Cake\Console\Error\MissingShellException when errors are encountered.
  */
 	public function findShell($shell) {
-		$classname = $this->_shellExists($shell);
-		if (!$classname && isset(static::$_aliases[$shell])) {
+		$className = $this->_shellExists($shell);
+		if (!$className && isset(static::$_aliases[$shell])) {
 			$shell = static::$_aliases[$shell];
-			$classname = $this->_shellExists($shell);
+			$className = $this->_shellExists($shell);
 		}
-		if ($classname) {
+		if ($className) {
 			list($plugin) = pluginSplit($shell);
-			$instance = new $classname();
+			$instance = new $className();
 			$instance->plugin = Inflector::camelize(trim($plugin, '.'));
 			return $instance;
 		}

--- a/src/Console/TaskRegistry.php
+++ b/src/Console/TaskRegistry.php
@@ -48,7 +48,7 @@ class TaskRegistry extends ObjectRegistry {
  * @return string|false Either the correct classname or false.
  */
 	protected function _resolveClassName($class) {
-		return App::classname($class, 'Console/Command/Task', 'Task');
+		return App::className($class, 'Console/Command/Task', 'Task');
 	}
 
 /**

--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -65,14 +65,14 @@ class AclComponent extends Component {
  */
 	public function __construct(ComponentRegistry $collection, array $config = array()) {
 		parent::__construct($collection, $config);
-		$classname = $name = Configure::read('Acl.classname');
-		if (!class_exists($classname)) {
-			$classname = App::className($name, 'Controller/Component/Acl');
-			if (!$classname) {
+		$className = $name = Configure::read('Acl.classname');
+		if (!class_exists($className)) {
+			$className = App::className($name, 'Controller/Component/Acl');
+			if (!$className) {
 				throw new Error\Exception(sprintf('Could not find %s.', $name));
 			}
 		}
-		$this->adapter($classname);
+		$this->adapter($className);
 	}
 
 /**

--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -67,7 +67,7 @@ class AclComponent extends Component {
 		parent::__construct($collection, $config);
 		$classname = $name = Configure::read('Acl.classname');
 		if (!class_exists($classname)) {
-			$classname = App::classname($name, 'Controller/Component/Acl');
+			$classname = App::className($name, 'Controller/Component/Acl');
 			if (!$classname) {
 				throw new Error\Exception(sprintf('Could not find %s.', $name));
 			}

--- a/src/Controller/Component/Auth/BaseAuthenticate.php
+++ b/src/Controller/Component/Auth/BaseAuthenticate.php
@@ -155,7 +155,7 @@ abstract class BaseAuthenticate {
 		}
 
 		list($plugin, $class) = pluginSplit($class, true);
-		$className = App::classname($class, 'Controller/Component/Auth', 'PasswordHasher');
+		$className = App::className($class, 'Controller/Component/Auth', 'PasswordHasher');
 		if (!class_exists($className)) {
 			throw new Error\Exception(sprintf('Password hasher class "%s" was not found.', $class));
 		}

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -460,7 +460,7 @@ class AuthComponent extends Component {
 			unset($authorize[AuthComponent::ALL]);
 		}
 		foreach ($authorize as $class => $config) {
-			$className = App::classname($class, 'Controller/Component/Auth', 'Authorize');
+			$className = App::className($class, 'Controller/Component/Auth', 'Authorize');
 			if (!class_exists($className)) {
 				throw new Error\Exception(sprintf('Authorization adapter "%s" was not found.', $class));
 			}
@@ -727,7 +727,7 @@ class AuthComponent extends Component {
 			unset($authenticate[AuthComponent::ALL]);
 		}
 		foreach ($authenticate as $class => $config) {
-			$className = App::classname($class, 'Controller/Component/Auth', 'Authenticate');
+			$className = App::className($class, 'Controller/Component/Auth', 'Authenticate');
 			if (!class_exists($className)) {
 				throw new Error\Exception(sprintf('Authentication adapter "%s" was not found.', $class));
 			}

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -514,7 +514,7 @@ class RequestHandlerComponent extends Component {
 		} else {
 			$view = Inflector::classify($type);
 		}
-		$viewClass = App::classname($view, 'View', 'View');
+		$viewClass = App::className($view, 'View', 'View');
 
 		if ($viewClass) {
 			$controller->viewClass = $viewClass;
@@ -540,7 +540,7 @@ class RequestHandlerComponent extends Component {
 		$helper = ucfirst($type);
 
 		if (!in_array($helper, $controller->helpers) && empty($controller->helpers[$helper])) {
-			$helperClass = App::classname($helper, 'View/Helper', 'Helper');
+			$helperClass = App::className($helper, 'View/Helper', 'Helper');
 			if ($helperClass) {
 				$controller->helpers[] = $helper;
 			}

--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -65,7 +65,7 @@ class ComponentRegistry extends ObjectRegistry {
  * @return string|false Either the correct classname or false.
  */
 	protected function _resolveClassName($class) {
-		return App::classname($class, 'Controller/Component', 'Component');
+		return App::className($class, 'Controller/Component', 'Component');
 	}
 
 /**

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -66,15 +66,15 @@ class App {
 	protected static $_objectCacheChange = false;
 
 /**
- * Return the classname namespaced. This method checks if the class is defined on the
+ * Return the class name namespaced. This method checks if the class is defined on the
  * application/plugin, otherwise try to load from the CakePHP core
  *
- * @param string $class Classname
+ * @param string $class Class name
  * @param string $type Type of class
- * @param string $suffix Classname suffix
- * @return bool|string False if the class is not found or namespaced classname
+ * @param string $suffix Class name suffix
+ * @return bool|string False if the class is not found or namespaced class name
  */
-	public static function classname($class, $type = '', $suffix = '') {
+	public static function className($class, $type = '', $suffix = '') {
 		if (strpos($class, '\\') !== false) {
 			return $class;
 		}

--- a/src/Datasource/ConnectionRegistry.php
+++ b/src/Datasource/ConnectionRegistry.php
@@ -37,7 +37,7 @@ class ConnectionRegistry extends ObjectRegistry {
 		if (is_object($class)) {
 			return $class;
 		}
-		return App::classname($class, 'Datasource');
+		return App::className($class, 'Datasource');
 	}
 
 /**

--- a/src/Error/ErrorHandler.php
+++ b/src/Error/ErrorHandler.php
@@ -129,7 +129,7 @@ class ErrorHandler extends BaseErrorHandler {
  * @throws \Exception When the chosen exception renderer is invalid.
  */
 	protected function _displayException($exception) {
-		$renderer = App::classname($this->_options['exceptionRenderer'], 'Error');
+		$renderer = App::className($this->_options['exceptionRenderer'], 'Error');
 		try {
 			if (!$renderer) {
 				throw new \Exception("$renderer is an invalid class.");

--- a/src/Log/LogEngineRegistry.php
+++ b/src/Log/LogEngineRegistry.php
@@ -37,7 +37,7 @@ class LogEngineRegistry extends ObjectRegistry {
 			return $class;
 		}
 
-		return App::classname($class, 'Log/Engine', 'Log');
+		return App::className($class, 'Log/Engine', 'Log');
 	}
 
 /**

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -947,7 +947,7 @@ class Email {
 		}
 
 		$config = static::$_transportConfig[$name];
-		$classname = App::classname($config['className'], 'Network/Email', 'Transport');
+		$classname = App::className($config['className'], 'Network/Email', 'Transport');
 		if (!$classname) {
 			throw new Exception(sprintf('Transport class "%s" not found.', $name));
 		} elseif (!method_exists($classname, 'send')) {
@@ -1685,9 +1685,9 @@ class Email {
 		}
 		$viewClass = $this->_viewRender;
 		if ($viewClass === 'View') {
-			$viewClass = App::classname('View', 'View');
+			$viewClass = App::className('View', 'View');
 		} else {
-			$viewClass = App::classname($viewClass, 'View', 'View');
+			$viewClass = App::className($viewClass, 'View', 'View');
 		}
 		$viewClass = 'Cake\View\View';
 

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -947,15 +947,15 @@ class Email {
 		}
 
 		$config = static::$_transportConfig[$name];
-		$classname = App::className($config['className'], 'Network/Email', 'Transport');
-		if (!$classname) {
+		$className = App::className($config['className'], 'Network/Email', 'Transport');
+		if (!$className) {
 			throw new Exception(sprintf('Transport class "%s" not found.', $name));
-		} elseif (!method_exists($classname, 'send')) {
-			throw new Exception(sprintf('The "%s" does not have a send() method.', $classname));
+		} elseif (!method_exists($className, 'send')) {
+			throw new Exception(sprintf('The "%s" does not have a send() method.', $className));
 		}
 
 		unset($config['className']);
-		return new $classname($config);
+		return new $className($config);
 	}
 
 /**

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -77,7 +77,7 @@ class BehaviorRegistry extends ObjectRegistry {
  * @return string|false Either the correct classname or false.
  */
 	protected function _resolveClassName($class) {
-		return App::classname($class, 'Model/Behavior', 'Behavior');
+		return App::className($class, 'Model/Behavior', 'Behavior');
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -441,7 +441,7 @@ class Table implements RepositoryInterface, EventListener {
 		}
 
 		if ($name !== null) {
-			$class = App::classname($name, 'Model/Entity');
+			$class = App::className($name, 'Model/Entity');
 			$this->_entityClass = $class;
 		}
 

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -153,7 +153,7 @@ class TableRegistry {
 		if (empty($options['className'])) {
 			$options['className'] = Inflector::camelize($name);
 		}
-		$className = App::classname($options['className'], 'Model/Table', 'Table');
+		$className = App::className($options['className'], 'Model/Table', 'Table');
 		$options['className'] = $className ?: 'Cake\ORM\Table';
 
 		if (isset(static::$_config[$alias])) {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -106,7 +106,7 @@ class Dispatcher implements EventListener {
 				$filter = array('callable' => $filter);
 			}
 			if (is_string($filter['callable'])) {
-				$callable = App::classname($filter['callable'], 'Routing/Filter');
+				$callable = App::className($filter['callable'], 'Routing/Filter');
 				if (!$callable) {
 					throw new Error\MissingDispatcherFilterException($filter['callable']);
 				}
@@ -271,7 +271,7 @@ class Dispatcher implements EventListener {
 			$namespace .= '/' . Inflector::camelize($request->params['prefix']);
 		}
 		if ($pluginPath . $controller) {
-			return App::classname($pluginPath . $controller, $namespace, 'Controller');
+			return App::className($pluginPath . $controller, $namespace, 'Controller');
 		}
 		return false;
 	}

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -340,7 +340,7 @@ class Router {
 		}
 		$routeClass = static::$_routeClass;
 		if (isset($options['routeClass'])) {
-			$routeClass = App::classname($options['routeClass'], 'Routing/Route');
+			$routeClass = App::className($options['routeClass'], 'Routing/Route');
 			$routeClass = static::_validateRouteClass($routeClass);
 			unset($options['routeClass']);
 		}

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -312,8 +312,8 @@ abstract class ControllerTestCase extends TestCase {
  * @throws \Cake\Controller\Error\MissingComponentException When components could not be created.
  */
 	public function generate($controller, array $mocks = array()) {
-		$classname = App::className($controller, 'Controller', 'Controller');
-		if (!$classname) {
+		$className = App::className($controller, 'Controller', 'Controller');
+		if (!$className) {
 			list($plugin, $controller) = pluginSplit($controller);
 			throw new MissingControllerException(array(
 				'class' => $controller . 'Controller',
@@ -326,13 +326,13 @@ abstract class ControllerTestCase extends TestCase {
 			'models' => array(),
 			'components' => array()
 		), $mocks);
-		list(, $controllerName) = namespaceSplit($classname);
+		list(, $controllerName) = namespaceSplit($className);
 		$name = substr($controllerName, 0, -10);
 
 		$request = $this->getMock('Cake\Network\Request');
 		$response = $this->getMock('Cake\Network\Response', array('_sendHeader', 'stop'));
 		$controller = $this->getMock(
-			$classname,
+			$className,
 			$mocks['methods'],
 			array($request, $response, $name)
 		);

--- a/src/TestSuite/ControllerTestCase.php
+++ b/src/TestSuite/ControllerTestCase.php
@@ -312,7 +312,7 @@ abstract class ControllerTestCase extends TestCase {
  * @throws \Cake\Controller\Error\MissingComponentException When components could not be created.
  */
 	public function generate($controller, array $mocks = array()) {
-		$classname = App::classname($controller, 'Controller', 'Controller');
+		$classname = App::className($controller, 'Controller', 'Controller');
 		if (!$classname) {
 			list($plugin, $controller) = pluginSplit($controller);
 			throw new MissingControllerException(array(
@@ -356,7 +356,7 @@ abstract class ControllerTestCase extends TestCase {
 			if ($methods === true) {
 				$methods = array();
 			}
-			$componentClass = App::classname($component, 'Controller/Component', 'Component');
+			$componentClass = App::className($component, 'Controller/Component', 'Component');
 			list(, $name) = pluginSplit($component, true);
 			if (!$componentClass) {
 				throw new MissingComponentException(array(

--- a/src/TestSuite/TestCase.php
+++ b/src/TestSuite/TestCase.php
@@ -538,7 +538,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	public function getMockForModel($alias, array $methods = array(), array $options = array()) {
 		if (empty($options['className'])) {
 			$class = Inflector::camelize($alias);
-			$className = App::classname($class, 'Model/Table', 'Table');
+			$className = App::className($class, 'Model/Table', 'Table');
 			if (!$className) {
 				throw new \Cake\ORM\Error\MissingTableClassException(array($alias));
 			}

--- a/src/Validation/Validation.php
+++ b/src/Validation/Validation.php
@@ -852,7 +852,7 @@ class Validation {
  * @return mixed Return of Passed method, false on failure
  */
 	protected static function _pass($method, $check, $classPrefix) {
-		$className = App::classname($classPrefix, 'Validation', 'Validation');
+		$className = App::className($classPrefix, 'Validation', 'Validation');
 		if (!$className) {
 			trigger_error('Could not find class for validation, unable to complete validation.', E_USER_WARNING);
 			return false;

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -64,7 +64,7 @@ trait CellTrait {
 
 		list($plugin, $cellName) = pluginSplit($pluginAndCell);
 
-		$className = App::classname($pluginAndCell, 'View/Cell', 'Cell');
+		$className = App::className($pluginAndCell, 'View/Cell', 'Cell');
 
 		if (!$className) {
 			throw new Error\MissingCellException(array('className' => $pluginAndCell . 'Cell'));

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -63,7 +63,7 @@ class NumberHelper extends Helper {
 
 		$config = $this->_config;
 
-		$engineClass = App::classname($config['engine'], 'Utility');
+		$engineClass = App::className($config['engine'], 'Utility');
 		if ($engineClass) {
 			$this->_engine = new $engineClass($config);
 		} else {

--- a/src/View/Helper/TextHelper.php
+++ b/src/View/Helper/TextHelper.php
@@ -78,7 +78,7 @@ class TextHelper extends Helper {
 		parent::__construct($View, $config);
 
 		$config = $this->_config;
-		$engineClass = App::classname($config['engine'], 'Utility');
+		$engineClass = App::className($config['engine'], 'Utility');
 		if ($engineClass) {
 			$this->_engine = new $engineClass($config);
 		} else {

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -107,7 +107,7 @@ class HelperRegistry extends ObjectRegistry {
  * @return string|false Either the correct classname or false.
  */
 	protected function _resolveClassName($class) {
-		return App::classname($class, 'View/Helper', 'Helper');
+		return App::className($class, 'View/Helper', 'Helper');
 	}
 
 /**

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -42,7 +42,7 @@ trait ViewVarsTrait {
 			$viewClass = $this->viewClass;
 			if ($this->viewClass !== 'View') {
 				list($plugin, $viewClass) = pluginSplit($viewClass, true);
-				$viewClass = App::classname($viewClass, 'View', 'View');
+				$viewClass = App::className($viewClass, 'View', 'View');
 			}
 		}
 		$viewOptions = array_intersect_key(get_object_vars($this), array_flip($this->_validViewOptions));

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -150,7 +150,7 @@ class WidgetRegistry {
 		}
 
 		$class = array_shift($widget);
-		$className = App::classname($class, 'View/Input');
+		$className = App::className($class, 'View/Input');
 		if ($className === false || !class_exists($className)) {
 			throw new \RuntimeException(sprintf('Unable to locate widget class "%s"', $class));
 		}

--- a/src/basics.php
+++ b/src/basics.php
@@ -235,7 +235,7 @@ if (!function_exists('namespaceSplit')) {
 /**
  * Split the namespace from the classname.
  *
- * Commonly used like `list($namespace, $classname) = namespaceSplit($class);`
+ * Commonly used like `list($namespace, $className) = namespaceSplit($class);`
  *
  * @param string $class The full class name, ie `Cake\Core\App`
  * @return array Array with 2 indexes. 0 => namespace, 1 => classname


### PR DESCRIPTION
Refs https://groups.google.com/forum/#!topic/cake-php/STfLJ6vXcHE

Unifies way "className" is used and spelled across the framework.
Especially since it is already camelBacked in `public function getRealClassName($type, $class) {}` etc.

It was actually already called as `App::className()` in several places.

One thing yet missing is `Configure::write('Acl.classname', 'DbAcl');` - should we do that afterwards in a separate PR maybe?
