### PR TITLE
2.6 insert

### DIFF
--- a/lib/Cake/Test/Case/Utility/StringTest.php
+++ b/lib/Cake/Test/Case/Utility/StringTest.php
@@ -228,6 +228,26 @@ class StringTest extends CakeTestCase {
 	}
 
 /**
+ * testInsertFlatten()
+ *
+ * @return void
+ */
+	public function testInsertFlatten() {
+		$user = array(
+			'User' => array('name' => 'nick', 'last_name' => 'baker'),
+			'Profile' => array('age' => '19', 'gender' => 'male'),
+		);
+		$result = String::insert(
+			'Hello :User.name. You are :Profile.age years old.',
+			$user,
+			array('flatten' => true)
+		);
+		$expected = 'Hello nick. You are 19 years old.';
+		debug($result);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * test Clean Insert
  *
  * @return void

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -15,6 +15,7 @@
  * @since         CakePHP(tm) v 1.2.0.5551
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+App::uses('Hash', 'Utility');
 
 /**
  * String handling methods.
@@ -186,6 +187,7 @@ class String {
  * - escape: The character or string used to escape the before character / string (Defaults to `\`)
  * - format: A regex to use for matching variable placeholders. Default is: `/(?<!\\)\:%s/`
  *   (Overwrites before, after, breaks escape / clean)
+ * - flatten: If a deep data array should be flattened using `.` as separator
  * - clean: A boolean or array with instructions for String::cleanInsert
  *
  * @param string $str A string containing variable placeholders
@@ -196,13 +198,17 @@ class String {
  */
 	public static function insert($str, $data, $options = array()) {
 		$defaults = array(
-			'before' => ':', 'after' => null, 'escape' => '\\', 'format' => null, 'clean' => false
+			'before' => ':', 'after' => null, 'escape' => '\\', 'format' => null, 'clean' => false,
+			'flatten' => false
 		);
 		$options += $defaults;
 		$format = $options['format'];
 		$data = (array)$data;
 		if (empty($data)) {
 			return ($options['clean']) ? String::cleanInsert($str, $options) : $str;
+		}
+		if ($options['flatten']) {
+			$data = Hash::flatten($data);
 		}
 
 		if (!isset($format)) {


### PR DESCRIPTION
Implementation of https://github.com/cakephp/cakephp/issues/1790

But in hindsight I think one could also just manually flatten before passing it into the method:

``` php
$result = String::insert(
    'Hello :User.name. You are :Profile.age years old.',
    Hash::flatten($user)
);
```

That would make the additional code unnecessary.
Then I would just close the original issue/ticket.

Or was the original idea something else?
