### PR TITLE
Allow for greater SSL support in HttpSocket

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -116,9 +116,6 @@ class CakeSocket {
  */
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
-		if (!is_numeric($this->config['protocol'])) {
-			$this->config['protocol'] = getprotobyname($this->config['protocol']);
-		}
 	}
 
 /**
@@ -130,11 +127,6 @@ class CakeSocket {
 	public function connect() {
 		if ($this->connection) {
 			$this->disconnect();
-		}
-
-		$scheme = null;
-		if (isset($this->config['request']['uri']) && $this->config['request']['uri']['scheme'] === 'https') {
-			$scheme = 'ssl://';
 		}
 
 		if (!empty($this->config['context'])) {
@@ -150,7 +142,7 @@ class CakeSocket {
 
 		set_error_handler(array($this, '_connectionErrorHandler'));
 		$this->connection = stream_socket_client(
-			$scheme . $this->config['host'] . ':' . $this->config['port'],
+			$this->config['protocol'] . "://" . $this->config['host'] . ':' . $this->config['port'],
 			$errNum,
 			$errStr,
 			$this->config['timeout'],

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -116,6 +116,11 @@ class CakeSocket {
  */
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
+		if (!is_numeric($this->config['protocol'])) {
+			if($protocol = getprotobyname($this->config['protocol'])) {
+                $this->config['protocol'] = $protocol;
+            }
+		}
 	}
 
 /**
@@ -128,6 +133,10 @@ class CakeSocket {
 		if ($this->connection) {
 			$this->disconnect();
 		}
+        
+        if(is_numeric($this->config['protocol'])){
+            $this->config['protocol'] = getprotobynumber($this->config['protocol']);
+        }
 
 		if (!empty($this->config['context'])) {
 			$context = stream_context_create($this->config['context']);
@@ -139,7 +148,6 @@ class CakeSocket {
 		if ($this->config['persistent']) {
 			$connectAs |= STREAM_CLIENT_PERSISTENT;
 		}
-
 		set_error_handler(array($this, '_connectionErrorHandler'));
 		$this->connection = stream_socket_client(
 			$this->config['protocol'] . '://' . $this->config['host'] . ':' . $this->config['port'],

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -350,7 +350,7 @@ class CakeSocket {
 /**
  * Encrypts current stream socket, using one of the defined encryption methods
  *
- * @param string $type can be one of 'ssl2', 'ssl3', 'ssl23' or 'tls'
+ * @param string $type can be one of 'sslv2', 'sslv3', 'sslv23' or 'tls'
  * @param string $clientOrServer can be one of 'client', 'server'. Default is 'client'
  * @param boolean $enable enable or disable encryption. Default is true (enable)
  * @return boolean True on success

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -142,7 +142,7 @@ class CakeSocket {
 
 		set_error_handler(array($this, '_connectionErrorHandler'));
 		$this->connection = stream_socket_client(
-			$this->config['protocol'] . "://" . $this->config['host'] . ':' . $this->config['port'],
+			$this->config['protocol'] . '://' . $this->config['host'] . ':' . $this->config['port'],
 			$errNum,
 			$errStr,
 			$this->config['timeout'],

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -134,7 +134,7 @@ class CakeSocket {
 			$this->disconnect();
 		}
         
-        if(is_numeric($this->config['protocol'])){
+        if (is_numeric($this->config['protocol'])) {
             $this->config['protocol'] = getprotobynumber($this->config['protocol']);
         }
 

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -117,7 +117,7 @@ class CakeSocket {
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
 		if (!is_numeric($this->config['protocol'])) {
-			if($protocol = getprotobyname($this->config['protocol'])) {
+			if ($protocol = getprotobyname($this->config['protocol'])) {
                 $this->config['protocol'] = $protocol;
             }
 		}
@@ -133,7 +133,7 @@ class CakeSocket {
 		if ($this->connection) {
 			$this->disconnect();
 		}
-        
+ 
         if (is_numeric($this->config['protocol'])) {
             $this->config['protocol'] = getprotobynumber($this->config['protocol']);
         }

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -791,7 +791,7 @@ class HttpSocket extends CakeSocket {
 			$uri['port'] = array_shift($uri['port']);
 		}
 	        if (isset($uri['scheme']) && $uri['scheme'] === 'https') {
-	            if($this->config['protocol']==='tcp'){
+	            if ($this->config['protocol'] === 'tcp') {
         	        $this->config['protocol'] = 'ssl';
             	    }
         	}

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -454,7 +454,6 @@ class HttpSocket extends CakeSocket {
 			}
 			$uri = $this->_buildUri($uri);
 		}
-
 		$request = Hash::merge(array('method' => 'GET', 'uri' => $uri), $request);
 		return $this->request($request);
 	}
@@ -785,16 +784,16 @@ class HttpSocket extends CakeSocket {
 		if (isset($uri['scheme']) && is_array($uri['scheme'])) {
 			$uri['scheme'] = array_shift($uri['scheme']);
 		}
-		
+
+        if (isset($uri['scheme']) && $uri['scheme'] === 'https') {
+	        if ($this->config['protocol'] === 'tcp') {
+        	    $this->config['protocol'] = 'ssl';
+            }
+        }
 
 		if (isset($uri['port']) && is_array($uri['port'])) {
 			$uri['port'] = array_shift($uri['port']);
 		}
-	        if (isset($uri['scheme']) && $uri['scheme'] === 'https') {
-	            if ($this->config['protocol'] === 'tcp') {
-        	        $this->config['protocol'] = 'ssl';
-            	    }
-        	}
 		if (array_key_exists('query', $uri)) {
 			$uri['query'] = $this->_parseQuery($uri['query']);
 		}

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -785,10 +785,16 @@ class HttpSocket extends CakeSocket {
 		if (isset($uri['scheme']) && is_array($uri['scheme'])) {
 			$uri['scheme'] = array_shift($uri['scheme']);
 		}
+		
+
 		if (isset($uri['port']) && is_array($uri['port'])) {
 			$uri['port'] = array_shift($uri['port']);
 		}
-
+	        if (isset($uri['scheme']) && $uri['scheme'] === 'https') {
+	            if($this->config['protocol']==='tcp'){
+        	        $this->config['protocol'] = 'ssl';
+            	    }
+        	}
 		if (array_key_exists('query', $uri)) {
 			$uri['query'] = $this->_parseQuery($uri['query']);
 		}

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -218,7 +218,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->__construct(array('host' => 'foo-bar'));
 		$baseConfig['host'] = 'foo-bar';
 		$baseConfig['protocol'] = getprotobyname($baseConfig['protocol']);
-		$this->assertEquals($this->Socket->config, $baseConfig);
+		$this->assertEquals($baseConfig, $this->Socket->config);
 
 		$this->Socket->reset();
 		$baseConfig = $this->Socket->config;
@@ -227,11 +227,11 @@ class HttpSocketTest extends CakeTestCase {
 		$baseConfig['port'] = $baseConfig['request']['uri']['port'] = 23;
 		$baseConfig['request']['uri']['scheme'] = 'http';
 		$baseConfig['protocol'] = getprotobyname($baseConfig['protocol']);
-		$this->assertEquals($this->Socket->config, $baseConfig);
+		$this->assertEquals($baseConfig, $this->Socket->config);
 
 		$this->Socket->reset();
 		$this->Socket->__construct(array('request' => array('uri' => 'http://www.cakephp.org:23/')));
-		$this->assertEquals($this->Socket->config, $baseConfig);
+		$this->assertEquals($baseConfig, $this->Socket->config);
 	}
 
 /**
@@ -557,9 +557,8 @@ class HttpSocketTest extends CakeTestCase {
 
 			$raw = $expectation['request']['raw'];
 			$expectation['request']['raw'] = $expectation['request']['line'] . $expectation['request']['header'] . "\r\n" . $raw;
-
 			$r = array('config' => $this->Socket->config, 'request' => $this->Socket->request);
-			$this->assertEquals($r, $expectation, 'Failed test #' . $i . ' ');
+			$this->assertEquals($expectation,$r, 'Failed test #' . $i . ' ');
 			$expectation['request']['raw'] = $raw;
 		}
 
@@ -637,7 +636,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->at(0))->method('read')->will($this->returnValue(false));
 		$this->Socket->expects($this->at(1))->method('read')->will($this->returnValue($serverResponse));
 		$response = (string)$this->Socket->request($request);
-		$this->assertEquals($response, "<h1>Hello, your lucky number is " . $number . "</h1>");
+		$this->assertEquals("<h1>Hello, your lucky number is " . $number . "</h1>", $response);
 	}
 
 /**
@@ -658,7 +657,7 @@ class HttpSocketTest extends CakeTestCase {
 			)
 		);
 		$this->assertEquals($expect, $result);
-		$this->assertEquals($this->Socket->config['request']['cookies']['www.cakephp.org'], $expect);
+		$this->assertEquals($expect, $this->Socket->config['request']['cookies']['www.cakephp.org']);
 		$this->assertFalse($this->Socket->connected);
 	}
 
@@ -712,7 +711,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->assertEquals('', $result);
 		$this->assertEquals('CakeHttp Server', $this->Socket->response['header']['Server']);
 		fclose($f);
-		$this->assertEquals(file_get_contents(TMP . 'download.txt'), '<h1>This is a test!</h1>');
+		$this->assertEquals('<h1>This is a test!</h1>', file_get_contents(TMP . 'download.txt'));
 		unlink(TMP . 'download.txt');
 
 		$this->Socket->setContentResource(false);
@@ -1072,7 +1071,7 @@ class HttpSocketTest extends CakeTestCase {
 				'pass' => 'hunter2'
 			)
 		));
-		$this->assertEquals($this->Socket->request['auth'], array('Basic' => array('user' => 'joel', 'pass' => 'hunter2')));
+		$this->assertEquals(array('Basic' => array('user' => 'joel', 'pass' => 'hunter2')), $this->Socket->request['auth']);
 		$this->assertTrue(strpos($this->Socket->request['header'], 'Authorization: Basic am9lbDpodW50ZXIy') !== false);
 	}
 
@@ -1283,7 +1282,7 @@ class HttpSocketTest extends CakeTestCase {
 		$this->assertEquals(array('path' => '/my-cool-path'), $uri);
 
 		$uri = $this->Socket->parseUri('http://bob:foo123@www.cakephp.org:40/search?q=dessert#results');
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.cakephp.org',
 			'port' => 40,
@@ -1292,17 +1291,17 @@ class HttpSocketTest extends CakeTestCase {
 			'path' => '/search',
 			'query' => array('q' => 'dessert'),
 			'fragment' => 'results'
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('http://www.cakephp.org/');
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.cakephp.org',
 			'path' => '/'
-		));
+		),$uri);
 
 		$uri = $this->Socket->parseUri('http://www.cakephp.org', true);
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.cakephp.org',
 			'port' => 80,
@@ -1311,10 +1310,10 @@ class HttpSocketTest extends CakeTestCase {
 			'path' => '/',
 			'query' => array(),
 			'fragment' => null
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('https://www.cakephp.org', true);
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'https',
 			'host' => 'www.cakephp.org',
 			'port' => 443,
@@ -1323,10 +1322,10 @@ class HttpSocketTest extends CakeTestCase {
 			'path' => '/',
 			'query' => array(),
 			'fragment' => null
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('www.cakephp.org:443/query?foo', true);
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'https',
 			'host' => 'www.cakephp.org',
 			'port' => 443,
@@ -1335,39 +1334,39 @@ class HttpSocketTest extends CakeTestCase {
 			'path' => '/query',
 			'query' => array('foo' => ""),
 			'fragment' => null
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('http://www.cakephp.org', array('host' => 'piephp.org', 'user' => 'bob', 'fragment' => 'results'));
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'host' => 'www.cakephp.org',
 			'user' => 'bob',
 			'fragment' => 'results',
 			'scheme' => 'http'
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('https://www.cakephp.org', array('scheme' => 'http', 'port' => 23));
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'https',
 			'port' => 23,
 			'host' => 'www.cakephp.org'
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('www.cakephp.org:59', array('scheme' => array('http', 'https'), 'port' => 80));
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'port' => 59,
 			'host' => 'www.cakephp.org'
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri(array('scheme' => 'http', 'host' => 'www.google.com', 'port' => 8080), array('scheme' => array('http', 'https'), 'host' => 'www.google.com', 'port' => array(80, 443)));
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.google.com',
 			'port' => 8080
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('http://www.cakephp.org/?param1=value1&param2=value2%3Dvalue3');
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.cakephp.org',
 			'path' => '/',
@@ -1375,10 +1374,10 @@ class HttpSocketTest extends CakeTestCase {
 				'param1' => 'value1',
 				'param2' => 'value2=value3'
 			)
-		));
+		), $uri);
 
 		$uri = $this->Socket->parseUri('http://www.cakephp.org/?param1=value1&param2=value2=value3');
-		$this->assertEquals($uri, array(
+		$this->assertEquals(array(
 			'scheme' => 'http',
 			'host' => 'www.cakephp.org',
 			'path' => '/',
@@ -1386,7 +1385,7 @@ class HttpSocketTest extends CakeTestCase {
 				'param1' => 'value1',
 				'param2' => 'value2=value3'
 			)
-		));
+		), $uri);
 	}
 
 /**


### PR DESCRIPTION
This pull request is a different solution to: https://github.com/cakephp/cakephp/pull/3295

I have a different solution for #3295. I don't think that CakeSocket should be handling anything with Http or Https, that should be handled by the HttpSocket class. In addition, there is an unused variable, protocol, that could be used to allow the scheme to remain https, but the protocol to change to ssl or sslv2 or sslv3. I think the default for https should be ssl, but if the dev wants to use a different protocol, that should be the devs choice. 

I submitted a pull request that adds functionality to the protocol variable and moves the https code to the HttpScoket class. On top of that the dev can now override the protocol in the constructor to use the protocol of his/her chocie. If none is specified, it still uses tcp by default and ssl for default https connections. 
