### PR TITLE
3.0 validate timestamps fix

### DIFF
--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -411,7 +411,7 @@ class ModelTask extends BakeTask {
  * @return array Array of validation for the field.
  */
 	public function fieldValidation($fieldName, array $metaData, $primaryKey) {
-		$ignoreFields = array_merge($primaryKey, ['created', 'modified', 'updated']);
+		$ignoreFields = ['created', 'modified', 'updated'];
 		if (in_array($fieldName, $ignoreFields)) {
 			return false;
 		}

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -412,7 +412,7 @@ class ModelTask extends BakeTask {
  */
 	public function fieldValidation($fieldName, array $metaData, $primaryKey) {
 		$ignoreFields = array_merge($primaryKey, ['created', 'modified', 'updated']);
-		if ($metaData['null'] === true && in_array($fieldName, $ignoreFields)) {
+		if (in_array($fieldName, $ignoreFields)) {
 			return false;
 		}
 

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -427,6 +427,7 @@ class ModelTaskTest extends TestCase {
 			'title' => ['rule' => false, 'allowEmpty' => false],
 			'body' => ['rule' => false, 'allowEmpty' => true],
 			'published' => ['rule' => 'boolean', 'allowEmpty' => true],
+			'id' => ['rule' => 'numeric', 'allowEmpty' => 'create']
 		];
 		$this->assertEquals($expected, $result);
 
@@ -436,7 +437,8 @@ class ModelTaskTest extends TestCase {
 			'bake_article_id' => ['rule' => 'numeric', 'allowEmpty' => false],
 			'bake_user_id' => ['rule' => 'numeric', 'allowEmpty' => false],
 			'comment' => ['rule' => false, 'allowEmpty' => true],
-			'published' => ['rule' => false,'allowEmpty' => true]
+			'published' => ['rule' => false,'allowEmpty' => true],
+			'otherid' => ['rule' => 'numeric', 'allowEmpty' => 'create']
 		];
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -436,7 +436,7 @@ class ModelTaskTest extends TestCase {
 			'bake_article_id' => ['rule' => 'numeric', 'allowEmpty' => false],
 			'bake_user_id' => ['rule' => 'numeric', 'allowEmpty' => false],
 			'comment' => ['rule' => false, 'allowEmpty' => true],
-			'published' => ['rule' => false,'allowEmpty' => true]
+			'published' => ['rule' => false, 'allowEmpty' => true]
 		];
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -423,11 +423,20 @@ class ModelTaskTest extends TestCase {
 		$model = TableRegistry::get('BakeArticles');
 		$result = $this->Task->getValidation($model);
 		$expected = [
-			'id' => ['rule' => 'numeric', 'allowEmpty' => 'create'],
 			'bake_user_id' => ['rule' => 'numeric', 'allowEmpty' => false],
 			'title' => ['rule' => false, 'allowEmpty' => false],
 			'body' => ['rule' => false, 'allowEmpty' => true],
 			'published' => ['rule' => 'boolean', 'allowEmpty' => true],
+		];
+		$this->assertEquals($expected, $result);
+
+		$model = TableRegistry::get('BakeComments');
+		$result = $this->Task->getValidation($model);
+		$expected = [
+			'bake_article_id' => ['rule' => 'numeric', 'allowEmpty' => false],
+			'bake_user_id' => ['rule' => 'numeric', 'allowEmpty' => false],
+			'comment' => ['rule' => false, 'allowEmpty' => true],
+			'published' => ['rule' => false,'allowEmpty' => true]
 		];
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
Not validating created and modified fields in baked tables, fixes #3464 
