### PR TITLE
Added the plugin name to the file mapping key

### DIFF
--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -786,12 +786,12 @@ class App {
 	protected static function _map($file, $name, $plugin = null) {
 		$key = $name;
 		if ($plugin) {
-			$key = 'plugin.' . $name;
+			$key = 'plugin.' . $plugin . '.' . $name;
 		}
 		if ($plugin && empty(self::$_map[$name])) {
 			self::$_map[$key] = $file;
 		}
-		if (!$plugin && empty(self::$_map['plugin.' . $name])) {
+		if (!$plugin && empty(self::$_map['plugin.' . $plugin . '.' . $name])) {
 			self::$_map[$key] = $file;
 		}
 		if (!self::$bootstrapping) {
@@ -809,7 +809,7 @@ class App {
 	protected static function _mapped($name, $plugin = null) {
 		$key = $name;
 		if ($plugin) {
-			$key = 'plugin.' . $name;
+			$key = 'plugin.' . $plugin . '.' . $name;
 		}
 		return isset(self::$_map[$key]) ? self::$_map[$key] : false;
 	}


### PR DESCRIPTION
This caused problems when two plugins had the same controller name
because it would conflict in the mapping. By adding the plugin name
to the mapping key this is solved.
