### PR TITLE
Allow PHPUnit from Composer

### DIFF
--- a/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
+++ b/lib/Cake/TestSuite/CakeTestSuiteDispatcher.php
@@ -138,7 +138,10 @@ class CakeTestSuiteDispatcher {
 		}
 		foreach (App::path('vendors') as $vendor) {
 			$vendor = rtrim($vendor, DS);
-			if (is_dir($vendor . DS . 'PHPUnit')) {
+			if (is_dir($vendor . DS . 'phpunit' . DS . 'phpunit' . DS . 'PHPUnit')) {
+				ini_set('include_path', $vendor . DS . 'phpunit' . DS . 'phpunit' . PATH_SEPARATOR . ini_get('include_path'));
+				break;
+			} elseif (is_dir($vendor . DS . 'PHPUnit')) {
 				ini_set('include_path', $vendor . PATH_SEPARATOR . ini_get('include_path'));
 				break;
 			}


### PR DESCRIPTION
**Scenario**
When updating PHPUnit using homebrew it updated to `4.1.0` which turns out to not be compatible. As downgrading using homebrew is very hard, I decided to use Composer. So I created a `composer.json` and added `phpunit/phpunit 3.7.37` as a dependancy.

**Environment**
Cake 2.5.0

**Issue**
The issue is that the Test Suite Dispatcher doens't understand vendor/package style folders.

**Fix**
Just updated the dispatcher to look for a vendor/package style folder inside `Vendors` before trying the default.
