### PR TITLE
Unset $db in DboSource::read().

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -1140,6 +1140,7 @@ class DboSource extends DataSource {
 						$stack['_joined'] = $joined;
 
 						$db->queryAssociation($Model, $LinkModel, $type, $assoc, $assocData, $array, true, $resultSet, $Model->recursive - 1, $stack);
+						unset($db);
 
 						if ($type === 'hasMany' || $type === 'hasAndBelongsToMany') {
 							$filtered[] = $assoc;


### PR DESCRIPTION
After calling $db->queryAssociatin(), it is necessary to unset $db. 
This reverts commit 52d425737af584d33352ff0540dbf769006d82f5.
