### PR TITLE
Fixed FormHelper::postLink() for baked files.

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1799,6 +1799,9 @@ class FormHelper extends AppHelper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/form.html#FormHelper::postLink
  */
 	public function postLink($title, $url = null, $options = array(), $confirmMessage = false) {
+		if ($options === null) {
+			$options = array();
+		}
 		$options += array('inline' => true, 'block' => null);
 		if (!$options['inline'] && empty($options['block'])) {
 			$options['block'] = __FUNCTION__;


### PR DESCRIPTION
Null is set as a 3rd parameter in the files baked by Console.
