### PR TITLE
3.0 log

### DIFF
--- a/src/Log/LogTrait.php
+++ b/src/Log/LogTrait.php
@@ -28,7 +28,7 @@ trait LogTrait {
  * @param string|array $scope The name of the log scope.
  * @return bool Success of log write.
  */
-	public function log($msg, $level = LOG_ERR, $scope = []) {
+	protected function _log($msg, $level = LOG_ERR, $scope = []) {
 		if (!is_string($msg)) {
 			$msg = print_r($msg, true);
 		}

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -83,7 +83,7 @@ class ShellTestShell extends Shell {
 	}
 
 	public function log_something() {
-		$this->log($this->testMessage);
+		$this->_log($this->testMessage);
 	}
 	//@codingStandardsIgnoreEnd
 

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -47,8 +47,11 @@ class LogTraitTest extends TestCase {
 		Log::config('trait_test', ['engine' => $mock]);
 		$subject = $this->getObjectForTrait('Cake\Log\LogTrait');
 
-		$subject->log('Testing');
-		$subject->log(array(1, 2), 'debug');
+		$reflectionMethod = new \ReflectionMethod('Cake\Log\LogTrait', '_log');
+		$reflectionMethod->setAccessible(true);
+
+		$reflectionMethod->invoke($subject, 'Testing');
+		$reflectionMethod->invoke($subject, array(1, 2), 'debug');
 	}
 
 }

--- a/tests/TestCase/Log/LogTraitTest.php
+++ b/tests/TestCase/Log/LogTraitTest.php
@@ -47,7 +47,7 @@ class LogTraitTest extends TestCase {
 		Log::config('trait_test', ['engine' => $mock]);
 		$subject = $this->getObjectForTrait('Cake\Log\LogTrait');
 
-		$reflectionMethod = new \ReflectionMethod('Cake\Log\LogTrait', '_log');
+		$reflectionMethod = new \ReflectionMethod($subject, '_log');
 		$reflectionMethod->setAccessible(true);
 
 		$reflectionMethod->invoke($subject, 'Testing');

--- a/tests/test_app/TestApp/Template/Element/nocache/contains_nocache.ctp
+++ b/tests/test_app/TestApp/Template/Element/nocache/contains_nocache.ctp
@@ -1,5 +1,5 @@
 <h2>Cache Me</h2>
 <!--nocache-->
 	<p>F. In Element With No Cache Tags</p>
-	<?php $this->log('6. in element with no cache tags') ?>
+	<?php $this->_log('6. in element with no cache tags') ?>
 <!--/nocache-->

--- a/tests/test_app/TestApp/Template/Element/nocache/plain.ctp
+++ b/tests/test_app/TestApp/Template/Element/nocache/plain.ctp
@@ -1,4 +1,4 @@
 <h2>Cache Me</h2>
 	<p>B. In Plain Element</p>
-	<?php $this->log('2. in plain element') ?>
+	<?php $this->_log('2. in plain element') ?>
 

--- a/tests/test_app/TestApp/Template/Layout/multi_cache.ctp
+++ b/tests/test_app/TestApp/Template/Layout/multi_cache.ctp
@@ -1,21 +1,21 @@
 <p>This is regular text</p>
 <!--nocache-->
 	<p>A. Layout Before Content</p>
-	<?php $this->log('1. layout before content') ?>
+	<?php $this->_log('1. layout before content') ?>
 <!--/nocache-->
 <!--nocache--><?= $this->element('nocache/plain'); ?><!--/nocache-->
 <!--nocache-->
 	<p>C. Layout After Test Element But Before Content</p>
-	<?php $this->log('3. layout after test element but before content') ?>
+	<?php $this->_log('3. layout after test element but before content') ?>
 <!--/nocache-->
 <?= $this->fetch('content'); ?>
 <!--nocache-->
 	<p>E. Layout After Content</p>
-	<?php $this->log('5. layout after content') ?>
+	<?php $this->_log('5. layout after content') ?>
 <!--/nocache-->
 <p>Additional regular text.</p>
 <?= $this->element('nocache/contains_nocache'); ?>
 <!--nocache-->
 	<p>G. Layout After Content And After Element With No Cache Tags</p>
-	<?php $this->log('7. layout after content and after element with no cache tags') ?>
+	<?php $this->_log('7. layout after content and after element with no cache tags') ?>
 <!--/nocache-->

--- a/tests/test_app/TestApp/Template/Posts/sequencial_nocache.ctp
+++ b/tests/test_app/TestApp/Template/Posts/sequencial_nocache.ctp
@@ -1,5 +1,5 @@
 <h1>Content</h1>
 <!--nocache-->
 	<p>D. In View File</p>
-	<?php $this->log('4. in view file') ?>
+	<?php $this->_log('4. in view file') ?>
 <!--/nocache-->


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/issues/3487

Resolves naming conflict with an action name "log" and `/some_controller/log`.
I think logging can be limited to the scope of the class where it was declared in (by including the LogTrait). It is easy enough to include the trait if needed.
