### PR TITLE
3.0 behavior manipulation

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -480,6 +480,28 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
+ * Removes a behavior.
+ *
+ * Removes a behavior from this table's behavior collection.
+ *
+ * Example:
+ *
+ * Unload a behavior, with some settings.
+ *
+ * {{{
+ * $this->removeBehavior('Tree');
+ * }}}
+ *
+ * @param string $name    The alias that the behavior was added with.
+ *
+ * @return void
+ * @see \Cake\ORM\Behavior
+ */
+	public function removeBehavior($name) {
+		$this->_behaviors->unload($name);
+	}
+
+/**
  * Get the list of Behaviors loaded.
  *
  * This method will return the *aliases* of the behaviors attached
@@ -502,6 +524,17 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
+ * Returns a behavior instance with the given alias.
+ *
+ * @param string $name The behavior alias to check.
+ *
+ * @return \Cake\ORM\Behavior or null
+ */
+	public function getBehavior($name) {
+		return $this->_behaviors->{$name};
+	}
+
+	/**
  * Returns a association objected configured for the specified alias if any
  *
  * @param string $name the alias used for the association

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -528,13 +528,13 @@ class Table implements RepositoryInterface, EventListener {
  *
  * @param string $name The behavior alias to check.
  *
- * @return \Cake\ORM\Behavior or null
+ * @return \Cake\ORM\Behavior|null
  */
 	public function getBehavior($name) {
 		return $this->_behaviors->{$name};
 	}
 
-	/**
+/**
  * Returns a association objected configured for the specified alias if any
  *
  * @param string $name the alias used for the association

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1028,6 +1028,45 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test removing a behavior from a table.
+ *
+ * @return void
+ */
+	public function testRemoveBehavior() {
+		$mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
+		$mock->expects($this->once())
+			->method('unload')
+			->with('Sluggable');
+
+		$table = new Table([
+			'table' => 'articles',
+			'behaviors' => $mock
+		]);
+		$table->removeBehavior('Sluggable');
+	}
+
+/**
+ * Test getting a behavior instance from a table.
+ *
+ * @return void
+ */
+	public function testGetBehavior() {
+		$returnValue = 'MockSlugInstance';
+		$mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
+		$mock->expects($this->once())
+			->method('__get')
+			->with('Sluggable')
+			->will($this->returnValue($returnValue));
+
+		$table = new Table([
+			'table' => 'articles',
+			'behaviors' => $mock
+		]);
+		$result = $table->getBehavior('Sluggable');
+		$this->assertSame($returnValue, $result);
+	}
+
+/**
  * Ensure exceptions are raised on missing behaviors.
  *
  * @expectedException \Cake\ORM\Error\MissingBehaviorException


### PR DESCRIPTION
With CakePHP 2.x it was possible to directly access the BehaviorCollection for a model in order to dynamically load, unload or alter an attached behavior. This was no longer possible with the new Table and BehaviorRegistry (With the exception of loading a behavior).

This pull requests adds the ability to remove behaviors and to retrieve the behavior instance that is attached to the Table.

It adds two methods to the Table class:
`$this->removeBehavior();` and `$this->getBehavior();`
