### PR TITLE
Behavior methods and finders should be removed when the behavior is removed from the table.

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -232,4 +232,43 @@ class BehaviorRegistry extends ObjectRegistry {
 		throw new Exception(sprintf('Cannot call finder "%s" it does not belong to any attached behavior.', $type));
 	}
 
+/**
+ * Removes the behavior methods during the removal of a behavior.
+ *
+ * @param \Cake\ORM\Behavior $instance
+ *
+ * @return void
+ */
+	protected function _removeMethods(Behavior $instance) {
+		$finders = array_change_key_case($instance->implementedFinders());
+		$methods = array_change_key_case($instance->implementedMethods());
+
+		foreach ($finders as $finder => $methodName) {
+			if (isset($this->_finderMap[$finder])) {
+				unset($this->_finderMap[$finder]);
+			}
+		}
+
+		foreach ($methods as $method => $methodName) {
+			if (isset($this->_methodMap[$method])) {
+				unset($this->_methodMap[$method]);
+			}
+		}
+	}
+
+/**
+ * Remove a behavior from the registry, also removes any methods or finders that were added when the behavior was loaded.
+ *
+ * @param string $objectName The alias of the behavior to remove from the registry.
+ *
+ * @return void
+ */
+	public function remove($objectName) {
+		$behavior = $this->{$objectName};
+		if ($behavior) {
+			$this->_removeMethods($behavior);
+		}
+		$this->unload($objectName);
+	}
+
 }

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -257,7 +257,9 @@ class BehaviorRegistry extends ObjectRegistry {
 	}
 
 /**
- * Remove a behavior from the registry, also removes any methods or finders that were added when the behavior was loaded.
+ * Removes a behavior from the registry.
+ * 
+ * Will remove any methods or finders that were added when the behavior was loaded.
  *
  * @param string $objectName The alias of the behavior to remove from the registry.
  *

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -498,7 +498,7 @@ class Table implements RepositoryInterface, EventListener {
  * @see \Cake\ORM\Behavior
  */
 	public function removeBehavior($name) {
-		$this->_behaviors->unload($name);
+		$this->_behaviors->remove($name);
 	}
 
 /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -200,6 +200,8 @@ class BehaviorRegistryTest extends TestCase {
  *
  * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot call "nope"
+ * 
+ * @return void
  */
 	public function testCallError() {
 		$this->Behaviors->load('Sluggable');
@@ -237,6 +239,8 @@ class BehaviorRegistryTest extends TestCase {
  *
  * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot call finder "nope"
+ *
+ * @return void
  */
 	public function testCallFinderError() {
 		$this->Behaviors->load('Sluggable');
@@ -248,6 +252,8 @@ class BehaviorRegistryTest extends TestCase {
  *
  * @expectedException \Cake\Error\Exception
  * @expectedExceptionMessage Cannot call "slugify"
+ * 
+ * @return void
  */
 	public function testCallRemoved() {
 		$this->Behaviors->load('Sluggable');

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -243,4 +243,28 @@ class BehaviorRegistryTest extends TestCase {
 		$this->Behaviors->callFinder('nope');
 	}
 
+/**
+ * Test errors on removed methods.
+ *
+ * @expectedException \Cake\Error\Exception
+ * @expectedExceptionMessage Cannot call "slugify"
+ */
+	public function testCallRemoved() {
+		$this->Behaviors->load('Sluggable');
+		$this->Behaviors->remove('Sluggable');
+
+		$this->Behaviors->call('slugify');
+	}
+
+/**
+ * Test remove() and then reload
+ *
+ * @return void
+ */
+	public function testRemoveThenReload() {
+		$this->Behaviors->load('Sluggable');
+
+		$this->Behaviors->remove('Sluggable');
+		$this->Behaviors->load('Sluggable');
+	}
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1035,7 +1035,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	public function testRemoveBehavior() {
 		$mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
 		$mock->expects($this->once())
-			->method('unload')
+			->method('remove')
 			->with('Sluggable');
 
 		$table = new Table([


### PR DESCRIPTION
While testing I realised that my previous pull request did not clear methods and finders when a behavior was unloaded. This corrects it.

It was necessary to create a `remove()` in the BehaviorRegistry, otherwise the `set()` method would remove the previously added methods and thereby break tests that used `set()` to load mocks (At the very least, possibly other places)
