### PR TITLE
Make sure invalid arrays return empty array instead of throwing notices.

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -2243,6 +2243,25 @@ class HashTest extends CakeTestCase {
 	}
 
 /**
+ * Tests that nest() returns an empty array for invalid input instead of throwing notices.
+ *
+ * @return void
+ */
+	public function testNestInvalid() {
+		$input = array(
+			array(
+				'ParentCategory' => array(
+					'id' => '1',
+					'name' => 'Lorem ipsum dolor sit amet',
+					'parent_id' => '1'
+				)
+			)
+		);
+		$result = Hash::nest($input);
+		$this->assertSame(array(), $result);
+	}
+
+/**
  * testMergeDiff method
  *
  * @return void

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -1037,6 +1037,8 @@ class Hash {
 
 		if ($options['root']) {
 			$root = $options['root'];
+		} elseif (!$return) {
+			return array();
 		} else {
 			$root = self::get($return[0], $parentKeys);
 		}


### PR DESCRIPTION
``` php
array(
    array(
        'ParentCategory' => array(
            'id' => '1',
            'name' => 'Lorem ipsum dolor sit amet',
            'parent_id' => '1'
        )
    )
)
```

Results in

```
Undefined offset: 0
public static function nest(array $data, $options = array()) {} 
Line 1041
```

https://github.com/cakephp/cakephp/blob/master/lib/Cake/Utility/Hash.php#L1041

This makes sure it returns an empty array.
