### PR TITLE
3.0 behavior registry updates

### DIFF
--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -137,7 +137,7 @@ class BehaviorRegistry extends ObjectRegistry {
 		$methods = array_change_key_case($instance->implementedMethods());
 
 		foreach ($finders as $finder => $methodName) {
-			if (isset($this->_finderMap[$finder])) {
+			if (isset($this->_finderMap[$finder]) && $this->loaded($this->_finderMap[$finder][0])) {
 				$duplicate = $this->_finderMap[$finder];
 				$error = sprintf(
 					'%s contains duplicate finder "%s" which is already provided by "%s"',
@@ -151,7 +151,7 @@ class BehaviorRegistry extends ObjectRegistry {
 		}
 
 		foreach ($methods as $method => $methodName) {
-			if (isset($this->_methodMap[$method])) {
+			if (isset($this->_methodMap[$method]) && $this->loaded($this->_methodMap[$method][0])) {
 				$duplicate = $this->_methodMap[$method];
 				$error = sprintf(
 					'%s contains duplicate method "%s" which is already provided by "%s"',
@@ -205,7 +205,7 @@ class BehaviorRegistry extends ObjectRegistry {
  */
 	public function call($method, array $args = []) {
 		$method = strtolower($method);
-		if ($this->hasMethod($method)) {
+		if ($this->hasMethod($method) && $this->loaded($this->_methodMap[$method][0])) {
 			list($behavior, $callMethod) = $this->_methodMap[$method];
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}
@@ -224,7 +224,7 @@ class BehaviorRegistry extends ObjectRegistry {
 	public function callFinder($type, array $args = []) {
 		$type = strtolower($type);
 
-		if ($this->hasFinder($type)) {
+		if ($this->hasFinder($type) && $this->loaded($this->_finderMap[$type][0])) {
 			list($behavior, $callMethod) = $this->_finderMap[$type];
 			return call_user_func_array([$this->_loaded[$behavior], $callMethod], $args);
 		}

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -480,13 +480,11 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
- * Removes a behavior.
- *
- * Removes a behavior from this table's behavior collection.
+ * Removes a behavior from this table's behavior registry.
  *
  * Example:
  *
- * Unload a behavior, with some settings.
+ * Remove a behavior from this table.
  *
  * {{{
  * $this->removeBehavior('Tree');
@@ -502,15 +500,12 @@ class Table implements RepositoryInterface, EventListener {
 	}
 
 /**
- * Get the list of Behaviors loaded.
+ * Returns the behavior registry for this table.
  *
- * This method will return the *aliases* of the behaviors attached
- * to this instance.
- *
- * @return array
+ * @return \Cake\ORM\BehaviorRegistry
  */
 	public function behaviors() {
-		return $this->_behaviors->loaded();
+		return $this->_behaviors;
 	}
 
 /**
@@ -521,17 +516,6 @@ class Table implements RepositoryInterface, EventListener {
  */
 	public function hasBehavior($name) {
 		return $this->_behaviors->loaded($name);
-	}
-
-/**
- * Returns a behavior instance with the given alias.
- *
- * @param string $name The behavior alias to check.
- *
- * @return \Cake\ORM\Behavior|null
- */
-	public function getBehavior($name) {
-		return $this->_behaviors->{$name};
 	}
 
 /**

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -243,4 +243,46 @@ class BehaviorRegistryTest extends TestCase {
 		$this->Behaviors->callFinder('nope');
 	}
 
+/**
+ * Test errors on unloaded behavior methods.
+ *
+ * @expectedException \Cake\Error\Exception
+ * @expectedExceptionMessage Cannot call "slugify" it does not belong to any attached behavior.
+ */
+	public function testUnloadBehaviorThenCall() {
+		$this->Behaviors->load('Sluggable');
+		$this->Behaviors->unload('Sluggable');
+
+		$this->Behaviors->call('slugify');
+	}
+
+/**
+ * Test errors on unloaded behavior finders.
+ *
+ * @expectedException \Cake\Error\Exception
+ * @expectedExceptionMessage Cannot call finder "noslug" it does not belong to any attached behavior.
+ */
+	public function testUnloadBehaviorThenCallFinder() {
+		$this->Behaviors->load('Sluggable');
+		$this->Behaviors->unload('Sluggable');
+
+		$this->Behaviors->callFinder('noSlug');
+	}
+
+/**
+ * Test that unloading then reloading a behavior does not throw any errors.
+ *
+ * @return void
+ */
+	public function testUnloadBehaviorThenReload() {
+		$this->Behaviors->load('Sluggable');
+		$this->Behaviors->unload('Sluggable');
+
+		$this->assertEmpty($this->Behaviors->loaded());
+
+		$this->Behaviors->load('Sluggable');
+
+		$this->assertEquals(['Sluggable'], $this->Behaviors->loaded());
+	}
+
 }

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -1050,20 +1050,10 @@ class TableTest extends \Cake\TestSuite\TestCase {
  *
  * @return void
  */
-	public function testGetBehavior() {
-		$returnValue = 'MockSlugInstance';
-		$mock = $this->getMock('Cake\ORM\BehaviorRegistry', [], [], '', false);
-		$mock->expects($this->once())
-			->method('__get')
-			->with('Sluggable')
-			->will($this->returnValue($returnValue));
-
-		$table = new Table([
-			'table' => 'articles',
-			'behaviors' => $mock
-		]);
-		$result = $table->getBehavior('Sluggable');
-		$this->assertSame($returnValue, $result);
+	public function testBehaviors() {
+		$table = TableRegistry::get('article');
+		$result = $table->behaviors();
+		$this->assertInstanceOf('\Cake\ORM\BehaviorRegistry', $result);
 	}
 
 /**
@@ -2255,10 +2245,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
  */
 	public function testBehaviorIntrospection() {
 		$table = TableRegistry::get('users');
-		$this->assertEquals([], $table->behaviors(), 'no loaded behaviors');
 
 		$table->addBehavior('Timestamp');
-		$this->assertEquals(['Timestamp'], $table->behaviors(), 'Should have loaded behavior');
 		$this->assertTrue($table->hasBehavior('Timestamp'), 'should be true on loaded behavior');
 		$this->assertFalse($table->hasBehavior('Tree'), 'should be false on unloaded behavior');
 	}


### PR DESCRIPTION
A continuation of #3492 and #3494.

Changed the `Table::behaviors()` method to match the `Table::associations()`  (and `Controller:components()`) method. It now returns the BehaviorRegistry instance for the table. I left in the `removeBehavior()` method to complement `addBehavior()`, but this can be removed if required.

The BehaviorRegistry was updated to take into account loaded behaviors when calling methods and finders, or when loading a behavior.
