### PR TITLE
3.0 middleware events with route

### DIFF
--- a/src/Routing/DispatcherFilter.php
+++ b/src/Routing/DispatcherFilter.php
@@ -148,7 +148,9 @@ class DispatcherFilter implements EventListener {
 	public function matches(Event $event) {
 		$request = $event->data['request'];
 		$pass = true;
-		if (!empty($this->_config['for'])) {
+		if ($this->_config['for'] instanceof Route\Route) {
+			$pass = (bool)$this->_config['for']->parse('/' . $request->url);
+		} elseif (!empty($this->_config['for'])) {
 			$pass = strpos($request->here(false), $this->_config['for']) === 0;
 		}
 		if ($pass && !empty($this->_config['when'])) {

--- a/tests/TestCase/Routing/DispatcherFilterTest.php
+++ b/tests/TestCase/Routing/DispatcherFilterTest.php
@@ -18,6 +18,7 @@ use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Routing\DispatcherFilter;
+use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -72,17 +73,39 @@ class DispatcherFilterTest extends TestCase {
 	}
 
 /**
- * Test basic matching with for option.
+ * Test basic matching with for option with string.
  *
  * @return void
  */
-	public function testMatchesWithFor() {
+	public function testMatchesWithForString() {
 		$request = new Request(['url' => '/articles/view']);
 		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request'));
 		$filter = new DispatcherFilter(['for' => '/articles']);
 		$this->assertTrue($filter->matches($event));
 
 		$request = new Request(['url' => '/blog/articles']);
+		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request'));
+		$this->assertFalse($filter->matches($event), 'Does not start with /articles');
+	}
+
+/**
+ * Test basic matching with for option with Route instance.
+ *
+ * @return void
+ */
+	public function testMatchesWithForRoute() {
+		$route = new Route('/articles/:action/:id', [], ['action' => 'index|view', 'id' => '\d+']);
+		$filter = new DispatcherFilter(['for' => $route]);
+
+		$request = new Request(['url' => '/articles/view/1']);
+		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request'));
+		$this->assertTrue($filter->matches($event));
+
+		$request = new Request(['url' => '/articles/edit/1']);
+		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request'));
+		$this->assertFalse($filter->matches($event), 'Action edit is not part of route');
+
+		$request = new Request(['url' => '/blog/articles/view/1']);
 		$event = new Event('Dispatcher.beforeDispatch', $this, compact('request'));
 		$this->assertFalse($filter->matches($event), 'Does not start with /articles');
 	}


### PR DESCRIPTION
It adds support to use routes on middleware conditions. It means you can use "regex" on the `for` condition.
