### PR TITLE
3.0 - Remove cell trait

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -30,7 +30,6 @@ use Cake\Routing\RequestActionTrait;
 use Cake\Routing\Router;
 use Cake\Utility\Inflector;
 use Cake\Utility\MergeVariablesTrait;
-use Cake\View\CellTrait;
 use Cake\View\View;
 use Cake\View\ViewVarsTrait;
 
@@ -79,7 +78,6 @@ use Cake\View\ViewVarsTrait;
  */
 class Controller implements EventListener {
 
-	use CellTrait;
 	use LogTrait;
 	use MergeVariablesTrait;
 	use ModelAwareTrait;


### PR DESCRIPTION
Since it isn't going to be used frequently from controllers, freeing up the cell() method is useful and currently contentious. If we find ourselves using cells in controllers frequently we can always re-include  the trait.
