### PR TITLE
Fixed bake Plugin.Classname to use Classname as the class name

### DIFF
--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -85,7 +85,7 @@ class ModelTask extends BakeTask {
 			}
 			return true;
 		}
-
+		list(,$name) = pluginSplit($name);
 		$this->bake($this->_modelName($name));
 	}
 

--- a/src/Console/Command/Task/SimpleBakeTask.php
+++ b/src/Console/Command/Task/SimpleBakeTask.php
@@ -77,6 +77,7 @@ abstract class SimpleBakeTask extends BakeTask {
 		if (empty($name)) {
 			return $this->error('You must provide a name to bake a ' . $this->name());
 		}
+		list(,$name) = pluginSplit($name);
 		$name = Inflector::camelize($name);
 		$this->bake($name);
 		$this->bakeTest($name);


### PR DESCRIPTION
When I run

``` sh
    ./Console/cake bake model Books.Book
```

I get several errors pertaining to the table books.book

when i run 

``` sh
    ./Console/cake bake model Book
```

everything works as expected.

when i run 

``` sh
    ./Console/cake bake helper Books.Book
```

cake creates `Plugin/Books/View/Helper/Books.BookHelper.php`

I added the fix to the SimpleBakeTask.php and ModelTask.php but I think it might be better to go up a level. BakeTask::main() might be a better place to put the fix but it currently does not take in a parameter or return one. I am open to thoughts and suggestions.
