### PR TITLE
3.0 Optimize Configure::load()

### DIFF
--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -49,6 +49,13 @@ class Configure {
 	protected static $_engines = [];
 
 /**
+ * Flag to track whether or not ini_set exists.
+ *
+ * @return void
+ */
+	protected static $_hasIniSet = null;
+
+/**
  * Used to store a dynamic variable in Configure.
  *
  * Usage:
@@ -81,11 +88,12 @@ class Configure {
 			static::$_values = Hash::insert(static::$_values, $name, $value);
 		}
 
-		if (isset($config['debug']) && function_exists('ini_set')) {
-			if (static::$_values['debug']) {
-				ini_set('display_errors', 1);
-			} else {
-				ini_set('display_errors', 0);
+		if (isset($config['debug'])) {
+			if (static::$_hasIniSet === null) {
+				static::$_hasIniSet = function_exists('ini_set');
+			}
+			if (static::$_hasIniSet) {
+				ini_set('display_errors', $config['debug'] ? 1 : 0);
 			}
 		}
 		return true;

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -254,8 +254,9 @@ class Configure {
 		if ($merge) {
 			$keys = array_keys($values);
 			foreach ($keys as $key) {
-				if (($c = static::read($key)) && is_array($values[$key]) && is_array($c)) {
-					$values[$key] = Hash::merge($c, $values[$key]);
+				$current = Hash::get(static::$_values, $key);
+				if ($current && is_array($values[$key]) && is_array($current)) {
+					$values[$key] = Hash::merge($current, $values[$key]);
 				}
 			}
 		}

--- a/src/Core/Configure.php
+++ b/src/Core/Configure.php
@@ -252,13 +252,7 @@ class Configure {
 		$values = $engine->read($key);
 
 		if ($merge) {
-			$keys = array_keys($values);
-			foreach ($keys as $key) {
-				$current = Hash::get(static::$_values, $key);
-				if ($current && is_array($values[$key]) && is_array($current)) {
-					$values[$key] = Hash::merge($current, $values[$key]);
-				}
-			}
+			$values = Hash::merge(static::$_values, $values);
 		}
 
 		return static::write($values);

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -323,12 +323,14 @@ class ConfigureTest extends TestCase {
 		Configure::write('my_key', 'value');
 		Configure::write('Read', 'old');
 		Configure::write('Deep.old', 'old');
+		Configure::write('TestAcl.classname', 'old');
 
 		Configure::load('var_test', 'test', true);
 		$this->assertEquals('value', Configure::read('Read'), 'Should load new data.');
 		$this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'), 'Should load new data');
 		$this->assertEquals('old', Configure::read('Deep.old'), 'Should not destroy old data.');
 		$this->assertEquals('value', Configure::read('my_key'), 'Should not destroy data.');
+		$this->assertEquals('Original', Configure::read('TestAcl.classname'), 'No arrays');
 	}
 
 /**

--- a/tests/TestCase/Core/ConfigureTest.php
+++ b/tests/TestCase/Core/ConfigureTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * ConfigureTest file
- *
- * Holds several tests
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -301,6 +297,38 @@ class ConfigureTest extends TestCase {
 		$this->assertEquals('value2', Configure::read('Read'));
 		$this->assertEquals('buried2', Configure::read('Deep.Second.SecondDeepest'));
 		$this->assertNull(Configure::read('Deep.Deeper.Deepest'));
+	}
+
+/**
+ * Test load() replacing existing data
+ *
+ * @return void
+ */
+	public function testLoadWithExistingData() {
+		Configure::config('test', new PhpConfig(TEST_APP . 'TestApp/Config/'));
+		Configure::write('my_key', 'value');
+
+		Configure::load('var_test', 'test');
+		$this->assertEquals('value', Configure::read('my_key'), 'Should not overwrite existing data.');
+		$this->assertEquals('value', Configure::read('Read'), 'Should load new data.');
+	}
+
+/**
+ * Test load() merging on top of existing data
+ *
+ * @return void
+ */
+	public function testLoadMergeWithExistingData() {
+		Configure::config('test', new PhpConfig(TEST_APP . 'TestApp/Config/'));
+		Configure::write('my_key', 'value');
+		Configure::write('Read', 'old');
+		Configure::write('Deep.old', 'old');
+
+		Configure::load('var_test', 'test', true);
+		$this->assertEquals('value', Configure::read('Read'), 'Should load new data.');
+		$this->assertEquals('buried', Configure::read('Deep.Deeper.Deepest'), 'Should load new data');
+		$this->assertEquals('old', Configure::read('Deep.old'), 'Should not destroy old data.');
+		$this->assertEquals('value', Configure::read('my_key'), 'Should not destroy data.');
 	}
 
 /**


### PR DESCRIPTION
After looking at #3450 and talking to @pschiel I thought there might be an opportunity to improve Configure::load() a bit as it does call merge() quite frequently. I've added some tests that passed on the old code, and fail on #3450.

These changes make  the merge case a bit faster (all numbers are for 1000 iterations of `Configure::load('app', 'default', true|false);`:
#### Before
- Loading with merging took 1.1380820274353 seconds
- Loading without merging took 0.21022701263428 seconds
#### After
- Loading with merging took 1.0779800415039 seconds
- Loading without merging took 0.21094512939453 seconds

I think the additional tests are worth merging regardless of whether or not the optimization seems useful.
