### PR TITLE
2.6 add 'atomic' option to "save()" API

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1714,8 +1714,7 @@ class Model extends Object implements CakeEventListener {
 			if ($transactionBegun) {
 				if ($success) {
 					$db->commit();
-				}
-				else {
+				} else {
 					$db->rollback();
 				}
 			}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -2037,7 +2037,7 @@ class Model extends Object implements CakeEventListener {
 						$Model->create();
 					}
 
-					$Model->save($data);
+					$Model->save($data, array('atomic' => false));
 				}
 			}
 
@@ -2281,9 +2281,9 @@ class Model extends Object implements CakeEventListener {
 			$saved = false;
 			if ($validates) {
 				if ($options['deep']) {
-					$saved = $this->saveAssociated($record, array_merge($options, array('atomic' => false)));
+					$saved = $this->saveAssociated($record, array('atomic' => false) + $options);
 				} else {
-					$saved = $this->save($record, $options);
+					$saved = $this->save($record, array('atomic' => false) + $options);
 				}
 			}
 
@@ -2435,7 +2435,7 @@ class Model extends Object implements CakeEventListener {
 			$return[$association] = $validates;
 		}
 
-		if ($validates && !($this->create(null) !== null && $this->save($data, $options))) {
+		if ($validates && !($this->create(null) !== null && $this->save($data, array('atomic' => false) + $options))) {
 			$validationErrors[$this->alias] = $this->validationErrors;
 			$validates = false;
 		}
@@ -2471,7 +2471,7 @@ class Model extends Object implements CakeEventListener {
 						if ($options['deep']) {
 							$saved = $Model->saveAssociated($values, array('atomic' => false) + $options);
 						} else {
-							$saved = $Model->save($values, $options);
+							$saved = $Model->save($values, array('atomic' => false) + $options);
 						}
 					}
 

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1712,14 +1712,12 @@ class Model extends Object implements CakeEventListener {
 		try {
 			$success = $this->_doSave($data, $options);
 			if ($transactionBegun) {
-				return $success;
-			}
-
-			if ($success) {
-				$db->commit();
-			}
-			else {
-				$db->rollback();
+				if ($success) {
+					$db->commit();
+				}
+				else {
+					$db->rollback();
+				}
 			}
 			return $success;
 		}

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -887,7 +887,7 @@ class ModelWriteTest extends BaseModelTest {
 		$ArticleModel = new Article();
 		$result = $ArticleModel->find('all', array('recursive' => -1));
 		$expectedArticles = array(
-			array('Articles' => array(
+			array('Article' => array(
 				'user_id' => 1,
 				'title' => 'First Article',
 				'body' => 'First Article Body',
@@ -895,7 +895,7 @@ class ModelWriteTest extends BaseModelTest {
 				'created' => '2007-03-18 10:39:23',
 				'updated' => '2007-03-18 10:41:31'
 			)),
-			array('Articles' => array(
+			array('Article' => array(
 				'user_id' => 3,
 				'title' => 'Second Article',
 				'body' => 'Second Article Body',
@@ -903,7 +903,7 @@ class ModelWriteTest extends BaseModelTest {
 				'created' => '2007-03-18 10:41:23',
 				'updated' => '2007-03-18 10:43:31'
 			)),
-			array('Articles' => array(
+			array('Article' => array(
 				'user_id' => 1,
 				'title' => 'Third Article',
 				'body' => 'Third Article Body',

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -888,28 +888,31 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $ArticleModel->find('all', array('recursive' => -1));
 		$expectedArticles = array(
 			array('Article' => array(
-				'user_id' => 1,
+				'user_id' => '1',
 				'title' => 'First Article',
 				'body' => 'First Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
+				'updated' => '2007-03-18 10:41:31',
+				'id' => '1'
 			)),
 			array('Article' => array(
-				'user_id' => 3,
+				'user_id' => '3',
 				'title' => 'Second Article',
 				'body' => 'Second Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
+				'updated' => '2007-03-18 10:43:31',
+				'id' => '2'
 			)),
 			array('Article' => array(
-				'user_id' => 1,
+				'user_id' => '1',
 				'title' => 'Third Article',
 				'body' => 'Third Article Body',
 				'published' => 'Y',
 				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
+				'updated' => '2007-03-18 10:45:31',
+				'id' => '3'
 			))
 		);
 		$this->assertEquals($expectedArticles, $result);

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -858,34 +858,7 @@ class ModelWriteTest extends BaseModelTest {
 				'updated' => '2007-03-18 10:45:31'
 		)));
 
-		if (count($result) != 3) {
-			// Database doesn't support transactions
-			$expectedPosts[] = array(
-				'Post' => array(
-					'id' => '4',
-					'author_id' => 1,
-					'title' => 'New Fourth Post',
-					'body' => null,
-					'published' => 'N',
-					'created' => self::date(),
-					'updated' => self::date()
-			));
-
-			$expectedPosts[] = array(
-				'Post' => array(
-					'id' => '5',
-					'author_id' => 1,
-					'title' => 'New Fifth Post',
-					'body' => null,
-					'published' => 'N',
-					'created' => self::date(),
-					'updated' => self::date()
-			));
-
-			$this->assertEquals($expectedPosts, $result);
-			// Skip the rest of the transactional tests
-			return;
-		}
+		$this->skipIf(count($result) != 3, 'Database does not support transactions.');
 
 		$this->assertEquals($expectedPosts, $result);
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -809,7 +809,7 @@ class ModelWriteTest extends BaseModelTest {
 		$this->assertFalse(empty($result));
 		
 		// force transaction to be rolled back in Post model
-		$event-stopPropagation();
+		$event->stopPropagation();
 		return false;
 	}
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -791,8 +791,8 @@ class ModelWriteTest extends BaseModelTest {
 	}
 
 /**
-* test callback used in testSaveTransaction method
-*/
+ * test callback used in testSaveTransaction method
+ */
 	public function callbackForTestSaveTransaction($event) {
 		$TestModel = new Article();
 

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -713,50 +713,60 @@ class ModelWriteTest extends BaseModelTest {
 
 		// Create record with 'atomic' = false
 
-		$data = array('Article' => array(
-			'user_id' => '1',
-			'title' => 'Fourth Article',
-			'body' => 'Fourth Article Body',
-			'published' => 'Y'
-		));
-		$result = $TestModel->create() && $TestModel->save($data, array('atomic' => false));
-		$this->assertFalse(empty($result));
+		$data = array(
+			'Article' => array(
+				'user_id' => '1',
+				'title' => 'Fourth Article',
+				'body' => 'Fourth Article Body',
+				'published' => 'Y'
+			)
+		);
+		$TestModel->create();
+		$result = $TestModel->save($data, array('atomic' => false));
+		$this->assertTrue((bool)$result);
 
 		// Check record we created
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body', 'published'), 4);
-		$expected = array('Article' => array(
-			'id' => '4',
-			'user_id' => '1',
-			'title' => 'Fourth Article',
-			'body' => 'Fourth Article Body',
-			'published' => 'Y'
-		));
+		$expected = array(
+			'Article' => array(
+				'id' => '4',
+				'user_id' => '1',
+				'title' => 'Fourth Article',
+				'body' => 'Fourth Article Body',
+				'published' => 'Y'
+			)
+		);
 		$this->assertEquals($expected, $result);
 
 		// Create record with 'atomic' = true
 
-		$data = array('Article' => array(
-			'user_id' => '4',
-			'title' => 'Fifth Article',
-			'body' => 'Fifth Article Body',
-			'published' => 'Y'
-		));
-		$result = $TestModel->create() && $TestModel->save($data, array('atomic' => true));
-		$this->assertFalse(empty($result));
+		$data = array(
+			'Article' => array(
+				'user_id' => '4',
+				'title' => 'Fifth Article',
+				'body' => 'Fifth Article Body',
+				'published' => 'Y'
+			)
+		);
+		$TestModel->create();
+		$result = $TestModel->save($data, array('atomic' => true));
+		$this->assertTrue((bool)$result);
 
 		// Check record we created
 
 		$TestModel->recursive = -1;
 		$result = $TestModel->read(array('id', 'user_id', 'title', 'body', 'published'), 5);
-		$expected = array('Article' => array(
-			'id' => '5',
-			'user_id' => '4',
-			'title' => 'Fifth Article',
-			'body' => 'Fifth Article Body',
-			'published' => 'Y'
-		));
+		$expected = array(
+			'Article' => array(
+				'id' => '5',
+				'user_id' => '4',
+				'title' => 'Fifth Article',
+				'body' => 'Fifth Article Body',
+				'published' => 'Y'
+			)
+		);
 		$this->assertEquals($expected, $result);
 	}
 
@@ -785,10 +795,12 @@ class ModelWriteTest extends BaseModelTest {
 		$callback = array($this, 'callbackForTestSaveTransaction');
 		$Post->getEventManager()->attach($callback, 'Model.beforeSave');
 
-		$data = array('Post' => array(
-			'author_id' => 1,
-			'title' => 'New Fourth Post'
-		));
+		$data = array(
+			'Post' => array(
+				'author_id' => 1,
+				'title' => 'New Fourth Post'
+			)
+		);
 		$Post->save($data, array('atomic' => true));
 	}
 
@@ -801,14 +813,17 @@ class ModelWriteTest extends BaseModelTest {
 		// Create record. Do not use same model as in testSaveTransaction
 		// to avoid infinite loop.
 
-		$data = array('Article' => array(
-			'user_id' => '1',
-			'title' => 'Fourth Article',
-			'body' => 'Fourth Article Body',
-			'published' => 'Y'
-		));
-		$result = $TestModel->create() && $TestModel->save($data);
-		$this->assertFalse(empty($result));
+		$data = array(
+			'Article' => array(
+				'user_id' => '1',
+				'title' => 'Fourth Article',
+				'body' => 'Fourth Article Body',
+				'published' => 'Y'
+			)
+		);
+		$TestModel->create();
+		$result = $TestModel->save($data);
+		$this->assertTrue((bool)$result);
 		
 		// force transaction to be rolled back in Post model
 		$event->stopPropagation();
@@ -836,44 +851,53 @@ class ModelWriteTest extends BaseModelTest {
 
 		$result = $PostModel->find('all', array('recursive' => -1));
 		$expectedPosts = array(
-			array('Post' => array(
-				'id' => '1',
-				'author_id' => 1,
-				'title' => 'First Post',
-				'body' => 'First Post Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31'
-			)),
-			array('Post' => array(
-				'id' => '2',
-				'author_id' => 3,
-				'title' => 'Second Post',
-				'body' => 'Second Post Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31'
-			)),
-			array('Post' => array(
-				'id' => '3',
-				'author_id' => 1,
-				'title' => 'Third Post',
-				'body' => 'Third Post Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31'
-		)));
+			array(
+				'Post' => array(
+					'id' => '1',
+					'author_id' => 1,
+					'title' => 'First Post',
+					'body' => 'First Post Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31'
+				)
+			),
+			array(
+				'Post' => array(
+					'id' => '2',
+					'author_id' => 3,
+					'title' => 'Second Post',
+					'body' => 'Second Post Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:41:23',
+					'updated' => '2007-03-18 10:43:31'
+				)
+			),
+			array(
+				'Post' => array(
+					'id' => '3',
+					'author_id' => 1,
+					'title' => 'Third Post',
+					'body' => 'Third Post Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:43:23',
+					'updated' => '2007-03-18 10:45:31'
+				)
+			)
+		);
 
-		$this->skipIf(count($result) != 3, 'Database does not support transactions.');
+		$this->skipIf(count($result) !== 3, 'Database does not support transactions.');
 
 		$this->assertEquals($expectedPosts, $result);
 
 		// Database supports transactions --> continue tests
 
-		$data = array('Post' => array(
-			'author_id' => 1,
-			'title' => 'New Fourth Post'
-		));
+		$data = array(
+			'Post' => array(
+				'author_id' => 1,
+				'title' => 'New Fourth Post'
+			)
+		);
 
 		$callback = array($this, 'callbackForTestSaveTransaction');
 		$PostModel->getEventManager()->attach($callback, 'Model.beforeSave');
@@ -891,33 +915,39 @@ class ModelWriteTest extends BaseModelTest {
 		$ArticleModel = new Article();
 		$result = $ArticleModel->find('all', array('recursive' => -1));
 		$expectedArticles = array(
-			array('Article' => array(
-				'user_id' => '1',
-				'title' => 'First Article',
-				'body' => 'First Article Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:39:23',
-				'updated' => '2007-03-18 10:41:31',
-				'id' => '1'
-			)),
-			array('Article' => array(
-				'user_id' => '3',
-				'title' => 'Second Article',
-				'body' => 'Second Article Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:41:23',
-				'updated' => '2007-03-18 10:43:31',
-				'id' => '2'
-			)),
-			array('Article' => array(
-				'user_id' => '1',
-				'title' => 'Third Article',
-				'body' => 'Third Article Body',
-				'published' => 'Y',
-				'created' => '2007-03-18 10:43:23',
-				'updated' => '2007-03-18 10:45:31',
-				'id' => '3'
-			))
+			array(
+				'Article' => array(
+					'user_id' => '1',
+					'title' => 'First Article',
+					'body' => 'First Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:39:23',
+					'updated' => '2007-03-18 10:41:31',
+					'id' => '1'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => '3',
+					'title' => 'Second Article',
+					'body' => 'Second Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:41:23',
+					'updated' => '2007-03-18 10:43:31',
+					'id' => '2'
+				)
+			),
+			array(
+				'Article' => array(
+					'user_id' => '1',
+					'title' => 'Third Article',
+					'body' => 'Third Article Body',
+					'published' => 'Y',
+					'created' => '2007-03-18 10:43:23',
+					'updated' => '2007-03-18 10:45:31',
+					'id' => '3'
+				)
+			)
 		);
 		$this->assertEquals($expectedArticles, $result);
 	}

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -766,15 +766,18 @@ class ModelWriteTest extends BaseModelTest {
  * @return void
  */
 	public function testSaveTransactionNoRollback() {
-		$this->loadFixtures('Post');
+		$this->loadFixtures('Post', 'Article');
 
 		$db = $this->getMock('DboSource', array('begin', 'connect', 'rollback', 'describe'));
 
 		$db->expects($this->once())
 			->method('describe')
 			->will($this->returnValue(array()));
-		$db->expects($this->once())->method('begin');
-		$db->expects($this->once())->method('rollback');
+		$db->expects($this->once())
+			->method('begin')
+			->will($this->returnValue(true));
+		$db->expects($this->once())
+			->method('rollback');
 
 		$Post = new TestPost();
 		$Post->setDataSourceObject($db);

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -794,6 +794,11 @@ class ModelWriteTest extends BaseModelTest {
  * test callback used in testSaveTransaction method
  */
 	public function callbackForTestSaveTransaction($event) {
+		if ($event->subject()->name === 'Article') {
+			$event->stopPropagation();
+			return false;
+		}
+
 		$TestModel = new Article();
 
 		// Create record. Do not use same model as in testSaveTransaction
@@ -864,15 +869,13 @@ class ModelWriteTest extends BaseModelTest {
 
 		// Database supports transactions --> continue tests
 
-		$PostModel->validate = array('title' => 'notEmpty');
-
 		$data = array('Post' => array(
 			'author_id' => 1,
-			'title' => ''
+			'title' => 'New Fourth Post'
 		));
 
 		$callback = array($this, 'callbackForTestSaveTransaction');
-		$PostModel->getEventManager()->attach($callback, 'Model.beforeSave');
+		CakeEventManager::instance()->attach($callback, 'Model.beforeSave');
 
 		$PostModel->create();
 		$result = $PostModel->save($data, array('atomic' => true));

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -872,7 +872,7 @@ class ModelWriteTest extends BaseModelTest {
 		));
 
 		$callback = array($this, 'callbackForTestSaveTransaction');
-		CakeEventManager::instance()->attach($callback, 'Model.beforeSave');
+		$PostModel->getEventManager()->attach($callback, 'Model.beforeSave');
 
 		$PostModel->create();
 		$result = $PostModel->save($data, array('atomic' => true));

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -794,11 +794,6 @@ class ModelWriteTest extends BaseModelTest {
  * test callback used in testSaveTransaction method
  */
 	public function callbackForTestSaveTransaction($event) {
-		if ($event->subject()->name === 'Article') {
-			$event->stopPropagation();
-			return false;
-		}
-
 		$TestModel = new Article();
 
 		// Create record. Do not use same model as in testSaveTransaction
@@ -812,6 +807,10 @@ class ModelWriteTest extends BaseModelTest {
 		));
 		$result = $TestModel->create() && $TestModel->save($data);
 		$this->assertFalse(empty($result));
+		
+		// force transaction to be rolled back in Post model
+		$event-stopPropagation();
+		return false;
 	}
 
 /**
@@ -875,7 +874,7 @@ class ModelWriteTest extends BaseModelTest {
 		));
 
 		$callback = array($this, 'callbackForTestSaveTransaction');
-		CakeEventManager::instance()->attach($callback, 'Model.beforeSave');
+		$PostModel->getEventManager()->attach($callback, 'Model.beforeSave');
 
 		$PostModel->create();
 		$result = $PostModel->save($data, array('atomic' => true));

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -793,7 +793,7 @@ class ModelWriteTest extends BaseModelTest {
 /**
 * test callback used in testSaveTransaction method
 */
-	public function testSaveTransactionCallback($event) {
+	public function callbackForTestSaveTransaction($event) {
 		$TestModel = new Article();
 
 		// Create record. Do not use same model as in testSaveTransaction
@@ -898,7 +898,7 @@ class ModelWriteTest extends BaseModelTest {
 			'title' => ''
 		));
 
-		$callback = array($this, 'testSaveTransactionCallback');
+		$callback = array($this, 'callbackForTestSaveTransaction');
 		CakeEventManager::instance()->attach($callback, 'Model.beforeSave');
 
 		$PostModel->create();
@@ -908,7 +908,7 @@ class ModelWriteTest extends BaseModelTest {
 		$result = $PostModel->find('all', array('recursive' => -1));
 		$this->assertEquals($expectedPosts, $result);
 
-		// Check record we created in testSaveTransactionCallback
+		// Check record we created in callbackForTestSaveTransaction method.
 		// record should not exist due to rollback
 
 		$ArticleModel = new Article();

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -779,15 +779,14 @@ class ModelWriteTest extends BaseModelTest {
 		$Post = new TestPost();
 		$Post->setDataSourceObject($db);
 
-		$Post->validate = array(
-			'title' => array('rule' => array('notEmpty'))
-		);
+		$callback = array($this, 'callbackForTestSaveTransaction');
+		$Post->getEventManager()->attach($callback, 'Model.beforeSave');
 
 		$data = array('Post' => array(
 			'author_id' => 1,
-			'title' => ''
+			'title' => 'New Fourth Post'
 		));
-		$Post->save($data, array('atomic' => true, 'validate' => true));
+		$Post->save($data, array('atomic' => true));
 	}
 
 /**


### PR DESCRIPTION
add a transaction context to 'save()' API in order to rollback possible modifications done
in some 'Model.beforeSave' listener callback.
this will allow cakephp 2.x to behave like 3.0 .

this commit resolves issue #3511
