### PR TITLE
3.0 plugin bake fix

### DIFF
--- a/src/Console/Command/Task/BakeTask.php
+++ b/src/Console/Command/Task/BakeTask.php
@@ -80,18 +80,28 @@ class BakeTask extends Shell {
  * @return void
  */
 	public function main() {
-		foreach ($this->args as $i => $arg) {
-			if (strpos($arg, '.')) {
-				list($this->params['plugin'], $this->args[$i]) = pluginSplit($arg);
-				break;
-			}
-		}
 		if (isset($this->params['plugin'])) {
 			$this->plugin = $this->params['plugin'];
 		}
 		if (isset($this->params['connection'])) {
 			$this->connection = $this->params['connection'];
 		}
+	}
+
+/**
+ * Handles splitting up the plugin prefix and classname.
+ *
+ * Sets the plugin parameter and plugin property.
+ *
+ * @param string $name The name to possibly split.
+ * @return string The name without the plugin prefix.
+ */
+	protected function _getName($name) {
+		if (strpos($name, '.')) {
+			list($plugin, $name) = pluginSplit($name);
+			$this->plugin = $this->params['plugin'] = $plugin;
+		}
+		return $name;
 	}
 
 /**

--- a/src/Console/Command/Task/ControllerTask.php
+++ b/src/Console/Command/Task/ControllerTask.php
@@ -46,6 +46,7 @@ class ControllerTask extends BakeTask {
  */
 	public function main($name = null) {
 		parent::main();
+		$name = $this->_getName($name);
 
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Possible controllers based on your current database:'));

--- a/src/Console/Command/Task/FixtureTask.php
+++ b/src/Console/Command/Task/FixtureTask.php
@@ -92,6 +92,7 @@ class FixtureTask extends BakeTask {
  */
 	public function main($name = null) {
 		parent::main();
+		$name = $this->_getName($name);
 
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a fixture to bake from the following:'));

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -77,6 +77,7 @@ class ModelTask extends BakeTask {
  */
 	public function main($name = null) {
 		parent::main();
+		$name = $this->_getName($name);
 
 		if (empty($name)) {
 			$this->out(__d('cake_console', 'Choose a model to bake from the following:'));

--- a/src/Console/Command/Task/SimpleBakeTask.php
+++ b/src/Console/Command/Task/SimpleBakeTask.php
@@ -77,6 +77,7 @@ abstract class SimpleBakeTask extends BakeTask {
 		if (empty($name)) {
 			return $this->error('You must provide a name to bake a ' . $this->name());
 		}
+		$name = $this->_getName($name);
 		$name = Inflector::camelize($name);
 		$this->bake($name);
 		$this->bakeTest($name);

--- a/src/Console/Command/Task/ViewTask.php
+++ b/src/Console/Command/Task/ViewTask.php
@@ -109,6 +109,7 @@ class ViewTask extends BakeTask {
 			}
 			return true;
 		}
+		$name = $this->_getName($name);
 
 		$controller = null;
 		if (!empty($this->params['controller'])) {

--- a/tests/TestCase/Console/Command/Task/CellTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/CellTaskTest.php
@@ -74,11 +74,36 @@ class CellTaskTest extends TestCase {
 	}
 
 /**
- * Test baking within a plugin.
+ * Test main within a plugin.
  *
  * @return void
  */
 	public function testMainPlugin() {
+		Plugin::load('TestPlugin');
+		$path = Plugin::path('TestPlugin');
+
+		$this->Task->expects($this->at(0))
+			->method('createFile')
+			->with(
+				$this->_normalizePath($path . 'Template/Cell/Example/display.ctp'),
+				''
+			);
+		$this->Task->expects($this->at(1))
+			->method('createFile')
+			->with(
+				$this->_normalizePath($path . 'View/Cell/ExampleCell.php'),
+				$this->stringContains('class ExampleCell extends Cell')
+			);
+
+		$this->Task->main('TestPlugin.Example');
+	}
+
+/**
+ * Test baking within a plugin.
+ *
+ * @return void
+ */
+	public function testBakePlugin() {
 		Plugin::load('TestPlugin');
 
 		$path = Plugin::path('TestPlugin');

--- a/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ControllerTaskTest.php
@@ -213,7 +213,6 @@ class ControllerTaskTest extends TestCase {
 	public function testBakeWithPlugin() {
 		$this->Task->plugin = 'ControllerTest';
 
-		//fake plugin path
 		Plugin::load('ControllerTest', array('path' => APP . 'Plugin/ControllerTest/'));
 		$path = APP . 'Plugin/ControllerTest/Controller/BakeArticlesController.php';
 
@@ -227,11 +226,11 @@ class ControllerTaskTest extends TestCase {
 		$result = $this->Task->bake('BakeArticles');
 		$this->assertContains('namespace ControllerTest\Controller;', $result);
 		$this->assertContains('use ControllerTest\Controller\AppController;', $result);
-
 		Plugin::unload();
 	}
 
 /**
+ *
  * test that bakeActions is creating the correct controller Code. (Using sessions)
  *
  * @return void
@@ -344,6 +343,27 @@ class ControllerTaskTest extends TestCase {
 			->method('createFile')
 			->with($filename, $this->stringContains('public function index()'));
 		$this->Task->main($name);
+	}
+
+/**
+ * test main with plugin.name
+ *
+ * @return void
+ */
+	public function testMainWithPluginDot() {
+		$this->Task->connection = 'test';
+
+		Plugin::load('ControllerTest', array('path' => APP . 'Plugin/ControllerTest/'));
+		$path = APP . 'Plugin/ControllerTest/Controller/BakeArticlesController.php';
+
+		$this->Task->expects($this->at(1))
+			->method('createFile')
+			->with(
+				$this->_normalizePath($path),
+				$this->stringContains('BakeArticlesController extends AppController')
+			)->will($this->returnValue(true));
+
+		$this->Task->main('ControllerTest.BakeArticles');
 	}
 
 }

--- a/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/FixtureTaskTest.php
@@ -206,6 +206,24 @@ class FixtureTaskTest extends TestCase {
 	}
 
 /**
+ * test that execute passes runs bake depending with named model.
+ *
+ * @return void
+ */
+	public function testMainWithPluginModel() {
+		$this->Task->connection = 'test';
+		$filename = $this->_normalizePath(TEST_APP . 'Plugin/TestPlugin/Test/Fixture/ArticleFixture.php');
+
+		Plugin::load('TestPlugin');
+
+		$this->Task->expects($this->at(0))
+			->method('createFile')
+			->with($filename, $this->stringContains('class ArticleFixture'));
+
+		$this->Task->main('TestPlugin.Article');
+	}
+
+/**
  * test that execute runs all() when args[0] = all
  *
  * @return void

--- a/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/SimpleBakeTaskTest.php
@@ -62,11 +62,11 @@ class SimpleBakeTaskTest extends TestCase {
 	}
 
 /**
- * Test the excute method.
+ * Test the main method.
  *
  * @return void
  */
-	public function testExecute() {
+	public function testMain() {
 		$this->Task->expects($this->once())
 			->method('createFile')
 			->with(
@@ -78,6 +78,27 @@ class SimpleBakeTaskTest extends TestCase {
 			->with('behavior', 'Example');
 
 		$this->Task->main('Example');
+	}
+
+/**
+ * Test the main with plugin.name method.
+ *
+ * @return void
+ */
+	public function testMainWithPlugin() {
+		Plugin::load('TestPlugin');
+		$filename = $this->_normalizePath(TEST_APP . 'Plugin/TestPlugin/Model/Behavior/ExampleBehavior.php');
+		$this->Task->expects($this->once())
+			->method('createFile')
+			->with(
+				$filename,
+				$this->stringContains('class ExampleBehavior extends Behavior')
+			);
+		$this->Task->Test->expects($this->once())
+			->method('bake')
+			->with('behavior', 'Example');
+
+		$this->Task->main('TestPlugin.Example');
 	}
 
 /**

--- a/tests/TestCase/Console/Command/Task/ViewTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ViewTaskTest.php
@@ -539,6 +539,25 @@ class ViewTaskTest extends TestCase {
 	}
 
 /**
+ * test that plugin.name works.
+ *
+ * @return void
+ */
+	public function testMainWithPluginName() {
+		$this->_setupTask(['in', 'err', 'createFile']);
+
+		$this->Task->connection = 'test';
+		$filename = $this->_normalizePath(TEST_APP . 'Plugin/TestPlugin/Template/ViewTaskComments/index.ctp');
+
+		Plugin::load('TestPlugin');
+
+		$this->Task->expects($this->at(0))
+			->method('createFile')
+			->with($filename);
+		$this->Task->main('TestPlugin.ViewTaskComments');
+	}
+
+/**
  * static dataprovider for test cases
  *
  * @return void


### PR DESCRIPTION
Alternative solution to #3512 fixing `Plugin.Name` parameters when invoking various bake tasks. I've also added tests cases.
