### PR TITLE
Fix issues saving belongsToMany associations

### DIFF
--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -385,8 +385,12 @@ class BelongsToMany extends Association {
 		$targetEntity = $entity->get($this->property());
 		$strategy = $this->saveStrategy();
 
-		if (!$targetEntity) {
+		if ($targetEntity === null) {
 			return false;
+		}
+
+		if ($targetEntity === [] && $entity->isNew()) {
+			return $entity;
 		}
 
 		if ($strategy === self::SAVE_APPEND) {
@@ -516,7 +520,7 @@ class BelongsToMany extends Association {
  *
  * This method does not check link uniqueness.
  *
- * ###Example:
+ * ### Example:
  *
  * {{{
  * $newTags = $tags->find('relevant')->execute();
@@ -682,12 +686,17 @@ class BelongsToMany extends Association {
 					return false;
 				}
 
+				$inserted = [];
 				$property = $this->property();
-				$inserted = array_combine(
-					array_keys($inserts),
-					(array)$sourceEntity->get($property)
-				);
-				$targetEntities = $inserted + $targetEntities;
+
+				if (count($inserts)) {
+					$inserted = array_combine(
+						array_keys($inserts),
+						(array)$sourceEntity->get($property)
+					);
+					$targetEntities = $inserted + $targetEntities;
+				}
+
 				ksort($targetEntities);
 				$sourceEntity->set($property, array_values($targetEntities));
 				$sourceEntity->dirty($property, false);

--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -170,7 +170,7 @@ class Marshaller {
  * @return array An array of built entities.
  */
 	protected function _belongsToMany(Association $assoc, array $data, $include = []) {
-		$hasIds = isset($data['_ids']);
+		$hasIds = array_key_exists('_ids', $data);
 		if ($hasIds && is_array($data['_ids'])) {
 			return $this->_loadBelongsToMany($assoc, $data['_ids']);
 		}
@@ -361,8 +361,12 @@ class Marshaller {
  * @return mixed
  */
 	protected function _mergeBelongsToMany($original, $assoc, $value, $include) {
-		if (isset($value['_ids']) && is_array($value['_ids'])) {
+		$hasIds = array_key_exists('_ids', $value);
+		if ($hasIds && is_array($value['_ids'])) {
 			return $this->_loadBelongsToMany($assoc, $value['_ids']);
+		}
+		if ($hasIds) {
+			return [];
 		}
 
 		if (!in_array('_joinData', $include) && !isset($include['_joinData'])) {

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -477,7 +477,22 @@ class MarshallerTest extends TestCase {
 		];
 		$marshall = new Marshaller($this->articles);
 		$result = $marshall->one($data, ['Tags']);
+		$this->assertCount(0, $result->tags);
 
+		$data = [
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
+			'tags' => ['_ids' => false]
+		];
+		$result = $marshall->one($data, ['Tags']);
+		$this->assertCount(0, $result->tags);
+
+		$data = [
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
+			'tags' => ['_ids' => null]
+		];
+		$result = $marshall->one($data, ['Tags']);
 		$this->assertCount(0, $result->tags);
 
 		$data = [
@@ -723,6 +738,46 @@ class MarshallerTest extends TestCase {
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[0]);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[1]);
 		$this->assertInstanceOf('Cake\ORM\Entity', $result->tags[2]);
+	}
+
+/**
+ * Tests that merging data to an entity containing belongsToMany and _ids
+ * will ignore empty values.
+ *
+ * @return void
+ */
+	public function testMergeBelongsToManyEntitiesFromIdsEmptyValue() {
+		$entity = new Entity([
+			'title' => 'Haz tags',
+			'body' => 'Some content here',
+			'tags' => [
+				new Entity(['id' => 1, 'name' => 'Cake']),
+				new Entity(['id' => 2, 'name' => 'PHP'])
+			]
+		]);
+
+		$data = [
+			'title' => 'Haz moar tags',
+			'tags' => ['_ids' => '']
+		];
+		$entity->accessible('*', true);
+		$marshall = new Marshaller($this->articles);
+		$result = $marshall->merge($entity, $data, ['Tags']);
+		$this->assertCount(0, $result->tags);
+
+		$data = [
+			'title' => 'Haz moar tags',
+			'tags' => ['_ids' => false]
+		];
+		$result = $marshall->merge($entity, $data, ['Tags']);
+		$this->assertCount(0, $result->tags);
+
+		$data = [
+			'title' => 'Haz moar tags',
+			'tags' => ['_ids' => null]
+		];
+		$result = $marshall->merge($entity, $data, ['Tags']);
+		$this->assertCount(0, $result->tags);
 	}
 
 /**


### PR DESCRIPTION
Fix several issues related to saving belongsToMany associations. I checked the following things manually and added additional test coverage for:
- Removing all associations.
- Adding associations.
- Removing all but one.
- Creating a new record with no belongsToMany links.

This set of changes resolves #3485.
