### PR TITLE
Harden the `cake` script to avoid `CDPATH` breakage.

### DIFF
--- a/lib/Cake/Console/cake
+++ b/lib/Cake/Console/cake
@@ -24,12 +24,12 @@ canonicalize() {
 	if [ -f "$NAME" ]
 	then
 		DIR=$(dirname -- "$NAME")
-		NAME=$(cd -P "$DIR" && pwd -P)/$(basename -- "$NAME")
+		NAME=$(cd -P "$DIR" > /dev/null && pwd -P)/$(basename -- "$NAME")
 	fi
 	while [ -h "$NAME" ]; do
 		DIR=$(dirname -- "$NAME")
 		SYM=$(readlink "$NAME")
-		NAME=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+		NAME=$(cd "$DIR" > /dev/null && cd $(dirname -- "$SYM") > /dev/null && pwd)/$(basename -- "$SYM")
 	done
 	echo "$NAME"
 }


### PR DESCRIPTION
When a user has a defined [`CDPATH`](http://www.tldp.org/LDP/abs/html/internalvariables.html#CDPATHREF) in their shell environment, bash changes the behavior of its `cd` builtin to echo the full path being changed to. This output interferes with scripts that attempt to use cd to capture values into a variable, such as the `cake` shell script. This typically manifests itself as unexpected errors like

```
$ Vendor/bin/cake
Could not open input file: ./Vendor/bin
/var/www/Vendor/bin/cake.php
```

There are typically two solutions to this:
1. `unset CDPATH` at the top of every script that might run into this conflict.
2. Redirect the stdout from the `cd` commands in your script to `/dev/null`.

This PR implements the latter since in the context the `cd` command is being used, any output is safely irrelevant and in fact troublesome when present.
