### PR TITLE
Regular expresion doesnt match 404

### DIFF
--- a/lib/Cake/Network/Http/HttpSocketResponse.php
+++ b/lib/Cake/Network/Http/HttpSocketResponse.php
@@ -159,7 +159,7 @@ class HttpSocketResponse implements ArrayAccess {
 		$this->raw = $message;
 		$this->body = (string)substr($message, strlen($match[0]));
 
-		if (preg_match("/(.+) ([0-9]{3})\s*([^ ]*)\r\n/DU", $statusLine, $match)) {
+		if (preg_match("/(.+) ([0-9]{3})\s*([\w\s]*)\r\n/DU", $statusLine, $match)) {
 			$this->httpVersion = $match[1];
 			$this->code = $match[2];
 			$this->reasonPhrase = $match[3];


### PR DESCRIPTION
Because it doesnt hope the error description has an space "OK" and "Not Found"
