### PR TITLE
3.0 Fix failing tests when there is no network

### DIFF
--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * SocketTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -17,6 +15,7 @@
 namespace Cake\Test\TestCase\Network;
 
 use Cake\Network\Socket;
+use Cake\Network\Error\SocketException;
 use Cake\TestSuite\TestCase;
 
 /**
@@ -383,8 +382,12 @@ class SocketTest extends TestCase {
 				'ssl' => array('capture_peer' => true)
 			)
 		);
+		try {
 		$this->Socket = new Socket($config);
 		$this->Socket->connect();
+		} catch (SocketException $e) {
+			$this->markTestSkipped('No network, skipping test.');
+		}
 		$result = $this->Socket->context();
 		$this->assertEquals($config['context'], $result);
 	}

--- a/tests/TestCase/Network/SocketTest.php
+++ b/tests/TestCase/Network/SocketTest.php
@@ -383,8 +383,8 @@ class SocketTest extends TestCase {
 			)
 		);
 		try {
-		$this->Socket = new Socket($config);
-		$this->Socket->connect();
+			$this->Socket = new Socket($config);
+			$this->Socket->connect();
 		} catch (SocketException $e) {
 			$this->markTestSkipped('No network, skipping test.');
 		}

--- a/tests/TestCase/TestSuite/TestCaseTest.php
+++ b/tests/TestCase/TestSuite/TestCaseTest.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * CakeTestCaseTest file
- *
- * Test Case for CakeTestCase class
- *
  * CakePHP : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -183,8 +179,6 @@ class TestCaseTest extends TestCase {
  * @return void
  */
 	public function testLoadFixturesOnDemand() {
-		$this->markTestIncomplete('Cannot work until fixtures are fixed');
-
 		$test = new FixturizedTestCase('testFixtureLoadOnDemand');
 		$test->autoFixtures = false;
 		$manager = $this->getMock('Cake\TestSuite\Fixture\FixtureManager');
@@ -193,40 +187,6 @@ class TestCaseTest extends TestCase {
 		$manager->expects($this->once())->method('loadSingle');
 		$result = $test->run();
 		$this->assertEquals(0, $result->errorCount());
-	}
-
-/**
- * testLoadFixturesOnDemand
- *
- * @return void
- */
-	public function testUnoadFixturesAfterFailure() {
-		$this->markTestIncomplete('Cannot work until fixtures are fixed');
-		$test = new FixturizedTestCase('testFixtureLoadOnDemand');
-		$test->autoFixtures = false;
-		$manager = $this->getMock('Cake\TestSuite\Fixture\FixtureManager');
-		$manager->fixturize($test);
-		$test->fixtureManager = $manager;
-		$manager->expects($this->once())->method('loadSingle');
-		$result = $test->run();
-		$this->assertEquals(0, $result->errorCount());
-	}
-
-/**
- * testThrowException
- *
- * @return void
- */
-	public function testThrowException() {
-		$this->markTestIncomplete('Cannot work until fixtures are fixed');
-		$test = new FixturizedTestCase('testThrowException');
-		$test->autoFixtures = false;
-		$manager = $this->getMock('Cake\TestSuite\Fixture\FixtureManager');
-		$manager->fixturize($test);
-		$test->fixtureManager = $manager;
-		$manager->expects($this->once())->method('unload');
-		$result = $test->run();
-		$this->assertEquals(1, $result->errorCount());
 	}
 
 /**
@@ -235,7 +195,6 @@ class TestCaseTest extends TestCase {
  * @return void
  */
 	public function testSkipIf() {
-		$this->markTestIncomplete('Cannot work until fixtures are fixed');
 		$test = new FixturizedTestCase('testSkipIfTrue');
 		$result = $test->run();
 		$this->assertEquals(1, $result->skippedCount());


### PR DESCRIPTION
Fix failing tests when the network is disabled, also remove some incomplete test markers as the tests pass, or are no longer required.
