### PR TITLE
Allow getting params the same way data() works

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -875,7 +875,7 @@ class CakeRequest implements ArrayAccess {
  */
 	public function param($name) {
 		if (!isset($this->params[$name])) {
-			return Hash::get($this->params, $name);
+			return Hash::get($this->params, $name, false);
 		}
 		return $this->params[$name];
 	}

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -874,6 +874,11 @@ class CakeRequest implements ArrayAccess {
  *   return false if the parameter doesn't exist or is falsey.
  */
 	public function param($name) {
+		$args = func_get_args();
+		if (count($args) === 2) {
+			$this->params = Hash::insert($this->params, $name, $args[1]);
+			return $this;
+		}
 		if (!isset($this->params[$name])) {
 			return Hash::get($this->params, $name, false);
 		}

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -875,7 +875,7 @@ class CakeRequest implements ArrayAccess {
  */
 	public function param($name) {
 		if (!isset($this->params[$name])) {
-			return false;
+			return Hash::get($this->params, $name);
 		}
 		return $this->params[$name];
 	}

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2114,6 +2114,31 @@ class CakeRequestTest extends CakeTestCase {
 		);
 	}
 
+	public function testParamWriting() {
+		$request = new CakeRequest('/');
+		$request->addParams(array(
+			'action' => 'index',
+		));
+
+		$this->assertInstanceOf('CakeRequest', $request->param('some', 'thing'), 'Method has not returned $this');
+
+		$request->param('Post.null', null);
+		$this->assertNull($request->params['Post']['null']);
+
+		$request->param('Post.false', false);
+		$this->assertFalse($request->params['Post']['false']);
+
+		$request->param('Post.zero', 0);
+		$this->assertSame(0, $request->params['Post']['zero']);
+
+		$request->param('Post.empty', '');
+		$this->assertSame('', $request->params['Post']['empty']);
+
+		$this->assertSame('index', $request->action);
+		$request->param('action', 'edit');
+		$this->assertSame('edit', $request->action);
+	}
+
 /**
  * Test accept language
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -1996,26 +1996,6 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
- * Test using param()
- *
- * @return void
- */
-	public function testReadingParams() {
-		$request = new CakeRequest();
-		$request->addParams(array(
-			'controller' => 'posts',
-			'admin' => true,
-			'truthy' => 1,
-			'zero' => '0',
-		));
-		$this->assertFalse($request->param('not_set'));
-		$this->assertTrue($request->param('admin'));
-		$this->assertEquals(1, $request->param('truthy'));
-		$this->assertEquals('posts', $request->param('controller'));
-		$this->assertEquals('0', $request->param('zero'));
-	}
-
-/**
  * Test the data() method reading
  *
  * @return void
@@ -2075,6 +2055,63 @@ class CakeRequestTest extends CakeTestCase {
 
 		$request->data('Post.empty', '');
 		$this->assertSame('', $request->data['Post']['empty']);
+	}
+
+/**
+ * @dataProvider paramReadingDataProvider
+ */
+	public function testParamReading($toRead, $expected) {
+		$request = new CakeRequest('/');
+		$request->addParams(array(
+			'action' => 'index',
+			'foo' => 'bar',
+			'baz' => array(
+				'a' => array(
+					'b' => 'c',
+				),
+			),
+			'admin' => true,
+			'truthy' => 1,
+			'zero' => '0',
+		));
+		$this->assertEquals($expected, $request->param($toRead));
+	}
+
+	public function paramReadingDataProvider() {
+		return array(
+			array(
+				'action',
+				'index',
+			),
+			array(
+				'baz',
+				array(
+					'a' => array(
+						'b' => 'c',
+					),
+				),
+			),
+			array(
+				'baz.a.b',
+				'c',
+			),
+			array(
+				'does_not_exist',
+				false,
+			),
+			array(
+				'admin',
+				true,
+			),
+			array(
+				'truthy',
+				1,
+			),
+			array(
+				'zero',
+				'0',
+			),
+		);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2058,6 +2058,8 @@ class CakeRequestTest extends CakeTestCase {
 	}
 
 /**
+ * Test reading params
+ *
  * @dataProvider paramReadingDataProvider
  */
 	public function testParamReading($toRead, $expected) {
@@ -2077,6 +2079,11 @@ class CakeRequestTest extends CakeTestCase {
 		$this->assertEquals($expected, $request->param($toRead));
 	}
 
+/**
+ * Data provider for testing reading values with CakeRequest::param()
+ * 
+ * @return array
+ */
 	public function paramReadingDataProvider() {
 		return array(
 			array(
@@ -2114,6 +2121,11 @@ class CakeRequestTest extends CakeTestCase {
 		);
 	}
 
+/**
+ * test writing request params with param()
+ *
+ * @return void
+ */
 	public function testParamWriting() {
 		$request = new CakeRequest('/');
 		$request->addParams(array(


### PR DESCRIPTION
I could improve this to do the `hash::insert()` to replace `addParams()` as is done in `data()`
