### PR TITLE
Fix undefined $_SESSION error when calling Session::check

### DIFF
--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -349,6 +349,10 @@ class Session {
 		if ($this->_hasSession() && !$this->started()) {
 			$this->start();
 		}
+		
+		if (!isset($_SESSION)) {
+			return null;
+		}		
 
 		return Hash::get($_SESSION, $name) !== null;
 	}


### PR DESCRIPTION
If you call session::check() before a session has been started you get a undefined variable $_SESSION error.

```
Notice (8): Undefined variable: _SESSION [CORE/src/Network/Session.php, line 353]
Cake\Network\Session::check() - CORE/src/Network/Session.php, line 353
App\Controller\UsersController::login() - APP/Controller/UsersController.php, line 15
ReflectionMethod::invokeArgs() - [internal], line ??
Cake\Controller\Controller::invokeAction() - CORE/src/Controller/Controller.php, line 379
Cake\Routing\Dispatcher::_invoke() - CORE/src/Routing/Dispatcher.php, line 137
Cake\Routing\Dispatcher::dispatch() - CORE/src/Routing/Dispatcher.php, line 109
[main] - ROOT/webroot/index.php, line 37
```

**Note:** This does not occur when running from the CLI (i.e. phpunit) due to the check in _hasSession.
