### PR TITLE
Changes to SqlServer drivers

### DIFF
--- a/src/Database/Schema/SqlserverSchema.php
+++ b/src/Database/Schema/SqlserverSchema.php
@@ -291,7 +291,7 @@ class SqlserverSchema extends BaseSchema {
 			'integer' => ' INTEGER',
 			'biginteger' => ' BIGINT',
 			'boolean' => ' BIT',
-			'binary' => ' BINARY',
+			'binary' => ' VARBINARY(MAX)',
 			'float' => ' FLOAT',
 			'decimal' => ' DECIMAL',
 			'text' => ' NVARCHAR(MAX)',

--- a/src/TestSuite/Fixture/TestFixture.php
+++ b/src/TestSuite/Fixture/TestFixture.php
@@ -302,7 +302,7 @@ class TestFixture {
 		}
 		$fields = array_values(array_unique($fields));
 		foreach ($fields as $field) {
-			$types[] = $this->_schema->column($field)['type'];
+			$types[$field] = $this->_schema->column($field)['type'];
 		}
 		$default = array_fill_keys($fields, null);
 		foreach ($this->records as $record) {

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -489,7 +489,7 @@ SQL;
 			[
 				'img',
 				['type' => 'binary'],
-				'[img] BINARY'
+				'[img] VARBINARY(MAX)'
 			],
 			// Boolean
 			[

--- a/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqlserverSchemaTest.php
@@ -43,7 +43,7 @@ class SqlserverSchemaTest extends TestCase {
  */
 	protected function _needsConnection() {
 		$config = ConnectionManager::config('test');
-		$this->skipIf(strpos($config['className'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
+		$this->skipIf(strpos($config['driver'], 'Sqlserver') === false, 'Not using Sqlserver for test config');
 	}
 
 /**
@@ -290,7 +290,7 @@ SQL;
 				'type' => 'biginteger',
 				'null' => false,
 				'default' => null,
-				'length' => 20,
+				'length' => 19,
 				'precision' => null,
 				'unsigned' => null,
 				'autoIncrement' => null,
@@ -343,7 +343,7 @@ SQL;
 				'comment' => null,
 			],
 			'created' => [
-				'type' => 'datetime',
+				'type' => 'timestamp',
 				'null' => true,
 				'default' => null,
 				'length' => null,

--- a/tests/TestCase/TestSuite/TestFixtureTest.php
+++ b/tests/TestCase/TestSuite/TestFixtureTest.php
@@ -234,7 +234,7 @@ class TestFixtureTest extends TestCase {
 
 		$query->expects($this->once())
 			->method('insert')
-			->with(['name', 'created'], ['string', 'datetime'])
+			->with(['name', 'created'], ['name' => 'string', 'created' => 'datetime'])
 			->will($this->returnSelf());
 
 		$query->expects($this->once())
@@ -285,7 +285,7 @@ class TestFixtureTest extends TestCase {
 
 		$query->expects($this->once())
 			->method('insert')
-			->with(['name', 'email', 'age'], ['string', 'string', 'integer'])
+			->with(['name', 'email', 'age'], ['name' => 'string', 'email' => 'string', 'age' => 'integer'])
 			->will($this->returnSelf());
 
 		$query->expects($this->once())


### PR DESCRIPTION
Fixed failing sqlserverschema tests

Change binary column type to VARBINARY(MAX):
SQL Server binary columns have a maximum length of 8000 bytes. Varbinary columns also have a maximum length of 8000 bytes. Varbinary(MAX) columns support up to 2 GB.

Fix for TestFixture to use columnName as the key for the column type array:
It was causing an issue with SqlServer and binary columns in a fixture since SqlServer is quite pedantic on how columns are bound.
