### PR TITLE
Add viewport to built-in options for HtmlHelper::meta()

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -214,6 +214,7 @@ class HtmlHelper extends Helper {
 			'keywords' => array('name' => 'keywords', 'content' => $content),
 			'description' => array('name' => 'description', 'content' => $content),
 			'robots' => array('name' => 'robots', 'content' => $content),
+			'viewport' => array('name' => 'viewport', 'content' => $content),
 		);
 
 		if ($type === 'icon' && $content === null) {

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * HtmlHelperTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -1514,6 +1512,12 @@ class HtmlHelperTest extends TestCase {
 
 		$result = $this->Html->meta('robots', 'ALL');
 		$this->assertTags($result, array('meta' => array('name' => 'robots', 'content' => 'ALL')));
+
+		$result = $this->Html->meta('viewport', 'width=device-width');
+		$expected = [
+			'meta' => ['name' => 'viewport', 'content' => 'width=device-width']
+		];
+		$this->assertTags($result, $expected);
 	}
 
 /**


### PR DESCRIPTION
Part of #3553 made me think it would be nice for meta() to provide an easy way to make viewport meta tags.
