### PR TITLE
2.6 memcached options

### DIFF
--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -45,6 +45,8 @@ class MemcachedEngine extends CacheEngine {
  *  - serialize = string, default => php. The serializer engine used to serialize data.
  *    Available engines are php, igbinary and json. Beside php, the memcached extension
  *    must be compiled with the appropriate serializer support.
+ *  - options - Additional options for the memcached client. Should be an array of option => value.
+ *    Use the Memcached::OPT_* constants as keys.
  *
  * @var array
  */
@@ -92,7 +94,8 @@ class MemcachedEngine extends CacheEngine {
 			'persistent' => false,
 			'login' => null,
 			'password' => null,
-			'serialize' => 'php'
+			'serialize' => 'php',
+			'options' => array()
 		);
 		parent::init($settings);
 
@@ -127,6 +130,11 @@ class MemcachedEngine extends CacheEngine {
 				);
 			}
 			$this->_Memcached->setSaslAuthData($this->settings['login'], $this->settings['password']);
+		}
+		if (is_array($this->settings['options'])) {
+			foreach ($this->settings['options'] as $opt => $value) {
+				$this->_Memcached->setOption($opt, $value);
+			}
 		}
 
 		return true;

--- a/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
+++ b/lib/Cake/Test/Case/Cache/Engine/MemcachedEngineTest.php
@@ -103,7 +103,8 @@ class MemcachedEngineTest extends CakeTestCase {
 			'login' => null,
 			'password' => null,
 			'groups' => array(),
-			'serialize' => 'php'
+			'serialize' => 'php',
+			'options' => array()
 		);
 		$this->assertEquals($expecting, $settings);
 	}
@@ -131,6 +132,23 @@ class MemcachedEngineTest extends CakeTestCase {
 		));
 
 		$this->assertTrue($MemcachedCompressed->getMemcached()->getOption(Memcached::OPT_COMPRESSION));
+	}
+
+/**
+ * test setting options
+ *
+ * @return void
+ */
+	public function testOptionsSetting() {
+		$memcached = new TestMemcachedEngine();
+		$memcached->init(array(
+			'engine' => 'Memcached',
+			'servers' => array('127.0.0.1:11211'),
+			'options' => array(
+				Memcached::OPT_BINARY_PROTOCOL => true
+			)
+		));
+		$this->assertEquals(1, $memcached->getMemcached()->getOption(Memcached::OPT_BINARY_PROTOCOL));
 	}
 
 /**


### PR DESCRIPTION
Add an options array to `MemcachedEngine`. Fixes #3477
