### PR TITLE
3.0 - Fix Request::data() and Hash::get() warnings and notices

### DIFF
--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -966,7 +966,10 @@ class Request implements \ArrayAccess {
 			$this->data = Hash::insert($this->data, $name, $args[1]);
 			return $this;
 		}
-		return Hash::get($this->data, $name);
+		if ($name !== null) {
+			return Hash::get($this->data, $name);
+		}
+		return $this->data;
 	}
 
 /**

--- a/src/Network/Request.php
+++ b/src/Network/Request.php
@@ -957,10 +957,10 @@ class Request implements \ArrayAccess {
  * You can write to any value, even paths/keys that do not exist, and the arrays
  * will be created for you.
  *
- * @param string $name,... Dot separated name of the value to read/write
+ * @param string|null $name Dot separated name of the value to read/write
  * @return mixed Either the value being read, or this so you can chain consecutive writes.
  */
-	public function data($name) {
+	public function data($name = null) {
 		$args = func_get_args();
 		if (count($args) === 2) {
 			$this->data = Hash::insert($this->data, $name, $args[1]);

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -32,13 +32,13 @@ class Hash {
  * but is faster for simple read operations.
  *
  * @param array $data Array of data to operate on.
- * @param string|array|null $path The path being searched for. Either a dot
+ * @param string|array $path The path being searched for. Either a dot
  *   separated string, or an array of path segments, or null.
  * @param mixed $default The return value when the path does not exist
  * @return mixed The value fetched from the array, or null.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::get
  */
-	public static function get(array $data, $path = null, $default = null) {
+	public static function get(array $data, $path, $default = null) {
 		if (empty($data)) {
 			return $default;
 		}
@@ -54,14 +54,11 @@ class Hash {
 		} else {
 			$parts = $path;
 		}
-
-		if ($path !== null) {
-			foreach ($parts as $key) {
-				if (is_array($data) && isset($data[$key])) {
-					$data =& $data[$key];
-				} else {
-					return $default;
-				}
+		foreach ($parts as $key) {
+			if (is_array($data) && isset($data[$key])) {
+				$data =& $data[$key];
+			} else {
+				return $default;
 			}
 		}
 		return $data;

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -32,13 +32,13 @@ class Hash {
  * but is faster for simple read operations.
  *
  * @param array $data Array of data to operate on.
- * @param string|array $path The path being searched for. Either a dot
- *   separated string, or an array of path segments.
+ * @param string|array|null $path The path being searched for. Either a dot
+ *   separated string, or an array of path segments, or null.
  * @param mixed $default The return value when the path does not exist
  * @return mixed The value fetched from the array, or null.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::get
  */
-	public static function get(array $data, $path, $default = null) {
+	public static function get(array $data, $path = null, $default = null) {
 		if (empty($data)) {
 			return $default;
 		}
@@ -54,11 +54,14 @@ class Hash {
 		} else {
 			$parts = $path;
 		}
-		foreach ($parts as $key) {
-			if (is_array($data) && isset($data[$key])) {
-				$data =& $data[$key];
-			} else {
-				return $default;
+
+		if ($path !== null) {
+			foreach ($parts as $key) {
+				if (is_array($data) && isset($data[$key])) {
+					$data =& $data[$key];
+				} else {
+					return $default;
+				}
 			}
 		}
 		return $data;

--- a/src/Utility/Hash.php
+++ b/src/Utility/Hash.php
@@ -33,7 +33,7 @@ class Hash {
  *
  * @param array $data Array of data to operate on.
  * @param string|array $path The path being searched for. Either a dot
- *   separated string, or an array of path segments, or null.
+ *   separated string, or an array of path segments.
  * @param mixed $default The return value when the path does not exist
  * @return mixed The value fetched from the array, or null.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::get

--- a/tests/TestCase/Network/RequestTest.php
+++ b/tests/TestCase/Network/RequestTest.php
@@ -1991,6 +1991,9 @@ class RequestTest extends TestCase {
 		$result = $request->data('Model');
 		$this->assertEquals($post['Model'], $result);
 
+		$result = $request->data();
+		$this->assertEquals($post, $result);
+
 		$result = $request->data('Model.imaginary');
 		$this->assertNull($result);
 	}


### PR DESCRIPTION
**What I'm doing:**
Using a custom validator to get validation errors in a controller.  See: https://gist.github.com/bcrowe/c439ef804cc03525ef54

**What's happening:**
See: https://gist.github.com/bcrowe/6298a6b61a46064375d9

I do get the validation errors just fine, but it comes along with these warnings/notices.
