### PR TITLE
3.0 - Fix datetime fields not being secured.

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -1955,6 +1955,9 @@ class FormHelper extends Helper {
 			'second' => false,
 		];
 		$secure = true;
+		if (!empty($options['disabled'])) {
+			$secure = false;
+		}
 		if (isset($options['secure'])) {
 			$secure = $options['secure'];
 		}
@@ -2093,6 +2096,9 @@ class FormHelper extends Helper {
 		$options['meridian'] = $options['second'] = false;
 
 		$secure = true;
+		if (!empty($options['disabled'])) {
+			$secure = false;
+		}
 		if (isset($options['secure'])) {
 			$secure = $options['secure'];
 		}

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -345,7 +345,6 @@ class FormHelper extends Helper {
 		if (!empty($append)) {
 			$append = $templater->format('hiddenblock', ['content' => $append]);
 		}
-
 		$this->_lastAction = $action;
 		if (strpos($action, '://')) {
 			$query = parse_url($action, PHP_URL_QUERY);
@@ -1955,8 +1954,20 @@ class FormHelper extends Helper {
 			'timeFormat' => 24,
 			'second' => false,
 		];
+		$secure = true;
+		if (isset($options['secure'])) {
+			$secure = $options['secure'];
+		}
+		$options['secure'] = static::SECURE_SKIP;
+
 		$options = $this->_initInputField($fieldName, $options);
 		$options = $this->_datetimeOptions($options);
+
+		foreach ($this->_datetimeParts as $type) {
+			if ($options[$type] !== false) {
+				$this->_secure($secure, $fieldName . '.' . $type);
+			}
+		}
 
 		return $this->widget('datetime', $options);
 	}
@@ -2080,8 +2091,21 @@ class FormHelper extends Helper {
 		];
 		$options['hour'] = $options['minute'] = false;
 		$options['meridian'] = $options['second'] = false;
+
+		$secure = true;
+		if (isset($options['secure'])) {
+			$secure = $options['secure'];
+		}
+		$options['secure'] = static::SECURE_SKIP;
+
 		$options = $this->_initInputField($fieldName, $options);
 		$options = $this->_datetimeOptions($options);
+
+		foreach ($this->_datetimeParts as $type) {
+			if ($options[$type] !== false) {
+				$this->_secure($secure, $fieldName . '.' . $type);
+			}
+		}
 
 		return $this->widget('datetime', $options);
 	}

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4234,6 +4234,34 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that datetime fields are added to protected fields list.
+ *
+ * @return void
+ */
+	public function testDateTimeSecured() {
+		$this->Form->request->params['_Token'] = ['unlockedFields' => []];
+		$this->Form->dateTime('Contact.date');
+		$expected = [
+			'Contact.date.year',
+			'Contact.date.month',
+			'Contact.date.day',
+			'Contact.date.hour',
+			'Contact.date.minute',
+			'Contact.date.meridian',
+		];
+		$this->assertEquals($expected, $this->Form->fields);
+
+		$this->Form->fields = [];
+		$this->Form->date('Contact.published');
+		$expected = [
+			'Contact.published.year',
+			'Contact.published.month',
+			'Contact.published.day',
+		];
+		$this->assertEquals($expected, $this->Form->fields);
+	}
+
+/**
  * Test empty defaulting to true for datetime.
  *
  * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -4262,6 +4262,23 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that datetime fields are added to protected fields list.
+ *
+ * @return void
+ */
+	public function testDateTimeSecuredDisabled() {
+		$this->Form->request->params['_Token'] = ['unlockedFields' => []];
+		$this->Form->dateTime('Contact.date', ['secure' => false]);
+		$expected = [];
+		$this->assertEquals($expected, $this->Form->fields);
+
+		$this->Form->fields = [];
+		$this->Form->date('Contact.published', ['secure' => false]);
+		$expected = [];
+		$this->assertEquals($expected, $this->Form->fields);
+	}
+
+/**
  * Test empty defaulting to true for datetime.
  *
  * @return void


### PR DESCRIPTION
Ensure all the various datetime fields are added to Form->fields so they are not blackholed later.

Fixes #3573
