### PR TITLE
3.0 - Accept older blowfish hashes.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -775,7 +775,11 @@ class AuthComponent extends Component {
 		}
 		$flashConfig = $this->_config['flash'];
 		$key = $flashConfig['key'];
-		$this->session->flash($message, 'error', $flashConfig['params'] + compact('key'));
+		$params = [];
+		if (isset($flashConfig['params'])) {
+			$params = $flashConfig['params'];
+		}
+		$this->session->flash($message, 'error', $params + compact('key'));
 	}
 
 }

--- a/src/Utility/Security.php
+++ b/src/Utility/Security.php
@@ -212,7 +212,12 @@ class Security {
 			$salt = vsprintf('$2y$%02d$%s', array(static::$hashCost, $salt));
 		}
 
-		if ($salt === true || strpos($salt, '$2y$') !== 0 || strlen($salt) < 29) {
+		$invalidCipher = (
+			strpos($salt, '$2y$') !== 0 &&
+			strpos($salt, '$2x$') !== 0 &&
+			strpos($salt, '$2a$') !== 0
+		);
+		if ($salt === true || $invalidCipher || strlen($salt) < 29) {
 			throw new Exception(sprintf(
 				'Invalid salt: %s for blowfish Please visit http://www.php.net/crypt and read the appropriate section for building blowfish salts.',
 				$salt

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -1141,14 +1141,23 @@ class AuthComponentTest extends TestCase {
  */
 	public function testFlashSettings() {
 		$this->Auth->session = $this->getMock('Cake\Network\Session');
-		$this->Auth->session->expects($this->once())
+		$this->Auth->session->expects($this->at(0))
 			->method('flash')
 			->with('Auth failure', 'error', array('key' => 'auth-key', 'element' => 'custom'));
+
+		$this->Auth->session->expects($this->at(1))
+			->method('flash')
+			->with('Auth failure', 'error', array('key' => 'auth-key'));
 
 		$this->Auth->config('flash', [
 			'params' => array('element' => 'custom'),
 			'key' => 'auth-key'
 		]);
+		$this->Auth->flash('Auth failure');
+
+		$this->Auth->config('flash', [
+			'key' => 'auth-key'
+		], false);
 		$this->Auth->flash('Auth failure');
 	}
 


### PR DESCRIPTION
Both `2a` and `2x` are valid types of blowfish hashes, that while being older should be accepted.
