### PR TITLE
Fixes #3581

### DIFF
--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -536,7 +536,10 @@ class CakeRoute {
 			$out = str_replace($search, $replace, $out);
 		}
 
-		if (strpos($this->template, '*')) {
+		if (strpos($this->template, '**')) {
+			$out = str_replace('**', $params['pass'], $out);
+		} 
+		elseif (strpos($this->template, '*')) {
 			$out = str_replace('*', $params['pass'], $out);
 		}
 		$out = str_replace('//', '/', $out);

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -536,10 +536,7 @@ class CakeRoute {
 			$out = str_replace($search, $replace, $out);
 		}
 
-		if (strpos($this->template, '**')) {
-			$out = str_replace('**', $params['pass'], $out);
-		} 
-		elseif (strpos($this->template, '*')) {
+		if (strpos($this->template, '*')) {
 			$out = str_replace('*', $params['pass'], $out);
 		}
 		$out = str_replace('//', '/', $out);

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -536,7 +536,11 @@ class CakeRoute {
 			$out = str_replace($search, $replace, $out);
 		}
 
-		if (strpos($this->template, '*')) {
+		if (strpos($this->template, '**')) {
+			$out = str_replace('**', $params['pass'], $out);
+			$out = str_replace('%2F', '/', $out);
+		} 
+		elseif (strpos($this->template, '*')) {
 			$out = str_replace('*', $params['pass'], $out);
 		}
 		$out = str_replace('//', '/', $out);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -334,6 +334,7 @@ class HtmlHelper extends AppHelper {
 		$escapeTitle = true;
 		if ($url !== null) {
 			$url = $this->url($url);
+			$url = str_replace('%2F', '/', $url);
 		} else {
 			$url = $this->url($title);
 			$title = htmlspecialchars_decode($url, ENT_QUOTES);

--- a/lib/Cake/View/Helper/HtmlHelper.php
+++ b/lib/Cake/View/Helper/HtmlHelper.php
@@ -334,7 +334,6 @@ class HtmlHelper extends AppHelper {
 		$escapeTitle = true;
 		if ($url !== null) {
 			$url = $this->url($url);
-			$url = str_replace('%2F', '/', $url);
 		} else {
 			$url = $this->url($title);
 			$title = htmlspecialchars_decode($url, ENT_QUOTES);


### PR DESCRIPTION
This fixes bug #3581 where routes like `/pages/**` were not well routed as HtmlHelper->link() would create links with doubled parameters when we expected to have a link that follows the behaviour described in the documentation:

```
The incoming URL of /pages/the-example-/-and-proof would result in a single passed argument of the-example-/-and-proof
```
