### PR TITLE
 Add empty contidition to ViewBlock::get() for displaying default string...

### DIFF
--- a/lib/Cake/View/ViewBlock.php
+++ b/lib/Cake/View/ViewBlock.php
@@ -192,7 +192,7 @@ class ViewBlock {
  * @return string The block content or $default if the block does not exist.
  */
 	public function get($name, $default = '') {
-		if (!isset($this->_blocks[$name])) {
+		if (!isset($this->_blocks[$name]) || empty($this->_blocks[$name] ) ) {
 			return $default;
 		}
 		return $this->_blocks[$name];


### PR DESCRIPTION
Add empty contidition to ViewBlock::get() for displaying default string not only if not defined, even if it's empty"

It's usefful when uses block on loops
