### PR TITLE
2.6 fix save() with habtm returning error

### DIFF
--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1869,7 +1869,9 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
-		$success = $this->data;
+		if (!empty($this->data)) {
+			$success = $this->data;
+		}
 
 		$this->_clearCache();
 		$this->validationErrors = array();

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1846,7 +1846,7 @@ class Model extends Object implements CakeEventListener {
 		if ($success) {
 			if (!empty($joined)) {
 				$this->_saveMulti($joined, $this->id, $db);
-			} else if ($count === 0) {
+			} elseif ($count === 0) {
 				$success = false;
 			}
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1807,6 +1807,11 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
+		if (empty($fields) && empty($joined)) {
+			$this->whitelist = $_whitelist;
+			return false;
+		}
+
 		$count = count($fields);
 
 		if (!$exists && $count > 0) {
@@ -1843,38 +1848,33 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
-		if ($success) {
-			if (!empty($joined)) {
-				$this->_saveMulti($joined, $this->id, $db);
-			} elseif ($count === 0) {
-				$success = false;
-			}
-		}
-
-		if ($success) {
-			if ($count > 0) {
-				if (!empty($this->data)) {
-					if ($created) {
-						$this->data[$this->alias][$this->primaryKey] = $this->id;
-					}
-				}
-
-				if ($options['callbacks'] === true || $options['callbacks'] === 'after') {
-					$event = new CakeEvent('Model.afterSave', $this, array($created, $options));
-					$this->getEventManager()->dispatch($event);
-				}
-			}
-
-			if (!empty($this->data)) {
-				$success = $this->data;
-			}
-
-			$this->_clearCache();
-			$this->validationErrors = array();
-			$this->data = false;
+		if ($success && !empty($joined)) {
+			$this->_saveMulti($joined, $this->id, $db);
 		}
 
 		$this->whitelist = $_whitelist;
+
+		if (!$success) {
+			return $success;
+		}
+
+		if ($count > 0) {
+			if ($created) {
+				$this->data[$this->alias][$this->primaryKey] = $this->id;
+			}
+
+			if ($options['callbacks'] === true || $options['callbacks'] === 'after') {
+				$event = new CakeEvent('Model.afterSave', $this, array($created, $options));
+				$this->getEventManager()->dispatch($event);
+			}
+		}
+
+		$success = $this->data;
+
+		$this->_clearCache();
+		$this->validationErrors = array();
+		$this->data = false;
+
 		return $success;
 	}
 

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -1784,7 +1784,7 @@ class Model extends Object implements CakeEventListener {
 		if (empty($this->data[$this->alias][$this->primaryKey])) {
 			unset($this->data[$this->alias][$this->primaryKey]);
 		}
-		$fields = $values = array();
+		$joined = $fields = $values = array();
 
 		foreach ($this->data as $n => $v) {
 			if (isset($this->hasAndBelongsToMany[$n])) {
@@ -1843,24 +1843,26 @@ class Model extends Object implements CakeEventListener {
 			}
 		}
 
-		if (!empty($joined) && $success === true) {
-			$this->_saveMulti($joined, $this->id, $db);
-		}
-
-		if ($success && $count === 0) {
-			$success = false;
-		}
-
-		if ($success && $count > 0) {
-			if (!empty($this->data)) {
-				if ($created) {
-					$this->data[$this->alias][$this->primaryKey] = $this->id;
-				}
+		if ($success) {
+			if (!empty($joined)) {
+				$this->_saveMulti($joined, $this->id, $db);
+			} else if ($count === 0) {
+				$success = false;
 			}
+		}
 
-			if ($options['callbacks'] === true || $options['callbacks'] === 'after') {
-				$event = new CakeEvent('Model.afterSave', $this, array($created, $options));
-				$this->getEventManager()->dispatch($event);
+		if ($success) {
+			if ($count > 0) {
+				if (!empty($this->data)) {
+					if ($created) {
+						$this->data[$this->alias][$this->primaryKey] = $this->id;
+					}
+				}
+
+				if ($options['callbacks'] === true || $options['callbacks'] === 'after') {
+					$event = new CakeEvent('Model.afterSave', $this, array($created, $options));
+					$this->getEventManager()->dispatch($event);
+				}
 			}
 
 			if (!empty($this->data)) {

--- a/lib/Cake/Test/Case/Model/ModelWriteTest.php
+++ b/lib/Cake/Test/Case/Model/ModelWriteTest.php
@@ -1824,7 +1824,9 @@ class ModelWriteTest extends BaseModelTest {
 
 		$data = array('Item' => array('Item' => array(1, 2)));
 		$TestModel->id = 2;
-		$TestModel->save($data);
+		$result = $TestModel->save($data);
+		$this->assertTrue((bool)$result);
+
 		$result = $TestModel->findById(2);
 		$result['Item'] = Hash::sort($result['Item'], '{n}.id', 'asc');
 		$expected = array(


### PR DESCRIPTION
bug found while handling PR 3516.
https://github.com/cakephp/cakephp/pull/3516

$Model->save($data) may return false if the given $data to save does not contain some $Model related data.
