### PR TITLE
Refactor _eventManager accessors to Cake\Event\EventManagerTrait

### DIFF
--- a/src/Controller/ComponentRegistry.php
+++ b/src/Controller/ComponentRegistry.php
@@ -17,6 +17,7 @@ namespace Cake\Controller;
 use Cake\Core\App;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\Utility\ObjectRegistry;
 
 /**
@@ -25,6 +26,8 @@ use Cake\Utility\ObjectRegistry;
  * Handles loading, constructing and binding events for component class objects.
  */
 class ComponentRegistry extends ObjectRegistry {
+
+	use EventManagerTrait;
 
 /**
  * The controller that this collection was initialized with.
@@ -41,9 +44,7 @@ class ComponentRegistry extends ObjectRegistry {
 	public function __construct(Controller $Controller = null) {
 		if ($Controller) {
 			$this->_Controller = $Controller;
-			$this->_eventManager = $Controller->getEventManager();
-		} else {
-			$this->_eventManager = new EventManager();
+			$this->eventManager($Controller->eventManager());
 		}
 	}
 
@@ -100,7 +101,7 @@ class ComponentRegistry extends ObjectRegistry {
 		$instance = new $class($this, $config);
 		$enable = isset($config['enabled']) ? $config['enabled'] : true;
 		if ($enable) {
-			$this->_eventManager->attach($instance);
+			$this->eventManager()->attach($instance);
 		}
 		return $instance;
 	}

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -21,6 +21,7 @@ use Cake\Error\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\Log\LogTrait;
 use Cake\Model\ModelAwareTrait;
 use Cake\Network\Request;
@@ -78,6 +79,7 @@ use Cake\View\ViewVarsTrait;
  */
 class Controller implements EventListener {
 
+	use EventManagerTrait;
 	use LogTrait;
 	use MergeVariablesTrait;
 	use ModelAwareTrait;
@@ -212,14 +214,6 @@ class Controller implements EventListener {
  * @var array
  */
 	public $methods = array();
-
-/**
- * Instance of the Cake\Event\EventManager this controller is using
- * to dispatch inner events.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager = null;
 
 /**
  * Constructor.
@@ -447,7 +441,7 @@ class Controller implements EventListener {
 	public function constructClasses() {
 		$this->_mergeControllerVars();
 		$this->_loadComponents();
-		$this->getEventManager()->attach($this);
+		$this->eventManager()->attach($this);
 	}
 
 /**
@@ -468,33 +462,6 @@ class Controller implements EventListener {
 	}
 
 /**
- * Returns the Cake\Event\EventManager manager instance for this controller.
- *
- * You can use this instance to register any new listeners or callbacks to the
- * controller events, or create your own events and trigger them at will.
- *
- * @return \Cake\Event\EventManager
- */
-	public function getEventManager() {
-		if (empty($this->_eventManager)) {
-			$this->_eventManager = new EventManager();
-		}
-		return $this->_eventManager;
-	}
-
-/**
- * Overwrite the existing EventManager
- *
- * Useful for testing
- *
- * @param \Cake\Event\EventManager $eventManager Event manager instance
- * @return void
- */
-	public function setEventManager(EventManager $eventManager) {
-		$this->_eventManager = $eventManager;
-	}
-
-/**
  * Perform the startup process for this controller.
  * Fire the Components and Controller callbacks in the correct order.
  *
@@ -505,11 +472,11 @@ class Controller implements EventListener {
  * @return void|\Cake\Network\Response
  */
 	public function startupProcess() {
-		$event = $this->getEventManager()->dispatch(new Event('Controller.initialize', $this));
+		$event = $this->eventManager()->dispatch(new Event('Controller.initialize', $this));
 		if ($event->result instanceof Response) {
 			return $event->result;
 		}
-		$event = $this->getEventManager()->dispatch(new Event('Controller.startup', $this));
+		$event = $this->eventManager()->dispatch(new Event('Controller.startup', $this));
 		if ($event->result instanceof Response) {
 			return $event->result;
 		}
@@ -525,7 +492,7 @@ class Controller implements EventListener {
  * @return void|\Cake\Network\Response
  */
 	public function shutdownProcess() {
-		$event = $this->getEventManager()->dispatch(new Event('Controller.shutdown', $this));
+		$event = $this->eventManager()->dispatch(new Event('Controller.shutdown', $this));
 		if ($event->result instanceof Response) {
 			return $event->result;
 		}
@@ -550,7 +517,7 @@ class Controller implements EventListener {
 		}
 
 		$event = new Event('Controller.beforeRedirect', $this, [$response, $url, $status]);
-		$event = $this->getEventManager()->dispatch($event);
+		$event = $this->eventManager()->dispatch($event);
 		if ($event->result instanceof Response) {
 			return $event->result;
 		}
@@ -597,7 +564,7 @@ class Controller implements EventListener {
  */
 	public function render($view = null, $layout = null) {
 		$event = new Event('Controller.beforeRender', $this);
-		$event = $this->getEventManager()->dispatch($event);
+		$event = $this->eventManager()->dispatch($event);
 		if ($event->result instanceof Response) {
 			$this->autoRender = false;
 			return $event->result;

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -37,7 +37,7 @@ class ErrorController extends Controller {
 		) {
 			$this->addComponent('RequestHandler');
 		}
-		$eventManager = $this->getEventManager();
+		$eventManager = $this->eventManager();
 		if (isset($this->Auth)) {
 			$eventManager->detach($this->Auth);
 		}

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -207,7 +207,7 @@ trait QueryTrait {
 
 		$table = $this->repository();
 		$event = new Event('Model.beforeFind', $table, [$this, $this->_options, !$this->eagerLoaded()]);
-		$table->getEventManager()->dispatch($event);
+		$table->eventManager()->dispatch($event);
 
 		if (isset($this->_results)) {
 			return $this->_results;

--- a/src/Event/EventManagerTrait.php
+++ b/src/Event/EventManagerTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Event;
+
+/**
+ *
+ * Provides the _eventManager property for usage in classes that require it.
+ *
+ */
+trait EventManagerTrait {
+
+/**
+ * Instance of the Cake\Event\EventManager this object is using
+ * to dispatch inner events.
+ *
+ * @var \Cake\Event\EventManager
+ */
+	protected $_eventManager = null;
+
+/**
+ * Returns the Cake\Event\EventManager manager instance for this object.
+ *
+ * You can use this instance to register any new listeners or callbacks to the
+ * object events, or create your own events and trigger them at will.
+ *
+ * @param \Cake\Event\EventManager $eventManager the eventManager to set
+ * @return \Cake\Event\EventManager
+ */
+	public function eventManager(EventManager $eventManager = null) {
+		if ($eventManager != null) {
+			$this->_eventManager = $eventManager;
+		} elseif (empty($this->_eventManager)) {
+			$this->_eventManager = new EventManager();
+		}
+		return $this->_eventManager;
+	}
+
+}

--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -544,7 +544,7 @@ abstract class Association {
 		$table = $this->target();
 		$options = $query->getOptions();
 		$event = new Event('Model.beforeFind', $table, [$query, $options, false]);
-		$table->getEventManager()->dispatch($event);
+		$table->eventManager()->dispatch($event);
 	}
 
 /**

--- a/src/ORM/BehaviorRegistry.php
+++ b/src/ORM/BehaviorRegistry.php
@@ -16,6 +16,7 @@ namespace Cake\ORM;
 
 use Cake\Core\App;
 use Cake\Error\Exception;
+use Cake\Event\EventManagerTrait;
 use Cake\ORM\Behavior;
 use Cake\ORM\Table;
 use Cake\Utility\ObjectRegistry;
@@ -28,21 +29,14 @@ use Cake\Utility\ObjectRegistry;
  */
 class BehaviorRegistry extends ObjectRegistry {
 
+	use EventManagerTrait;
+
 /**
  * The table using this registry.
  *
  * @var \Cake\ORM\Table
  */
 	protected $_table;
-
-/**
- * EventManager instance.
- *
- * Behaviors constructed by this object will be subscribed to this manager.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager;
 
 /**
  * Method mappings.
@@ -65,7 +59,7 @@ class BehaviorRegistry extends ObjectRegistry {
  */
 	public function __construct(Table $table) {
 		$this->_table = $table;
-		$this->_eventManager = $table->getEventManager();
+		$this->eventManager($table->eventManager());
 	}
 
 /**
@@ -111,7 +105,7 @@ class BehaviorRegistry extends ObjectRegistry {
 		$instance = new $class($this->_table, $config);
 		$enable = isset($config['enabled']) ? $config['enabled'] : true;
 		if ($enable) {
-			$this->_eventManager->attach($instance);
+			$this->eventManager()->attach($instance);
 		}
 		$methods = $this->_getMethods($instance, $class, $alias);
 		$this->_methodMap += $methods['methods'];

--- a/src/ORM/EntityValidator.php
+++ b/src/ORM/EntityValidator.php
@@ -139,7 +139,7 @@ class EntityValidator {
 		$validator = $this->_table->validator($type);
 		$pass = compact('entity', 'options', 'validator');
 		$event = new Event('Model.beforeValidate', $this->_table, $pass);
-		$this->_table->getEventManager()->dispatch($event);
+		$this->_table->eventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			return (bool)$event->result;
@@ -152,7 +152,7 @@ class EntityValidator {
 		$success = $entity->validate($validator);
 
 		$event = new Event('Model.afterValidate', $this->_table, $pass);
-		$this->_table->getEventManager()->dispatch($event);
+		$this->_table->eventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			$success = (bool)$event->result;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -22,6 +22,7 @@ use Cake\Datasource\RepositoryInterface;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\ORM\Associations;
 use Cake\ORM\Association\BelongsTo;
 use Cake\ORM\Association\BelongsToMany;
@@ -91,6 +92,8 @@ use Cake\Validation\Validator;
  */
 class Table implements RepositoryInterface, EventListener {
 
+	use EventManagerTrait;
+
 /**
  * Name of the table as it can be found in the database
  *
@@ -140,15 +143,6 @@ class Table implements RepositoryInterface, EventListener {
  * @var \Cake\ORM\Associations
  */
 	protected $_associations;
-
-/**
- * EventManager for this table.
- *
- * All model/behavior callbacks will be dispatched on this manager.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager;
 
 /**
  * BehaviorRegistry for this table
@@ -306,15 +300,6 @@ class Table implements RepositoryInterface, EventListener {
 			return $this->_connection;
 		}
 		return $this->_connection = $conn;
-	}
-
-/**
- * Get the event manager for this Table.
- *
- * @return \Cake\Event\EventManager
- */
-	public function getEventManager() {
-		return $this->_eventManager;
 	}
 
 /**
@@ -1144,7 +1129,7 @@ class Table implements RepositoryInterface, EventListener {
 
 		$options['associated'] = $this->_associations->normalizeKeys($associated);
 		$event = new Event('Model.beforeSave', $this, compact('entity', 'options'));
-		$this->getEventManager()->dispatch($event);
+		$this->eventManager()->dispatch($event);
 
 		if ($event->isStopped()) {
 			return $event->result;
@@ -1181,7 +1166,7 @@ class Table implements RepositoryInterface, EventListener {
 			if ($success || !$options['atomic']) {
 				$entity->clean();
 				$event = new Event('Model.afterSave', $this, compact('entity', 'options'));
-				$this->getEventManager()->dispatch($event);
+				$this->eventManager()->dispatch($event);
 				$entity->isNew(false);
 				$entity->source($this->alias());
 				$success = true;
@@ -1358,7 +1343,7 @@ class Table implements RepositoryInterface, EventListener {
  * @return bool success
  */
 	protected function _processDelete($entity, $options) {
-		$eventManager = $this->getEventManager();
+		$eventManager = $this->eventManager();
 		$event = new Event('Model.beforeDelete', $this, [
 			'entity' => $entity,
 			'options' => $options

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -23,6 +23,7 @@ use Cake\Error\Exception;
 use Cake\Event\Event;
 use Cake\Event\EventListener;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Inflector;
@@ -35,12 +36,7 @@ use Cake\Utility\Inflector;
  */
 class Dispatcher {
 
-/**
- * Event manager, used to handle dispatcher filters
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager;
+	use EventManagerTrait;
 
 /**
  * Connected filter objects
@@ -48,19 +44,6 @@ class Dispatcher {
  * @var array
  */
 	protected $_filters = [];
-
-/**
- * Returns the Cake\Event\EventManager instance or creates one if none was
- * created. Attaches the default listeners and filters
- *
- * @return \Cake\Event\EventManager
- */
-	public function getEventManager() {
-		if (!$this->_eventManager) {
-			$this->_eventManager = new EventManager();
-		}
-		return $this->_eventManager;
-	}
 
 /**
  * Dispatches and invokes given Request, handing over control to the involved controller. If the controller is set
@@ -81,7 +64,7 @@ class Dispatcher {
  */
 	public function dispatch(Request $request, Response $response) {
 		$beforeEvent = new Event('Dispatcher.beforeDispatch', $this, compact('request', 'response'));
-		$this->getEventManager()->dispatch($beforeEvent);
+		$this->eventManager()->dispatch($beforeEvent);
 
 		$request = $beforeEvent->data['request'];
 		if ($beforeEvent->result instanceof Response) {
@@ -112,7 +95,7 @@ class Dispatcher {
 		}
 
 		$afterEvent = new Event('Dispatcher.afterDispatch', $this, compact('request', 'response'));
-		$this->getEventManager()->dispatch($afterEvent);
+		$this->eventManager()->dispatch($afterEvent);
 		$afterEvent->data['response']->send();
 	}
 
@@ -165,7 +148,7 @@ class Dispatcher {
  */
 	public function addFilter(EventListener $filter) {
 		$this->_filters[] = $filter;
-		$this->getEventManager()->attach($filter);
+		$this->eventManager()->attach($filter);
 	}
 
 /**

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -23,6 +23,9 @@ namespace Cake\Utility;
  * Each subclass needs to implement the various abstract methods to complete
  * the template method load().
  *
+ * The ObjectRegistry is EventManager aware, but each extending class will need to use
+ * \Cake\Event\EventManagerTrait to attach and detach on set and bind
+ *
  * @see \Cake\Controller\ComponentRegistry
  * @see \Cake\View\HelperRegistry
  * @see \Cake\Console\TaskRegistry
@@ -35,13 +38,6 @@ abstract class ObjectRegistry {
  * @var array
  */
 	protected $_loaded = [];
-
-/**
- * The event manager to bind components to.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager;
 
 /**
  * Loads/constructs a object instance.
@@ -201,7 +197,7 @@ abstract class ObjectRegistry {
 		list($plugin, $name) = pluginSplit($objectName);
 		$this->unload($objectName);
 		if (isset($this->_eventManager)) {
-			$this->_eventManager->attach($object);
+			$this->eventManager()->attach($object);
 		}
 		$this->_loaded[$name] = $object;
 	}
@@ -220,7 +216,7 @@ abstract class ObjectRegistry {
 		}
 		$object = $this->_loaded[$objectName];
 		if (isset($this->_eventManager)) {
-			$this->_eventManager->detach($object);
+			$this->eventManager()->detach($object);
 		}
 		unset($this->_loaded[$objectName]);
 	}

--- a/src/View/Cell.php
+++ b/src/View/Cell.php
@@ -16,6 +16,7 @@ namespace Cake\View;
 
 use Cake\Core\App;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\Model\ModelAwareTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
@@ -28,6 +29,7 @@ use Cake\View\ViewVarsTrait;
  */
 abstract class Cell {
 
+	use EventManagerTrait;
 	use ModelAwareTrait;
 	use ViewVarsTrait;
 
@@ -85,14 +87,6 @@ abstract class Cell {
 	public $theme;
 
 /**
- * Instance of the Cake\Event\EventManager this cell is using
- * to dispatch inner events.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager = null;
-
-/**
  * These properties can be set directly on Cell and passed to the View as options.
  *
  * @var array
@@ -114,14 +108,14 @@ abstract class Cell {
 /**
  * Constructor.
  *
- * @param \Cake\Network\Request $request
- * @param \Cake\Network\Response $response
- * @param \Cake\Event\EventManager $eventManager
- * @param array $cellOptions
+ * @param \Cake\Network\Request $request the request to use in the cell
+ * @param \Cake\Network\Response $response the response to use in the cell
+ * @param \Cake\Event\EventManager $eventManager then eventManager to bind events to
+ * @param array $cellOptions cell options to apply
  */
 	public function __construct(Request $request = null, Response $response = null,
 			EventManager $eventManager = null, array $cellOptions = []) {
-		$this->_eventManager = $eventManager;
+		$this->eventManager($eventManager);
 		$this->request = $request;
 		$this->response = $response;
 		$this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
@@ -182,21 +176,6 @@ abstract class Cell {
 			'request' => $this->request,
 			'response' => $this->response,
 		];
-	}
-
-/**
- * Returns the Cake\Event\EventManager manager instance for this cell.
- *
- * You can use this instance to register any new listeners or callbacks to the
- * cell events, or create your own events and trigger them at will.
- *
- * @return \Cake\Event\EventManager
- */
-	public function getEventManager() {
-		if (empty($this->_eventManager)) {
-			$this->_eventManager = new EventManager();
-		}
-		return $this->_eventManager;
 	}
 
 }

--- a/src/View/CellTrait.php
+++ b/src/View/CellTrait.php
@@ -70,7 +70,7 @@ trait CellTrait {
 			throw new Error\MissingCellException(array('className' => $pluginAndCell . 'Cell'));
 		}
 
-		$cellInstance = new $className($this->request, $this->response, $this->getEventManager(), $options);
+		$cellInstance = new $className($this->request, $this->response, $this->eventManager(), $options);
 		$cellInstance->template = Inflector::underscore($action);
 		$cellInstance->plugin = !empty($plugin) ? $plugin : null;
 		$cellInstance->theme = !empty($this->theme) ? $this->theme : null;

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -16,6 +16,7 @@ namespace Cake\View;
 
 use Cake\Core\App;
 use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
 use Cake\Utility\ObjectRegistry;
 use Cake\View\View;
 
@@ -25,6 +26,8 @@ use Cake\View\View;
  */
 class HelperRegistry extends ObjectRegistry {
 
+	use EventManagerTrait;
+
 /**
  * View object to use when making helpers.
  *
@@ -33,22 +36,13 @@ class HelperRegistry extends ObjectRegistry {
 	protected $_View;
 
 /**
- * EventManager instance.
- *
- * Helpers constructed by this object will be subscribed to this manager.
- *
- * @var \Cake\Event\EventManager
- */
-	protected $_eventManager;
-
-/**
  * Constructor
  *
  * @param View $view
  */
 	public function __construct(View $view) {
 		$this->_View = $view;
-		$this->_eventManager = $view->getEventManager();
+		$this->eventManager($view->eventManager());
 	}
 
 /**
@@ -145,7 +139,7 @@ class HelperRegistry extends ObjectRegistry {
 		}
 		$enable = isset($settings['enabled']) ? $settings['enabled'] : true;
 		if ($enable) {
-			$this->_eventManager->attach($instance);
+			$this->eventManager()->attach($instance);
 		}
 		return $instance;
 	}

--- a/src/View/ViewVarsTrait.php
+++ b/src/View/ViewVarsTrait.php
@@ -46,7 +46,7 @@ trait ViewVarsTrait {
 			}
 		}
 		$viewOptions = array_intersect_key(get_object_vars($this), array_flip($this->_validViewOptions));
-		return new $viewClass($this->request, $this->response, $this->getEventManager(), $viewOptions);
+		return new $viewClass($this->request, $this->response, $this->eventManager(), $viewOptions);
 	}
 
 /**

--- a/tests/TestCase/Controller/ComponentRegistryTest.php
+++ b/tests/TestCase/Controller/ComponentRegistryTest.php
@@ -104,7 +104,7 @@ class ComponentRegistryTest extends TestCase {
 		$mock->expects($this->never())
 			->method('attach');
 
-		$this->Components->getController()->setEventManager($mock);
+		$this->Components->getController()->eventManager($mock);
 
 		$result = $this->Components->load('Cookie', array('enabled' => false));
 		$this->assertInstanceOf('Cake\Controller\Component\CookieComponent', $result);
@@ -164,7 +164,7 @@ class ComponentRegistryTest extends TestCase {
  * @return void
  */
 	public function testReset() {
-		$eventManager = $this->Components->getController()->getEventManager();
+		$eventManager = $this->Components->getController()->eventManager();
 		$instance = $this->Components->load('Auth');
 		$this->assertSame(
 			$instance,
@@ -185,7 +185,7 @@ class ComponentRegistryTest extends TestCase {
  * @return void
  */
 	public function testUnload() {
-		$eventManager = $this->Components->getController()->getEventManager();
+		$eventManager = $this->Components->getController()->eventManager();
 
 		$result = $this->Components->load('Auth');
 		$this->Components->unload('Auth');
@@ -200,7 +200,7 @@ class ComponentRegistryTest extends TestCase {
  * @return void
  */
 	public function testSet() {
-		$eventManager = $this->Components->getController()->getEventManager();
+		$eventManager = $this->Components->getController()->eventManager();
 		$this->assertCount(0, $eventManager->listeners('Controller.startup'));
 
 		$auth = new AuthComponent($this->Components);

--- a/tests/TestCase/Controller/ComponentTest.php
+++ b/tests/TestCase/Controller/ComponentTest.php
@@ -77,7 +77,7 @@ class ComponentTest extends TestCase {
 	public function testInnerComponentsAreNotEnabled() {
 		$mock = $this->getMock('Cake\Event\EventManager');
 		$controller = new Controller();
-		$controller->setEventManager($mock);
+		$controller->eventManager($mock);
 
 		$mock->expects($this->once())
 			->method('attach')

--- a/tests/TestCase/Controller/ControllerTest.php
+++ b/tests/TestCase/Controller/ControllerTest.php
@@ -345,7 +345,7 @@ class ControllerTest extends TestCase {
 		Configure::write('App.namespace', 'TestApp');
 		$Controller = new Controller(new Request, new Response());
 
-		$Controller->getEventManager()->attach(function ($event) {
+		$Controller->eventManager()->attach(function ($event) {
 			$controller = $event->subject();
 			$controller->viewClass = 'Json';
 		}, 'Controller.beforeRender');
@@ -369,7 +369,7 @@ class ControllerTest extends TestCase {
 	public function testBeforeRenderEventCancelsRender() {
 		$Controller = new Controller(new Request, new Response());
 
-		$Controller->getEventManager()->attach(function ($event) {
+		$Controller->eventManager()->attach(function ($event) {
 			return false;
 		}, 'Controller.beforeRender');
 
@@ -420,7 +420,7 @@ class ControllerTest extends TestCase {
 		$Controller = new Controller(null);
 		$Controller->response = new Response();
 
-		$Controller->getEventManager()->attach(function ($event, $response, $url) {
+		$Controller->eventManager()->attach(function ($event, $response, $url) {
 			$response->location('http://book.cakephp.org');
 		}, 'Controller.beforeRedirect');
 
@@ -438,7 +438,7 @@ class ControllerTest extends TestCase {
 		$Response = $this->getMock('Cake\Network\Response', array('stop'));
 		$Controller = new Controller(null, $Response);
 
-		$Controller->getEventManager()->attach(function ($event, $response, $url) {
+		$Controller->eventManager()->attach(function ($event, $response, $url) {
 			$response->statusCode(302);
 		}, 'Controller.beforeRedirect');
 
@@ -457,7 +457,7 @@ class ControllerTest extends TestCase {
 		$Response = $this->getMock('Cake\Network\Response', array('stop', 'header'));
 		$Controller = new Controller(null, $Response);
 
-		$Controller->getEventManager()->attach(function ($event, $response, $url, $status) {
+		$Controller->eventManager()->attach(function ($event, $response, $url, $status) {
 			return false;
 		}, 'Controller.beforeRedirect');
 
@@ -597,7 +597,7 @@ class ControllerTest extends TestCase {
  * @return void
  */
 	public function testStartupProcess() {
-		$Controller = $this->getMock('Cake\Controller\Controller', array('getEventManager'));
+		$Controller = $this->getMock('Cake\Controller\Controller', array('eventManager'));
 
 		$eventManager = $this->getMock('Cake\Event\EventManager');
 		$eventManager->expects($this->at(0))->method('dispatch')
@@ -620,7 +620,7 @@ class ControllerTest extends TestCase {
 			)
 			->will($this->returnValue($this->getMock('Cake\Event\Event', null, [], '', false)));
 
-		$Controller->expects($this->exactly(2))->method('getEventManager')
+		$Controller->expects($this->exactly(2))->method('eventManager')
 			->will($this->returnValue($eventManager));
 
 		$Controller->startupProcess();
@@ -632,7 +632,7 @@ class ControllerTest extends TestCase {
  * @return void
  */
 	public function testShutdownProcess() {
-		$Controller = $this->getMock('Cake\Controller\Controller', array('getEventManager'));
+		$Controller = $this->getMock('Cake\Controller\Controller', array('eventManager'));
 
 		$eventManager = $this->getMock('Cake\Event\EventManager');
 		$eventManager->expects($this->once())->method('dispatch')
@@ -645,7 +645,7 @@ class ControllerTest extends TestCase {
 			)
 			->will($this->returnValue($this->getMock('Cake\Event\Event', null, [], '', false)));
 
-		$Controller->expects($this->once())->method('getEventManager')
+		$Controller->expects($this->once())->method('eventManager')
 			->will($this->returnValue($eventManager));
 
 		$Controller->shutdownProcess();

--- a/tests/TestCase/Event/EventManagerTraitTest.php
+++ b/tests/TestCase/Event/EventManagerTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Test\TestCase\Event;
+
+use Cake\Event\EventManager;
+use Cake\Event\EventManagerTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * EventManagerTrait test case
+ *
+ */
+class EventManagerTraitTest extends TestCase {
+
+/**
+ * setup
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+
+		$this->subject = $this->getObjectForTrait('Cake\Event\EventManagerTrait');
+	}
+
+/**
+ * testIsInitiallyEmpty
+ *
+ * @return void
+ */
+	public function testIsInitiallyEmpty() {
+		$this->assertAttributeEmpty('_eventManager', $this->subject);
+	}
+
+/**
+ * testSettingEventManager
+ *
+ * @covers EventManagerTrait::eventManager
+ * @return void
+ */
+	public function testSettingEventManager() {
+		$eventManager = new EventManager();
+
+		$this->subject->eventManager($eventManager);
+
+		$this->assertSame($eventManager, $this->subject->eventManager());
+	}
+}

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -1607,7 +1607,7 @@ class BelongsToManyTest extends TestCase {
 		$table = TableRegistry::get('ArticlesTags');
 		$association = new BelongsToMany('Tags', $config);
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->tag->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->tag->eventManager()->attach($listener, 'Model.beforeFind');
 		$listener->expects($this->once())->method('__invoke')
 			->with(
 				$this->isInstanceOf('\Cake\Event\Event'),
@@ -1617,7 +1617,7 @@ class BelongsToManyTest extends TestCase {
 			);
 
 		$listener2 = $this->getMock('stdClass', ['__invoke']);
-		$table->getEventManager()->attach($listener2, 'Model.beforeFind');
+		$table->eventManager()->attach($listener2, 'Model.beforeFind');
 		$listener2->expects($this->once())->method('__invoke')
 			->with(
 				$this->isInstanceOf('\Cake\Event\Event'),
@@ -1644,7 +1644,7 @@ class BelongsToManyTest extends TestCase {
 		$table = TableRegistry::get('ArticlesTags');
 		$association = new BelongsToMany('Tags', $config);
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->tag->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->tag->eventManager()->attach($listener, 'Model.beforeFind');
 		$opts = ['something' => 'more'];
 		$listener->expects($this->once())->method('__invoke')
 			->with(
@@ -1655,7 +1655,7 @@ class BelongsToManyTest extends TestCase {
 			);
 
 		$listener2 = $this->getMock('stdClass', ['__invoke']);
-		$table->getEventManager()->attach($listener2, 'Model.beforeFind');
+		$table->eventManager()->attach($listener2, 'Model.beforeFind');
 		$listener2->expects($this->once())->method('__invoke')
 			->with(
 				$this->isInstanceOf('\Cake\Event\Event'),

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -391,7 +391,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->company
 		];
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->company->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->company->eventManager()->attach($listener, 'Model.beforeFind');
 		$association = new BelongsTo('Companies', $config);
 		$listener->expects($this->once())->method('__invoke')
 			->with(
@@ -417,7 +417,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->company
 		];
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->company->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->company->eventManager()->attach($listener, 'Model.beforeFind');
 		$association = new BelongsTo('Companies', $config);
 		$options = ['something' => 'more'];
 		$listener->expects($this->once())->method('__invoke')

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -805,7 +805,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$listener = $this->getMock('stdClass', ['__invoke']);
 		$association = new HasMany('Articles', $config);
-		$this->article->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->article->eventManager()->attach($listener, 'Model.beforeFind');
 		$listener->expects($this->once())->method('__invoke')
 			->with(
 				$this->isInstanceOf('\Cake\Event\Event'),
@@ -831,7 +831,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 
 		$listener = $this->getMock('stdClass', ['__invoke']);
 		$association = new HasMany('Articles', $config);
-		$this->article->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->article->eventManager()->attach($listener, 'Model.beforeFind');
 		$opts = ['something' => 'more'];
 		$listener->expects($this->once())->method('__invoke')
 			->with(

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -337,7 +337,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->profile,
 		];
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->profile->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->profile->eventManager()->attach($listener, 'Model.beforeFind');
 		$association = new HasOne('Profiles', $config);
 		$listener->expects($this->once())->method('__invoke')
 			->with(
@@ -363,7 +363,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 			'targetTable' => $this->profile,
 		];
 		$listener = $this->getMock('stdClass', ['__invoke']);
-		$this->profile->getEventManager()->attach($listener, 'Model.beforeFind');
+		$this->profile->eventManager()->attach($listener, 'Model.beforeFind');
 		$association = new HasOne('Profiles', $config);
 		$opts = ['something' => 'more'];
 		$listener->expects($this->once())->method('__invoke')

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -33,7 +33,7 @@ class BehaviorRegistryTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->Table = new Table(['table' => 'articles']);
-		$this->EventManager = $this->Table->getEventManager();
+		$this->EventManager = $this->Table->eventManager();
 		$this->Behaviors = new BehaviorRegistry($this->Table);
 		Configure::write('App.namespace', 'TestApp');
 	}

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -1876,12 +1876,12 @@ class QueryTest extends TestCase {
 		}]);
 		$this->assertFalse($query->eagerLoaded());
 
-		$table->getEventManager()->attach(function($e, $q, $o, $primary) {
+		$table->eventManager()->attach(function($e, $q, $o, $primary) {
 			$this->assertTrue($primary);
 		}, 'Model.beforeFind');
 
 		TableRegistry::get('articles')
-			->getEventManager()->attach(function($e, $q, $o, $primary) {
+			->eventManager()->attach(function($e, $q, $o, $primary) {
 				$this->assertFalse($primary);
 			}, 'Model.beforeFind');
 		$query->all();

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -376,7 +376,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'table' => 'users',
 			'connection' => $this->connection,
 		]);
-		$table->getEventManager()->attach(function ($event, $query, $options) {
+		$table->eventManager()->attach(function ($event, $query, $options) {
 			$query->limit(1);
 		}, 'Model.beforeFind');
 
@@ -396,7 +396,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'connection' => $this->connection,
 		]);
 		$expected = ['One', 'Two', 'Three'];
-		$table->getEventManager()->attach(function ($event, $query, $options) use ($expected) {
+		$table->eventManager()->attach(function ($event, $query, $options) use ($expected) {
 			$query->setResult($expected);
 			$event->stopPropagation();
 		}, 'Model.beforeFind');
@@ -1211,7 +1211,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			$this->assertSame($data, $entity);
 			$entity->set('password', 'foo');
 		};
-		$table->getEventManager()->attach($listener, 'Model.beforeSave');
+		$table->eventManager()->attach($listener, 'Model.beforeSave');
 		$this->assertSame($data, $table->save($data));
 		$this->assertEquals($data->id, self::$nextUserId);
 		$row = $table->find('all')->where(['id' => self::$nextUserId])->first();
@@ -1238,8 +1238,8 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$listener2 = function($e, $entity, $options) {
 			$this->assertTrue($options['crazy']);
 		};
-		$table->getEventManager()->attach($listener1, 'Model.beforeSave');
-		$table->getEventManager()->attach($listener2, 'Model.beforeSave');
+		$table->eventManager()->attach($listener1, 'Model.beforeSave');
+		$table->eventManager()->attach($listener2, 'Model.beforeSave');
 		$this->assertSame($data, $table->save($data));
 		$this->assertEquals($data->id, self::$nextUserId);
 
@@ -1265,7 +1265,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			$e->stopPropagation();
 			return $entity;
 		};
-		$table->getEventManager()->attach($listener, 'Model.beforeSave');
+		$table->eventManager()->attach($listener, 'Model.beforeSave');
 		$this->assertSame($data, $table->save($data));
 		$this->assertNull($data->id);
 		$row = $table->find('all')->where(['id' => self::$nextUserId])->first();
@@ -1291,7 +1291,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			$this->assertSame($data, $entity);
 			$called = true;
 		};
-		$table->getEventManager()->attach($listener, 'Model.afterSave');
+		$table->eventManager()->attach($listener, 'Model.afterSave');
 		$this->assertSame($data, $table->save($data));
 		$this->assertEquals($data->id, self::$nextUserId);
 		$this->assertTrue($called);
@@ -1336,7 +1336,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		$listener = function($e, $entity, $options) use ($data, &$called) {
 			$called = true;
 		};
-		$table->getEventManager()->attach($listener, 'Model.afterSave');
+		$table->eventManager()->attach($listener, 'Model.afterSave');
 		$this->assertFalse($table->save($data));
 		$this->assertFalse($called);
 	}
@@ -1578,7 +1578,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			$this->assertFalse($entity->isNew());
 			$called = true;
 		};
-		$table->getEventManager()->attach($listener, 'Model.beforeSave');
+		$table->eventManager()->attach($listener, 'Model.beforeSave');
 		$this->assertSame($entity, $table->save($entity));
 		$this->assertTrue($called);
 	}
@@ -2029,7 +2029,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'username' => 'superuser'
 		]);
 		$table = TableRegistry::get('users');
-		$table->getEventManager()->attach(function($ev, $en, $opt, $val) use ($entity) {
+		$table->eventManager()->attach(function($ev, $en, $opt, $val) use ($entity) {
 			$this->assertSame($entity, $en);
 			$this->assertTrue($opt['crazy']);
 			$this->assertSame($ev->subject()->validator('default'), $val);
@@ -2049,7 +2049,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 			'username' => 'superuser'
 		]);
 		$table = TableRegistry::get('users');
-		$table->getEventManager()->attach(function($ev, $en) {
+		$table->eventManager()->attach(function($ev, $en) {
 			$en->errors('username', 'Not good');
 			return false;
 		}, 'Model.beforeValidate');
@@ -2069,7 +2069,7 @@ class TableTest extends \Cake\TestSuite\TestCase {
 		]);
 		$table = TableRegistry::get('users');
 		$table->validator()->validatePresence('password');
-		$table->getEventManager()->attach(function($ev, $en, $opt, $val) use ($entity) {
+		$table->eventManager()->attach(function($ev, $en, $opt, $val) use ($entity) {
 			$this->assertSame($entity, $en);
 			$this->assertTrue($opt['crazy']);
 			$this->assertSame($ev->subject()->validator('default'), $val);

--- a/tests/TestCase/View/HelperRegistryTest.php
+++ b/tests/TestCase/View/HelperRegistryTest.php
@@ -45,7 +45,7 @@ class HelperRegistryTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->View = new View();
-		$this->Events = $this->View->getEventManager();
+		$this->Events = $this->View->eventManager();
 		$this->Helpers = new HelperRegistry($this->View);
 	}
 

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -463,7 +463,7 @@ class HelperTest extends TestCase {
 		Plugin::loadAll();
 
 		$events = $this->getMock('\Cake\Event\EventManager');
-		$this->View->setEventManager($events);
+		$this->View->eventManager($events);
 
 		$events->expects($this->never())
 			->method('attach');

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -667,7 +667,7 @@ class ViewTest extends TestCase {
 		$callback = function ($event, $file) use (&$count) {
 			$count++;
 		};
-		$events = $this->View->getEventManager();
+		$events = $this->View->eventManager();
 		$events->attach($callback, 'View.beforeRender');
 		$events->attach($callback, 'View.afterRender');
 
@@ -808,7 +808,7 @@ class ViewTest extends TestCase {
 		$View = $this->PostsController->createView();
 
 		$manager = $this->getMock('Cake\Event\EventManager');
-		$View->setEventManager($manager);
+		$View->eventManager($manager);
 
 		$manager->expects($this->at(0))->method('dispatch')
 			->with(


### PR DESCRIPTION
Addresses issue #3592
Use a single method to set and get EventManager.
Always returns an EventManager, if none was previously set.
Cake\Utility\ObjectRegistry is aware of an optional EventManager.
Each class extending ObjectRegistry will need to use the trait.
