### PR TITLE
3.0 cookie component

### DIFF
--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -28,17 +28,21 @@ use Cake\Utility\Security;
 /**
  * Cookie Component.
  *
- * Cookie handling for the controller.
+ * Provides enhanced cookie handling features for use in the controller layer.
+ * In addition to the basic features offered be Cake\Network\Response, this class lets you:
+ *
+ * - Create and read encrypted cookies.
+ * - Store non-scalar data.
+ * - Use hash compatible syntax to read/write/delete values.
  *
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html
- *
  */
 class CookieComponent extends Component {
 
 /**
  * Default config
  *
- * - `expires` - How long the cookies should last for by default.
+ * - `expires` - How long the cookies should last for. Defaults to 1 month.
  * - `path` - The path on the server in which the cookie will be available on.
  *   If path is set to '/foo/', the cookie will only be available within the
  *   /foo/ directory and all sub-directories such as /foo/bar/ of domain.
@@ -48,7 +52,7 @@ class CookieComponent extends Component {
  * - `secure` - Indicates that the cookie should only be transmitted over a
  *   secure HTTPS connection. When set to true, the cookie will only be set if
  *   a secure connection exists.
- * - `key` - Encryption key.
+ * - `key` - Encryption key used when encrypted cookies are enabled. Defaults to Security.salt.
  * - `httpOnly` - Set to true to make HTTP only cookies. Cookies that are HTTP only
  *   are not accessible in JavaScript. Default false.
  * - `encryption` - Type of encryption to use. Defaults to 'aes'.
@@ -62,7 +66,7 @@ class CookieComponent extends Component {
 		'key' => null,
 		'httpOnly' => false,
 		'encryption' => 'aes',
-		'expires' => null,
+		'expires' => '+1 month',
 	];
 
 /**

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Cookie Component
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -71,6 +69,16 @@ class CookieComponent extends Component {
 	];
 
 /**
+ * Config specific to a given top level key name.
+ *
+ * The values in this array are merged with the general config
+ * to generate the configuration for a given top level cookie name.
+ *
+ * @var array
+ */
+	protected $_keyConfig = [];
+
+/**
  * Values stored in the cookie.
  *
  * Accessed in the controller using $this->Cookie->read('Name.key');
@@ -79,22 +87,6 @@ class CookieComponent extends Component {
  * @var string
  */
 	protected $_values = array();
-
-/**
- * Used to reset cookie time if $expire is passed to CookieComponent::write()
- *
- * @var string
- */
-	protected $_reset = null;
-
-/**
- * Expire time of the cookie
- *
- * This is controlled by CookieComponent::time;
- *
- * @var string
- */
-	protected $_expires = 0;
 
 /**
  * A reference to the Controller's Cake\Network\Response object
@@ -139,6 +131,27 @@ class CookieComponent extends Component {
 		} else {
 			$this->_response = new Response();
 		}
+	}
+
+/**
+ * Set the configuration for a specific top level key.
+ *
+ * @param string $keyname The top level keyname to configure.
+ * @param null|string|array $option Either the option name to set, or an array of options to set,
+ *   or null to read config options for a given key.
+ * @param string|null $value Either the value to set, or empty when $option is an array.
+ * @return void
+ */
+	public function configKey($keyname, $option = null, $value = null) {
+		if ($option === null) {
+			$default = $this->_config;
+			$local = isset($this->_keyConfig[$keyname]) ? $this->_keyConfig[$keyname] : [];
+			return $local + $default;
+		}
+		if (!is_array($option)) {
+			$option = [$option => $value];
+		}
+		$this->_keyConfig[$keyname] = $option;
 	}
 
 /**

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -16,7 +16,6 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
-use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Event\Event;
@@ -24,6 +23,7 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Hash;
 use Cake\Utility\Security;
+use Cake\Utility\Time;
 
 /**
  * Cookie Component.
@@ -301,7 +301,7 @@ class CookieComponent extends Component {
  */
 	protected function _write($name, $value) {
 		$config = $this->configKey($name);
-		$expires = new \DateTime($config['expires']);
+		$expires = new Time($config['expires']);
 
 		$this->_response->cookie(array(
 			'name' => $name,
@@ -325,7 +325,7 @@ class CookieComponent extends Component {
  */
 	protected function _delete($name) {
 		$config = $this->configKey($name);
-		$expires = new \DateTime('now');
+		$expires = new Time('now');
 
 		$this->_response->cookie(array(
 			'name' => $name,

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -140,6 +140,23 @@ class CookieComponent extends Component {
 /**
  * Set the configuration for a specific top level key.
  *
+ * ### Examples:
+ *
+ * Set a single config option for a key:
+ *
+ * {{{
+ * $this->Cookie->configKey('User', 'expires', '+3 months');
+ * }}}
+ *
+ * Set multiple options:
+ *
+ * {{{
+ * $this->Cookie->configKey('User', [
+ *   'expires', '+3 months',
+ *   'httpOnly' => true,
+ * ]);
+ * }}}
+ *
  * @param string $keyname The top level keyname to configure.
  * @param null|string|array $option Either the option name to set, or an array of options to set,
  *   or null to read config options for a given key.
@@ -168,10 +185,7 @@ class CookieComponent extends Component {
 	}
 
 /**
- * Write a value to the $_COOKIE[$key];
- *
- * By default all values are encrypted.
- * You must pass $encrypt false to store values in clear test
+ * Write a value to the response cookies.
  *
  * You must use this method before any output is sent to the browser.
  * Failure to do so will result in header already sent errors.
@@ -204,6 +218,9 @@ class CookieComponent extends Component {
 
 /**
  * Read the value of key path from request cookies.
+ *
+ * This method will also allow you to read cookies that have been written in this
+ * request, but not yet sent to the client.
  *
  * @param string $key Key of the value to be obtained. If none specified, obtain map key => values
  * @return string or null, value for specified key
@@ -253,9 +270,8 @@ class CookieComponent extends Component {
  * You must use this method before any output is sent to the browser.
  * Failure to do so will result in header already sent errors.
  *
- * This method will delete both the top level and 2nd level cookies set.
- * For example assuming that $name = App, deleting `User` will delete
- * both `App[User]` and any other cookie values like `App[User][email]`
+ * Deleting a top level key will delete all keys nested within that key.
+ * For example deleting the `User` key, will also delete `User.email`.
  *
  * @param string $key Key of the value to be deleted
  * @return void

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -84,10 +84,9 @@ class CookieComponent extends Component {
  *
  * Accessed in the controller using $this->Cookie->read('Name.key');
  *
- * @see CookieComponent::read();
  * @var string
  */
-	protected $_values = array();
+	protected $_values = [];
 
 /**
  * A reference to the Controller's Cake\Network\Response object

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -326,7 +326,6 @@ class CookieComponent extends Component {
  */
 	protected function _write($name, $value) {
 		$config = $this->config();
-
 		$expires = new \DateTime($config['expires']);
 
 		$this->_response->cookie(array(
@@ -348,10 +347,12 @@ class CookieComponent extends Component {
  */
 	protected function _delete($name) {
 		$config = $this->config();
+		$expires = new \DateTime($config['expires']);
+
 		$this->_response->cookie(array(
-			'name' => $config['name'] . $name,
+			'name' => $name,
 			'value' => '',
-			'expire' => time() - 42000,
+			'expire' => $expires->format('U') - 42000,
 			'path' => $config['path'],
 			'domain' => $config['domain'],
 			'secure' => $config['secure'],
@@ -389,9 +390,12 @@ class CookieComponent extends Component {
  * @return string decrypted string
  */
 	protected function _decrypt($values) {
-		$decrypted = array();
+		if (is_string($values)) {
+			return $this->_decode($values);
+		}
 
-		foreach ((array)$values as $name => $value) {
+		$decrypted = array();
+		foreach ($values as $name => $value) {
 			if (is_array($value)) {
 				foreach ($value as $key => $val) {
 					$decrypted[$name][$key] = $this->_decode($val);

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -267,29 +267,6 @@ class CookieComponent extends Component {
 	}
 
 /**
- * Get / set encryption type. Use this method in ex: AppController::beforeFilter()
- * before you have read or written any cookies.
- *
- * @param string|null $type Encryption type to set or null to get current type.
- * @return string|null
- * @throws \Cake\Error\Exception When an unknown type is used.
- */
-	public function encryption($type = null) {
-		if ($type === null) {
-			return $this->_config['encryption'];
-		}
-
-		$availableTypes = [
-			'rijndael',
-			'aes'
-		];
-		if (!in_array($type, $availableTypes)) {
-			throw new Error\Exception('You must use rijndael, or aes for cookie encryption type');
-		}
-		$this->config('encryption', $type);
-	}
-
-/**
  * Set cookie
  *
  * @param string $name Name for cookie

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -376,13 +376,7 @@ class CookieComponent extends Component {
 
 		$decrypted = array();
 		foreach ($values as $name => $value) {
-			if (is_array($value)) {
-				foreach ($value as $key => $val) {
-					$decrypted[$name][$key] = $this->_decode($val, $mode);
-				}
-			} else {
-				$decrypted[$name] = $this->_decode($value, $mode);
-			}
+			$decrypted[$name] = $this->_decode($value, $mode);
 		}
 		return $decrypted;
 	}

--- a/src/Controller/Component/CookieComponent.php
+++ b/src/Controller/Component/CookieComponent.php
@@ -267,33 +267,6 @@ class CookieComponent extends Component {
 	}
 
 /**
- * Destroy current cookie
- *
- * You must use this method before any output is sent to the browser.
- * Failure to do so will result in header already sent errors.
- *
- * @return void
- * @link http://book.cakephp.org/2.0/en/core-libraries/components/cookie.html#CookieComponent::destroy
- */
-	public function destroy() {
-		$cookieName = $this->config('name');
-		if (empty($this->_values[$cookieName])) {
-			$this->read();
-		}
-
-		foreach ($this->_values[$cookieName] as $name => $value) {
-			if (is_array($value)) {
-				foreach ($value as $key => $val) {
-					unset($this->_values[$cookieName][$name][$key]);
-					$this->_delete("[$name][$key]");
-				}
-			}
-			unset($this->_values[$cookieName][$name]);
-			$this->_delete("[$name]");
-		}
-	}
-
-/**
  * Get / set encryption type. Use this method in ex: AppController::beforeFilter()
  * before you have read or written any cookies.
  *

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * CookieComponentTest file
- *
  * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -69,6 +67,53 @@ class CookieComponentTest extends TestCase {
 	public function tearDown() {
 		parent::tearDown();
 		$this->Cookie->destroy();
+	}
+
+/**
+ * Test setting config per key.
+ *
+ * @return void
+ */
+	public function testConfigKey() {
+		$this->Cookie->configKey('User', 'expires', '+3 days');
+		$result = $this->Cookie->configKey('User');
+		$expected = [
+			'expires' => '+3 days',
+			'path' => '/',
+			'domain' => '',
+			'key' => 'somerandomhaskeysomerandomhaskey',
+			'secure' => false,
+			'httpOnly' => false,
+			'encryption' => 'aes',
+			'name' => 'CakeTestCookie',
+			'time' => 10,
+		];
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * Test setting config per key.
+ *
+ * @return void
+ */
+	public function testConfigKeyArray() {
+		$this->Cookie->configKey('User', [
+			'expires' => '+3 days',
+			'path' => '/shop'
+		]);
+		$result = $this->Cookie->configKey('User');
+		$expected = [
+			'expires' => '+3 days',
+			'path' => '/shop',
+			'domain' => '',
+			'key' => 'somerandomhaskeysomerandomhaskey',
+			'secure' => false,
+			'httpOnly' => false,
+			'encryption' => 'aes',
+			'name' => 'CakeTestCookie',
+			'time' => 10,
+		];
+		$this->assertEquals($expected, $result);
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -567,69 +567,12 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
- * testReadingCookieDataWithoutStartup
- *
- * @return void
- */
-	public function testReadingCookieDataWithoutStartup() {
-		$this->markTestIncomplete();
-		$data = $this->Cookie->read('Encrytped_array');
-		$expected = null;
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Encrytped_multi_cookies');
-		$expected = null;
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Plain_array');
-		$expected = null;
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Plain_multi_cookies');
-		$expected = null;
-		$this->assertEquals($expected, $data);
-
-		$this->request->cookies['CakeTestCookie'] = array(
-			'Encrytped_array' => $this->_encrypt(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!')),
-			'Encrytped_multi_cookies' => array(
-				'name' => $this->_encrypt('CakePHP'),
-				'version' => $this->_encrypt('1.2.0.x'),
-				'tag' => $this->_encrypt('CakePHP Rocks!')
-			),
-			'Plain_array' => '{"name":"CakePHP","version":"1.2.0.x","tag":"CakePHP Rocks!"}',
-			'Plain_multi_cookies' => array(
-				'name' => 'CakePHP',
-				'version' => '1.2.0.x',
-				'tag' => 'CakePHP Rocks!'
-			)
-		);
-
-		$data = $this->Cookie->read('Encrytped_array');
-		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Encrytped_multi_cookies');
-		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Plain_array');
-		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($expected, $data);
-
-		$data = $this->Cookie->read('Plain_multi_cookies');
-		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
-		$this->assertEquals($expected, $data);
-		$this->Cookie->destroy();
-	}
-
-/**
  * Test Reading legacy cookie values.
  *
  * @return void
  */
 	public function testReadLegacyCookieValue() {
-		$this->markTestIncomplete();
-		$this->request->cookies['CakeTestCookie'] = array(
+		$this->request->cookies = array(
 			'Legacy' => array('value' => $this->_oldImplode(array(1, 2, 3)))
 		);
 		$result = $this->Cookie->read('Legacy.value');
@@ -643,8 +586,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testReadEmpty() {
-		$this->markTestIncomplete();
-		$this->request->cookies['CakeTestCookie'] = array(
+		$this->request->cookies = array(
 			'JSON' => '{"name":"value"}',
 			'Empty' => '',
 			'String' => '{"somewhat:"broken"}',
@@ -658,24 +600,11 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
- * test that no error is issued for non array data.
- *
- * @return void
- */
-	public function testNoErrorOnNonArrayData() {
-		$this->markTestIncomplete();
-		$this->request->cookies['CakeTestCookie'] = 'kaboom';
-
-		$this->assertNull($this->Cookie->read('value'));
-	}
-
-/**
  * testCheck method
  *
  * @return void
  */
 	public function testCheck() {
-		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponentTestCase', 'value');
 		$this->assertTrue($this->Cookie->check('CookieComponentTestCase'));
 
@@ -688,7 +617,6 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckingSavedEmpty() {
-		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponentTestCase', 0);
 		$this->assertTrue($this->Cookie->check('CookieComponentTestCase'));
 
@@ -702,7 +630,6 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckKeyWithSpaces() {
-		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponent Test', "test");
 		$this->assertTrue($this->Cookie->check('CookieComponent Test'));
 		$this->Cookie->delete('CookieComponent Test');
@@ -717,7 +644,6 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckEmpty() {
-		$this->markTestIncomplete();
 		$this->assertFalse($this->Cookie->check());
 	}
 

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -47,26 +47,12 @@ class CookieComponentTest extends TestCase {
 		$this->request = $controller->request;
 
 		$this->Cookie->config([
-			'name' => 'CakeTestCookie',
-			'time' => 10,
+			'expires' => '+10 seconds',
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
 			'key' => 'somerandomhaskeysomerandomhaskey'
 		]);
-
-		$event = new Event('Controller.startup', $this->Controller);
-		$this->Cookie->startup($event);
-	}
-
-/**
- * end
- *
- * @return void
- */
-	public function tearDown() {
-		parent::tearDown();
-		$this->Cookie->destroy();
 	}
 
 /**
@@ -85,8 +71,6 @@ class CookieComponentTest extends TestCase {
 			'secure' => false,
 			'httpOnly' => false,
 			'encryption' => 'aes',
-			'name' => 'CakeTestCookie',
-			'time' => 10,
 		];
 		$this->assertEquals($expected, $result);
 	}
@@ -110,8 +94,6 @@ class CookieComponentTest extends TestCase {
 			'secure' => false,
 			'httpOnly' => false,
 			'encryption' => 'aes',
-			'name' => 'CakeTestCookie',
-			'time' => 10,
 		];
 		$this->assertEquals($expected, $result);
 	}
@@ -149,20 +131,12 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
- * testCookieName
- *
- * @return void
- */
-	public function testCookieName() {
-		$this->assertEquals('CakeTestCookie', $this->Cookie->config('name'));
-	}
-
-/**
  * testReadEncryptedCookieData
  *
  * @return void
  */
 	public function testReadEncryptedCookieData() {
+		$this->markTestIncomplete();
 		$this->_setCookieData();
 		$data = $this->Cookie->read('Encrytped_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
@@ -179,6 +153,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testReadPlainCookieData() {
+		$this->markTestIncomplete();
 		$this->_setCookieData();
 		$data = $this->Cookie->read('Plain_array');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
@@ -194,19 +169,18 @@ class CookieComponentTest extends TestCase {
  *
  * @return void
  */
-	public function testReadWithNameSwitch() {
+	public function testReadMultipleNames() {
 		$this->request->cookies = array(
-			'CakeTestCookie' => array(
+			'CakeCookie' => array(
 				'key' => 'value'
 			),
-			'OtherTestCookie' => array(
+			'OtherCookie' => array(
 				'key' => 'other value'
 			)
 		);
-		$this->assertEquals('value', $this->Cookie->read('key'));
-
-		$this->Cookie->config('name', 'OtherTestCookie');
-		$this->assertEquals('other value', $this->Cookie->read('key'));
+		$this->assertEquals('value', $this->Cookie->read('CakeCookie.key'));
+		$this->assertEquals(['key' => 'value'], $this->Cookie->read('CakeCookie'));
+		$this->assertEquals('other value', $this->Cookie->read('OtherCookie.key'));
 	}
 
 /**
@@ -215,6 +189,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteSimple() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('Testing', 'value');
 		$result = $this->Cookie->read('Testing');
 
@@ -227,6 +202,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteWithFalseyValue() {
+		$this->markTestIncomplete();
 		$this->Cookie->encryption('aes');
 		$this->Cookie->key = 'qSI232qs*&sXOw!adre@34SAv!@*(XSL#$%)asGb$@11~_+!@#HKis~#^';
 
@@ -261,6 +237,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteMultipleShareExpiry() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('key1', 'value1', false);
 		$this->Cookie->write('key2', 'value2', false);
 
@@ -279,6 +256,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteFarFuture() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('Testing', 'value', false, '+90 years');
 		$future = new \DateTime('now');
 		$future->modify('+90 years');
@@ -304,6 +282,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteHttpOnly() {
+		$this->markTestIncomplete();
 		$this->Cookie->config([
 			'httpOnly' => true,
 			'secure' => false
@@ -327,6 +306,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteHttpOnly() {
+		$this->markTestIncomplete();
 		$this->Cookie->config([
 			'httpOnly' => true,
 			'secure' => false
@@ -350,6 +330,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWritePlainCookieArray() {
+		$this->markTestIncomplete();
 		$this->Cookie->write(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!'), null, false);
 
 		$this->assertEquals('CakePHP', $this->Cookie->read('name'));
@@ -367,6 +348,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteArrayValues() {
+		$this->markTestIncomplete();
 		$this->Cookie->config('secure', false);
 		$this->Cookie->write('Testing', array(1, 2, 3), false);
 		$expected = array(
@@ -389,6 +371,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteMixedArray() {
+		$this->markTestIncomplete();
 		$this->Cookie->config('encrypt', false);
 		$this->Cookie->write('User', array('name' => 'mark'), false);
 		$this->Cookie->write('User.email', 'mark@example.com', false);
@@ -422,11 +405,11 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
- * testReadingCookieValue
+ * test reading all values at once.
  *
  * @return void
  */
-	public function testReadingCookieValue() {
+	public function testReadingAllValues() {
 		$this->_setCookieData();
 		$data = $this->Cookie->read();
 		$expected = array(
@@ -455,6 +438,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteCookieValue() {
+		$this->markTestIncomplete();
 		$this->_setCookieData();
 		$this->Cookie->delete('Encrytped_multi_cookies.name');
 		$data = $this->Cookie->read('Encrytped_multi_cookies');
@@ -537,7 +521,7 @@ class CookieComponentTest extends TestCase {
  *
  * @return void
  */
-	public function testReadingCookieDataOnStartup() {
+	public function testReadingDataFromRequest() {
 		$data = $this->Cookie->read('Encrytped_array');
 		$this->assertNull($data);
 
@@ -550,7 +534,7 @@ class CookieComponentTest extends TestCase {
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$this->assertNull($data);
 
-		$this->request->cookies['CakeTestCookie'] = array(
+		$this->request->cookies = array(
 			'Encrytped_array' => $this->_encrypt(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!')),
 			'Encrytped_multi_cookies' => array(
 				'name' => $this->_encrypt('CakePHP'),
@@ -580,7 +564,6 @@ class CookieComponentTest extends TestCase {
 		$data = $this->Cookie->read('Plain_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
 		$this->assertEquals($expected, $data);
-		$this->Cookie->destroy();
 	}
 
 /**
@@ -589,6 +572,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testReadingCookieDataWithoutStartup() {
+		$this->markTestIncomplete();
 		$data = $this->Cookie->read('Encrytped_array');
 		$expected = null;
 		$this->assertEquals($expected, $data);
@@ -644,6 +628,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testReadLegacyCookieValue() {
+		$this->markTestIncomplete();
 		$this->request->cookies['CakeTestCookie'] = array(
 			'Legacy' => array('value' => $this->_oldImplode(array(1, 2, 3)))
 		);
@@ -658,6 +643,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testReadEmpty() {
+		$this->markTestIncomplete();
 		$this->request->cookies['CakeTestCookie'] = array(
 			'JSON' => '{"name":"value"}',
 			'Empty' => '',
@@ -677,6 +663,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testNoErrorOnNonArrayData() {
+		$this->markTestIncomplete();
 		$this->request->cookies['CakeTestCookie'] = 'kaboom';
 
 		$this->assertNull($this->Cookie->read('value'));
@@ -688,6 +675,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheck() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponentTestCase', 'value');
 		$this->assertTrue($this->Cookie->check('CookieComponentTestCase'));
 
@@ -700,6 +688,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckingSavedEmpty() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponentTestCase', 0);
 		$this->assertTrue($this->Cookie->check('CookieComponentTestCase'));
 
@@ -713,6 +702,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckKeyWithSpaces() {
+		$this->markTestIncomplete();
 		$this->Cookie->write('CookieComponent Test', "test");
 		$this->assertTrue($this->Cookie->check('CookieComponent Test'));
 		$this->Cookie->delete('CookieComponent Test');
@@ -727,6 +717,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testCheckEmpty() {
+		$this->markTestIncomplete();
 		$this->assertFalse($this->Cookie->check());
 	}
 
@@ -736,6 +727,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteRemovesChildren() {
+		$this->markTestIncomplete();
 		$this->request->cookies['CakeTestCookie'] = array(
 			'User' => array('email' => 'example@example.com', 'name' => 'mark'),
 			'other' => 'value'
@@ -753,6 +745,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteChildrenNotExist() {
+		$this->markTestIncomplete();
 		$this->assertNull($this->Cookie->delete('NotFound'));
 		$this->assertNull($this->Cookie->delete('Not.Found'));
 	}

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -213,8 +213,10 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteWithFalseyValue() {
-		$this->Cookie->encryption('aes');
-		$this->Cookie->key = 'qSI232qs*&sXOw!adre@34SAv!@*(XSL#$%)asGb$@11~_+!@#HKis~#^';
+		$this->Cookie->config([
+			'encryption' => 'aes',
+			'key' => 'qSI232qs*&sXOw!adre@34SAv!@*(XSL#$%)asGb$@11~_+!@#HKis~#^',
+		]);
 
 		$this->Cookie->write('Testing');
 		$result = $this->Cookie->read('Testing');

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -195,6 +195,19 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
+ * Test writes don't omit request data from being read.
+ *
+ * @return void
+ */
+	public function testWriteThanRead() {
+		$this->request->cookies = [
+			'User' => ['name' => 'mark']
+		];
+		$this->Cookie->write('Testing', 'value');
+		$this->assertEquals('mark', $this->Cookie->read('User.name'));
+	}
+
+/**
  * test write() encrypted data with falsey value
  *
  * @return void

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -22,6 +22,7 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
+use Cake\Utility\Time;
 
 /**
  * CookieComponentTest class
@@ -278,7 +279,7 @@ class CookieComponentTest extends TestCase {
 	public function testWriteFarFuture() {
 		$this->Cookie->configKey('Testing', 'expires', '+90 years');
 		$this->Cookie->write('Testing', 'value');
-		$future = new \DateTime('now');
+		$future = new Time('now');
 		$future->modify('+90 years');
 
 		$expected = array(
@@ -310,7 +311,7 @@ class CookieComponentTest extends TestCase {
 		$expected = array(
 			'name' => 'Testing',
 			'value' => 'value',
-			'expire' => time() + 10,
+			'expire' => (new Time('+10 seconds'))->format('U'),
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
@@ -361,7 +362,7 @@ class CookieComponentTest extends TestCase {
 		$expected = array(
 			'name' => 'Testing',
 			'value' => '',
-			'expire' => time() - 42000,
+			'expire' => (new Time('now'))->format('U') - 42000,
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
@@ -387,7 +388,8 @@ class CookieComponentTest extends TestCase {
 		);
 		$result = $this->Controller->response->cookie('Testing');
 
-		$this->assertWithinMargin($result['expire'], time() + 10, 1);
+		$time = new Time('now');
+		$this->assertWithinMargin($result['expire'], $time->format('U') + 10, 1);
 		unset($result['expire']);
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -106,9 +106,9 @@ class CookieComponentTest extends TestCase {
  */
 	protected function _setCookieData() {
 		$this->Cookie->write(array('Encrytped_array' => array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!')));
-		$this->Cookie->write(array('Encrytped_multi_cookies.name' => 'CakePHP'));
-		$this->Cookie->write(array('Encrytped_multi_cookies.version' => '1.2.0.x'));
-		$this->Cookie->write(array('Encrytped_multi_cookies.tag' => 'CakePHP Rocks!'));
+		$this->Cookie->write(array('Encrypted_multi_cookies.name' => 'CakePHP'));
+		$this->Cookie->write(array('Encrypted_multi_cookies.version' => '1.2.0.x'));
+		$this->Cookie->write(array('Encrypted_multi_cookies.tag' => 'CakePHP Rocks!'));
 
 		$this->Cookie->write(array('Plain_array' => array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!')), null, false);
 		$this->Cookie->write(array('Plain_multi_cookies.name' => 'CakePHP'), null, false);
@@ -142,7 +142,7 @@ class CookieComponentTest extends TestCase {
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
 		$this->assertEquals($expected, $data);
 
-		$data = $this->Cookie->read('Encrytped_multi_cookies');
+		$data = $this->Cookie->read('Encrypted_multi_cookies');
 		$expected = array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
 		$this->assertEquals($expected, $data);
 	}
@@ -311,40 +311,21 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteHttpOnly() {
-		$this->markTestIncomplete();
 		$this->Cookie->config([
 			'httpOnly' => true,
 			'secure' => false
 		]);
-		$this->Cookie->delete('Testing', false);
+		$this->Cookie->delete('Testing');
 		$expected = array(
-			'name' => $this->Cookie->config('name') . '[Testing]',
+			'name' => 'Testing',
 			'value' => '',
 			'expire' => time() - 42000,
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
 			'httpOnly' => true);
-		$result = $this->Controller->response->cookie($this->Cookie->config('name') . '[Testing]');
+		$result = $this->Controller->response->cookie('Testing');
 		$this->assertEquals($expected, $result);
-	}
-
-/**
- * testWritePlainCookieArray
- *
- * @return void
- */
-	public function testWritePlainCookieArray() {
-		$this->markTestIncomplete();
-		$this->Cookie->write(array('name' => 'CakePHP', 'version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!'), null, false);
-
-		$this->assertEquals('CakePHP', $this->Cookie->read('name'));
-		$this->assertEquals('1.2.0.x', $this->Cookie->read('version'));
-		$this->assertEquals('CakePHP Rocks!', $this->Cookie->read('tag'));
-
-		$this->Cookie->delete('name');
-		$this->Cookie->delete('version');
-		$this->Cookie->delete('tag');
 	}
 
 /**
@@ -353,17 +334,16 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteArrayValues() {
-		$this->markTestIncomplete();
-		$this->Cookie->config('secure', false);
-		$this->Cookie->write('Testing', array(1, 2, 3), false);
+		$this->Cookie->write('Testing', array(1, 2, 3));
 		$expected = array(
-			'name' => $this->Cookie->config('name') . '[Testing]',
+			'name' => 'Testing',
 			'value' => '[1,2,3]',
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
-			'httpOnly' => false);
-		$result = $this->Controller->response->cookie($this->Cookie->config('name') . '[Testing]');
+			'httpOnly' => false
+		);
+		$result = $this->Controller->response->cookie('Testing');
 
 		$this->assertWithinMargin($result['expire'], time() + 10, 1);
 		unset($result['expire']);
@@ -376,19 +356,17 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testWriteMixedArray() {
-		$this->markTestIncomplete();
-		$this->Cookie->config('encrypt', false);
 		$this->Cookie->write('User', array('name' => 'mark'), false);
 		$this->Cookie->write('User.email', 'mark@example.com', false);
 		$expected = array(
-			'name' => $this->Cookie->config('name') . '[User]',
+			'name' => 'User',
 			'value' => '{"name":"mark","email":"mark@example.com"}',
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
 			'httpOnly' => false
 		);
-		$result = $this->Controller->response->cookie($this->Cookie->config('name') . '[User]');
+		$result = $this->Controller->response->cookie('User');
 		unset($result['expire']);
 
 		$this->assertEquals($expected, $result);
@@ -396,14 +374,14 @@ class CookieComponentTest extends TestCase {
 		$this->Cookie->write('User.email', 'mark@example.com', false);
 		$this->Cookie->write('User', array('name' => 'mark'), false);
 		$expected = array(
-			'name' => $this->Cookie->config('name') . '[User]',
+			'name' => 'User',
 			'value' => '{"name":"mark"}',
 			'path' => '/',
 			'domain' => '',
 			'secure' => false,
 			'httpOnly' => false
 		);
-		$result = $this->Controller->response->cookie($this->Cookie->config('name') . '[User]');
+		$result = $this->Controller->response->cookie('User');
 		unset($result['expire']);
 
 		$this->assertEquals($expected, $result);
@@ -422,7 +400,7 @@ class CookieComponentTest extends TestCase {
 				'name' => 'CakePHP',
 				'version' => '1.2.0.x',
 				'tag' => 'CakePHP Rocks!'),
-			'Encrytped_multi_cookies' => array(
+			'Encrypted_multi_cookies' => array(
 				'name' => 'CakePHP',
 				'version' => '1.2.0.x',
 				'tag' => 'CakePHP Rocks!'),
@@ -443,10 +421,9 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteCookieValue() {
-		$this->markTestIncomplete();
 		$this->_setCookieData();
-		$this->Cookie->delete('Encrytped_multi_cookies.name');
-		$data = $this->Cookie->read('Encrytped_multi_cookies');
+		$this->Cookie->delete('Encrypted_multi_cookies.name');
+		$data = $this->Cookie->read('Encrypted_multi_cookies');
 		$expected = array('version' => '1.2.0.x', 'tag' => 'CakePHP Rocks!');
 		$this->assertEquals($expected, $data);
 
@@ -484,15 +461,15 @@ class CookieComponentTest extends TestCase {
 		$expected = 'CakePHP Rocks!';
 		$this->assertEquals($expected, $data);
 
-		$data = $this->Cookie->read('Encrytped_multi_cookies.name');
+		$data = $this->Cookie->read('Encrypted_multi_cookies.name');
 		$expected = 'CakePHP';
 		$this->assertEquals($expected, $data);
 
-		$data = $this->Cookie->read('Encrytped_multi_cookies.version');
+		$data = $this->Cookie->read('Encrypted_multi_cookies.version');
 		$expected = '1.2.0.x';
 		$this->assertEquals($expected, $data);
 
-		$data = $this->Cookie->read('Encrytped_multi_cookies.tag');
+		$data = $this->Cookie->read('Encrypted_multi_cookies.tag');
 		$expected = 'CakePHP Rocks!';
 		$this->assertEquals($expected, $data);
 
@@ -661,8 +638,7 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteRemovesChildren() {
-		$this->markTestIncomplete();
-		$this->request->cookies['CakeTestCookie'] = array(
+		$this->request->cookies = array(
 			'User' => array('email' => 'example@example.com', 'name' => 'mark'),
 			'other' => 'value'
 		);
@@ -670,7 +646,11 @@ class CookieComponentTest extends TestCase {
 
 		$this->Cookie->delete('User');
 		$this->assertNull($this->Cookie->read('User.email'));
-		$this->Cookie->destroy();
+		$this->assertNull($this->Cookie->read('User.name'));
+
+		$result = $this->Controller->response->cookie('User');
+		$this->assertEquals('', $result['value']);
+		$this->assertLessThan(time(), $result['expire']);
 	}
 
 /**
@@ -679,7 +659,6 @@ class CookieComponentTest extends TestCase {
  * @return void
  */
 	public function testDeleteChildrenNotExist() {
-		$this->markTestIncomplete();
 		$this->assertNull($this->Cookie->delete('NotFound'));
 		$this->assertNull($this->Cookie->delete('Not.Found'));
 	}

--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -132,6 +132,21 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
+ * Test read when an invalid cipher is configured.
+ *
+ * @expectedException \RuntimeException
+ * @expectedExceptionMessage Invalid encryption cipher. Must be one of aes, rijndael.
+ * @return void
+ */
+	public function testReadInvalidCipher() {
+		$this->request->cookies = [
+			'Test' => $this->_encrypt('value'),
+		];
+		$this->Cookie->config('encryption', 'derp');
+		$this->Cookie->read('Test');
+	}
+
+/**
  * testReadEncryptedCookieData
  *
  * @return void
@@ -192,6 +207,18 @@ class CookieComponentTest extends TestCase {
 		$result = $this->Cookie->read('Testing');
 
 		$this->assertEquals('value', $result);
+	}
+
+/**
+ * Test write when an invalid cipher is configured.
+ *
+ * @expectedException \RuntimeException
+ * @expectedExceptionMessage Invalid encryption cipher. Must be one of aes, rijndael.
+ * @return void
+ */
+	public function testWriteInvalidCipher() {
+		$this->Cookie->config('encryption', 'derp');
+		$this->Cookie->write('Test', 'nope');
 	}
 
 /**


### PR DESCRIPTION
Implement the changes described in #2218. CookieComponent can now:
- Manage multiple cookie namespaces.
- Configure each namespace independently.
- Work mostly like it always has.

And it does all this with fewer lines of code and simpler code.
