### PR TITLE
Set default sort direction to 'asc'.

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -23,6 +23,11 @@ App::uses('Hash', 'Utility');
  */
 class HashTest extends CakeTestCase {
 
+/**
+ * Data provider
+ *
+ * @return array
+ */
 	public static function articleData() {
 		return array(
 			array(
@@ -136,6 +141,11 @@ class HashTest extends CakeTestCase {
 		);
 	}
 
+/**
+ * Data provider
+ *
+ * @return array
+ */
 	public static function userData() {
 		return array(
 			array(
@@ -1021,7 +1031,7 @@ class HashTest extends CakeTestCase {
  * @return void
  */
 	public function testSort() {
-		$result = Hash::sort(array(), '{n}.name', 'asc');
+		$result = Hash::sort(array(), '{n}.name');
 		$this->assertEquals(array(), $result);
 
 		$a = array(
@@ -1044,7 +1054,7 @@ class HashTest extends CakeTestCase {
 				'Friend' => array(array('name' => 'Nate'))
 			)
 		);
-		$a = Hash::sort($a, '{n}.Friend.{n}.name', 'asc');
+		$a = Hash::sort($a, '{n}.Friend.{n}.name');
 		$this->assertEquals($a, $b);
 
 		$b = array(
@@ -1786,6 +1796,11 @@ class HashTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * testApply
+ *
+ * @return void
+ */
 	public function testApply() {
 		$data = self::articleData();
 
@@ -1808,8 +1823,8 @@ class HashTest extends CakeTestCase {
 /**
  * testing method for map callbacks.
  *
- * @param mixed $value
- * @return mixed.
+ * @param mixed $value Value
+ * @return mixed
  */
 	public function mapCallback($value) {
 		return $value * 2;
@@ -1818,9 +1833,9 @@ class HashTest extends CakeTestCase {
 /**
  * testing method for reduce callbacks.
  *
- * @param mixed $one
- * @param mixed $two
- * @return mixed.
+ * @param mixed $one First param
+ * @param mixed $two Second param
+ * @return mixed
  */
 	public function reduceCallback($one, $two) {
 		return $one + $two;

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -800,12 +800,12 @@ class Hash {
  *
  * @param array $data An array of data to sort
  * @param string $path A Set-compatible path to the array value
- * @param string $dir See directions above.
+ * @param string $dir See directions above. Defaults to 'asc'.
  * @param string $type See direction types above. Defaults to 'regular'.
  * @return array Sorted array of data
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::sort
  */
-	public static function sort(array $data, $path, $dir, $type = 'regular') {
+	public static function sort(array $data, $path, $dir = 'asc', $type = 'regular') {
 		if (empty($data)) {
 			return array();
 		}


### PR DESCRIPTION
Don't see the need to force user to specify direction. 'asc' is reasonable default.
