### PR TITLE
Update session component to not specify a default element.

### DIFF
--- a/src/Controller/Component/SessionComponent.php
+++ b/src/Controller/Component/SessionComponent.php
@@ -121,7 +121,7 @@ class SessionComponent extends Component {
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#creating-notification-messages
  */
-	public function setFlash($message, $element = 'default', array $params = array(), $key = 'flash') {
+	public function setFlash($message, $element = null, array $params = array(), $key = 'flash') {
 		$this->_session->flash($message, 'info', $params + compact('element', 'key'));
 	}
 

--- a/tests/TestCase/Controller/Component/SessionComponentTest.php
+++ b/tests/TestCase/Controller/Component/SessionComponentTest.php
@@ -173,7 +173,7 @@ class SessionComponentTest extends TestCase {
 		$Session->setFlash('This is a test message');
 		$this->assertEquals(array(
 				'message' => 'This is a test message',
-				'params' => array('element' => 'default'),
+				'params' => array('element' => null),
 				'type' => 'info'
 			), $Session->read('Message.flash'));
 	}


### PR DESCRIPTION
By omitting the default element name backwards compatibility is restored.

Fixes #3603  
