### PR TITLE
Remove redundant method arg.

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -703,23 +703,19 @@ class Controller implements EventListener {
  * The beforeRedirect method is invoked when the controller's redirect method is called but before any
  * further action.
  *
- * If this method returns false the controller will not continue on to redirect the request.
- * The $url, $status and $exit variables have same meaning as for the controller's method. You can also
- * return a string which will be interpreted as the URL to redirect to or return associative array with
- * key 'url' and optionally 'status' and 'exit'.
+ * If the event is stopped the controller will not continue on to redirect the request.
+ * The $url and $status variables have same meaning as for the controller's method.
+ * You can set the event result to response instance or modify the redirect location
+ * using controller's response instance.
  *
  * @param Event $event An Event instance
  * @param string|array $url A string or array-based URL pointing to another location within the app,
  *     or an absolute URL
  * @param int $status Optional HTTP status code (eg: 404)
- * @param bool $exit If true, exit() will be called after the redirect
- *   false to stop redirection event,
- *   string controllers a new redirection URL or
- *   array with the keys url, status and exit to be used by the redirect method.
  * @return void
  * @link http://book.cakephp.org/2.0/en/controllers.html#request-life-cycle-callbacks
  */
-	public function beforeRedirect(Event $event, $url, $status = null, $exit = true) {
+	public function beforeRedirect(Event $event, $url, $status = null) {
 	}
 
 /**


### PR DESCRIPTION
Getting rid of $exit param from callback since Controller::redirect() no longer exits.
