### PR TITLE
3.0 - Simplify View blocks

### DIFF
--- a/src/View/View.php
+++ b/src/View/View.php
@@ -644,39 +644,30 @@ class View {
 	}
 
 /**
- * Start capturing output for a 'block' if it has no content
+ * Append to an existing or new block.
  *
- * @param string $name The name of the block to capture for.
- * @return void
- * @see ViewBlock::startIfEmpty()
- */
-	public function startIfEmpty($name) {
-		$this->Blocks->startIfEmpty($name);
-	}
-
-/**
- * Append to an existing or new block. Appending to a new
- * block will create the block.
+ * Appending to a new block will create the block.
  *
  * @param string $name Name of the block
  * @param mixed $value The content for the block.
  * @return void
  * @see ViewBlock::concat()
  */
-	public function append($name, $value = null) {
+	public function append($name, $value) {
 		$this->Blocks->concat($name, $value);
 	}
 
 /**
- * Prepend to an existing or new block. Prepending to a new
- * block will create the block.
+ * Prepend to an existing or new block.
+ *
+ * Prepending to a new block will create the block.
  *
  * @param string $name Name of the block
  * @param mixed $value The content for the block.
  * @return void
  * @see ViewBlock::concat()
  */
-	public function prepend($name, $value = null) {
+	public function prepend($name, $value) {
 		$this->Blocks->concat($name, $value, ViewBlock::PREPEND);
 	}
 

--- a/src/View/ViewBlock.php
+++ b/src/View/ViewBlock.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -85,26 +84,6 @@ class ViewBlock {
 	}
 
 /**
- * Start capturing output for a 'block' if it is empty
- *
- * Blocks allow you to create slots or blocks of dynamic content in the layout.
- * view files can implement some or all of a layout's slots.
- *
- * You can end capturing blocks using View::end(). Blocks can be output
- * using View::get();
- *
- * @param string $name The name of the block to capture for.
- * @return void
- */
-	public function startIfEmpty($name) {
-		if (empty($this->_blocks[$name])) {
-			return $this->start($name);
-		}
-		$this->_discardActiveBufferOnEnd = true;
-		ob_start();
-	}
-
-/**
  * End a capturing block. The compliment to ViewBlock::start()
  *
  * @return void
@@ -119,10 +98,7 @@ class ViewBlock {
 		if (!empty($this->_active)) {
 			$active = end($this->_active);
 			$content = ob_get_clean();
-			if (!isset($this->_blocks[$active])) {
-				$this->_blocks[$active] = '';
-			}
-			$this->_blocks[$active] .= $content;
+			$this->_blocks[$active] = $content;
 			array_pop($this->_active);
 		}
 	}
@@ -141,18 +117,14 @@ class ViewBlock {
  *   If ViewBlock::PREPEND it will be prepended.
  * @return void
  */
-	public function concat($name, $value = null, $mode = ViewBlock::APPEND) {
-		if (isset($value)) {
-			if (!isset($this->_blocks[$name])) {
-				$this->_blocks[$name] = '';
-			}
-			if ($mode === ViewBlock::PREPEND) {
-				$this->_blocks[$name] = $value . $this->_blocks[$name];
-			} else {
-				$this->_blocks[$name] .= $value;
-			}
+	public function concat($name, $value, $mode = ViewBlock::APPEND) {
+		if (!isset($this->_blocks[$name])) {
+			$this->_blocks[$name] = '';
+		}
+		if ($mode === ViewBlock::PREPEND) {
+			$this->_blocks[$name] = $value . $this->_blocks[$name];
 		} else {
-			$this->start($name);
+			$this->_blocks[$name] .= $value;
 		}
 	}
 

--- a/tests/TestCase/View/ViewTest.php
+++ b/tests/TestCase/View/ViewTest.php
@@ -1128,6 +1128,43 @@ class ViewTest extends TestCase {
  *
  * @return void
  */
+	public function testBlockCaptureOverwrite() {
+		$this->View->start('test');
+		echo 'Block content';
+		$this->View->end();
+
+		$this->View->start('test');
+		echo 'New content';
+		$this->View->end();
+
+		$result = $this->View->fetch('test');
+		$this->assertEquals('New content', $result);
+	}
+
+/**
+ * Test that blocks can be fetched inside a block with the same name
+ *
+ * @return void
+ */
+	public function testBlockExtend() {
+		$this->View->start('test');
+		echo 'Block content';
+		$this->View->end();
+
+		$this->View->start('test');
+		echo $this->View->fetch('test');
+		echo 'New content';
+		$this->View->end();
+
+		$result = $this->View->fetch('test');
+		$this->assertEquals('Block contentNew content', $result);
+	}
+
+/**
+ * Test creating a block with capturing output.
+ *
+ * @return void
+ */
 	public function testBlockCapture() {
 		$this->View->start('test');
 		echo 'Block content';
@@ -1135,42 +1172,6 @@ class ViewTest extends TestCase {
 
 		$result = $this->View->fetch('test');
 		$this->assertEquals('Block content', $result);
-	}
-
-/**
- * Test block with startIfEmpty
- *
- * @return void
- */
-	public function testBlockCaptureStartIfEmpty() {
-		$this->View->startIfEmpty('test');
-		echo "Block content 1";
-		$this->View->end();
-
-		$this->View->startIfEmpty('test');
-		echo "Block content 2";
-		$this->View->end();
-
-		$result = $this->View->fetch('test');
-		$this->assertEquals('Block content 1', $result);
-	}
-
-/**
- * Test block with startIfEmpty
- *
- * @return void
- */
-	public function testBlockCaptureStartStartIfEmpty() {
-		$this->View->start('test');
-		echo "Block content 1";
-		$this->View->end();
-
-		$this->View->startIfEmpty('test');
-		echo "Block content 2";
-		$this->View->end();
-
-		$result = $this->View->fetch('test');
-		$this->assertEquals('Block content 1', $result);
 	}
 
 /**
@@ -1183,9 +1184,7 @@ class ViewTest extends TestCase {
 		echo 'Block';
 		$this->View->end();
 
-		$this->View->append('test');
-		echo ' content';
-		$this->View->end();
+		$this->View->append('test', ' content');
 
 		$result = $this->View->fetch('test');
 		$this->assertEquals('Block content', $result);


### PR DESCRIPTION
This set of changes breaks the existing behavior of blocks in a few ways, but leaves us with a simpler and easier to reason about API. It also solves weird behavior with prepend() where it wouldn't prepend at
all.
- startIfEmpty() is removed, as that behavior is not relevant when blocks always overwrite.
- append() and prepend() no longer have capturing modes. They can only be used to append/prepend content into blocks. The capturing mode of prepend never worked so I dobut anyone will miss this.
- Additional tests were added for the new behavior.

Refs #3561
