### PR TITLE
#3623: Allow username "0" with FormAuthenticate

### DIFF
--- a/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/FormAuthenticate.php
@@ -51,7 +51,7 @@ class FormAuthenticate extends BaseAuthenticate {
 		}
 		foreach (array($fields['username'], $fields['password']) as $field) {
 			$value = $request->data($model . '.' . $field);
-			if (empty($value) || !is_string($value)) {
+			if (empty($value) && $value !== "0" || !is_string($value)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
`FormAuthenticate::_checkFields` returns `false` if the username is `"0"`.
Solution:
Replace
`if(empty($value) || !is_string($value))`
by
`if(empty($value) && $value !== "0" || !is_string($value))`
