### PR TITLE
ORM\Associations: Add removeAll() method

### DIFF
--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -123,6 +123,19 @@ class Associations {
 	}
 
 /**
+ * Remove all registered associations.
+ *
+ * Once removed associations will not longer be reachable
+ *
+ * @return void
+ */
+	public function removeAll() {
+		foreach ($this->_items as $alias => $object) {
+			$this->remove($alias);
+		}
+	}
+
+/**
  * Save all the associations that are parents of the given entity.
  *
  * Parent associations include any association where the given table

--- a/tests/TestCase/ORM/AssociationsTest.php
+++ b/tests/TestCase/ORM/AssociationsTest.php
@@ -64,6 +64,23 @@ class AssociationsTest extends TestCase {
 	}
 
 /**
+ * Test removeAll method
+ *
+ * @return void
+ */
+	public function testRemoveAll() {
+		$this->assertEmpty($this->associations->keys());
+
+		$belongsTo = new BelongsTo([]);
+		$this->assertSame($belongsTo, $this->associations->add('Users', $belongsTo));
+		$belongsToMany = new BelongsToMany([]);
+		$this->assertSame($belongsToMany, $this->associations->add('Cart', $belongsToMany));
+
+		$this->associations->removeAll();
+		$this->assertEmpty($this->associations->keys());
+	}
+
+/**
  * Test getting associations by property.
  *
  * @return void


### PR DESCRIPTION
Useful in cases where you want to rebind associations manually.

In my case, I was extending the AcoTable model and wanted to clear out all associations setup by parent::initialize().

I'll add test if this is desired.
