### PR TITLE
Remove bonus inflection in _setModelClass()

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -145,7 +145,7 @@ class Shell {
 	protected $_io;
 
 /**
- *  Constructs this Shell instance.
+ * Constructs this Shell instance.
  *
  * @param \Cake\Console\ConsoleIo $io An io instance.
  * @link http://book.cakephp.org/3.0/en/console-and-shells.html#Shell
@@ -157,7 +157,6 @@ class Shell {
 		}
 		$this->_io = $io ?: new ConsoleIo();
 
-		$this->_setModelClass($this->name);
 		$this->modelFactory('Table', ['Cake\ORM\TableRegistry', 'get']);
 		$this->Tasks = new TaskRegistry($this);
 
@@ -166,6 +165,10 @@ class Shell {
 			['tasks'],
 			['associative' => ['tasks']]
 		);
+
+		if (isset($this->modelClass)) {
+			$this->loadModel();
+		}
 	}
 
 /**
@@ -219,22 +222,6 @@ class Shell {
 		$this->out(__d('cake_console', 'App : %s', APP_DIR));
 		$this->out(__d('cake_console', 'Path: %s', APP));
 		$this->hr();
-	}
-
-/**
- * Lazy loads models using the loadModel() method if it matches modelClass
- *
- * @param string $name
- * @return void
- */
-	public function __isset($name) {
-		if ($name === $this->modelClass) {
-			list($plugin, $class) = pluginSplit($name, true);
-			if (!$plugin) {
-				$plugin = $this->plugin ? $this->plugin . '.' : null;
-			}
-			return $this->loadModel($plugin . $this->modelClass);
-		}
 	}
 
 /**

--- a/src/Model/ModelAwareTrait.php
+++ b/src/Model/ModelAwareTrait.php
@@ -15,7 +15,6 @@
 namespace Cake\Model;
 
 use Cake\Error\Exception;
-use Cake\Utility\Inflector;
 
 /**
  * Provides functionality for loading table classes
@@ -27,8 +26,8 @@ use Cake\Utility\Inflector;
 trait ModelAwareTrait {
 
 /**
- * This object's primary model class name, the Inflector::pluralized()'ed version of
- * the object's $name property.
+ * This object's primary model class name. Should be a plural form.
+ * CakePHP will not inflect the name.
  *
  * Example: For a object named 'Comments', the modelClass would be 'Comments'
  *
@@ -53,7 +52,7 @@ trait ModelAwareTrait {
  */
 	protected function _setModelClass($name) {
 		if (empty($this->modelClass)) {
-			$this->modelClass = Inflector::pluralize($name);
+			$this->modelClass = $name;
 		}
 	}
 

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -164,8 +164,9 @@ class ShellTest extends TestCase {
 		Plugin::load('TestPlugin');
 		$this->Shell->tasks = array('DbConfig' => array('one', 'two'));
 		$this->Shell->plugin = 'TestPlugin';
-		$this->Shell->modelClass = 'TestPluginComments';
+		$this->Shell->modelClass = 'TestPlugin.TestPluginComments';
 		$this->Shell->initialize();
+		$this->Shell->loadModel();
 
 		$this->assertTrue(isset($this->Shell->TestPluginComments));
 		$this->assertInstanceOf(


### PR DESCRIPTION
This inflection was causing issues in controllers that had plural names. For example NavigationMenusController. I've also axed automatically setting modelClass on shell classes. Many shells don't need the conventional model. By defining a modelClass property shells can opt-in to having a model initialized for free.

Fixes #3629
