### PR TITLE
3.0 - FlashComponent + FlashHelper

### DIFF
--- a/src/Console/Templates/default/actions/controller_actions.ctp
+++ b/src/Console/Templates/default/actions/controller_actions.ctp
@@ -72,10 +72,10 @@ $allAssociations = array_merge(
 		$<?= $singularName ?> = $this-><?= $currentModelName ?>->newEntity($this->request->data);
 		if ($this->request->is('post')) {
 			if ($this-><?= $currentModelName; ?>->save($<?= $singularName ?>)) {
-				$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> has been saved.'));
+				$this->Flash->success('The <?= strtolower($singularHumanName); ?> has been saved.');
 				return $this->redirect(['action' => 'index']);
 			} else {
-				$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> could not be saved. Please, try again.'));
+				$this->Flash->error('The <?= strtolower($singularHumanName); ?> could not be saved. Please, try again.');
 			}
 		}
 <?php
@@ -105,10 +105,10 @@ $allAssociations = array_merge(
 		if ($this->request->is(['post', 'put'])) {
 			$<?= $singularName ?> = $this-><?= $currentModelName ?>->patchEntity($<?= $singularName ?>, $this->request->data);
 			if ($this-><?= $currentModelName; ?>->save($<?= $singularName ?>)) {
-				$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> has been saved.'));
+				$this->Flash->success('The <?= strtolower($singularHumanName); ?> has been saved.');
 				return $this->redirect(['action' => 'index']);
 			} else {
-				$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> could not be saved. Please, try again.'));
+				$this->Flash->error('The <?= strtolower($singularHumanName); ?> could not be saved. Please, try again.');
 			}
 		}
 <?php
@@ -134,9 +134,9 @@ $allAssociations = array_merge(
 		$<?= $singularName ?> = $this-><?= $currentModelName ?>->get($id);
 		$this->request->allowMethod('post', 'delete');
 		if ($this-><?= $currentModelName; ?>->delete($<?= $singularName ?>)) {
-			$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> has been deleted.'));
+			$this->Flash->success('The <?= strtolower($singularHumanName); ?> has been deleted.');
 		} else {
-			$this->Session->setFlash(__('The <?= strtolower($singularHumanName); ?> could not be deleted. Please, try again.'));
+			$this->Flash->error('The <?= strtolower($singularHumanName); ?> could not be deleted. Please, try again.');
 		}
 		return $this->redirect(['action' => 'index']);
 	}

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -20,14 +20,15 @@ use Cake\Utility\Inflector;
 use Cake\Error\InternalErrorException;
 use Cake\Event\Event;
 
-
 /**
- * FlashComponent
+ * The CakePHP FlashComponent provides a way for you to write a flash variable
+ * to the session from your controllers, to be rendered in a view with the
+ * FlashHelper.
  */
 class FlashComponent extends Component {
 
 /**
- * The session
+ * The Session object instance
  *
  * @var \Cake\Network\Session
  */
@@ -64,7 +65,6 @@ class FlashComponent extends Component {
  *
  * - `key` The key to set under the session's Message key
  * - `element` The element used to render the flash message
- * - `escape` Whether or not to escape the flash message, defaults to true
  * - `params` An array of variables to make available when using an element
  *
  * @param string $message Message to be flashed
@@ -88,6 +88,9 @@ class FlashComponent extends Component {
 
 /**
  * Magic method for verbose flash methods based on element names.
+ *
+ * For example: $this->Flash->success('My message') would use the
+ * flash_success.ctp element for rendering the flash message.
  *
  * @param string $name Element name to use, omitting the "flash_" prefix.
  * @param array $args Parameters to pass when calling `FlashComponent::set`.

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -54,6 +54,22 @@ class FlashComponent extends Component {
 		$this->_session = $collection->getController()->request->session();
 	}
 
+/**
+ * Used to set a session variable that can be used to output messages in the view.
+ *
+ * In your controller: $this->Flash->set('This has been saved');
+ *
+ * ### Options:
+ *
+ * - `key` The key to set under the session's Message key
+ * - `element` The element used to render the flash message
+ * - `class` The class to give the flash message whenever an element isn't supplied
+ * - `params` An array of variables to make available when using an element
+ *
+ * @param string $message Message to be flashed
+ * @param array $options An array of options
+ * @return void
+ */
 	public function set($message, array $options = []) {
 		$opts = array_merge($this->_defaultConfig, $options);
 
@@ -70,6 +86,15 @@ class FlashComponent extends Component {
 		]);
 	}
 
+
+/**
+ * Magic method for verbose flash methods based on element names.
+ *
+ * @param string $name Element name to use, omitting the "flash_" prefix.
+ * @param array $args Parameters to pass when calling `FlashComponent::set`.
+ * @return void
+ * @throws \Cake\Error\InternalErrorException If missing the flash message.
+*/
 	public function __call($name, $args) {
 		$options = ['element' => 'flash_' . $name];
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -78,7 +78,7 @@ class FlashComponent extends Component {
 			$message = $message->getMessage();
 		}
 
-		$this->_session->write("Flash.{$opts['key']}", [
+		$this->_session->write('Flash.' . $opts['key'], [
 			'message' => $message,
 			'key' => $opts['key'],
 			'element' => $opts['element'],

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -41,7 +41,6 @@ class FlashComponent extends Component {
 	protected $_defaultConfig = [
 		'key' => 'flash',
 		'element' => null,
-		'escape' => true,
 		'params' => []
 	];
 
@@ -77,10 +76,6 @@ class FlashComponent extends Component {
 
 		if ($message instanceof \Exception) {
 			$message = $message->getMessage();
-		}
-
-		if ($opts['escape'] === true) {
-			$message = h($message);
 		}
 
 		$this->_session->write("Message.{$opts['key']}", [

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -16,8 +16,10 @@ namespace Cake\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Controller\ComponentRegistry;
+use Cake\Utility\Inflector;
 use Cake\Error\InternalErrorException;
 use Cake\Event\Event;
+
 
 /**
  * FlashComponent
@@ -96,7 +98,7 @@ class FlashComponent extends Component {
  * @throws \Cake\Error\InternalErrorException If missing the flash message.
 */
 	public function __call($name, $args) {
-		$options = ['element' => 'flash_' . $name];
+		$options = ['element' => 'flash_' . Inflector::underscore($name)];
 
 		if (count($args) < 1) {
 			throw new InternalErrorException('Flash message missing.');

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -63,7 +63,7 @@ class FlashComponent extends Component {
  *
  * ### Options:
  *
- * - `key` The key to set under the session's Message key
+ * - `key` The key to set under the session's Flash key
  * - `element` The element used to render the flash message
  * - `params` An array of variables to make available when using an element
  *
@@ -78,7 +78,7 @@ class FlashComponent extends Component {
 			$message = $message->getMessage();
 		}
 
-		$this->_session->write("Message.{$opts['key']}", [
+		$this->_session->write("Flash.{$opts['key']}", [
 			'message' => $message,
 			'key' => $opts['key'],
 			'element' => $opts['element'],

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Controller\Component;
+
+use Cake\Controller\Component;
+use Cake\Controller\ComponentRegistry;
+use Cake\Error\InternalErrorException;
+use Cake\Event\Event;
+
+/**
+ * FlashComponent
+ */
+class FlashComponent extends Component {
+
+/**
+ * The session
+ *
+ * @var \Cake\Network\Session
+ */
+	protected $_session;
+
+/**
+ * Constructor
+ *
+ * @param ComponentRegistry $collection A ComponentRegistry for this component
+ * @param array $config Array of config.
+ */
+	public function __construct(ComponentRegistry $collection, array $config = []) {
+		parent::__construct($collection, $config);
+		$this->_session = $collection->getController()->request->session();
+	}
+
+	public function set($message, $element = null, array $params = array(), $key = 'flash') {
+		$this->_writeFlash($message, 'info', $params + compact('element', 'key'));
+	}
+
+	protected function _writeFlash($message, $type = 'info', $options = []) {
+		$options += ['key' => 'flash'];
+		$key = $options['key'];
+		unset($options['key']);
+		$this->_session->write("Message.$key", [
+			'message' => $message,
+			'type' => $type,
+			'params' => $options
+		]);
+	}
+}

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -78,6 +78,16 @@ class FlashComponent extends Component {
 			$message = $message->getMessage();
 		}
 
+		if ($opts['element'] !== null) {
+			list($plugin, $element) = pluginSplit($opts['element']);
+
+			if ($plugin) {
+				$opts['element'] = $plugin . '.Flash/' . $element;
+			} else {
+				$opts['element'] = 'Flash/' . $element;
+			}
+		}
+
 		$this->_session->write('Flash.' . $opts['key'], [
 			'message' => $message,
 			'key' => $opts['key'],
@@ -90,15 +100,16 @@ class FlashComponent extends Component {
  * Magic method for verbose flash methods based on element names.
  *
  * For example: $this->Flash->success('My message') would use the
- * flash_success.ctp element for rendering the flash message.
+ * success.ctp element under `Template/Element/Flash` for rendering the
+ * flash message.
  *
- * @param string $name Element name to use, omitting the "flash_" prefix.
- * @param array $args Parameters to pass when calling `FlashComponent::set`.
+ * @param string $name Element name to use.
+ * @param array $args Parameters to pass when calling `FlashComponent::set()`.
  * @return void
  * @throws \Cake\Error\InternalErrorException If missing the flash message.
 */
 	public function __call($name, $args) {
-		$options = ['element' => 'flash_' . Inflector::underscore($name)];
+		$options = ['element' => Inflector::underscore($name)];
 
 		if (count($args) < 1) {
 			throw new InternalErrorException('Flash message missing.');

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -41,7 +41,7 @@ class FlashComponent extends Component {
 	protected $_defaultConfig = [
 		'key' => 'flash',
 		'element' => null,
-		'class' => 'info',
+		'escape' => true,
 		'params' => []
 	];
 
@@ -65,7 +65,7 @@ class FlashComponent extends Component {
  *
  * - `key` The key to set under the session's Message key
  * - `element` The element used to render the flash message
- * - `class` The class to give the flash message whenever an element isn't supplied
+ * - `escape` Whether or not to escape the flash message, defaults to true
  * - `params` An array of variables to make available when using an element
  *
  * @param string $message Message to be flashed
@@ -79,15 +79,17 @@ class FlashComponent extends Component {
 			$message = $message->getMessage();
 		}
 
+		if ($opts['escape'] === true) {
+			$message = h($message);
+		}
+
 		$this->_session->write("Message.{$opts['key']}", [
 			'message' => $message,
 			'key' => $opts['key'],
 			'element' => $opts['element'],
-			'class' => $opts['class'],
 			'params' => $opts['params']
 		]);
 	}
-
 
 /**
  * Magic method for verbose flash methods based on element names.

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -43,6 +43,9 @@ class FlashComponent extends Component {
 	}
 
 	public function set($message, $element = null, array $params = array(), $key = 'flash') {
+		if ($message instanceof \Exception) {
+			$message = $message->getMessage();
+		}
 		$this->_writeFlash($message, 'info', $params + compact('element', 'key'));
 	}
 

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -32,6 +32,18 @@ class FlashComponent extends Component {
 	protected $_session;
 
 /**
+ * Default configuration
+ *
+ * @var array
+ */
+	protected $_defaultConfig = [
+		'key' => 'flash',
+		'element' => null,
+		'class' => 'info',
+		'params' => []
+	];
+
+/**
  * Constructor
  *
  * @param ComponentRegistry $collection A ComponentRegistry for this component
@@ -42,21 +54,19 @@ class FlashComponent extends Component {
 		$this->_session = $collection->getController()->request->session();
 	}
 
-	public function set($message, $element = null, array $params = array(), $key = 'flash') {
+	public function set($message, array $options = []) {
+		$opts = array_merge($this->_defaultConfig, $options);
+
 		if ($message instanceof \Exception) {
 			$message = $message->getMessage();
 		}
-		$this->_writeFlash($message, 'info', $params + compact('element', 'key'));
-	}
 
-	protected function _writeFlash($message, $type = 'info', $options = []) {
-		$options += ['key' => 'flash'];
-		$key = $options['key'];
-		unset($options['key']);
-		$this->_session->write("Message.$key", [
+		$this->_session->write("Message.{$opts['key']}", [
 			'message' => $message,
-			'type' => $type,
-			'params' => $options
+			'key' => $opts['key'],
+			'element' => $opts['element'],
+			'class' => $opts['class'],
+			'params' => $opts['params']
 		]);
 	}
 }

--- a/src/Controller/Component/FlashComponent.php
+++ b/src/Controller/Component/FlashComponent.php
@@ -69,4 +69,18 @@ class FlashComponent extends Component {
 			'params' => $opts['params']
 		]);
 	}
+
+	public function __call($name, $args) {
+		$options = ['element' => 'flash_' . $name];
+
+		if (count($args) < 1) {
+			throw new InternalErrorException('Flash message missing.');
+		}
+
+		if (!empty($args[1])) {
+			$options += (array)$args[1];
+		}
+
+		$this->set($args[0], $options);
+	}
 }

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -67,13 +67,12 @@ class FlashHelper extends Helper {
  * echo $this->Flash->out('flash', [element' => 'my_custom_element']);
  * }}}
  *
- * If you want to use an element from a plugin for rendering your flash message you can do that using the
- * plugin param:
+ * If you want to use an element from a plugin for rendering your flash message
+ * you can use the dot notation for the plugin's element name:
  *
  * {{{
- * echo $this->Session->flash('flash', [
- *   'element' => 'my_custom_element',
- *   'params' => ['plugin' => 'my_plugin'])
+ * echo $this->Flash->out('flash', [
+ *   'element' => 'MyPlugin.my_custom_element',
  * ]);
  * }}}
  *

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -42,7 +42,7 @@ class FlashHelper extends Helper {
  * This would pass the current user's name into the flash message, so you could create personalized
  * messages without the controller needing access to that data.
  *
- * Lastly you can choose the element that is rendered when rendering the flash message. Using
+ * Lastly you can choose the element that is used for rendering the flash message. Using
  * custom elements allows you to fully customize how flash messages are generated.
  *
  * {{{

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -26,19 +26,6 @@ use Cake\View\View;
  */
 class FlashHelper extends Helper {
 
-	use StringTemplateTrait;
-
-/**
- * Default config for this class
- *
- * @var array
- */
-	protected $_defaultConfig = [
-		'templates' => [
-			'flash' => '<div id="{{key}}-message" class="message-{{class}}">{{message}}</div>'
-		]
-	];
-
 /**
  * Used to render the message set in FlashComponent::set()
  *
@@ -95,11 +82,7 @@ class FlashHelper extends Helper {
 		$flash = array_merge($flash, $attrs);
 
 		if ($flash['element'] === null) {
-			return $this->formatTemplate('flash', [
-				'key' => $key,
-				'class' => $flash['class'],
-				'message' => $flash['message']
-			]);
+			return $flash['message'];
 		}
 
 		return $this->_View->element($flash['element'], $flash);

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -67,11 +67,11 @@ class FlashHelper extends Helper {
  * }}}
  *
  * @param string $key The [Message.]key you are rendering in the view.
- * @param array $attrs Additional attributes to use for the creation of this flash message.
+ * @param array $options Additional options to use for the creation of this flash message.
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
  */
-	public function render($key = 'flash', $attrs = []) {
+	public function render($key = 'flash', $options = []) {
 		$flash = $this->request->session()->read("Message.$key");
 		$this->request->session()->delete("Message.$key");
 
@@ -79,7 +79,7 @@ class FlashHelper extends Helper {
 			return '';
 		}
 
-		$flash = array_merge($flash, $attrs);
+		$flash = array_merge($flash, $options);
 
 		if ($flash['element'] === null) {
 			return $flash['message'];

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -39,14 +39,14 @@ class FlashHelper extends Helper {
 /**
  * Used to render the message set in FlashCompnet::set()
  *
- * In your view: $this->Flash->out('somekey');
+ * In your view: $this->Flash->render('somekey');
  * Will default to flash if no param is passed
  *
  * You can pass additional information into the flash message generation. This allows you
  * to consolidate all the parameters for a given type of flash message into the view.
  *
  * {{{
- * echo $this->Flash->out('flash', ['class' => 'new-flash']);
+ * echo $this->Flash->render('flash', ['class' => 'new-flash']);
  * }}}
  *
  * The above would generate a flash message with a custom class name. Using $attrs['params'] you
@@ -54,7 +54,7 @@ class FlashHelper extends Helper {
  * when the element is rendered:
  *
  * {{{
- * echo $this->Flash->out('flash', ['params' => ['name' => $user['User']['name']]]);
+ * echo $this->Flash->render('flash', ['params' => ['name' => $user['User']['name']]]);
  * }}}
  *
  * This would pass the current user's name into the flash message, so you could create personalized
@@ -64,14 +64,14 @@ class FlashHelper extends Helper {
  * custom elements allows you to fully customize how flash messages are generated.
  *
  * {{{
- * echo $this->Flash->out('flash', [element' => 'my_custom_element']);
+ * echo $this->Flash->render('flash', [element' => 'my_custom_element']);
  * }}}
  *
  * If you want to use an element from a plugin for rendering your flash message
  * you can use the dot notation for the plugin's element name:
  *
  * {{{
- * echo $this->Flash->out('flash', [
+ * echo $this->Flash->render('flash', [
  *   'element' => 'MyPlugin.my_custom_element',
  * ]);
  * }}}
@@ -81,7 +81,7 @@ class FlashHelper extends Helper {
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
  */
-	public function out($key = 'flash', $attrs = []) {
+	public function render($key = 'flash', $attrs = []) {
 		$flash = $this->request->session()->read("Message.$key");
 		$this->request->session()->delete("Message.$key");
 

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -58,14 +58,14 @@ class FlashHelper extends Helper {
  * ]);
  * }}}
  *
- * @param string $key The [Message.]key you are rendering in the view.
+ * @param string $key The [Flash.]key you are rendering in the view.
  * @param array $options Additional options to use for the creation of this flash message.
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
  */
 	public function render($key = 'flash', array $options = []) {
-		$flash = $this->request->session()->read("Message.$key");
-		$this->request->session()->delete("Message.$key");
+		$flash = $this->request->session()->read("Flash.$key");
+		$this->request->session()->delete("Flash.$key");
 
 		if (!$flash) {
 			return '';

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -19,7 +19,10 @@ use Cake\View\Helper;
 use Cake\View\View;
 
 /**
- * FlashHelper
+ * FlashHelper class to render flash messages.
+ *
+ * After setting messsages in your controllers with FlashComponent, you can use
+ * this class to output your flash messages in your views.
  */
 class FlashHelper extends Helper {
 
@@ -37,7 +40,7 @@ class FlashHelper extends Helper {
 	];
 
 /**
- * Used to render the message set in FlashCompnet::set()
+ * Used to render the message set in FlashComponent::set()
  *
  * In your view: $this->Flash->render('somekey');
  * Will default to flash if no param is passed

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -25,12 +25,63 @@ class FlashHelper extends Helper {
 
 	use StringTemplateTrait;
 
+/**
+ * Default config for this class
+ *
+ * @var array
+ */
 	protected $_defaultConfig = [
 		'templates' => [
 			'flash' => '<div id="{{key}}-message" class="message-{{class}}">{{message}}</div>'
 		]
 	];
 
+/**
+ * Used to render the message set in FlashCompnet::set()
+ *
+ * In your view: $this->Flash->out('somekey');
+ * Will default to flash if no param is passed
+ *
+ * You can pass additional information into the flash message generation. This allows you
+ * to consolidate all the parameters for a given type of flash message into the view.
+ *
+ * {{{
+ * echo $this->Flash->out('flash', ['class' => 'new-flash']);
+ * }}}
+ *
+ * The above would generate a flash message with a custom class name. Using $attrs['params'] you
+ * can pass additional data into the element rendering that will be made available as local variables
+ * when the element is rendered:
+ *
+ * {{{
+ * echo $this->Flash->out('flash', ['params' => ['name' => $user['User']['name']]]);
+ * }}}
+ *
+ * This would pass the current user's name into the flash message, so you could create personalized
+ * messages without the controller needing access to that data.
+ *
+ * Lastly you can choose the element that is rendered when creating the flash message. Using
+ * custom elements allows you to fully customize how flash messages are generated.
+ *
+ * {{{
+ * echo $this->Flash->out('flash', [element' => 'my_custom_element']);
+ * }}}
+ *
+ * If you want to use an element from a plugin for rendering your flash message you can do that using the
+ * plugin param:
+ *
+ * {{{
+ * echo $this->Session->flash('flash', [
+ *   'element' => 'my_custom_element',
+ *   'params' => ['plugin' => 'my_plugin'])
+ * ]);
+ * }}}
+ *
+ * @param string $key The [Message.]key you are rendering in the view.
+ * @param array $attrs Additional attributes to use for the creation of this flash message.
+ *    Supports the 'params', and 'element' keys that are used in the helper.
+ * @return string
+ */
 	public function out($key = 'flash', $attrs = []) {
 		$flash = $this->request->session()->read("Message.$key");
 		$this->request->session()->delete("Message.$key");

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\View\Helper;
+
+use Cake\Network\Session;
+use Cake\View\Helper;
+use Cake\View\View;
+
+/**
+ * FlashHelper
+ */
+class FlashHelper extends Helper {
+
+	use StringTemplateTrait;
+
+	protected $_defaultConfig = [
+		'templates' => [
+			'flash' => '<div id="{{key}}-message" class="message-{{class}}">{{message}}</div>'
+		]
+	];
+
+	public function out($key = 'flash', $attrs = []) {
+		$flash = $this->request->session()->read("Message.$key");
+		$this->request->session()->delete("Message.$key");
+
+		if (!$flash) {
+			return '';
+		}
+
+		if (!empty($attrs)) {
+			$flash = array_merge($flash, $attrs);
+		}
+
+		$message = $flash['message'];
+		$class = $flash['type'];
+		$params = $flash['params'];
+
+		if (isset($flash['element'])) {
+			$params['element'] = $flash['element'];
+		}
+
+		if (empty($params['element'])) {
+			if (!empty($flash['class'])) {
+				$class = $flash['class'];
+			}
+			return $this->formatTemplate('flash', [
+				'class' => $class,
+				'key' => $key,
+				'message' => $message
+			]);
+		}
+
+		$params['message'] = $message;
+		$params['type'] = $class;
+
+		return $this->_View->element($params['element'], $params);
+	}
+
+/**
+ * Event listeners.
+ *
+ * @return array
+ */
+	public function implementedEvents() {
+		return [];
+	}
+}

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -39,33 +39,17 @@ class FlashHelper extends Helper {
 			return '';
 		}
 
-		if (!empty($attrs)) {
-			$flash = array_merge($flash, $attrs);
-		}
+		$flash = array_merge($flash, $attrs);
 
-		$message = $flash['message'];
-		$class = $flash['type'];
-		$params = $flash['params'];
-
-		if (isset($flash['element'])) {
-			$params['element'] = $flash['element'];
-		}
-
-		if (empty($params['element'])) {
-			if (!empty($flash['class'])) {
-				$class = $flash['class'];
-			}
+		if ($flash['element'] === null) {
 			return $this->formatTemplate('flash', [
-				'class' => $class,
 				'key' => $key,
-				'message' => $message
+				'class' => $flash['class'],
+				'message' => $flash['message']
 			]);
 		}
 
-		$params['message'] = $message;
-		$params['type'] = $class;
-
-		return $this->_View->element($params['element'], $params);
+		return $this->_View->element($flash['element'], $flash);
 	}
 
 /**

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -36,21 +36,13 @@ class FlashHelper extends Helper {
  * to consolidate all the parameters for a given type of flash message into the view.
  *
  * {{{
- * echo $this->Flash->render('flash', ['class' => 'new-flash']);
- * }}}
- *
- * The above would generate a flash message with a custom class name. Using $attrs['params'] you
- * can pass additional data into the element rendering that will be made available as local variables
- * when the element is rendered:
- *
- * {{{
  * echo $this->Flash->render('flash', ['params' => ['name' => $user['User']['name']]]);
  * }}}
  *
  * This would pass the current user's name into the flash message, so you could create personalized
  * messages without the controller needing access to that data.
  *
- * Lastly you can choose the element that is rendered when creating the flash message. Using
+ * Lastly you can choose the element that is rendered when rendering the flash message. Using
  * custom elements allows you to fully customize how flash messages are generated.
  *
  * {{{
@@ -71,7 +63,7 @@ class FlashHelper extends Helper {
  *    Supports the 'params', and 'element' keys that are used in the helper.
  * @return string
  */
-	public function render($key = 'flash', $options = []) {
+	public function render($key = 'flash', array $options = []) {
 		$flash = $this->request->session()->read("Message.$key");
 		$this->request->session()->delete("Message.$key");
 
@@ -79,7 +71,7 @@ class FlashHelper extends Helper {
 			return '';
 		}
 
-		$flash = array_merge($flash, $options);
+		$flash = $options + $flash;
 
 		if ($flash['element'] === null) {
 			return $flash['message'];

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -96,22 +96,46 @@ class FlashComponentTest extends TestCase {
 		$this->assertNull($this->Session->read('Message.flash'));
 
 		$this->Flash->set('This is a test message');
-		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => null,
+			'class' => 'info',
+			'params' => []
+		];
 		$result = $this->Session->read('Message.flash');
 		$this->assertEquals($expected, $result);
 
-		$this->Flash->set('This is a test message', 'test', ['foo' => 'bar']);
-		$expected = ['message' => 'This is a test message','params' => ['foo' => 'bar', 'element' => 'test'], 'type' => 'info'];
+		$this->Flash->set('This is a test message', ['element' => 'test', 'params' => ['foo' => 'bar']]);
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'test',
+			'class' => 'info',
+			'params' => ['foo' => 'bar']
+		];
 		$result = $this->Session->read('Message.flash');
 		$this->assertEquals($expected, $result);
 
-		$this->Flash->set('This is a test message', 'MyPlugin.alert');
-		$expected = ['message' => 'This is a test message', 'params' => ['element' => 'MyPlugin.alert'], 'type' => 'info'];
+		$this->Flash->set('This is a test message', ['element' => 'MyPlugin.alert']);
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => 'MyPlugin.alert',
+			'class' => 'info',
+			'params' => []
+		];
 		$result = $this->Session->read('Message.flash');
 		$this->assertEquals($expected, $result);
 
-		$this->Flash->set('This is a test message', null, [], 'foobar');
-		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$this->Flash->set('This is a test message', ['key' => 'foobar']);
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'foobar',
+			'element' => null,
+			'class' => 'info',
+			'params' => []
+		];
 		$result = $this->Session->read('Message.foobar');
 		$this->assertEquals($expected, $result);
 	}
@@ -126,7 +150,13 @@ class FlashComponentTest extends TestCase {
 		$this->assertNull($this->Session->read('Message.flash'));
 
 		$this->Flash->set(new \Exception('This is a test message'));
-		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$expected = [
+			'message' => 'This is a test message',
+			'key' => 'flash',
+			'element' => null,
+			'class' => 'info',
+			'params' => []
+		];
 		$result = $this->Session->read('Message.flash');
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Controller\Component;
+
+use Cake\Controller\ComponentRegistry;
+use Cake\Controller\Component\FlashComponent;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Network\Request;
+use Cake\Event\Event;
+use Cake\Network\Session;
+use Cake\TestSuite\TestCase;
+
+/**
+ * FlashComponentTest class
+ *
+ */
+class FlashComponentTest extends TestCase {
+
+	protected static $_sessionBackup;
+
+/**
+ * fixtures
+ *
+ * @var string
+ */
+	public $fixtures = array('core.session');
+
+/**
+ * test case startup
+ *
+ * @return void
+ */
+	public static function setupBeforeClass() {
+		static::$_sessionBackup = Configure::read('Session');
+		Configure::write('Session', array(
+			'defaults' => 'php',
+			'timeout' => 100,
+			'cookie' => 'test'
+		));
+	}
+
+/**
+ * cleanup after test case.
+ *
+ * @return void
+ */
+	public static function teardownAfterClass() {
+		Configure::write('Session', static::$_sessionBackup);
+	}
+
+/**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$_SESSION = [];
+		Configure::write('App.namespace', 'TestApp');
+		$controller = new Controller(new Request(['session' => new Session()]));
+		$this->ComponentRegistry = new ComponentRegistry($controller);
+		$this->Flash = new FlashComponent($this->ComponentRegistry);
+		$this->Session = new Session();
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		$this->Session->destroy();
+	}
+
+/**
+ * testSet method
+ *
+ * @return void
+ * @covers \Cake\Controller\Component\FlashComponent::set
+ */
+	public function testSet() {
+		$this->assertNull($this->Session->read('Message.flash'));
+
+		$this->Flash->set('This is a test message');
+		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$result = $this->Session->read('Message.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', 'test', ['foo' => 'bar']);
+		$expected = ['message' => 'This is a test message','params' => ['foo' => 'bar', 'element' => 'test'], 'type' => 'info'];
+		$result = $this->Session->read('Message.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', 'MyPlugin.alert');
+		$expected = ['message' => 'This is a test message', 'params' => ['element' => 'MyPlugin.alert'], 'type' => 'info'];
+		$result = $this->Session->read('Message.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('This is a test message', null, [], 'foobar');
+		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$result = $this->Session->read('Message.foobar');
+		$this->assertEquals($expected, $result);
+	}
+}

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -29,38 +29,6 @@ use Cake\TestSuite\TestCase;
  */
 class FlashComponentTest extends TestCase {
 
-	protected static $_sessionBackup;
-
-/**
- * fixtures
- *
- * @var string
- */
-	public $fixtures = array('core.session');
-
-/**
- * test case startup
- *
- * @return void
- */
-	public static function setupBeforeClass() {
-		static::$_sessionBackup = Configure::read('Session');
-		Configure::write('Session', array(
-			'defaults' => 'php',
-			'timeout' => 100,
-			'cookie' => 'test'
-		));
-	}
-
-/**
- * cleanup after test case.
- *
- * @return void
- */
-	public static function teardownAfterClass() {
-		Configure::write('Session', static::$_sessionBackup);
-	}
-
 /**
  * setUp method
  *
@@ -68,7 +36,6 @@ class FlashComponentTest extends TestCase {
  */
 	public function setUp() {
 		parent::setUp();
-		$_SESSION = [];
 		Configure::write('App.namespace', 'TestApp');
 		$controller = new Controller(new Request(['session' => new Session()]));
 		$this->ComponentRegistry = new ComponentRegistry($controller);

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -137,36 +137,6 @@ class FlashComponentTest extends TestCase {
 	}
 
 /**
- * testSetWithEscape method
- *
- * @return void
- * @covers \Cake\Controller\Component\FlashComponent::set
- */
-	public function testSetWithEscape() {
-		$this->assertNull($this->Session->read('Message.flash'));
-
-		$this->Flash->set('Hello <b>Beakman</b>!');
-		$expected = [
-			'message' => 'Hello &lt;b&gt;Beakman&lt;/b&gt;!',
-			'key' => 'flash',
-			'element' => null,
-			'params' => []
-		];
-		$result = $this->Session->read('Message.flash');
-		$this->assertEquals($expected, $result);
-
-		$this->Flash->set('Hello <b>Beakman</b>!', ['escape' => false]);
-		$expected = [
-			'message' => 'Hello <b>Beakman</b>!',
-			'key' => 'flash',
-			'element' => null,
-			'params' => []
-		];
-		$result = $this->Session->read('Message.flash');
-		$this->assertEquals($expected, $result);
-	}
-
-/**
  * testSetWithException method
  *
  * @return void

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -115,4 +115,19 @@ class FlashComponentTest extends TestCase {
 		$result = $this->Session->read('Message.foobar');
 		$this->assertEquals($expected, $result);
 	}
+
+/**
+ * testSetWithException method
+ *
+ * @return void
+ * @covers \Cake\Controller\Component\FlashComponent::set
+ */
+	public function testSetWithException() {
+		$this->assertNull($this->Session->read('Message.flash'));
+
+		$this->Flash->set(new \Exception('This is a test message'));
+		$expected = ['message' => 'This is a test message', 'params' => ['element' => null], 'type' => 'info'];
+		$result = $this->Session->read('Message.flash');
+		$this->assertEquals($expected, $result);
+	}
 }

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -76,7 +76,7 @@ class FlashComponentTest extends TestCase {
 		$expected = [
 			'message' => 'This is a test message',
 			'key' => 'flash',
-			'element' => 'test',
+			'element' => 'Flash/test',
 			'params' => ['foo' => 'bar']
 		];
 		$result = $this->Session->read('Flash.flash');
@@ -86,7 +86,7 @@ class FlashComponentTest extends TestCase {
 		$expected = [
 			'message' => 'This is a test message',
 			'key' => 'flash',
-			'element' => 'MyPlugin.alert',
+			'element' => 'MyPlugin.Flash/alert',
 			'params' => []
 		];
 		$result = $this->Session->read('Flash.flash');

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -100,7 +100,6 @@ class FlashComponentTest extends TestCase {
 			'message' => 'This is a test message',
 			'key' => 'flash',
 			'element' => null,
-			'class' => 'info',
 			'params' => []
 		];
 		$result = $this->Session->read('Message.flash');
@@ -111,7 +110,6 @@ class FlashComponentTest extends TestCase {
 			'message' => 'This is a test message',
 			'key' => 'flash',
 			'element' => 'test',
-			'class' => 'info',
 			'params' => ['foo' => 'bar']
 		];
 		$result = $this->Session->read('Message.flash');
@@ -122,7 +120,6 @@ class FlashComponentTest extends TestCase {
 			'message' => 'This is a test message',
 			'key' => 'flash',
 			'element' => 'MyPlugin.alert',
-			'class' => 'info',
 			'params' => []
 		];
 		$result = $this->Session->read('Message.flash');
@@ -133,10 +130,39 @@ class FlashComponentTest extends TestCase {
 			'message' => 'This is a test message',
 			'key' => 'foobar',
 			'element' => null,
-			'class' => 'info',
 			'params' => []
 		];
 		$result = $this->Session->read('Message.foobar');
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testSetWithEscape method
+ *
+ * @return void
+ * @covers \Cake\Controller\Component\FlashComponent::set
+ */
+	public function testSetWithEscape() {
+		$this->assertNull($this->Session->read('Message.flash'));
+
+		$this->Flash->set('Hello <b>Beakman</b>!');
+		$expected = [
+			'message' => 'Hello &lt;b&gt;Beakman&lt;/b&gt;!',
+			'key' => 'flash',
+			'element' => null,
+			'params' => []
+		];
+		$result = $this->Session->read('Message.flash');
+		$this->assertEquals($expected, $result);
+
+		$this->Flash->set('Hello <b>Beakman</b>!', ['escape' => false]);
+		$expected = [
+			'message' => 'Hello <b>Beakman</b>!',
+			'key' => 'flash',
+			'element' => null,
+			'params' => []
+		];
+		$result = $this->Session->read('Message.flash');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -154,7 +180,6 @@ class FlashComponentTest extends TestCase {
 			'message' => 'This is a test message',
 			'key' => 'flash',
 			'element' => null,
-			'class' => 'info',
 			'params' => []
 		];
 		$result = $this->Session->read('Message.flash');

--- a/tests/TestCase/Controller/Component/FlashComponentTest.php
+++ b/tests/TestCase/Controller/Component/FlashComponentTest.php
@@ -60,7 +60,7 @@ class FlashComponentTest extends TestCase {
  * @covers \Cake\Controller\Component\FlashComponent::set
  */
 	public function testSet() {
-		$this->assertNull($this->Session->read('Message.flash'));
+		$this->assertNull($this->Session->read('Flash.flash'));
 
 		$this->Flash->set('This is a test message');
 		$expected = [
@@ -69,7 +69,7 @@ class FlashComponentTest extends TestCase {
 			'element' => null,
 			'params' => []
 		];
-		$result = $this->Session->read('Message.flash');
+		$result = $this->Session->read('Flash.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', ['element' => 'test', 'params' => ['foo' => 'bar']]);
@@ -79,7 +79,7 @@ class FlashComponentTest extends TestCase {
 			'element' => 'test',
 			'params' => ['foo' => 'bar']
 		];
-		$result = $this->Session->read('Message.flash');
+		$result = $this->Session->read('Flash.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', ['element' => 'MyPlugin.alert']);
@@ -89,7 +89,7 @@ class FlashComponentTest extends TestCase {
 			'element' => 'MyPlugin.alert',
 			'params' => []
 		];
-		$result = $this->Session->read('Message.flash');
+		$result = $this->Session->read('Flash.flash');
 		$this->assertEquals($expected, $result);
 
 		$this->Flash->set('This is a test message', ['key' => 'foobar']);
@@ -99,7 +99,7 @@ class FlashComponentTest extends TestCase {
 			'element' => null,
 			'params' => []
 		];
-		$result = $this->Session->read('Message.foobar');
+		$result = $this->Session->read('Flash.foobar');
 		$this->assertEquals($expected, $result);
 	}
 
@@ -110,7 +110,7 @@ class FlashComponentTest extends TestCase {
  * @covers \Cake\Controller\Component\FlashComponent::set
  */
 	public function testSetWithException() {
-		$this->assertNull($this->Session->read('Message.flash'));
+		$this->assertNull($this->Session->read('Flash.flash'));
 
 		$this->Flash->set(new \Exception('This is a test message'));
 		$expected = [
@@ -119,7 +119,7 @@ class FlashComponentTest extends TestCase {
 			'element' => null,
 			'params' => []
 		];
-		$result = $this->Session->read('Message.flash');
+		$result = $this->Session->read('Flash.flash');
 		$this->assertEquals($expected, $result);
 	}
 }

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -146,8 +146,8 @@ class FlashHelperTest extends TestCase {
 	public function testFlashWithPluginElement() {
 		Plugin::load('TestPlugin');
 
-		$result = $this->Flash->render('flash', array('element' => 'TestPlugin.plugin_element'));
-		$expected = 'this is the plugin element using params[plugin]';
+		$result = $this->Flash->render('flash', array('element' => 'TestPlugin.Flash/plugin_element'));
+		$expected = 'this is the plugin element';
 		$this->assertEquals($expected, $result);
 	}
 }

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * CakePHP(tm) Tests <http://book.cakephp.org/2.0/en/development/testing.html>
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
+ * @since         1.2.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\View\Helper;
+
+use Cake\Controller\Controller;
+use Cake\Core\App;
+use Cake\Core\Plugin;
+use Cake\Network\Request;
+use Cake\Network\Session;
+use Cake\TestSuite\TestCase;
+use Cake\View\Helper\FlashHelper;
+use Cake\View\View;
+
+/**
+ * FlashHelperTest class
+ *
+ */
+class FlashHelperTest extends TestCase {
+
+/**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->View = new View();
+		$session = new Session();
+		$this->View->request = new Request(['session' => $session]);
+		$this->Flash = new FlashHelper($this->View);
+
+		$session->write(array(
+			'Message' => array(
+				'flash' => array(
+					'type' => 'info',
+					'params' => array(),
+					'message' => 'This is a calling'
+				),
+				'notification' => array(
+					'type' => 'info',
+					'params' => array(
+						'title' => 'Notice!',
+						'name' => 'Alert!',
+						'element' => 'session_helper'
+					),
+					'message' => 'This is a test of the emergency broadcasting system',
+				),
+				'classy' => array(
+					'type' => 'success',
+					'params' => array('class' => 'positive'),
+					'message' => 'Recorded'
+				)
+			)
+		));
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
+		$_SESSION = [];
+		unset($this->View, $this->Session);
+		Plugin::unload();
+		parent::tearDown();
+	}
+
+/**
+ * testFlash method
+ *
+ * @return void
+ */
+	public function testFlash() {
+		$result = $this->Flash->out();
+		$expected = '<div id="flash-message" class="message-info">This is a calling</div>';
+		$this->assertEquals($expected, $result);
+
+		$expected = '<div id="classy-message" class="message-success">Recorded</div>';
+		$result = $this->Flash->out('classy');
+		$this->assertEquals($expected, $result);
+
+		$result = $this->Flash->out('notification');
+		$result = str_replace("\r\n", "\n", $result);
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test flash() with the attributes.
+ *
+ * @return void
+ */
+	public function testFlashAttributes() {
+		$result = $this->Flash->out('flash', array('class' => 'crazy'));
+		$expected = '<div id="flash-message" class="message-crazy">This is a calling</div>';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * test setting the element from the attrs.
+ *
+ * @return void
+ */
+	public function testFlashElementInAttrs() {
+		$result = $this->Flash->out('flash', array(
+			'element' => 'session_helper',
+			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
+		));
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a calling</p>\n</div>";
+		$this->assertTextEquals($expected, $result);
+	}
+
+/**
+ * test using elements in plugins.
+ *
+ * @return void
+ */
+	public function testFlashWithPluginElement() {
+		Plugin::load('TestPlugin');
+
+		$result = $this->Flash->out('flash', array('element' => 'TestPlugin.plugin_element'));
+		$expected = 'this is the plugin element using params[plugin]';
+		$this->assertEquals($expected, $result);
+	}
+}

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -98,9 +98,27 @@ class FlashHelperTest extends TestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Flash->render('notification');
-		$result = str_replace("\r\n", "\n", $result);
-		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
-		$this->assertEquals($expected, $result);
+		
+		$children = [
+			['tag' => 'h1', 'content' => 'Alert!'],
+			['tag' => 'h3', 'content' => 'Notice!'],
+			['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system']
+		];
+
+		$expected = [
+			'tag' => 'div',
+			'id' => 'notificationLayout',
+			'child' => []
+		];
+
+		$expected['child'] = ['tag' => 'h1', 'content' => 'Alert!'];
+		$this->assertTag($expected, $result);
+
+		$expected['child'] = ['tag' => 'h3', 'content' => 'Notice!'];
+		$this->assertTag($expected, $result);
+
+		$expected['child'] = ['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system'];
+		$this->assertTag($expected, $result);
 	}
 
 /**
@@ -124,8 +142,27 @@ class FlashHelperTest extends TestCase {
 			'element' => 'flash_helper',
 			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
 		));
-		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
-		$this->assertTextEquals($expected, $result);
+
+		$children = [
+			['tag' => 'h1', 'content' => 'Alert!'],
+			['tag' => 'h3', 'content' => 'Notice!'],
+			['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system']
+		];
+
+		$expected = [
+			'tag' => 'div',
+			'id' => 'notificationLayout',
+			'child' => []
+		];
+
+		$expected['child'] = ['tag' => 'h1', 'content' => 'Alert!'];
+		$this->assertTag($expected, $result);
+
+		$expected['child'] = ['tag' => 'h3', 'content' => 'Notice!'];
+		$this->assertTag($expected, $result);
+
+		$expected['child'] = ['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system'];
+		$this->assertTag($expected, $result);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -44,23 +44,28 @@ class FlashHelperTest extends TestCase {
 		$session->write(array(
 			'Message' => array(
 				'flash' => array(
-					'type' => 'info',
-					'params' => array(),
-					'message' => 'This is a calling'
+					'key' => 'flash',
+					'message' => 'This is a calling',
+					'element' => null,
+					'class' => 'info',
+					'params' => array()
 				),
 				'notification' => array(
-					'type' => 'info',
+					'key' => 'notification',
+					'message' => 'This is a test of the emergency broadcasting system',
+					'element' => 'flash_helper',
+					'class' => 'info',
 					'params' => array(
 						'title' => 'Notice!',
-						'name' => 'Alert!',
-						'element' => 'session_helper'
-					),
-					'message' => 'This is a test of the emergency broadcasting system',
+						'name' => 'Alert!'
+					)
 				),
 				'classy' => array(
-					'type' => 'success',
-					'params' => array('class' => 'positive'),
-					'message' => 'Recorded'
+					'key' => 'classy',
+					'message' => 'Recorded',
+					'element' => null,
+					'class' => 'positive',
+					'params' => array()
 				)
 			)
 		));
@@ -88,7 +93,7 @@ class FlashHelperTest extends TestCase {
 		$expected = '<div id="flash-message" class="message-info">This is a calling</div>';
 		$this->assertEquals($expected, $result);
 
-		$expected = '<div id="classy-message" class="message-success">Recorded</div>';
+		$expected = '<div id="classy-message" class="message-positive">Recorded</div>';
 		$result = $this->Flash->out('classy');
 		$this->assertEquals($expected, $result);
 
@@ -115,11 +120,11 @@ class FlashHelperTest extends TestCase {
  * @return void
  */
 	public function testFlashElementInAttrs() {
-		$result = $this->Flash->out('flash', array(
-			'element' => 'session_helper',
+		$result = $this->Flash->out('notification', array(
+			'element' => 'flash_helper',
 			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
 		));
-		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a calling</p>\n</div>";
+		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
 		$this->assertTextEquals($expected, $result);
 	}
 

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -9,7 +9,7 @@
  *
  * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
- * @since         1.2.0
+ * @since         3.0.0
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 namespace Cake\Test\TestCase\View\Helper;

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -89,15 +89,15 @@ class FlashHelperTest extends TestCase {
  * @return void
  */
 	public function testFlash() {
-		$result = $this->Flash->out();
+		$result = $this->Flash->render();
 		$expected = '<div id="flash-message" class="message-info">This is a calling</div>';
 		$this->assertEquals($expected, $result);
 
 		$expected = '<div id="classy-message" class="message-positive">Recorded</div>';
-		$result = $this->Flash->out('classy');
+		$result = $this->Flash->render('classy');
 		$this->assertEquals($expected, $result);
 
-		$result = $this->Flash->out('notification');
+		$result = $this->Flash->render('notification');
 		$result = str_replace("\r\n", "\n", $result);
 		$expected = "<div id=\"notificationLayout\">\n\t<h1>Alert!</h1>\n\t<h3>Notice!</h3>\n\t<p>This is a test of the emergency broadcasting system</p>\n</div>";
 		$this->assertEquals($expected, $result);
@@ -109,7 +109,7 @@ class FlashHelperTest extends TestCase {
  * @return void
  */
 	public function testFlashAttributes() {
-		$result = $this->Flash->out('flash', array('class' => 'crazy'));
+		$result = $this->Flash->render('flash', array('class' => 'crazy'));
 		$expected = '<div id="flash-message" class="message-crazy">This is a calling</div>';
 		$this->assertEquals($expected, $result);
 	}
@@ -120,7 +120,7 @@ class FlashHelperTest extends TestCase {
  * @return void
  */
 	public function testFlashElementInAttrs() {
-		$result = $this->Flash->out('notification', array(
+		$result = $this->Flash->render('notification', array(
 			'element' => 'flash_helper',
 			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
 		));
@@ -136,7 +136,7 @@ class FlashHelperTest extends TestCase {
 	public function testFlashWithPluginElement() {
 		Plugin::load('TestPlugin');
 
-		$result = $this->Flash->out('flash', array('element' => 'TestPlugin.plugin_element'));
+		$result = $this->Flash->render('flash', array('element' => 'TestPlugin.plugin_element'));
 		$expected = 'this is the plugin element using params[plugin]';
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -42,7 +42,7 @@ class FlashHelperTest extends TestCase {
 		$this->Flash = new FlashHelper($this->View);
 
 		$session->write(array(
-			'Message' => array(
+			'Flash' => array(
 				'flash' => array(
 					'key' => 'flash',
 					'message' => 'This is a calling',

--- a/tests/TestCase/View/Helper/FlashHelperTest.php
+++ b/tests/TestCase/View/Helper/FlashHelperTest.php
@@ -47,14 +47,12 @@ class FlashHelperTest extends TestCase {
 					'key' => 'flash',
 					'message' => 'This is a calling',
 					'element' => null,
-					'class' => 'info',
 					'params' => array()
 				),
 				'notification' => array(
 					'key' => 'notification',
 					'message' => 'This is a test of the emergency broadcasting system',
 					'element' => 'flash_helper',
-					'class' => 'info',
 					'params' => array(
 						'title' => 'Notice!',
 						'name' => 'Alert!'
@@ -63,8 +61,7 @@ class FlashHelperTest extends TestCase {
 				'classy' => array(
 					'key' => 'classy',
 					'message' => 'Recorded',
-					'element' => null,
-					'class' => 'positive',
+					'element' => 'flash_classy',
 					'params' => array()
 				)
 			)
@@ -90,21 +87,14 @@ class FlashHelperTest extends TestCase {
  */
 	public function testFlash() {
 		$result = $this->Flash->render();
-		$expected = '<div id="flash-message" class="message-info">This is a calling</div>';
+		$expected = 'This is a calling';
 		$this->assertEquals($expected, $result);
 
-		$expected = '<div id="classy-message" class="message-positive">Recorded</div>';
+		$expected = '<div id="classy-message">Recorded</div>';
 		$result = $this->Flash->render('classy');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Flash->render('notification');
-		
-		$children = [
-			['tag' => 'h1', 'content' => 'Alert!'],
-			['tag' => 'h3', 'content' => 'Notice!'],
-			['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system']
-		];
-
 		$expected = [
 			'tag' => 'div',
 			'id' => 'notificationLayout',
@@ -122,17 +112,6 @@ class FlashHelperTest extends TestCase {
 	}
 
 /**
- * test flash() with the attributes.
- *
- * @return void
- */
-	public function testFlashAttributes() {
-		$result = $this->Flash->render('flash', array('class' => 'crazy'));
-		$expected = '<div id="flash-message" class="message-crazy">This is a calling</div>';
-		$this->assertEquals($expected, $result);
-	}
-
-/**
  * test setting the element from the attrs.
  *
  * @return void
@@ -142,12 +121,6 @@ class FlashHelperTest extends TestCase {
 			'element' => 'flash_helper',
 			'params' => array('title' => 'Notice!', 'name' => 'Alert!')
 		));
-
-		$children = [
-			['tag' => 'h1', 'content' => 'Alert!'],
-			['tag' => 'h3', 'content' => 'Notice!'],
-			['tag' => 'p', 'content' => 'This is a test of the emergency broadcasting system']
-		];
 
 		$expected = [
 			'tag' => 'div',

--- a/tests/bake_compare/Controller/Actions.ctp
+++ b/tests/bake_compare/Controller/Actions.ctp
@@ -34,10 +34,10 @@
 		$bakeArticle = $this->BakeArticles->newEntity($this->request->data);
 		if ($this->request->is('post')) {
 			if ($this->BakeArticles->save($bakeArticle)) {
-				$this->Session->setFlash(__('The bake article has been saved.'));
+				$this->Flash->success('The bake article has been saved.');
 				return $this->redirect(['action' => 'index']);
 			} else {
-				$this->Session->setFlash(__('The bake article could not be saved. Please, try again.'));
+				$this->Flash->error('The bake article could not be saved. Please, try again.');
 			}
 		}
 		$bakeUsers = $this->BakeArticles->BakeUsers->find('list');
@@ -59,10 +59,10 @@
 		if ($this->request->is(['post', 'put'])) {
 			$bakeArticle = $this->BakeArticles->patchEntity($bakeArticle, $this->request->data);
 			if ($this->BakeArticles->save($bakeArticle)) {
-				$this->Session->setFlash(__('The bake article has been saved.'));
+				$this->Flash->success('The bake article has been saved.');
 				return $this->redirect(['action' => 'index']);
 			} else {
-				$this->Session->setFlash(__('The bake article could not be saved. Please, try again.'));
+				$this->Flash->error('The bake article could not be saved. Please, try again.');
 			}
 		}
 		$bakeUsers = $this->BakeArticles->BakeUsers->find('list');
@@ -81,9 +81,9 @@
 		$bakeArticle = $this->BakeArticles->get($id);
 		$this->request->allowMethod('post', 'delete');
 		if ($this->BakeArticles->delete($bakeArticle)) {
-			$this->Session->setFlash(__('The bake article has been deleted.'));
+			$this->Flash->success('The bake article has been deleted.');
 		} else {
-			$this->Session->setFlash(__('The bake article could not be deleted. Please, try again.'));
+			$this->Flash->error('The bake article could not be deleted. Please, try again.');
 		}
 		return $this->redirect(['action' => 'index']);
 	}

--- a/tests/test_app/Plugin/TestPlugin/Template/Element/Flash/plugin_element.ctp
+++ b/tests/test_app/Plugin/TestPlugin/Template/Element/Flash/plugin_element.ctp
@@ -1,0 +1,1 @@
+<?= 'this is the plugin element'; ?>

--- a/tests/test_app/TestApp/Template/Element/flash_classy.ctp
+++ b/tests/test_app/TestApp/Template/Element/flash_classy.ctp
@@ -1,0 +1,1 @@
+<div id="<?= $key ?>-message"><?= $message; ?></div>

--- a/tests/test_app/TestApp/Template/Element/flash_helper.ctp
+++ b/tests/test_app/TestApp/Template/Element/flash_helper.ctp
@@ -1,0 +1,5 @@
+<div id="notificationLayout">
+	<h1><?= $params['name']; ?></h1>
+	<h3><?= $params['title']; ?></h3>
+	<p><?= $message; ?></p>
+</div>


### PR DESCRIPTION
In a nutshell, this PR ports the existing flash functionality into a separate Component/Helper -- and is a follow-up to https://github.com/cakephp/cakephp/pull/3409 after digesting the feedback within.  In which, I largely agree with @jippi's comment.
- Different from the previous PR: logging stuff, default message string templates, static Session calls were all scratched, etc.
- Ported Session classes' flash handling into this Component/Helper
- Added ability to pass an exception as a flash message
- Condensed positional parameters into `$options` array
- Added `__call` magic method to set flash's element, for verbosity
- Kept the "when element === null" default string template around for the sake of the future of `cake.generic.css`
- Scratched the ability to set string templates, as these are better suited for elements, because after Cake's default output/css these will need to be customized to a CSS framework or a user's specifics needs -- to the point where defining all the HTML/tokens in a string template would become silly.

Up for discussion:  FlashComponent's `__call` could look for elements within `Template/Element/Flash` instead of a `flash_` prefix.

With these changes the following can be deprecated/removed:
- Cake\Network:Session::flash()
- Cake\Network:Session::readFlash()
- Cake\Network:Session::deleteFlash()
- Cake\Controller\Component\SessionComponent::setFlash()
- Cake\View\Helper\SessionHelper::flash()
