### PR TITLE
No truncate when drop table.

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -229,7 +229,9 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 				$db->begin();
 				$this->_setupTable($fixture, $db, $test->dropTables);
-				$fixture->truncate($db);
+				if (!$test->dropTables) {
+					$fixture->truncate($db);
+				}
 				$fixture->insert($db);
 				$db->commit();
 			}
@@ -274,7 +276,9 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 			}
 			$this->_setupTable($fixture, $db, $dropTables);
-			$fixture->truncate($db);
+			if (!$dropTables) {
+				$fixture->truncate($db);
+			}
 			$fixture->insert($db);
 		} else {
 			throw new UnexpectedValueException(__d('cake_dev', 'Referenced fixture class %s not found', $name));


### PR DESCRIPTION
It was made not to TRUNCATE When drop table in the test case. 

This is because it takes time to TRUNCATE In some environments, it is because the bottleneck of the execution time of the test. 

For example, in the instance of m3.medium Amazon RDS, which may take from 150 to 500ms TRUNCATE.

```
# db.m3.medium
mysql> truncate table foo;
Query OK, 0 rows affected (0.15 sec)

mysql> truncate table foo;
Query OK, 0 rows affected (0.32 sec)

mysql> truncate table foo;
Query OK, 0 rows affected (0.46 sec)

mysql> truncate table foo;
Query OK, 0 rows affected (0.49 sec)
```
