### PR TITLE
3.0 auth improvements

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -73,16 +73,12 @@ abstract class BaseAuthenticate {
 	protected $_passwordHasher;
 
 /**
- * Contains a key indicated whether or not the user authenticated by this class
+ * Whether or not the user authenticated by this class
  * requires their password to be rehashed with another algorithm.
  *
- * @var array
+ * @var bool
  */
-	protected $passwordInfo = [
-		'password' => null,
-		'needsRehash' => false
-	];
-
+	protected $_needsPasswordRehash = false;
 /**
  * Constructor
  *
@@ -140,8 +136,7 @@ abstract class BaseAuthenticate {
 				return false;
 			}
 
-			$this->_passwordInfo['password'] = $password;
-			$this->_passwordInfo['needsRehash'] = $hasher->needsRehash($hashedPassword);
+			$this->_needsPasswordRehash = $hasher->needsRehash($hashedPassword);
 			unset($result[$fields['password']]);
 		}
 
@@ -171,22 +166,7 @@ abstract class BaseAuthenticate {
  * @return bool
  */
 	public function needsPasswordRehash() {
-		return $this->_passwordInfo['needsRehash'];
-	}
-
-/**
- * Returns a freshly hashed password using the hashing alogrithm from the configured
- * password hasher. This method uses the plain password provided when successfully
- * authenticating the user.
- *
- * @return string
- * @throws \RuntimeException if no user has been authenticated using this object
- */
-	public function rehashPassword() {
-		if ($this->_passwordInfo['password'] === null) {
-			throw new \RuntimeException('No user has been authenticated using this provider');
-		}
-		return $this->passwordHasher()->hash($this->_passwordInfo['password']);
+		return $this->_needsPasswordRehash;
 	}
 
 /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -821,6 +821,6 @@ class AuthComponent extends Component {
  * @return \Cake\Auth\BaseAuthorize|null
  */
 	public function authorizationProvider() {
-		return $this->_authenticateProvider;
+		return $this->_authorizationProvider;
 	}
 }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -227,7 +227,7 @@ class AuthComponent extends Component {
  *
  * @var Cake\Auth\BaseAuthenticate
  */
-	protected $_authenticateProvider;
+	protected $_authenticationProvider;
 
 /**
  * The instance of the Authorize provider that was used to grant
@@ -740,7 +740,7 @@ class AuthComponent extends Component {
 		foreach ($this->_authenticateObjects as $auth) {
 			$result = $auth->authenticate($request, $response);
 			if (!empty($result) && is_array($result)) {
-				$this->_authenticateProvider = $auth;
+				$this->_authenticationProvider = $auth;
 				return $result;
 			}
 		}
@@ -809,8 +809,8 @@ class AuthComponent extends Component {
  *
  * @return \Cake\Auth\BaseAuthenticate|null
  */
-	public function loginProvider() {
-		return $this->_authenticateProvider;
+	public function authenticationProvider() {
+		return $this->_authenticationProvider;
 	}
 
 /**

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -221,6 +221,23 @@ class AuthComponent extends Component {
 	protected $_methods = array();
 
 /**
+ * The instance of the Authenticate provider that was used for
+ * successfully logging in the current user after calling `login()`
+ * in the same request
+ *
+ * @var Cake\Auth\BaseAuthenticate
+ */
+	protected $_authenticateProvider;
+
+/**
+ * The instance of the Authorize provider that was used to grant
+ * access to the current user to the url they are requesting.
+ *
+ * @var Cake\Auth\BaseAuthorize
+ */
+	protected $_authorizationProvider;
+
+/**
  * Initializes AuthComponent for use in the controller.
  *
  * @param Event $event The initialize event.
@@ -455,6 +472,7 @@ class AuthComponent extends Component {
 		}
 		foreach ($this->_authorizeObjects as $authorizer) {
 			if ($authorizer->authorize($user, $request) === true) {
+				$this->_authorizationProvider = $authorizer;
 				return true;
 			}
 		}
@@ -722,6 +740,7 @@ class AuthComponent extends Component {
 		foreach ($this->_authenticateObjects as $auth) {
 			$result = $auth->authenticate($request, $response);
 			if (!empty($result) && is_array($result)) {
+				$this->_authenticateProvider = $auth;
 				return $result;
 			}
 		}
@@ -783,4 +802,25 @@ class AuthComponent extends Component {
 		$this->session->flash($message, 'error', $params + compact('key'));
 	}
 
+/**
+ * If login was called during this request and the suer was successfully
+ * authenticated, this function will return the instance of the authentication
+ * object that was used for logging the user in.
+ *
+ * @return \Cake\Auth\BaseAuthenticate|null
+ */
+	public function loginProvider() {
+		return $this->_authenticateProvider;
+	}
+
+/**
+ * If there was any authorization processing for the current request, this function
+ * will return the instance of the Authorization object that granted access to the
+ * user to the current address.
+ *
+ * @return \Cake\Auth\BaseAuthorize|null
+ */
+	public function authorizationProvider() {
+		return $this->_authenticateProvider;
+	}
 }

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -803,7 +803,7 @@ class AuthComponent extends Component {
 	}
 
 /**
- * If login was called during this request and the suer was successfully
+ * If login was called during this request and the user was successfully
  * authenticated, this function will return the instance of the authentication
  * object that was used for logging the user in.
  *

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -347,7 +347,6 @@ class FormAuthenticateTest extends TestCase {
 		$result = $this->auth->authenticate($request, $this->response);
 		$this->assertNotEmpty($result);
 		$this->assertTrue($this->auth->needsPasswordRehash());
-		$this->assertSame($password, $this->auth->rehashPassword());
 	}
 
 }

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -175,7 +175,7 @@ class AuthComponentTest extends TestCase {
 
 		$this->assertTrue((bool)$this->Auth->user());
 		$this->assertEquals($user, $this->Auth->user());
-		$this->assertSame($AuthLoginFormAuthenticate, $this->Auth->loginProvider());
+		$this->assertSame($AuthLoginFormAuthenticate, $this->Auth->authenticationProvider());
 	}
 
 /**

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -175,6 +175,7 @@ class AuthComponentTest extends TestCase {
 
 		$this->assertTrue((bool)$this->Auth->user());
 		$this->assertEquals($user, $this->Auth->user());
+		$this->assertSame($AuthLoginFormAuthenticate, $this->Auth->loginProvider());
 	}
 
 /**
@@ -273,6 +274,7 @@ class AuthComponentTest extends TestCase {
 			->method('authorize');
 
 		$this->assertTrue($this->Auth->isAuthorized(array('User'), $request));
+		$this->assertSame($AuthMockTwoAuthorize, $this->Auth->authorizationProvider());
 	}
 
 /**


### PR DESCRIPTION
This solves 2 problems:
- I often needed to know which authentication or authorization provider was used in the current request. I alway had to hack that by adding setting some global state form the providers. This patch adds a couple methods that will return the instance of the auth providers that were successfully used.
- Now it is possible to rehash password by asking the relevant auth provider to do it for you. It will not save to database, though. Users are still responsible for persisting the freshly hashed password
### Example:

``` php
if ($this->Auth->login()) {
  $provider = $this->Auth->loginProvider();
  $hasher = $provider->passwordHasher()
  $rehashed = $provider->needsPasswordRehash() ?
    $hasher->hash($this->request->data('password'))
    :
    null;
  if ($rehashed) {
    $this->Users->save(...)
  }
}
```

Edit: Removed a derp method that I originally added to BaseAuthenticate
