### PR TITLE
3.0 - Fix prefixed controllers not working with testAction().

### DIFF
--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -199,6 +199,24 @@ class ControllerTestCaseTest extends TestCase {
 	}
 
 /**
+ * Test testAction() with prefix routes.
+ *
+ * @return void
+ */
+	public function testActionWithPrefix() {
+		Configure::write('Routing.prefixes', ['admin']);
+		Plugin::load('TestPlugin');
+
+		$result = $this->Case->testAction('/admin/posts/index', ['return' => 'view']);
+		$expected = '<h1>Admin Post Index</h1>';
+		$this->assertContains($expected, $result);
+
+		$result = $this->Case->testAction('/admin/test_plugin/comments/index', ['return' => 'view']);
+		$expected = '<h1>TestPlugin Admin Comments</h1>';
+		$this->assertContains($expected, $result);
+	}
+
+/**
  * Make sure testAction() can hit plugin controllers.
  *
  * @return void

--- a/tests/TestCase/TestSuite/ControllerTestCaseTest.php
+++ b/tests/TestCase/TestSuite/ControllerTestCaseTest.php
@@ -26,36 +26,6 @@ use Cake\TestSuite\Reporter\HtmlReporter;
 use Cake\TestSuite\TestCase;
 
 /**
- * AppController class
- *
- */
-class AppController extends Controller {
-
-/**
- * helpers property
- *
- * @var array
- */
-	public $helpers = array('Html');
-
-/**
- * components property
- *
- * @var array
- */
-	public $components = array('Cookie');
-}
-
-
-/**
- * ControllerTestCaseTest controller
- *
- */
-class ControllerTestCaseTestController extends AppController {
-
-}
-
-/**
  * ControllerTestCaseTest
  *
  */

--- a/tests/test_app/Plugin/TestPlugin/Template/Admin/Comments/index.ctp
+++ b/tests/test_app/Plugin/TestPlugin/Template/Admin/Comments/index.ctp
@@ -1,0 +1,1 @@
+<h1>TestPlugin Admin Comments</h1>

--- a/tests/test_app/TestApp/Template/Admin/Posts/index.ctp
+++ b/tests/test_app/TestApp/Template/Admin/Posts/index.ctp
@@ -1,0 +1,1 @@
+<h1>Admin Post Index</h1>


### PR DESCRIPTION
The generated controller class needs to be aware that it is in a prefix and adjust the classname + viewPath accordingly.

Refs #3636
