### PR TITLE
Skip token when it is a subcommand

### DIFF
--- a/src/Console/ConsoleOptionParser.php
+++ b/src/Console/ConsoleOptionParser.php
@@ -474,7 +474,9 @@ class ConsoleOptionParser {
 		$params = $args = [];
 		$this->_tokens = $argv;
 		while (($token = array_shift($this->_tokens)) !== null) {
-			if (substr($token, 0, 2) === '--') {
+			if (isset($this->_subcommands[$token])) {
+				continue;
+			} elseif (substr($token, 0, 2) === '--') {
 				$params = $this->_parseLongOption($token, $params);
 			} elseif (substr($token, 0, 1) === '-') {
 				$params = $this->_parseShortOption($token, $params);


### PR DESCRIPTION
Not skipping the token will then cause it to be passed through parseArg()
which will see it as too many arguments being passed.
