### PR TITLE
3.0 widget improvements

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2275,7 +2275,11 @@ class FormHelper extends Helper {
 		}
 		unset($data['secure']);
 
-		return $widget->render($data);
+		$out = $widget->render($data);
+		if (method_exists($widget, 'afterRender')) {
+			$widget->afterRender($this->_View, $data);
+		}
+		return $out;
 	}
 
 /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2275,11 +2275,7 @@ class FormHelper extends Helper {
 		}
 		unset($data['secure']);
 
-		$out = $widget->render($data);
-		if (method_exists($widget, 'afterRender')) {
-			$widget->afterRender($this->_View, $data);
-		}
-		return $out;
+		return $widget->render($data);
 	}
 
 /**

--- a/src/View/Widget/Basic.php
+++ b/src/View/Widget/Basic.php
@@ -75,4 +75,11 @@ class Basic implements WidgetInterface {
 		]);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/Button.php
+++ b/src/View/Widget/Button.php
@@ -68,4 +68,14 @@ class Button implements WidgetInterface {
 		]);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		if (!isset($data['name'])) {
+			return [];
+		}
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/Checkbox.php
+++ b/src/View/Widget/Checkbox.php
@@ -94,4 +94,11 @@ class Checkbox implements WidgetInterface {
 		return false;
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -517,4 +517,17 @@ class DateTime implements WidgetInterface {
 		return $numbers;
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		$fields = [];
+		foreach ($this->_selects as $type) {
+			if ($data[$type] !== false) {
+				$fields[] = $data['name'] . '[' . $type . ']';
+			}
+		}
+		return $fields;
+	}
+
 }

--- a/src/View/Widget/File.php
+++ b/src/View/Widget/File.php
@@ -63,4 +63,15 @@ class File implements WidgetInterface {
 		]);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		$fields = [];
+		foreach (['name', 'type', 'tmp_name', 'error', 'size'] as $suffix) {
+			$fields[] = $data['name'] . '[' . $suffix . ']';
+		}
+		return $fields;
+	}
+
 }

--- a/src/View/Widget/Label.php
+++ b/src/View/Widget/Label.php
@@ -73,4 +73,11 @@ class Label implements WidgetInterface {
 		]);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [];
+	}
+
 }

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -207,4 +207,11 @@ class MultiCheckbox implements WidgetInterface {
 		return in_array((string)$key, $disabled, $strict);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -215,4 +215,11 @@ class Radio implements WidgetInterface {
 		return $this->_label->render($labelAttrs);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/SelectBox.php
+++ b/src/View/Widget/SelectBox.php
@@ -286,4 +286,11 @@ class SelectBox implements WidgetInterface {
 		return in_array((string)$key, $disabled, $strict);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/Textarea.php
+++ b/src/View/Widget/Textarea.php
@@ -62,4 +62,11 @@ class Textarea implements WidgetInterface {
 		]);
 	}
 
+/**
+ * {@inheritDoc}
+ */
+	public function secureFields(array $data) {
+		return [$data['name']];
+	}
+
 }

--- a/src/View/Widget/WidgetInterface.php
+++ b/src/View/Widget/WidgetInterface.php
@@ -23,8 +23,17 @@ interface WidgetInterface {
  * Converts the $data into one or many HTML elements.
  *
  * @param array $data The data to render.
- * @return string
+ * @return string Generated HTML for the widget element.
  */
 	public function render(array $data);
+
+/**
+ * Returns a list of fields that need to be secured for
+ * this widget. Fields are in the form of Model[field][suffix]
+ *
+ * @param array $data The data to render.
+ * @return array Array of fields to secure.
+ */
+	public function secureFields(array $data);
 
 }


### PR DESCRIPTION
Implements the changes described in #3613. Notably adding:
- An `afterRender()` hook to widget objects.
- Refactored secure field list generation into a widget feature over a FormHelper feature. This has made FormHelper quite a bit simpler and resulted in more powerful widget classes :metal:
