### PR TITLE
3.0 association save

### DIFF
--- a/src/ORM/Association.php
+++ b/src/ORM/Association.php
@@ -763,7 +763,8 @@ abstract class Association {
 	public abstract function isOwningSide(Table $side);
 
 /**
- * Proxies the saving operation for an entity to the target table
+ * Extract the target's associaiton data our from the passed entity and proxies
+ * the saving operation to the target table.
  *
  * @param \Cake\ORM\Entity $entity the data to be saved
  * @param array|\ArrayObject $options
@@ -771,6 +772,6 @@ abstract class Association {
  * the saved entity
  * @see Table::save()
  */
-	public abstract function save(Entity $entity, array $options = []);
+	public abstract function saveAssociated(Entity $entity, array $options = []);
 
 }

--- a/src/ORM/Association/BelongsTo.php
+++ b/src/ORM/Association/BelongsTo.php
@@ -115,7 +115,7 @@ class BelongsTo extends Association {
  * the saved entity
  * @see Table::save()
  */
-	public function save(Entity $entity, array $options = []) {
+	public function saveAssociated(Entity $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
 		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
 			return $entity;

--- a/src/ORM/Association/BelongsToMany.php
+++ b/src/ORM/Association/BelongsToMany.php
@@ -382,7 +382,7 @@ class BelongsToMany extends Association {
  * @see Table::save()
  * @see BelongsToMany::replaceLinks()
  */
-	public function save(Entity $entity, array $options = []) {
+	public function saveAssociated(Entity $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
 		$strategy = $this->saveStrategy();
 

--- a/src/ORM/Association/HasMany.php
+++ b/src/ORM/Association/HasMany.php
@@ -72,7 +72,7 @@ class HasMany extends Association {
  * @see Table::save()
  * @throws \InvalidArgumentException when the association data cannot be traversed.
  */
-	public function save(Entity $entity, array $options = []) {
+	public function saveAssociated(Entity $entity, array $options = []) {
 		$targetEntities = $entity->get($this->property());
 		if (empty($targetEntities)) {
 			return $entity;

--- a/src/ORM/Association/HasOne.php
+++ b/src/ORM/Association/HasOne.php
@@ -110,7 +110,7 @@ class HasOne extends Association {
  * the saved entity
  * @see Table::save()
  */
-	public function save(Entity $entity, array $options = []) {
+	public function saveAssociated(Entity $entity, array $options = []) {
 		$targetEntity = $entity->get($this->property());
 		if (empty($targetEntity) || !($targetEntity instanceof Entity)) {
 			return $entity;

--- a/src/ORM/Associations.php
+++ b/src/ORM/Associations.php
@@ -229,7 +229,7 @@ class Associations {
 		if (!empty($nested)) {
 			$options = (array)$nested + $options;
 		}
-		return (bool)$association->save($entity, $options);
+		return (bool)$association->saveAssociated($entity, $options);
 	}
 
 /**

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -199,7 +199,7 @@ class BelongsToManyTest extends TestCase {
 	}
 
 /**
- * Tests that it is possible to pass the save strategy in the constructor
+ * Tests that it is possible to pass the saveAssociated strategy in the constructor
  *
  * @return void
  */
@@ -1240,7 +1240,7 @@ class BelongsToManyTest extends TestCase {
 	}
 
 /**
- * Test that replaceLinks() can save an empty set, removing all rows.
+ * Test that replaceLinks() can saveAssociated an empty set, removing all rows.
  *
  * @return void
  */
@@ -1415,7 +1415,7 @@ class BelongsToManyTest extends TestCase {
  *
  * @return void
  */
-	public function testSaveEmptySetSuccess() {
+	public function testSaveAssociatedEmptySetSuccess() {
 		$assoc = $this->getMock(
 			'\Cake\ORM\Association\BelongsToMany',
 			['_saveTarget', 'replaceLinks'],
@@ -1431,7 +1431,7 @@ class BelongsToManyTest extends TestCase {
 			->method('replaceLinks');
 		$assoc->expects($this->never())
 			->method('_saveTarget');
-		$this->assertSame($entity, $assoc->save($entity));
+		$this->assertSame($entity, $assoc->saveAssociated($entity));
 	}
 
 /**
@@ -1439,7 +1439,7 @@ class BelongsToManyTest extends TestCase {
  *
  * @return void
  */
-	public function testSaveWithReplace() {
+	public function testSaveAssociatedWithReplace() {
 		$assoc = $this->getMock(
 			'\Cake\ORM\Association\BelongsToMany',
 			['replaceLinks'],
@@ -1457,7 +1457,7 @@ class BelongsToManyTest extends TestCase {
 		$assoc->expects($this->once())->method('replaceLinks')
 			->with($entity, $entity->tags, $options)
 			->will($this->returnValue(true));
-		$this->assertSame($entity, $assoc->save($entity, $options));
+		$this->assertSame($entity, $assoc->saveAssociated($entity, $options));
 	}
 
 /**
@@ -1465,7 +1465,7 @@ class BelongsToManyTest extends TestCase {
  *
  * @return void
  */
-	public function testSaveWithReplaceReturnFalse() {
+	public function testSaveAssociatedWithReplaceReturnFalse() {
 		$assoc = $this->getMock(
 			'\Cake\ORM\Association\BelongsToMany',
 			['replaceLinks'],
@@ -1483,19 +1483,19 @@ class BelongsToManyTest extends TestCase {
 		$assoc->expects($this->once())->method('replaceLinks')
 			->with($entity, $entity->tags, $options)
 			->will($this->returnValue(false));
-		$this->assertFalse($assoc->save($entity, $options));
+		$this->assertFalse($assoc->saveAssociated($entity, $options));
 	}
 
 /**
- * Test that save() ignores non entity values.
+ * Test that saveAssociated() ignores non entity values.
  *
  * @return void
  */
-	public function testSaveOnlyEntities() {
+	public function testSaveAssociatedOnlyEntities() {
 		$connection = ConnectionManager::get('test');
 		$mock = $this->getMock(
 			'Cake\ORM\Table',
-			['save', 'schema'],
+			['saveAssociated', 'schema'],
 			[['table' => 'tags', 'connection' => $connection]]
 		);
 		$mock->primaryKey('id');
@@ -1516,10 +1516,10 @@ class BelongsToManyTest extends TestCase {
 		]);
 
 		$mock->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$association = new BelongsToMany('Tags', $config);
-		$association->save($entity);
+		$association->saveAssociated($entity);
 	}
 
 /**

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -270,18 +270,18 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test that save() ignores non entity values.
+ * Test that saveAssociated() ignores non entity values.
  *
  * @return void
  */
-	public function testSaveOnlyEntities() {
+	public function testSaveAssociatedOnlyEntities() {
 		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
 		$config = [
 			'sourceTable' => $this->client,
 			'targetTable' => $mock,
 		];
 		$mock->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$entity = new Entity([
 			'title' => 'A Title',
@@ -290,7 +290,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
 		]);
 
 		$association = new BelongsTo('Authors', $config);
-		$result = $association->save($entity);
+		$result = $association->saveAssociated($entity);
 		$this->assertSame($result, $entity);
 		$this->assertNull($entity->author_id);
 	}

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -737,11 +737,11 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test that save() ignores non entity values.
+ * Test that saveAssociated() ignores non entity values.
  *
  * @return void
  */
-	public function testSaveOnlyEntities() {
+	public function testSaveAssociatedOnlyEntities() {
 		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
 		$config = [
 			'sourceTable' => $this->author,
@@ -758,10 +758,10 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		]);
 
 		$mock->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$association = new HasMany('Articles', $config);
-		$association->save($entity);
+		$association->saveAssociated($entity);
 	}
 
 /**

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -272,18 +272,18 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
- * Test that save() ignores non entity values.
+ * Test that saveAssociated() ignores non entity values.
  *
  * @return void
  */
-	public function testSaveOnlyEntities() {
+	public function testSaveAssociatedOnlyEntities() {
 		$mock = $this->getMock('Cake\ORM\Table', [], [], '', false);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $mock,
 		];
 		$mock->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$entity = new Entity([
 			'username' => 'Mark',
@@ -292,7 +292,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
 		]);
 
 		$association = new HasOne('Profiles', $config);
-		$result = $association->save($entity);
+		$result = $association->saveAssociated($entity);
 
 		$this->assertSame($result, $entity);
 	}

--- a/tests/TestCase/ORM/AssociationTest.php
+++ b/tests/TestCase/ORM/AssociationTest.php
@@ -52,7 +52,7 @@ class AssociationTest extends \Cake\TestSuite\TestCase {
 			'\Cake\ORM\Association',
 			[
 				'_options', 'attachTo', '_joinCondition', 'cascadeDelete', 'isOwningSide',
-				'save', 'eagerLoader', 'type'
+				'saveAssociated', 'eagerLoader', 'type'
 			],
 			['Foo', $config]
 		);

--- a/tests/TestCase/ORM/AssociationsTest.php
+++ b/tests/TestCase/ORM/AssociationsTest.php
@@ -175,13 +175,13 @@ class AssociationsTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table', [], [[]]);
 		$mockOne = $this->getMock(
 			'Cake\ORM\Association\BelongsTo',
-			['save'],
+			['saveAssociated'],
 			['Parent', [
 				'sourceTable' => $table,
 			]]);
 		$mockTwo = $this->getMock(
 			'Cake\ORM\Association\HasMany',
-			['save'],
+			['saveAssociated'],
 			['Child', [
 				'sourceTable' => $table
 			]]);
@@ -196,12 +196,12 @@ class AssociationsTest extends TestCase {
 		$options = ['option' => 'value'];
 
 		$mockOne->expects($this->once())
-			->method('save')
+			->method('saveAssociated')
 			->with($entity, $options)
 			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$result = $this->associations->saveParents(
 			$table,
@@ -221,13 +221,13 @@ class AssociationsTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table', [], [[]]);
 		$mockOne = $this->getMock(
 			'Cake\ORM\Association\BelongsTo',
-			['save'],
+			['saveAssociated'],
 			['Parents', [
 				'sourceTable' => $table,
 			]]);
 		$mockTwo = $this->getMock(
 			'Cake\ORM\Association\BelongsTo',
-			['save'],
+			['saveAssociated'],
 			['Categories', [
 				'sourceTable' => $table
 			]]);
@@ -242,12 +242,12 @@ class AssociationsTest extends TestCase {
 		$options = ['atomic' => true];
 
 		$mockOne->expects($this->once())
-			->method('save')
+			->method('saveAssociated')
 			->with($entity, ['atomic' => true, 'associated' => ['Others']])
 			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$result = $this->associations->saveParents(
 			$table,
@@ -267,13 +267,13 @@ class AssociationsTest extends TestCase {
 		$table = $this->getMock('Cake\ORM\Table', [], [[]]);
 		$mockOne = $this->getMock(
 			'Cake\ORM\Association\HasMany',
-			['save'],
+			['saveAssociated'],
 			['Comments', [
 				'sourceTable' => $table,
 			]]);
 		$mockTwo = $this->getMock(
 			'Cake\ORM\Association\HasOne',
-			['save'],
+			['saveAssociated'],
 			['Profiles', [
 				'sourceTable' => $table
 			]]);
@@ -288,12 +288,12 @@ class AssociationsTest extends TestCase {
 		$options = ['atomic' => true];
 
 		$mockOne->expects($this->once())
-			->method('save')
+			->method('saveAssociated')
 			->with($entity, $options + ['associated' => ['Other']])
 			->will($this->returnValue(true));
 
 		$mockTwo->expects($this->never())
-			->method('save');
+			->method('saveAssociated');
 
 		$result = $this->associations->saveChildren(
 			$table,


### PR DESCRIPTION
Given that Association is also a proxy for any Table method, having function that does a different thing to another with the same name in Table was not a good idea. This removes the name clash and allow the original save() to be proxied correctly
