### PR TITLE
Add a detector for REST requests

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -145,9 +145,7 @@ class CakeRequest implements ArrayAccess {
 		}
 		$this->here = $this->base . '/' . $this->url;
 
-		$this->addDetector('rest', array('callback' => function (\CakeRequest $request) {
-			return isset($request->params['[method]']);
-		}));
+		$this->addDetector('rest', array('callback' => array($this, '_checkForRest')));
 	}
 
 /**
@@ -1026,5 +1024,16 @@ class CakeRequest implements ArrayAccess {
 	public function offsetUnset($name) {
 		unset($this->params[$name]);
 	}
+
+	/**
+	 * Checks whenever a request is done using a REST request
+	 *
+	 * @param CakeRequest $request The request to run the check on
+	 * @return bool
+	 */
+	protected function _checkForRest(CakeRequest $request) {
+		return isset($request->params['[method]']);
+	}
+
 
 }

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -144,6 +144,10 @@ class CakeRequest implements ArrayAccess {
 			$this->_processFiles();
 		}
 		$this->here = $this->base . '/' . $this->url;
+
+		$this->addDetector('rest', array('callback' => function (\CakeRequest $request) {
+			return isset($request->params['[method]']);
+		}));
 	}
 
 /**

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2265,6 +2265,32 @@ XML;
 	}
 
 /**
+ * Test is('rest') and isRest()
+ *
+ * @return void
+ */
+	public function testIsRest() {
+		$request = new CakeRequest('/posts/index');
+		$request->addParams(array(
+			'controller' => 'posts',
+			'action' => 'index',
+			'plugin' => null,
+			'[method]' => 'post'
+		));
+		$this->assertTrue($request->is('rest'));
+		$this->assertTrue($request->isRest());
+
+		$request = new CakeRequest('/posts/index');
+		$request->addParams(array(
+			'controller' => 'posts',
+			'action' => 'index',
+			'plugin' => null,
+		));
+		$this->assertFalse($request->is('rest'));
+		$this->assertFalse($request->isRest());
+	}
+
+/**
  * loadEnvironment method
  *
  * @param array $env


### PR DESCRIPTION
This detector is added in the constructor because PHP properties
don't allow anonymous functions to be created in side of them.

This detector can be useful when having for example a redirect on
a posts controller to make sure that the slug for a post is correct
when viewing it. That causes problems with REST requests however
because the REST request will be redirected as well.
