### PR TITLE
Accept `base` config key in Plugin::load()

### DIFF
--- a/tests/TestCase/Core/PluginTest.php
+++ b/tests/TestCase/Core/PluginTest.php
@@ -75,6 +75,26 @@ class PluginTest extends TestCase {
 	}
 
 /**
+ * Tests loading plugin with base path
+ *
+ * @return void
+ */
+	public function testLoadSingleWithBasePath() {
+		Plugin::unload();
+		Plugin::load('TestPluginFour', ['base' => 'src']);
+		$expected = array('TestPluginFour');
+		$this->assertEquals($expected, Plugin::loaded());
+
+		$result = Plugin::root('TestPluginFour');
+		$expected = TEST_APP . 'Plugin' . DS . 'TestPluginFour' . DS;
+		$this->assertEquals($expected, $result);
+
+		$result = Plugin::path('TestPluginFour');
+		$expected = TEST_APP . 'Plugin' . DS . 'TestPluginFour' . DS . 'src' . DS;
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Tests unloading plugins
  *
  * @return void
@@ -254,7 +274,7 @@ class PluginTest extends TestCase {
  */
 	public function testLoadAll() {
 		Plugin::loadAll();
-		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginTwo', 'TestTheme'];
+		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
 		$this->assertEquals($expected, Plugin::loaded());
 	}
 
@@ -277,7 +297,7 @@ class PluginTest extends TestCase {
 	public function testLoadAllWithDefaults() {
 		$defaults = array('bootstrap' => true, 'ignoreMissing' => true);
 		Plugin::loadAll(array($defaults));
-		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginTwo', 'TestTheme'];
+		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
 		$this->assertEquals($expected, Plugin::loaded());
 		$this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
 		$this->assertEquals('loaded plugin bootstrap', Configure::read('PluginTest.test_plugin.bootstrap'));
@@ -297,7 +317,7 @@ class PluginTest extends TestCase {
 		));
 		Plugin::routes();
 
-		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginTwo', 'TestTheme'];
+		$expected = ['Company', 'PluginJs', 'TestPlugin', 'TestPluginFour', 'TestPluginTwo', 'TestTheme'];
 		$this->assertEquals($expected, Plugin::loaded());
 		$this->assertEquals('loaded js plugin bootstrap', Configure::read('PluginTest.js_plugin.bootstrap'));
 		$this->assertEquals('loaded plugin routes', Configure::read('PluginTest.test_plugin.routes'));


### PR DESCRIPTION
- Enable plugins to specify a different base path defining where its
  class files can be found. The value `base` is relative to `path`.
- New method Plugin::root(), returning the absolute root path of a plugin

Alternative to #3662:
- Does not force use of `src` as basepath
- Easier upgrade path for plugins
- Less core files are touched/modified, smaller diffstat:
  - `3 files changed, 97 insertions(+), 18 deletions(-))` **vs**
  - `165 files changed, 1383 insertions(+), 1357 deletions(-)`
