### PR TITLE
3.0 camelcase commands

### DIFF
--- a/src/Console/Shell.php
+++ b/src/Console/Shell.php
@@ -259,7 +259,7 @@ class Shell {
 	public function hasMethod($name) {
 		try {
 			$method = new \ReflectionMethod($this, $name);
-			if (!$method->isPublic() || substr($name, 0, 1) === '_') {
+			if (!$method->isPublic()) {
 				return false;
 			}
 			if ($method->getDeclaringClass()->name === 'Cake\Console\Shell') {
@@ -352,24 +352,24 @@ class Shell {
 		}
 
 		$subcommands = $this->OptionParser->subcommands();
-		$isMethod = $this->hasMethod($command);
+		$method = Inflector::camelize($command);
+		$isMethod = $this->hasMethod($method);
 
 		if ($isMethod && $autoMethod && count($subcommands) === 0) {
 			array_shift($this->args);
 			$this->startup();
-			return call_user_func_array([$this, $command], $this->args);
+			return call_user_func_array([$this, $method], $this->args);
 		}
 
 		if ($isMethod && isset($subcommands[$command])) {
 			$this->startup();
-			return call_user_func_array([$this, $command], $this->args);
+			return call_user_func_array([$this, $method], $this->args);
 		}
 
 		if ($this->hasTask($command) && isset($subcommands[$command])) {
 			$this->startup();
-			$command = Inflector::camelize($command);
 			array_shift($argv);
-			return $this->{$command}->runCommand($argv, false);
+			return $this->{$method}->runCommand($argv, false);
 		}
 
 		if ($this->hasMethod('main')) {

--- a/tests/TestCase/Console/ShellTest.php
+++ b/tests/TestCase/Console/ShellTest.php
@@ -76,13 +76,13 @@ class ShellTestShell extends Shell {
 	}
 
 	//@codingStandardsIgnoreStart
-	public function do_something() {
+	public function doSomething() {
 	}
 
-	protected function no_access() {
+	protected function noAccess() {
 	}
 
-	public function log_something() {
+	public function logSomething() {
 		$this->log($this->testMessage);
 	}
 	//@codingStandardsIgnoreEnd
@@ -513,7 +513,7 @@ class ShellTest extends TestCase {
  * @return void
  */
 	public function testHasMethod() {
-		$this->assertTrue($this->Shell->hasMethod('do_something'));
+		$this->assertTrue($this->Shell->hasMethod('doSomething'));
 		$this->assertFalse($this->Shell->hasMethod('hr'), 'hr is callable');
 		$this->assertFalse($this->Shell->hasMethod('_secret'), '_secret is callable');
 		$this->assertFalse($this->Shell->hasMethod('no_access'), 'no_access is callable');
@@ -543,10 +543,10 @@ class ShellTest extends TestCase {
  */
 	public function testRunCommandWithMethod() {
 		$io = $this->getMock('Cake\Console\ConsoleIo');
-		$shell = $this->getMock('Cake\Console\Shell', ['hit_me', 'startup'], [$io]);
+		$shell = $this->getMock('Cake\Console\Shell', ['hitMe', 'startup'], [$io]);
 
 		$shell->expects($this->once())->method('startup');
-		$shell->expects($this->once())->method('hit_me')
+		$shell->expects($this->once())->method('hitMe')
 			->with('cakes')
 			->will($this->returnValue(true));
 		$result = $shell->runCommand(['hit_me', 'cakes', '--verbose'], true);


### PR DESCRIPTION
Changes the convention for shell methods to be camelCased instead of underscored. Invoking the methods with snake_case is still acceptable.

Refs https://github.com/cakephp/cakephp/issues/2125
