### PR TITLE
3.0 Add __debugInfo to a few classes that cause recursion

### DIFF
--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -320,4 +320,19 @@ class EventManager {
 		}
 		return $this->_listeners[$eventKey];
 	}
+
+/**
+ * Debug friendly object properties.
+ *
+ * @return array
+ */
+	public function __debugInfo() {
+		$properties = get_object_vars($this);
+		$properties['_generalManager'] = '(object) EventManager';
+		$properties['_listeners'] = [];
+		foreach ($this->_listeners as $key => $listeners) {
+			$properties['_listeners'][$key] = count($listeners) . ' listener(s)';
+		}
+		return $properties;
+	}
 }

--- a/src/Utility/Debugger.php
+++ b/src/Utility/Debugger.php
@@ -576,7 +576,7 @@ class Debugger {
 		$break = "\n" . str_repeat("\t", $indent);
 		$end = "\n" . str_repeat("\t", $indent - 1);
 
-		if (method_exists($var, '__debugInfo')) {
+		if ($depth > 0 && method_exists($var, '__debugInfo')) {
 			return $out . "\n" .
 				substr(static::_array($var->__debugInfo(), $depth - 1, $indent), 1, -1) .
 				$end . '}';

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -221,4 +221,16 @@ abstract class ObjectRegistry {
 		unset($this->_loaded[$objectName]);
 	}
 
+/**
+ * Debug friendly object properties.
+ *
+ * @return array
+ */
+	public function __debugInfo() {
+		$properties = get_object_vars($this);
+		$properties['_loaded'] = array_keys($properties['_loaded']);
+		return $properties;
+	}
+
+
 }

--- a/tests/TestCase/Utility/DebuggerTest.php
+++ b/tests/TestCase/Utility/DebuggerTest.php
@@ -645,11 +645,7 @@ TEXT;
 object(Cake\Test\TestCase\Utility\DebuggableThing) {
 
 	'foo' => 'bar',
-	'inner' => object(Cake\Test\TestCase\Utility\DebuggableThing) {
-
-		[maximum depth reached]
-	
-	}
+	'inner' => object(Cake\Test\TestCase\Utility\DebuggableThing) {}
 
 }
 eos;


### PR DESCRIPTION
These objects often hold complicated cyclic references. This causes something like debug($controller) to go horribly wrong. This removes the most verbose cyclic references.
