### PR TITLE
3.0 widget context

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -2275,7 +2275,7 @@ class FormHelper extends Helper {
 		}
 		unset($data['secure']);
 
-		return $widget->render($data);
+		return $widget->render($data, $this->context());
 	}
 
 /**

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -197,7 +197,7 @@ class FormHelper extends Helper {
 	public function widgetRegistry(WidgetRegistry $instance = null, $widgets = []) {
 		if ($instance === null) {
 			if ($this->_registry === null) {
-				$this->_registry = new WidgetRegistry($this->templater(), $widgets);
+				$this->_registry = new WidgetRegistry($this->templater(), $this->_View, $widgets);
 			}
 			return $this->_registry;
 		}

--- a/src/View/Widget/Basic.php
+++ b/src/View/Widget/Basic.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -53,9 +54,10 @@ class Basic implements WidgetInterface {
  * Any other keys provided in $data will be converted into HTML attributes.
  *
  * @param array $data The data to build an input with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'val' => null,

--- a/src/View/Widget/Button.php
+++ b/src/View/Widget/Button.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -54,9 +55,10 @@ class Button implements WidgetInterface {
  * Any other keys provided in $data will be converted into HTML attributes.
  *
  * @param array $data The data to build a button with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'text' => '',
 			'type' => 'submit',

--- a/src/View/Widget/Checkbox.php
+++ b/src/View/Widget/Checkbox.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -51,9 +52,10 @@ class Checkbox implements WidgetInterface {
  * Any other attributes passed in will be treated as HTML attributes.
  *
  * @param array $data The data to create a checkbox with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string Generated HTML string.
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'value' => 1,

--- a/src/View/Widget/DateTime.php
+++ b/src/View/Widget/DateTime.php
@@ -15,6 +15,7 @@
 namespace Cake\View\Widget;
 
 use Cake\Utility\Time;
+use Cake\View\Form\ContextInterface;
 use Cake\View\StringTemplate;
 use Cake\View\Widget\WidgetInterface;
 
@@ -113,10 +114,11 @@ class DateTime implements WidgetInterface {
  *   should be rounded to match the select options.
  *
  * @param array $data Data to render with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string A generated select box.
  * @throws \RuntimeException When option data is invalid.
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'empty' => false,
@@ -164,7 +166,7 @@ class DateTime implements WidgetInterface {
 			if (!isset($data[$select]['disabled'])) {
 				$data[$select]['disabled'] = $data['disabled'];
 			}
-			$templateOptions[$select] = $this->{$method}($data[$select]);
+			$templateOptions[$select] = $this->{$method}($data[$select], $context);
 			unset($data[$select]);
 		}
 		unset($data['name'], $data['empty'], $data['disabled'], $data['val']);
@@ -259,9 +261,10 @@ class DateTime implements WidgetInterface {
  * Generates a year select
  *
  * @param array $options
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _yearSelect($options = []) {
+	protected function _yearSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -282,16 +285,17 @@ class DateTime implements WidgetInterface {
 			$options['options'] = array_reverse($options['options'], true);
 		}
 		unset($options['start'], $options['end'], $options['order']);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a month select
  *
- * @param array $options
+ * @param array $options The options to build the month select with
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _monthSelect($options = []) {
+	protected function _monthSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'names' => false,
@@ -311,16 +315,17 @@ class DateTime implements WidgetInterface {
 		}
 
 		unset($options['leadingZeroKey'], $options['leadingZeroValue'], $options['names']);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a day select
  *
- * @param array $options
+ * @param array $options The options to generate a day select with.
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _daySelect($options = []) {
+	protected function _daySelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -330,16 +335,17 @@ class DateTime implements WidgetInterface {
 		$options['options'] = $this->_generateNumbers(1, 31, $options);
 
 		unset($options['names'], $options['leadingZeroKey'], $options['leadingZeroValue']);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a hour select
  *
- * @param array $options
+ * @param array $options The options to generate an hour select with
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _hourSelect($options = []) {
+	protected function _hourSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -380,16 +386,17 @@ class DateTime implements WidgetInterface {
 			$options['format'], $options['leadingZeroKey'],
 			$options['leadingZeroValue']
 		);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a minute select
  *
- * @param array $options
+ * @param array $options The options to generate a minute select with.
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _minuteSelect($options = []) {
+	protected function _minuteSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -409,16 +416,17 @@ class DateTime implements WidgetInterface {
 			$options['interval'],
 			$options['round']
 		);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a second select
  *
- * @param array $options
+ * @param array $options The options to generate a second select with
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _secondSelect($options = []) {
+	protected function _secondSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
@@ -428,22 +436,23 @@ class DateTime implements WidgetInterface {
 		];
 
 		unset($options['leadingZeroKey'], $options['leadingZeroValue']);
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**
  * Generates a meridian select
  *
- * @param array $options
+ * @param array $options The options to generate a meridian select with.
+ * @param \Cake\View\Form\ContextInterface $context The current form context.
  * @return string
  */
-	protected function _meridianSelect($options = []) {
+	protected function _meridianSelect($options, $context) {
 		$options += [
 			'name' => '',
 			'val' => null,
 			'options' => ['am' => 'am', 'pm' => 'pm']
 		];
-		return $this->_select->render($options);
+		return $this->_select->render($options, $context);
 	}
 
 /**

--- a/src/View/Widget/File.php
+++ b/src/View/Widget/File.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -46,9 +47,10 @@ class File implements WidgetInterface {
  * ignored.
  *
  * @param array $data The data to build a file input with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string HTML elements.
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'escape' => true,

--- a/src/View/Widget/Label.php
+++ b/src/View/Widget/Label.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -57,9 +58,10 @@ class Label implements WidgetInterface {
  * All other attributes will be converted into HTML attributes.
  *
  * @param array $data
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'text' => '',
 			'input' => '',

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Helper\IdGeneratorTrait;
 use Cake\View\Widget\WidgetInterface;
 
@@ -96,10 +97,11 @@ class MultiCheckbox implements WidgetInterface {
  * This form **requires** that both the `value` and `text` keys be defined.
  * If either is not set options will not be generated correctly.
  *
- * @param array $data
+ * @param array $data The data to generate a checkbox set with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'escape' => true,
@@ -132,7 +134,7 @@ class MultiCheckbox implements WidgetInterface {
 				$checkbox['id'] = $this->_id($checkbox['name'], $checkbox['value']);
 			}
 
-			$out[] = $this->_renderInput($checkbox);
+			$out[] = $this->_renderInput($checkbox, $context);
 		}
 		return implode('', $out);
 	}
@@ -141,9 +143,10 @@ class MultiCheckbox implements WidgetInterface {
  * Render a single checkbox & wrapper.
  *
  * @param array $checkbox An array containing checkbox key/value option pairs
+ * @param \Cake\View\Form\ContextInterface Context object.
  * @return string
  */
-	protected function _renderInput($checkbox) {
+	protected function _renderInput($checkbox, $context) {
 		$input = $this->_templates->format('checkbox', [
 			'name' => $checkbox['name'] . '[]',
 			'value' => $checkbox['escape'] ? h($checkbox['value']) : $checkbox['value'],
@@ -162,7 +165,7 @@ class MultiCheckbox implements WidgetInterface {
 		if (!empty($checkbox['checked']) && empty($labelAttrs['class'])) {
 			$labelAttrs['class'] = 'selected';
 		}
-		$label = $this->_label->render($labelAttrs);
+		$label = $this->_label->render($labelAttrs, $context);
 
 		return $this->_templates->format('checkboxContainer', [
 			'label' => $label,

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Helper\IdGeneratorTrait;
 use Cake\View\Widget\WidgetInterface;
 use Traversable;
@@ -78,9 +79,10 @@ class Radio implements WidgetInterface {
  * - `idPrefix` Prefix for generated ID attributes.
  *
  * @param array $data The data to build radio buttons with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'options' => [],
@@ -107,7 +109,7 @@ class Radio implements WidgetInterface {
 		$this->_clearIds();
 		$opts = [];
 		foreach ($options as $val => $text) {
-			$opts[] = $this->_renderInput($val, $text, $data);
+			$opts[] = $this->_renderInput($val, $text, $data, $context);
 		}
 		return implode('', $opts);
 	}
@@ -136,9 +138,10 @@ class Radio implements WidgetInterface {
  * @param string|int $val The value of the radio input.
  * @param string|array $text The label text, or complex radio type.
  * @param array $data Additional options for input generation.
+ * @param \Cake\View\Form\ContextInterface The form context
  * @return string
  */
-	protected function _renderInput($val, $text, $data) {
+	protected function _renderInput($val, $text, $data, $context) {
 		$escape = $data['escape'];
 		if (is_int($val) && isset($text['text'], $text['value'])) {
 			$radio = $text;
@@ -180,6 +183,7 @@ class Radio implements WidgetInterface {
 			$radio,
 			$data['label'],
 			$input,
+			$context,
 			$escape
 		);
 
@@ -198,10 +202,11 @@ class Radio implements WidgetInterface {
  * @param array $radio The input properties.
  * @param false|string|array $label The properties for a label.
  * @param string $input The input widget.
+ * @param \Cake\View\Form\ContextInterface $context The form context.
  * @param bool $escape Whether or not to HTML escape the label.
  * @return string Generated label.
  */
-	protected function _renderLabel($radio, $label, $input, $escape) {
+	protected function _renderLabel($radio, $label, $input, $context, $escape) {
 		if ($label === false) {
 			return false;
 		}
@@ -212,7 +217,7 @@ class Radio implements WidgetInterface {
 			'text' => $radio['text'],
 			'input' => $input,
 		];
-		return $this->_label->render($labelAttrs);
+		return $this->_label->render($labelAttrs, $context);
 	}
 
 /**

--- a/src/View/Widget/SelectBox.php
+++ b/src/View/Widget/SelectBox.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 use Traversable;
 
@@ -111,10 +112,11 @@ class SelectBox implements WidgetInterface {
  * nest complex types as required.
  *
  * @param array $data Data to render with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string A generated select box.
  * @throws \RuntimeException when the name attribute is empty.
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'name' => '',
 			'empty' => false,

--- a/src/View/Widget/Textarea.php
+++ b/src/View/Widget/Textarea.php
@@ -14,6 +14,7 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
 use Cake\View\Widget\WidgetInterface;
 
 /**
@@ -45,9 +46,10 @@ class Textarea implements WidgetInterface {
  * All other keys will be converted into HTML attributes.
  *
  * @param array $data The data to build a textarea with.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string HTML elements.
  */
-	public function render(array $data) {
+	public function render(array $data, ContextInterface $context) {
 		$data += [
 			'val' => '',
 			'name' => '',

--- a/src/View/Widget/WidgetInterface.php
+++ b/src/View/Widget/WidgetInterface.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\View\Widget;
 
+use Cake\View\Form\ContextInterface;
+
 /**
  * Interface for input widgets.
  */
@@ -23,9 +25,10 @@ interface WidgetInterface {
  * Converts the $data into one or many HTML elements.
  *
  * @param array $data The data to render.
+ * @param \Cake\View\Form\ContextInterface The current form context.
  * @return string Generated HTML for the widget element.
  */
-	public function render(array $data);
+	public function render(array $data, ContextInterface $context);
 
 /**
  * Returns a list of fields that need to be secured for

--- a/src/View/Widget/WidgetRegistry.php
+++ b/src/View/Widget/WidgetRegistry.php
@@ -16,6 +16,7 @@ namespace Cake\View\Widget;
 
 use Cake\Core\App;
 use Cake\View\StringTemplate;
+use Cake\View\View;
 use Cake\View\Widget\WidgetInterface;
 use \ReflectionClass;
 
@@ -31,6 +32,8 @@ use \ReflectionClass;
  *
  * Each widget should expect a StringTemplate instance as their first
  * argument. All other dependencies will be included after.
+ *
+ * Widgets can ask for the current view by using the `_view` widget.
  */
 class WidgetRegistry {
 
@@ -62,14 +65,16 @@ class WidgetRegistry {
 /**
  * Constructor
  *
- * @param StringTemplate $templates Templates instance to use.
+ * @param \Cake\View\StringTemplate $templates Templates instance to use.
+ * @param \Cake\View\View $view The view instance to set as a widget.
  * @param array $widgets See add() method for more information.
  */
-	public function __construct(StringTemplate $templates, array $widgets = []) {
+	public function __construct(StringTemplate $templates, View $view, array $widgets = []) {
 		$this->_templates = $templates;
 		if (!empty($widgets)) {
 			$this->add($widgets);
 		}
+		$this->add(['_view' => $view]);
 	}
 
 /**

--- a/tests/TestCase/View/Widget/BasicTest.php
+++ b/tests/TestCase/View/Widget/BasicTest.php
@@ -29,6 +29,7 @@ class BasicTest extends TestCase {
 			'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -38,7 +39,7 @@ class BasicTest extends TestCase {
  */
 	public function testRenderSimple() {
 		$text = new Basic($this->templates);
-		$result = $text->render(['name' => 'my_input']);
+		$result = $text->render(['name' => 'my_input'], $this->context);
 		$expected = [
 			'input' => ['type' => 'text', 'name' => 'my_input']
 		];
@@ -56,7 +57,7 @@ class BasicTest extends TestCase {
 			'name' => 'my_input',
 			'type' => 'email',
 		];
-		$result = $text->render($data);
+		$result = $text->render($data, $this->context);
 		$expected = [
 			'input' => ['type' => 'email', 'name' => 'my_input']
 		];
@@ -75,7 +76,7 @@ class BasicTest extends TestCase {
 			'type' => 'email',
 			'val' => 'Some <value>'
 		];
-		$result = $text->render($data);
+		$result = $text->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'email',
@@ -99,7 +100,7 @@ class BasicTest extends TestCase {
 			'class' => 'form-control',
 			'required' => true
 		];
-		$result = $text->render($data);
+		$result = $text->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'email',

--- a/tests/TestCase/View/Widget/ButtonTest.php
+++ b/tests/TestCase/View/Widget/ButtonTest.php
@@ -29,6 +29,7 @@ class ButtonTest extends TestCase {
 			'button' => '<button{{attrs}}>{{text}}</button>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -38,7 +39,7 @@ class ButtonTest extends TestCase {
  */
 	public function testRenderSimple() {
 		$button = new Button($this->templates);
-		$result = $button->render(['name' => 'my_input']);
+		$result = $button->render(['name' => 'my_input'], $this->context);
 		$expected = [
 			'button' => ['type' => 'submit', 'name' => 'my_input'],
 			'/button'
@@ -58,7 +59,7 @@ class ButtonTest extends TestCase {
 			'type' => 'button',
 			'text' => 'Some button'
 		];
-		$result = $button->render($data);
+		$result = $button->render($data, $this->context);
 		$expected = [
 			'button' => ['type' => 'button', 'name' => 'my_input'],
 			'Some button',
@@ -77,7 +78,7 @@ class ButtonTest extends TestCase {
 		$data = [
 			'text' => 'Some <value>'
 		];
-		$result = $button->render($data);
+		$result = $button->render($data, $this->context);
 		$expected = [
 			'button' => ['type' => 'submit'],
 			'Some <value>',
@@ -86,7 +87,7 @@ class ButtonTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['escape'] = true;
-		$result = $button->render($data);
+		$result = $button->render($data, $this->context);
 		$expected = [
 			'button' => ['type' => 'submit'],
 			'Some &lt;value&gt;',
@@ -108,7 +109,7 @@ class ButtonTest extends TestCase {
 			'class' => 'btn',
 			'required' => true
 		];
-		$result = $button->render($data);
+		$result = $button->render($data, $this->context);
 		$expected = [
 			'button' => [
 				'type' => 'submit',

--- a/tests/TestCase/View/Widget/CheckboxTest.php
+++ b/tests/TestCase/View/Widget/CheckboxTest.php
@@ -34,6 +34,7 @@ class CheckboxTest extends TestCase {
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -46,7 +47,7 @@ class CheckboxTest extends TestCase {
 		$data = [
 			'name' => 'Comment[spam]',
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',
@@ -60,7 +61,7 @@ class CheckboxTest extends TestCase {
 			'name' => 'Comment[spam]',
 			'value' => 99,
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',
@@ -82,7 +83,7 @@ class CheckboxTest extends TestCase {
 			'name' => 'Comment[spam]',
 			'disabled' => true,
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',
@@ -106,7 +107,7 @@ class CheckboxTest extends TestCase {
 			'value' => 1,
 			'checked' => 1,
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',
@@ -122,11 +123,11 @@ class CheckboxTest extends TestCase {
 			'value' => 1,
 			'val' => 1,
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = '1';
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data = [
@@ -134,7 +135,7 @@ class CheckboxTest extends TestCase {
 			'value' => 1,
 			'val' => '1x',
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',
@@ -172,7 +173,7 @@ class CheckboxTest extends TestCase {
 			'value' => 1,
 			'checked' => $checked,
 		];
-		$result = $checkbox->render($data);
+		$result = $checkbox->render($data, $this->context);
 		$expected = [
 			'input' => [
 				'type' => 'checkbox',

--- a/tests/TestCase/View/Widget/DateTimeTest.php
+++ b/tests/TestCase/View/Widget/DateTimeTest.php
@@ -38,6 +38,7 @@ class DateTimeTest extends TestCase {
 			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}'
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 		$this->selectBox = new SelectBox($this->templates);
 		$this->DateTime = new DateTime($this->templates, $this->selectBox);
 	}
@@ -67,7 +68,7 @@ class DateTimeTest extends TestCase {
  * @return void
  */
 	public function testRenderSelectedInvalid($selected) {
-		$result = $this->DateTime->render(['val' => $selected]);
+		$result = $this->DateTime->render(['val' => $selected], $this->context);
 		$now = new \DateTime();
 		$format = '<option value="%s" selected="selected">%s</option>';
 		$this->assertContains(
@@ -101,7 +102,7 @@ class DateTimeTest extends TestCase {
  * @return void
  */
 	public function testRenderSelected($selected) {
-		$result = $this->DateTime->render(['val' => $selected]);
+		$result = $this->DateTime->render(['val' => $selected], $this->context);
 		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
 		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
 		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
@@ -120,7 +121,7 @@ class DateTimeTest extends TestCase {
 			'year' => '2014', 'month' => '01', 'day' => '20',
 			'hour' => '12', 'minute' => '30'
 		];
-		$result = $this->DateTime->render(['name' => 'created', 'val' => $selected]);
+		$result = $this->DateTime->render(['name' => 'created', 'val' => $selected], $this->context);
 		$this->assertContains('name="created[year]"', $result);
 		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
 		$this->assertContains('name="created[month]"', $result);
@@ -145,7 +146,7 @@ class DateTimeTest extends TestCase {
 			'year' => '2014', 'month' => '01', 'day' => '20',
 			'hour' => '7', 'minute' => '30', 'meridian' => 'pm'
 		];
-		$result = $this->DateTime->render(['val' => $selected]);
+		$result = $this->DateTime->render(['val' => $selected], $this->context);
 		$this->assertContains('<option value="2014" selected="selected">2014</option>', $result);
 		$this->assertContains('<option value="01" selected="selected">1</option>', $result);
 		$this->assertContains('<option value="20" selected="selected">20</option>', $result);
@@ -166,7 +167,7 @@ class DateTimeTest extends TestCase {
 			'minute' => ['empty' => 'MINUTE'],
 			'second' => ['empty' => 'SECOND'],
 			'meridian' => ['empty' => 'MERIDIAN'],
-		]);
+		], $this->context);
 		$this->assertContains('<option value="" selected="selected">YEAR</option>', $result);
 		$this->assertContains('<option value="" selected="selected">MONTH</option>', $result);
 		$this->assertContains('<option value="" selected="selected">DAY</option>', $result);
@@ -190,7 +191,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$year = $now->format('Y');
 		$format = '<option value="%s" selected="selected">%s</option>';
 		$this->assertContains(sprintf($format, $year, $year), $result);
@@ -230,7 +231,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'val' => $now,
 			'orderYear' => 'asc',
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[year]', 'data-foo' => 'test'],
 			['option' => ['value' => '2013']], '2013', '/option',
@@ -253,7 +254,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[year]'],
 			['option' => ['value' => '2015']], '2015', '/option',
@@ -284,7 +285,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[year]'],
 			['option' => ['value' => '2015']], '2015', '/option',
@@ -310,7 +311,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[year]'],
 			['option' => ['value' => '2013', 'selected' => 'selected']], '2013', '/option',
@@ -337,7 +338,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[month]'],
 			['option' => ['value' => '01']], '1', '/option',
@@ -373,7 +374,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'month' => ['data-foo' => 'test', 'names' => true],
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[month]', 'data-foo' => 'test'],
 			['option' => ['value' => '01']], 'January', '/option',
@@ -411,7 +412,7 @@ class DateTimeTest extends TestCase {
 				'names' => ['01' => 'Jan', '02' => 'Feb']
 			],
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[month]'],
 			['option' => ['value' => '01']], 'Jan', '/option',
@@ -439,7 +440,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[day]', 'data-foo' => 'test'],
 			['option' => ['value' => '01']], '1', '/option',
@@ -497,7 +498,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[hour]">', $result);
 		$this->assertNotContains(
 			'<option value="01">1</option>',
@@ -542,7 +543,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'val' => $now,
 			'meridian' => [],
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[hour]" data-foo="test">', $result);
 		$this->assertContains('<option value="00">0</option>', $result);
 		$this->assertContains(
@@ -585,11 +586,11 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'val' => $now,
 		];
-		$result = $this->DateTime->render($data);
+		$result = $this->DateTime->render($data, $this->context);
 		$this->assertContains('<option value="23" selected="selected">23</option>', $result);
 
 		$data['val'] = '2010-09-09 23:00:00';
-		$result = $this->DateTime->render($data);
+		$result = $this->DateTime->render($data, $this->context);
 		$this->assertContains('<option value="23" selected="selected">23</option>', $result);
 	}
 
@@ -612,7 +613,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[hour]" data-foo="test">', $result);
 		$this->assertContains(
 			'<option value="01" selected="selected">1</option>',
@@ -659,7 +660,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains(
 			'<option value="12" selected="selected">12</option>',
 			$result,
@@ -686,7 +687,7 @@ class DateTimeTest extends TestCase {
 			'minute' => false,
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[hour]">', $result);
 		$this->assertContains(
 			'<option value="08">8</option>',
@@ -733,7 +734,7 @@ class DateTimeTest extends TestCase {
 			],
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[minute]" data-foo="test">', $result);
 		$this->assertContains(
 			'<option value="00">00</option>',
@@ -776,7 +777,7 @@ class DateTimeTest extends TestCase {
 			],
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[minute]">', $result);
 		$this->assertContains(
 			'<option value="00">00</option>',
@@ -825,7 +826,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'val' => $now,
 		];
-		$result = $this->DateTime->render($data);
+		$result = $this->DateTime->render($data, $this->context);
 		$this->assertContains(
 			'<option value="25" selected="selected">25</option>',
 			$result,
@@ -834,7 +835,7 @@ class DateTimeTest extends TestCase {
 		$this->assertNotContains('value="23"', $result, 'No 23 value');
 
 		$data['minute']['round'] = 'down';
-		$result = $this->DateTime->render($data);
+		$result = $this->DateTime->render($data, $this->context);
 		$this->assertContains(
 			'<option value="20" selected="selected">20</option>',
 			$result,
@@ -860,7 +861,7 @@ class DateTimeTest extends TestCase {
 			],
 			'second' => false,
 			'val' => $now,
-		]);
+		], $this->context);
 
 		$this->assertContains(
 			'<option value="00" selected="selected">00</option>',
@@ -892,7 +893,7 @@ class DateTimeTest extends TestCase {
 				'data-foo' => 'test',
 			],
 			'val' => $now,
-		]);
+		], $this->context);
 		$this->assertContains('<select name="date[second]" data-foo="test">', $result);
 		$this->assertContains(
 			'<option value="01">01</option>',
@@ -935,7 +936,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'meridian' => [],
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[meridian]'],
 			['option' => ['value' => 'am']], 'am', '/option',
@@ -955,7 +956,7 @@ class DateTimeTest extends TestCase {
 			'second' => false,
 			'meridian' => [],
 			'val' => $now,
-		]);
+		], $this->context);
 		$expected = [
 			'select' => ['name' => 'date[meridian]'],
 			['option' => ['value' => 'am', 'selected' => 'selected']], 'am', '/option',

--- a/tests/TestCase/View/Widget/FileTest.php
+++ b/tests/TestCase/View/Widget/FileTest.php
@@ -34,6 +34,7 @@ class FileTest extends TestCase {
 			'file' => '<input type="file" name="{{name}}"{{attrs}}>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -43,7 +44,7 @@ class FileTest extends TestCase {
  */
 	public function testRenderSimple() {
 		$input = new File($this->templates);
-		$result = $input->render(['name' => 'image']);
+		$result = $input->render(['name' => 'image'], $this->context);
 		$expected = [
 			'input' => ['type' => 'file', 'name' => 'image'],
 		];
@@ -58,7 +59,7 @@ class FileTest extends TestCase {
 	public function testRenderAttributes() {
 		$input = new File($this->templates);
 		$data = ['name' => 'image', 'required' => true, 'val' => 'nope'];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			'input' => ['type' => 'file', 'required' => 'required', 'name' => 'image'],
 		];

--- a/tests/TestCase/View/Widget/LabelTest.php
+++ b/tests/TestCase/View/Widget/LabelTest.php
@@ -34,6 +34,7 @@ class LabelTest extends TestCase {
 			'label' => '<label{{attrs}}>{{text}}</label>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -46,7 +47,7 @@ class LabelTest extends TestCase {
 		$data = [
 			'text' => 'My text',
 		];
-		$result = $label->render($data);
+		$result = $label->render($data, $this->context);
 		$expected = [
 			'label' => [],
 			'My text',
@@ -67,7 +68,7 @@ class LabelTest extends TestCase {
 			'for' => 'Some > value',
 			'escape' => false,
 		];
-		$result = $label->render($data);
+		$result = $label->render($data, $this->context);
 		$expected = [
 			'label' => ['for' => 'Some > value'],
 			'My > text',
@@ -89,7 +90,7 @@ class LabelTest extends TestCase {
 			'id' => 'some-id',
 			'data-foo' => 'value',
 		];
-		$result = $label->render($data);
+		$result = $label->render($data, $this->context);
 		$expected = [
 			'label' => ['id' => 'some-id', 'data-foo' => 'value', 'for' => 'some-id'],
 			'My &gt; text',

--- a/tests/TestCase/View/Widget/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxTest.php
@@ -37,6 +37,7 @@ class MultiCheckboxTest extends TestCase {
 			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -54,7 +55,7 @@ class MultiCheckboxTest extends TestCase {
 				2 => 'Development',
 			]
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [
@@ -97,7 +98,7 @@ class MultiCheckboxTest extends TestCase {
 				['value' => '2', 'text' => 'Development', 'class' => 'custom'],
 			]
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [
@@ -141,7 +142,7 @@ class MultiCheckboxTest extends TestCase {
 				'>' => '>>',
 			]
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [
@@ -175,7 +176,7 @@ class MultiCheckboxTest extends TestCase {
 			'val' => [1],
 			'disabled' => false
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [
@@ -204,11 +205,11 @@ class MultiCheckboxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['val'] = 1;
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = '1';
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$this->assertTags($result, $expected);
 	}
 
@@ -228,7 +229,7 @@ class MultiCheckboxTest extends TestCase {
 			],
 			'disabled' => true,
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [
@@ -258,7 +259,7 @@ class MultiCheckboxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['disabled'] = 'a string';
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['disabled'] = ['1', '1x'];
@@ -272,7 +273,7 @@ class MultiCheckboxTest extends TestCase {
 			],
 			'disabled' => [1]
 		];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			['div' => ['class' => 'checkbox']],
 			['input' => [

--- a/tests/TestCase/View/Widget/RadioTest.php
+++ b/tests/TestCase/View/Widget/RadioTest.php
@@ -38,6 +38,7 @@ class RadioTest extends TestCase {
 			'radioContainer' => '{{input}}{{label}}',
 		];
 		$this->templates = new StringTemplate($templates);
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 	}
 
 /**
@@ -53,7 +54,7 @@ class RadioTest extends TestCase {
 			'label' => null,
 			'options' => ['r' => 'Red', 'b' => 'Black']
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'type' => 'radio',
@@ -80,7 +81,7 @@ class RadioTest extends TestCase {
 			'name' => 'Crayons[color]',
 			'options' => new Collection(['r' => 'Red', 'b' => 'Black'])
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 	}
 
@@ -99,7 +100,7 @@ class RadioTest extends TestCase {
 				['value' => 'b', 'text' => 'Black', 'id' => 'my_id_2', 'data-test' => 'test'],
 			]
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'type' => 'radio',
@@ -136,7 +137,7 @@ class RadioTest extends TestCase {
 			'name' => 'Thing[value]',
 			'options' => ['a>b' => 'First', 'a<b' => 'Second']
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'type' => 'radio',
@@ -173,7 +174,7 @@ class RadioTest extends TestCase {
 			'options' => ['1' => 'Yes', '0' => 'No'],
 			'val' => '0'
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = array(
 			array('input' => array('type' => 'radio', 'name' => 'Model[field]', 'value' => '1', 'id' => 'model-field-1')),
 			array('label' => array('for' => 'model-field-1')),
@@ -187,11 +188,11 @@ class RadioTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['val'] = 0;
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = false;
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$expected = array(
@@ -205,11 +206,11 @@ class RadioTest extends TestCase {
 			'/label',
 		);
 		$data['val'] = null;
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = '';
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$expected = array(
@@ -223,15 +224,15 @@ class RadioTest extends TestCase {
 			'/label',
 		);
 		$data['val'] = '1';
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = 1;
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['val'] = true;
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 	}
 
@@ -249,7 +250,7 @@ class RadioTest extends TestCase {
 			'required' => true,
 			'form' => 'my-form',
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => ['type' => 'radio', 'name' => 'published', 'value' => '0',
 				'id' => 'published-0', 'required' => 'required', 'form' => 'my-form']],
@@ -278,7 +279,7 @@ class RadioTest extends TestCase {
 			'options' => ['r' => 'Red'],
 			'empty' => true,
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'type' => 'radio',
@@ -302,7 +303,7 @@ class RadioTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['empty'] = 'Choose one';
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'type' => 'radio',
@@ -342,7 +343,7 @@ class RadioTest extends TestCase {
 			'name' => 'Crayons[color]',
 			'options' => ['r' => 'Red'],
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['label' => ['for' => 'crayons-color-r']],
 			['input' => [
@@ -374,7 +375,7 @@ class RadioTest extends TestCase {
 				'2' => 'two',
 			]
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'id' => 'versions-ver-1',
@@ -425,7 +426,7 @@ class RadioTest extends TestCase {
 			],
 			'disabled' => true,
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'id' => 'versions-ver-1',
@@ -451,11 +452,11 @@ class RadioTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['disabled'] = 'a string';
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertTags($result, $expected);
 
 		$data['disabled'] = ['1'];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'id' => 'versions-ver-1',
@@ -497,7 +498,7 @@ class RadioTest extends TestCase {
 			],
 			'label' => false,
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'id' => 'versions-ver-1',
@@ -525,7 +526,7 @@ class RadioTest extends TestCase {
 				'class' => 'my-class',
 			]
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$expected = [
 			['input' => [
 				'id' => 'versions-ver-1',
@@ -569,7 +570,7 @@ class RadioTest extends TestCase {
 				'2' => 'two',
 			],
 		];
-		$result = $radio->render($data);
+		$result = $radio->render($data, $this->context);
 		$this->assertContains(
 			'<div class="radio"><input type="radio"',
 			$result

--- a/tests/TestCase/View/Widget/SelectBoxTest.php
+++ b/tests/TestCase/View/Widget/SelectBoxTest.php
@@ -36,6 +36,7 @@ class SelectBoxTest extends TestCase {
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
 			'optgroup' => '<optgroup label="{{label}}"{{attrs}}>{{content}}</optgroup>',
 		];
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 		$this->templates = new StringTemplate($templates);
 	}
 
@@ -51,7 +52,7 @@ class SelectBoxTest extends TestCase {
 			'name' => 'Birds[name]',
 			'options' => []
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			'/select'
@@ -71,7 +72,7 @@ class SelectBoxTest extends TestCase {
 			'name' => 'Birds[name]',
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie']
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => 'a']], 'Albatross', '/option',
@@ -94,7 +95,7 @@ class SelectBoxTest extends TestCase {
 			'options' => $options,
 			'empty' => true
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]'],
 			['option' => ['value' => '']], '/option',
@@ -120,7 +121,7 @@ class SelectBoxTest extends TestCase {
 				['value' => 'b', 'text' => 'Budgie', 'data-foo' => 'bar'],
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => 'a']],
@@ -152,7 +153,7 @@ class SelectBoxTest extends TestCase {
 				'2x' => 'two x',
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => '1', 'selected' => 'selected']], 'one', '/option',
@@ -164,7 +165,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['val'] = 2;
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => '1']], 'one', '/option',
@@ -189,7 +190,7 @@ class SelectBoxTest extends TestCase {
 			'multiple' => true,
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie']
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name][]',
@@ -222,7 +223,7 @@ class SelectBoxTest extends TestCase {
 				'2x' => 'two x',
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name][]',
@@ -258,7 +259,7 @@ class SelectBoxTest extends TestCase {
 				]
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -299,7 +300,7 @@ class SelectBoxTest extends TestCase {
 				],
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -314,7 +315,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['escape'] = false;
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -349,7 +350,7 @@ class SelectBoxTest extends TestCase {
 				]
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -385,7 +386,7 @@ class SelectBoxTest extends TestCase {
 				]
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -433,7 +434,7 @@ class SelectBoxTest extends TestCase {
 				]
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -465,7 +466,7 @@ class SelectBoxTest extends TestCase {
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie'],
 			'val' => 'a',
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -483,7 +484,7 @@ class SelectBoxTest extends TestCase {
 			'name' => 'numbers',
 			'options' => ['1' => 'One', '2' => 'Two'],
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'numbers',
@@ -512,7 +513,7 @@ class SelectBoxTest extends TestCase {
 				'c' => 'Canary',
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -544,7 +545,7 @@ class SelectBoxTest extends TestCase {
 			'empty' => true,
 			'options' => ['a' => 'Albatross', 'b' => 'Budgie']
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => '']], '/option',
@@ -555,7 +556,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['empty'] = 'empty';
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => '']], 'empty', '/option',
@@ -567,7 +568,7 @@ class SelectBoxTest extends TestCase {
 
 		$data['empty'] = 'empty';
 		$data['val'] = '';
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => ['name' => 'Birds[name]', 'id' => 'BirdName'],
 			['option' => ['value' => '', 'selected' => 'selected']], 'empty', '/option',
@@ -578,7 +579,7 @@ class SelectBoxTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['val'] = false;
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$this->assertTags($result, $expected);
 	}
 
@@ -597,7 +598,7 @@ class SelectBoxTest extends TestCase {
 				'c' => '>Canary',
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',
@@ -622,7 +623,7 @@ class SelectBoxTest extends TestCase {
 				'>a' => '>Albatross',
 			]
 		];
-		$result = $select->render($data);
+		$result = $select->render($data, $this->context);
 		$expected = [
 			'select' => [
 				'name' => 'Birds[name]',

--- a/tests/TestCase/View/Widget/TextareaTest.php
+++ b/tests/TestCase/View/Widget/TextareaTest.php
@@ -33,6 +33,7 @@ class TextareaTest extends TestCase {
 		$templates = [
 			'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
 		];
+		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
 		$this->templates = new StringTemplate($templates);
 	}
 
@@ -43,7 +44,7 @@ class TextareaTest extends TestCase {
  */
 	public function testRenderSimple() {
 		$input = new Textarea($this->templates);
-		$result = $input->render(['name' => 'comment']);
+		$result = $input->render(['name' => 'comment'], $this->context);
 		$expected = [
 			'textarea' => ['name' => 'comment'],
 			'/textarea',
@@ -59,7 +60,7 @@ class TextareaTest extends TestCase {
 	public function testRenderWithValue() {
 		$input = new Textarea($this->templates);
 		$data = ['name' => 'comment', 'data-foo' => '<val>', 'val' => 'some <html>'];
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			'textarea' => ['name' => 'comment', 'data-foo' => '&lt;val&gt;'],
 			'some &lt;html&gt;',
@@ -68,7 +69,7 @@ class TextareaTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$data['escape'] = false;
-		$result = $input->render($data);
+		$result = $input->render($data, $this->context);
 		$expected = [
 			'textarea' => ['name' => 'comment', 'data-foo' => '<val>'],
 			'some <html>',

--- a/tests/TestCase/View/Widget/WidgetRegistryTest.php
+++ b/tests/TestCase/View/Widget/WidgetRegistryTest.php
@@ -16,6 +16,7 @@ namespace Cake\Test\TestCase\View\Widget;
 
 use Cake\TestSuite\TestCase;
 use Cake\View\StringTemplate;
+use Cake\View\View;
 use Cake\View\Widget\WidgetRegistry;
 
 /**
@@ -31,6 +32,7 @@ class WidgetRegistryTestCase extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->templates = new StringTemplate();
+		$this->view = new View();
 	}
 
 /**
@@ -42,7 +44,7 @@ class WidgetRegistryTestCase extends TestCase {
 		$widgets = [
 			'text' => ['Cake\View\Widget\Basic'],
 		];
-		$inputs = new WidgetRegistry($this->templates, $widgets);
+		$inputs = new WidgetRegistry($this->templates, $this->view, $widgets);
 		$result = $inputs->get('text');
 		$this->assertInstanceOf('Cake\View\Widget\Basic', $result);
 	}
@@ -53,7 +55,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testAdd() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$result = $inputs->add([
 			'text' => ['Cake\View\Widget\Basic'],
 		]);
@@ -61,7 +63,7 @@ class WidgetRegistryTestCase extends TestCase {
 		$result = $inputs->get('text');
 		$this->assertInstanceOf('Cake\View\Widget\WidgetInterface', $result);
 
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$result = $inputs->add([
 			'hidden' => 'Cake\View\Widget\Basic',
 		]);
@@ -78,7 +80,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testAddInvalidType() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add([
 			'text' => new \StdClass()
 		]);
@@ -91,7 +93,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGet() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add([
 			'text' => ['Cake\View\Widget\Basic'],
 		]);
@@ -106,7 +108,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetFallback() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add([
 			'_default' => ['Cake\View\Widget\Basic'],
 		]);
@@ -125,7 +127,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetNoFallbackError() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->clear();
 		$inputs->get('foo');
 	}
@@ -136,7 +138,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetResolveDependency() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->clear();
 		$inputs->add([
 			'label' => ['Cake\View\Widget\Label'],
@@ -154,7 +156,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetResolveDependencyMissingClass() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->add(['test' => ['TestApp\View\Derp']]);
 		$inputs->get('test');
 	}
@@ -167,7 +169,7 @@ class WidgetRegistryTestCase extends TestCase {
  * @return void
  */
 	public function testGetResolveDependencyMissingDependency() {
-		$inputs = new WidgetRegistry($this->templates);
+		$inputs = new WidgetRegistry($this->templates, $this->view);
 		$inputs->clear();
 		$inputs->add(['multicheckbox' => ['Cake\View\Widget\MultiCheckbox', 'label']]);
 		$inputs->get('multicheckbox');


### PR DESCRIPTION
Pass the current form context into widgets when they are rendered. This will make it easier for widgets to generate multiple inputs. The use case that drove these changes was having a date range picker that created a start and end date input. With these changes both the start/end input values & schema data could be accessed by the widget.

Related to #3658
