### PR TITLE
3.0 merges simplified

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -119,7 +119,7 @@ class Component implements EventListener {
  */
 	public function __get($name) {
 		if (isset($this->_componentMap[$name]) && !isset($this->{$name})) {
-			$config = array_merge((array)$this->_componentMap[$name]['config'], array('enabled' => false));
+			$config = array('enabled' => false) + (array)$this->_componentMap[$name]['config'];
 			$this->{$name} = $this->_registry->load($this->_componentMap[$name]['class'], $config);
 		}
 		if (isset($this->{$name})) {

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -504,7 +504,7 @@ class AuthComponent extends Component {
 			if (!method_exists($className, 'authorize')) {
 				throw new Error\Exception('Authorization objects must implement an authorize() method.');
 			}
-			$config = array_merge($global, (array)$config);
+			$config = (array)$config + $global;
 			$this->_authorizeObjects[] = new $className($this->_registry, $config);
 		}
 		return $this->_authorizeObjects;

--- a/src/Network/Email/Email.php
+++ b/src/Network/Email/Email.php
@@ -1214,7 +1214,7 @@ class Email {
 				if (!is_array($this->_profile['log'])) {
 					$this->_profile['log'] = ['level' => $this->_profile['log']];
 				}
-				$config = array_merge($config, $this->_profile['log']);
+				$config = $this->_profile['log'] + $config;
 			}
 			Log::write(
 				$config['level'],

--- a/src/ORM/TableRegistry.php
+++ b/src/ORM/TableRegistry.php
@@ -157,7 +157,7 @@ class TableRegistry {
 		$options['className'] = $className ?: 'Cake\ORM\Table';
 
 		if (isset(static::$_config[$alias])) {
-			$options = array_merge(static::$_config[$alias], $options);
+			$options += static::$_config[$alias];
 		}
 		if (empty($options['connection'])) {
 			$connectionName = $options['className']::defaultConnectionName();

--- a/src/Routing/RequestActionTrait.php
+++ b/src/Routing/RequestActionTrait.php
@@ -105,10 +105,7 @@ trait RequestActionTrait {
 			$extra['autoRender'] = 1;
 			unset($extra[$index]);
 		}
-		$extra = array_merge(
-			['autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1],
-			$extra
-		);
+		$extra += ['autoRender' => 0, 'return' => 1, 'bare' => 1, 'requested' => 1];
 
 		$baseUrl = Configure::read('App.fullBaseUrl');
 		if (is_string($url) && strpos($url, $baseUrl) === 0) {

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -435,10 +435,10 @@ class Router {
  * @return array Array of mapped resources
  */
 	public static function mapResources($controller, $options = []) {
-		$options = array_merge(array(
+		$options += array(
 			'connectOptions' => [],
 			'id' => static::ID . '|' . static::UUID
-		), $options);
+		);
 
 		$connectOptions = $options['connectOptions'];
 		unset($options['connectOptions']);

--- a/src/Utility/String.php
+++ b/src/Utility/String.php
@@ -269,11 +269,11 @@ class String {
 		}
 		switch ($clean['method']) {
 			case 'html':
-				$clean = array_merge(array(
+				$clean += array(
 					'word' => '[\w,.]+',
 					'andText' => true,
 					'replacement' => '',
-				), $clean);
+				);
 				$kleenex = sprintf(
 					'/[\s]*[a-z]+=(")(%s%s%s[\s]*)+\\1/i',
 					preg_quote($options['before'], '/'),
@@ -287,11 +287,11 @@ class String {
 				}
 				break;
 			case 'text':
-				$clean = array_merge(array(
+				$clean += array(
 					'word' => '[\w,.]+',
 					'gap' => '[\s]*(?:(?:and|or)[\s]*)?',
 					'replacement' => '',
-				), $clean);
+				);
 
 				$kleenex = sprintf(
 					'/(%s%s%s%s|%s%s%s%s)/',

--- a/src/Utility/Time.php
+++ b/src/Utility/Time.php
@@ -246,7 +246,7 @@ class Time extends Carbon implements JsonSerializable {
 
 		if (isset($options['accuracy'])) {
 			if (is_array($options['accuracy'])) {
-				$accuracy = array_merge($accuracy, $options['accuracy']);
+				$accuracy = $options['accuracy'] + $accuracy;
 			} else {
 				foreach ($accuracy as $key => $level) {
 					$accuracy[$key] = $options['accuracy'];

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -175,7 +175,6 @@ class Helper implements EventListener {
  */
 	public function __get($name) {
 		if (isset($this->_helperMap[$name]) && !isset($this->{$name})) {
-			$settings = array_merge((array)$this->_helperMap[$name]['config'], array('enabled' => false));
 			$this->{$name} = $this->_View->addHelper($this->_helperMap[$name]['class'], $this->_config);
 		}
 		if (isset($this->{$name})) {

--- a/src/View/Helper.php
+++ b/src/View/Helper.php
@@ -175,7 +175,8 @@ class Helper implements EventListener {
  */
 	public function __get($name) {
 		if (isset($this->_helperMap[$name]) && !isset($this->{$name})) {
-			$this->{$name} = $this->_View->addHelper($this->_helperMap[$name]['class'], $this->_config);
+			$config = ['enabled' => false] + (array)$this->_helperMap[$name]['config'];
+			$this->{$name} = $this->_View->addHelper($this->_helperMap[$name]['class'], $config);
 		}
 		if (isset($this->{$name})) {
 			return $this->{$name};

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -339,7 +339,7 @@ class FormHelper extends Helper {
 		}
 		unset($options['type'], $options['encoding']);
 
-		$htmlAttributes = array_merge($options, $htmlAttributes);
+		$htmlAttributes += $options;
 
 		$this->fields = array();
 		if ($this->requestType !== 'get') {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -467,7 +467,8 @@ class HtmlHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/html.html#HtmlHelper::script
  */
 	public function script($url, array $options = array()) {
-		$options = array_merge(array('block' => null, 'once' => true), $options);
+		$defaults = array('block' => null, 'once' => true);
+		$options += $defaults;
 
 		if (is_array($url)) {
 			$out = '';

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -270,7 +270,7 @@ class PaginatorHelper extends Helper {
 			'disabledTitle' => $title,
 			'escape' => true,
 		];
-		$options = array_merge($defaults, (array)$options);
+		$options += $defaults;
 		$options['step'] = -1;
 
 		$enabled = $this->hasPrev($options['model']);
@@ -305,7 +305,7 @@ class PaginatorHelper extends Helper {
 			'disabledTitle' => $title,
 			'escape' => true,
 		];
-		$options = array_merge($defaults, (array)$options);
+		$options += $defaults;
 		$options['step'] = 1;
 
 		$enabled = $this->hasNext($options['model']);

--- a/src/View/View.php
+++ b/src/View/View.php
@@ -1082,7 +1082,7 @@ class View {
 				'config' => $this->elementCache,
 				'key' => $this->elementCacheSettings['key']
 			);
-			$this->elementCacheSettings = array_merge($defaults, $options['cache']);
+			$this->elementCacheSettings = $options['cache'] + $defaults;
 		}
 		$this->elementCacheSettings['key'] = 'element_' . $this->elementCacheSettings['key'];
 		return Cache::read($this->elementCacheSettings['key'], $this->elementCacheSettings['config']);


### PR DESCRIPTION
For consistency across 3.0 classes. It's also 5-7x faster.

The (dead) removed line in src/View/Helper.php probably needs some follow up @AD7six
It was introduced in https://github.com/cakephp/cakephp/commit/12b281ac7bc678454c0e9d2e1f3a0c2055d02792#diff-73cae20de0f595ea9d7dcbe7610774f7R180

There might be a missing test case for `'enabled' => false/true`
