### PR TITLE
3.0 Fix CSS and Script once option

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -91,7 +91,10 @@ class HtmlHelper extends Helper {
  *
  * @var array
  */
-	protected $_includedAssets = array();
+	protected $_includedAssets = array(
+		'css' => array(),
+		'script' => array()
+	);
 
 /**
  * Options for the currently opened script block buffer if any.
@@ -405,11 +408,11 @@ class HtmlHelper extends Helper {
 			return;
 		}
 
-		if ($options['once'] && isset($this->_includedAssets[$path])) {
+		if ($options['once'] && isset($this->_includedAssets['css'][$path])) {
 			return '';
 		}
 		unset($options['once']);
-		$this->_includedAssets[$path] = true;
+		$this->_includedAssets['css'][$path] = true;
 
 		if (strpos($path, '//') !== false) {
 			$url = $path;
@@ -489,10 +492,10 @@ class HtmlHelper extends Helper {
 			}
 			return null;
 		}
-		if ($options['once'] && isset($this->_includedAssets[$url])) {
+		if ($options['once'] && isset($this->_includedAssets['script'][$url])) {
 			return null;
 		}
-		$this->_includedAssets[$url] = true;
+		$this->_includedAssets['script'][$url] = true;
 
 		if (strpos($url, '//') === false) {
 			$url = $this->assetUrl($url, $options + array('pathPrefix' => Configure::read('App.jsBaseUrl'), 'ext' => '.js'));

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -91,10 +91,7 @@ class HtmlHelper extends Helper {
  *
  * @var array
  */
-	protected $_includedAssets = array(
-		'css' => array(),
-		'script' => array()
-	);
+	protected $_includedAssets = array();
 
 /**
  * Options for the currently opened script block buffer if any.
@@ -408,18 +405,18 @@ class HtmlHelper extends Helper {
 			return;
 		}
 
-		if ($options['once'] && isset($this->_includedAssets['css'][$path])) {
-			return '';
-		}
-		unset($options['once']);
-		$this->_includedAssets['css'][$path] = true;
-
 		if (strpos($path, '//') !== false) {
 			$url = $path;
 		} else {
 			$url = $this->assetUrl($path, $options + array('pathPrefix' => Configure::read('App.cssBaseUrl'), 'ext' => '.css'));
 			$options = array_diff_key($options, array('fullBase' => null, 'pathPrefix' => null));
 		}
+
+		if ($options['once'] && isset($this->_includedAssets[$url])) {
+			return '';
+		}
+		unset($options['once']);
+		$this->_includedAssets[$url] = true;
 
 		if ($options['rel'] === 'import') {
 			$out = $this->formatTemplate('style', [
@@ -492,15 +489,17 @@ class HtmlHelper extends Helper {
 			}
 			return null;
 		}
-		if ($options['once'] && isset($this->_includedAssets['script'][$url])) {
-			return null;
-		}
-		$this->_includedAssets['script'][$url] = true;
 
 		if (strpos($url, '//') === false) {
 			$url = $this->assetUrl($url, $options + array('pathPrefix' => Configure::read('App.jsBaseUrl'), 'ext' => '.js'));
 			$options = array_diff_key($options, array('fullBase' => null, 'pathPrefix' => null));
 		}
+
+		if ($options['once'] && isset($this->_includedAssets[$url])) {
+			return null;
+		}
+		$this->_includedAssets[$url] = true;
+
 		$out = $this->formatTemplate('javascriptlink', [
 			'url' => $url,
 			'attrs' => $this->templater()->formatAttributes($options, ['block', 'once']),

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -1979,4 +1979,23 @@ class HtmlHelperTest extends TestCase {
 		);
 	}
 
+/**
+ * Tests that CSS and Javascript files of the same name don't conflict with the 'once' test
+ *
+ * @return void
+ */
+	public function testCssAndScriptWithSameName() {
+		$result = $this->Html->css('foo');
+		$expected = array(
+			'link' => array('rel' => 'stylesheet', 'href' => 'preg:/.*css\/foo\.css/')
+		);
+		$this->assertTags($result, $expected);
+
+		$result = $this->Html->script('foo');
+		$expected = array(
+			'script' => array('src' => 'js/foo.js')
+		);
+		$this->assertTags($result, $expected);
+	}
+
 }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -515,7 +515,7 @@ class HtmlHelperTest extends TestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		$result = $this->Html->css('screen.css');
+		$result = $this->Html->css('screen.css', array('once' => false));
 		$this->assertTags($result, $expected);
 
 		Plugin::load('TestPlugin');


### PR DESCRIPTION
The recently added 'CSS' once option introduces an issue if you have a css file and js file that use the same name. This fixes that issue by splitting the css and script files into separate arrays.
