### PR TITLE
3.0 form container template

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -80,7 +80,8 @@ class FormHelper extends Helper {
 		'templates' => [
 			'button' => '<button{{attrs}}>{{text}}</button>',
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
-			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
+			'checkboxFormGroup' => '{{input}}{{label}}',
+			'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
 			'dateWidget' => '{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}',
 			'error' => '<div class="error-message">{{content}}</div>',
 			'errorList' => '<ul>{{content}}</ul>',
@@ -89,9 +90,12 @@ class FormHelper extends Helper {
 			'fieldset' => '<fieldset>{{content}}</fieldset>',
 			'formstart' => '<form{{attrs}}>',
 			'formend' => '</form>',
+			'formGroup' => '{{label}}{{input}}',
 			'hiddenblock' => '<div style="display:none;">{{content}}</div>',
 			'input' => '<input type="{{type}}" name="{{name}}"{{attrs}}>',
 			'inputsubmit' => '<input type="{{type}}"{{attrs}}>',
+			'inputContainer' => '<div class="input {{type}}{{required}}">{{content}}</div>',
+			'inputContainerError' => '<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>',
 			'label' => '<label{{attrs}}>{{text}}</label>',
 			'legend' => '<legend>{{text}}</legend>',
 			'option' => '<option value="{{value}}"{{attrs}}>{{text}}</option>',
@@ -99,12 +103,8 @@ class FormHelper extends Helper {
 			'select' => '<select name="{{name}}"{{attrs}}>{{content}}</select>',
 			'selectMultiple' => '<select name="{{name}}[]" multiple="multiple"{{attrs}}>{{content}}</select>',
 			'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
-			'radioContainer' => '{{input}}{{label}}',
+			'radioWrapper' => '{{input}}{{label}}',
 			'textarea' => '<textarea name="{{name}}"{{attrs}}>{{value}}</textarea>',
-			'formGroup' => '{{label}}{{input}}',
-			'checkboxFormGroup' => '{{input}}{{label}}',
-			'groupContainer' => '<div class="input {{type}}{{required}}">{{content}}</div>',
-			'groupContainerError' => '<div class="input {{type}}{{required}} error">{{content}}{{error}}</div>',
 			'submitContainer' => '<div class="submit">{{content}}</div>',
 		]
 	];
@@ -895,13 +895,14 @@ class FormHelper extends Helper {
 		$this->templates($options['templates']);
 		unset($options['templates']);
 
-		$template = 'groupContainer';
 		$error = null;
+		$errorSuffix = '';
 		if ($options['type'] !== 'hidden' && $options['error'] !== false) {
 			$error = $this->error($fieldName, $options['error']);
-			$template = empty($error) ? $template : 'groupContainerError';
+			$errorSuffix = empty($error) ? '' : 'Error';
 			unset($options['error']);
 		}
+		$template = 'inputContainer' . $errorSuffix;
 
 		$label = $options['label'];
 		if ($options['type'] !== 'radio') {

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -902,7 +902,11 @@ class FormHelper extends Helper {
 			$errorSuffix = empty($error) ? '' : 'Error';
 			unset($options['error']);
 		}
-		$template = 'inputContainer' . $errorSuffix;
+
+		$template = $options['type'] . 'Container' . $errorSuffix;
+		if (!$this->templates($template)) {
+			$template = 'inputContainer' . $errorSuffix;
+		}
 
 		$label = $options['label'];
 		if ($options['type'] !== 'radio') {

--- a/src/View/Widget/MultiCheckbox.php
+++ b/src/View/Widget/MultiCheckbox.php
@@ -47,7 +47,7 @@ class MultiCheckbox implements WidgetInterface {
  *
  * - `checkbox` Renders checkbox input controls. Accepts
  *   the `name`, `value` and `attrs` variables.
- * - `checkboxContainer` Renders the containing div/element for
+ * - `checkboxWrapper` Renders the containing div/element for
  *   a checkbox and its label. Accepts the `input`, and `label`
  *   variables.
  *
@@ -167,7 +167,7 @@ class MultiCheckbox implements WidgetInterface {
 		}
 		$label = $this->_label->render($labelAttrs, $context);
 
-		return $this->_templates->format('checkboxContainer', [
+		return $this->_templates->format('checkboxWrapper', [
 			'label' => $label,
 			'input' => $input
 		]);

--- a/src/View/Widget/Radio.php
+++ b/src/View/Widget/Radio.php
@@ -50,7 +50,7 @@ class Radio implements WidgetInterface {
  *
  * - `radio` Used to generate the input for a radio button.
  *   Can use the following variables `name`, `value`, `attrs`.
- * - `radioContainer` Used to generate the container element for
+ * - `radioWrapper` Used to generate the container element for
  *   the radio + input element. Can use the `input` and `label`
  *   variables.
  *
@@ -187,7 +187,7 @@ class Radio implements WidgetInterface {
 			$escape
 		);
 
-		return $this->_templates->format('radioContainer', [
+		return $this->_templates->format('radioWrapper', [
 			'input' => $input,
 			'label' => $label,
 		]);

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6077,6 +6077,7 @@ class FormHelperTest extends TestCase {
 			'checkboxContainer' => '<div class="check">{{content}}</div>',
 			'radioContainer' => '<div class="rad">{{content}}</div>',
 			'radioContainerError' => '<div class="rad err">{{content}}</div>',
+			'datetimeContainer' => '<div class="dt">{{content}}</div>',
 		]);
 
 		$this->article['errors'] = [
@@ -6109,6 +6110,11 @@ class FormHelperTest extends TestCase {
 			'options' => ['Y', 'N']
 		]);
 		$this->assertContains('<div class="rad err">', $result);
+
+		$result = $this->Form->input('Article.created', [
+			'type' => 'datetime',
+		]);
+		$this->assertContains('<div class="dt">', $result);
 	}
 
 /**

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -6068,6 +6068,50 @@ class FormHelperTest extends TestCase {
 	}
 
 /**
+ * Test that *Container templates are used by input.
+ *
+ * @return void
+ */
+	public function testInputContainerTemplates() {
+		$this->Form->templates([
+			'checkboxContainer' => '<div class="check">{{content}}</div>',
+			'radioContainer' => '<div class="rad">{{content}}</div>',
+			'radioContainerError' => '<div class="rad err">{{content}}</div>',
+		]);
+
+		$this->article['errors'] = [
+			'Article' => ['published' => 'error message']
+		];
+		$this->Form->create($this->article);
+
+		$result = $this->Form->input('accept', [
+			'type' => 'checkbox'
+		]);
+		$expected = [
+			'div' => ['class' => 'check'],
+			['input' => ['type' => 'hidden', 'name' => 'accept', 'value' => 0]],
+			['input' => ['id' => 'accept', 'type' => 'checkbox', 'name' => 'accept', 'value' => 1]],
+			'label' => ['for' => 'accept'],
+			'Accept',
+			'/label',
+			'/div'
+		];
+		$this->assertTags($result, $expected);
+
+		$result = $this->Form->input('accept', [
+			'type' => 'radio',
+			'options' => ['Y', 'N']
+		]);
+		$this->assertContains('<div class="rad">', $result);
+
+		$result = $this->Form->input('Article.published', [
+			'type' => 'radio',
+			'options' => ['Y', 'N']
+		]);
+		$this->assertContains('<div class="rad err">', $result);
+	}
+
+/**
  * Test resetting templates.
  *
  * @return void

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -1683,7 +1683,7 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->input('Article.title', [
 			'templates' => [
-				'groupContainerError' => '<div class="input {{type}}{{required}} error">{{content}}</div>'
+				'inputContainerError' => '<div class="input {{type}}{{required}} error">{{content}}</div>'
 			]
 		]);
 
@@ -1902,7 +1902,7 @@ class FormHelperTest extends TestCase {
 		$this->assertTags($result, $expected);
 
 		$result = $this->Form->input('Contact.email', array(
-			'templates' => ['groupContainer' => '<div>{{content}}</div>']
+			'templates' => ['inputContainer' => '<div>{{content}}</div>']
 		));
 		$expected = array(
 			'<div',
@@ -2031,7 +2031,7 @@ class FormHelperTest extends TestCase {
 
 		$result = $this->Form->input('Contact.field', array(
 			'templates' => [
-				'groupContainerError' => '{{content}}{{error}}',
+				'inputContainerError' => '{{content}}{{error}}',
 				'error' => '<span class="error-message">{{content}}</span>'
 			]
 		));
@@ -3253,7 +3253,7 @@ class FormHelperTest extends TestCase {
 	public function testRadioInputInsideLabel() {
 		$this->Form->templates([
 			'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
-			'radioContainer' => '{{label}}'
+			'radioWrapper' => '{{label}}'
 		]);
 
 		$result = $this->Form->radio('Model.field', ['option A', 'option B']);
@@ -5710,7 +5710,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testForMagicInputNonExistingNorValidated() {
 		$result = $this->Form->create($this->article);
-		$this->Form->templates(['groupContainer' => '{{content}}']);
+		$this->Form->templates(['inputContainer' => '{{content}}']);
 		$result = $this->Form->input('non_existing_nor_validated');
 		$expected = array(
 			'label' => array('for' => 'non-existing-nor-validated'),
@@ -5761,7 +5761,7 @@ class FormHelperTest extends TestCase {
 			'className' => __NAMESPACE__ . '\ContactsTable'
 		]);
 		$this->Form->create([], ['context' => ['table' => 'Contacts']]);
-		$this->Form->templates(['groupContainer' => '{{content}}']);
+		$this->Form->templates(['inputContainer' => '{{content}}']);
 
 		$result = $this->Form->input('Contacts.name', array('label' => 'My label'));
 		$expected = array(
@@ -5973,7 +5973,7 @@ class FormHelperTest extends TestCase {
  */
 	public function testHtml5InputWithInput() {
 		$this->Form->create();
-		$this->Form->templates(['groupContainer' => '{{content}}']);
+		$this->Form->templates(['inputContainer' => '{{content}}']);
 		$result = $this->Form->input('website', array(
 			'type' => 'url',
 			'val' => 'http://domain.tld',

--- a/tests/TestCase/View/Widget/MultiCheckboxTest.php
+++ b/tests/TestCase/View/Widget/MultiCheckboxTest.php
@@ -34,7 +34,7 @@ class MultiCheckboxTest extends TestCase {
 		$templates = [
 			'checkbox' => '<input type="checkbox" name="{{name}}" value="{{value}}"{{attrs}}>',
 			'label' => '<label{{attrs}}>{{text}}</label>',
-			'checkboxContainer' => '<div class="checkbox">{{input}}{{label}}</div>',
+			'checkboxWrapper' => '<div class="checkbox">{{input}}{{label}}</div>',
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->context = $this->getMock('Cake\View\Form\ContextInterface');

--- a/tests/TestCase/View/Widget/RadioTest.php
+++ b/tests/TestCase/View/Widget/RadioTest.php
@@ -35,7 +35,7 @@ class RadioTest extends TestCase {
 		$templates = [
 			'radio' => '<input type="radio" name="{{name}}" value="{{value}}"{{attrs}}>',
 			'label' => '<label{{attrs}}>{{text}}</label>',
-			'radioContainer' => '{{input}}{{label}}',
+			'radioWrapper' => '{{input}}{{label}}',
 		];
 		$this->templates = new StringTemplate($templates);
 		$this->context = $this->getMock('Cake\View\Form\ContextInterface');
@@ -335,7 +335,7 @@ class RadioTest extends TestCase {
 	public function testRenderInputInsideLabel() {
 		$this->templates->add([
 			'label' => '<label{{attrs}}>{{input}}{{text}}</label>',
-			'radioContainer' => '{{label}}',
+			'radioWrapper' => '{{label}}',
 		]);
 		$label = new Label($this->templates);
 		$radio = new Radio($this->templates, $label);
@@ -558,7 +558,7 @@ class RadioTest extends TestCase {
  */
 	public function testRenderContainerTemplate() {
 		$this->templates->add([
-			'radioContainer' => '<div class="radio">{{input}}{{label}}</div>'
+			'radioWrapper' => '<div class="radio">{{input}}{{label}}</div>'
 		]);
 		$label = new Label($this->templates);
 		$radio = new Radio($this->templates, $label);


### PR DESCRIPTION
This set of changes renames a few of the templates (better names are welcome). It also adds the ability to have per input type containers that developers can use to make the HTML generated by input() vary for each input type.  This change was initiated by the discussion in #3651.
