### PR TITLE
Fix Hash::extract() not matching 1/0 to true/false.

### DIFF
--- a/lib/Cake/Test/Case/Utility/HashTest.php
+++ b/lib/Cake/Test/Case/Utility/HashTest.php
@@ -868,9 +868,18 @@ class HashTest extends CakeTestCase {
 				'active' => false
 			),
 		);
+		$result = Hash::extract($users, '{n}[active=0]');
+		$this->assertCount(1, $result);
+		$this->assertEquals($users[2], $result[0]);
+
 		$result = Hash::extract($users, '{n}[active=false]');
 		$this->assertCount(1, $result);
 		$this->assertEquals($users[2], $result[0]);
+
+		$result = Hash::extract($users, '{n}[active=1]');
+		$this->assertCount(2, $result);
+		$this->assertEquals($users[0], $result[0]);
+		$this->assertEquals($users[1], $result[1]);
 
 		$result = Hash::extract($users, '{n}[active=true]');
 		$this->assertCount(2, $result);

--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -208,7 +208,10 @@ class Hash {
 			if (isset($data[$attr])) {
 				$prop = $data[$attr];
 			}
-			if ($prop === true || $prop === false) {
+			$isBool = is_bool($prop);
+			if ($isBool && is_numeric($val)) {
+				$prop = $prop ? '1' : '0';
+			} elseif ($isBool) {
 				$prop = $prop ? 'true' : 'false';
 			}
 


### PR DESCRIPTION
Historically [prop=1] has matched prop=true as well. This restores that and also fixes [prop=0] not finding falsey values.

This makes the typing less strict in Hash::extract() but I don't think it is unreasonable given PHP's type juggling.

Refs #3288
