### PR TITLE
Add support for specifying protocol in Cakesocket/HttpSocket.  Add HEAD function to HttpSocket

### DIFF
--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -116,7 +116,6 @@ class CakeSocket {
  */
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
-		//if(isset())
 	}
 
 /**

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -116,9 +116,7 @@ class CakeSocket {
  */
 	public function __construct($config = array()) {
 		$this->config = array_merge($this->_baseConfig, $config);
-		if (!is_numeric($this->config['protocol'])) {
-			$this->config['protocol'] = getprotobyname($this->config['protocol']);
-		}
+		//if(isset())
 	}
 
 /**
@@ -133,8 +131,8 @@ class CakeSocket {
 		}
 
 		$scheme = null;
-		if (isset($this->config['request']['uri']) && $this->config['request']['uri']['scheme'] === 'https') {
-			$scheme = 'ssl://';
+		if (!empty($this->config['protocol']) &&  strpos($this->config['host'], '://') === false)  {
+			$scheme = $this->config['protocol'].'://';
 		}
 
 		if (!empty($this->config['context'])) {
@@ -387,3 +385,4 @@ class CakeSocket {
 	}
 
 }
+

--- a/lib/Cake/Network/CakeSocket.php
+++ b/lib/Cake/Network/CakeSocket.php
@@ -131,8 +131,8 @@ class CakeSocket {
 		}
 
 		$scheme = null;
-		if (!empty($this->config['protocol']) &&  strpos($this->config['host'], '://') === false)  {
-			$scheme = $this->config['protocol'].'://';
+		if (!empty($this->config['protocol']) && strpos($this->config['host'], '://') === false) {
+			$scheme = $this->config['protocol'] . '://';
 		}
 
 		if (!empty($this->config['context'])) {

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -341,7 +341,7 @@ class HttpSocket extends CakeSocket {
 		if (!empty($this->request['body']) && !isset($this->request['header']['Content-Length'])) {
 			$this->request['header']['Content-Length'] = strlen($this->request['body']);
 		}
-		if (isset($this->request['uri']['scheme']) && $this->request['uri']['scheme'] === 'https' && empty($this->config['protocol'])) {
+		if (isset($this->request['uri']['scheme']) && $this->request['uri']['scheme'] === 'https' && in_array($this->config['protocol'], array(false, 'tcp'))) {
 			$this->config['protocol'] = 'ssl';
 		}
 

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -294,6 +294,7 @@ class HttpSocket extends CakeSocket {
 		if (isset($host)) {
 			$this->config['host'] = $host;
 		}
+
 		$this->_setProxy();
 		$this->request['proxy'] = $this->_proxy;
 
@@ -339,6 +340,9 @@ class HttpSocket extends CakeSocket {
 
 		if (!empty($this->request['body']) && !isset($this->request['header']['Content-Length'])) {
 			$this->request['header']['Content-Length'] = strlen($this->request['body']);
+		}
+		if(isset($this->request['uri']['scheme']) && $this->request['uri']['scheme'] === 'https'){
+			$this->config['protocol'] = 'ssl'; 
 		}
 
 		$connectionType = null;
@@ -519,6 +523,21 @@ class HttpSocket extends CakeSocket {
 		$request = Hash::merge(array('method' => 'DELETE', 'uri' => $uri, 'body' => $data), $request);
 		return $this->request($request);
 	}
+
+/**
+ * Issues a HEADER request to the specified URI, query, and request.
+ *
+ * @param string|array $uri URI to request (see {@link _parseUri()})
+ * @param array $data Array of request body data keys and values.
+ * @param array $request An indexed array with indexes such as 'method' or uri
+ * @return mixed Result of request
+ */
+	public function head($uri = null, $data = array(), $request = array()) {
+		$request = Hash::merge(array('method' => 'HEAD', 'uri' => $uri, 'body' => $data), $request);
+		return $this->request($request);
+	}
+
+
 
 /**
  * Normalizes URLs into a $uriTemplate. If no template is provided
@@ -1030,3 +1049,4 @@ class HttpSocket extends CakeSocket {
 	}
 
 }
+

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -341,8 +341,8 @@ class HttpSocket extends CakeSocket {
 		if (!empty($this->request['body']) && !isset($this->request['header']['Content-Length'])) {
 			$this->request['header']['Content-Length'] = strlen($this->request['body']);
 		}
-		if(isset($this->request['uri']['scheme']) && $this->request['uri']['scheme'] === 'https'){
-			$this->config['protocol'] = 'ssl'; 
+		if (isset($this->request['uri']['scheme']) && $this->request['uri']['scheme'] === 'https' && empty($this->config['protocol'])) {
+			$this->config['protocol'] = 'ssl';
 		}
 
 		$connectionType = null;
@@ -525,7 +525,7 @@ class HttpSocket extends CakeSocket {
 	}
 
 /**
- * Issues a HEADER request to the specified URI, query, and request.
+ * Issues a HEAD request to the specified URI, query, and request.
  *
  * @param string|array $uri URI to request (see {@link _parseUri()})
  * @param array $data Array of request body data keys and values.
@@ -536,8 +536,6 @@ class HttpSocket extends CakeSocket {
 		$request = Hash::merge(array('method' => 'HEAD', 'uri' => $uri, 'body' => $data), $request);
 		return $this->request($request);
 	}
-
-
 
 /**
  * Normalizes URLs into a $uriTemplate. If no template is provided

--- a/lib/Cake/Test/Case/Network/CakeSocketTest.php
+++ b/lib/Cake/Test/Case/Network/CakeSocketTest.php
@@ -56,7 +56,7 @@ class CakeSocketTest extends CakeTestCase {
 		$this->assertSame($config, array(
 			'persistent'	=> false,
 			'host'			=> 'localhost',
-			'protocol'		=> getprotobyname('tcp'),
+			'protocol'		=> 'tcp',
 			'port'			=> 80,
 			'timeout'		=> 30
 		));
@@ -71,7 +71,7 @@ class CakeSocketTest extends CakeTestCase {
 
 		$config['host'] = 'www.cakephp.org';
 		$config['port'] = 23;
-		$config['protocol'] = 17;
+		$config['protocol'] = 'udp';
 
 		$this->assertSame($this->Socket->config, $config);
 	}

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -217,7 +217,6 @@ class HttpSocketTest extends CakeTestCase {
 		$this->Socket->expects($this->never())->method('connect');
 		$this->Socket->__construct(array('host' => 'foo-bar'));
 		$baseConfig['host'] = 'foo-bar';
-		$baseConfig['protocol'] = getprotobyname($baseConfig['protocol']);
 		$this->assertEquals($this->Socket->config, $baseConfig);
 
 		$this->Socket->reset();
@@ -226,7 +225,6 @@ class HttpSocketTest extends CakeTestCase {
 		$baseConfig['host'] = $baseConfig['request']['uri']['host'] = 'www.cakephp.org';
 		$baseConfig['port'] = $baseConfig['request']['uri']['port'] = 23;
 		$baseConfig['request']['uri']['scheme'] = 'http';
-		$baseConfig['protocol'] = getprotobyname($baseConfig['protocol']);
 		$this->assertEquals($this->Socket->config, $baseConfig);
 
 		$this->Socket->reset();
@@ -494,6 +492,9 @@ class HttpSocketTest extends CakeTestCase {
 						'header' => "Host: www.cakephp.org:8080\r\nConnection: close\r\nUser-Agent: CakePHP\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 38\r\n"
 					)
 				)
+			),
+			'reset9' => array(
+				'config.protocol' => 'ssl'
 			),
 			array(
 				'request' => array(

--- a/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
+++ b/lib/Cake/Test/Case/Network/Http/HttpSocketTest.php
@@ -493,7 +493,7 @@ class HttpSocketTest extends CakeTestCase {
 					)
 				)
 			),
-			'reset9' => array(
+			'reset10' => array(
 				'config.protocol' => 'ssl'
 			),
 			array(
@@ -523,6 +523,9 @@ class HttpSocketTest extends CakeTestCase {
 						'header' => "Host: www.cakephp.org\r\nConnection: close\r\nUser-Agent: CakePHP\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 38\r\n"
 					)
 				)
+			),
+			'reset11' => array(
+				'config.protocol' => 'ssl'
 			),
 			array(
 				'request' => array(


### PR DESCRIPTION
For some reason I can't update my other pull request https://github.com/cakephp/cakephp/pull/3295, so I'll just create another one. 

These changes give you the ability to specify the protocol to use when using CakeSocket and HttpSocket. I tried to accommodate as many scenarios as I could think of :
CakeSocket
1.Regular host with protocol param in constructor (host:www.google.com protocol:udp)
2.Host with protocol included in the host string (accommodate anyone with ssl://x.x.x.x  as host values in their email.php file)
3.Leaving protocol out defaults to TCP just it always has.

HttpSocket
1.Specifying a  protocol in the constructor  will override the default of 'ssl' when https url is given.  (Get access to working API on badly configured third party server that prevents PHP from detecting the SSL version)
2.Specifying a protocol in the URL itself is not supported and shouldn't be. This is HttpSocket, and we shouldn't be passing it non http urls.  ( tls://www.google.com  will be ignored and treated as https, and simply use the default ssl://host protocol unless specifically overridden in the constructor. )

Unrelated: Added a HEAD function to HttpSocket to go along with the GET/POST/PATCH/PUT/DELETE functions that are already there. Useful addition if using cake to fetch resources, and you need to know if the remote resource is already present locally without downloading the whole file. 
