### PR TITLE
3.0 join data marshall

### DIFF
--- a/src/ORM/Marshaller.php
+++ b/src/ORM/Marshaller.php
@@ -179,10 +179,6 @@ class Marshaller {
 		}
 
 		$records = $this->many($data, $include);
-		if (!in_array('_joinData', $include) && !isset($include['_joinData'])) {
-			return $records;
-		}
-
 		$joint = $assoc->junction();
 		$jointMarshaller = $joint->marshaller();
 

--- a/tests/TestCase/ORM/MarshallerTest.php
+++ b/tests/TestCase/ORM/MarshallerTest.php
@@ -298,9 +298,7 @@ class MarshallerTest extends TestCase {
 		];
 		$marshall = new Marshaller($this->articles);
 		$result = $marshall->one($data, [
-			'Tags' => [
-				'associated' => ['_joinData']
-			]
+			'Tags'
 		]);
 
 		$this->assertEquals($data['title'], $result->title);


### PR DESCRIPTION
Always marshalling _joinData, The a belongsToMany could become meaningless if this data is not always used. Fixes #3632
