### PR TITLE
Improve missing aliased class exception

### DIFF
--- a/src/Template/Error/missing_helper.ctp
+++ b/src/Template/Error/missing_helper.ctp
@@ -16,15 +16,29 @@
 use Cake\Core\Plugin;
 
 $pluginDot = empty($plugin) ? null : $plugin . '.';
+if (empty($plugin)) {
+	$filePath = APP_DIR . DS;
+}
+if (!empty($plugin) && Plugin::loaded($plugin)) {
+	$filePath = Plugin::path($plugin);
+}
+if (!empty($plugin) && !Plugin::loaded($plugin)) {
+	$filePath = APP_DIR . DS . 'Plugin' . DS . h($plugin) . DS;
+}
 ?>
 <h2>Missing Helper</h2>
 <p class="error">
 	<strong>Error: </strong>
 	<?= sprintf('<em>%s</em> could not be found.', h($pluginDot . $class)); ?>
+	<?php
+		if (!empty($plugin) && !Plugin::loaded($plugin)):
+			echo sprintf('Make sure your plugin %s is in the %s directory and was loaded.', h($plugin), APP_DIR . DS . 'Plugin');
+		endif;
+	?>
 </p>
 <p class="error">
 	<strong>Error: </strong>
-	<?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), (empty($plugin) ? APP_DIR . DS : Plugin::path($plugin)) . 'View' . DS . 'Helper' . DS . h($class) . '.php'); ?>
+	<?= sprintf('Create the class <em>%s</em> below in file: %s', h($class), $filePath . 'View' . DS . 'Helper' . DS . h($class) . '.php'); ?>
 </p>
 <pre>
 &lt;?php

--- a/src/Utility/ObjectRegistry.php
+++ b/src/Utility/ObjectRegistry.php
@@ -69,13 +69,12 @@ abstract class ObjectRegistry {
 			return $this->_loaded[$name];
 		}
 		if (is_array($config) && isset($config['className'])) {
-			$className = $this->_resolveClassName($config['className']);
+			$objectName = $config['className'];
 		}
-		if (!isset($className)) {
-			$className = $this->_resolveClassName($objectName);
-		}
+		$className = $this->_resolveClassName($objectName);
 		if (!$className) {
-			$this->_throwMissingClassError($objectName, substr($plugin, 0, -1));
+			list($plugin, $objectName) = pluginSplit($objectName);
+			$this->_throwMissingClassError($objectName, $plugin);
 		}
 		$instance = $this->_create($className, $name, $config);
 		$this->_loaded[$name] = $instance;

--- a/src/View/HelperRegistry.php
+++ b/src/View/HelperRegistry.php
@@ -115,7 +115,7 @@ class HelperRegistry extends ObjectRegistry {
  */
 	protected function _throwMissingClassError($class, $plugin) {
 		throw new Error\MissingHelperException([
-			'class' => $class,
+			'class' => $class . 'Helper',
 			'plugin' => $plugin
 		]);
 	}


### PR DESCRIPTION
Current behavior:
- In case of a missing helper: 
  `public $helpers = ['NonExistentHtml'];`
  Error: NonExistent could not be found.
  Create the class NonExistent below in file: App\View\Helper\NonExistent.php
- Missing alias class: 
  `public $helpers = ['Html' => ['className' => 'NonExistentHtml']];`
  Error: Html could not be found.
-  In case of a missing or not loaded plugin:
  `public $helpers = ['Nope.Html];` or 
  `public $helpers = ['Html' => ['className' => 'Nope.MyHtml']];`
  Error: Html could not be found.
  Error: 
  Error: An Internal Error Has Occurred.

After these changes to the exception reporting, ObjectRegistry reports correctly missing alias class and plugin name:

`public $helpers = ['Html' => ['className' => 'Nope.MyHtml']];`

```
Error: Nope.MyHtmlHelper could not be found. Make sure your plugin Nope 
is in the App\Plugin directory and was loaded.

Error: Create the class MyHtmlHelper below in file: App\Plugin\Nope\View\Helper\MyHtmlHelper.php
```

Plugin::path() throws exception if plugin is missing, resulting in broken missing_helper template and Internal Server error. That's why additional plugin path juggling is required in the template.

Related to #3699

If this is a way to go, I can also update missing_component and missing_behavior templates...
