### PR TITLE
Changed isAbsolute()-method of Folder class so it recognizes registered ...

### DIFF
--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -549,6 +549,7 @@ class FolderTest extends CakeTestCase {
 		$this->assertFalse(Folder::isAbsolute('\\path/to/file'));
 		$this->assertFalse(Folder::isAbsolute('\\path\\to\\file'));
 		$this->assertFalse(Folder::isAbsolute('notRegisteredStreamWrapper://example'));
+		$this->assertFalse(Folder::isAbsolute('://example'));
 
 		$this->assertTrue(Folder::isAbsolute('/usr/local'));
 		$this->assertTrue(Folder::isAbsolute('//path/to/file'));

--- a/lib/Cake/Test/Case/Utility/FolderTest.php
+++ b/lib/Cake/Test/Case/Utility/FolderTest.php
@@ -548,6 +548,7 @@ class FolderTest extends CakeTestCase {
 		$this->assertFalse(Folder::isAbsolute('0:\\path\\to\\file'));
 		$this->assertFalse(Folder::isAbsolute('\\path/to/file'));
 		$this->assertFalse(Folder::isAbsolute('\\path\\to\\file'));
+		$this->assertFalse(Folder::isAbsolute('notRegisteredStreamWrapper://example'));
 
 		$this->assertTrue(Folder::isAbsolute('/usr/local'));
 		$this->assertTrue(Folder::isAbsolute('//path/to/file'));
@@ -555,6 +556,7 @@ class FolderTest extends CakeTestCase {
 		$this->assertTrue(Folder::isAbsolute('C:\\path\\to\\file'));
 		$this->assertTrue(Folder::isAbsolute('d:\\path\\to\\file'));
 		$this->assertTrue(Folder::isAbsolute('\\\\vmware-host\\Shared Folders\\file'));
+		$this->assertTrue(Folder::isAbsolute('http://www.example.com'));
 	}
 
 /**

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -289,13 +289,8 @@ class Folder {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isRegisteredStreamWrapper
  */
 	public static function isRegisteredStreamWrapper($path) {
-		if (!empty($path)) {
-			preg_match('/^[A-Z]+(?=:\/\/)/i', $path, $matches);
-			if (!empty($matches[0])) {
-				if (in_array($matches[0], stream_get_wrappers())) {
-					return true;
-				}
-			}
+		if (preg_match('/^[A-Z]+(?=:\/\/)/i', $path, $matches) && in_array($matches[0], stream_get_wrappers())) {
+			return true;
 		}
 		return false;
 	}

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -278,7 +278,26 @@ class Folder {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isAbsolute
  */
 	public static function isAbsolute($path) {
-		return !empty($path) && ($path[0] === '/' || preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) === '\\\\');
+		return !empty($path) && ($path[0] === '/' || preg_match('/^[A-Z]:\\\\/i', $path) || substr($path, 0, 2) === '\\\\' || self::isRegisteredStreamWrapper($path));
+	}
+
+/**
+ * Returns true if given $path is a registered stream wrapper.
+ *
+ * @param string $path Path to check
+ * @return boolean true if path is registered stream wrapper.
+ * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isRegisteredStreamWrapper
+ */
+	public static function isRegisteredStreamWrapper($path) {
+		if(!empty($path)){
+			preg_match('/^[A-Z]*(?=:\/\/)/i', $path, $matches);
+			if(!empty($matches[0])){
+				if(in_array($matches[0], stream_get_wrappers())){
+					return TRUE;
+				}
+			}
+		}
+		return FALSE;
 	}
 
 /**

--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -289,15 +289,15 @@ class Folder {
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/file-folder.html#Folder::isRegisteredStreamWrapper
  */
 	public static function isRegisteredStreamWrapper($path) {
-		if(!empty($path)){
-			preg_match('/^[A-Z]*(?=:\/\/)/i', $path, $matches);
-			if(!empty($matches[0])){
-				if(in_array($matches[0], stream_get_wrappers())){
-					return TRUE;
+		if (!empty($path)) {
+			preg_match('/^[A-Z]+(?=:\/\/)/i', $path, $matches);
+			if (!empty($matches[0])) {
+				if (in_array($matches[0], stream_get_wrappers())) {
+					return true;
 				}
 			}
 		}
-		return FALSE;
+		return false;
 	}
 
 /**


### PR DESCRIPTION
...stream wrappers as absolute paths.

This has the benefit that the realpath() method is not applied to a registered stream wrapper in the constructor of the folder class. Using the realpath() method will break the stream.

This patch will make it possible to use vfsStream (a library for testing filesystem operations) together with cakephp apps

See also: http://stackoverflow.com/questions/24188008/is-it-possible-to-use-vfsstream-with-cakephp-2-4

I appreaciate all feedback!
