### PR TITLE
3.0 optimize string template

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -892,7 +892,11 @@ class FormHelper extends Helper {
 		$options += ['id' => $this->_domId($fieldName)];
 
 		$originalTemplates = $this->templates();
-		$this->templates($options['templates']);
+		$newTemplates = $options['templates'];
+
+		if ($newTemplates) {
+			$this->templates($options['templates']);
+		}
 		unset($options['templates']);
 
 		$error = null;
@@ -930,7 +934,10 @@ class FormHelper extends Helper {
 			'type' => $options['type'],
 		]);
 
-		$this->templates($originalTemplates);
+		if ($newTemplates) {
+			$this->templates($originalTemplates);
+		}
+
 		return $result;
 	}
 

--- a/tests/TestCase/View/StringTemplateTest.php
+++ b/tests/TestCase/View/StringTemplateTest.php
@@ -194,4 +194,19 @@ class StringTemplateTest extends TestCase {
 		);
 	}
 
+/**
+ * Tests that compile information is refreshed on adds and removes
+ *
+ * @return void
+ */
+	public function testCopiledInfoRefresh() {
+		$compilation = $this->template->compile('link');
+		$this->template->add([
+			'link' => '<a bar="{{foo}}">{{baz}}</a>'
+		]);
+		$this->assertNotEquals($compilation, $this->template->compile('link'));
+		$this->template->remove('link');
+		$this->assertEquals([null, null], $this->template->compile('link'));
+	}
+
 }


### PR DESCRIPTION
I baked some view for a table that contained around 30 fields and I noticed that forms were rendering quite slow. A little profiling showed that StringTemplate was the problem. This set of changes fix the problem by making StringTemplate twice as fast when formatting the same string more than once.

The technique that I used was to pre-compile templates before using them by replacing the placeholders with `sprintf` markers and then using that function for doing the actual replacement.

This is the output of my micro benchmark:

```
Original
   => 1.8427798748016
Compile Each Time
   => 1.8326361179352
Already Compiled
   => 0.90882086753845
```

It shows that in the case of having to compile templates each time (no templates are reused) we have not lost any performance, but most importantly, it shows that when reusing templates the function is twice as fast.

Gotchas:

Any percentage sign inside a template will need to be escaped by the developer or they will get an error from sprintf. I find this to be a fair tradeoff as escaping percentage signs is easy to do, rare to actually come up with a case, and straight forward to document.

Thoughts?
