### PR TITLE
3.0 - Database api docs

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -134,11 +134,11 @@ class Connection {
  *
  * If no params are passed it will return the current driver instance.
  *
- * @param string|Driver $driver
+ * @param string|Driver $driver The driver instance to use.
  * @param array|null $config Either config for a new driver or null.
  * @throws \Cake\Database\Error\MissingDriverException When a driver class is missing.
  * @throws \Cake\Database\Error\MissingExtensionException When a driver's PHP extension is missing.
- * @return Driver
+ * @return \Cake\Database\Driver
  */
 	public function driver($driver = null, $config = null) {
 		if ($driver === null) {
@@ -192,7 +192,7 @@ class Connection {
 /**
  * Prepares a SQL statement to be executed.
  *
- * @param string|\Cake\Database\Query $sql
+ * @param string|\Cake\Database\Query $sql The SQL to convert into a prepared statement.
  * @return \Cake\Database\StatementInterface
  */
 	public function prepare($sql) {
@@ -259,7 +259,7 @@ class Connection {
 /**
  * Executes a SQL statement and returns the Statement object as result.
  *
- * @param string $sql
+ * @param string $sql The SQL query to execute.
  * @return \Cake\Database\StatementInterface
  */
 	public function query($sql) {
@@ -271,7 +271,7 @@ class Connection {
 /**
  * Create a new Query instance for this connection.
  *
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function newQuery() {
 		return new Query($this);
@@ -422,7 +422,7 @@ class Connection {
  * `$connection->useSavePoints(false)` Disables usage of savepoints and returns false
  * `$connection->useSavePoints()` Returns current status
  *
- * @param bool|null $enable
+ * @param bool|null $enable Whether or not save points should be used.
  * @return bool true if enabled, false otherwise
  */
 	public function useSavePoints($enable = null) {
@@ -440,7 +440,7 @@ class Connection {
 /**
  * Creates a new save point for nested transactions.
  *
- * @param string $name
+ * @param string $name The save point name.
  * @return void
  */
 	public function createSavePoint($name) {
@@ -450,7 +450,7 @@ class Connection {
 /**
  * Releases a save point by its name.
  *
- * @param string $name
+ * @param string $name The save point name.
  * @return void
  */
 	public function releaseSavePoint($name) {
@@ -460,7 +460,7 @@ class Connection {
 /**
  * Rollback a save point by its name.
  *
- * @param string $name
+ * @param string $name The save point name.
  * @return void
  */
 	public function rollbackSavepoint($name) {
@@ -480,7 +480,7 @@ class Connection {
  *
  * {{{
  * $connection->transactional(function($connection) {
- *	$connection->newQuery()->delete('users')->execute();
+ *   $connection->newQuery()->delete('users')->execute();
  * });
  * }}}
  *
@@ -511,7 +511,7 @@ class Connection {
 /**
  * Quotes value to be used safely in database query.
  *
- * @param mixed $value
+ * @param mixed $value The value to quote.
  * @param string $type Type to be used for determining kind of quoting to perform
  * @return mixed quoted value
  */
@@ -533,7 +533,7 @@ class Connection {
  * Quotes a database identifier (a column name, table name, etc..) to
  * be used safely in queries without the risk of using reserved words.
  *
- * @param string $identifier
+ * @param string $identifier The identifier to quote.
  * @return string
  */
 	public function quoteIdentifier($identifier) {

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -134,7 +134,7 @@ class Connection {
  *
  * If no params are passed it will return the current driver instance.
  *
- * @param string|Driver $driver The driver instance to use.
+ * @param string|\Cake\Database\Driver $driver The driver instance to use.
  * @param array|null $config Either config for a new driver or null.
  * @throws \Cake\Database\Error\MissingDriverException When a driver class is missing.
  * @throws \Cake\Database\Error\MissingExtensionException When a driver's PHP extension is missing.

--- a/src/Database/Dialect/MysqlDialectTrait.php
+++ b/src/Database/Dialect/MysqlDialectTrait.php
@@ -19,6 +19,8 @@ use Cake\Database\SqlDialectTrait;
 /**
  * Contains functions that encapsulates the SQL dialect used by MySQL,
  * including query translators and schema introspection.
+ *
+ * @internal
  */
 trait MysqlDialectTrait {
 

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -62,7 +62,7 @@ trait PostgresDialectTrait {
  * Modifies the original insert query to append a "RETURNING *" epilogue
  * so that the latest insert id can be retrieved
  *
- * @param \Cake\Database\Query $query
+ * @param \Cake\Database\Query $query The query to translate.
  * @return \Cake\Database\Query
  */
 	protected function _insertQueryTranslator($query) {
@@ -89,7 +89,8 @@ trait PostgresDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param \Cake\Database\Expression\FunctionExpression
+ * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to convert
+ *   to postgres SQL.
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {

--- a/src/Database/Dialect/PostgresDialectTrait.php
+++ b/src/Database/Dialect/PostgresDialectTrait.php
@@ -22,6 +22,8 @@ use Cake\Database\SqlDialectTrait;
 /**
  * Contains functions that encapsulates the SQL dialect used by Postgres,
  * including query translators and schema introspection.
+ *
+ * @internal
  */
 trait PostgresDialectTrait {
 

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -66,7 +66,8 @@ trait SqliteDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param \Cake\Database\Expression\FunctionExpression
+ * @param \Cake\Database\Expression\FunctionExpression $expression The function expression
+ *   to translate for SQLite.
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {

--- a/src/Database/Dialect/SqliteDialectTrait.php
+++ b/src/Database/Dialect/SqliteDialectTrait.php
@@ -20,7 +20,9 @@ use Cake\Database\Expression\FunctionExpression;
 use Cake\Database\SqlDialectTrait;
 
 /**
- * Sql dialect trait
+ * SQLite dialect trait
+ *
+ * @internal
  */
 trait SqliteDialectTrait {
 

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -26,6 +26,8 @@ use PDO;
 /**
  * Contains functions that encapsulates the SQL dialect used by SQLServer,
  * including query translators and schema introspection.
+ *
+ * @internal
  */
 trait SqlserverDialectTrait {
 

--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -86,7 +86,7 @@ trait SqlserverDialectTrait {
  * Prior to SQLServer 2012 there was no equivalent to LIMIT OFFSET, so a subquery must
  * be used.
  *
- * @param \Cake\Database\Query $query The query to wrap in a subquery.
+ * @param \Cake\Database\Query $original The query to wrap in a subquery.
  * @param int $limit The number of rows to fetch.
  * @param int $offset The number of rows to offset.
  * @return \Cake\Database\Query Modified query object.
@@ -143,7 +143,7 @@ trait SqlserverDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param Cake\Database\Expression\FunctionExpression
+ * @param Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {
@@ -213,6 +213,8 @@ trait SqlserverDialectTrait {
 
 /**
  * {@inheritDoc}
+ *
+ * @return \Cake\Database\SqlserverCompiler
  */
 	public function newCompiler() {
 		return new SqlserverCompiler();

--- a/src/Database/Dialect/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Dialect/TupleComparisonTranslatorTrait.php
@@ -21,6 +21,8 @@ use Cake\Database\Query;
 
 /**
  * Provides a translator method for tuple comparisons
+ *
+ * @internal
  */
 trait TupleComparisonTranslatorTrait {
 

--- a/src/Database/Dialect/TupleComparisonTranslatorTrait.php
+++ b/src/Database/Dialect/TupleComparisonTranslatorTrait.php
@@ -25,7 +25,6 @@ use Cake\Database\Query;
 trait TupleComparisonTranslatorTrait {
 
 /**
- *
  * Receives a TupleExpression and changes it so that it conforms to this
  * SQL dialect.
  *
@@ -40,8 +39,8 @@ trait TupleComparisonTranslatorTrait {
  *
  * 1 = (SELECT 1 FROM a_table WHERE (a = c) AND (b = d))
  *
- * @param \Cake\Database\Expression\TupleComparison $expression
- * @param \Cake\Database\Query $query
+ * @param \Cake\Database\Expression\TupleComparison $expression The expression to transform
+ * @param \Cake\Database\Query $query The query to update.
  * @return void
  */
 	protected function _transformTupleComparison(TupleComparison $expression, $query) {

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -52,7 +52,7 @@ trait PDODriverTrait {
  * If first argument is passed, it will set internal conenction object or
  * result to the value passed
  *
- * @param null|PDO instance $connection
+ * @param null|PDO instance $connection The PDO connection instance.
  * @return mixed connection object used internally
  */
 	public function connection($connection = null) {
@@ -74,7 +74,7 @@ trait PDODriverTrait {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|\Cake\Database\Query $query
+ * @param string|\Cake\Database\Query $query The query to turn into a prepared statement.
  * @return \Cake\Database\StatementInterface
  */
 	public function prepare($query) {
@@ -124,7 +124,7 @@ trait PDODriverTrait {
 /**
  * Returns a value in a safe representation to be used in a query string
  *
- * @param mixed $value
+ * @param mixed $value The value to quote.
  * @param string $type Type to be used for determining kind of quoting to perform
  * @return string
  */

--- a/src/Database/Driver/PDODriverTrait.php
+++ b/src/Database/Driver/PDODriverTrait.php
@@ -52,7 +52,7 @@ trait PDODriverTrait {
  * If first argument is passed, it will set internal conenction object or
  * result to the value passed
  *
- * @param null|PDO instance $connection The PDO connection instance.
+ * @param null|\PDO instance $connection The PDO connection instance.
  * @return mixed connection object used internally
  */
 	public function connection($connection = null) {

--- a/src/Database/Driver/Postgres.php
+++ b/src/Database/Driver/Postgres.php
@@ -94,7 +94,7 @@ class Postgres extends \Cake\Database\Driver {
 /**
  * Sets connection encoding
  *
- * @param string $encoding
+ * @param string $encoding The encoding to use.
  * @return void
  */
 	public function setEncoding($encoding) {
@@ -106,7 +106,7 @@ class Postgres extends \Cake\Database\Driver {
  * Sets connection default schema, if any relation defined in a query is not fully qualified
  * postgres will fallback to looking the relation into defined default schema
  *
- * @param string $schema
+ * @param string $schema The schema names to set `search_path` to.
  * @return void
  */
 	public function setSchema($schema) {

--- a/src/Database/Driver/Sqlite.php
+++ b/src/Database/Driver/Sqlite.php
@@ -83,7 +83,7 @@ class Sqlite extends \Cake\Database\Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|\Cake\Database\Query $query
+ * @param string|\Cake\Database\Query $query The query to prepare.
  * @return \Cake\Database\StatementInterface
  */
 	public function prepare($query) {

--- a/src/Database/Driver/Sqlserver.php
+++ b/src/Database/Driver/Sqlserver.php
@@ -94,7 +94,7 @@ class Sqlserver extends \Cake\Database\Driver {
 /**
  * Prepares a sql statement to be executed
  *
- * @param string|\Cake\Database\Query $query
+ * @param string|\Cake\Database\Query $query The query to prepare.
  * @return \Cake\Database\StatementInterface
  */
 	public function prepare($query) {

--- a/src/Database/Expression/Comparison.php
+++ b/src/Database/Expression/Comparison.php
@@ -22,6 +22,7 @@ use Cake\Database\ValueBinder;
  * involving a field an operator and a value. In its most common form the
  * string representation of a comparison is `field = value`
  *
+ * @internal
  */
 class Comparison extends QueryExpression {
 

--- a/src/Database/Expression/FunctionExpression.php
+++ b/src/Database/Expression/FunctionExpression.php
@@ -22,6 +22,8 @@ use Cake\Database\ValueBinder;
  * constructed by passing the name of the function and a list of params.
  * For security reasons, all params passed are quoted by default unless
  * explicitly told otherwise.
+ *
+ * @internal
  */
 class FunctionExpression extends QueryExpression {
 

--- a/src/Database/Expression/IdentifierExpression.php
+++ b/src/Database/Expression/IdentifierExpression.php
@@ -20,6 +20,7 @@ use Cake\Database\ValueBinder;
 /**
  * Represents a single identifier name in the database
  *
+ * @internal
  */
 class IdentifierExpression implements ExpressionInterface {
 

--- a/src/Database/Expression/OrderByExpression.php
+++ b/src/Database/Expression/OrderByExpression.php
@@ -17,6 +17,11 @@ namespace Cake\Database\Expression;
 use Cake\Database\ExpressionInterface;
 use Cake\Database\ValueBinder;
 
+/**
+ * An expression object for ORDER BY clauses
+ *
+ * @internal
+ */
 class OrderByExpression extends QueryExpression {
 
 /**

--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -26,6 +26,7 @@ use \Countable;
  * expressions that can be compiled by converting this object to string
  * and will contain a correctly parenthesized and nested expression.
  *
+ * @internal
  */
 class QueryExpression implements ExpressionInterface, Countable {
 

--- a/src/Database/Expression/TupleComparison.php
+++ b/src/Database/Expression/TupleComparison.php
@@ -21,6 +21,8 @@ use Cake\Database\ValueBinder;
 /**
  * This expression represents SQL fragments that are used for comparing one tuple
  * to another, one tuple to a set of other tuples or one tuple to an expression
+ *
+ * @internal
  */
 class TupleComparison extends Comparison {
 

--- a/src/Database/Expression/UnaryExpression.php
+++ b/src/Database/Expression/UnaryExpression.php
@@ -19,6 +19,8 @@ use Cake\Database\ValueBinder;
 
 /**
  * An expression object that represents an expression with only a single operand.
+ *
+ * @internal
  */
 class UnaryExpression extends QueryExpression {
 

--- a/src/Database/Expression/ValuesExpression.php
+++ b/src/Database/Expression/ValuesExpression.php
@@ -26,6 +26,8 @@ use \Countable;
  *
  * Helps generate SQL with the correct number of placeholders and bind
  * values correctly into the statement.
+ *
+ * @internal
  */
 class ValuesExpression implements ExpressionInterface {
 

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -21,6 +21,8 @@ use Cake\Database\Expression\OrderByExpression;
 
 /**
  * Contains all the logic related to quoting identifiers in a Query object
+ *
+ * @internal
  */
 class IdentifierQuoter {
 

--- a/src/Database/IdentifierQuoter.php
+++ b/src/Database/IdentifierQuoter.php
@@ -21,7 +21,6 @@ use Cake\Database\Expression\OrderByExpression;
 
 /**
  * Contains all the logic related to quoting identifiers in a Query object
- *
  */
 class IdentifierQuoter {
 
@@ -35,7 +34,7 @@ class IdentifierQuoter {
 /**
  * Constructor
  *
- * @param \Cake\Database\Driver The driver instance used to do the identifier quoting
+ * @param \Cake\Database\Driver $driver The driver instance used to do the identifier quoting
  */
 	public function __construct(Driver $driver) {
 		$this->_driver = $driver;
@@ -45,8 +44,8 @@ class IdentifierQuoter {
  * Iterates over each of the clauses in a query looking for identifiers and
  * quotes them
  *
- * @param Query $query The query to have its identifiers quoted
- * @return Query
+ * @param \Cake\Database\Query $query The query to have its identifiers quoted
+ * @return \Cake\Database\Query
  */
 	public function quote(Query $query) {
 		$binder = $query->valueBinder();
@@ -66,7 +65,7 @@ class IdentifierQuoter {
 /**
  * Quotes identifiers inside expression objects
  *
- * @param \Cake\Database\ExpressionInterface $expression
+ * @param \Cake\Database\ExpressionInterface $expression The expression object to walk and quote.
  * @return void
  */
 	public function quoteExpression($expression) {
@@ -89,7 +88,7 @@ class IdentifierQuoter {
 /**
  * Quotes all identifiers in each of the clauses of a query
  *
- * @param Query
+ * @param \Cake\Database\Query $query The query to quote.
  * @return void
  */
 	protected function _quoteParts($query) {
@@ -133,7 +132,7 @@ class IdentifierQuoter {
  * Quotes both the table and alias for an array of joins as stored in a Query
  * object
  *
- * @param array $joins
+ * @param array $joins The joins to quote.
  * @return array
  */
 	protected function _quoteJoins($joins) {
@@ -158,7 +157,7 @@ class IdentifierQuoter {
 /**
  * Quotes the table name and columns for an insert query
  *
- * @param Query $query
+ * @param \Cake\Database\Query $query The insert query to quote.
  * @return void
  */
 	protected function _quoteInsert($query) {
@@ -175,7 +174,7 @@ class IdentifierQuoter {
 /**
  * Quotes identifiers in comparison expression objects
  *
- * @param \Cake\Database\Expression\Comparison $expression
+ * @param \Cake\Database\Expression\Comparison $expression The comparison expression to quote.
  * @return void
  */
 	protected function _quoteComparison(Comparison $expression) {
@@ -217,7 +216,7 @@ class IdentifierQuoter {
 /**
  * Quotes identifiers in "order by" expression objects
  *
- * @param \Cake\Database\Expression\IdentifierExpression $expression
+ * @param \Cake\Database\Expression\IdentifierExpression $expression The identifiers to quote.
  * @return void
  */
 	protected function _quoteIndetifierExpression(IdentifierExpression $expression) {

--- a/src/Database/Log/LoggedQuery.php
+++ b/src/Database/Log/LoggedQuery.php
@@ -17,6 +17,8 @@ namespace Cake\Database\Log;
 /**
  * Contains a query string, the params used to executed it, time taken to do it
  * and the number of rows found or affected by its execution.
+ *
+ * @internal
  */
 class LoggedQuery {
 

--- a/src/Database/Log/LoggingStatement.php
+++ b/src/Database/Log/LoggingStatement.php
@@ -19,7 +19,7 @@ use Cake\Database\Statement\StatementDecorator;
 /**
  * Statement decorator used to
  *
- * @return void
+ * @internal
  */
 class LoggingStatement extends StatementDecorator {
 

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -22,6 +22,7 @@ use Cake\Utility\String;
  * This class is a bridge used to write LoggedQuery objects into a real log.
  * by default this class use the built-in CakePHP Log class to accomplish this
  *
+ * @internal
  */
 class QueryLogger {
 

--- a/src/Database/Log/QueryLogger.php
+++ b/src/Database/Log/QueryLogger.php
@@ -53,7 +53,7 @@ class QueryLogger {
  * Helper function used to replace query placeholders by the real
  * params used to execute the query
  *
- * @param LoggedQuery $query
+ * @param LoggedQuery $query The query to log
  * @return string
  */
 	protected function _interpolate($query) {

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -278,19 +278,19 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ##Examples:
  *
  * {{{
- *  // Filters products with the same name and city
- *	$query->select(['name', 'city'])->from('products')->distinct();
+ * // Filters products with the same name and city
+ * $query->select(['name', 'city'])->from('products')->distinct();
  *
- *  // Filters products in the same city
- *	$query->distinct(['city']);
+ * // Filters products in the same city
+ * $query->distinct(['city']);
  *
- *  // Filter products with the same name
- *	$query->distinct(['name'], true);
+ * // Filter products with the same name
+ * $query->distinct(['name'], true);
  * }}}
  *
- * @param array|ExpressionInterface fields to be filtered on
+ * @param array|ExpressionInterface $on fields to be filtered on
  * @param bool $overwrite whether to reset fields with passed list or not
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function distinct($on = [], $overwrite = false) {
 		if ($on === []) {
@@ -319,18 +319,18 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ### Example:
  *
  * {{{
- *  // Ignore cache query in MySQL
- *	$query->select(['name', 'city'])->from('products')->modifier('SQL_NO_CACHE');
- *	// It will produce the SQL: SELECT SQL_NO_CACHE name, city FROM products
+ * // Ignore cache query in MySQL
+ * $query->select(['name', 'city'])->from('products')->modifier('SQL_NO_CACHE');
+ * // It will produce the SQL: SELECT SQL_NO_CACHE name, city FROM products
  *
- *  // Or with multiple modifiers
- *	$query->select(['name', 'city'])->from('products')->modifier(['HIGH_PRIORITY', 'SQL_NO_CACHE']);
- *	// It will produce the SQL: SELECT HIGH_PRIORITY SQL_NO_CACHE name, city FROM products
+ * // Or with multiple modifiers
+ * $query->select(['name', 'city'])->from('products')->modifier(['HIGH_PRIORITY', 'SQL_NO_CACHE']);
+ * // It will produce the SQL: SELECT HIGH_PRIORITY SQL_NO_CACHE name, city FROM products
  * }}}
  *
  * @param array|ExpressionInterface|string $modifiers modifiers to be applied to the query
  * @param bool $overwrite whether to reset order with field list or not
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function modifier($modifiers, $overwrite = false) {
 		$this->_dirty();
@@ -612,12 +612,12 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * If you use string conditions make sure that your values are correctly quoted.
  * The safest thing you can do is to never use string conditions.
  *
- * @param string|array|ExpressionInterface|callback $conditions
+ * @param string|array|ExpressionInterface|callback $conditions The conditions to filter on.
  * @param array $types associative array of type names used to bind values to query
  * @param bool $overwrite whether to reset conditions with passed list or not
  * @see \Cake\Database\Type
  * @see \Cake\Database\QueryExpression
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function where($conditions = null, $types = [], $overwrite = false) {
 		if ($overwrite) {
@@ -646,7 +646,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ##Examples:
  *
  * {{{
- *	$query->where(['title' => 'Hello World')->andWhere(['author_id' => 1]);
+ * $query->where(['title' => 'Hello World')->andWhere(['author_id' => 1]);
  * }}}
  *
  * Will produce:
@@ -654,9 +654,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``WHERE title = 'Hello World' AND author_id = 1``
  *
  * {{{
- *	$query
- *		->where(['OR' => ['published' => false, 'published is NULL']])
- *		->andWhere(['author_id' => 1, 'comments_count >' => 10])
+ * $query
+ *   ->where(['OR' => ['published' => false, 'published is NULL']])
+ *   ->andWhere(['author_id' => 1, 'comments_count >' => 10])
  * }}}
  *
  * Produces:
@@ -664,24 +664,24 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``WHERE (published = 0 OR published IS NULL) AND author_id = 1 AND comments_count > 10``
  *
  * {{{
- *	$query
- *		->where(['title' => 'Foo'])
- *		->andWhere(function($exp, $query) {
- *			return $exp
- *			->add(['author_id' => 1])
- *			->or_(['author_id' => 2]);
- *		});
+ * $query
+ *   ->where(['title' => 'Foo'])
+ *   ->andWhere(function($exp, $query) {
+ *     return $exp
+ *       ->add(['author_id' => 1])
+ *       ->or_(['author_id' => 2]);
+ *   });
  * }}}
  *
  * Generates the following conditions:
  *
  * ``WHERE (title = 'Foo') AND (author_id = 1 OR author_id = 2)``
  *
- * @param string|array|ExpressionInterface|callback $conditions
+ * @param string|array|ExpressionInterface|callback $conditions The conditions to add with AND.
  * @param array $types associative array of type names used to bind values to query
  * @see \Cake\Database\Query::where()
  * @see \Cake\Database\Type
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function andWhere($conditions, $types = []) {
 		$this->_conjugate('where', $conditions, 'AND', $types);
@@ -707,7 +707,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ##Examples:
  *
  * {{{
- *	$query->where(['title' => 'Hello World')->orWhere(['title' => 'Foo']);
+ * $query->where(['title' => 'Hello World')->orWhere(['title' => 'Foo']);
  * }}}
  *
  * Will produce:
@@ -715,9 +715,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``WHERE title = 'Hello World' OR title = 'Foo'``
  *
  * {{{
- *	$query
- *		->where(['OR' => ['published' => false, 'published is NULL']])
- *		->orWhere(['author_id' => 1, 'comments_count >' => 10])
+ * $query
+ *   ->where(['OR' => ['published' => false, 'published is NULL']])
+ *   ->orWhere(['author_id' => 1, 'comments_count >' => 10])
  * }}}
  *
  * Produces:
@@ -725,24 +725,24 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``WHERE (published = 0 OR published IS NULL) OR (author_id = 1 AND comments_count > 10)``
  *
  * {{{
- *	$query
- *		->where(['title' => 'Foo'])
- *		->orWhere(function($exp, $query) {
- *			return $exp
- *			->add(['author_id' => 1])
- *			->or_(['author_id' => 2]);
- *		});
+ * $query
+ *   ->where(['title' => 'Foo'])
+ *   ->orWhere(function($exp, $query) {
+ *     return $exp
+ *       ->add(['author_id' => 1])
+ *       ->or_(['author_id' => 2]);
+ *   });
  * }}}
  *
  * Generates the following conditions:
  *
  * ``WHERE (title = 'Foo') OR (author_id = 1 OR author_id = 2)``
  *
- * @param string|array|ExpressionInterface|callback $conditions
+ * @param string|array|ExpressionInterface|callback $conditions The conditions to add with OR.
  * @param array $types associative array of type names used to bind values to query
  * @see \Cake\Database\Query::where()
  * @see \Cake\Database\Type
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function orWhere($conditions, $types = []) {
 		$this->_conjugate('where', $conditions, 'OR', $types);
@@ -765,7 +765,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ##Examples:
  *
  * {{{
- *	$query->order(['title' => 'DESC', 'author_id' => 'ASC']);
+ * $query->order(['title' => 'DESC', 'author_id' => 'ASC']);
  * }}}
  *
  * Produces:
@@ -773,7 +773,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``ORDER BY title DESC, author_id ASC``
  *
  * {{{
- *	$query->order(['title' => 'DESC NULLS FIRST'])->order('author_id');
+ * $query->order(['title' => 'DESC NULLS FIRST'])->order('author_id');
  * }}}
  *
  * Will generate:
@@ -781,17 +781,17 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ``ORDER BY title DESC NULLS FIRST, author_id``
  *
  * {{{
- *	$expression = $query->newExpr()->add(['id % 2 = 0']);
- *	$query->order($expression)->order(['title' => 'ASC']);
+ * $expression = $query->newExpr()->add(['id % 2 = 0']);
+ * $query->order($expression)->order(['title' => 'ASC']);
  * }}}
  *
  * Will become:
  *
  * ``ORDER BY (id %2 = 0), title ASC``
  *
- * @param array|ExpressionInterface|string $fields fields to be added to the list
+ * @param array|\Cake\Database\ExpressionInterface|string $fields fields to be added to the list
  * @param bool $overwrite whether to reset order with field list or not
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function order($fields, $overwrite = false) {
 		if ($overwrite) {
@@ -820,13 +820,16 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ##Examples:
  *
  * {{{
- *	$query->group(['id', 'title']); // Produces GROUP BY id, title
- *	$query->group('title'); // Produces GROUP BY title
+ * // Produces GROUP BY id, title
+ * $query->group(['id', 'title']);
+ *
+ * // Produces GROUP BY title
+ * $query->group('title');
  * }}}
  *
  * @param array|ExpressionInterface|string $fields fields to be added to the list
  * @param bool $overwrite whether to reset fields with passed list or not
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function group($fields, $overwrite = false) {
 		if ($overwrite) {
@@ -844,15 +847,15 @@ class Query implements ExpressionInterface, IteratorAggregate {
 
 /**
  * Adds a condition or set of conditions to be used in the HAVING clause for this
- * query. This method operates in exactly the same way as the method ``where()``
+ * query. This method operates in exactly the same way as the method `where()`
  * does. Please refer to its documentation for an insight on how to using each
  * parameter.
  *
- * @param string|array|ExpressionInterface|callback $conditions
+ * @param string|array|ExpressionInterface|callback $conditions The having conditions.
  * @param array $types associative array of type names used to bind values to query
  * @param bool $overwrite whether to reset conditions with passed list or not
  * @see \Cake\Database\Query::where()
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function having($conditions = null, $types = [], $overwrite = false) {
 		if ($overwrite) {
@@ -868,10 +871,10 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * the same way as the method ``andWhere()`` does. Please refer to its
  * documentation for an insight on how to using each parameter.
  *
- * @param string|array|ExpressionInterface|callback $conditions
+ * @param string|array|ExpressionInterface|callback $conditions The AND conditions for HAVING.
  * @param array $types associative array of type names used to bind values to query
  * @see \Cake\Database\Query::andWhere()
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function andHaving($conditions, $types = []) {
 		$this->_conjugate('having', $conditions, 'AND', $types);
@@ -884,10 +887,10 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * the same way as the method ``orWhere()`` does. Please refer to its
  * documentation for an insight on how to using each parameter.
  *
- * @param string|array|ExpressionInterface|callback $conditions
- * @param array $types associative array of type names used to bind values to query
+ * @param string|array|ExpressionInterface|callback $conditions The OR conditions for HAVING.
+ * @param array $types associative array of type names used to bind values to query.
  * @see \Cake\Database\Query::orWhere()
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function orHaving($conditions, $types = []) {
 		$this->_conjugate('having', $conditions, 'OR', $types);
@@ -904,7 +907,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * Pages should start at 1.
  *
  * @param int $num The page number you want.
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function page($num) {
 		$limit = $this->clause('limit');
@@ -929,12 +932,12 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ## Examples
  *
  * {{{
- *	$query->limit(10) // generates LIMIT 10
- *	$query->limit($query->newExpr()->add(['1 + 1'])); // LIMIT (1 + 1)
+ * $query->limit(10) // generates LIMIT 10
+ * $query->limit($query->newExpr()->add(['1 + 1'])); // LIMIT (1 + 1)
  * }}}
  *
  * @param int|ExpressionInterface $num number of records to be returned
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function limit($num) {
 		$this->_dirty();
@@ -1183,13 +1186,13 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * {{{
  * $query->select('id')->where(['author_id' => 1])->epilog('FOR UPDATE');
  * $query
- *	->insert('articles', ['title'])
- *	->values(['author_id' => 1])
- *	->epilog('RETURNING id');
+ *  ->insert('articles', ['title'])
+ *  ->values(['author_id' => 1])
+ *  ->epilog('RETURNING id');
  * }}}
  *
- * @param string|QueryExpression the expression to be appended
- * @return Query
+ * @param string|\Cake\Database\QueryExpression $expression The expression to be appended
+ * @return \Cake\Database\Query
  */
 	public function epilog($expression = null) {
 		$this->_dirty();
@@ -1212,7 +1215,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * this function in subclasses to use a more specialized QueryExpression class
  * if required.
  *
- * @return QueryExpression
+ * @return \Cake\Database\QueryExpression
  */
 	public function newExpr() {
 		return new QueryExpression([], $this->typeMap());
@@ -1229,7 +1232,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * $query->func()->dateDiff(['2012-01-05', '2012-01-02'])
  * }}}
  *
- * @return FunctionsBuilder
+ * @return \Cake\Database\FunctionsBuilder
  */
 	public function func() {
 		if (empty($this->_functionsBuilder)) {
@@ -1306,15 +1309,15 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * ## Example
  *
  * {{{
- *	$query->decorateResults(function($row) {
- *		$row['order_total'] = $row['subtotal'] + ($row['subtotal'] * $row['tax']);
- *		return $row;
- *	});
+ * $query->decorateResults(function($row) {
+ *   $row['order_total'] = $row['subtotal'] + ($row['subtotal'] * $row['tax']);
+ *    return $row;
+ * });
  * }}}
  *
- * @param null|callable $callback
- * @param bool $overwrite
- * @return Query
+ * @param null|callable $callback The callback to invoke when results are fetched.
+ * @param bool $overwrite Whether or not this should append or replace all existing decorators.
+ * @return \Cake\Database\Query
  */
 	public function decorateResults($callback, $overwrite = false) {
 		if ($overwrite) {
@@ -1338,7 +1341,7 @@ class Query implements ExpressionInterface, IteratorAggregate {
  *
  * @param callable $callback the function to be executed for each ExpressionInterface
  *   found inside this query.
- * @return Query
+ * @return \Cake\Database\Query
  */
 	public function traverseExpressions(callable $callback) {
 		$visitor = function($expression) use (&$visitor, $callback) {
@@ -1369,11 +1372,11 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * will create several placeholders of type string.
  *
  * @param string|int $param placeholder to be replaced with quoted version
- * of $value
+ *   of $value
  * @param mixed $value The value to be bound
  * @param string|int $type the mapped type name, used for casting when sending
- * to database
- * @return Query
+ *   to database
+ * @return \Cake\Database\Query
  */
 	public function bind($param, $value, $type = 'string') {
 		$this->valueBinder()->bind($param, $value, $type);
@@ -1388,9 +1391,9 @@ class Query implements ExpressionInterface, IteratorAggregate {
  * associate values to those placeholders so that they can be passed correctly
  * statement object.
  *
- * @param ValueBinder $binder new instance to be set. If no value is passed the
- * default one will be returned
- * @return Query|\Cake\Database\ValueBinder
+ * @param \Cake\Database\ValueBinder $binder new instance to be set. If no value is passed the
+ *   default one will be returned
+ * @return \Cake\Database\Query|\Cake\Database\ValueBinder
  */
 	public function valueBinder($binder = null) {
 		if ($binder === null) {

--- a/src/Database/QueryCompiler.php
+++ b/src/Database/QueryCompiler.php
@@ -20,6 +20,7 @@ use Cake\Database\ValueBinder;
 /**
  * Responsible for compiling a Query object into its SQL representation
  *
+ * @internal
  */
 class QueryCompiler {
 

--- a/src/Database/SqlserverCompiler.php
+++ b/src/Database/SqlserverCompiler.php
@@ -20,6 +20,7 @@ use Cake\Database\QueryCompiler;
  * Responsible for compiling a Query object into its SQL representation
  * for SQL Server
  *
+ * @internal
  */
 class SqlserverCompiler extends QueryCompiler {
 

--- a/src/Database/Statement/BufferedStatement.php
+++ b/src/Database/Statement/BufferedStatement.php
@@ -24,6 +24,7 @@ class BufferedStatement extends StatementDecorator {
 
 /**
  * Records count
+ *
  * @var int
  */
 	protected $_count = 0;
@@ -72,6 +73,9 @@ class BufferedStatement extends StatementDecorator {
 
 /**
  * {@inheritDoc}
+ *
+ * @param string $type The type to fetch.
+ * @return mixed
  */
 	public function fetch($type = 'num') {
 		if ($this->_allFetched) {
@@ -96,6 +100,9 @@ class BufferedStatement extends StatementDecorator {
 
 /**
  * {@inheritDoc}
+ *
+ * @param string $type The type to fetch.
+ * @return mixed
  */
 	public function fetchAll($type = 'num') {
 		if ($this->_allFetched) {
@@ -124,6 +131,8 @@ class BufferedStatement extends StatementDecorator {
 
 /**
  * Rewind the _counter property
+ *
+ * @return void
  */
 	public function rewind() {
 		$this->_counter = 0;
@@ -131,6 +140,8 @@ class BufferedStatement extends StatementDecorator {
 
 /**
  * Reset all properties
+ *
+ * @return void
  */
 	protected function _reset() {
 		$this->_count = $this->_counter = 0;

--- a/src/Database/Statement/PDOStatement.php
+++ b/src/Database/Statement/PDOStatement.php
@@ -26,8 +26,8 @@ class PDOStatement extends StatementDecorator {
 /**
  * Constructor
  *
- * @param \PDOStatement original statement to be decorated
- * @param \Cake\Database\Driver instance $driver
+ * @param \PDOStatement $statement Original statement to be decorated.
+ * @param \Cake\Database\Driver $driver Driver instance.
  */
 	public function __construct(Statement $statement = null, $driver = null) {
 		$this->_statement = $statement;
@@ -47,10 +47,12 @@ class PDOStatement extends StatementDecorator {
  *
  * ## Examples:
  *
- *	`$statement->bindValue(1, 'a title');`
- *	`$statement->bindValue(2, 5, PDO::INT);`
- *	`$statement->bindValue('active', true, 'boolean');`
- *	`$statement->bindValue(5, new \DateTime(), 'date');`
+ * {{{
+ * $statement->bindValue(1, 'a title');
+ * $statement->bindValue(2, 5, PDO::INT);
+ * $statement->bindValue('active', true, 'boolean');
+ * $statement->bindValue(5, new \DateTime(), 'date');
+ * }}}
  *
  * @param string|int $column name or param position to be bound
  * @param mixed $value The value to bind to variable in query

--- a/src/Database/Statement/SqliteStatement.php
+++ b/src/Database/Statement/SqliteStatement.php
@@ -17,6 +17,7 @@ namespace Cake\Database\Statement;
 /**
  * Statement class meant to be used by an Sqlite driver
  *
+ * @internal
  */
 class SqliteStatement extends BufferedStatement {
 

--- a/src/Database/Statement/SqlserverStatement.php
+++ b/src/Database/Statement/SqlserverStatement.php
@@ -20,6 +20,7 @@ use PDO;
 /**
  * Statement class meant to be used by an Sqlserver driver
  *
+ * @internal
  */
 class SqlserverStatement extends PDOStatement {
 

--- a/src/Database/Statement/SqlserverStatement.php
+++ b/src/Database/Statement/SqlserverStatement.php
@@ -24,10 +24,10 @@ use PDO;
 class SqlserverStatement extends PDOStatement {
 
 /**
- * {@inheritDoc}
- *
  * The SQL Server PDO driver requires that binary parameters be bound with the SQLSRV_ENCODING_BINARY attribute.
  * This overrides the PDOStatement::bindValue method in order to bind binary columns using the required attribute.
+ *
+ * {@inheritDoc}
  */
 	public function bindValue($column, $value, $type = 'string') {
 		if ($type === null) {

--- a/src/Database/Type.php
+++ b/src/Database/Type.php
@@ -107,7 +107,7 @@ class Type {
  * If $className is omitted it will return mapped class for $type
  *
  * @param string|array $type if string name of type to map, if array list of arrays to be mapped
- * @param string $className
+ * @param string $className The classname to register.
  * @return array|string|null if $type is null then array with current map, if $className is null string
  * configured class name for give $type, null otherwise
  */

--- a/src/Database/TypeConverterTrait.php
+++ b/src/Database/TypeConverterTrait.php
@@ -23,8 +23,8 @@ trait TypeConverterTrait {
  * Converts a give value to a suitable database value based on type
  * and return relevant internal statement type
  *
- * @param mixed $value
- * @param string $type
+ * @param mixed $value The value to cast
+ * @param \Cake\Database\Type|string $type The type name or type instance to use.
  * @return array list containing converted value and internal type
  */
 	public function cast($value, $type) {

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -16,6 +16,8 @@ namespace Cake\Database;
 
 /**
  * Value binder class manages list of values bound to conditions.
+ *
+ * @internal
  */
 class ValueBinder {
 


### PR DESCRIPTION
Update many of the API doc block errors in Database/. I've also started using `@internal` on the database internals that I don't think users will often need to interact with directly. I've done this for a few reasons:
- Having a smaller stable API makes any mistakes we make easier to fix in the future.
- The database layer is still new and we can easily remove `@internal` more than we can add it.
