### PR TITLE
DS console cake unification

### DIFF
--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -17,20 +17,24 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$ds = DIRECTORY_SEPARATOR;
-$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
+if (!defined('DS')) {
+	define('DS', DIRECTORY_SEPARATOR);
+}
+
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 
 if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
 
 	// the following line differs from its sibling
 	// /lib/Cake/Console/Templates/skel/Console/cake.php
-	ini_set('include_path', $root . $ds . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+	ini_set('include_path', $root . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
+	unset($root);
 }
 
 if (!include $dispatcher) {
 	trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
 }
-unset($paths, $path, $dispatcher, $root, $ds);
+unset($dispatcher);
 
 return ShellDispatcher::run($argv);

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -79,7 +79,6 @@ class ShellDispatcher {
 		}
 
 		if (!defined('CAKE_CORE_INCLUDE_PATH')) {
-			define('DS', DIRECTORY_SEPARATOR);
 			define('CAKE_CORE_INCLUDE_PATH', dirname(dirname(dirname(__FILE__))));
 			define('CAKEPHP_SHELL', true);
 			if (!defined('CORE_PATH')) {

--- a/lib/Cake/Console/Templates/skel/Console/cake.php
+++ b/lib/Cake/Console/Templates/skel/Console/cake.php
@@ -16,8 +16,11 @@
  * @since         CakePHP(tm) v 2.0
  */
 
-$ds = DIRECTORY_SEPARATOR;
-$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
+if (!defined('DS')) {
+	define('DS', DIRECTORY_SEPARATOR);
+}
+
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 
 if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
@@ -25,11 +28,12 @@ if (function_exists('ini_set')) {
 	// the following line differs from its sibling
 	// /app/Console/cake.php
 	ini_set('include_path', $root . PATH_SEPARATOR . __CAKE_PATH__ . PATH_SEPARATOR . ini_get('include_path'));
+	unset($root);
 }
 
 if (!include $dispatcher) {
 	trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
 }
-unset($paths, $path, $dispatcher, $root, $ds);
+unset($dispatcher);
 
 return ShellDispatcher::run($argv);

--- a/lib/Cake/Console/cake.php
+++ b/lib/Cake/Console/cake.php
@@ -17,21 +17,24 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-$ds = DIRECTORY_SEPARATOR;
-$dispatcher = 'Cake' . $ds . 'Console' . $ds . 'ShellDispatcher.php';
+if (!defined('DS')) {
+	define('DS', DIRECTORY_SEPARATOR);
+}
+
+$dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 $found = false;
 $paths = explode(PATH_SEPARATOR, ini_get('include_path'));
 
 foreach ($paths as $path) {
-	if (file_exists($path . $ds . $dispatcher)) {
+	if (file_exists($path . DS . $dispatcher)) {
 		$found = $path;
 		break;
 	}
 }
 
 if (!$found) {
-	$rootInstall = dirname(dirname(dirname(__FILE__))) . $ds . $dispatcher;
-	$composerInstall = dirname(dirname(__FILE__)) . $ds . $dispatcher;
+	$rootInstall = dirname(dirname(dirname(__FILE__))) . DS . $dispatcher;
+	$composerInstall = dirname(dirname(__FILE__)) . DS . $dispatcher;
 
 	if (file_exists($composerInstall)) {
 		include $composerInstall;
@@ -40,10 +43,12 @@ if (!$found) {
 	} else {
 		trigger_error('Could not locate CakePHP core files.', E_USER_ERROR);
 	}
+	unset($rootInstall, $composerInstall);
+
 } else {
-	include $found . $ds . $dispatcher;
+	include $found . DS . $dispatcher;
 }
 
-unset($paths, $path, $found, $dispatcher, $root, $ds);
+unset($paths, $path, $found, $dispatcher);
 
 return ShellDispatcher::run($argv);


### PR DESCRIPTION
and cleanup
- In both Core and App versions some variables have been unsetted that didnt even exist.
- I also unified DS the same way it is for [index.php](https://github.com/cakephp/cakephp/blob/master/app/webroot/index.php#L24) and test.php since it used later anyway, as well.
- Added the missing `unset($rootInstall, $composerInstall);` part.
