### PR TITLE
Fix TextHelper::autoLinkEmail() near HTML

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -363,54 +363,71 @@ class TextHelperTest extends CakeTestCase {
 	}
 
 /**
- * testAutoLinkEmails method
+ * Data provider for autoLinkEmail.
  *
  * @return void
  */
-	public function testAutoLinkEmails() {
-		$text = 'This is a test text';
-		$expected = 'This is a test text';
-		$result = $this->Text->autoLinkUrls($text);
-		$this->assertEquals($expected, $result);
+	public function autoLinkEmailProvider() {
+		return array(
+			array(
+				'This is a test text',
+				'This is a test text',
+			),
 
-		$text = 'email@example.com address';
-		$expected = '<a href="mailto:email@example.com">email@example.com</a> address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				'email@example.com address',
+				'<a href="mailto:email@example.com">email@example.com</a> address',
+			),
 
-		$text = 'email@example.com address';
-		$expected = '<a href="mailto:email@example.com">email@example.com</a> address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				'email@example.com address',
+				'<a href="mailto:email@example.com">email@example.com</a> address',
+			),
 
-		$text = '(email@example.com) address';
-		$expected = '(<a href="mailto:email@example.com">email@example.com</a>) address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				'(email@example.com) address',
+				'(<a href="mailto:email@example.com">email@example.com</a>) address',
+			),
 
-		$text = 'Text with email@example.com address';
-		$expected = 'Text with <a href="mailto:email@example.com">email@example.com</a> address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				'Text with email@example.com address',
+				'Text with <a href="mailto:email@example.com">email@example.com</a> address',
+			),
 
-		$text = "Text with o'hare._-bob@example.com address";
-		$expected = 'Text with <a href="mailto:o&#039;hare._-bob@example.com">o&#039;hare._-bob@example.com</a> address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				"Text with o'hare._-bob@example.com address",
+				'Text with <a href="mailto:o&#039;hare._-bob@example.com">o&#039;hare._-bob@example.com</a> address',
+			),
 
-		$text = 'Text with email@example.com address';
-		$expected = 'Text with <a href="mailto:email@example.com" class="link">email@example.com</a> address';
-		$result = $this->Text->autoLinkEmails($text, array('class' => 'link'));
-		$this->assertEquals($expected, $result);
+			array(
+				'Text with düsentrieb@küchenschöhn-not-working.de address',
+				'Text with <a href="mailto:düsentrieb@küchenschöhn-not-working.de">düsentrieb@küchenschöhn-not-working.de</a> address',
+			),
 
-		$text = 'Text with düsentrieb@küchenschöhn-not-working.de address';
-		$expected = 'Text with <a href="mailto:düsentrieb@küchenschöhn-not-working.de">düsentrieb@küchenschöhn-not-working.de</a> address';
-		$result = $this->Text->autoLinkEmails($text);
-		$this->assertEquals($expected, $result);
+			array(
+				'Text with me@subdomain.küchenschöhn.de address',
+				'Text with <a href="mailto:me@subdomain.küchenschöhn.de">me@subdomain.küchenschöhn.de</a> address',
+			),
 
-		$text = 'Text with me@subdomain.küchenschöhn.de address';
-		$expected = 'Text with <a href="mailto:me@subdomain.küchenschöhn.de">me@subdomain.küchenschöhn.de</a> address';
-		$result = $this->Text->autoLinkEmails($text);
+			array(
+				'Text with email@example.com address',
+				'Text with <a href="mailto:email@example.com" class="link">email@example.com</a> address',
+				array('class' => 'link'),
+			),
+
+		);
+	}
+
+/**
+ * testAutoLinkEmails method
+ *
+ * @param string $text The text to link
+ * @param string $expected The expected results.
+ * @dataProvider autoLinkEmailProvider
+ * @return void
+ */
+	public function testAutoLinkEmails($text, $expected, $attrs = array()) {
+		$result = $this->Text->autoLinkEmails($text, $attrs);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/TextHelperTest.php
@@ -415,6 +415,17 @@ class TextHelperTest extends CakeTestCase {
 				array('class' => 'link'),
 			),
 
+			array(
+				'<p>mark@example.com</p>',
+				'<p><a href="mailto:mark@example.com">mark@example.com</a></p>',
+				array('escape' => false)
+			),
+
+			array(
+				'Some&nbsp;mark@example.com&nbsp;Text',
+				'Some&nbsp;<a href="mailto:mark@example.com">mark@example.com</a>&nbsp;Text',
+				array('escape' => false)
+			),
 		);
 	}
 

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -190,7 +190,7 @@ class TextHelper extends AppHelper {
 
 		$atom = '[\p{L}0-9!#$%&\'*+\/=?^_`{|}~-]';
 		$text = preg_replace_callback(
-			'/(?<=\s|^|\()(' . $atom . '*(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[\p{L}0-9-]+)+)/ui',
+			'/(?<=\s|^|\(|\>|\;)(' . $atom . '*(?:\.' . $atom . '+)*@[\p{L}0-9-]+(?:\.[\p{L}0-9-]+)+)/ui',
 			array(&$this, '_insertPlaceholder'),
 			$text
 		);


### PR DESCRIPTION
Fix up autoLinkEmail() near HTML, and restructure the test cases to use a provider which I think makes the tests easier to read/modify/run. Linking email addresses near HTML tags and HTML entities should work now.

Fixes #3656
