### PR TITLE
Remove use of request info to identify user in AuthComponent::login().

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -584,26 +584,19 @@ class AuthComponent extends Component {
 /**
  * Log a user in.
  *
- * If a $user is provided that data will be stored as the logged in user. If `$user` is empty or not
- * specified, the request will be used to identify a user. If the identification was successful,
- * the user record is written to the session key specified in AuthComponent::$sessionKey. Logging in
- * will also change the session id in order to help mitigate session replays.
+ * The provided user data will be stored as the logged in user. The user record
+ * is written to the session key specified in AuthComponent::$sessionKey. Logging
+ * in will also change the session id in order to help mitigate session replays.
  *
- * @param array $user Either an array of user data, or null to identify a user using the current request.
- * @return bool True on login success, false on failure
+ * @param array $user Array of user data.
+ * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
  */
-	public function login($user = null) {
+	public function login(array $user) {
 		$this->_setDefaults();
 
-		if (empty($user)) {
-			$user = $this->identify($this->request, $this->response);
-		}
-		if ($user) {
-			$this->session->renew();
-			$this->session->write($this->sessionKey, $user);
-		}
-		return (bool)$this->user();
+		$this->session->renew();
+		$this->session->write($this->sessionKey, $user);
 	}
 
 /**
@@ -729,16 +722,16 @@ class AuthComponent extends Component {
  * Use the configured authentication adapters, and attempt to identify the user
  * by credentials contained in $request.
  *
- * @param \Cake\Network\Request $request The request that contains authentication data.
- * @param \Cake\Network\Response $response The response
  * @return array User record data, or false, if the user could not be identified.
  */
-	public function identify(Request $request, Response $response) {
+	public function identify() {
+		$this->_setDefaults();
+
 		if (empty($this->_authenticateObjects)) {
 			$this->constructAuthenticate();
 		}
 		foreach ($this->_authenticateObjects as $auth) {
-			$result = $auth->authenticate($request, $response);
+			$result = $auth->authenticate($this->request, $this->response);
 			if (!empty($result) && is_array($result)) {
 				$this->_authenticationProvider = $auth;
 				return $result;

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -592,8 +592,6 @@ class AuthComponent extends Component {
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
  */
 	public function setUser(array $user) {
-		$this->_setDefaults();
-
 		$this->session->renew();
 		$this->session->write($this->sessionKey, $user);
 	}

--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -582,17 +582,16 @@ class AuthComponent extends Component {
 	}
 
 /**
- * Log a user in.
+ * Set provided user info to session as logged in user.
  *
- * The provided user data will be stored as the logged in user. The user record
- * is written to the session key specified in AuthComponent::$sessionKey. Logging
- * in will also change the session id in order to help mitigate session replays.
+ * The user recordis written to the session key specified in AuthComponent::$sessionKey.
+ * Thehe session id will also be changed in order to help mitigate session replays.
  *
  * @param array $user Array of user data.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/authentication.html#identifying-users-and-logging-them-in
  */
-	public function login(array $user) {
+	public function setUser(array $user) {
 		$this->_setDefaults();
 
 		$this->session->renew();

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -722,7 +722,7 @@ class AuthComponentTest extends TestCase {
 		$Request->env('HTTP_REFERER', false);
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->config('authorize', ['Controller']);
-		$this->Auth->login(array('username' => 'mariano', 'password' => 'cake'));
+		$this->Auth->setUser(array('username' => 'mariano', 'password' => 'cake'));
 		$this->Auth->config('loginRedirect', [
 			'controller' => 'something', 'action' => 'else'
 		]);
@@ -759,7 +759,7 @@ class AuthComponentTest extends TestCase {
 		]);
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->config('authorize', ['Controller']);
-		$this->Auth->login(array('username' => 'admad', 'password' => 'cake'));
+		$this->Auth->setUser(array('username' => 'admad', 'password' => 'cake'));
 
 		$expected = ['controller' => 'no_can_do', 'action' => 'jack'];
 		$this->Auth->config('unauthorizedRedirect', $expected);
@@ -796,7 +796,7 @@ class AuthComponentTest extends TestCase {
 		$this->Auth->request = $Request = new Request($url);
 		$this->Auth->request->addParams(Router::parse($url));
 		$this->Auth->config('authorize', ['Controller']);
-		$this->Auth->login(array('username' => 'admad', 'password' => 'cake'));
+		$this->Auth->setUser(array('username' => 'admad', 'password' => 'cake'));
 		$expected = ['controller' => 'no_can_do', 'action' => 'jack'];
 		$this->Auth->config('unauthorizedRedirect', $expected);
 		$this->Auth->config('authError', false);
@@ -833,7 +833,7 @@ class AuthComponentTest extends TestCase {
 			'authorize' => ['Controller'],
 			'unauthorizedRedirect' => false
 		]);
-		$this->Auth->login(array('username' => 'baker', 'password' => 'cake'));
+		$this->Auth->setUser(array('username' => 'baker', 'password' => 'cake'));
 
 		$response = new Response();
 		$Controller = $this->getMock(
@@ -1093,11 +1093,11 @@ class AuthComponentTest extends TestCase {
 	}
 
 /**
- * test logging in.
+ * test setting user info to session.
  *
  * @return void
  */
-	public function testLogin() {
+	public function testSetUser() {
 		$this->Auth->session = $this->getMock(
 			'Cake\Network\Session',
 			array('renew', 'write')
@@ -1112,15 +1112,15 @@ class AuthComponentTest extends TestCase {
 			->method('write')
 			->with($this->Auth->sessionKey, $user);
 
-		$this->Auth->login($user);
+		$this->Auth->setUser($user);
 	}
 
 /**
- * testGettingUserAfterLogin
+ * testGettingUserAfterSetUser
  *
  * @return void
  */
-	public function testGettingUserAfterLogin() {
+	public function testGettingUserAfterSetUser() {
 		$this->assertFalse((bool)$this->Auth->user());
 
 		$user = array(
@@ -1129,7 +1129,7 @@ class AuthComponentTest extends TestCase {
 			'created' => new \DateTime('2007-03-17 01:16:23'),
 			'updated' => new \DateTime('2007-03-17 01:18:31')
 		);
-		$this->Auth->login($user);
+		$this->Auth->setUser($user);
 		$this->assertTrue((bool)$this->Auth->user());
 		$this->assertEquals($user['username'], $this->Auth->user('username'));
 	}


### PR DESCRIPTION
Your login action would now be similar to:

``` php
...
if ($this->request->is('post')) {
    $user = $this->Auth->identify();
    if ($user) {
        $this->Auth->login($user);
        // redirect somewhere
    }
    // set error flash
}
...
```
