### PR TITLE
Mysql Binary fields should be mapped to LONGBLOB rather than BLOB

### DIFF
--- a/src/Database/Schema/MysqlSchema.php
+++ b/src/Database/Schema/MysqlSchema.php
@@ -253,7 +253,7 @@ class MysqlSchema extends BaseSchema {
 			'integer' => ' INTEGER',
 			'biginteger' => ' BIGINT',
 			'boolean' => ' BOOLEAN',
-			'binary' => ' BLOB',
+			'binary' => ' LONGBLOB',
 			'float' => ' FLOAT',
 			'decimal' => ' DECIMAL',
 			'text' => ' TEXT',


### PR DESCRIPTION
A MySQL blob field can only be 65kb maximum, this can create some issues if a binary field is being used for fixture data. Changed this to a longblob.
