### PR TITLE
2.6 Improve missing view error pages

### DIFF
--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -30,6 +30,9 @@
 <?php
 	$paths = $this->_paths($this->plugin);
 	foreach ($paths as $path):
+		if (strpos($path, CORE_PATH) !== false) {
+			continue;
+		}
 		echo sprintf('<li>%s%s</li>', h($path), h($file));
 	endforeach;
 ?>

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -21,19 +21,16 @@
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
 	<?php echo __d('cake_dev', 'The layout file %s can not be found or does not exist.', '<em>' . h($file) . '</em>'); ?>
 </p>
-<p class="error">
-	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', '<em>' . h($file) . '</em>'); ?>
-</p>
 
 <p>
-	You should create "<?php echo h($file); ?>" in one of he following paths:
+	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', h($file)); ?>
+	in one of the following paths:
 </p>
 <ul>
 <?php
 	$paths = $this->_paths($this->plugin);
 	foreach ($paths as $path):
-		echo sprintf('<li>%s%s%s</li>', h($path), DS, h($file));
+		echo sprintf('<li>%s%s</li>', h($path), h($file));
 	endforeach;
 ?>
 </ul>

--- a/lib/Cake/View/Errors/missing_layout.ctp
+++ b/lib/Cake/View/Errors/missing_layout.ctp
@@ -25,6 +25,19 @@
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
 	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', '<em>' . h($file) . '</em>'); ?>
 </p>
+
+<p>
+	You should create "<?php echo h($file); ?>" in one of he following paths:
+</p>
+<ul>
+<?php
+	$paths = $this->_paths($this->plugin);
+	foreach ($paths as $path):
+		echo sprintf('<li>%s%s%s</li>', h($path), DS, h($file));
+	endforeach;
+?>
+</ul>
+
 <p class="notice">
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_layout.ctp'); ?>

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -25,6 +25,19 @@
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
 	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', h($file)); ?>
 </p>
+
+<p>
+	You should create "<?php echo h($file); ?>" in one of he following paths:
+</p>
+<ul>
+<?php
+	$paths = $this->_paths($this->plugin);
+	foreach ($paths as $path):
+		echo sprintf('<li>%s%s%s</li>', h($path), DS, h($file));
+	endforeach;
+?>
+</ul>
+
 <p class="notice">
 	<strong><?php echo __d('cake_dev', 'Notice'); ?>: </strong>
 	<?php echo __d('cake_dev', 'If you want to customize this error message, create %s', APP_DIR . DS . 'View' . DS . 'Errors' . DS . 'missing_view.ctp'); ?>

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -28,6 +28,9 @@
 <?php
 	$paths = $this->_paths($this->plugin);
 	foreach ($paths as $path):
+		if (strpos($path, CORE_PATH) !== false) {
+			continue;
+		}
 		echo sprintf('<li>%s%s</li>', h($path), h($file));
 	endforeach;
 ?>

--- a/lib/Cake/View/Errors/missing_view.ctp
+++ b/lib/Cake/View/Errors/missing_view.ctp
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -21,19 +19,16 @@
 	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
 	<?php echo __d('cake_dev', 'The view for %1$s%2$s was not found.', '<em>' . h(Inflector::camelize($this->request->controller)) . 'Controller::</em>', '<em>' . h($this->request->action) . '()</em>'); ?>
 </p>
-<p class="error">
-	<strong><?php echo __d('cake_dev', 'Error'); ?>: </strong>
-	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', h($file)); ?>
-</p>
 
 <p>
-	You should create "<?php echo h($file); ?>" in one of he following paths:
+	<?php echo __d('cake_dev', 'Confirm you have created the file: %s', h($file)); ?>
+	in one of the following paths:
 </p>
 <ul>
 <?php
 	$paths = $this->_paths($this->plugin);
 	foreach ($paths as $path):
-		echo sprintf('<li>%s%s%s</li>', h($path), DS, h($file));
+		echo sprintf('<li>%s%s</li>', h($path), h($file));
 	endforeach;
 ?>
 </ul>

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -1008,17 +1008,6 @@ class View extends Object {
 				}
 			}
 		}
-		$defaultPath = $paths[0];
-
-		if ($this->plugin) {
-			$pluginPaths = App::path('plugins');
-			foreach ($paths as $path) {
-				if (strpos($path, $pluginPaths[0]) === 0) {
-					$defaultPath = $path;
-					break;
-				}
-			}
-		}
 		throw new MissingViewException(array('file' => $name . $this->ext));
 	}
 

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -1019,7 +1019,7 @@ class View extends Object {
 				}
 			}
 		}
-		throw new MissingViewException(array('file' => $defaultPath . $name . $this->ext));
+		throw new MissingViewException(array('file' => $name . $this->ext));
 	}
 
 /**
@@ -1072,7 +1072,7 @@ class View extends Object {
 				}
 			}
 		}
-		throw new MissingLayoutException(array('file' => $paths[0] . $file . $this->ext));
+		throw new MissingLayoutException(array('file' => $file . $this->ext));
 	}
 
 /**


### PR DESCRIPTION
As per #3712 this set of changes improves the MissingView and MissingLayout error pages to include a bulleted list of all the places you can put your missing view/layout to satisfy the error.
