### PR TITLE
2.6 toList() localization

### DIFF
--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -672,7 +672,7 @@ class String {
 	}
 
 /**
- * Creates a comma separated list where the last two items are joined with 'and', forming natural English.
+ * Creates a comma separated list where the last two items are joined with 'and', forming natural language.
  *
  * @param array $list The list to be joined.
  * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.

--- a/lib/Cake/Utility/String.php
+++ b/lib/Cake/Utility/String.php
@@ -672,15 +672,18 @@ class String {
 	}
 
 /**
- * Creates a comma separated list where the last two items are joined with 'and', forming natural English
+ * Creates a comma separated list where the last two items are joined with 'and', forming natural English.
  *
- * @param array $list The list to be joined
- * @param string $and The word used to join the last and second last items together with. Defaults to 'and'
- * @param string $separator The separator used to join all the other items together. Defaults to ', '
+ * @param array $list The list to be joined.
+ * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.
+ * @param string $separator The separator used to join all the other items together. Defaults to ', '.
  * @return string The glued together string.
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::toList
  */
-	public static function toList($list, $and = 'and', $separator = ', ') {
+	public static function toList($list, $and = null, $separator = ', ') {
+		if ($and === null) {
+			$and = __d('cake', 'and');
+		}
 		if (count($list) > 1) {
 			return implode($separator, array_slice($list, null, -1)) . ' ' . $and . ' ' . array_pop($list);
 		}

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -329,7 +329,7 @@ class TextHelper extends AppHelper {
 	}
 
 /**
- * Creates a comma separated list where the last two items are joined with 'and', forming natural English.
+ * Creates a comma separated list where the last two items are joined with 'and', forming natural language.
  *
  * @param array $list The list to be joined.
  * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.

--- a/lib/Cake/View/Helper/TextHelper.php
+++ b/lib/Cake/View/Helper/TextHelper.php
@@ -329,16 +329,16 @@ class TextHelper extends AppHelper {
 	}
 
 /**
- * Creates a comma separated list where the last two items are joined with 'and', forming natural English
+ * Creates a comma separated list where the last two items are joined with 'and', forming natural English.
  *
- * @param array $list The list to be joined
- * @param string $and The word used to join the last and second last items together with. Defaults to 'and'
- * @param string $separator The separator used to join all the other items together. Defaults to ', '
+ * @param array $list The list to be joined.
+ * @param string $and The word used to join the last and second last items together with. Defaults to 'and'.
+ * @param string $separator The separator used to join all the other items together. Defaults to ', '.
  * @return string The glued together string.
  * @see String::toList()
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/text.html#TextHelper::toList
  */
-	public function toList($list, $and = 'and', $separator = ', ') {
+	public function toList($list, $and = null, $separator = ', ') {
 		return $this->_engine->toList($list, $and, $separator);
 	}
 


### PR DESCRIPTION
Currently it is not possible for a non English context to use the defaults of toList().
You would always have to provide the second argument:

```
echo $this->Text->toList($list, __('and'));
```

With this change it is possible to do

```
echo $this->Text->toList($list);
```

and have the "and" translated.

Also, for using the third argument, you dont have to retype the word again, this suffices:

```
echo $this->Text->toList($list, null, ' - ');
```

This change is 100% BC.
