### PR TITLE
De-duplicate session flash features.

### DIFF
--- a/src/Controller/Component/AuthComponent.php
+++ b/src/Controller/Component/AuthComponent.php
@@ -151,7 +151,7 @@ class AuthComponent extends Component {
  *
  * @var array
  */
-	public $components = array('RequestHandler');
+	public $components = ['RequestHandler', 'Flash'];
 
 /**
  * Objects that will be used for authentication checks.
@@ -799,7 +799,10 @@ class AuthComponent extends Component {
 		if (isset($flashConfig['params'])) {
 			$params = $flashConfig['params'];
 		}
-		$this->session->flash($message, 'error', $params + compact('key'));
+		if (empty($params['element'])) {
+			$params['element'] = 'error';
+		}
+		$this->Flash->set($message, $params + compact('key'));
 	}
 
 /**

--- a/src/Controller/Component/SessionComponent.php
+++ b/src/Controller/Component/SessionComponent.php
@@ -56,7 +56,7 @@ class SessionComponent extends Component {
  * In your controller: $this->Session->write('Controller.sessKey', 'session value');
  *
  * @param string $name The name of the key your are setting in the session.
- * 							This should be in a Controller.key format for better organizing
+ *    This should be in a Controller.key format for better organizing
  * @param string $value The value you want to store in a session.
  * @return void
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#SessionComponent::write
@@ -122,7 +122,12 @@ class SessionComponent extends Component {
  * @link http://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#creating-notification-messages
  */
 	public function setFlash($message, $element = null, array $params = array(), $key = 'flash') {
-		$this->_session->flash($message, 'info', $params + compact('element', 'key'));
+		$this->_session->write('Flash.' . $key, [
+			'message' => $message,
+			'key' => $key,
+			'element' => $element,
+			'params' => $params
+		]);
 	}
 
 /**

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -527,57 +527,6 @@ class Session {
 	}
 
 /**
- * Stores a single string under the "Message.flash" session key. This is useful
- * for persisting messages from one request to another that should be displayed
- * to the user.
- *
- * The options array accepts `key`, this is is useful for assigning a domain
- * to the flash message since you can only store one per domain.
- *
- * ### Example
- *
- * {{{
- *	$session->flash('Welcome, Mark', 'success');
- *	$session->flash('This is a message in a different domain', 'info', ['key' => 'another']);
- * }}}
- *
- * @param string $message the message to display to persist
- * @param string $type the type of message
- * @param array $options A list of extra options to persist related to this message
- * @return void
- */
-	public function flash($message, $type = 'info', $options = []) {
-		$options += ['key' => 'flash'];
-		$key = $options['key'];
-		unset($options['key']);
-		$this->write("Message.$key", [
-			'message' => $message,
-			'type' => $type,
-			'params' => $options
-		]);
-	}
-
-/**
- * Returns the flash message stored in the given key if exists.
- *
- * @param string $key the message domain
- * @return array|null
- */
-	public function readFlash($key = 'flash') {
-		return $this->read("Message.$key");
-	}
-
-/**
- * Deletes the flash message stored in the given key
- *
- * @param string $key the message domain
- * @return void
- */
-	public function deleteFlash($key = 'flash') {
-		$this->delete("Message.$key");
-	}
-
-/**
  * Returns true if the session is no longer valid because the last time it was
  * accessed was after the configured timeout.
  *

--- a/src/View/Helper/SessionHelper.php
+++ b/src/View/Helper/SessionHelper.php
@@ -116,13 +116,13 @@ class SessionHelper extends Helper {
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/session.html#SessionHelper::flash
  */
 	public function flash($key = 'flash', $attrs = []) {
-		$flash = $this->request->session()->readFlash($key);
+		$flash = $this->request->session()->read('Flash.' . $key);
 
 		if (!$flash) {
 			return '';
 		}
 
-		$this->request->session()->deleteFlash($key);
+		$this->request->session()->delete('Flash.' . $key);
 
 		if (!empty($attrs)) {
 			$flash = array_merge($flash, $attrs);

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -220,7 +220,7 @@ class AuthComponentTest extends TestCase {
 		$result = $this->Controller->Auth->startup($event);
 		$this->assertTrue($event->isStopped());
 		$this->assertInstanceOf('Cake\Network\Response', $result);
-		$this->assertTrue($this->Auth->session->check('Message.auth'));
+		$this->assertTrue($this->Auth->session->check('Flash.auth'));
 
 		$this->Controller->request->addParams(Router::parse('auth_test/camelCase'));
 		$result = $this->Controller->Auth->startup($event);
@@ -750,9 +750,10 @@ class AuthComponentTest extends TestCase {
  */
 	public function testRedirectToUnauthorizedRedirect() {
 		$url = '/party/on';
-		$this->Auth->session = $this->getMock(
-			'Cake\Network\Session',
-			array('flash')
+		$this->Auth->Flash = $this->getMock(
+			'Cake\Controller\Component\FlashComponent',
+			['set'],
+			[$this->Controller->components()]
 		);
 		$this->Auth->request = $request = new Request([
 			'url' => $url,
@@ -776,8 +777,8 @@ class AuthComponentTest extends TestCase {
 			->method('redirect')
 			->with($this->equalTo($expected));
 
-		$this->Auth->session->expects($this->once())
-			->method('flash');
+		$this->Auth->Flash->expects($this->once())
+			->method('set');
 
 		$event = new Event('Controller.startup', $Controller);
 		$this->Auth->startup($event);
@@ -1142,14 +1143,18 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testFlashSettings() {
-		$this->Auth->session = $this->getMock('Cake\Network\Session');
-		$this->Auth->session->expects($this->at(0))
-			->method('flash')
-			->with('Auth failure', 'error', array('key' => 'auth-key', 'element' => 'custom'));
+		$this->Auth->Flash = $this->getMock(
+			'Cake\Controller\Component\FlashComponent',
+			[],
+			[$this->Controller->components()]
+		);
+		$this->Auth->Flash->expects($this->at(0))
+			->method('set')
+			->with('Auth failure', array('key' => 'auth-key', 'element' => 'custom'));
 
-		$this->Auth->session->expects($this->at(1))
-			->method('flash')
-			->with('Auth failure', 'error', array('key' => 'auth-key'));
+		$this->Auth->Flash->expects($this->at(1))
+			->method('set')
+			->with('Auth failure', array('element' => 'error', 'key' => 'auth-key'));
 
 		$this->Auth->config('flash', [
 			'params' => array('element' => 'custom'),

--- a/tests/TestCase/Controller/Component/SessionComponentTest.php
+++ b/tests/TestCase/Controller/Component/SessionComponentTest.php
@@ -169,14 +169,15 @@ class SessionComponentTest extends TestCase {
 	public function testSessionFlash() {
 		$Session = new SessionComponent($this->ComponentRegistry);
 
-		$this->assertNull($Session->read('Message.flash'));
+		$this->assertNull($Session->read('Flash.flash'));
 
 		$Session->setFlash('This is a test message');
 		$this->assertEquals(array(
 				'message' => 'This is a test message',
-				'params' => array('element' => null),
-				'type' => 'info'
-			), $Session->read('Message.flash'));
+				'element' => null,
+				'params' => array(),
+				'key' => 'flash'
+			), $Session->read('Flash.flash'));
 	}
 
 /**

--- a/tests/TestCase/Network/SessionTest.php
+++ b/tests/TestCase/Network/SessionTest.php
@@ -444,48 +444,6 @@ class SessionTest extends TestCase {
 	}
 
 /**
- * Tests setting, reading and deleting flash messages
- *
- * @return void
- */
-	public function testFlash() {
-		$session = new Session();
-		$session->flash('Hello there!');
-		$expected = [
-			'message' => 'Hello there!',
-			'type' => 'info',
-			'params' => []
-		];
-		$this->assertEquals($expected, $session->readFlash());
-
-		$this->assertEquals($expected, $session->readFlash());
-		$session->deleteFlash();
-		$this->assertNull($session->readFlash());
-	}
-
-/**
- * Tests using the key option in the flash method
- *
- * @return void
- */
-	public function testFlashKey() {
-		$session = new Session();
-		$session->flash('Hello there!', 'success', ['key' => 'foo']);
-		$expected = [
-			'message' => 'Hello there!',
-			'type' => 'success',
-			'params' => []
-		];
-
-		$this->assertNull($session->readFlash());
-		$this->assertEquals($expected, $session->readFlash('foo'));
-		$session->deleteFlash();
-		$this->assertEquals($expected, $session->readFlash('foo'));
-		$session->deleteFlash('foo');
-		$this->assertNull($session->readFlash('foo'));
-	}
-
-/**
  * Tests that the cookie name can be changed with configuration
  *
  * @return void

--- a/tests/TestCase/View/Helper/SessionHelperTest.php
+++ b/tests/TestCase/View/Helper/SessionHelperTest.php
@@ -45,7 +45,7 @@ class SessionHelperTest extends TestCase {
 
 		$session->write(array(
 			'test' => 'info',
-			'Message' => array(
+			'Flash' => array(
 				'flash' => array(
 					'type' => 'info',
 					'params' => array(),
@@ -102,7 +102,7 @@ class SessionHelperTest extends TestCase {
  */
 	public function testCheck() {
 		$this->assertTrue($this->Session->check('test'));
-		$this->assertTrue($this->Session->check('Message.flash'));
+		$this->assertTrue($this->Session->check('Flash.flash'));
 		$this->assertFalse($this->Session->check('Does.not.exist'));
 		$this->assertFalse($this->Session->check('Nope'));
 	}


### PR DESCRIPTION
With a proper FlashComponent and FlashHelper we don't need to have a duplicated set of features in the Session object. This change also unifies the keys SessionComponent/SessionHelper and FlashComponent/FlashHelper use so no matter which interface you use, everything plays nicely together.

Refs cakephp/docs#1430
