### PR TITLE
3.0 - Fix reverse routing of uninflected routes

### DIFF
--- a/src/Routing/RouteCollection.php
+++ b/src/Routing/RouteCollection.php
@@ -142,7 +142,7 @@ class RouteCollection implements \Countable {
 			];
 		}
 		foreach ($fallbacks as $i => $template) {
-			$fallbacks[$i] = sprintf($template, $plugin, $url['controller'], $url['action']);
+			$fallbacks[$i] = strtolower(sprintf($template, $plugin, $url['controller'], $url['action']));
 		}
 		if ($name) {
 			array_unshift($fallbacks, $name);

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -702,6 +702,19 @@ class RouterTest extends TestCase {
 	}
 
 /**
+ * Test that generated names for routes are case-insensitive.
+ *
+ * @return void
+ */
+	public function testRouteNameCasing() {
+		Router::connect('/articles/:id', ['controller' => 'Articles', 'action' => 'view']);
+		Router::connect('/:controller/:action/*', [], ['routeClass' => 'InflectedRoute']);
+		$result = Router::url(['controller' => 'Articles', 'action' => 'view', 'id' => 10]);
+		$expected = '/articles/10';
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * Test generation of routes with query string parameters.
  *
  * @return void


### PR DESCRIPTION
When creating names for reverse routing, always lowercase the names, as `Route::name()` will also lowercase the names. With routing keys no longer being underscored() casing starts to matter more for generated names.

Refs #3752
