### PR TITLE
3.0 Improve missing controller errors a bit, and fix an issue in Table::get()

### DIFF
--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -885,15 +885,14 @@ class Table implements RepositoryInterface, EventListener {
 		$conditions = array_combine($key, $primaryKey);
 		$entity = $this->find('all', $options)->where($conditions)->first();
 
-		if (!$entity) {
-			throw new RecordNotFoundException(sprintf(
-				'Record "%s" not found in table "%s"',
-				implode(',', (array)$primaryKey),
-				$this->table()
-			));
+		if ($entity) {
+			return $entity;
 		}
-
-		return $entity;
+		throw new RecordNotFoundException(sprintf(
+			'Record "%s" not found in table "%s"',
+			implode(',', (array)$primaryKey),
+			$this->table()
+		));
 	}
 
 /**

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -864,8 +864,9 @@ class Table implements RepositoryInterface, EventListener {
 /**
  * {@inheritDoc}
  *
- * @throws \Cake\ORM\Error\RecordNotFoundException if no record can be found give
- * such primary key value.
+ * @throws \Cake\ORM\Error\RecordNotFoundException if no record can be found given
+ * a primary key value.
+ * @throws \InvalidArgumentException When $primaryKey has an incorrect number of elements.
  */
 	public function get($primaryKey, $options = []) {
 		$key = (array)$this->primaryKey();
@@ -873,7 +874,15 @@ class Table implements RepositoryInterface, EventListener {
 		foreach ($key as $index => $keyname) {
 			$key[$index] = $alias . '.' . $keyname;
 		}
-		$conditions = array_combine($key, (array)$primaryKey);
+		$primaryKey = (array)$primaryKey;
+		if (count($key) !== count($primaryKey)) {
+			throw new \InvalidArgumentException(sprintf(
+				"Incorrect number of primary key values. Expected %d got %d.",
+				count($key),
+				count($primaryKey)
+			));
+		}
+		$conditions = array_combine($key, $primaryKey);
 		$entity = $this->find('all', $options)->where($conditions)->first();
 
 		if (!$entity) {

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -26,7 +26,6 @@ use Cake\Event\EventManager;
 use Cake\Event\EventManagerTrait;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\Utility\Inflector;
 
 /**
  * Dispatcher converts Requests into controller actions. It uses the dispatched Request

--- a/src/Routing/Dispatcher.php
+++ b/src/Routing/Dispatcher.php
@@ -82,9 +82,9 @@ class Dispatcher {
 
 		if (!($controller instanceof Controller)) {
 			throw new MissingControllerException(array(
-				'class' => Inflector::camelize($request->params['controller']),
-				'plugin' => empty($request->params['plugin']) ? null : Inflector::camelize($request->params['plugin']),
-				'prefix' => empty($request->params['prefix']) ? null : Inflector::camelize($request->params['prefix']),
+				'class' => $request->params['controller'],
+				'plugin' => empty($request->params['plugin']) ? null : $request->params['plugin'],
+				'prefix' => empty($request->params['prefix']) ? null : $request->params['prefix'],
 				'_ext' => empty($request->params['_ext']) ? null : $request->params['_ext']
 			));
 		}

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3183,39 +3183,13 @@ class TableTest extends \Cake\TestSuite\TestCase {
  * @expectedExceptionMessage Record "10" not found in table "articles"
  * @return void
  */
-	public function testGetException() {
-		$table = $this->getMock(
-			'\Cake\ORM\Table',
-			['callFinder', 'query'],
-			[[
-				'connection' => $this->connection,
-				'table' => 'articles',
-				'schema' => [
-					'id' => ['type' => 'integer'],
-					'bar' => ['type' => 'integer'],
-					'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['bar']]]
-				]
-			]]
-		);
-
-		$query = $this->getMock(
-			'\Cake\ORM\Query',
-			['addDefaultTypes', 'first', 'where'],
-			[$this->connection, $table]
-		);
-
-		$table->expects($this->once())->method('query')
-			->will($this->returnValue($query));
-		$table->expects($this->once())->method('callFinder')
-			->with('all', $query, ['contain' => ['foo']])
-			->will($this->returnValue($query));
-
-		$query->expects($this->once())->method('where')
-			->with([$table->alias() . '.bar' => 10])
-			->will($this->returnSelf());
-		$query->expects($this->once())->method('first')
-			->will($this->returnValue(false));
-		$result = $table->get(10, ['contain' => ['foo']]);
+	public function testGetNotFoundException() {
+		$table = new Table([
+			'name' => 'Articles',
+			'connection' => $this->connection,
+			'table' => 'articles',
+		]);
+		$table->get(10);
 	}
 
 /**

--- a/tests/TestCase/ORM/TableTest.php
+++ b/tests/TestCase/ORM/TableTest.php
@@ -3193,6 +3193,22 @@ class TableTest extends \Cake\TestSuite\TestCase {
 	}
 
 /**
+ * Test that an exception is raised when there are not enough keys.
+ *
+ * @expectedException \InvalidArgumentException
+ * @expectedExceptionMessage Incorrect number of primary key values. Expected 1 got 0.
+ * @return void
+ */
+	public function testGetExceptionOnIncorrectData() {
+		$table = new Table([
+			'name' => 'Articles',
+			'connection' => $this->connection,
+			'table' => 'articles',
+		]);
+		$table->get(null);
+	}
+
+/**
  * Tests entityValidator
  *
  * @return void

--- a/tests/TestCase/Routing/DispatcherTest.php
+++ b/tests/TestCase/Routing/DispatcherTest.php
@@ -244,7 +244,7 @@ class DispatcherTest extends TestCase {
 		$request = new Request([
 			'url' => 'some_controller/home',
 			'params' => [
-				'controller' => 'some_controller',
+				'controller' => 'SomeController',
 				'action' => 'home',
 			]
 		]);
@@ -263,7 +263,7 @@ class DispatcherTest extends TestCase {
 		$request = new Request([
 			'url' => 'dispatcher_test_interface/index',
 			'params' => [
-				'controller' => 'dispatcher_test_interface',
+				'controller' => 'DispatcherTestInterface',
 				'action' => 'index',
 			]
 		]);
@@ -283,7 +283,7 @@ class DispatcherTest extends TestCase {
 		$request = new Request([
 			'url' => 'abstract/index',
 			'params' => [
-				'controller' => 'abstract',
+				'controller' => 'Abstract',
 				'action' => 'index',
 			]
 		]);
@@ -300,7 +300,7 @@ class DispatcherTest extends TestCase {
 		$url = new Request([
 			'url' => 'pages/home',
 			'params' => [
-				'controller' => 'pages',
+				'controller' => 'Pages',
 				'action' => 'display',
 				'pass' => ['extract'],
 				'return' => 1


### PR DESCRIPTION
- Remove the inflection from the MissingControllerException as it can create misleading error messages.
- Fix `Table::get()` when the number of arguments does not match the number of columns in the primary key. Prior to this an error from array_combine would be emitted, which is pretty unhelpful.
