### PR TITLE
Add setInput function to CakeRequest

### DIFF
--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -919,6 +919,7 @@ class CakeRequest implements ArrayAccess {
  * Modify data originally from `php://input`. Useful for altering json/xml data
  * in middleware or DispatcherFilters before it gets to RequestHandlerComponent
  *
+ * @param string $input A string to replace original parsed data from input()
  * @return void
  */
 	public function setInput($input) {

--- a/lib/Cake/Network/CakeRequest.php
+++ b/lib/Cake/Network/CakeRequest.php
@@ -916,6 +916,16 @@ class CakeRequest implements ArrayAccess {
 	}
 
 /**
+ * Modify data originally from `php://input`. Useful for altering json/xml data
+ * in middleware or DispatcherFilters before it gets to RequestHandlerComponent
+ *
+ * @return void
+ */
+	public function setInput($input) {
+		$this->_input = $input;
+	}
+
+/**
  * Allow only certain HTTP request methods. If the request method does not match
  * a 405 error will be shown and the required "Allow" response header will be set.
  *

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2223,6 +2223,24 @@ class CakeRequestTest extends CakeTestCase {
  *
  * @return void
  */
+	public function testSetInput() {
+		$request = $this->getMock('CakeRequest', array('_readInput'));
+		$request->expects($this->once())->method('_readInput')
+			->will($this->returnValue('I came from stdin'));
+
+		$result = $request->input();
+		$this->assertEquals('I came from stdin', $result);
+
+		$request->setInput('I came from setInput');
+		$result = $request->input();
+		$this->assertEquals('I came from setInput', $result);
+	}
+
+/**
+ * Test the input() method.
+ *
+ * @return void
+ */
 	public function testInput() {
 		$request = $this->getMock('CakeRequest', array('_readInput'));
 		$request->expects($this->once())->method('_readInput')

--- a/lib/Cake/Test/Case/Network/CakeRequestTest.php
+++ b/lib/Cake/Test/Case/Network/CakeRequestTest.php
@@ -2081,7 +2081,7 @@ class CakeRequestTest extends CakeTestCase {
 
 /**
  * Data provider for testing reading values with CakeRequest::param()
- * 
+ *
  * @return array
  */
 	public function paramReadingDataProvider() {
@@ -2225,13 +2225,15 @@ class CakeRequestTest extends CakeTestCase {
  */
 	public function testSetInput() {
 		$request = $this->getMock('CakeRequest', array('_readInput'));
-		$request->expects($this->once())->method('_readInput')
-			->will($this->returnValue('I came from stdin'));
 
+		$request->expects($this->at(0))->method('_readInput')
+			->will($this->returnValue('I came from stdin'));
 		$result = $request->input();
 		$this->assertEquals('I came from stdin', $result);
 
 		$request->setInput('I came from setInput');
+		$request->expects($this->at(1))->method('_readInput')
+			->will($this->returnValue('I came from setInput'));
 		$result = $request->input();
 		$this->assertEquals('I came from setInput', $result);
 	}


### PR DESCRIPTION
Modify data originally from `php://input`. Useful for altering json/xml data in middleware or DispatcherFilters before it gets to RequestHandlerComponent or other controllers.

My problem is that I'm using friendsofcake/crud which relies on the RequestHandlerComponent. I have a dispatch filter that I want to modify incoming data before Cake processes, which I can do, but RequestHandler goes and reads straight from CakeRequest::input(), and there isn't a way to hook into that. This seems like a good way for someone to intercept data using a filter and input() function, then overwrite CakeRequest::_input which is originally set by _readInput.
