### PR TITLE
Typehint Response for beforeRedirect

### DIFF
--- a/src/Controller/Component.php
+++ b/src/Controller/Component.php
@@ -52,7 +52,7 @@ use Cake\Event\EventListener;
  * - `intitalize(Event $event)`
  * - `startup(Event $event)`
  * - `beforeRender(Event $event)`
- * - `beforeRedirect(Event $event $url, Response $response)`
+ * - `beforeRedirect(Event $event, $url, Response $response)`
  * - `shutdown(Event $event)`
  *
  * While the controller is not an explicit argument it is the subject of each event

--- a/src/Controller/Component/RequestHandlerComponent.php
+++ b/src/Controller/Component/RequestHandlerComponent.php
@@ -275,7 +275,7 @@ class RequestHandlerComponent extends Component {
  * @param \Cake\Network\Response $response The response object.
  * @return void
  */
-	public function beforeRedirect(Event $event, $url, $response) {
+	public function beforeRedirect(Event $event, $url, Response $response) {
 		if (!$this->request->is('ajax')) {
 			return;
 		}

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -528,7 +528,7 @@ class Controller implements EventListener {
 			$response->statusCode($status);
 		}
 
-		$event = new Event('Controller.beforeRedirect', $this, [$response, $url, $status]);
+		$event = new Event('Controller.beforeRedirect', $this, [$url, $response]);
 		$event = $this->eventManager()->dispatch($event);
 		if ($event->result instanceof Response) {
 			return $event->result;

--- a/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
+++ b/tests/TestCase/Controller/Component/RequestHandlerComponentTest.php
@@ -483,7 +483,7 @@ class RequestHandlerComponentTest extends TestCase {
 	public function testAjaxRedirectWithNoUrl() {
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 		$event = new Event('Controller.startup', $this->Controller);
-		$this->Controller->response = $this->getMock('CakeResponse');
+		$this->Controller->response = $this->getMock('Response');
 
 		$this->Controller->response->expects($this->never())
 			->method('body');


### PR DESCRIPTION
It is already documented as such:

```
- `beforeRedirect(Event $event, $url, Response $response)`
```

But it seems some tests don't pass now.
Thats interesting as the method expects a valid object to work with:

```
$response->body(...);
...
```

So I guess in those cases it returns early and thus this is undetected so far.
