### PR TITLE
Unify namespaces for doc block params

### DIFF
--- a/src/Database/Dialect/SqlserverDialectTrait.php
+++ b/src/Database/Dialect/SqlserverDialectTrait.php
@@ -51,8 +51,8 @@ trait SqlserverDialectTrait {
 /**
  * Modify the limit/offset to TSQL
  *
- * @param Cake\Database\Query $query The query to translate
- * @return Cake\Database\Query The modified query
+ * @param \Cake\Database\Query $query The query to translate
+ * @return \Cake\Database\Query The modified query
  */
 	protected function _selectQueryTranslator($query) {
 		$limit = $query->clause('limit');
@@ -145,7 +145,7 @@ trait SqlserverDialectTrait {
  * Receives a FunctionExpression and changes it so that it conforms to this
  * SQL dialect.
  *
- * @param Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
+ * @param \Cake\Database\Expression\FunctionExpression $expression The function expression to convert to TSQL.
  * @return void
  */
 	protected function _transformFunctionExpression(FunctionExpression $expression) {
@@ -177,7 +177,7 @@ trait SqlserverDialectTrait {
  * Used by Cake\Schema package to reflect schema and
  * generate schema.
  *
- * @return Cake\Database\Schema\MysqlSchema
+ * @return \Cake\Database\Schema\MysqlSchema
  */
 	public function schemaDialect() {
 		return new \Cake\Database\Schema\SqlserverSchema($this);

--- a/src/Network/Http/Auth/Basic.php
+++ b/src/Network/Http/Auth/Basic.php
@@ -26,7 +26,7 @@ class Basic {
 /**
  * Add Authorization header to the request.
  *
- * @param Cake\Network\Request $request Request instance.
+ * @param \Cake\Network\Request $request Request instance.
  * @param array $credentials Credentials.
  * @return void
  * @see http://www.ietf.org/rfc/rfc2617.txt
@@ -41,7 +41,7 @@ class Basic {
 /**
  * Proxy Authentication
  *
- * @param Cake\Network\Request $request Request instance.
+ * @param \Cake\Network\Request $request Request instance.
  * @param array $credentials Credentials.
  * @return void
  * @see http://www.ietf.org/rfc/rfc2617.txt

--- a/src/Network/Session.php
+++ b/src/Network/Session.php
@@ -87,7 +87,7 @@ class Session {
  * - timeout: The time in minutes the session should stay active
  *
  * @param array $sessionConfig Session config.
- * @return Cake\Network\Session
+ * @return \Cake\Network\Session
  * @see Session::__construct()
  */
 	public static function create($sessionConfig = []) {

--- a/src/View/Helper/TimeHelper.php
+++ b/src/View/Helper/TimeHelper.php
@@ -35,7 +35,7 @@ class TimeHelper extends Helper {
  *
  * @param int|string|\DateTime $dateString UNIX timestamp, strtotime() valid string or DateTime object
  * @param string|\DateTimeZone $timezone User's timezone string or DateTimeZone object
- * @return Cake\Utility\Time
+ * @return \Cake\Utility\Time
  * @link http://book.cakephp.org/2.0/en/core-libraries/helpers/time.html#formatting
  */
 	public function fromString($dateString, $timezone = null) {

--- a/src/View/JsonView.php
+++ b/src/View/JsonView.php
@@ -71,9 +71,9 @@ class JsonView extends View {
 /**
  * Constructor
  *
- * @param Cake\Network\Request $request Request instance.
- * @param Cake\Network\Response $response Response instance.
- * @param Cake\Event\EventManager $eventManager EventManager instance.
+ * @param \Cake\Network\Request $request Request instance.
+ * @param \Cake\Network\Response $response Response instance.
+ * @param \Cake\Event\EventManager $eventManager EventManager instance.
  * @param array $viewOptions An array of view options
  */
 	public function __construct(Request $request = null, Response $response = null,

--- a/src/View/XmlView.php
+++ b/src/View/XmlView.php
@@ -72,9 +72,9 @@ class XmlView extends View {
 /**
  * Constructor
  *
- * @param Cake\Network\Request $request Request instance
- * @param Cake\Network\Response $response Response instance
- * @param Cake\Event\EventManager $eventManager Event Manager
+ * @param \Cake\Network\Request $request Request instance
+ * @param \Cake\Network\Response $response Response instance
+ * @param \Cake\Event\EventManager $eventManager Event Manager
  * @param array $viewOptions View options.
  */
 	public function __construct(Request $request = null, Response $response = null,


### PR DESCRIPTION
This unifies doc block namespaces across the src code.

It seems like we are using the `\Cake\...` declaration instead of `Cake\...`.
Is there any significant difference in the usage?
In use statements we don't prefix with \ for example for Cake classes, but we do for others like \DateTime.
