### PR TITLE
Whitelist more URL-y characters in digest parsing.

### DIFF
--- a/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
+++ b/lib/Cake/Controller/Component/Auth/DigestAuthenticate.php
@@ -1,7 +1,5 @@
 <?php
 /**
- *
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *
@@ -164,7 +162,7 @@ class DigestAuthenticate extends BasicAuthenticate {
 		}
 		$keys = $match = array();
 		$req = array('nonce' => 1, 'nc' => 1, 'cnonce' => 1, 'qop' => 1, 'username' => 1, 'uri' => 1, 'response' => 1);
-		preg_match_all('/(\w+)=([\'"]?)([a-zA-Z0-9@=.\/_-]+)\2/', $digest, $match, PREG_SET_ORDER);
+		preg_match_all('/(\w+)=([\'"]?)([a-zA-Z0-9\:\#\%@=.\/_-]+)\2/', $digest, $match, PREG_SET_ORDER);
 
 		foreach ($match as $i) {
 			$keys[$i[1]] = $i[3];

--- a/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/Auth/DigestAuthenticateTest.php
@@ -243,6 +243,29 @@ DIGEST;
 	}
 
 /**
+ * Test parsing a full URI. While not part of the spec some mobile clients will do it wrong.
+ *
+ * @return void
+ */
+	public function testParseAuthDataFullUri() {
+		$digest = <<<DIGEST
+			Digest username="admin",
+			realm="192.168.0.2",
+			nonce="53a7f9b83f61b",
+			uri="http://192.168.0.2/pvcollection/sites/pull/HFD%200001.json#fragment",
+			qop=auth,
+			nc=00000001,
+			cnonce="b85ff144e496e6e18d1c73020566ea3b",
+			response="5894f5d9cd41d012bac09eeb89d2ddf2",
+			opaque="6f65e91667cf98dd13464deaf2739fde"
+DIGEST;
+
+		$expected = 'http://192.168.0.2/pvcollection/sites/pull/HFD%200001.json#fragment';
+		$result = $this->auth->parseAuthData($digest);
+		$this->assertSame($expected, $result['uri']);
+	}
+
+/**
  * test parsing digest information with email addresses
  *
  * @return void


### PR DESCRIPTION
Android clients include a full URL instead of just the URI. Also handle situations where URLencoded bytes and document fragments are used.

Refs #3779
