### PR TITLE
Mark App::pluginPath as deprecated and don't use it anymore.

### DIFF
--- a/lib/Cake/Configure/IniReader.php
+++ b/lib/Cake/Configure/IniReader.php
@@ -17,6 +17,7 @@
  */
 
 App::uses('Hash', 'Utility');
+App::uses('CakePlugin', 'Core');
 
 /**
  * Ini file configuration engine.
@@ -218,7 +219,7 @@ class IniReader implements ConfigReaderInterface {
 		}
 
 		if ($plugin) {
-			$file = App::pluginPath($plugin) . 'Config' . DS . $key;
+			$file = CakePlugin::path($plugin) . 'Config' . DS . $key;
 		} else {
 			$file = $this->_path . $key;
 		}

--- a/lib/Cake/Configure/PhpReader.php
+++ b/lib/Cake/Configure/PhpReader.php
@@ -15,6 +15,8 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+App::uses('CakePlugin', 'Core');
+
 /**
  * PHP Reader allows Configure to load configuration values from
  * files containing simple PHP arrays.
@@ -49,7 +51,7 @@ class PhpReader implements ConfigReaderInterface {
  * Read a config file and return its contents.
  *
  * Files with `.` in the name will be treated as values in plugins. Instead of reading from
- * the initialized path, plugin keys will be located using App::pluginPath().
+ * the initialized path, plugin keys will be located using CakePlugin::path().
  *
  * @param string $key The identifier to read from. If the key has a . it will be treated
  *  as a plugin prefix.
@@ -105,7 +107,7 @@ class PhpReader implements ConfigReaderInterface {
 		$key .= '.php';
 
 		if ($plugin) {
-			$file = App::pluginPath($plugin) . 'Config' . DS . $key;
+			$file = CakePlugin::path($plugin) . 'Config' . DS . $key;
 		} else {
 			$file = $this->_path . $key;
 		}

--- a/lib/Cake/Console/Command/UpgradeShell.php
+++ b/lib/Cake/Console/Command/UpgradeShell.php
@@ -18,6 +18,7 @@
 
 App::uses('AppShell', 'Console/Command');
 App::uses('Folder', 'Utility');
+App::uses('CakePlugin', 'Core');
 
 /**
  * A shell class to help developers upgrade applications to CakePHP 2.0
@@ -102,7 +103,7 @@ class UpgradeShell extends AppShell {
 	public function tests() {
 		$this->_paths = array(APP . 'tests' . DS);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']) . 'tests' . DS);
+			$this->_paths = array(CakePlugin::path($this->params['plugin']) . 'tests' . DS);
 		}
 		$patterns = array(
 			array(
@@ -128,7 +129,7 @@ class UpgradeShell extends AppShell {
 		$cwd = getcwd();
 
 		if (!empty($this->params['plugin'])) {
-			chdir(App::pluginPath($this->params['plugin']));
+			chdir(CakePlugin::path($this->params['plugin']));
 		}
 
 		if (is_dir('plugins')) {
@@ -215,7 +216,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_diff(App::path('views'), App::core('views'));
 
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']) . 'views' . DS);
+			$this->_paths = array(CakePlugin::path($this->params['plugin']) . 'views' . DS);
 		}
 
 		$patterns = array();
@@ -229,7 +230,7 @@ class UpgradeShell extends AppShell {
 			CakePlugin::load($plugin);
 			$pluginHelpers = array_merge(
 				$pluginHelpers,
-				App::objects('helper', App::pluginPath($plugin) . DS . 'views' . DS . 'helpers' . DS, false)
+				App::objects('helper', CakePlugin::path($plugin) . DS . 'views' . DS . 'helpers' . DS, false)
 			);
 		}
 		$helpers = array_merge($pluginHelpers, $helpers);
@@ -260,7 +261,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array(CakePlugin::path($this->params['plugin']));
 		}
 
 		$patterns = array(
@@ -299,7 +300,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array(CakePlugin::path($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -354,7 +355,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_merge($views, $controllers, $components);
 
 		if (!empty($this->params['plugin'])) {
-			$pluginPath = App::pluginPath($this->params['plugin']);
+			$pluginPath = CakePlugin::path($this->params['plugin']);
 			$this->_paths = array(
 				$pluginPath . 'controllers' . DS,
 				$pluginPath . 'controllers' . DS . 'components' . DS,
@@ -411,7 +412,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array(CakePlugin::path($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -433,7 +434,7 @@ class UpgradeShell extends AppShell {
 			APP
 		);
 		if (!empty($this->params['plugin'])) {
-			$this->_paths = array(App::pluginPath($this->params['plugin']));
+			$this->_paths = array(CakePlugin::path($this->params['plugin']));
 		}
 		$patterns = array(
 			array(
@@ -564,7 +565,7 @@ class UpgradeShell extends AppShell {
 		$this->_paths = array_merge($controllers, $components);
 
 		if (!empty($this->params['plugin'])) {
-			$pluginPath = App::pluginPath($this->params['plugin']);
+			$pluginPath = CakePlugin::path($this->params['plugin']);
 			$this->_paths = array(
 				$pluginPath . 'controllers' . DS,
 				$pluginPath . 'controllers' . DS . 'components' . DS,

--- a/lib/Cake/Core/App.php
+++ b/lib/Cake/Core/App.php
@@ -17,6 +17,7 @@
  */
 
 App::uses('Inflector', 'Utility');
+App::uses('CakePlugin', 'Core');
 
 /**
  * App is responsible for path management, class location and class loading.
@@ -223,7 +224,7 @@ class App {
 
 		if (!empty($plugin)) {
 			$path = array();
-			$pluginPath = self::pluginPath($plugin);
+			$pluginPath = CakePlugin::path($plugin);
 			$packageFormat = self::_packageFormat();
 			if (!empty($packageFormat[$type])) {
 				foreach ($packageFormat[$type] as $f) {
@@ -360,6 +361,7 @@ class App {
  * @param string $plugin CamelCased/lower_cased plugin name to find the path of.
  * @return string full path to the plugin.
  * @link http://book.cakephp.org/2.0/en/core-utility-libraries/app.html#App::pluginPath
+ * @deprecated Use CakePlugin::path() instead.
  */
 	public static function pluginPath($plugin) {
 		return CakePlugin::path($plugin);
@@ -552,7 +554,7 @@ class App {
 			$paths[] = APP . $package . DS;
 			$paths[] = CAKE . $package . DS;
 		} else {
-			$pluginPath = self::pluginPath($plugin);
+			$pluginPath = CakePlugin::path($plugin);
 			$paths[] = $pluginPath . 'Lib' . DS . $package . DS;
 			$paths[] = $pluginPath . $package . DS;
 		}

--- a/lib/Cake/Test/Case/Core/AppTest.php
+++ b/lib/Cake/Test/Case/Core/AppTest.php
@@ -431,27 +431,6 @@ class AppTest extends CakeTestCase {
 	}
 
 /**
- * test that pluginPath can find paths for plugins.
- *
- * @return void
- */
-	public function testPluginPath() {
-		App::build(array(
-			'plugins' => array(CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS)
-		));
-		CakePlugin::load(array('TestPlugin', 'TestPluginTwo'));
-
-		$path = App::pluginPath('TestPlugin');
-		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPlugin' . DS;
-		$this->assertEquals($expected, $path);
-
-		$path = App::pluginPath('TestPluginTwo');
-		$expected = CAKE . 'Test' . DS . 'test_app' . DS . 'Plugin' . DS . 'TestPluginTwo' . DS;
-		$this->assertEquals($expected, $path);
-		App::build();
-	}
-
-/**
  * test that themePath can find paths for themes.
  *
  * @return void

--- a/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/HtmlHelperTest.php
@@ -23,6 +23,7 @@ App::uses('HtmlHelper', 'View/Helper');
 App::uses('FormHelper', 'View/Helper');
 App::uses('ClassRegistry', 'Utility');
 App::uses('Folder', 'Utility');
+App::uses('CakePlugin', 'Core');
 
 if (!defined('FULL_BASE_URL')) {
 	define('FULL_BASE_URL', 'http://cakephp.org');
@@ -906,7 +907,7 @@ class HtmlHelperTest extends CakeTestCase {
 	public function testPluginScriptTimestamping() {
 		CakePlugin::load('TestPlugin');
 
-		$pluginPath = App::pluginPath('TestPlugin');
+		$pluginPath = CakePlugin::path('TestPlugin');
 		$pluginJsPath = $pluginPath . 'webroot/js';
 		$this->skipIf(!is_writable($pluginJsPath), $pluginJsPath . ' is not Writable, timestamp testing has been skipped.');
 

--- a/lib/Cake/TestSuite/Coverage/BaseCoverageReport.php
+++ b/lib/Cake/TestSuite/Coverage/BaseCoverageReport.php
@@ -19,6 +19,9 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+App::uses('Inflector', 'Utility');
+App::uses('CakePlugin', 'Core');
+
 /**
  * Abstract class for common CoverageReport methods.
  * Provides several template methods for custom output.
@@ -102,7 +105,7 @@ abstract class BaseCoverageReport {
 		if ($this->appTest) {
 			$path .= APP_DIR . DS;
 		} elseif ($this->pluginTest) {
-			$path = App::pluginPath($this->pluginTest);
+			$path = CakePlugin::path($this->pluginTest);
 		} else {
 			$path = CAKE;
 		}


### PR DESCRIPTION
It was already just a BC wrapper:

```
public static function pluginPath($plugin) {
    return CakePlugin::path($plugin);
}
```

So there is no need to go through that still.
Directly using CakePlugin::path makes most sense. 
Added a note that it is deprecated and that the new method should be used from here on forward.
