### PR TITLE
Fix composer app issues with cake.php

### DIFF
--- a/app/Console/cake.php
+++ b/app/Console/cake.php
@@ -25,11 +25,18 @@ $dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 
 if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
+	$appDir = basename(dirname(dirname(__FILE__)));
+	$install = $root . DS . 'lib';
+	$composerInstall = $root . DS . $appDir . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
 
-	// the following line differs from its sibling
+	// the following lines differ from its sibling
 	// /lib/Cake/Console/Templates/skel/Console/cake.php
-	ini_set('include_path', $root . DS . 'lib' . PATH_SEPARATOR . ini_get('include_path'));
-	unset($root);
+	if (file_exists($composerInstall . DS . $dispatcher)) {
+		$install = $composerInstall;
+	}
+
+	ini_set('include_path', $install . PATH_SEPARATOR . ini_get('include_path'));
+	unset($root, $appDir, $install, $composerInstall);
 }
 
 if (!include $dispatcher) {

--- a/lib/Cake/Console/Templates/skel/Console/cake.php
+++ b/lib/Cake/Console/Templates/skel/Console/cake.php
@@ -24,11 +24,20 @@ $dispatcher = 'Cake' . DS . 'Console' . DS . 'ShellDispatcher.php';
 
 if (function_exists('ini_set')) {
 	$root = dirname(dirname(dirname(__FILE__)));
+	$appDir = basename(dirname(dirname(__FILE__)));
+	$install = $root . DS . 'lib';
+	$composerInstall = $root . DS . $appDir . DS . 'Vendor' . DS . 'cakephp' . DS . 'cakephp' . DS . 'lib';
 
-	// the following line differs from its sibling
+	// the following lines differ from its sibling
 	// /app/Console/cake.php
-	ini_set('include_path', $root . PATH_SEPARATOR . __CAKE_PATH__ . PATH_SEPARATOR . ini_get('include_path'));
-	unset($root);
+	if (file_exists($composerInstall . DS . $dispatcher)) {
+		$install = $composerInstall;
+	} elseif (!file_exists($install . DS . $dispatcher)) {
+		$install = $root . PATH_SEPARATOR . __CAKE_PATH__;
+	}
+
+	ini_set('include_path', $install . PATH_SEPARATOR . ini_get('include_path'));
+	unset($root, $appDir, $install, $composerInstall);
 }
 
 if (!include $dispatcher) {


### PR DESCRIPTION
Refs https://github.com/cakephp/cakephp/pull/3726

This fixes the problem that one has to manually adjust the cake.php Console file after baking a new project - and using composer.
This auto-detects composer and uses the old root one as fallback.

I had to leave the app one as it is and only modify the template one as tests otherwise fail.
