### PR TITLE
3.0 scoped routes

### DIFF
--- a/src/Routing/Route/Route.php
+++ b/src/Routing/Route/Route.php
@@ -150,7 +150,7 @@ class Route {
  * @return array Returns a string regular expression of the compiled route.
  */
 	public function compile() {
-		if ($this->compiled()) {
+		if (!empty($this->compiledRoute)) {
 			return $this->_compiledRoute;
 		}
 		$this->_writeRoute();
@@ -259,7 +259,7 @@ class Route {
 	public function parse($url) {
 		$request = Router::getRequest(true) ?: Request::createFromGlobals();
 
-		if (!$this->compiled()) {
+		if (empty($this->_compiledRoute)) {
 			$this->compile();
 		}
 		list($url, $ext) = $this->_parseExtension($url);
@@ -399,7 +399,7 @@ class Route {
  * @return mixed Either a string url for the parameters if they match or false.
  */
 	public function match(array $url, array $context = []) {
-		if (!$this->compiled()) {
+		if (empty($this->_compiledRoute)) {
 			$this->compile();
 		}
 		$defaults = $this->defaults;

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1076,6 +1076,7 @@ class Router {
  * @param array $params An array of routing defaults to add to each connected route.
  *   If you have no parameters, this argument can be a callable.
  * @param callable $callback The callback to invoke with the scoped collection.
+ * @throws \InvalidArgumentException When an invalid callable is provided.
  * @return void
  */
 	public static function scope($path, $params = [], $callback = null) {
@@ -1085,7 +1086,7 @@ class Router {
 		}
 		if (!is_callable($callback)) {
 			$msg = 'Need a callable function/object to connect routes.';
-			throw Error\Exception($msg);
+			throw new \InvalidArgumentException($msg);
 		}
 
 		$collection = new ScopedRouteCollection($path, $params, static::$_validExtensions);

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -19,6 +19,7 @@ use Cake\Core\Configure;
 use Cake\Error;
 use Cake\Network\Request;
 use Cake\Routing\RouteCollection;
+use Cake\Routing\ScopedRouteCollection;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
 
@@ -115,6 +116,13 @@ class Router {
  * @var string
  */
 	const UUID = '[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}';
+
+/**
+ * A hash of ScopedRouteCollection objects indexed by path.
+ *
+ * @var array
+ */
+	protected static $_pathScopes = [];
 
 /**
  * Named expressions
@@ -1033,6 +1041,61 @@ class Router {
 		}
 		$request->params['named'] = $named;
 		return $request;
+	}
+
+/**
+ * Create a routing scope.
+ *
+ * Routing scopes allow you to keep your routes DRY and avoid repeating
+ * common path prefixes, and or parameter sets.
+ *
+ * Scoped collections will be indexed by path for faster route parsing. If you
+ * re-open or re-use a scope the connected routes will be merged with the
+ * existing ones.
+ *
+ * ### Example
+ *
+ * {{{
+ * Router::scope('/blog', ['plugin' => 'Blog'], function($routes) {
+ *    $routes->connect('/', ['controller' => 'Articles']);
+ * });
+ * }}}
+ *
+ * The above would result in a `/blog/` route being created, with both the
+ * plugin & controller default parameters set.
+ *
+ * You can use Router::plugin() and Router::prefix() as shortcuts to creating
+ * specific kinds of scopes.
+ *
+ * Routing scopes will inherit the globally set extensions configured with
+ * Router::parseExtensions(). You can also set valid extensions using 
+ * `$routes->extensions()` in your closure.
+ *
+ * @param string $path The path prefix for the scope. This path will be prepended
+ *    to all routes connected in the scoped collection.
+ * @param array $params An array of routing defaults to add to each connected route.
+ *   If you have no parameters, this argument can be a callable.
+ * @param callable $callback The callback to invoke with the scoped collection.
+ * @return void
+ */
+	public static function scope($path, $params = [], $callback = null) {
+		if ($callback === null) {
+			$callback = $params;
+			$params = [];
+		}
+		if (!is_callable($callback)) {
+			$msg = 'Need a callable function/object to connect routes.';
+			throw Error\Exception($msg);
+		}
+
+		$collection = new ScopedRouteCollection($path, $params, static::$_validExtensions);
+		$callback($collection);
+
+		if (empty(static::$_pathScopes[$path])) {
+			static::$_pathScopes[$path] = $collection;
+		} else {
+			static::$_pathScopes[$path]->merge($collection);
+		}
 	}
 
 /**

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -219,6 +219,10 @@ class ScopedRouteCollection {
  * @return array Array of mapped resources
  */
 	public function resource($name, $options = [], $callback = null) {
+		if (is_callable($options) && $callback === null) {
+			$callback = $options;
+			$options = [];
+		}
 		$options += array(
 			'connectOptions' => [],
 			'id' => static::ID . '|' . static::UUID
@@ -227,8 +231,8 @@ class ScopedRouteCollection {
 		unset($options['connectOptions']);
 
 		$urlName = Inflector::underscore($name);
-		$ext = null;
 
+		$ext = null;
 		if (!empty($options['_ext'])) {
 			$ext = $options['_ext'];
 		}
@@ -251,7 +255,7 @@ class ScopedRouteCollection {
 
 		if (is_callable($callback)) {
 			$idName = Inflector::singularize($urlName) . '_id';
-			$path = '/' . $urlName . '/:' . $idName;
+			$path = $this->_path . '/' . $urlName . '/:' . $idName;
 			Router::scope($path, $this->params(), $callback);
 		}
 	}

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -55,18 +55,25 @@ class ScopedRouteCollection {
 	);
 
 /**
+ * The extensions that should be set into the routes connected.
+ *
+ * @var array
+ */
+	protected $_extensions;
+
+/**
  * The path prefix scope that this collection uses.
  *
  * @var string
  */
-	protected $path;
+	protected $_path;
 
 /**
  * The scope parameters if there are any.
  *
  * @var array
  */
-	protected $params;
+	protected $_params;
 
 /**
  * The routes connected to this collection.
@@ -88,9 +95,25 @@ class ScopedRouteCollection {
  * @param string $path The path prefix the scope is for.
  * @param array $params The scope's routing parameters.
  */
-	public function __construct($path, array $params = []) {
+	public function __construct($path, array $params = [], array $extensions = []) {
 		$this->_path = $path;
 		$this->_params = $params;
+		$this->_extensions = $extensions;
+	}
+
+/**
+ * Get or set the extensions in this route collection.
+ *
+ * Setting extensions does not modify existing routes.
+ *
+ * @param null|array $extensions Either the extensions to use or null.
+ * @return array|void
+ */
+	public function extensions($extensions = null) {
+		if ($extensions === null) {
+			return $this->_extensions;
+		}
+		$this->_extensions = $extensions;
 	}
 
 /**
@@ -99,6 +122,10 @@ class ScopedRouteCollection {
  * @return string
  */
 	public function path() {
+		$routeKey = strpos($this->_path, ':');
+		if ($routeKey !== false) {
+			return substr($this->_path, 0, $routeKey);
+		}
 		return $this->_path;
 	}
 
@@ -308,7 +335,7 @@ class ScopedRouteCollection {
 		}
 
 		if (empty($options['_ext'])) {
-			$options['_ext'] = Router::extensions();
+			$options['_ext'] = $this->_extensions;
 		}
 
 		// TODO don't hardcode
@@ -325,10 +352,6 @@ class ScopedRouteCollection {
 		$route = str_replace('//', '/', $this->_path . $route);
 		if (is_array($defaults)) {
 			$defaults += $this->_params;
-		}
-
-		if (isset($options['_name']) && !empty($this->_named[$options['_name']])) {
-			throw new Error\Exception('Cannot have duplicated named routes.');
 		}
 
 		// Store the route and named index if possible.

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -471,18 +471,18 @@ class ScopedRouteCollection {
 * @param callable $callback The callback to invoke that builds the plugin routes.
 *   Only required when $options is defined.
 * @return void
-* @throws \Cake\Error\Exception When an invalid callback is provided
 */
 	public function plugin($name, $options = [], $callback = null) {
 		if ($callback === null) {
 			$callback = $options;
 			$options = [];
 		}
-		$params = ['plugin' => $name];
-		if (empty($optons['path'])) {
+		$params = ['plugin' => $name] + $this->_params;
+		if (empty($options['path'])) {
 			$options['path'] = '/' . Inflector::underscore($name);
 		}
-		return Router::scope($options['path'], $params, $callback);
+		$options['path'] = $this->_path . $options['path'];
+		Router::scope($options['path'], $params, $callback);
 	}
 
 /**

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -189,7 +189,7 @@ class ScopedRouteCollection {
  *
  * {{{
  * Router::plugin('Comments', function ($routes) {
- *   $routes->resource('Comments');
+ *   $routes->resources('Comments');
  * });
  * }}}
  *
@@ -201,7 +201,7 @@ class ScopedRouteCollection {
  *
  * {{{
  * Router::prefix('admin', function ($routes) {
- *   $routes->resource('Articles');
+ *   $routes->resources('Articles');
  * });
  * }}}
  *
@@ -211,8 +211,8 @@ class ScopedRouteCollection {
  * You can create nested resources by passing a callback in:
  *
  * {{{
- * $routes->resource('Articles', function($routes) {
- *   $routes->resource('Comments');
+ * $routes->resources('Articles', function($routes) {
+ *   $routes->resources('Comments');
  * });
  * }}}
  *
@@ -229,7 +229,7 @@ class ScopedRouteCollection {
  *   scopes inherit the existing path and 'id' parameter.
  * @return array Array of mapped resources
  */
-	public function resource($name, $options = [], $callback = null) {
+	public function resources($name, $options = [], $callback = null) {
 		if (is_callable($options) && $callback === null) {
 			$callback = $options;
 			$options = [];

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -1,0 +1,577 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Routing;
+
+use Cake\Core\App;
+use Cake\Error;
+use Cake\Routing\Router;
+use Cake\Routing\Route\Route;
+use Cake\Utility\Inflector;
+
+/**
+ * Contains a collection of routes related to a specific path scope.
+ * Path scopes can be read with the `path()` method.
+ */
+class ScopedRouteCollection {
+
+/**
+ * Regular expression for auto increment IDs
+ *
+ * @var string
+ */
+	const ID = '[0-9]+';
+
+/**
+ * Regular expression for UUIDs
+ *
+ * @var string
+ */
+	const UUID = '[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}';
+
+/**
+ * Default HTTP request method => controller action map.
+ *
+ * @var array
+ */
+	protected static $_resourceMap = array(
+		array('action' => 'index', 'method' => 'GET', 'id' => false),
+		array('action' => 'view', 'method' => 'GET', 'id' => true),
+		array('action' => 'add', 'method' => 'POST', 'id' => false),
+		array('action' => 'edit', 'method' => 'PUT', 'id' => true),
+		array('action' => 'delete', 'method' => 'DELETE', 'id' => true),
+		array('action' => 'edit', 'method' => 'POST', 'id' => true)
+	);
+
+/**
+ * The path prefix scope that this collection uses.
+ *
+ * @var string
+ */
+	protected $path;
+
+/**
+ * The scope parameters if there are any.
+ *
+ * @var array
+ */
+	protected $params;
+
+/**
+ * The routes connected to this collection.
+ *
+ * @var array
+ */
+	protected $_routes = [];
+
+/**
+ * The hash map of named routes that are in this collection.
+ *
+ * @var array
+ */
+	protected $_named = [];
+
+/**
+ * Constructor
+ *
+ * @param string $path The path prefix the scope is for.
+ * @param array $params The scope's routing parameters.
+ */
+	public function __construct($path, array $params = []) {
+		$this->_path = $path;
+		$this->_params = $params;
+	}
+
+/**
+ * Get the path this scope is for.
+ *
+ * @return string
+ */
+	public function path() {
+		return $this->_path;
+	}
+
+/**
+ * Get the parameter names/values for this scope.
+ *
+ * @return string
+ */
+	public function params() {
+		return $this->_params;
+	}
+
+/**
+ * Get the explicity named routes in the collectio.
+ *
+ * @return array An array of named routes indexed by their name.
+ */
+	public function named() {
+		return $this->_named;
+	}
+
+/**
+ * Get all the routes in this collection.
+ *
+ * @return array
+ * @return array An array of routes.
+ */
+	public function routes() {
+		return $this->_routes;
+	}
+
+/**
+ * Get a route by its name.
+ *
+ * *Note* This method only works on explicitly named routes.
+ *
+ * @param string $name The name of the route to get.
+ * @return false|\Cake\Routing\Route The route.
+ */
+	public function get($name) {
+		if (isset($this->_named[$name])) {
+			return $this->_named[$name];
+		}
+		return false;
+	}
+
+/**
+ * Generate REST resource routes for the given controller(s).
+ *
+ * A quick way to generate a default routes to a set of REST resources (controller(s)).
+ *
+ * ### Usage
+ *
+ * Connect resource routes for an app controller:
+ *
+ * {{{
+ * Router::mapResources('Posts');
+ * }}}
+ *
+ * Connect resource routes for the Comment controller in the
+ * Comments plugin:
+ *
+ * {{{
+ * Router::mapResources('Comments.Comment');
+ * }}}
+ *
+ * Plugins will create lower_case underscored resource routes. e.g
+ * `/comments/comment`
+ *
+ * Connect resource routes for the Posts controller in the
+ * Admin prefix:
+ *
+ * {{{
+ * Router::mapResources('Posts', ['prefix' => 'admin']);
+ * }}}
+ *
+ * Prefixes will create lower_case underscored resource routes. e.g
+ * `/admin/posts`
+ *
+ * ### Options:
+ *
+ * - 'id' - The regular expression fragment to use when matching IDs. By default, matches
+ *    integer values and UUIDs.
+ * - 'prefix' - Routing prefix to use for the generated routes. Defaults to ''.
+ *   Using this option will create prefixed routes, similar to using Routing.prefixes.
+ *
+ * @param string|array $controller A controller name or array of controller names (i.e. "Posts" or "ListItems")
+ * @param array $options Options to use when generating REST routes
+ * @param callable $callback An optional callback to be executed in a nested scope. Nested
+ *   scopes inherit the existing path and 'id' parameter.
+ * @return array Array of mapped resources
+ */
+	public function resource($name, $options = [], $callback = null) {
+		$options += array(
+			'connectOptions' => [],
+			'id' => static::ID . '|' . static::UUID
+		);
+		$connectOptions = $options['connectOptions'];
+		unset($options['connectOptions']);
+
+		$urlName = Inflector::underscore($name);
+		$ext = null;
+
+		if (!empty($options['_ext'])) {
+			$ext = $options['_ext'];
+		}
+
+		foreach (static::$_resourceMap as $params) {
+			$id = $params['id'] ? ':id' : '';
+			$url = '/' . implode('/', array_filter(array($urlName, $id)));
+			$params = array(
+				'controller' => $name,
+				'action' => $params['action'],
+				'[method]' => $params['method'],
+				'_ext' => $ext
+			);
+			$routeOptions = array_merge(array(
+				'id' => $options['id'],
+				'pass' => array('id')
+			), $connectOptions);
+			$this->connect($url, $params, $routeOptions);
+		}
+
+		if (is_callable($callback)) {
+			$idName = Inflector::singularize($urlName) . '_id';
+			$path = '/' . $urlName . '/:' . $idName;
+			Router::scope($path, $this->params(), $callback);
+		}
+	}
+
+/**
+ * Connects a new Route.
+ *
+ * Routes are a way of connecting request URLs to objects in your application.
+ * At their core routes are a set or regular expressions that are used to
+ * match requests to destinations.
+ *
+ * Examples:
+ *
+ * `$routes->connect('/:controller/:action/*');`
+ *
+ * The first parameter will be used as a controller name while the second is
+ * used as the action name. The '/*' syntax makes this route greedy in that
+ * it will match requests like `/posts/index` as well as requests
+ * like `/posts/edit/1/foo/bar`.
+ *
+ * `$routes->connect('/home-page', ['controller' => 'pages', 'action' => 'display', 'home']);`
+ *
+ * The above shows the use of route parameter defaults. And providing routing
+ * parameters for a static route.
+ *
+ * {{{
+ * $routes->connect(
+ *   '/:lang/:controller/:action/:id',
+ *   [],
+ *   ['id' => '[0-9]+', 'lang' => '[a-z]{3}']
+ * );
+ * }}}
+ *
+ * Shows connecting a route with custom route parameters as well as
+ * providing patterns for those parameters. Patterns for routing parameters
+ * do not need capturing groups, as one will be added for each route params.
+ *
+ * $options offers several 'special' keys that have special meaning
+ * in the $options array.
+ *
+ * - `pass` is used to define which of the routed parameters should be shifted
+ *   into the pass array. Adding a parameter to pass will remove it from the
+ *   regular route array. Ex. `'pass' => array('slug')`.
+ * - `routeClass` is used to extend and change how individual routes parse requests
+ *   and handle reverse routing, via a custom routing class.
+ *   Ex. `'routeClass' => 'SlugRoute'`
+ * - `_name` is used to define a specific name for routes. This can be used to optimize
+ *   reverse routing lookups. If undefined a name will be generated for each
+ *   connected route.
+ * - `_ext` is an array of filename extensions that will be parsed out of the url if present.
+ *   See {@link Route::parseExtensions()}.
+ *
+ * You can also add additional conditions for matching routes to the $defaults array.
+ * The following conditions can be used:
+ *
+ * - `[type]` Only match requests for specific content types.
+ * - `[method]` Only match requests with specific HTTP verbs.
+ * - `[server]` Only match when $_SERVER['SERVER_NAME'] matches the given value.
+ *
+ * Example of using the `[method]` condition:
+ *
+ * `$routes->connect('/tasks', array('controller' => 'tasks', 'action' => 'index', '[method]' => 'GET'));`
+ *
+ * The above route will only be matched for GET requests. POST requests will fail to match this route.
+ *
+ * @param string $route A string describing the template of the route
+ * @param array $defaults An array describing the default route parameters. These parameters will be used by default
+ *   and can supply routing parameters that are not dynamic. See above.
+ * @param array $options An array matching the named elements in the route to regular expressions which that
+ *   element should match. Also contains additional parameters such as which routed parameters should be
+ *   shifted into the passed arguments, supplying patterns for routing parameters and supplying the name of a
+ *   custom routing class.
+ * @see routes
+ * @return void
+ * @throws \Cake\Error\Exception
+ */
+	public function connect($route, array $defaults = [], $options = []) {
+		$defaults += ['plugin' => null];
+		if (empty($options['action'])) {
+			$defaults += array('action' => 'index');
+		}
+
+		if (empty($options['_ext'])) {
+			$options['_ext'] = Router::extensions();
+		}
+
+		// TODO don't hardcode
+		$routeClass = 'Cake\Routing\Route\Route';
+		if (isset($options['routeClass'])) {
+			$routeClass = App::className($options['routeClass'], 'Routing/Route');
+			$routeClass = $this->_validateRouteClass($routeClass);
+			unset($options['routeClass']);
+		}
+		if ($routeClass === 'Cake\Routing\Route\RedirectRoute' && isset($defaults['redirect'])) {
+			$defaults = $defaults['redirect'];
+		}
+
+		$route = str_replace('//', '/', $this->_path . $route);
+		if (is_array($defaults)) {
+			$defaults += $this->_params;
+		}
+
+		if (isset($options['_name']) && !empty($this->_named[$options['_name']])) {
+			throw new Error\Exception('Cannot have duplicated named routes.');
+		}
+
+		// Store the route and named index if possible.
+		$route = new $routeClass($route, $defaults, $options);
+
+		if (isset($options['_name'])) {
+			$this->_named[$options['_name']] = $route;
+		}
+
+		$name = $route->getName();
+		if (!isset($this->_routeTable[$name])) {
+			$this->_routeTable[$name] = [];
+		}
+		$this->_routeTable[$name][] = $route;
+		$this->_routes[] = $route;
+	}
+
+/**
+ * Validates that the passed route class exists and is a subclass of Cake Route
+ *
+ * @param string $routeClass Route class name
+ * @return string
+ * @throws \Cake\Error\Exception
+ */
+	protected function _validateRouteClass($routeClass) {
+		if (
+			$routeClass != 'Cake\Routing\Route\Route' &&
+			(!class_exists($routeClass) || !is_subclass_of($routeClass, 'Cake\Routing\Route\Route'))
+		) {
+			throw new Error\Exception('Route class not found, or route class is not a subclass of Cake\Routing\Route\Route');
+		}
+		return $routeClass;
+	}
+
+/**
+ * Connects a new redirection Route in the router.
+ *
+ * Redirection routes are different from normal routes as they perform an actual
+ * header redirection if a match is found. The redirection can occur within your
+ * application or redirect to an outside location.
+ *
+ * Examples:
+ *
+ * `$routes->redirect('/home/*', array('controller' => 'posts', 'action' => 'view'));`
+ *
+ * Redirects /home/* to /posts/view and passes the parameters to /posts/view. Using an array as the
+ * redirect destination allows you to use other routes to define where an URL string should be redirected to.
+ *
+ * `$routes-redirect('/posts/*', 'http://google.com', array('status' => 302));`
+ *
+ * Redirects /posts/* to http://google.com with a HTTP status of 302
+ *
+ * ### Options:
+ *
+ * - `status` Sets the HTTP status (default 301)
+ * - `persist` Passes the params to the redirected route, if it can. This is useful with greedy routes,
+ *   routes that end in `*` are greedy. As you can remap URLs and not loose any passed args.
+ *
+ * @param string $route A string describing the template of the route
+ * @param array $url An URL to redirect to. Can be a string or a Cake array-based URL
+ * @param array $options An array matching the named elements in the route to regular expressions which that
+ *   element should match. Also contains additional parameters such as which routed parameters should be
+ *   shifted into the passed arguments. As well as supplying patterns for routing parameters.
+ * @see routes
+ * @return array Array of routes
+ */
+	public function redirect($route, $url, $options = []) {
+		$options['routeClass'] = 'Cake\Routing\Route\RedirectRoute';
+		if (is_string($url)) {
+			$url = array('redirect' => $url);
+		}
+		return $this->connect($route, $url, $options);
+	}
+
+/**
+* Add prefixed routes.
+*
+* This method creates a new scoped route collection that includes
+* relevant prefix information.
+*
+* The path parameter is used to generate the routing parameter name.
+* For example a path of `admin` would result in `'prefix' => 'admin'` being
+* applied to all connected routes.
+*
+* You can re-open a prefix as many times as necessary, as well as nest prefixes.
+* Nested prefixes will result in prefix values like `admin/api` which translates
+* to the `Controller\Admin\Api\` namespace.
+*
+* @param string $name The prefix name to use.
+* @param callable $callback The callback to invoke that builds the prefixed routes.
+* @return void
+*/
+	public function prefix($name, callable $callback) {
+		if (isset($this->_params['prefix'])) {
+			$name = $this->_params['prefix'] . '/' . $name;
+		}
+		$params = ['prefix' => $name];
+		$path = '/' . Inflector::underscore($name);
+		return Router::scope($path, $params, $callback);
+	}
+
+/**
+* Add plugin routes.
+*
+* This method creates a new scoped route collection that includes
+* relevant plugin information.
+*
+* The plugin name will be inflected to the underscore version to create
+* the routing path. If you want a custom path name, use the `path` option.
+*
+* Routes connected in the scoped collection will have the correct path segment
+* prepended, and have a matching plugin routing key set.
+*
+* @param string $path The path name to use for the prefix.
+* @param array|callable $options Either the options to use, or a callback.
+* @param callable $callback The callback to invoke that builds the plugin routes.
+*   Only required when $options is defined.
+* @return void
+* @throws \Cake\Error\Exception When an invalid callback is provided
+*/
+	public function plugin($name, $options = [], $callback = null) {
+		if ($callback === null) {
+			$callback = $options;
+			$options = [];
+		}
+		$params = ['plugin' => $name];
+		if (empty($optons['path'])) {
+			$options['path'] = '/' . Inflector::underscore($name);
+		}
+		return Router::scope($options['path'], $params, $callback);
+	}
+
+/**
+ * Takes the URL string and iterates the routes until one is able to parse the route.
+ *
+ * @param string $url Url to parse.
+ * @return array An array of request parameters parsed from the url.
+ */
+	public function parse($url) {
+		$queryParameters = null;
+		if (strpos($url, '?') !== false) {
+			list($url, $queryParameters) = explode('?', $url, 2);
+			parse_str($queryParameters, $queryParameters);
+		}
+		$out = array();
+		for ($i = 0, $len = count($this->_routes); $i < $len; $i++) {
+			$r = $this->_routes[$i]->parse($url);
+			if ($r !== false && $queryParameters) {
+				$r['?'] = $queryParameters;
+				return $r;
+			}
+			if ($r !== false) {
+				return $r;
+			}
+		}
+		return $out;
+	}
+
+/**
+ * Reverse route or match a $url array with the defined routes.
+ * Returns either the string URL generate by the route, or false on failure.
+ *
+ * @param array $url The url to match.
+ * @param array $context The request context to use. Contains _base, _port,
+ *    _host, and _scheme keys.
+ * @return void
+ */
+	public function match($url, $context) {
+		foreach ($this->_getNames($url) as $name) {
+			if (empty($this->_routeTable[$name])) {
+				continue;
+			}
+			foreach ($this->_routeTable[$name] as $route) {
+				$match = $route->match($url, $context);
+				if ($match) {
+					return strlen($match) > 1 ? trim($match, '/') : $match;
+				}
+			}
+		}
+		return '/';
+	}
+
+/**
+ * Get the set of names from the $url.  Accepts both older style array urls,
+ * and newer style urls containing '_name'
+ *
+ * @param array $url The url to match.
+ * @return string The name of the url
+ */
+	protected function _getNames($url) {
+		$name = false;
+		if (isset($url['_name'])) {
+			$name = $url['_name'];
+		}
+		$plugin = false;
+		if (isset($url['plugin'])) {
+			$plugin = $url['plugin'];
+		}
+		$fallbacks = [
+			'%2$s:%3$s',
+			'%2$s:_action',
+			'_controller:%3$s',
+			'_controller:_action'
+		];
+		if ($plugin) {
+			$fallbacks = [
+				'%1$s.%2$s:%3$s',
+				'%1$s.%2$s:_action',
+				'%1$s._controller:%3$s',
+				'%1$s._controller:_action',
+				'_plugin._controller:%3$s',
+				'_plugin._controller:_action',
+				'_controller:_action'
+			];
+		}
+		foreach ($fallbacks as $i => $template) {
+			$fallbacks[$i] = strtolower(sprintf($template, $plugin, $url['controller'], $url['action']));
+		}
+		if ($name) {
+			array_unshift($fallbacks, $name);
+		}
+		return $fallbacks;
+	}
+
+/**
+ * Merge another ScopedRouteCollection with this one.
+ *
+ * Combines all the routes, from one collection into the current one.
+ * Used internally when scopes are duplicated.
+ *
+ * @param \Cake\Routing\ScopedRouteCollection $collection
+ * @return void
+ */
+	public function merge(ScopedRouteCollection $collection) {
+		foreach ($collection->routes() as $route) {
+			$name = $route->getName();
+			if (!isset($this->_routeTable[$name])) {
+				$this->_routeTable[$name] = [];
+			}
+			$this->_routeTable[$name][] = $route;
+			$this->_routes[] = $route;
+		}
+		$this->_named += $collection->named();
+	}
+
+}

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -497,16 +497,17 @@ class ScopedRouteCollection {
 			list($url, $queryParameters) = explode('?', $url, 2);
 			parse_str($queryParameters, $queryParameters);
 		}
-		$out = array();
+		$out = [];
 		for ($i = 0, $len = count($this->_routes); $i < $len; $i++) {
 			$r = $this->_routes[$i]->parse($url);
-			if ($r !== false && $queryParameters) {
+			if ($r === false) {
+				continue;
+			}
+			if ($queryParameters) {
 				$r['?'] = $queryParameters;
 				return $r;
 			}
-			if ($r !== false) {
-				return $r;
-			}
+			return $r;
 		}
 		return $out;
 	}
@@ -518,7 +519,7 @@ class ScopedRouteCollection {
  * @param array $url The url to match.
  * @param array $context The request context to use. Contains _base, _port,
  *    _host, and _scheme keys.
- * @return void
+ * @return string|false Either a string on match, or false on failure.
  */
 	public function match($url, $context) {
 		foreach ($this->_getNames($url) as $name) {
@@ -532,7 +533,7 @@ class ScopedRouteCollection {
 				}
 			}
 		}
-		return '/';
+		return false;
 	}
 
 /**

--- a/src/Routing/ScopedRouteCollection.php
+++ b/src/Routing/ScopedRouteCollection.php
@@ -427,30 +427,31 @@ class ScopedRouteCollection {
 	}
 
 /**
-* Add prefixed routes.
-*
-* This method creates a new scoped route collection that includes
-* relevant prefix information.
-*
-* The path parameter is used to generate the routing parameter name.
-* For example a path of `admin` would result in `'prefix' => 'admin'` being
-* applied to all connected routes.
-*
-* You can re-open a prefix as many times as necessary, as well as nest prefixes.
-* Nested prefixes will result in prefix values like `admin/api` which translates
-* to the `Controller\Admin\Api\` namespace.
-*
-* @param string $name The prefix name to use.
-* @param callable $callback The callback to invoke that builds the prefixed routes.
-* @return void
-*/
+ * Add prefixed routes.
+ *
+ * This method creates a new scoped route collection that includes
+ * relevant prefix information.
+ *
+ * The path parameter is used to generate the routing parameter name.
+ * For example a path of `admin` would result in `'prefix' => 'admin'` being
+ * applied to all connected routes.
+ *
+ * You can re-open a prefix as many times as necessary, as well as nest prefixes.
+ * Nested prefixes will result in prefix values like `admin/api` which translates
+ * to the `Controller\Admin\Api\` namespace.
+ *
+ * @param string $name The prefix name to use.
+ * @param callable $callback The callback to invoke that builds the prefixed routes.
+ * @return void
+ */
 	public function prefix($name, callable $callback) {
+		$name = Inflector::underscore($name);
+		$path = $this->_path . '/' . $name;
 		if (isset($this->_params['prefix'])) {
 			$name = $this->_params['prefix'] . '/' . $name;
 		}
-		$params = ['prefix' => $name];
-		$path = '/' . Inflector::underscore($name);
-		return Router::scope($path, $params, $callback);
+		$params = ['prefix' => $name] + $this->_params;
+		Router::scope($path, $params, $callback);
 	}
 
 /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -2856,4 +2856,33 @@ class RouterTest extends TestCase {
 		$this->assertEquals('/en/posts/index', $result, 'promote() should move 2nd route ahead.');
 	}
 
+/**
+ * Test the scope() method
+ *
+ * @return void
+ */
+	public function testScope() {
+		Router::scope('/path', ['param' => 'value'], function($routes) {
+			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $routes);
+			$this->assertCount(0, $routes->routes());
+			$this->assertEquals('/path', $routes->path());
+			$this->assertEquals(['param' => 'value'], $routes->params());
+
+			$routes->connect('/articles', ['controller' => 'Articles']);
+		});
+		Router::scope('/path', function($routes) {
+			$this->assertCount(0, $routes->routes());
+		});
+	}
+
+/**
+ * Test the scope() method
+ *
+ * @expectedException \InvalidArgumentException
+ * @return void
+ */
+	public function testScopeError() {
+		Router::scope('/path', 'derpy');
+	}
+
 }

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -198,4 +198,31 @@ class ScopedRouteCollectionTest extends TestCase {
 		$this->assertNull($res);
 	}
 
+/**
+ * Test creating sub-scopes with plugin()
+ *
+ * @return void
+ */
+	public function testNestedPlugin() {
+		$routes = new ScopedRouteCollection('/b', ['key' => 'value']);
+		$res = $routes->plugin('Contacts', function($r) {
+			$this->assertEquals('/b/contacts', $r->path());
+			$this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
+		});
+		$this->assertNull($res);
+	}
+
+/**
+ * Test creating sub-scopes with plugin() + path option
+ *
+ * @return void
+ */
+	public function testNestedPluginPathOption() {
+		$routes = new ScopedRouteCollection('/b', ['key' => 'value']);
+		$routes->plugin('Contacts', ['path' => '/people'], function($r) {
+			$this->assertEquals('/b/people', $r->path());
+			$this->assertEquals(['plugin' => 'Contacts', 'key' => 'value'], $r->params());
+		});
+	}
+
 }

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Test\TestCase\Routing;
+
+use Cake\Routing\Route\Route;
+use Cake\Routing\Router;
+use Cake\Routing\ScopedRouteCollection;
+use Cake\TestSuite\TestCase;
+
+/**
+ * ScopedRouteCollection test case
+ */
+class ScopedRouteCollectionTest extends TestCase {
+
+/**
+ * Test path()
+ *
+ * @return void
+ */
+	public function testPath() {
+		$routes = new ScopedRouteCollection('/some/path');
+		$this->assertEquals('/some/path', $routes->path());
+
+		$routes = new ScopedRouteCollection('/:book_id');
+		$this->assertEquals('/', $routes->path());
+
+		$routes = new ScopedRouteCollection('/path/:book_id');
+		$this->assertEquals('/path/', $routes->path());
+
+		$routes = new ScopedRouteCollection('/path/book:book_id');
+		$this->assertEquals('/path/book', $routes->path());
+	}
+
+/**
+ * Test params()
+ *
+ * @return void
+ */
+	public function testParams() {
+		$routes = new ScopedRouteCollection('/api', ['prefix' => 'api']);
+		$this->assertEquals(['prefix' => 'api'], $routes->params());
+	}
+
+/**
+ * Test getting connected routes.
+ *
+ * @return void
+ */
+	public function testRoutes() {
+		$routes = new ScopedRouteCollection('/l');
+		$routes->connect('/:controller', ['action' => 'index']);
+		$routes->connect('/:controller/:action/*');
+
+		$all = $routes->routes();
+		$this->assertCount(2, $all);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $all[0]);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $all[1]);
+	}
+
+/**
+ * Test getting named routes.
+ *
+ * @return void
+ */
+	public function testNamed() {
+		$routes = new ScopedRouteCollection('/l');
+		$routes->connect('/:controller', ['action' => 'index'], ['_name' => 'cntrl']);
+		$routes->connect('/:controller/:action/*');
+
+		$all = $routes->named();
+		$this->assertCount(1, $all);
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $all['cntrl']);
+		$this->assertEquals('/l/:controller', $all['cntrl']->template);
+	}
+
+/**
+ * Test getting named routes.
+ *
+ * @return void
+ */
+	public function testGetNamed() {
+		$routes = new ScopedRouteCollection('/l');
+		$routes->connect('/:controller', ['action' => 'index'], ['_name' => 'cntrl']);
+		$routes->connect('/:controller/:action/*');
+
+		$this->assertFalse($routes->get('nope'));
+		$route = $routes->get('cntrl');
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $route);
+		$this->assertEquals('/l/:controller', $route->template);
+	}
+
+/**
+ * Test connecting basic routes.
+ *
+ * @return void
+ */
+	public function testConnectBasic() {
+		$routes = new ScopedRouteCollection('/l', ['prefix' => 'api']);
+
+		$this->assertNull($routes->connect('/:controller'));
+		$route = $routes->routes()[0];
+
+		$this->assertInstanceOf('Cake\Routing\Route\Route', $route);
+		$this->assertEquals('/l/:controller', $route->template);
+		$expected = ['prefix' => 'api', 'action' => 'index', 'plugin' => null];
+		$this->assertEquals($expected, $route->defaults);
+	}
+
+/**
+ * Test extensions being connected to routes.
+ *
+ * @return void
+ */
+	public function testConnectExtensions() {
+		$routes = new ScopedRouteCollection('/l', [], ['json']);
+		$routes->connect('/:controller');
+		$route = $routes->routes()[0];
+
+		$this->assertEquals(['json'], $route->options['_ext']);
+		$routes->extensions(['xml', 'json']);
+
+		$routes->connect('/:controller/:action');
+		$new = $routes->routes()[1];
+		$this->assertEquals(['json'], $route->options['_ext']);
+		$this->assertEquals(['xml', 'json'], $new->options['_ext']);
+	}
+
+/**
+ * Test error on invalid route class
+ *
+ * @expectedException \Cake\Error\Exception
+ * @expectedExceptionMessage Route class not found, or route class is not a subclass of
+ * @return void
+ */
+	public function testConnectErrorInvalidRouteClass() {
+		$routes = new ScopedRouteCollection('/l', [], ['json']);
+		$routes->connect('/:controller', [], ['routeClass' => '\StdClass']);
+	}
+
+}

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -261,4 +261,31 @@ class ScopedRouteCollectionTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * Test matching routes.
+ *
+ * @return void
+ */
+	public function testMatch() {
+		$context = [
+			'_base' => '/',
+			'_scheme' => 'http',
+			'_host' => 'example.org',
+		];
+		$routes = new ScopedRouteCollection('/b');
+		$routes->connect('/', ['controller' => 'Articles']);
+		$routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+
+		$result = $routes->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'index'], $context);
+		$this->assertEquals('b', $result);
+
+		$result = $routes->match(
+			['id' => 'thing', 'plugin' => null, 'controller' => 'Articles', 'action' => 'view'],
+			$context);
+		$this->assertEquals('b/thing', $result);
+
+		$result = $routes->match(['plugin' => null, 'controller' => 'Articles', 'action' => 'add'], $context);
+		$this->assertFalse($result, 'No matches');
+	}
+
 }

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -225,4 +225,40 @@ class ScopedRouteCollectionTest extends TestCase {
 		});
 	}
 
+/**
+ * Test parsing routes.
+ *
+ * @return void
+ */
+	public function testParse() {
+		$routes = new ScopedRouteCollection('/b', ['key' => 'value']);
+		$routes->connect('/', ['controller' => 'Articles']);
+		$routes->connect('/:id', ['controller' => 'Articles', 'action' => 'view']);
+
+		$result = $routes->parse('/');
+		$this->assertEquals([], $result, 'Should not match, missing /b');
+
+		$result = $routes->parse('/b/');
+		$expected = [
+			'controller' => 'Articles',
+			'action' => 'index',
+			'pass' => [],
+			'plugin' => null,
+			'key' => 'value',
+		];
+		$this->assertEquals($expected, $result);
+
+		$result = $routes->parse('/b/the-thing?one=two');
+		$expected = [
+			'controller' => 'Articles',
+			'action' => 'view',
+			'id' => 'the-thing',
+			'pass' => [],
+			'plugin' => null,
+			'key' => 'value',
+			'?' => ['one' => 'two'],
+		];
+		$this->assertEquals($expected, $result);
+	}
+
 }

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -319,9 +319,9 @@ class ScopedRouteCollectionTest extends TestCase {
  *
  * @return void
  */
-	public function testResource() {
+	public function testResources() {
 		$routes = new ScopedRouteCollection('/api', ['prefix' => 'api']);
-		$routes->resource('Articles', ['_ext' => 'json']);
+		$routes->resources('Articles', ['_ext' => 'json']);
 
 		$all = $routes->routes();
 		$this->assertCount(6, $all);
@@ -336,13 +336,13 @@ class ScopedRouteCollectionTest extends TestCase {
  *
  * @return void
  */
-	public function testResourceNested() {
+	public function testResourcesNested() {
 		$routes = new ScopedRouteCollection('/api', ['prefix' => 'api']);
-		$routes->resource('Articles', function($routes) {
+		$routes->resources('Articles', function($routes) {
 			$this->assertEquals('/api/articles/', $routes->path());
 			$this->assertEquals(['prefix' => 'api'], $routes->params());
 
-			$routes->resource('Comments');
+			$routes->resources('Comments');
 			$route = $routes->routes()[0];
 			$this->assertEquals('/api/articles/:article_id/comments', $route->template);
 		});

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -149,4 +149,23 @@ class ScopedRouteCollectionTest extends TestCase {
 		$routes->connect('/:controller', [], ['routeClass' => '\StdClass']);
 	}
 
+/**
+ * Test connecting redirect routes.
+ *
+ * @return void
+ */
+	public function testRedirect() {
+		$routes = new ScopedRouteCollection('/');
+		$routes->redirect('/p/:id', ['controller' => 'posts', 'action' => 'view'], ['status' => 301]);
+		$route = $routes->routes()[0];
+
+		$this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
+
+		$routes->redirect('/old', '/forums', ['status' => 301]);
+		$route = $routes->routes()[1];
+
+		$this->assertInstanceOf('Cake\Routing\Route\RedirectRoute', $route);
+		$this->assertEquals('/forums', $route->redirect[0]);
+	}
+
 }

--- a/tests/TestCase/Routing/ScopedRouteCollectionTest.php
+++ b/tests/TestCase/Routing/ScopedRouteCollectionTest.php
@@ -168,4 +168,34 @@ class ScopedRouteCollectionTest extends TestCase {
 		$this->assertEquals('/forums', $route->redirect[0]);
 	}
 
+/**
+ * Test creating sub-scopes with prefix()
+ *
+ * @return void
+ */
+	public function testPrefix() {
+		$routes = new ScopedRouteCollection('/path', ['key' => 'value']);
+		$res = $routes->prefix('admin', function($r) {
+			$this->assertInstanceOf('Cake\Routing\ScopedRouteCollection', $r);
+			$this->assertCount(0, $r->routes());
+			$this->assertEquals('/path/admin', $r->path());
+			$this->assertEquals(['prefix' => 'admin', 'key' => 'value'], $r->params());
+		});
+		$this->assertNull($res);
+	}
+
+/**
+ * Test creating sub-scopes with prefix()
+ *
+ * @return void
+ */
+	public function testNestedPrefix() {
+		$routes = new ScopedRouteCollection('/admin', ['prefix' => 'admin']);
+		$res = $routes->prefix('api', function($r) {
+			$this->assertEquals('/admin/api', $r->path());
+			$this->assertEquals(['prefix' => 'admin/api'], $r->params());
+		});
+		$this->assertNull($res);
+	}
+
 }


### PR DESCRIPTION
This is the first part of #3693. It adds the `ScopedRouteCollection` class which will eventually replace `RouteCollection` and form the underlying API for the new router features.

A few interesting features to note:
- Each collection can have extensions set independently.
- There is currently no way to modify the mapped resource methods. I don't really like the global setting we currently have. I'd prefer to allow customizing the methods via the options parameter, and will do that in a separate pull request.
- There is no way to set the default route class. I don't think this was frequently used, and it might be a pointless feature to have given the `routeClass` option.
