### PR TITLE
Rename SimplePasswordHasher to DefaultPasswordHasher.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -38,7 +38,7 @@ abstract class BaseAuthenticate {
  * - `contain` Extra models to contain and store in session.
  * - `passwordHasher` Password hasher class. Can be a string specifying class name
  *    or an array containing `className` key, any other keys will be passed as
- *    config to the class. Defaults to 'Simple'.
+ *    config to the class. Defaults to 'Default'.
  *
  * @var array
  */
@@ -50,7 +50,7 @@ abstract class BaseAuthenticate {
 		'userModel' => 'Users',
 		'scope' => [],
 		'contain' => null,
-		'passwordHasher' => 'Simple'
+		'passwordHasher' => 'Default'
 	];
 
 /**

--- a/src/Auth/DefaultPasswordHasher.php
+++ b/src/Auth/DefaultPasswordHasher.php
@@ -17,10 +17,10 @@ namespace Cake\Auth;
 use Cake\Auth\AbstractPasswordHasher;
 
 /**
- * Simple password hashing class.
+ * Default password hashing class.
  *
  */
-class SimplePasswordHasher extends AbstractPasswordHasher {
+class DefaultPasswordHasher extends AbstractPasswordHasher {
 
 /**
  * Default config for this object.

--- a/tests/TestCase/Auth/DefaultPasswordHasherTest.php
+++ b/tests/TestCase/Auth/DefaultPasswordHasherTest.php
@@ -14,23 +14,23 @@
  */
 namespace Cake\Test\TestCase\Auth;
 
-use Cake\Auth\SimplePasswordHasher;
+use Cake\Auth\DefaultPasswordHasher;
 use Cake\TestSuite\TestCase;
 
 /**
- * Test case for SimplePasswordHasher
+ * Test case for DefaultPasswordHasher
  *
  */
-class SimplePasswordHasherTest extends TestCase {
+class DefaultPasswordHasherTest extends TestCase {
 
 /**
- * Tests that a password not produced by SimplePasswordHasher needs
+ * Tests that a password not produced by DefaultPasswordHasher needs
  * to be rehashed
  *
  * @return void
  */
 	public function testNeedsRehash() {
-		$hasher = new SimplePasswordHasher();
+		$hasher = new DefaultPasswordHasher();
 		$this->assertTrue($hasher->needsRehash(md5('foo')));
 		$password = $hasher->hash('foo');
 		$this->assertFalse($hasher->needsRehash($password));

--- a/tests/TestCase/Auth/FallbackPasswordHasherTest.php
+++ b/tests/TestCase/Auth/FallbackPasswordHasherTest.php
@@ -14,8 +14,8 @@
  */
 namespace Cake\Test\TestCase\Auth;
 
+use Cake\Auth\DefaultPasswordHasher;
 use Cake\Auth\FallbackPasswordHasher;
-use Cake\Auth\SimplePasswordHasher;
 use Cake\Auth\WeakPasswordHasher;
 use Cake\TestSuite\TestCase;
 
@@ -31,12 +31,12 @@ class FallbackPasswordHasherTest extends TestCase {
  * @return void
  */
 	public function testHash() {
-		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Simple']]);
+		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Default']]);
 		$weak = new WeakPasswordHasher();
 		$this->assertSame($weak->hash('foo'), $hasher->hash('foo'));
 
-		$simple = new SimplePasswordHasher();
-		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Simple']]);
+		$simple = new DefaultPasswordHasher();
+		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Default']]);
 		$this->assertSame($weak->hash('foo'), $hasher->hash('foo'));
 	}
 
@@ -47,9 +47,9 @@ class FallbackPasswordHasherTest extends TestCase {
  * @return void
  */
 	public function testCheck() {
-		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Simple']]);
+		$hasher = new FallbackPasswordHasher(['hashers' => ['Weak', 'Default']]);
 		$weak = new WeakPasswordHasher();
-		$simple = new SimplePasswordHasher();
+		$simple = new DefaultPasswordHasher();
 
 		$hash = $simple->hash('foo');
 		$otherHash = $weak->hash('foo');
@@ -63,12 +63,12 @@ class FallbackPasswordHasherTest extends TestCase {
  * @return void
  */
 	public function testNeedsRehash() {
-		$hasher = new FallbackPasswordHasher(['hashers' => ['Simple', 'Weak']]);
+		$hasher = new FallbackPasswordHasher(['hashers' => ['Default', 'Weak']]);
 		$weak = new WeakPasswordHasher();
 		$otherHash = $weak->hash('foo');
 		$this->assertTrue($hasher->needsRehash($otherHash));
 
-		$simple = new SimplePasswordHasher();
+		$simple = new DefaultPasswordHasher();
 		$hash = $simple->hash('foo');
 		$this->assertFalse($hasher->needsRehash($hash));
 	}

--- a/tests/TestCase/Auth/FormAuthenticateTest.php
+++ b/tests/TestCase/Auth/FormAuthenticateTest.php
@@ -263,7 +263,7 @@ class FormAuthenticateTest extends TestCase {
  */
 	public function testPasswordHasherSettings() {
 		$this->auth->config('passwordHasher', [
-			'className' => 'Simple',
+			'className' => 'Default',
 			'hashType' => PASSWORD_BCRYPT
 		]);
 
@@ -298,7 +298,7 @@ class FormAuthenticateTest extends TestCase {
 			'userModel' => 'Users'
 		]);
 		$this->auth->config('passwordHasher', [
-			'className' => 'Simple'
+			'className' => 'Default'
 		]);
 		$this->assertEquals($expected, $this->auth->authenticate($request, $this->response));
 
@@ -326,7 +326,7 @@ class FormAuthenticateTest extends TestCase {
 	}
 
 /**
- * Tests that not using the Simple password hasher means that the password
+ * Tests that not using the Default password hasher means that the password
  * needs to be rehashed
  *
  * @return void

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -364,7 +364,7 @@ class AuthComponentTest extends TestCase {
  */
 	public function testSameAuthenticateWithDifferentHashers() {
 		$this->Controller->Auth->config('authenticate', [
-			'FormSimple' => ['className' => 'Form', 'passwordHasher' => 'Simple'],
+			'FormSimple' => ['className' => 'Form', 'passwordHasher' => 'Default'],
 			'FormBlowfish' => ['className' => 'Form', 'passwordHasher' => 'Fallback'],
 		]);
 
@@ -374,7 +374,7 @@ class AuthComponentTest extends TestCase {
 		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects[0]);
 		$this->assertInstanceOf('Cake\Auth\FormAuthenticate', $objects[1]);
 
-		$this->assertInstanceOf('Cake\Auth\SimplePasswordHasher', $objects[0]->passwordHasher());
+		$this->assertInstanceOf('Cake\Auth\DefaultPasswordHasher', $objects[0]->passwordHasher());
 		$this->assertInstanceOf('Cake\Auth\FallbackPasswordHasher', $objects[1]->passwordHasher());
 	}
 


### PR DESCRIPTION
This avoids confusion with SimplePasswordHasher class of 2.x which doesn't use
the same hashing scheme.
