### PR TITLE
Add defensive typehinting for public methods for a cleaner API.

### DIFF
--- a/src/Auth/BaseAuthenticate.php
+++ b/src/Auth/BaseAuthenticate.php
@@ -81,7 +81,7 @@ abstract class BaseAuthenticate {
  * @param \Cake\Controller\ComponentRegistry $registry The Component registry used on this request.
  * @param array $config Array of config to use.
  */
-	public function __construct(ComponentRegistry $registry, $config) {
+	public function __construct(ComponentRegistry $registry, array $config = []) {
 		$this->_registry = $registry;
 		$this->config($config);
 	}

--- a/src/Auth/BasicAuthenticate.php
+++ b/src/Auth/BasicAuthenticate.php
@@ -82,8 +82,8 @@ class BasicAuthenticate extends BaseAuthenticate {
 /**
  * Handles an unauthenticated access attempt by sending appropriate login headers
  *
- * @param Request $request A request object.
- * @param Response $response A response object.
+ * @param \Cake\Network\Request $request A request object.
+ * @param \Cake\Network\Response $response A response object.
  * @return void
  * @throws \Cake\Error\UnauthorizedException
  */

--- a/src/Auth/DigestAuthenticate.php
+++ b/src/Auth/DigestAuthenticate.php
@@ -77,7 +77,7 @@ class DigestAuthenticate extends BasicAuthenticate {
  *   used on this request.
  * @param array $config Array of config to use.
  */
-	public function __construct(ComponentRegistry $registry, $config) {
+	public function __construct(ComponentRegistry $registry, array $config = []) {
 		$this->_registry = $registry;
 
 		$this->config([

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -233,7 +233,7 @@ class Controller implements EventListener {
  * @param \Cake\Network\Response $response Response object for this controller.
  * @param string $name Override the name useful in testing when using mocks.
  */
-	public function __construct($request = null, $response = null, $name = null) {
+	public function __construct(Request $request = null, Response $response = null, $name = null) {
 		if ($this->name === null && $name === null) {
 			list(, $name) = namespaceSplit(get_class($this));
 			$name = substr($name, 0, -10);

--- a/src/Database/ValueBinder.php
+++ b/src/Database/ValueBinder.php
@@ -14,6 +14,8 @@
  */
 namespace Cake\Database;
 
+use Cake\Database\StatementInterface;
+
 /**
  * Value binder class manages list of values bound to conditions.
  *
@@ -108,7 +110,7 @@ class ValueBinder {
  * @param \Cake\Database\StatementInterface $statement The statement to add parameters to.
  * @return void
  */
-	public function attachTo($statement) {
+	public function attachTo(StatementInterface $statement) {
 		$bindings = $this->bindings();
 		if (empty($bindings)) {
 			return;

--- a/src/Datasource/QueryTrait.php
+++ b/src/Datasource/QueryTrait.php
@@ -109,7 +109,7 @@ trait QueryTrait {
  *
  * This method is most useful when combined with results stored in a persistent cache.
  *
- * @param \Cake\ORM\ResultSet $results The results this query should return.
+ * @param \Cake\ORM\ResultSet|\ArrayIterator $results The results this query should return.
  * @return \Cake\ORM\Query The query instance.
  */
 	public function setResult($results) {

--- a/src/Network/Http/Client.php
+++ b/src/Network/Http/Client.php
@@ -425,7 +425,7 @@ class Client {
  * Uses the authentication type to choose the correct strategy
  * and use its methods to add headers.
  *
- * @param Request $request The request to modify.
+ * @param \Cake\Network\Http\Request $request The request to modify.
  * @param array $options Array of options containing the 'auth' key.
  * @return void
  */
@@ -441,7 +441,7 @@ class Client {
  * Uses the authentication type to choose the correct strategy
  * and use its methods to add headers.
  *
- * @param Request $request The request to modify.
+ * @param \Cake\Network\Http\Request $request The request to modify.
  * @param array $options Array of options containing the 'proxy' key.
  * @return void
  */

--- a/src/ORM/Query.php
+++ b/src/ORM/Query.php
@@ -102,7 +102,7 @@ class Query extends DatabaseQuery {
  * @param \Cake\Database\Connection $connection The connection object
  * @param \Cake\ORM\Table $table The table this query is starting on
  */
-	public function __construct($connection, $table) {
+	public function __construct($connection, Table $table) {
 		parent::__construct($connection);
 		$this->repository($table);
 

--- a/src/ORM/ResultSet.php
+++ b/src/ORM/ResultSet.php
@@ -16,7 +16,9 @@ namespace Cake\ORM;
 
 use Cake\Collection\CollectionTrait;
 use Cake\Database\Exception;
+use Cake\Database\StatementInterface;
 use Cake\Database\Type;
+use Cake\ORM\Query;
 use \Countable;
 use \Iterator;
 use \JsonSerializable;
@@ -124,7 +126,7 @@ class ResultSet implements Countable, Iterator, Serializable, JsonSerializable {
  * @param \Cake\ORM\Query $query Query from where results come
  * @param \Cake\Database\StatementInterface $statement The statement to fetch from
  */
-	public function __construct($query, $statement) {
+	public function __construct(Query $query, StatementInterface $statement) {
 		$repository = $query->repository();
 		$this->_query = $query;
 		$this->_statement = $statement;

--- a/src/ORM/Table.php
+++ b/src/ORM/Table.php
@@ -32,6 +32,7 @@ use Cake\ORM\BehaviorRegistry;
 use Cake\ORM\Error\MissingEntityException;
 use Cake\ORM\Error\RecordNotFoundException;
 use Cake\ORM\Marshaller;
+use Cake\ORM\Query;
 use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -767,11 +767,11 @@ class Router {
  *
  * - `separator` The string to use as a separator.  Defaults to `:`.
  *
- * @param Request $request The request object to modify.
+ * @param \Cake\Network\Request $request The request object to modify.
  * @param array $options The array of options.
  * @return \Cake\Network\Request The modified request
  */
-	public static function parseNamedParams(Request $request, $options = []) {
+	public static function parseNamedParams(Request $request, array $options = []) {
 		$options += array('separator' => ':');
 		if (empty($request->params['pass'])) {
 			$request->params['named'] = [];

--- a/tests/TestCase/ORM/Association/BelongsToManyTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToManyTest.php
@@ -226,7 +226,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -273,7 +273,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -314,7 +314,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachToWithQueryBuilder() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -367,7 +367,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachToMultiPrimaryKey() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -419,7 +419,7 @@ class BelongsToManyTest extends TestCase {
 		];
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['all', 'matching'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all', 'matching'], [null, $this->article]);
 
 		$this->tag->expects($this->once())
 			->method('find')
@@ -437,7 +437,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $keys) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with(['ArticlesTags.article_id IN' => $keys])
@@ -480,7 +480,7 @@ class BelongsToManyTest extends TestCase {
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['all', 'matching', 'where', 'order'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, $this->article]);
 		$this->tag->expects($this->once())
 			->method('find')
 			->with('all')
@@ -496,7 +496,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $keys) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with(['ArticlesTags.article_id IN' => $keys])
@@ -537,7 +537,7 @@ class BelongsToManyTest extends TestCase {
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['all', 'matching', 'where', 'order', 'select'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, $this->article]);
 		$this->tag->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -550,7 +550,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $keys) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with(['ArticlesTags.article_id IN' => $keys])
@@ -607,7 +607,7 @@ class BelongsToManyTest extends TestCase {
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [1, 2, 3, 4];
 		$methods = ['all', 'contain', 'where', 'order', 'select'];
-		$query = $this->getMock('Cake\ORM\Query', $methods, [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', $methods, [null, $this->article]);
 		$this->tag->expects($this->once())
 			->method('find')
 			->with('all')
@@ -680,7 +680,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $expected) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with(['ArticlesTags.article_id IN' => $expected])
@@ -725,7 +725,7 @@ class BelongsToManyTest extends TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'matching', 'andWhere', 'limit'],
-			[null, null]
+			[null, $this->article]
 		);
 
 		$this->tag->expects($this->once())
@@ -744,7 +744,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $keys) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with(['ArticlesTags.article_id IN' => $keys])
@@ -795,7 +795,7 @@ class BelongsToManyTest extends TestCase {
 		]);
 		$association = new BelongsToMany('Tags', $config);
 		$keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
-		$query = $this->getMock('Cake\ORM\Query', ['all', 'matching'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all', 'matching'], [null, $this->article]);
 
 		$this->tag->expects($this->once())
 			->method('find')
@@ -832,7 +832,7 @@ class BelongsToManyTest extends TestCase {
 		$query->expects($this->once())->method('matching')
 			->will($this->returnCallback(function($alias, $callable) use ($query, $tuple) {
 				$this->assertEquals('ArticlesTags', $alias);
-				$q = $this->getMock('Cake\ORM\Query', [], [null, null]);
+				$q = $this->getMock('Cake\ORM\Query', [], [null, $this->article]);
 
 				$q->expects($this->once())->method('andWhere')
 					->with($tuple)
@@ -924,7 +924,7 @@ class BelongsToManyTest extends TestCase {
 			$articleTagTwo
 		]);
 
-		$query = $this->getMock('\Cake\ORM\Query', [], [], '', false);
+		$query = $this->getMock('\Cake\ORM\Query', [], [null, $this->article], '', false);
 		$query->expects($this->at(0))
 			->method('where')
 			->with(['click_count' => 3])
@@ -1599,7 +1599,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachToBeforeFind() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,
@@ -1636,7 +1636,7 @@ class BelongsToManyTest extends TestCase {
  * @return void
  */
 	public function testAttachToBeforeFindExtraOptions() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->article]);
 		$config = [
 			'sourceTable' => $this->article,
 			'targetTable' => $this->tag,

--- a/tests/TestCase/ORM/Association/BelongsToTest.php
+++ b/tests/TestCase/ORM/Association/BelongsToTest.php
@@ -104,7 +104,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -136,7 +136,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -170,7 +170,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'sourceTable' => $this->client,
 			'targetTable' => $this->company,
@@ -199,7 +199,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToWithQueryBuilder() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'sourceTable' => $this->client,
 			'targetTable' => $this->company,
@@ -236,7 +236,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToMatching() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -317,7 +317,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  */
 	public function testAttachToMultiPrimaryKey() {
 		$this->company->primaryKey(['id', 'tenant_id']);
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => ['company_id', 'company_tenant_id'],
 			'sourceTable' => $this->client,
@@ -354,7 +354,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {
 		$this->company->primaryKey(['id', 'tenant_id']);
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -398,7 +398,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFind() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,
@@ -424,7 +424,7 @@ class BelongsToTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFindExtraOptions() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->client]);
 		$config = [
 			'foreignKey' => 'company_id',
 			'sourceTable' => $this->client,

--- a/tests/TestCase/ORM/Association/HasManyTest.php
+++ b/tests/TestCase/ORM/Association/HasManyTest.php
@@ -128,7 +128,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		];
 		$association = new HasMany('Articles', $config);
 		$keys = [1, 2, 3, 4];
-		$query = $this->getMock('Cake\ORM\Query', ['all'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all'], [null, $this->author]);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -172,7 +172,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'where', 'andWhere', 'order'],
-			[null, null]
+			[null, $this->author]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -221,7 +221,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'where', 'andWhere', 'order', 'select', 'contain'],
-			[null, null]
+			[null, $this->author]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -291,7 +291,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all'],
-			[null, null]
+			[null, $this->author]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -321,7 +321,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'where', 'andWhere', 'order', 'select', 'contain'],
-			[null, null]
+			[null, $this->author]
 		);
 
 		$this->article->expects($this->once())->method('find')->with('all')
@@ -385,7 +385,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$query = $this->getMock(
 			'Cake\ORM\Query',
 			['all', 'select', 'join', 'where'],
-			[null, null]
+			[null, $this->author]
 		);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
@@ -436,7 +436,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 		$this->author->primaryKey(['id', 'site_id']);
 		$association = new HasMany('Articles', $config);
 		$keys = [[1, 10], [2, 20], [3, 30], [4, 40]];
-		$query = $this->getMock('Cake\ORM\Query', ['all', 'andWhere'], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', ['all', 'andWhere'], [null, $this->author]);
 		$this->article->expects($this->once())->method('find')->with('all')
 			->will($this->returnValue($query));
 		$results = [
@@ -476,7 +476,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -509,7 +509,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -543,7 +543,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -572,7 +572,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToMultiPrimaryKey() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$this->author->primaryKey(['id', 'site_id']);
 		$config = [
 			'sourceTable' => $this->author,
@@ -606,7 +606,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$this->author->primaryKey(['id', 'site_id']);
 		$config = [
 			'sourceTable' => $this->author,
@@ -627,7 +627,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToWithQueryBuilder() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -704,7 +704,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
 			$articleTwo
 		]);
 
-		$query = $this->getMock('\Cake\ORM\Query', [], [], '', false);
+		$query = $this->getMock('\Cake\ORM\Query', [], [null, $this->author], '', false);
 		$query->expects($this->at(0))
 			->method('where')
 			->with(['Articles.is_active' => true])
@@ -797,7 +797,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFind() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,
@@ -823,7 +823,7 @@ class HasManyTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFindExtraOptions() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->author]);
 		$config = [
 			'sourceTable' => $this->author,
 			'targetTable' => $this->article,

--- a/tests/TestCase/ORM/Association/HasOneTest.php
+++ b/tests/TestCase/ORM/Association/HasOneTest.php
@@ -92,7 +92,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachTo() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
@@ -125,7 +125,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToConfigOverride() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
@@ -160,7 +160,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToNoFields() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
@@ -189,7 +189,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToWithQueryBuilder() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
@@ -226,7 +226,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToMultiPrimaryKey() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
@@ -260,7 +260,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToMultiPrimaryKeyMistmatch() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'sourceTable' => $this->user,
 			'targetTable' => $this->profile,
@@ -330,7 +330,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFind() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,
@@ -356,7 +356,7 @@ class HasOneTest extends \Cake\TestSuite\TestCase {
  * @return void
  */
 	public function testAttachToBeforeFindExtraOptions() {
-		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, null]);
+		$query = $this->getMock('\Cake\ORM\Query', ['join', 'select'], [null, $this->user]);
 		$config = [
 			'foreignKey' => 'user_id',
 			'sourceTable' => $this->user,

--- a/tests/TestCase/ORM/BehaviorRegistryTest.php
+++ b/tests/TestCase/ORM/BehaviorRegistryTest.php
@@ -222,7 +222,7 @@ class BehaviorRegistryTest extends TestCase {
 			->getMock();
 		$this->Behaviors->set('Sluggable', $mockedBehavior);
 
-		$query = $this->getMock('Cake\ORM\Query', [], [null, null]);
+		$query = $this->getMock('Cake\ORM\Query', [], [null, $this->Table]);
 		$mockedBehavior
 			->expects($this->once())
 			->method('findNoSlug')

--- a/tests/TestCase/ORM/QueryTest.php
+++ b/tests/TestCase/ORM/QueryTest.php
@@ -957,7 +957,7 @@ class QueryTest extends TestCase {
  */
 	public function testResultsAreWrappedInMapReduce() {
 		$params = [$this->connection, $this->table];
-		$query = $this->getMock('\Cake\ORM\Query', ['execute'], $params);
+		$query = $this->getMock('\Cake\ORM\Query', [], $params);
 
 		$statement = $this->getMock(
 			'\Database\StatementInterface',
@@ -1455,7 +1455,8 @@ class QueryTest extends TestCase {
 			[$this->connection, $this->table]
 		);
 		$query->select();
-		$resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, null]);
+		$stmt = $this->getMock('\Cake\Database\StatementInterface');
+		$resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, $stmt]);
 		$query->expects($this->once())
 			->method('all')
 			->will($this->returnValue($resultSet));
@@ -1504,7 +1505,8 @@ class QueryTest extends TestCase {
 			'\Cake\ORM\Query', ['execute'],
 			[$this->connection, $this->table]
 		);
-		$resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, null]);
+		$stmt = $this->getMock('\Cake\Database\StatementInterface');
+		$resultSet = $this->getMock('\Cake\ORM\ResultSet', [], [$query, $stmt]);
 
 		$query->expects($this->never())
 			->method('execute');


### PR DESCRIPTION
Follow up on https://github.com/cakephp/cakephp/pull/3775

As it got quite controversial I decided to extract the public API changes into this PR
and then will rebase the other one on top of it afterwards - so only the actually relevant changes around protected methods are then visible. 

One test fails:

```
Argument 1 passed to iterator_to_array() must implement interface Traversable, null given
```
