### PR TITLE
Fix notice in CakeSession

### DIFF
--- a/lib/Cake/Model/Datasource/CakeSession.php
+++ b/lib/Cake/Model/Datasource/CakeSession.php
@@ -348,7 +348,7 @@ class CakeSession {
 		$config = self::read('Config');
 		$validAgent = (
 			Configure::read('Session.checkAgent') === false ||
-			self::$_userAgent == $config['userAgent']
+			!empty($config['userAgent']) && self::$_userAgent === $config['userAgent']
 		);
 		return ($validAgent && self::$time <= $config['time']);
 	}


### PR DESCRIPTION
When first visiting a cake app, this notice happens:

```
Notice (8): Undefined index: userAgent [APP\Vendor\cakephp\cakephp\lib\Cake\Model\Datasource\CakeSession.php, line 351]
```

On page refresh it's gone.

Win, PHP5.4, Cake2.5.2

This middle in the night hotfix first checks on the existence.
But I wonder if there might be a more correct approach here - there must be reason the index is undefined.
Looks like in that case _checkValid() is invoked not soon enough - thus _writeConfig() is too late and the configs haven't been written yet in this dispatching process prior to reading the configs.

//EDIT
As the tests don't pass we need to find another solution.
