### PR TITLE
Updated CakeEmail to default to "default" config for RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /build
 /dist
 /tags
-/.idea
+.idea
 
 # OS generated files #
 ######################

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /build
 /dist
 /tags
-.idea
 
 # OS generated files #
 ######################

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /build
 /dist
 /tags
+/.idea
 
 # OS generated files #
 ######################

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -344,7 +344,7 @@ class CakeEmail {
 		if (empty($this->_domain)) {
 			$this->_domain = php_uname('n');
 		}
-		if (!empty($config)) {
+		if ($config) {
 			$this->config($config);
 		}
 		if (empty($this->headerCharset)) {

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -335,22 +335,22 @@ class CakeEmail {
  *
  * @param array|string $config Array of configs, or string to load configs from email.php
  */
-    public function __construct($config = 'default') {
-        $this->_appCharset = Configure::read('App.encoding');
-        if ($this->_appCharset !== null) {
-            $this->charset = $this->_appCharset;
-        }
-        $this->_domain = preg_replace('/\:\d+$/', '', env('HTTP_HOST'));
-        if (empty($this->_domain)) {
-            $this->_domain = php_uname('n');
-        }
-        if (!empty($config)) {
-            $this->config($config);
-        }
-        if (empty($this->headerCharset)) {
-            $this->headerCharset = $this->charset;
-        }
-    }
+	public function __construct($config = 'default') {
+		$this->_appCharset = Configure::read('App.encoding');
+		if ($this->_appCharset !== null) {
+		    $this->charset = $this->_appCharset;
+		}
+		$this->_domain = preg_replace('/\:\d+$/', '', env('HTTP_HOST'));
+		if (empty($this->_domain)) {
+		    $this->_domain = php_uname('n');
+		}
+		if (!empty($config)) {
+		    $this->config($config);
+		}
+		if (empty($this->headerCharset)) {
+		    $this->headerCharset = $this->charset;
+		}
+    	}
 
 /**
  * From

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -338,19 +338,19 @@ class CakeEmail {
 	public function __construct($config = 'default') {
 		$this->_appCharset = Configure::read('App.encoding');
 		if ($this->_appCharset !== null) {
-		    $this->charset = $this->_appCharset;
+			$this->charset = $this->_appCharset;
 		}
 		$this->_domain = preg_replace('/\:\d+$/', '', env('HTTP_HOST'));
 		if (empty($this->_domain)) {
-		    $this->_domain = php_uname('n');
+			$this->_domain = php_uname('n');
 		}
 		if (!empty($config)) {
-		    $this->config($config);
+			$this->config($config);
 		}
 		if (empty($this->headerCharset)) {
-		    $this->headerCharset = $this->charset;
+			$this->headerCharset = $this->charset;
 		}
-    	}
+	}
 
 /**
  * From

--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -335,23 +335,22 @@ class CakeEmail {
  *
  * @param array|string $config Array of configs, or string to load configs from email.php
  */
-	public function __construct($config = null) {
-		$this->_appCharset = Configure::read('App.encoding');
-		if ($this->_appCharset !== null) {
-			$this->charset = $this->_appCharset;
-		}
-		$this->_domain = preg_replace('/\:\d+$/', '', env('HTTP_HOST'));
-		if (empty($this->_domain)) {
-			$this->_domain = php_uname('n');
-		}
-
-		if ($config) {
-			$this->config($config);
-		}
-		if (empty($this->headerCharset)) {
-			$this->headerCharset = $this->charset;
-		}
-	}
+    public function __construct($config = 'default') {
+        $this->_appCharset = Configure::read('App.encoding');
+        if ($this->_appCharset !== null) {
+            $this->charset = $this->_appCharset;
+        }
+        $this->_domain = preg_replace('/\:\d+$/', '', env('HTTP_HOST'));
+        if (empty($this->_domain)) {
+            $this->_domain = php_uname('n');
+        }
+        if (!empty($config)) {
+            $this->config($config);
+        }
+        if (empty($this->headerCharset)) {
+            $this->headerCharset = $this->charset;
+        }
+    }
 
 /**
  * From


### PR DESCRIPTION
I guess there might be a reason for this not being done (or it just isn't considered important), but why does the CakeEmail config not default to "default" when that is the name of the provided config in email.php.default? 

If it is left empty having it use the "default" config seems sensible, and if it is provided then use that config.

Also I'm not sure if / what tests to alter for this? It seems to be handled in the current tests checking for empty.
