### PR TITLE
Exiting with 1 when Exception::getCode() returns non-integer values.

### DIFF
--- a/lib/Cake/Console/ConsoleErrorHandler.php
+++ b/lib/Cake/Console/ConsoleErrorHandler.php
@@ -58,7 +58,9 @@ class ConsoleErrorHandler {
 			$exception->getMessage(),
 			$exception->getTraceAsString()
 		));
-		return $this->_stop($exception->getCode() ? $exception->getCode() : 1);
+		$code = $exception->getCode();
+		$code = ($code && is_integer($code)) ? $code : 1;
+		return $this->_stop($code);
 	}
 
 /**

--- a/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
+++ b/lib/Cake/Test/Case/Console/ConsoleErrorHandlerTest.php
@@ -147,4 +147,31 @@ class ConsoleErrorHandlerTest extends CakeTestCase {
 		$this->Error->handleException($exception);
 	}
 
+/**
+ * test a exception with non-integer code
+ *
+ * @return void
+ */
+	public function testNonIntegerExceptionCode() {
+		if (PHP_VERSION_ID < 50300) {
+			$this->markTestSkipped('ReflectionProperty::setAccessible() is available since 5.3');
+		}
+
+		$exception = new Exception('Non-integer exception code');
+
+		$class = new ReflectionClass('Exception');
+		$property = $class->getProperty('code');
+		$property->setAccessible(true);
+		$property->setValue($exception, '42S22');
+
+		ConsoleErrorHandler::$stderr->expects($this->once())->method('write')
+			->with($this->stringContains('Non-integer exception code'));
+
+		$this->Error->expects($this->once())
+			->method('_stop')
+			->with(1);
+
+		$this->Error->handleException($exception);
+	}
+
 }


### PR DESCRIPTION
From [php.net/exception.getcode](http://php.net/exception.getcode)

> Returns the exception code as integer in Exception but possibly as other type in Exception descendants (for example as string in PDOException).

Yes, it uses Reflection. But since the method is final I couldn't use PHPUnit Mock Generator on it and instantiating Exception with a non-integer code results in error. Only solution I found was to use Reflection in order to properly test this.
