### PR TITLE
Add missing className option to generated associations.

### DIFF
--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -228,6 +228,7 @@ class ModelTask extends BakeTask {
 			} elseif ($fieldName === 'parent_id') {
 				$associations['belongsTo'][] = [
 					'alias' => 'Parent' . $model->alias(),
+					'className' => $model->alias(),
 					'foreignKey' => $fieldName
 				];
 			}
@@ -269,6 +270,7 @@ class ModelTask extends BakeTask {
 				} elseif ($otherTable == $tableName && $fieldName === 'parent_id') {
 					$assoc = [
 						'alias' => 'Child' . $model->alias(),
+						'className' => $model->alias(),
 						'foreignKey' => $fieldName
 					];
 				}

--- a/src/Console/Command/Task/ModelTask.php
+++ b/src/Console/Command/Task/ModelTask.php
@@ -226,9 +226,10 @@ class ModelTask extends BakeTask {
 					'foreignKey' => $fieldName
 				];
 			} elseif ($fieldName === 'parent_id') {
+				$className = ($this->plugin) ? $this->plugin . '.' . $model->alias() : $model->alias();
 				$associations['belongsTo'][] = [
 					'alias' => 'Parent' . $model->alias(),
-					'className' => $model->alias(),
+					'className' => $className,
 					'foreignKey' => $fieldName
 				];
 			}
@@ -268,9 +269,10 @@ class ModelTask extends BakeTask {
 						'foreignKey' => $fieldName
 					];
 				} elseif ($otherTable == $tableName && $fieldName === 'parent_id') {
+					$className = ($this->plugin) ? $this->plugin . '.' . $model->alias() : $model->alias();
 					$assoc = [
 						'alias' => 'Child' . $model->alias(),
-						'className' => $model->alias(),
+						'className' => $className,
 						'foreignKey' => $fieldName
 					];
 				}

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -298,6 +298,19 @@ class ModelTaskTest extends TestCase {
 			]
 		];
 		$this->assertEquals($expected, $result);
+
+		$this->Task->plugin = 'Blog';
+		$result = $this->Task->findBelongsTo($model, array());
+		$expected = [
+			'belongsTo' => [
+				[
+					'alias' => 'ParentCategoryThreads',
+					'className' => 'Blog.CategoryThreads',
+					'foreignKey' => 'parent_id'
+				],
+			]
+		];
+		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -327,6 +340,19 @@ class ModelTaskTest extends TestCase {
 					'alias' => 'ChildCategoryThreads',
 					'className' => 'CategoryThreads',
 					'foreignKey' => 'parent_id',
+				],
+			]
+		];
+		$this->assertEquals($expected, $result);
+
+		$this->Task->plugin = 'Blog';
+		$result = $this->Task->findHasMany($model, array());
+		$expected = [
+			'hasMany' => [
+				[
+					'alias' => 'ChildCategoryThreads',
+					'className' => 'Blog.CategoryThreads',
+					'foreignKey' => 'parent_id'
 				],
 			]
 		];

--- a/tests/TestCase/Console/Command/Task/ModelTaskTest.php
+++ b/tests/TestCase/Console/Command/Task/ModelTaskTest.php
@@ -292,6 +292,7 @@ class ModelTaskTest extends TestCase {
 			'belongsTo' => [
 				[
 					'alias' => 'ParentCategoryThreads',
+					'className' => 'CategoryThreads',
 					'foreignKey' => 'parent_id'
 				],
 			]
@@ -324,6 +325,7 @@ class ModelTaskTest extends TestCase {
 			'hasMany' => [
 				[
 					'alias' => 'ChildCategoryThreads',
+					'className' => 'CategoryThreads',
 					'foreignKey' => 'parent_id',
 				],
 			]


### PR DESCRIPTION
Child/Parent associations need to specify the className key or the incorrect classname will be inferred at runtime causing errors.

We're using the alias as a proxy for classname, as we can't use the actual classname as bake may be using a base class replacement.

Refs #3791
