### PR TITLE
WIP 3.0: Fix tests on windows

### DIFF
--- a/tests/TestCase/Database/Schema/MysqlSchemaTest.php
+++ b/tests/TestCase/Database/Schema/MysqlSchemaTest.php
@@ -723,7 +723,7 @@ PRIMARY KEY (`id`)
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 	}
 
 /**
@@ -779,7 +779,7 @@ PRIMARY KEY (`article_id`, `tag_id`)
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 
 		$table = (new Table('composite_key'))
 			->addColumn('id', [
@@ -805,7 +805,7 @@ PRIMARY KEY (`id`, `account_id`)
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/PostgresSchemaTest.php
+++ b/tests/TestCase/Database/Schema/PostgresSchemaTest.php
@@ -646,7 +646,7 @@ SQL;
 			'type' => 'integer',
 		])->addConstraint($name, $data);
 
-		$this->assertEquals($expected, $schema->constraintSql($table, $name));
+		$this->assertTextEquals($expected, $schema->constraintSql($table, $name));
 	}
 
 /**
@@ -692,7 +692,7 @@ SQL;
 		$result = $table->createSql($connection);
 
 		$this->assertCount(3, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 		$this->assertEquals(
 			'CREATE INDEX "title_idx" ON "schema_articles" ("title")',
 			$result[1]
@@ -756,7 +756,7 @@ PRIMARY KEY ("article_id", "tag_id")
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 
 		$table = (new Table('composite_key'))
 			->addColumn('id', [
@@ -782,7 +782,7 @@ PRIMARY KEY ("id", "account_id")
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 	}
 
 /**

--- a/tests/TestCase/Database/Schema/SqliteSchemaTest.php
+++ b/tests/TestCase/Database/Schema/SqliteSchemaTest.php
@@ -772,7 +772,7 @@ CONSTRAINT "primary" PRIMARY KEY ("article_id", "tag_id")
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 
 		// Sqlite only supports AUTO_INCREMENT on single column primary
 		// keys. Ensure that schema data follows the limitations of Sqlite.
@@ -800,7 +800,7 @@ CONSTRAINT "primary" PRIMARY KEY ("id", "account_id")
 SQL;
 		$result = $table->createSql($connection);
 		$this->assertCount(1, $result);
-		$this->assertEquals($expected, $result[0]);
+		$this->assertTextEquals($expected, $result[0]);
 	}
 
 /**


### PR DESCRIPTION
Before

```
Assertions: 19008, Failures: 47, Errors: 33, Incomplete: 3, Skipped: 219
```

After

```
Assertions: 19218, Failures: 37, Errors: 33, Incomplete: 3, Skipped: 219
```

Others seem to be missing defaults:

```
35) Cake\Test\TestCase\View\Helper\TimeHelperTest::testFormat
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1/14/10 1:59 PM'
+'14.01.10 13:59'
```

And minor differences:

```
5) Cake\Test\TestCase\Network\ResponseTest::testFileRange
xpectation failed for method name is equal to <string:header> when invoked at s
quence index 4
arameter 0 for invocation Cake\Network\Response::header(Array (...), null) does
not match expected value.
ailed asserting that two arrays are equal.
-- Expected
++ Actual
@ @@
Array (
     'Content-Length' => 18
-    'Content-Range' => 'bytes 8-25/38'
+    'Content-Range' => 'bytes 8-25/39'
)
```

Not sure what to make this those.
