### PR TITLE
Add lazy reading of cookie data.

### DIFF
--- a/tests/TestCase/Controller/Component/CookieComponentTest.php
+++ b/tests/TestCase/Controller/Component/CookieComponentTest.php
@@ -432,34 +432,6 @@ class CookieComponentTest extends TestCase {
 	}
 
 /**
- * test reading all values at once.
- *
- * @return void
- */
-	public function testReadingAllValues() {
-		$this->_setCookieData();
-		$data = $this->Cookie->read();
-		$expected = array(
-			'Encrytped_array' => array(
-				'name' => 'CakePHP',
-				'version' => '1.2.0.x',
-				'tag' => 'CakePHP Rocks!'),
-			'Encrypted_multi_cookies' => array(
-				'name' => 'CakePHP',
-				'version' => '1.2.0.x',
-				'tag' => 'CakePHP Rocks!'),
-			'Plain_array' => array(
-				'name' => 'CakePHP',
-				'version' => '1.2.0.x',
-				'tag' => 'CakePHP Rocks!'),
-			'Plain_multi_cookies' => array(
-				'name' => 'CakePHP',
-				'version' => '1.2.0.x',
-				'tag' => 'CakePHP Rocks!'));
-		$this->assertEquals($expected, $data);
-	}
-
-/**
  * testDeleteCookieValue
  *
  * @return void


### PR DESCRIPTION
Individual cookie values are now read on an ad hoc basis as they are accessed. This alleviates issues where javascript libraries add cookies that CookieComponent does not know about. Previously, these cookies would trigger encrypted cookie warnings.

Unfortunately reading cookies lazily means we don't have a way to read _all_ cookies.

Refs #3814
