### PR TITLE
Revert "No truncate when drop table."

### DIFF
--- a/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
+++ b/lib/Cake/TestSuite/Fixture/CakeFixtureManager.php
@@ -229,9 +229,7 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 				$db->begin();
 				$this->_setupTable($fixture, $db, $test->dropTables);
-				if (!$test->dropTables) {
-					$fixture->truncate($db);
-				}
+				$fixture->truncate($db);
 				$fixture->insert($db);
 				$db->commit();
 			}
@@ -276,9 +274,7 @@ class CakeFixtureManager {
 				$db = ConnectionManager::getDataSource($fixture->useDbConfig);
 			}
 			$this->_setupTable($fixture, $db, $dropTables);
-			if (!$dropTables) {
-				$fixture->truncate($db);
-			}
+			$fixture->truncate($db);
 			$fixture->insert($db);
 		} else {
 			throw new UnexpectedValueException(__d('cake_dev', 'Referenced fixture class %s not found', $name));


### PR DESCRIPTION
Reverts cakephp/cakephp#3646

As it seems that the benefit of speed (especially for testing) is irrelevant compared to the damage of BC breaking in existing applications.
We should still investigate as where the issue comes from and if we can still apply it somewhere in 2.6 or 3.0.
