### PR TITLE
Update SessionHelper::flash attributes merge logic.

### DIFF
--- a/src/View/Helper/SessionHelper.php
+++ b/src/View/Helper/SessionHelper.php
@@ -123,7 +123,7 @@ class SessionHelper extends Helper {
 		$this->request->session()->delete('Flash.' . $key);
 
 		if (!empty($attrs)) {
-			$flash = $attrs + $flash;
+			$flash += $attrs;
 		}
 		$flash += ['message' => '', 'type' => 'info', 'params' => []];
 


### PR DESCRIPTION
Having the SessionHelper::flash method overwrite the specified element seems backwards to me.

In my controller:

```
$this->Session->setFlash('Item was saved');
```

In my view:

```
$this->Session->flash('flash', array('element' => 'success'));
```

This works great. However, when I specify an element:

```
$this->Session->setFlash('Item could not be saved', 'error');
```

The element is still rendered out as a success message. I know I can just add success to all of my `setFlash()` calls but just thought I would express my point of view.
