### PR TITLE
3.0 router

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -757,10 +757,6 @@ class Router {
 				$frag = '#' . $url['#'];
 				unset($url['#']);
 			}
-			if (isset($url['ext'])) {
-				$url['_ext'] = $url['ext'];
-				unset($url['ext']);
-			}
 			if (isset($url['ssl'])) {
 				$url['_scheme'] = ($url['ssl'] == true) ? 'https' : 'http';
 				unset($url['ssl']);
@@ -1079,7 +1075,7 @@ class Router {
  * specific kinds of scopes.
  *
  * Routing scopes will inherit the globally set extensions configured with
- * Router::parseExtensions(). You can also set valid extensions using 
+ * Router::parseExtensions(). You can also set valid extensions using
  * `$routes->extensions()` in your closure.
  *
  * @param string $path The path prefix for the scope. This path will be prepended

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -680,7 +680,7 @@ class Router {
  * - `_port` - Set the port if you need to create links on non-standard ports.
  * - `_full` - If true output of `Router::fullBaseUrl()` will be prepended to generated URLs.
  * - `#` - Allows you to set URL hash fragments.
- * - `ssl` - Set to true to convert the generated URL to https, or false to force http.
+ * - `_ssl` - Set to true to convert the generated URL to https, or false to force http.
  *
  * @param string|array $url Cake-relative URL, like "/products/edit/92" or "/presidents/elect/4"
  *   or an array specifying any of the following: 'controller', 'action', 'plugin'
@@ -757,9 +757,9 @@ class Router {
 				$frag = '#' . $url['#'];
 				unset($url['#']);
 			}
-			if (isset($url['ssl'])) {
-				$url['_scheme'] = ($url['ssl'] == true) ? 'https' : 'http';
-				unset($url['ssl']);
+			if (isset($url['_ssl'])) {
+				$url['_scheme'] = ($url['_ssl'] === true) ? 'https' : 'http';
+				unset($url['_ssl']);
 			}
 
 			// Copy the current action if the controller is the current one.

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1045,15 +1045,6 @@ class RouterTest extends TestCase {
 		));
 		$expected = '/articles.json';
 		$this->assertEquals($expected, $result);
-
-		$result = Router::url(array(
-			'plugin' => null,
-			'controller' => 'articles',
-			'action' => 'index',
-			'ext' => 'json'
-		));
-		$expected = '/articles.json';
-		$this->assertEquals($expected, $result);
 	}
 
 /**
@@ -1819,12 +1810,12 @@ class RouterTest extends TestCase {
 		);
 
 		$result = Router::url(array(
-			'ssl' => true
+			'_ssl' => true
 		));
 		$this->assertEquals('https://localhost/images/index', $result);
 
 		$result = Router::url(array(
-			'ssl' => false
+			'_ssl' => false
 		));
 		$this->assertEquals('http://localhost/images/index', $result);
 	}
@@ -1853,12 +1844,12 @@ class RouterTest extends TestCase {
 		);
 
 		$result = Router::url(array(
-			'ssl' => false
+			'_ssl' => false
 		));
 		$this->assertEquals('http://localhost/images/index', $result);
 
 		$result = Router::url(array(
-			'ssl' => true
+			'_ssl' => true
 		));
 		$this->assertEquals('https://localhost/images/index', $result);
 	}
@@ -2087,7 +2078,6 @@ class RouterTest extends TestCase {
 
 		$result = Router::parse('/blog/foobar');
 		$this->assertSame([], $result);
-
 	}
 
 /**
@@ -2503,7 +2493,7 @@ class RouterTest extends TestCase {
 			'controller' => 'posts',
 			'action' => 'view',
 			'pass' => array(1),
-			'ext' => 'json',
+			'_ext' => 'json',
 		));
 		$request->query = [];
 		$result = Router::reverse($request);

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -333,7 +333,7 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->image('//google.com/logo.gif');
 		$this->assertTags($result, array('img' => array('src' => '//google.com/logo.gif', 'alt' => '')));
 
-		$result = $this->Html->image(array('controller' => 'test', 'action' => 'view', 1, 'ext' => 'gif'));
+		$result = $this->Html->image(array('controller' => 'test', 'action' => 'view', 1, '_ext' => 'gif'));
 		$this->assertTags($result, array('img' => array('src' => '/test/view/1.gif', 'alt' => '')));
 
 		$result = $this->Html->image('/test/view/1.gif');
@@ -1509,13 +1509,13 @@ class HtmlHelperTest extends TestCase {
 	public function testMeta() {
 		Router::connect('/:controller', array('action' => 'index'));
 
-		$result = $this->Html->meta('this is an rss feed', array('controller' => 'posts', 'ext' => 'rss'));
+		$result = $this->Html->meta('this is an rss feed', array('controller' => 'posts', '_ext' => 'rss'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/posts\.rss/', 'type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => 'this is an rss feed')));
 
-		$result = $this->Html->meta('rss', array('controller' => 'posts', 'ext' => 'rss'), array('title' => 'this is an rss feed'));
+		$result = $this->Html->meta('rss', array('controller' => 'posts', '_ext' => 'rss'), array('title' => 'this is an rss feed'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/posts\.rss/', 'type' => 'application/rss+xml', 'rel' => 'alternate', 'title' => 'this is an rss feed')));
 
-		$result = $this->Html->meta('atom', array('controller' => 'posts', 'ext' => 'xml'));
+		$result = $this->Html->meta('atom', array('controller' => 'posts', '_ext' => 'xml'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/posts\.xml/', 'type' => 'application/atom+xml', 'title' => 'atom')));
 
 		$result = $this->Html->meta('non-existing');
@@ -1527,7 +1527,7 @@ class HtmlHelperTest extends TestCase {
 		$result = $this->Html->meta('non-existing', '/posts.xpp', array('type' => 'atom'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/posts\.xpp/', 'type' => 'application/atom+xml', 'title' => 'non-existing')));
 
-		$result = $this->Html->meta('atom', array('controller' => 'posts', 'ext' => 'xml'), array('link' => '/articles.rss'));
+		$result = $this->Html->meta('atom', array('controller' => 'posts', '_ext' => 'xml'), array('link' => '/articles.rss'));
 		$this->assertTags($result, array('link' => array('href' => 'preg:/.*\/articles\.rss/', 'type' => 'application/atom+xml', 'title' => 'atom')));
 
 		$result = $this->Html->meta('keywords', 'these, are, some, meta, keywords');

--- a/tests/TestCase/View/HelperTest.php
+++ b/tests/TestCase/View/HelperTest.php
@@ -304,7 +304,7 @@ class HelperTest extends TestCase {
 		$result = $this->Helper->assetUrl(array(
 				'controller' => 'js',
 				'action' => 'post',
-				'ext' => 'js'
+				'_ext' => 'js'
 			),
 			array('fullBase' => true)
 		);


### PR DESCRIPTION
- It's better to remove the `ext` to `_ext` BC mapping right now than leaving for later. Once people start relying on that it will be difficult to remove.
- With all special options being prefixed with underscore `ssl` was the odd one out. So changed it to `_ssl` for consistency.
