### PR TITLE
3.0 routing errors

### DIFF
--- a/src/Cache/Engine/ApcEngine.php
+++ b/src/Cache/Engine/ApcEngine.php
@@ -16,6 +16,7 @@ namespace Cake\Cache\Engine;
 
 use Cake\Cache\CacheEngine;
 use Cake\Utility\Inflector;
+use APCIterator;
 
 /**
  * APC storage engine for cache
@@ -135,7 +136,7 @@ class ApcEngine extends CacheEngine {
 		if (class_exists('APCIterator', false)) {
 			$iterator = new APCIterator(
 				'user',
-				'/^' . preg_quote($this->settings['prefix'], '/') . '/',
+				'/^' . preg_quote($this->_config['prefix'], '/') . '/',
 				APC_ITER_NONE
 			);
 			apc_delete($iterator);
@@ -143,7 +144,7 @@ class ApcEngine extends CacheEngine {
 		}
 		$cache = apc_cache_info('user');
 		foreach ($cache['cache_list'] as $key) {
-			if (strpos($key['info'], $this->settings['prefix']) === 0) {
+			if (strpos($key['info'], $this->_config['prefix']) === 0) {
 				apc_delete($key['info']);
 			}
 		}

--- a/src/Routing/Error/MissingRouteException.php
+++ b/src/Routing/Error/MissingRouteException.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://book.cakephp.org/2.0/en/development/testing.html
+ * @since         3.0.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Routing\Error;
+
+use Cake\Error\Exception;
+
+/**
+ * Exception raised when a URL cannot be reverse routed
+ * or when a URL cannot be parsed.
+ */
+class MissingRouteException extends Exception {
+
+	protected $_messageTemplate = 'A route matching "%s" could not be found.';
+
+}

--- a/src/Routing/Error/MissingRouteException.php
+++ b/src/Routing/Error/MissingRouteException.php
@@ -21,6 +21,16 @@ use Cake\Error\Exception;
  */
 class MissingRouteException extends Exception {
 
+/**
+ * {@inheritDoc}
+ */
 	protected $_messageTemplate = 'A route matching "%s" could not be found.';
+
+/**
+ * {@inheritDoc}
+ */
+	public function __construct($message, $code = 404) {
+		parent::__construct($message, $code);
+	}
 
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -493,10 +493,14 @@ class Router {
 
 		foreach (static::$_pathScopes as $path => $collection) {
 			if (strpos($url, $path) === 0) {
-				return $collection->parse($url);
+				break;
 			}
 		}
-		throw new MissingRouteException($url);
+		$result = $collection->parse($url);
+		if ($result) {
+			return $result;
+		}
+		throw new MissingRouteException(['url' => $url]);
 	}
 
 /**
@@ -848,7 +852,7 @@ class Router {
 			}
 		}
 
-		throw new MissingRouteException(var_export($url, true));
+		throw new MissingRouteException(['url' => var_export($url, true)]);
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -16,8 +16,8 @@ namespace Cake\Routing;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Error;
 use Cake\Network\Request;
+use Cake\Routing\Error\MissingRouteException;
 use Cake\Routing\ScopedRouteCollection;
 use Cake\Routing\Route\Route;
 use Cake\Utility\Inflector;
@@ -481,7 +481,7 @@ class Router {
  *
  * @param string $url URL to be parsed
  * @return array Parsed elements from URL
- * @throws \Cake\Error\Exception When a route cannot be handled
+ * @throws \Cake\Routing\Error\MissingRouteException When a route cannot be handled
  */
 	public static function parse($url) {
 		if (!static::$initialized) {
@@ -496,8 +496,7 @@ class Router {
 				return $collection->parse($url);
 			}
 		}
-		// TODO improve this with a custom exception.
-		throw new Error\Exception('No routes match the given URL.');
+		throw new MissingRouteException($url);
 	}
 
 /**
@@ -849,11 +848,7 @@ class Router {
 			}
 		}
 
-		// TODO improve with custom exception
-		throw new Error\Exception(sprintf(
-			'Unable to find a matching route for %s',
-			var_export($url, true)
-		));
+		throw new MissingRouteException(var_export($url, true));
 	}
 
 /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1179,6 +1179,15 @@ class Router {
 	}
 
 /**
+ * Get the route scopes and their connected routes.
+ *
+ * @return array
+ */
+	public static function routes() {
+		return array_values(static::$_pathScopes);
+	}
+
+/**
  * Loads route configuration
  *
  * @return void

--- a/src/Template/Error/missing_layout.ctp
+++ b/src/Template/Error/missing_layout.ctp
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  *

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -1,0 +1,44 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @since         0.10.0
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Cake\Routing\Router;
+use Cake\Utility\Debugger;
+
+?>
+<h2>Missing Route</h2>
+<p class="error">
+	<strong>Error: </strong>
+	<?= $error->getMessage(); ?>
+</p>
+
+<h3>Connected Routes</h3>
+<?php
+foreach (Router::routes() as $scope):
+	printf('<h4>Scope: %s</h4>', $scope->path());
+	echo '<table cellspacing="0" cellpadding="0">';
+	echo '<tr><th>Template</th><th>Defaults</th><th>Options</th></tr>';
+
+	foreach ($scope->routes() as $route):
+		echo '<tr>';
+		printf(
+			'<th width="25%%">%s</th><th>%s</th><th width="20%%">%s</th>',
+			$route->template,
+			Debugger::exportVar($route->defaults),
+			Debugger::exportVar($route->options)
+		);
+		echo '</tr>';
+	endforeach;
+	echo '</table>';
+endforeach;

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -23,6 +23,9 @@ use Cake\Utility\Debugger;
 	<?= $error->getMessage(); ?>
 </p>
 
+<p class="notice">None of the currently connected routes match the given URL or parameters.
+Add a matching route to <?= APP_DIR . DS . 'Config' . DS . 'routes.php' ?></p>
+
 <h3>Connected Routes</h3>
 <?php
 foreach (Router::routes() as $scope):

--- a/src/Template/Error/missing_route.ctp
+++ b/src/Template/Error/missing_route.ctp
@@ -42,3 +42,9 @@ foreach (Router::routes() as $scope):
 	endforeach;
 	echo '</table>';
 endforeach;
+?>
+<p class="notice">
+	<strong>Notice: </strong>
+	<?= sprintf('If you want to customize this error message, create %s', APP_DIR . DS . 'Template' . DS . 'Error' . DS . 'missing_route.ctp'); ?>
+</p>
+<?= $this->element('exception_stack_trace'); ?>

--- a/tests/TestCase/Controller/Component/AuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/AuthComponentTest.php
@@ -979,6 +979,8 @@ class AuthComponentTest extends TestCase {
  * @return void
  */
 	public function testComponentSettings() {
+		Router::connect('/:controller');
+
 		$request = new Request();
 		$this->Controller = new AuthTestController($request, $this->getMock('Cake\Network\Response'));
 

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -186,10 +186,6 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/posts/13');
 		$this->assertEquals($expected, $result);
 
-		$_SERVER['REQUEST_METHOD'] = 'GET';
-		$result = Router::parse('/posts/add');
-		$this->assertSame([], $result);
-
 		Router::reload();
 		$result = Router::mapResources('Posts', ['id' => '[a-z0-9_]+']);
 		$this->assertEquals(['posts'], $result);
@@ -590,7 +586,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/:plugin/:id/*', array('controller' => 'posts', 'action' => 'view'), array('id' => $ID));
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'plugin' => 'cake_plugin',
@@ -613,7 +608,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/:controller/:action/:id', [], array('id' => $ID));
-		Router::parse('/');
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 'id' => '1'));
 		$expected = '/posts/view/1';
@@ -621,7 +615,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/:controller/:id', array('action' => 'view'));
-		Router::parse('/');
 
 		$result = Router::url(array('controller' => 'posts', 'action' => 'view', 'id' => '1'));
 		$expected = '/posts/1';
@@ -634,7 +627,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/:controller/:action');
-		Router::parse('/');
 		$request = new Request();
 		$request->addParams(array(
 			'action' => 'index',
@@ -652,7 +644,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/contact/:action', array('plugin' => 'contact', 'controller' => 'contact'));
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'plugin' => 'contact',
@@ -780,7 +771,6 @@ class RouterTest extends TestCase {
 			array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar'),
 			array('month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}')
 		);
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'plugin' => 'shows',
@@ -799,7 +789,6 @@ class RouterTest extends TestCase {
 			array('month' => '0[1-9]|1[012]', 'year' => '[12][0-9]{3}')
 		);
 		Router::connect('/kalender/*', array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar'));
-		Router::parse('/');
 
 		$result = Router::url(array('plugin' => 'shows', 'controller' => 'shows', 'action' => 'calendar', 'min-forestilling'));
 		$expected = '/kalender/min-forestilling';
@@ -852,7 +841,6 @@ class RouterTest extends TestCase {
 		Router::reload();
 		Router::connect('/admin/subscriptions/:action/*', array('controller' => 'subscribe', 'prefix' => 'admin'));
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parse('/');
 
 		$request = new Request();
 		$request->addParams(array(
@@ -888,7 +876,6 @@ class RouterTest extends TestCase {
 		Router::setRequestInfo($request);
 
 		Router::connect('/page/*', array('controller' => 'pages', 'action' => 'view', 'prefix' => 'admin'));
-		Router::parse('/');
 
 		$result = Router::url(array('prefix' => 'admin', 'controller' => 'pages', 'action' => 'view', 'my-page'));
 		$expected = '/page/my-page';
@@ -908,7 +895,6 @@ class RouterTest extends TestCase {
 		$request->here = '/admin/pages/add';
 		$request->webroot = '/';
 		Router::setRequestInfo($request);
-		Router::parse('/');
 
 		$result = Router::url(array('plugin' => null, 'controller' => 'pages', 'action' => 'add', 'id' => false));
 		$expected = '/admin/pages/add';
@@ -916,7 +902,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parse('/');
 		$request = new Request();
 		$request->addParams(array(
 			'plugin' => null,
@@ -935,7 +920,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/admin/:controller/:action/:id', array('prefix' => 'admin'), array('id' => '[0-9]+'));
-		Router::parse('/');
 		$request = new Request();
 		Router::setRequestInfo(
 			$request->addParams(array(
@@ -957,7 +941,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parse('/');
 
 		$request = new Request();
 		Router::setRequestInfo(
@@ -974,7 +957,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
-		Router::parse('/');
 
 		$request = new Request();
 		Router::setRequestInfo(
@@ -992,7 +974,6 @@ class RouterTest extends TestCase {
 
 		Router::reload();
 		Router::connect('/admin/posts/*', array('controller' => 'posts', 'action' => 'index', 'prefix' => 'admin'));
-		Router::parse('/');
 		Router::setRequestInfo(
 			$request->addParams(array(
 				'plugin' => null, 'controller' => 'posts', 'action' => 'index', 'prefix' => 'admin',
@@ -1015,7 +996,6 @@ class RouterTest extends TestCase {
 	public function testUrlGenerationWithExtensions() {
 		Router::connect('/:controller', array('action' => 'index'));
 		Router::connect('/:controller/:action');
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'plugin' => null,
@@ -1459,7 +1439,6 @@ class RouterTest extends TestCase {
 			array('controller' => 'pages', 'action' => 'view', 'extra' => null),
 			array("extra" => '[a-z1-9_]*', "slug" => '[a-z1-9_]+')
 		);
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'admin' => null,
@@ -1485,6 +1464,16 @@ class RouterTest extends TestCase {
 	}
 
 /**
+ * Test exceptions when parsing fails.
+ *
+ * @expectedException Cake\Routing\Error\MissingRouteException
+ */
+	public function testParseError() {
+		Router::connect('/', ['controller' => 'Pages', 'action' => 'display', 'home']);
+		Router::parse('/nope');
+	}
+
+/**
  * Test parse and reverse symmetry
  *
  * @return void
@@ -1502,7 +1491,6 @@ class RouterTest extends TestCase {
  */
 	public function parseReverseSymmetryData() {
 		return array(
-			array('/'),
 			array('/controller/action'),
 			array('/controller/action/param'),
 			array('/controller/action?param1=value1&param2=value2'),
@@ -1559,7 +1547,6 @@ class RouterTest extends TestCase {
 				'webroot' => '/base/',
 			))
 		);
-		Router::parse('/');
 
 		$result = Router::url(array(
 			'plugin' => 'test_plugin',
@@ -1738,8 +1725,6 @@ class RouterTest extends TestCase {
 		Router::connect('/admin/:controller/:action/*', array('prefix' => 'admin'));
 		Router::connect('/:controller/:action/*');
 
-		Router::parse('/');
-
 		$request = new Request();
 		Router::setRequestInfo(
 			$request->addParams(array(
@@ -1863,7 +1848,6 @@ class RouterTest extends TestCase {
 		Router::reload();
 		Router::connect('/protected/:controller/:action', array('prefix' => 'protected'));
 		Router::connect('/:controller/:action');
-		Router::parse('/');
 
 		$request = new Request();
 		Router::setRequestInfo(
@@ -2058,6 +2042,7 @@ class RouterTest extends TestCase {
 /**
  * test that patterns work for :action
  *
+ * @expectedException Cake\Routing\Error\MissingRouteException
  * @return void
  */
 	public function testParsingWithPatternOnAction() {
@@ -2076,8 +2061,7 @@ class RouterTest extends TestCase {
 		);
 		$this->assertEquals($expected, $result);
 
-		$result = Router::parse('/blog/foobar');
-		$this->assertSame([], $result);
+		Router::parse('/blog/foobar');
 	}
 
 /**
@@ -2086,7 +2070,7 @@ class RouterTest extends TestCase {
  * @expectedException Cake\Routing\Error\MissingRouteException
  * @return void
  */
-	public function testUrlPatterOnAction() {
+	public function testUrlPatternOnAction() {
 		Router::connect(
 			'/blog/:action/*',
 			array('controller' => 'blog_posts'),
@@ -2241,7 +2225,6 @@ class RouterTest extends TestCase {
 		Router::connect('/test-passed/*', array('controller' => 'pages', 'action' => 'display', 'home'));
 		Router::connect('/test2/*', array('controller' => 'pages', 'action' => 'display', 2));
 		Router::connect('/test/*', array('controller' => 'pages', 'action' => 'display', 1));
-		Router::parse('/');
 
 		$result = Router::url(array('controller' => 'pages', 'action' => 'display', 1, 'whatever'));
 		$expected = '/test/whatever';
@@ -2267,9 +2250,17 @@ class RouterTest extends TestCase {
 		$result = Router::parse('/eng/test/test_action');
 		$expected = array('pass' => [], 'locale' => 'eng', 'controller' => 'test', 'action' => 'test_action', 'plugin' => null);
 		$this->assertEquals($expected, $result);
+	}
 
-		$result = Router::parse('/badness/test/test_action');
-		$this->assertSame([], $result);
+/**
+ * testRegexRouteMatching error
+ *
+ * @expectedException Cake\Routing\Error\MissingRouteException
+ * @return void
+ */
+	public function testRegexRouteMatchingError() {
+		Router::connect('/:locale/:controller/:action/*', [], array('locale' => 'dan|eng'));
+		Router::parse('/badness/test/test_action');
 	}
 
 /**
@@ -2302,18 +2293,6 @@ class RouterTest extends TestCase {
 		$result = Router::url(array('action' => 'test_another_action'));
 		$expected = '/';
 		$this->assertEquals($expected, $result);
-	}
-
-/**
- * test that connectDefaults() can disable default route connection
- *
- * @return void
- */
-	public function testDefaultsMethod() {
-		Router::connect('/test/*', array('controller' => 'pages', 'action' => 'display', 2));
-		$result = Router::parse('/posts/edit/5');
-		$this->assertFalse(isset($result['controller']));
-		$this->assertFalse(isset($result['action']));
 	}
 
 /**

--- a/tests/TestCase/Routing/RouterTest.php
+++ b/tests/TestCase/Routing/RouterTest.php
@@ -1074,7 +1074,7 @@ class RouterTest extends TestCase {
 /**
  * Test that using invalid names causes exceptions.
  *
- * @expectedException \Cake\Error\Exception
+ * @expectedException \Cake\Routing\Error\MissingRouteException
  * @return void
  */
 	public function testNamedRouteException() {
@@ -2083,7 +2083,7 @@ class RouterTest extends TestCase {
 /**
  * Test url() works with patterns on :action
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Routing\Error\MissingRouteException
  * @return void
  */
 	public function testUrlPatterOnAction() {
@@ -2275,7 +2275,7 @@ class RouterTest extends TestCase {
 /**
  * testRegexRouteMatching method
  *
- * @expectedException Cake\Error\Exception
+ * @expectedException Cake\Routing\Error\MissingRouteException
  * @return void
  */
 	public function testRegexRouteMatchUrl() {


### PR DESCRIPTION
Add and improve routing errors. This change adds a new framework error for when routes cannot be parsed, or when reverse routing fails. The error template prints out all the connected routes and currently looks like:

![screen shot 2014-07-01 at 10 08 07 am](https://cloud.githubusercontent.com/assets/24086/3443993/80c28b80-0129-11e4-86b4-254dca66bc12.png)

Part of #3693
