### PR TITLE
Added ability to parse fragment identifiers (#) in a URL when using Router::parse()

### DIFF
--- a/lib/Cake/Routing/Router.php
+++ b/lib/Cake/Routing/Router.php
@@ -607,6 +607,11 @@ class Router {
 			list($url, $queryParameters) = explode('?', $url, 2);
 			parse_str($queryParameters, $queryParameters);
 		}
+		if (strpos($url, '#') !== false) {
+			$position = strpos($url, '#');
+			$frag = substr($url, $position + 1);
+			$url = substr_replace($url, '', $position);
+		}
 
 		extract(self::_parseExtension($url));
 
@@ -629,6 +634,10 @@ class Router {
 
 		if (!empty($queryParameters) && !isset($out['?'])) {
 			$out['?'] = $queryParameters;
+		}
+
+		if (!empty($frag) && !isset($out['#'])) {
+			$out['#'] = $frag;
 		}
 		return $out;
 	}

--- a/lib/Cake/Test/Case/Routing/RouterTest.php
+++ b/lib/Cake/Test/Case/Routing/RouterTest.php
@@ -1569,6 +1569,25 @@ class RouterTest extends CakeTestCase {
 	}
 
 /**
+ * testFragmentIdentifierUrlParsing
+ *
+ * @return void
+ */
+	public function testFragmentIdentifierUrlParsing() {
+		$result = Router::parse('/controller/action#fragment');
+		$expected = array('controller' => 'controller', 'action' => 'action', 'named' => array(), 'pass' => array(), 'plugin' => null, '#' => 'fragment');
+		$this->assertEquals($expected, $result);
+
+		$result = Router::parse('#fragment');
+		$expected = array('named' => array(), 'pass' => array('home'), 'controller' => 'pages', 'action' => 'display', 'plugin' => null, '#' => 'fragment');
+		$this->assertEquals($expected, $result);
+
+		$result = Router::parse('#');
+		$expected = array('named' => array(), 'pass' => array('home'), 'controller' => 'pages', 'action' => 'display', 'plugin' => null);
+		$this->assertEquals($expected, $result);
+	}
+
+/**
  * testNamedArgsUrlParsing method
  *
  * @return void


### PR DESCRIPTION
The `Router::url()` method does recognise the fragment identifier (#) in the array and appends it to a string. However, `Router::parse()` does not recognise the fragment identifier and incorrectly appends it to whatever preceded it. 
E.g.

```
Router::parse(/controller/action#fragment) 
// returns array('controller' => 'controller', 'action' => 'action#fragment') instead of
// array('controller' => 'controller', 'action' => 'action', '#' => 'fragment')
```

This pull request fixes the above issue.
