### PR TITLE
Allow to use closure in QueryExpression

### DIFF
--- a/src/Database/Expression/QueryExpression.php
+++ b/src/Database/Expression/QueryExpression.php
@@ -434,6 +434,11 @@ class QueryExpression implements ExpressionInterface, Countable {
 			if ($numericKey && empty($c)) {
 				continue;
 			}
+			
+			if (is_callable($c)) {
+				$expr = new QueryExpression([], $typeMap);
+				$c = $c($expr, $this);
+			}
 
 			if ($numericKey && is_string($c)) {
 				$this->_conditions[] = $c;

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -75,7 +75,7 @@ class TupleComparisonTest extends TestCase {
  * @return void
  */
 	public function testTupleWithClosureExpression() {
-		$field1 = new QueryExpression([function($e){return $e->eq('a', 1);}]);
+		$field1 = new QueryExpression([function($e) {return $e->eq('a', 1);}]);
 		$f = new TupleComparison([$field1, 'field2'], [4, 5], ['integer', 'integer'], '>');
 		$binder = new ValueBinder;
 		$this->assertEquals('(a = :c0, field2) > (:c1, :c2)', $f->sql($binder));

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -70,6 +70,21 @@ class TupleComparisonTest extends TestCase {
 	}
 
 /**
+ * Tests generating tuples in the values side containing expressions
+ *
+ * @return void
+ */
+	public function testTupleWithClosureExpression() {
+		$field1 = new QueryExpression([function($e){return $e->eq('a', 1);}]);
+		$f = new TupleComparison([$field1, 'field2'], [4, 5], ['integer', 'integer'], '>');
+		$binder = new ValueBinder;
+		$this->assertEquals('(a = :c0, field2) > (:c1, :c2)', $f->sql($binder));
+		$this->assertSame(1, $binder->bindings()[':c0']['value']);
+		$this->assertSame(4, $binder->bindings()[':c1']['value']);
+		$this->assertSame(5, $binder->bindings()[':c2']['value']);
+	}
+
+/**
  * Tests generating tuples using the IN conjunction
  *
  * @return void

--- a/tests/TestCase/Database/Expression/TupleComparisonTest.php
+++ b/tests/TestCase/Database/Expression/TupleComparisonTest.php
@@ -70,7 +70,7 @@ class TupleComparisonTest extends TestCase {
 	}
 
 /**
- * Tests generating tuples in the values side containing expressions
+ * Tests generating tuples in the values side containing closure expressions
  *
  * @return void
  */


### PR DESCRIPTION
Allow to use closure in QueryExpression. Fixes #3852
